### PR TITLE
fix prepareThreshold bug

### DIFF
--- a/org/postgresql/jdbc2/AbstractJdbc2Connection.java
+++ b/org/postgresql/jdbc2/AbstractJdbc2Connection.java
@@ -63,6 +63,10 @@ public abstract class AbstractJdbc2Connection implements BaseConnection
 
     // Default statement prepare threshold.
     protected int prepareThreshold;
+
+    // Default forcebinary option.
+    protected boolean forcebinary = false;
+
     // Connection's autocommit state.
     public boolean autoCommit = true;
     // Connection's readonly state.
@@ -116,7 +120,10 @@ public abstract class AbstractJdbc2Connection implements BaseConnection
         {
             prepareThreshold = Integer.parseInt(info.getProperty("prepareThreshold", "5"));
             if (prepareThreshold < 0)
+            {
+                forcebinary = true;
                 prepareThreshold = 0;
+            }
         }
         catch (Exception e)
         {
@@ -1198,6 +1205,14 @@ public abstract class AbstractJdbc2Connection implements BaseConnection
 
     public void setPrepareThreshold(int newThreshold) {
         this.prepareThreshold = (newThreshold <= 0 ? 0 : newThreshold);
+    }
+
+    public boolean getForceBinary() {
+        return forcebinary;
+    }
+
+    public void setForceBinary(boolean newValue) {
+        this.forcebinary = newValue;
     }
 
 

--- a/org/postgresql/test/jdbc4/BinaryTest.java
+++ b/org/postgresql/test/jdbc4/BinaryTest.java
@@ -33,6 +33,8 @@ public class BinaryTest extends TestCase {
     protected void setUp() throws Exception {
         connection = TestUtil.openDB();
         statement = connection.prepareStatement("select 1");
+
+        ((PGStatement) statement).setPrepareThreshold(5);
     }
 
     @Override
@@ -50,17 +52,19 @@ public class BinaryTest extends TestCase {
         assertEquals(Field.TEXT_FORMAT, getFormat(results));
 
         results = statement.executeQuery();
-        assertEquals(Field.BINARY_FORMAT, getFormat(results));
+        assertEquals(Field.TEXT_FORMAT, getFormat(results));
 
         results = statement.executeQuery();
         assertEquals(Field.BINARY_FORMAT, getFormat(results));
+
+        ((PGStatement) statement).setPrepareThreshold(5);
     }
 
     public void testPreparedStatement_1() throws Exception {
         ((PGStatement) statement).setPrepareThreshold(1);
 
         results = statement.executeQuery();
-        assertEquals(Field.BINARY_FORMAT, getFormat(results));
+        assertEquals(Field.TEXT_FORMAT, getFormat(results));
 
         results = statement.executeQuery();
         assertEquals(Field.BINARY_FORMAT, getFormat(results));
@@ -70,6 +74,8 @@ public class BinaryTest extends TestCase {
 
         results = statement.executeQuery();
         assertEquals(Field.BINARY_FORMAT, getFormat(results));
+
+        ((PGStatement) statement).setPrepareThreshold(5);
     }
 
     public void testPreparedStatement_0() throws Exception {
@@ -86,6 +92,26 @@ public class BinaryTest extends TestCase {
 
         results = statement.executeQuery();
         assertEquals(Field.TEXT_FORMAT, getFormat(results));
+
+        ((PGStatement) statement).setPrepareThreshold(5);
+    }
+
+    public void testPreparedStatement_negative1() throws Exception {
+        ((PGStatement) statement).setPrepareThreshold(-1);
+
+        results = statement.executeQuery();
+        assertEquals(Field.BINARY_FORMAT, getFormat(results));
+
+        results = statement.executeQuery();
+        assertEquals(Field.BINARY_FORMAT, getFormat(results));
+
+        results = statement.executeQuery();
+        assertEquals(Field.BINARY_FORMAT, getFormat(results));
+
+        results = statement.executeQuery();
+        assertEquals(Field.BINARY_FORMAT, getFormat(results));
+
+        ((PGStatement) statement).setPrepareThreshold(5);
     }
 
     private int getFormat(ResultSet results) throws SQLException {


### PR DESCRIPTION
A commit(dbf76c2d66) was committed for the people who want to
use binaryTransfer at first time preparedStatement execution.

The change was good for the aim, but the compatibility with
pre-9.2 driver has been broken and the performance has been
degraded.

I fixed this problem.
My solution is to introduce preparedThreshold=-1 for forcing
binaryTransfer.

I want to fix master and 93_STABLE.

regards,

Tomonari Katsumata
