### PR TITLE
fix bug of fail to prepareCall("{CALL func()}")

### DIFF
--- a/org/postgresql/jdbc2/AbstractJdbc2Statement.java
+++ b/org/postgresql/jdbc2/AbstractJdbc2Statement.java
@@ -2378,7 +2378,7 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
                     ++i;
                     ++state;
                 }
-                else if (ch == 'c')
+                else if (ch == 'c' || ch == 'C')
                 {  // { call ... }      -- proc with no out parameters
                     state += 3; // Don't increase 'i'
                 }


### PR DESCRIPTION
Now,the result of JDBC escape syntax for call statements is as following
prepareCall("{call func()}")  OK
prepareCall("{cALL func()}")  OK
prepareCall("{CALL func()}") NG
prepareCall("?={CALL func()}") OK

Consider other cases,the keyword 'call' is case insensitive,and the result of prepareCall("{CALL func()}")  should be OK.
