### PR TITLE
Add SSL factory SingleCertValidatingFactory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@ jars
 nbproject
 .idea
 *.iml
-
+build.local.properties

--- a/build.xml
+++ b/build.xml
@@ -172,9 +172,10 @@
        <exclude name="${package}/jdcb4/Jdbc4*.java" unless="jdbc4any" />
 
        <!-- ssl -->
+       <include name="${package}/ssl/SingleCertValidatingFactory.java" if="jdbc4any"/>
        <include name="${package}/ssl/jdbc4/*.java" if="jdbc4any"/>
        <include name="${package}/ssl/jdbc3/*.java" if="jdbc3any"/>
-
+       
        <!-- gss -->
        <include name="${package}/gss/*.java" />
 
@@ -446,6 +447,7 @@
       <test name="org.postgresql.test.extensions.ExtensionsSuite" outfile="${testResultsDir}/extensions"/>
       <test name="org.postgresql.test.jdbc4.Jdbc4TestSuite" if="jdbc4tests" outfile="${testResultsDir}/jdbc4"/>
       <test name="org.postgresql.test.ssl.SslTestSuite" if="jdbc4tests" outfile="${testResultsDir}/ssl"/>
+      <test name="org.postgresql.test.ssl.SingleCertValidatingFactoryTest" if="jdbc4tests" outfile="${testResultsDir}/scsf-ssl"/>
     </junit>
   </target>
   
@@ -470,11 +472,12 @@
         <include name="util/PGmoney.java" />
         <include name="util/PGInterval.java" />
         <include name="util/ServerErrorMessage.java" />
-	<include name="ssl/WrappedFactory.java" />
-	<include name="ssl/NonValidatingFactory.java" />
-	<include name="ds/PG*.java" />
-	<include name="ds/common/BaseDataSource.java" />
-	<include name="xa/PGXADataSource.java" />
+        <include name="ssl/WrappedFactory.java" />
+        <include name="ssl/NonValidatingFactory.java" />
+        <include name="ssl/SingleCertValidatingFactory.java" />
+        <include name="ds/PG*.java" />
+        <include name="ds/common/BaseDataSource.java" />
+        <include name="xa/PGXADataSource.java" />
       </fileset>
     </javadoc>
   </target>

--- a/org/postgresql/ssl/SingleCertValidatingFactory.java
+++ b/org/postgresql/ssl/SingleCertValidatingFactory.java
@@ -1,0 +1,190 @@
+/*-------------------------------------------------------------------------
+*
+* Copyright (c) 2004-2011, PostgreSQL Global Development Group
+*
+*
+*-------------------------------------------------------------------------
+*/
+package org.postgresql.ssl;
+
+import java.io.ByteArrayInputStream;
+import java.io.BufferedInputStream;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.io.IOException;
+import java.util.UUID;
+
+import java.security.KeyStore;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.security.GeneralSecurityException;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509TrustManager;
+
+import org.postgresql.util.GT;
+import org.postgresql.ssl.WrappedFactory;
+
+/**
+ * Provides a SSLSocketFactory that authenticates the remote server against
+ * an explicit pre-shared SSL certificate. This is more secure than using the 
+ * NonValidatingFactory as it prevents "man in the middle" attacks. It is also
+ * more secure than relying on a central CA signing your server's certificate
+ * as it pins the server's certificate.
+ * 
+ * <p />
+ *
+ * This class requires a single String parameter specified by setting
+ * the connection property <code>sslfactoryarg</code>. The value of this property
+ * is the PEM-encoded remote server's SSL certificate.
+ *
+ * <p />
+ * Where the certificate is loaded from is based upon the prefix of the 
+ * <code>sslfactoryarg</code> property. The following table lists the valid
+ * set of prefixes.
+ * <table border="1">
+ *   <tr>
+ *     <th>Prefix</th>
+ *     <th>Example</th>
+ *     <th>Explanation</th>
+ *   </tr>
+ *   <tr>
+ *     <td><code>classpath:</code></td>
+ *     <td><code>classpath:ssl/server.crt</code></td>
+ *     <td>Loaded from the classpath.</td>
+ *   </tr>
+ *   <tr>
+ *     <td><code>file:</code></td>
+ *     <td><code>file:/foo/bar/server.crt</code></td>
+ *     <td>Loaded from the filesystem.</td>
+ *   </tr>
+ *   <tr>
+ *     <td><code>env:</code></td>
+ *     <td><code>env:mydb_cert<pre>
+ *     <td>Loaded from string value of the <code>mydb_cert</code>
+ *     environment variable.</td>
+ *   </tr>
+ *   <tr>
+ *     <td><code>sys:</code></td>
+ *     <td><code>sys:mydb_cert<pre>
+ *     <td>Loaded from string value of the <code>mydb_cert</code>
+ *     system property.</td>
+ *   </tr>
+ *   <tr>
+ *     <td><code>-----BEGIN CERTIFICATE------</code></td>
+ *     <td><pre>
+-----BEGIN CERTIFICATE-----
+MIIDQzCCAqygAwIBAgIJAOd1tlfiGoEoMA0GCSqGSIb3DQEBBQUAMHUxCzAJBgNV
+[... truncated ...]
+UCmmYqgiVkAGWRETVo+byOSDZ4swb10=
+-----END CERTIFICATE-----
+ </pre></td>
+ *     <td>Loaded from string value of the argument.</td>
+ *   </tr>
+ * </table>
+ */
+
+public class SingleCertValidatingFactory extends WrappedFactory {
+    private static final String FILE_PREFIX = "file:";
+    private static final String CLASSPATH_PREFIX = "classpath:";
+    private static final String ENV_PREFIX = "env:";
+    private static final String SYS_PROP_PREFIX = "sys:";
+
+    public SingleCertValidatingFactory(String sslFactoryArg) throws GeneralSecurityException {
+        if( sslFactoryArg == null || sslFactoryArg.equals("")) {
+            throw new GeneralSecurityException(GT.tr("The sslfactoryarg property may not be empty."));
+        }
+        InputStream in = null;
+        try {            
+            if( sslFactoryArg.startsWith(FILE_PREFIX) ) {
+                String path = sslFactoryArg.substring(FILE_PREFIX.length());
+                in = new BufferedInputStream(new FileInputStream(path));
+            } else if( sslFactoryArg.startsWith(CLASSPATH_PREFIX) ) {
+                String path = sslFactoryArg.substring(CLASSPATH_PREFIX.length());
+                in = new BufferedInputStream(Thread.currentThread().getContextClassLoader().getResourceAsStream(path));
+            } else if( sslFactoryArg.startsWith(ENV_PREFIX) ) {
+                String name = sslFactoryArg.substring(ENV_PREFIX.length());
+                String cert = System.getenv(name);
+                if( cert == null || "".equals(cert) ) {
+                    throw new GeneralSecurityException(
+                        GT.tr("The environment variable containing the server's SSL certificate must not be empty."));
+                }
+                in = new ByteArrayInputStream(cert.getBytes("UTF-8"));
+            } else if( sslFactoryArg.startsWith(SYS_PROP_PREFIX) ) {
+                String name = sslFactoryArg.substring(SYS_PROP_PREFIX.length());
+                String cert = System.getProperty(name);
+                if( cert == null || "".equals(cert) ) {
+                    throw new GeneralSecurityException(
+                        GT.tr("The system property containing the server's SSL certificate must not be empty."));
+                }
+                in = new ByteArrayInputStream(cert.getBytes("UTF-8"));
+            } else if( sslFactoryArg.startsWith("-----BEGIN CERTIFICATE-----") ) {
+                in = new ByteArrayInputStream(sslFactoryArg.getBytes("UTF-8"));
+            } else {
+                throw new GeneralSecurityException(
+                    GT.tr("The sslfactoryarg property must start with the prefix file:, classpath:, env:, sys:, or -----BEGIN CERTIFICATE-----."));
+            }
+
+            SSLContext ctx = SSLContext.getInstance("TLS");
+            ctx.init(null, new TrustManager[] { new SingleCertTrustManager(in) }, null);
+            _factory = ctx.getSocketFactory();
+        } catch( RuntimeException e ) {
+            throw (RuntimeException)e;
+        } catch( Exception e ) {
+            if( e instanceof GeneralSecurityException ) {
+                throw (GeneralSecurityException) e;
+            }
+            throw new GeneralSecurityException(GT.tr("An error occurred reading the certificate"), e);
+        } finally {
+            if( in != null ) {
+                try {
+                    in.close();
+                } catch( Exception e2) {
+                    // ignore
+                }
+            }
+        }
+    }
+
+    public class SingleCertTrustManager implements X509TrustManager {
+        X509Certificate cert;
+        X509TrustManager trustManager;        
+
+        public SingleCertTrustManager(InputStream in) throws IOException, GeneralSecurityException {
+            KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
+            try {
+                // Note: KeyStore requires it be loaded even if you don't load anything into it:
+                ks.load(null);
+            } catch (Exception e) {
+            }
+            CertificateFactory cf = CertificateFactory.getInstance("X509");
+            cert = (X509Certificate) cf.generateCertificate(in);
+            ks.setCertificateEntry(UUID.randomUUID().toString(), cert);
+            TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+            tmf.init(ks);
+            for (TrustManager tm : tmf.getTrustManagers()) {
+                if (tm instanceof X509TrustManager) {
+                    trustManager = (X509TrustManager) tm;
+                    break;
+                }
+            }
+            if (trustManager == null) {
+                throw new GeneralSecurityException(GT.tr("No X509TrustManager found"));
+            }
+        }
+
+        public void checkClientTrusted(X509Certificate[] chain, String authType) throws CertificateException {
+        }
+
+        public void checkServerTrusted(X509Certificate[] chain, String authType) throws CertificateException {
+            trustManager.checkServerTrusted(chain, authType);
+        }
+
+        public X509Certificate[] getAcceptedIssuers() {
+            return new X509Certificate[] { cert };
+        }
+    }
+}

--- a/org/postgresql/test/ssl/SingleCertValidatingFactoryTest.java
+++ b/org/postgresql/test/ssl/SingleCertValidatingFactoryTest.java
@@ -1,0 +1,395 @@
+package org.postgresql.test.ssl;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.FileInputStream;
+import java.util.Properties;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Collection;
+import java.sql.*;
+
+import org.postgresql.util.PSQLException;
+
+@RunWith(Parameterized.class)
+public class SingleCertValidatingFactoryTest {
+	private static String IS_ENABLED_PROP_NAME = "testsinglecertfactory";
+
+	/**
+	 * This method returns the paramaters that JUnit will use
+	 * when constructing this class for testing. It returns a
+	 * collection of arrays, each containing a single value
+	 * for the JDBC URL to test against.
+	 *
+	 * To point the test at a different set of test databases
+	 * edit the JDBC URL list accordingly. By default it points
+	 * to the test databases setup by the pgjdbc-test-vm virtual
+	 * machine.
+	 *
+	 * Note: The test assumes that the username as password for
+	 * all the test databases are the same (pulled from system
+	 * properties).
+	 */
+	@Parameters
+    public static Collection<Object[]> data() throws IOException {
+    	Properties props = new Properties();
+      	props.load(new FileInputStream(System.getProperty("ssltest.properties")));
+      	String testSingleCertFactory = props.getProperty(IS_ENABLED_PROP_NAME);
+      	boolean skipTest = testSingleCertFactory == null || "".equals(testSingleCertFactory);
+      	if( skipTest ) {
+      		System.out.println("Skipping SingleCertSocketFactoryTests. To enable set the property "
+      			+ IS_ENABLED_PROP_NAME + "=true in the ssltest.properties file.");
+      		return Collections.emptyList();
+      	}
+
+    	return Arrays.asList(new Object[][] {
+    		{"jdbc:postgresql://localhost:10084/test"},
+    		{"jdbc:postgresql://localhost:10090/test"},
+    		{"jdbc:postgresql://localhost:10091/test"},
+    		{"jdbc:postgresql://localhost:10092/test"},
+    		{"jdbc:postgresql://localhost:10093/test"},
+    	});
+    }
+
+   	// The valid and invalid server SSL certfiicates:
+	private static final String goodServerCertPath = "certdir/goodroot.crt";
+	private static final String badServerCertPath = "certdir/badroot.crt";
+
+	private String getGoodServerCert() {
+		return loadFile(goodServerCertPath);
+	}
+
+	private String getBadServerCert() {
+		return loadFile(badServerCertPath);
+	}
+
+  	protected String getUsername() {
+  		return System.getProperty("username");
+	}
+
+	protected String getPassword() {
+		return System.getProperty("password");
+	}
+
+	private String serverJdbcUrl;
+
+	public SingleCertValidatingFactoryTest(String serverJdbcUrl) {
+		this.serverJdbcUrl = serverJdbcUrl;
+	}
+
+	protected String getServerJdbcUrl() {
+		return serverJdbcUrl;
+	}
+
+	/**
+	 * Helper method to create a connection using the additional properites specified
+	 * in the "info" paramater.
+	 *
+	 * @param info The additional properties to use when creating a connection
+	 */
+	protected Connection getConnection(Properties info) throws SQLException {
+		String url = getServerJdbcUrl();
+		info.setProperty("user", getUsername());
+		info.setProperty("password", getPassword());
+		try {
+			Class.forName("org.postgresql.Driver");
+		} catch( ClassNotFoundException e) {
+			throw new RuntimeException(e);
+		}
+		return DriverManager.getConnection(url, info);
+	}
+
+	/**
+	 * Tests whether a given throwable or one of it's root causes matches of
+	 * a given class.
+	 */
+	private boolean matchesExpected(Throwable t, Class<? extends Throwable> expectedThrowable) throws SQLException {
+		if( t == null || expectedThrowable == null) {
+			return false;
+		}
+		if( expectedThrowable.isAssignableFrom(t.getClass()) ) {
+			return true;
+		}
+		return matchesExpected(t.getCause(), expectedThrowable);
+	}
+
+	protected void testConnect(Properties info, boolean sslExpected) throws SQLException {
+		testConnect(info, sslExpected, null);
+	}
+
+	/**
+	 * Connects to the database with the given connection properties and
+	 * then verifies that connection is using SSL.
+	 */
+	protected void testConnect(Properties info, boolean sslExpected, Class<? extends Throwable> expectedThrowable) throws SQLException {
+		Connection conn = null;
+		try {
+			conn = getConnection(info);
+			Statement stmt = conn.createStatement();
+			// Basic SELECT test:
+			ResultSet rs = stmt.executeQuery("SELECT 1");
+			rs.next();
+			Assert.assertEquals(1, rs.getInt(1));
+			rs.close();
+			// Verify SSL usage is as expected:
+			rs = stmt.executeQuery("SELECT ssl_is_used()");
+			rs.next();
+			boolean sslActual = rs.getBoolean(1);	
+			Assert.assertEquals(sslExpected, sslActual);
+			stmt.close();
+		} catch(Exception e) {
+			if( matchesExpected(e, expectedThrowable) ) {
+				// do nothing and just suppress the exception
+				return;
+			} else {
+				if( e instanceof RuntimeException ) {
+					throw (RuntimeException)e;
+				} else if( e instanceof SQLException ) {
+					throw (SQLException)e;
+				} else {
+					throw new RuntimeException(e);
+				}
+			}
+		} finally {
+			if (conn != null) {
+				try {
+					conn.close();
+				} catch (Exception e) {
+				}
+			}
+		}
+
+		if( expectedThrowable != null ) {
+			Assert.fail("Expected exception " + expectedThrowable.getName() + " but it did not occur.");
+		}
+	}
+
+	/**
+	 * Connect using SSL and attempt to validate the server's certificate but
+	 * don't actually provide it. This connection attempt should *fail* as the
+	 * client should reject the server.
+	 */
+	@Test
+	public void connectSSLWithValidationNoCert() throws SQLException {
+		Properties info = new Properties();
+		info.setProperty("ssl", "true");
+		testConnect(info, true, javax.net.ssl.SSLHandshakeException.class);
+	}
+
+	/**
+	 * Connect using SSL and attempt to validate the server's certificate
+	 * against the wrong pre shared certificate. This test uses a pre generated
+	 * certificate that will *not* match the test PostgreSQL server (the
+	 * certificate is for properssl.example.com).
+	 * 
+	 * This connection uses a custom SSLSocketFactory using a custom trust
+	 * manager that validates the remote server's certificate against the pre
+	 * shared certificate.
+	 * 
+	 * This test should throw an exception as the client should reject the
+	 * server since the certificate does not match.
+	 * 
+	 * @throws SQLException
+	 */
+	@Test
+	public void connectSSLWithValidationWrongCert() throws SQLException,
+			IOException {
+		Properties info = new Properties();
+		info.setProperty("ssl", "true");
+		info.setProperty("sslfactory", "org.postgresql.ssl.SingleCertValidatingFactory");
+		info.setProperty("sslfactoryarg", "file:" + badServerCertPath);
+		testConnect(info, true, javax.net.ssl.SSLHandshakeException.class);
+	}
+
+	@Test
+	public void fileCertInvalid() throws SQLException,
+			IOException {
+		Properties info = new Properties();
+		info.setProperty("ssl", "true");
+		info.setProperty("sslfactory", "org.postgresql.ssl.SingleCertValidatingFactory");
+		info.setProperty("sslfactoryarg", "file:foo/bar/baz");
+		testConnect(info, true, java.io.FileNotFoundException.class);
+	}
+
+	@Test
+	public void stringCertInvalid() throws SQLException,
+			IOException {
+		Properties info = new Properties();
+		info.setProperty("ssl", "true");
+		info.setProperty("sslfactory", "org.postgresql.ssl.SingleCertValidatingFactory");
+		info.setProperty("sslfactoryarg", "foobar!");
+		testConnect(info, true, java.security.GeneralSecurityException.class);
+	}
+
+	/**
+	 * Connect using SSL and attempt to validate the server's certificate
+	 * against the proper pre shared certificate. The certificate is specified
+	 * as a String. Note that the test read's the certificate from a local file.
+	 * 
+	 * @throws SQLException
+	 */
+	@Test
+	public void connectSSLWithValidationProperCertFile() throws SQLException,
+			IOException {
+		Properties info = new Properties();
+		info.setProperty("ssl", "true");
+		info.setProperty("sslfactory", "org.postgresql.ssl.SingleCertValidatingFactory");
+		info.setProperty("sslfactoryarg", "file:" + goodServerCertPath);
+		testConnect(info, true);
+	}
+
+	/**
+	 * Connect using SSL and attempt to validate the server's certificate
+	 * against the proper pre shared certificate. The certificate is specified
+	 * as a String (eg. the "----- BEGIN CERTIFICATE ----- ... etc").
+	 * 
+	 * @throws SQLException
+	 */
+	@Test
+	public void connectSSLWithValidationProperCertString() throws SQLException,
+			IOException {
+		Properties info = new Properties();
+		info.setProperty("ssl", "true");
+		info.setProperty("sslfactory", "org.postgresql.ssl.SingleCertValidatingFactory");
+		info.setProperty("sslfactoryarg", getGoodServerCert());
+		testConnect(info, true);
+	}
+
+	/**
+	 * Connect using SSL and attempt to validate the server's certificate
+	 * against the proper pre shared certificate. The certificate is specified
+	 * as a system property.
+	 * 
+	 * @throws SQLException
+	 */
+	@Test
+	public void connectSSLWithValidationProperCertSysProp() throws SQLException,
+			IOException {
+		// System property name we're using for the SSL cert. This can be anything.
+		String sysPropName = "org.postgresql.jdbc.test.sslcert";
+
+		try {
+			System.setProperty(sysPropName, getGoodServerCert());
+
+			Properties info = new Properties();
+			info.setProperty("ssl", "true");
+			info.setProperty("sslfactory", "org.postgresql.ssl.SingleCertValidatingFactory");
+			info.setProperty("sslfactoryarg", "sys:" + sysPropName);
+			testConnect(info, true);
+		} finally {
+			// Clear it out when we're done:
+			System.setProperty(sysPropName, "");
+		}
+	}
+
+	/**
+	 * Connect using SSL and attempt to validate the server's certificate
+	 * against the proper pre shared certificate. The certificate is specified
+	 * as an environment variable.
+	 * 
+	 * Note: To execute this test succesfully you need to set the value of the 
+	 * environment variable DATASOURCE_SSL_CERT prior to running the test.
+	 *
+	 * Here's one way to do it:
+	 *   $ DATASOURCE_SSL_CERT=$(cat certdir/goodroot.crt) ant clean test
+	 * 
+	 * @throws SQLException
+	 */
+	@Test
+	public void connectSSLWithValidationProperCertEnvVar() throws SQLException,
+			IOException {
+		String envVarName = "DATASOURCE_SSL_CERT";
+		if( System.getProperty(envVarName) == null ) {
+			System.out.println("Skipping test connectSSLWithValidationProperCertEnvVar (env variable is not defined)");
+			return;
+		}
+
+		Properties info = new Properties();
+		info.setProperty("ssl", "true");
+		info.setProperty("sslfactory", "org.postgresql.ssl.SingleCertValidatingFactory");
+		info.setProperty("sslfactoryarg", "env:" + envVarName);
+		testConnect(info, true);
+	}
+
+	/**
+	 * Connect using SSL using a system property to specify the SSL certificate but
+	 * not actually having it set. This tests whether the proper exception is thrown.
+	 */
+	@Test
+	public void connectSSLWithValidationMissingSysProp() throws SQLException,
+			IOException {
+		// System property name we're using for the SSL cert. This can be anything.
+		String sysPropName = "org.postgresql.jdbc.test.sslcert";
+
+		try {
+			System.setProperty(sysPropName, "");
+
+			Properties info = new Properties();
+			info.setProperty("ssl", "true");
+			info.setProperty("sslfactory", "org.postgresql.ssl.SingleCertValidatingFactory");
+			info.setProperty("sslfactoryarg", "sys:" + sysPropName);
+			testConnect(info, true, java.security.GeneralSecurityException.class);
+		} finally {
+			// Clear it out when we're done:
+			System.setProperty(sysPropName, "");
+		}
+	}
+
+	/**
+	 * Connect using SSL using an environment var to specify the SSL certificate but
+	 * not actually having it set. This tests whether the proper exception is thrown.
+	 */
+	@Test
+	public void connectSSLWithValidationMissingEnvVar() throws SQLException,
+			IOException {
+		// Use an environment variable that does *not* exist:
+		String envVarName = "MISSING_DATASOURCE_SSL_CERT";
+		if( System.getProperty(envVarName) != null ) {
+			System.out.println("Skipping test connectSSLWithValidationMissingEnvVar (env variable is defined)");
+			return;
+		}
+
+		Properties info = new Properties();
+		info.setProperty("ssl", "true");
+		info.setProperty("sslfactory", "org.postgresql.ssl.SingleCertValidatingFactory");
+		info.setProperty("sslfactoryarg", "env:" + envVarName);
+		testConnect(info, true, java.security.GeneralSecurityException.class);
+	}
+
+	///////////////////////////////////////////////////////////////////
+
+	/**
+	 * Utility function to load a file as a string
+	 */
+	public static String loadFile(String path) {
+		BufferedReader br = null;
+		try {
+			br = new BufferedReader(new InputStreamReader(new FileInputStream(path)));
+			StringBuilder sb = new StringBuilder();
+			String line = null;
+			while( (line = br.readLine()) != null ) {
+				sb.append(line);
+				sb.append("\n");
+			}
+			return sb.toString();
+		} catch( IOException e ) {
+			throw new RuntimeException(e);
+		} finally {
+			if( br != null ) {
+				try {
+					br.close();
+				} catch( Exception e ) {
+				}
+			}
+		}
+	}
+}

--- a/ssltest.properties
+++ b/ssltest.properties
@@ -1,6 +1,9 @@
 
   
 certdir=certdir
+
+# Uncomment to enable testing of SingleCertValidatingFactory
+#testsinglecertfactory=true
   
 ssloff8=
 ssloff8prefix=


### PR DESCRIPTION
Add a new SSL socket factory that allows users to specify and verify the SSL certificate of the remote server to prevent MITM attacks. The socket factory allows for easily specifying and pinning of remote server SSL certificates when creating a new connection to a database. The SSL certificate can be specified as the String value of the
certificate itself, a file path, a classpath relative path, a system property, or an environment variable.

Also included is a new test class that uses the new socket factory. The test class is disabled by default but can be enabled by setting `testsinglecertfactory=true` in the ssltests.properties config file.

By default the tests are configured to run against a SSL test database VM running on localhost on the ports 10084, 10090, 10091, 10092, and 10093. To test against a different set of databases edit the test parameters (JDBC URLs) at the top of the class.

The last test case pulls the SSL certificate from an enviroment var. For it to run the env var must be set prior to running the test. Otherwise the test is skipped. You can set it and run the test via:

```
$ DATASOURCE_SSL_CERT=$(cat certdir/goodroot.crt) ant clean test
```

The easiest way to test it and the JDBC SSL tests in general is to use the test VM I put together. It's available at: https://github.com/jackdb/pgjdbc-test-vm

To use it:
1. Clone that repo
2. Install [Vagrant](http://vagrantup.com) and [Virtual Box](https://www.virtualbox.org/)
3. Start up the VM (from the repo's directory):
   
   $ vagrant up
4. Create a file `build.local.properties` in your JDBC driver root directory with the line `port=10093` (or replace that with a different port for a different server version).

The VM that gets created is configured to run all the SSL tests (old and my new one) and can also be used to run the non-SSL tests.
