### PR TITLE
Basic table name for resultset metadata

### DIFF
--- a/org/postgresql/jdbc2/AbstractJdbc2ResultSetMetaData.java
+++ b/org/postgresql/jdbc2/AbstractJdbc2ResultSetMetaData.java
@@ -294,10 +294,11 @@ public abstract class AbstractJdbc2ResultSetMetaData implements PGResultSetMetaD
      * @param column the first column is 1, the second is 2...
      * @return column name, or "" if not applicable
      * @exception SQLException if a database access error occurs
+     * @see #getBaseTableName
      */
     public String getTableName(int column) throws SQLException
     {
-        return "";
+        return getBaseTableName(column);
     }
 
     public String getBaseTableName(int column) throws SQLException

--- a/org/postgresql/test/jdbc2/ResultSetMetaDataTest.java
+++ b/org/postgresql/test/jdbc2/ResultSetMetaDataTest.java
@@ -100,7 +100,7 @@ public class ResultSetMetaDataTest extends TestCase
             assertEquals("", pgrsmd.getBaseSchemaName(4));
         }
 
-        assertEquals("", rsmd.getTableName(1));
+        assertEquals("rsmd1", rsmd.getTableName(1));
         assertEquals("", rsmd.getTableName(4));
         if (TestUtil.isProtocolVersion(conn, 3))
         {


### PR DESCRIPTION
For now table name on resultset metadata is hardcode `""`, even if it's not perfect for all cases, returning the same as current `getBaseTableName` is more useful.
