### PR TITLE
Fix various setQueryTimeout bugs.

### DIFF
--- a/org/postgresql/jdbc2/AbstractJdbc2Statement.java
+++ b/org/postgresql/jdbc2/AbstractJdbc2Statement.java
@@ -76,7 +76,7 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
     /** Number of rows to get in a batch. */
     protected int fetchSize = 0;
 
-    /** Timeout (in seconds) for a query (not used) */
+    /** Timeout (in seconds) for a query */
     protected int timeout = 0;
 
     protected boolean replaceProcessingEnabled = true;
@@ -555,14 +555,13 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
         result = null;
         try
         {
-            
-        
-        connection.getQueryExecutor().execute(queryToExecute,
-                                              queryParameters,
-                                              handler,
-                                              maxrows,
-                                              fetchSize,
-                                              flags);
+            startTimer();
+            connection.getQueryExecutor().execute(queryToExecute,
+                                                  queryParameters,
+                                                  handler,
+                                                  maxrows,
+                                                  fetchSize,
+                                                  flags);
         }
         finally
         {
@@ -717,27 +716,6 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
         if (seconds < 0)
             throw new PSQLException(GT.tr("Query timeout must be a value greater than or equals to 0."),
                                     PSQLState.INVALID_PARAMETER_VALUE);
-
-        if (seconds == 0) {
-            killTimer();
-            return;
-        }
-
-        cancelTimer = new TimerTask() {
-            public void run()
-            {
-                try {
-                    AbstractJdbc2Statement.this.cancel();
-                } catch (SQLException e) {
-                }
-                finally
-                {
-                    killTimer();
-                }
-            }
-        };
-        
-        Driver.addTimerTask( cancelTimer, seconds * 1000);
         timeout = seconds;
     }
 
@@ -2906,12 +2884,17 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
 		handler = new BatchResultHandler(queries, parameterLists, updateCounts, wantsGeneratedKeysAlways);
 	}
         
-        connection.getQueryExecutor().execute(queries,
-                                              parameterLists,
-                                              handler,
-                                              maxrows,
-                                              fetchSize,
-                                              flags);
+	try {
+	    startTimer();
+	    connection.getQueryExecutor().execute(queries,
+						  parameterLists,
+						  handler,
+						  maxrows,
+						  fetchSize,
+						  flags);
+	} finally {
+	    killTimer();
+	}
 
         if (wantsGeneratedKeysAlways) {
             generatedKeys = new ResultWrapper(((BatchResultHandler)handler).getGeneratedKeys());
@@ -3422,6 +3405,30 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
     public void registerOutParameter(int parameterIndex, int sqlType, String typeName) throws SQLException
     {
         throw Driver.notImplemented(this.getClass(), "registerOutParameter(int,int,String)");
+    }
+
+    protected synchronized void startTimer()
+    {
+	if (timeout == 0)
+	    return;
+
+	/*
+	 * there shouldn't be any previous timer active, but better safe than
+	 * sorry.
+	 */
+	killTimer();
+
+	cancelTimer = new TimerTask() {
+	    public void run()
+	    {
+		try {
+		    AbstractJdbc2Statement.this.cancel();
+		} catch (SQLException e) {
+		}
+	    }
+	};
+
+	Driver.addTimerTask( cancelTimer, timeout * 1000);
     }
 
     private synchronized void killTimer()


### PR DESCRIPTION
1. If you call setQueryTimeout(5), wait 10 seconds, and call execute(), the
   cancel timer has already expired, and the statement will be allowed to run
   forever. Likewise, if you call setQueryTimeout(5), wait 4 seconds, and call
   execute(), the statement will be canceled after only 1 second.
2. If you call setQueryTimeout on a PreparedStatement, and execute the same
   statement several times, the timeout only takes affect on the first
   statement.
3. If you call setQueryTimeout on one Statement, but don't execute it, the
   timer will still fire, possible on an unrelated victim Statement.

The root cause of all of these bugs was that the timer was started at the
setQueryTimeout() call, not on the execute() call.

Also, remove the finally-block from the cancellation task's run-method,
because that might erroneously cancel the timer for the next query, if a
new query is started using the same statement fast enough.
