### PR TITLE
Expose PID of the backend process serving a paricular JDBC connection

### DIFF
--- a/org/postgresql/PGConnection.java
+++ b/org/postgresql/PGConnection.java
@@ -110,5 +110,11 @@ public interface PGConnection
      */
     public int getPrepareThreshold();
 
+    /**
+     * Return the process ID (PID) of the backend server process handling this connection.
+     * 
+     * @return PID of backned server process. 
+     */
+    public int getBackendPID();
 }
 

--- a/org/postgresql/core/ProtocolConnection.java
+++ b/org/postgresql/core/ProtocolConnection.java
@@ -143,4 +143,9 @@ public interface ProtocolConnection {
      * @return the server integer_datetime setting.
      */
     public boolean getIntegerDateTimes();
+
+    /**
+     * Return the process ID (PID) of the backend server process handling this connection.
+     */
+    public int getBackendPID();
 }

--- a/org/postgresql/core/v2/ProtocolConnectionImpl.java
+++ b/org/postgresql/core/v2/ProtocolConnectionImpl.java
@@ -207,6 +207,11 @@ class ProtocolConnectionImpl implements ProtocolConnection {
         return false;
     }
 
+    public int getBackendPID()
+    {
+    	return cancelPid;
+    }
+
     private String serverVersion;
     private int cancelPid;
     private int cancelKey;

--- a/org/postgresql/core/v3/ProtocolConnectionImpl.java
+++ b/org/postgresql/core/v3/ProtocolConnectionImpl.java
@@ -198,6 +198,11 @@ class ProtocolConnectionImpl implements ProtocolConnection {
     {
         return 3;
     }
+    
+    public int getBackendPID()
+    {
+    	return cancelPid;
+    }
 
     public boolean useBinaryForReceive(int oid) {
         return useBinaryForOids.contains(oid);

--- a/org/postgresql/jdbc2/AbstractJdbc2Connection.java
+++ b/org/postgresql/jdbc2/AbstractJdbc2Connection.java
@@ -1227,4 +1227,9 @@ public abstract class AbstractJdbc2Connection implements BaseConnection
     public boolean binaryTransferSend(int oid) {
         return useBinarySendForOids.contains(oid);
     }
+    
+    public int getBackendPID()
+    {
+    	return protoConnection.getBackendPID();
+    }
 }


### PR DESCRIPTION
I'm chasing a deadlock problem in my application occurring once per several million transactions. Before I start blaming the database, I want to make sure that my application is not doing something stupid. For that I need to keep track of Java thread - PostgresSQL backend worker association.
I know I can push information about the thread using a connection to PostgreSQL 9.0+ using setClientInfo but it is more convenient for me to put information about associated backend PID into the logs produced on Java side - I'm saving myself the effort needed to correlate the two log streams with one another.
The information about PID was already there, in ProtocolConnection (both v2 and v3) so the only thing I needed was exposing that information through PGConnection interface. I'm running a patched 9.1 driver now and it works great, so I thought that I'll share the patch - perhaps other users will also find it useful.
