### PR TITLE
Drastically increase the performance of DatabaseMetaData.getTypeInfo()

### DIFF
--- a/org/postgresql/jdbc2/TypeInfoCache.java
+++ b/org/postgresql/jdbc2/TypeInfoCache.java
@@ -394,7 +394,7 @@ public class TypeInfoCache implements TypeInfo {
                 throw new PSQLException(GT.tr("No results were returned by the query."), PSQLState.NO_DATA);
 
             ResultSet rs = getArrayElementOidStatement.getResultSet();
-            while (!rs.next()) {
+            while (rs.next()) {
 
                 pgType = new Integer((int)rs.getLong(1));
                 _pgArrayToPgType.put(new Integer(rs.getInt(3)), pgType);


### PR DESCRIPTION
When lazy loading type information in TypeInfoCache, load all information for all types in the database instead of just the requested type.  This decreased the runtime of DatabaseMetaData.getTypeInfo() from ~27s to less than 1s.
