### PR TITLE
Test against Oracle's JDK release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,5 @@ script: ant -lib lib test
 jdk:
  - openjdk7
  - openjdk6
+ - oraclejdk7
+ - oraclejdk8


### PR DESCRIPTION
Travis CI supports testing against Oracle's JDK 7 and 8. To make
sure we're supporting these "official" releases we should test against
them.
