### PR TITLE
Use DSTSavings when converting to binary timestamp and date. Reported by Vlad Skarzhevskyy Bug fix

### DIFF
--- a/org/postgresql/jdbc2/TimestampUtils.java
+++ b/org/postgresql/jdbc2/TimestampUtils.java
@@ -768,7 +768,7 @@ public class TimestampUtils {
             if (tz == null) {
                 tz = defaultTz;
             }
-            millis -= tz.getOffset(millis);
+            millis -= tz.getOffset(millis) + tz.getDSTSavings();
         }
 
         Timestamp ts = new Timestamp(millis);


### PR DESCRIPTION
Previous versions only used the offset and failed to account for daylight savings time.

There are other places where this failure is evident, however at this time I'm reluctant to change them until a bug is reported

convertToTime
toTimeBin
toDateBin

are a few
