### PR TITLE
Use proper System property

### DIFF
--- a/org/postgresql/ssl/jdbc4/LibPQFactory.java
+++ b/org/postgresql/ssl/jdbc4/LibPQFactory.java
@@ -61,7 +61,7 @@ public class LibPQFactory extends WrappedFactory implements HostnameVerifier {
         SSLContext ctx = SSLContext.getInstance("TLS"); // or "SSL" ?
         
         //Determinig the default file location
-        String pathsep = System.getProperty("path.separator");
+        String pathsep = System.getProperty("file.separator");
         String defaultdir;
         boolean defaultfile = false;
         if (System.getProperty("os.name").toLowerCase().indexOf("windows") > -1)


### PR DESCRIPTION
Using 'path.separator' results in malformed paths such as:
/default/dir:./postgresql/root.crt
This corrects the problem.
