### PR TITLE
DbKeyStoreFactory

### DIFF
--- a/org/postgresql/ssl/DbKeyStoreSocketFactory.java
+++ b/org/postgresql/ssl/DbKeyStoreSocketFactory.java
@@ -1,0 +1,65 @@
+package acme;
+
+import java.io.InputStream;
+import java.security.KeyStore;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
+
+abstract public class DbKeyStoreSocketFactory extends org.postgresql.ssl.WrappedFactory {
+    /*
+     * Populate the WrappedFactory member _factory with an SSL Socket Factory
+     * that uses the JKS keystore provided by getKeyStorePassword() and
+     * getKeyStoreStream().  A subclass only needs to implement these two
+     * methods.  The key store will be used both for selecting a private key
+     * certificate to send to the server, as well as checking the server's
+     * certificate against a set of trusted CAs.
+     */
+    public DbKeyStoreSocketFactory() throws DbKeyStoreSocketException {
+        KeyStore keys;
+        char[] password;
+        try {
+            keys = KeyStore.getInstance("JKS");
+            password = getKeyStorePassword();
+            keys.load(getKeyStoreStream(), password);
+        }
+        catch (java.security.GeneralSecurityException gse) {
+            throw new DbKeyStoreSocketException("Failed to load keystore: " + gse.getMessage());
+        }
+        catch (java.io.FileNotFoundException fnfe) {
+            throw new DbKeyStoreSocketException("Failed to find keystore file." + fnfe.getMessage());
+        }
+        catch (java.io.IOException ioe) {
+            throw new DbKeyStoreSocketException("Failed to read keystore file: " + ioe.getMessage());
+        }
+        try {
+            KeyManagerFactory keyfact = KeyManagerFactory.getInstance(
+                    KeyManagerFactory.getDefaultAlgorithm());
+            keyfact.init(keys, password);
+
+            TrustManagerFactory trustfact = TrustManagerFactory.getInstance(
+                    TrustManagerFactory.getDefaultAlgorithm());
+            trustfact.init(keys);
+
+            SSLContext ctx = SSLContext.getInstance("SSL");
+            ctx.init(
+                    keyfact.getKeyManagers(),
+                    trustfact.getTrustManagers(),
+                    null);
+            _factory = ctx.getSocketFactory();
+        }
+        catch (java.security.GeneralSecurityException gse) {
+            throw new DbKeyStoreSocketException("Failed to set up database socket factory: " + gse.getMessage());
+        }
+    }
+
+    abstract public char[] getKeyStorePassword();
+    abstract public InputStream getKeyStoreStream();
+
+    public static class DbKeyStoreSocketException extends Exception {
+        public DbKeyStoreSocketException(String message) {
+            super(message);
+        }
+    }
+}
+


### PR DESCRIPTION
...ndan Jurd

It seems that the most common way to deal with this situation is to
specify the keystore file and the password via system properties
(javax.net.ssl.keyStore et. al.), but that wasn't suitable in my case.
 I needed to be able to load the keystore from a Resource file
embedded in the compiled JAR.

The class I came up with is attached.  It builds on the WrappedFactory
provided in jdbc-postgres.  All the implementer needs to do is
override the two abstract methods to provide an InputStream of the key
store, and the password to access it.  The InputStream could be a
FileInputStream, or an InputStream returned by getResource(), or
whatever.

This class uses the same keystore for KeyManager (selecting the
key/cert to send as the client) and for TrustManager (verifying the
server's certificate against trusted CAs).  It could easily be
extended to allow for two separate keystores by adding another couple
of methods.
