### PR TITLE
Fix #92, missing NonValidatingFactory in JDBC3 driver

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -85,6 +85,7 @@
     <!-- ssl -->
     <include name="${package}/ssl/jdbc4/*.java" if="jdbc4any"/>
     <include name="${package}/ssl/jdbc3/*.java" if="jdbc3any"/>
+    <include name="${package}/ssl/.java" if="jdbc3any"/>
 
     <!-- gss -->
     <include name="${package}/gss/*.java"/>
@@ -249,6 +250,7 @@
        <!-- ssl -->
        <include name="${package}/ssl/jdbc4/*.java" if="jdbc4any"/>
        <include name="${package}/ssl/jdbc3/*.java" if="jdbc3any"/>
+       <include name="${package}/ssl/*.java" if="jdbc3any"/>
 
        <!-- gss -->
        <include name="${package}/gss/*.java" />


### PR DESCRIPTION
See https://github.com/pgjdbc/pgjdbc/issues/92

You need this patch if attempts to use a URL like

```
jdbc:postgresql://ipaddress:port/dbname?ssl=true&sslfactory=org.postgresql.ssl.NonValidatingFactory
```

fails with:

```
java.lang.ClassNotFoundException: org.postgresql.ssl.NonValidatingFactory
```

in the stack trace.
