### PR TITLE
connectTimeout property support

### DIFF
--- a/org/postgresql/core/PGStream.java
+++ b/org/postgresql/core/PGStream.java
@@ -50,19 +50,31 @@ public class PGStream
      * a stream connection.
      *
      * @param hostSpec the host and port to connect to
+     * @param timeout timeout in milliseconds, or 0 if no timeout set
      * @exception IOException if an IOException occurs below it.
      */
-    public PGStream(HostSpec hostSpec) throws IOException
+    public PGStream(HostSpec hostSpec, int timeout) throws IOException
     {
         this.hostSpec = hostSpec;
 
         Socket socket = new Socket();
-        socket.connect(new InetSocketAddress(hostSpec.getHost(), hostSpec.getPort()));
+        socket.connect(new InetSocketAddress(hostSpec.getHost(), hostSpec.getPort()), timeout);
         changeSocket(socket);
         setEncoding(Encoding.getJVMEncoding("US-ASCII"));
 
         _int2buf = new byte[2];
         _int4buf = new byte[4];
+    }
+
+    /**
+     * Constructor:  Connect to the PostgreSQL back end and return
+     * a stream connection.
+     *
+     * @param hostSpec the host and port to connect to
+     * @throws IOException if an IOException occurs below it.
+     */
+    public PGStream(HostSpec hostSpec) throws IOException {
+      this(hostSpec, 0);
     }
 
     public HostSpec getHostSpec() {

--- a/org/postgresql/core/v2/ProtocolConnectionImpl.java
+++ b/org/postgresql/core/v2/ProtocolConnectionImpl.java
@@ -24,12 +24,13 @@ import org.postgresql.util.HostSpec;
  * @author Oliver Jowett (oliver@opencloud.com)
  */
 class ProtocolConnectionImpl implements ProtocolConnection {
-    ProtocolConnectionImpl(PGStream pgStream, String user, String database, Logger logger) {
+    ProtocolConnectionImpl(PGStream pgStream, String user, String database, Logger logger, int connectTimeout) {
         this.pgStream = pgStream;
         this.user = user;
         this.database = database;
         this.logger = logger;
         this.executor = new QueryExecutorImpl(this, pgStream, logger);
+        this.connectTimeout = connectTimeout;
     }
 
     public HostSpec getHostSpec() {
@@ -87,7 +88,7 @@ class ProtocolConnectionImpl implements ProtocolConnection {
             if (logger.logDebug())
                 logger.debug(" FE=> CancelRequest(pid=" + cancelPid + ",ckey=" + cancelKey + ")");
 
-            cancelStream = new PGStream(pgStream.getHostSpec());
+            cancelStream = new PGStream(pgStream.getHostSpec(), connectTimeout);
             cancelStream.SendInteger4(16);
             cancelStream.SendInteger2(1234);
             cancelStream.SendInteger2(5678);
@@ -229,4 +230,6 @@ class ProtocolConnectionImpl implements ProtocolConnection {
     private final String database;
     private final QueryExecutorImpl executor;
     private final Logger logger;
+
+    private final int connectTimeout;
 }

--- a/org/postgresql/core/v3/ProtocolConnectionImpl.java
+++ b/org/postgresql/core/v3/ProtocolConnectionImpl.java
@@ -27,7 +27,7 @@ import java.util.Properties;
  * @author Oliver Jowett (oliver@opencloud.com)
  */
 class ProtocolConnectionImpl implements ProtocolConnection {
-    ProtocolConnectionImpl(PGStream pgStream, String user, String database, Properties info, Logger logger) {
+    ProtocolConnectionImpl(PGStream pgStream, String user, String database, Properties info, Logger logger, int connectTimeout) {
         this.pgStream = pgStream;
         this.user = user;
         this.database = database;
@@ -35,6 +35,7 @@ class ProtocolConnectionImpl implements ProtocolConnection {
         this.executor = new QueryExecutorImpl(this, pgStream, info, logger);
         // default value for server versions that don't report standard_conforming_strings
         this.standardConformingStrings = false;
+        this.connectTimeout = connectTimeout;
     }
 
     public HostSpec getHostSpec() {
@@ -89,7 +90,7 @@ class ProtocolConnectionImpl implements ProtocolConnection {
             if (logger.logDebug())
                 logger.debug(" FE=> CancelRequest(pid=" + cancelPid + ",ckey=" + cancelKey + ")");
 
-            cancelStream = new PGStream(pgStream.getHostSpec());
+            cancelStream = new PGStream(pgStream.getHostSpec(), connectTimeout);
             cancelStream.SendInteger4(16);
             cancelStream.SendInteger2(1234);
             cancelStream.SendInteger2(5678);
@@ -249,4 +250,6 @@ class ProtocolConnectionImpl implements ProtocolConnection {
     private final String database;
     private final QueryExecutorImpl executor;
     private final Logger logger;
+
+    private final int connectTimeout;
 }


### PR DESCRIPTION
There is an issue.
Try to connect to unreachable network address, e.g. jdbc:postgresql://192.168.101.10/test
Environment: Mac OS, HotSpot, "1.7.0_51"
It hangs infinitely. No general option on Socket.connect(address, timeout) is available to set.

Note: the documentation is not updated. And there is not test yet.
If this deserves to live (I hope so, I feel real problem about that), please describe, what am I supposed to do.
