### PR TITLE
Fix equals-method of the wrapper returned by PGXAConnection.getConnection()

### DIFF
--- a/org/postgresql/test/xa/XADataSourceTest.java
+++ b/org/postgresql/test/xa/XADataSourceTest.java
@@ -127,6 +127,14 @@ public class XADataSourceTest extends TestCase {
         }
     }
 
+    /*
+     * Check that the equals method works for the connection wrapper returned
+     * by PGXAConnection.getConnection().
+     */
+    public void testWrapperEquals() throws Exception {
+        assertTrue("Wrappers should be equal", conn.equals(conn));
+    }
+
     public void testOnePhase() throws Exception {
         Xid xid = new CustomXid(1);
         xaRes.start(xid, XAResource.TMNOFLAGS);

--- a/org/postgresql/xa/PGXAConnection.java
+++ b/org/postgresql/xa/PGXAConnection.java
@@ -150,6 +150,23 @@ public class PGXAConnection extends PGPooledConnection implements XAConnection, 
                 }
             }
             try {
+		/*
+		 * If the argument to equals-method is also a wrapper,
+		 * present the original unwrapped connection to the underlying
+		 * equals method.
+		 */
+		if (method.getName().equals("equals")) {
+                    Object arg = args[0];
+                    if (Proxy.isProxyClass(arg.getClass())) {
+                        InvocationHandler h = Proxy.getInvocationHandler(arg);
+                        if (h instanceof ConnectionHandler) {
+                            // unwrap argument
+                            args = new Object[] {
+((ConnectionHandler) h).con };
+                        }
+                    }
+                }
+
                 return method.invoke(con, args);
             } catch (InvocationTargetException ex) {
                 throw ex.getTargetException();


### PR DESCRIPTION
This is fixes the long-standing issue discussed here:

http://www.postgresql.org/message-id/F3EFBAE2-4B9A-4D5A-B436-02BF1C0A0DA0@leonisapps.pl

This is the patch by Florent Guillaume from http://www.postgresql.org/message-id/CAF-4BpPdTUVnZQd-Y70-uSHVUJ-hfxLmfCW+MBL1i1AEaLoPMg@mail.gmail.com. I just added a few comments 
