### PR TITLE
Remove unnecessary SQLException specifications in HStoreConverter.

### DIFF
--- a/org/postgresql/util/HStoreConverter.java
+++ b/org/postgresql/util/HStoreConverter.java
@@ -63,7 +63,7 @@ public class HStoreConverter {
        return baos.toByteArray();
    }
 
-   public static String toString(Map map) throws SQLException {
+   public static String toString(Map map) {
        if (map.isEmpty()) {
            return "";
        }
@@ -79,7 +79,7 @@ public class HStoreConverter {
        return sb.toString();
    }
 
-   private static void appendEscaped(StringBuffer sb, Object val) throws SQLException {
+   private static void appendEscaped(StringBuffer sb, Object val) {
       if (val != null) {
           sb.append('"');
           String s = val.toString();


### PR DESCRIPTION
Both toString and appendEscaped indicate that they can throw an SQLException, however neither methods throw this or call any methods that throw it themselves.
