### PR TITLE
Bug reference 7766 reported by Zelaine Fong

### DIFF
--- a/org/postgresql/core/v2/QueryExecutorImpl.java
+++ b/org/postgresql/core/v2/QueryExecutorImpl.java
@@ -594,8 +594,7 @@ public class QueryExecutorImpl implements QueryExecutor {
             }
             catch (NumberFormatException nfe)
             {
-                handler.handleError(new PSQLException(GT.tr("Unable to interpret the update count in command completion tag: {0}.", status), PSQLState.CONNECTION_FAILURE));
-                return ;
+                update_count=Statement.SUCCESS_NO_INFO;
             }
         }
 

--- a/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -2196,8 +2196,7 @@ public class QueryExecutorImpl implements QueryExecutor {
             }
             catch (NumberFormatException nfe)
             {
-                handler.handleError(new PSQLException(GT.tr("Unable to interpret the update count in command completion tag: {0}.", status), PSQLState.CONNECTION_FAILURE));
-                return ;
+                update_count=Statement.SUCCESS_NO_INFO;
             }
         }
 


### PR DESCRIPTION
if an insert or update or delete statement affects more than 2^32 rows
we now return Statement.SUCCESS_NO_INFO
