### PR TITLE
Array delimiter for type is always comma

### DIFF
--- a/org/postgresql/jdbc4/AbstractJdbc4Connection.java
+++ b/org/postgresql/jdbc4/AbstractJdbc4Connection.java
@@ -82,29 +82,30 @@ abstract class AbstractJdbc4Connection extends org.postgresql.jdbc3g.AbstractJdb
         if (oid == Oid.UNSPECIFIED)
             throw new PSQLException(GT.tr("Unable to find server array type for provided name {0}.", typeName), PSQLState.INVALID_NAME);
 
+        char delim = getTypeInfo().getArrayDelimiter(oid);
         StringBuffer sb = new StringBuffer();
-        appendArray(sb, elements);
+        appendArray(sb, elements, delim);
 
         // This will not work once we have a JDBC 5,
         // but it'll do for now.
         return new Jdbc4Array(this, oid, sb.toString());
     }
 
-    private static void appendArray(StringBuffer sb, Object elements)
+    private static void appendArray(StringBuffer sb, Object elements, char delim)
     {
         sb.append('{');
 
         int nElements = java.lang.reflect.Array.getLength(elements);
         for (int i=0; i<nElements; i++) {
             if (i > 0) {
-                sb.append(',');
+                sb.append(delim);
             }
 
             Object o = java.lang.reflect.Array.get(elements, i);
             if (o == null) {
                 sb.append("NULL");
             } else if (o.getClass().isArray()) {
-                appendArray(sb, o);
+                appendArray(sb, o, delim);
             } else {
                 String s = o.toString();
                 AbstractJdbc2Array.escapeArrayElement(sb, s);


### PR DESCRIPTION
When using createArrayOf(..) the SQL generated does not use the array delimiter for the specific type, instead using comma. This breaks postgis 2.0 (others?) as it uses the colon as an array delimiter. 
