### PR TITLE
fix prepared statement ERROR due to EMPTY_QUERY defined as static. Reported by: Naoya Anzai

### DIFF
--- a/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -2260,5 +2260,5 @@ public class QueryExecutorImpl implements QueryExecutor {
 
     private final SimpleQuery beginTransactionQuery = new SimpleQuery(new String[] { "BEGIN" }, null);
 
-    private final static SimpleQuery EMPTY_QUERY = new SimpleQuery(new String[] { "" }, null);
+    private final SimpleQuery EMPTY_QUERY = new SimpleQuery(new String[] { "" }, null);
 }


### PR DESCRIPTION
backpatch to 9.3
