### PR TITLE
pgbouncer transaction patch

### DIFF
--- a/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -424,7 +424,11 @@ public class QueryExecutorImpl implements QueryExecutor {
                 protoConnection.getTransactionState() != ProtocolConnection.TRANSACTION_IDLE)
             return delegateHandler;
 
-        sendOneQuery(beginTransactionQuery, SimpleQuery.NO_PARAMETERS, 0, 0, QueryExecutor.QUERY_NO_METADATA);
+        int beginFlags = QueryExecutor.QUERY_NO_METADATA;
+        if ((flags & QueryExecutor.QUERY_ONESHOT) != 0) {
+          beginFlags |= QueryExecutor.QUERY_ONESHOT;
+        }
+        sendOneQuery(beginTransactionQuery, SimpleQuery.NO_PARAMETERS, 0, 0, beginFlags);
 
         // Insert a handler that intercepts the BEGIN.
         return new ResultHandler() {

--- a/org/postgresql/jdbc2/AbstractJdbc2Connection.java
+++ b/org/postgresql/jdbc2/AbstractJdbc2Connection.java
@@ -796,8 +796,13 @@ public abstract class AbstractJdbc2Connection implements BaseConnection
     }
 
     private void executeTransactionCommand(Query query) throws SQLException {
+        int flags = QueryExecutor.QUERY_NO_METADATA | QueryExecutor.QUERY_NO_RESULTS | QueryExecutor.QUERY_SUPPRESS_BEGIN;
+        if (prepareThreshold == 0) {
+          flags |= QueryExecutor.QUERY_ONESHOT;
+        }
+
         getQueryExecutor().execute(query, null, new TransactionCommandHandler(),
-                                   0, 0, QueryExecutor.QUERY_NO_METADATA | QueryExecutor.QUERY_NO_RESULTS | QueryExecutor.QUERY_SUPPRESS_BEGIN);
+                                   0, 0, flags);
     }
 
     /*


### PR DESCRIPTION
Adding pgbouncer transaction patch.
Originally from http://treehou.se/~omar/postgresql-jdbc-8.4-701-pgbouncer_txn.patch
