### PR TITLE
Update org/postgresql/jdbc2/AbstractJdbc2ResultSet.java

### DIFF
--- a/org/postgresql/jdbc2/AbstractJdbc2ResultSet.java
+++ b/org/postgresql/jdbc2/AbstractJdbc2ResultSet.java
@@ -2731,6 +2731,15 @@ public abstract class AbstractJdbc2ResultSet implements BaseResultSet, org.postg
 
     private int findColumnIndex(String columnName)
     {
+    	if (columnName.charAt(0) == '"')
+		{
+			int lastCharIdx = columnName.length() - 1;
+			if (columnName.charAt(lastCharIdx) == '"')
+			{
+  			    columnName = columnName.substring(1, lastCharIdx);
+			}
+		}
+
         if (columnNameIndexMap == null)
         {
             columnNameIndexMap = new HashMap(fields.length * 2);


### PR DESCRIPTION
fixed a mapping problem when using jpa+hibernate native queries and column names containing upper case letters.

use case:
--- DB---

<pre>
create table test_table (
    id integer not null,
    "testCOLUMN" varchar(10)
);

insert into test_table (id, "testCOLUMN") values (0,'hello');
insert into test_table (id, "testCOLUMN") values (1,'world');
</pre>


--- JAVA ---

<pre>
@Entity
@Table(name = "test_table")
public class TestEntity {
  
  @Id
  private int           id;
  
  @Column(name = "\"testCOLUMN\"")
  private String    testCOLUMN;
  
  // getters & setters
  
}

...

final List<TestEntity> resultList = em.createNativeQuery("select * from test_table where \"testCOLUMN\"= :value", TestEntity.class).setParameter("value", "hello").getResultList();
</pre>
