### PR TITLE
the driver will always return Maps for hstore columns

### DIFF
--- a/org/postgresql/jdbc2/TypeInfoCache.java
+++ b/org/postgresql/jdbc2/TypeInfoCache.java
@@ -132,6 +132,7 @@ public class TypeInfoCache implements TypeInfo {
             addCoreType(pgTypeName, oid, sqlType, javaClass, arrayOid);
         }
 
+        _pgNameToJavaClass.put("hstore", Map.class.getName());
     }
 
     public synchronized void addCoreType(String pgTypeName, Integer oid, Integer sqlType, String javaClass, Integer arrayOid)

--- a/org/postgresql/test/extensions/HStoreTest.java
+++ b/org/postgresql/test/extensions/HStoreTest.java
@@ -37,6 +37,7 @@ public class HStoreTest extends TestCase {
     public void testHStoreSelect() throws SQLException {
         PreparedStatement pstmt = _conn.prepareStatement("SELECT 'a=>1,b=>2'::hstore");
         ResultSet rs = pstmt.executeQuery();
+        assertEquals(Map.class.getName(), rs.getMetaData().getColumnClassName(1));
         assertTrue(rs.next());
         String str = rs.getString(1);
         if (!("\"a\"=>\"1\", \"b\"=>\"2\"".equals(str) || "\"b\"=>\"2\", \"a\"=>\"1\"".equals(str))) {
@@ -51,6 +52,7 @@ public class HStoreTest extends TestCase {
     public void testHStoreSelectNullValue() throws SQLException {
         PreparedStatement pstmt = _conn.prepareStatement("SELECT 'a=>NULL'::hstore");
         ResultSet rs = pstmt.executeQuery();
+        assertEquals(Map.class.getName(), rs.getMetaData().getColumnClassName(1));
         assertTrue(rs.next());
         assertEquals("\"a\"=>NULL", rs.getString(1));
         Map correct = Collections.singletonMap("a", null);
@@ -62,6 +64,7 @@ public class HStoreTest extends TestCase {
         PreparedStatement pstmt = _conn.prepareStatement("SELECT ?::text");
         pstmt.setObject(1, correct);
         ResultSet rs = pstmt.executeQuery();
+        assertEquals(String.class.getName(), rs.getMetaData().getColumnClassName(1));
         assertTrue(rs.next());
         assertEquals("\"a\"=>\"1\"", rs.getString(1));
     }
@@ -71,6 +74,7 @@ public class HStoreTest extends TestCase {
         PreparedStatement pstmt = _conn.prepareStatement("SELECT ?");
         pstmt.setObject(1, correct);
         ResultSet rs = pstmt.executeQuery();
+        assertEquals(Map.class.getName(), rs.getMetaData().getColumnClassName(1));
         assertTrue(rs.next());
         assertEquals(correct, rs.getObject(1));
         assertEquals("\"a\"=>\"t'e\ns\\\"t\"", rs.getString(1));


### PR DESCRIPTION
The driver always returns java.util.Map objects for hstore columns, so we should provide this information to the user via the ResultSetMetadata.
