### PR TITLE
Add a MainClass that tells the user they can't just run the JDBC driver

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -216,6 +216,9 @@
 
       <metainf dir="META-INF">
       </metainf>
+      <manifest>
+        <attribute name="Main-Class" value="org.postgresql.util.PGJDBCMain"/>
+      </manifest>
     </jar>
   </target>
 

--- a/org/postgresql/util/PGJDBCMain.java
+++ b/org/postgresql/util/PGJDBCMain.java
@@ -1,0 +1,24 @@
+package org.postgresql.util;
+
+public class PGJDBCMain {
+
+	public static void main(String[] args) {
+
+		PSQLDriverVersion.main(args);
+
+		System.out.println(
+			"\nThe PgJDBC driver is not an executable Java program.\n\n" +
+
+			"You must install it according to the JDBC driver installation " +
+			"instructions for your application / container / appserver, " +
+			"then use it by specifying a JDBC URL of the form \n" +
+			"    jdbc:postgresql://\n" +
+			"or using an application specific method.\n\n" +
+			"See the PgJDBC documentation: http://jdbc.postgresql.org/documentation/head/index.html\n\n" +
+			"This command has had no effect.\n"
+			);
+
+		System.exit(1);
+	}
+
+}


### PR DESCRIPTION
After one too many reports of
      "Failed to load Main-Class manifest attribute from postgresql-xxx.jar"
I'm submitting a dummy main-class that tells the user what they should
do instead.

The message looks like:

---

PostgreSQL x.y JDBC4.1 (build bbbb)
Found in: jar:file:/path/to/postgresql-x.y-bbbb.jdbc41.jar!/org/postgresql/Driver.class

The PgJDBC driver is not an executable Java program.

You must install it according to the JDBC driver installation instructions for your application / container / appserver, then use it by specifying a JDBC URL of the form
    jdbc:postgresql://
or using an application specific method.

See the PgJDBC documentation: http://jdbc.postgresql.org/documentation/head/index.html

This command has had no effect.

---
