### PR TITLE
Show the build status in the README for users that are getting started

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 <img src="http://developer.postgresql.org/~josh/graphics/logos/elephant-64.png" />
 # PostgreSQL JDBC driver
 
+[![Build Status](https://travis-ci.org/pgjdbc/pgjdbc.png)](https://travis-ci.org/pgjdbc/pgjdbc)
+
 This is a simple readme describing how to compile and use the Postgresql JDBC driver.
 
 ## Info


### PR DESCRIPTION
Be friendly and show the build status of the master branch when users
hit the source code homepage on GitHub.
