### PR TITLE
Added test case for checking the return code when an xid does not exist.

### DIFF
--- a/org/postgresql/test/xa/XADataSourceTest.java
+++ b/org/postgresql/test/xa/XADataSourceTest.java
@@ -339,6 +339,7 @@ public class XADataSourceTest extends TestCase {
         try
         {
         	xaRes.rollback(xid);
+		fail("Rollback was successful");
         }
         catch (XAException xae)
         {


### PR DESCRIPTION
This PR demonstrates how the current driver does not report back an error code during transaction recovery process. Calling recover on the same Xid should return an error indicating the xid was not found. Instead it is reporting a general error about the resource manager.

Regards,
Jeremy
