### PR TITLE
Clob will now use the connection encoding

### DIFF
--- a/org/postgresql/jdbc2/AbstractJdbc2Clob.java
+++ b/org/postgresql/jdbc2/AbstractJdbc2Clob.java
@@ -8,12 +8,14 @@
 package org.postgresql.jdbc2;
 
 
-import org.postgresql.core.BaseConnection;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.nio.charset.Charset;
 import java.sql.Clob;
 import java.sql.SQLException;
+
+import org.postgresql.core.BaseConnection;
 
 public abstract class AbstractJdbc2Clob extends AbstractJdbc2BlobClob
 {
@@ -30,7 +32,8 @@ public abstract class AbstractJdbc2Clob extends AbstractJdbc2BlobClob
 
     public synchronized Reader getCharacterStream() throws SQLException
     {
-        return new InputStreamReader(getBinaryStream());
+        Charset connectionCharset = Charset.forName(conn.getEncoding().name());
+        return new InputStreamReader(getBinaryStream(), connectionCharset);
     }
 
     public synchronized String getSubString(long i, int j) throws SQLException

--- a/org/postgresql/jdbc2/AbstractJdbc2Statement.java
+++ b/org/postgresql/jdbc2/AbstractJdbc2Statement.java
@@ -12,6 +12,7 @@ import java.io.*;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.math.*;
+import java.nio.charset.Charset;
 import java.sql.*;
 import java.util.ArrayList;
 import java.util.List;
@@ -3174,12 +3175,14 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
             return;
         }
 
-        InputStream l_inStream = x.getAsciiStream();
+        Reader l_inStream = x.getCharacterStream();
         int l_length = (int) x.length();
         LargeObjectManager lom = connection.getLargeObjectAPI();
         long oid = lom.createLO();
         LargeObject lob = lom.open(oid);
+        Charset connectionCharset = Charset.forName(connection.getEncoding().name());
         OutputStream los = lob.getOutputStream();
+        Writer lw = new OutputStreamWriter(los, connectionCharset);
         try
         {
             // could be buffered, but then the OutputStream returned by LargeObject
@@ -3189,11 +3192,11 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
             int p = 0;
             while (c > -1 && p < l_length)
             {
-                los.write(c);
+                lw.write(c);
                 c = l_inStream.read();
                 p++;
             }
-            los.close();
+            lw.close();
         }
         catch (IOException se)
         {


### PR DESCRIPTION
Suggested fix to make CLOB handling with the large object store a little better. Uses the encoding from the connection to determine how the character stream should be encoded before storing it in the large object store. Not a perfect solution, but the best we can do without storing the encoding with the large object. Should at least be better than mangling the data as US-ASCII.
