### PR TITLE
set a fixed lc_monetary to avoid error in some culture.

### DIFF
--- a/org/postgresql/core/v2/ConnectionFactoryImpl.java
+++ b/org/postgresql/core/v2/ConnectionFactoryImpl.java
@@ -422,7 +422,7 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
             if (logger.logDebug())
                 logger.debug("Switching to UTF8 client_encoding");
 
-            String sql = "begin; set autocommit = on; set client_encoding = 'UTF8'; ";
+            String sql = "begin; set autocommit = on; set client_encoding = 'UTF8'; set lc_monetary = 'C'; ";
             if (dbVersion.compareTo("9.0") >= 0) {
                 sql += "SET extra_float_digits=3; ";
             } else if (dbVersion.compareTo("7.4") >= 0) {

--- a/org/postgresql/core/v3/ConnectionFactoryImpl.java
+++ b/org/postgresql/core/v3/ConnectionFactoryImpl.java
@@ -164,7 +164,8 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
                                     { "client_encoding", "UTF8" },
                                     { "DateStyle", "ISO" },
                                     { "extra_float_digits", "2" },
-                                    { "TimeZone",  createPostgresTimeZone() },                                    
+                                    { "TimeZone",  createPostgresTimeZone() },
+                                    { "lc_monetary",  "C" },
                                 };
 
             sendStartupPacket(newStream, params, logger);


### PR DESCRIPTION
Hi , all

Currenttly pgjdbc seem to only supported dollar as monetary .
For example,when lc_monetary = 'zh_CN.UTF8',the folloing code will fail.

PreparedStatement stmt = con.prepareStatement("select 1::money");
ResultSet rs = stmt.executeQuery();
rs.next()
System.out.print(rs.getObject(1));// throw error:Bad value for type double : ￥1

To support all monetaries is not practical.Since pgjdbc only support dollar i suggest set  lc_monetary to 'C' when connecting. So regardless the setting of  lc_monetary in the backend we can read and write money data via pgjdbc.

regard,
Chen Huajun
