### PR TITLE
fixed bug PreparedStatement.getMetaData failed if result set was closed

### DIFF
--- a/org/postgresql/jdbc2/AbstractJdbc2Statement.java
+++ b/org/postgresql/jdbc2/AbstractJdbc2Statement.java
@@ -2979,8 +2979,9 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
         checkClosed();
         ResultSet rs = getResultSet();
 
-        if (rs == null) {
-            // OK, we haven't executed it yet, we've got to go to the backend
+        if (rs == null || rs.isClosed() ) {
+            // OK, we haven't executed it yet, or it was closed
+            // we've got to go to the backend
             // for more info.  We send the full query, but just don't
             // execute it.
 

--- a/org/postgresql/test/jdbc2/ResultSetMetaDataTest.java
+++ b/org/postgresql/test/jdbc2/ResultSetMetaDataTest.java
@@ -222,5 +222,24 @@ public class ResultSetMetaDataTest extends TestCase
         assertEquals(Types.STRUCT, rsmd.getColumnType(1));
         assertEquals("rsmd1", rsmd.getColumnTypeName(1));
     }
+    
+    public void testUnexecutedStatement() throws Exception 
+    {
+        PreparedStatement pstmt = conn.prepareStatement("SELECT col FROM compositetest");
+        // we have not executed the statement but we can still get the metadata
+        ResultSetMetaData rsmd = pstmt.getMetaData();
+        assertEquals(Types.STRUCT, rsmd.getColumnType(1));
+        assertEquals("rsmd1", rsmd.getColumnTypeName(1));
+    }
+    public void testClosedResultSet() throws Exception 
+    {
+        PreparedStatement pstmt = conn.prepareStatement("SELECT col FROM compositetest");
+        ResultSet rs = pstmt.executeQuery();
+        rs.close();
+        // close the statement and make sure we can still get the metadata
+        ResultSetMetaData rsmd = pstmt.getMetaData();
+        assertEquals(Types.STRUCT, rsmd.getColumnType(1));
+        assertEquals("rsmd1", rsmd.getColumnTypeName(1));
+    }
 
 }


### PR DESCRIPTION
reported by Emmanuel Guiton
