### PR TITLE
fix for setBlob with large blob

### DIFF
--- a/org/postgresql/jdbc2/AbstractJdbc2Statement.java
+++ b/org/postgresql/jdbc2/AbstractJdbc2Statement.java
@@ -3069,8 +3069,8 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
             // could be buffered, but then the OutputStream returned by LargeObject
             // is buffered internally anyhow, so there would be no performance
             // boost gained, if anything it would be worse!
-            int bytesRemaining = (int)x.length();
-            int numRead = l_inStream.read(buf, 0, Math.min(buf.length, bytesRemaining));
+            long bytesRemaining = x.length();
+            int numRead = l_inStream.read(buf, 0, (int)Math.min((long)buf.length, bytesRemaining));
             while (numRead != -1 && bytesRemaining > 0)
             {
                 bytesRemaining -= numRead;
@@ -3078,7 +3078,7 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
                     los.write(buf); // saves a buffer creation and copy in LargeObject since it's full
                 else
                     los.write(buf, 0, numRead);
-                numRead = l_inStream.read(buf, 0, Math.min(buf.length, bytesRemaining));
+                numRead = l_inStream.read(buf, 0, (int)Math.min((long)buf.length, bytesRemaining));
             }
         }
         catch (IOException se)


### PR DESCRIPTION
I am using setBlob(int, Blob) with a 3.2GB large blob, but got the following stack trace.

java.lang.IndexOutOfBoundsException
    at java.io.BufferedInputStream.read(BufferedInputStream.java:327)
    at org.postgresql.jdbc2.AbstractJdbc2Statement.setBlob(AbstractJdbc2Statement.java:3073)

This patch fixes this problem for me.
