### PR TITLE
fix copyOut close hanging bug

### DIFF
--- a/org/postgresql/copy/CopyManager.java
+++ b/org/postgresql/copy/CopyManager.java
@@ -84,7 +84,18 @@ public class CopyManager {
                 to.write(encoding.decode(buf));
             }
             return cp.getHandledRowCount();
-        } finally { // see to it that we do not leave the connection locked
+        }
+        catch ( IOException ioEX) {
+            // if not handled this way the close call will hang, at least in 8.2
+            if(cp.isActive())
+                cp.cancelCopy();
+            try {  // read until excausted or operation cancelled SQLException
+                while( (buf = cp.readFromCopy()) != null ) {}
+            }
+            catch ( SQLException sqĺEx ) {} // typically after several kB
+            throw ioEX;
+        }
+        finally { // see to it that we do not leave the connection locked
             if(cp.isActive())
                 cp.cancelCopy();
         }
@@ -106,7 +117,18 @@ public class CopyManager {
                 to.write(buf);
             }
             return cp.getHandledRowCount();
-        } finally { // see to it that we do not leave the connection locked
+        } 
+        catch ( IOException ioEX) {
+            // if not handled this way the close call will hang, at least in 8.2
+            if(cp.isActive())
+                cp.cancelCopy();
+            try {  // read until excausted or operation cancelled SQLException
+                while( (buf = cp.readFromCopy()) != null ) {}
+            } 
+            catch ( SQLException sqĺEx ) {} // typically after several kB 
+            throw ioEX ;  
+        }
+        finally { // see to it that we do not leave the connection locked
             if(cp.isActive())
                 cp.cancelCopy();
         }


### PR DESCRIPTION
I encountered a bug within CopyManger when using "public long copyOut(final String sql, OutputStream to)".
If the output stream is closed and throws an IOException (e.g. its a tcp stream and other side hung up),
then the close call to the java.sql.connection hangs indefinitely. (it appeared when working against an 8.2 server)
A workaround as done here is to cancel the copy operation and then continue reading until an SQL exception stating that the operation is cancelled is thrown.
Unfortunately I couldnt get the unit test running as I am working on an old ubuntu 12.04.
