### PR TITLE
Use server_version_num not server_version, per github issue #167

### DIFF
--- a/org/postgresql/core/BaseConnection.java
+++ b/org/postgresql/core/BaseConnection.java
@@ -78,20 +78,57 @@ public interface BaseConnection extends PGConnection, Connection
      * driver version. This defaults to behaving as the actual driver's version
      * but can be overridden by the "compatible" URL parameter.
      *
+     * If possible you should use the integer version of this method instead.
+     * It was introduced with the 9.4 driver release.
+     *
+     * @deprecated Avoid using this in new code that can require PgJDBC
+     * 9.4.
+     *
      * @param ver the driver version to check
      * @return true if the driver's behavioural version is at least "ver".
      * @throws SQLException if something goes wrong
      */
+    @Deprecated
     public boolean haveMinimumCompatibleVersion(String ver);
 
     /**
+     * Check if we should use driver behaviour introduced in a particular
+     * driver version.
+     *
+     * This defaults to behaving as the actual driver's version but can be
+     * overridden by the "compatible" URL parameter.
+     *
+     * The version is of the form xxyyzz, e.g. 90401 for PgJDBC 9.4.1.
+     *
+     * @param ver the driver version to check, eg 90401 for 9.4.1
+     * @return true if the driver's behavioural version is at least "ver".
+     * @throws SQLException if something goes wrong
+     */
+    public boolean haveMinimumCompatibleVersion(int ver);
+
+    /**
      * Check if we have at least a particular server version.
+     *
+     * @deprecated Use haveMinimumServerVersion(int) instead
      *
      * @param ver the server version to check
      * @return true if the server version is at least "ver".
      * @throws SQLException if something goes wrong
      */
+    @Deprecated
     public boolean haveMinimumServerVersion(String ver);
+
+    /**
+     * Check if we have at least a particular server version.
+     *
+     * The input version is of the form xxyyzz, matching a PostgreSQL
+     * version like xx.yy.zz. So 9.0.12 is 90012 .
+     *
+     * @param ver the server version to check, of the form xxyyzz eg 90401
+     * @return true if the server version is at least "ver".
+     * @throws SQLException if something goes wrong
+     */
+    public boolean haveMinimumServerVersion(int ver);
 
     /**
      * Encode a string using the database's client_encoding

--- a/org/postgresql/core/ProtocolConnection.java
+++ b/org/postgresql/core/ProtocolConnection.java
@@ -55,9 +55,33 @@ public interface ProtocolConnection {
     String getDatabase();
 
     /**
-     * @return the server version of the connected server, formatted as X.Y.Z.
+     * Return the server version from the server_version GUC.
+     *
+     * Note that there's no requirement for this to be numeric or of the form
+     * x.y.z. PostgreSQL development releases usually have the format x.ydevel
+     * e.g. 9.4devel; betas usually x.ybetan e.g.  9.4beta1. The
+     * --with-extra-version configure option may add an arbitrary string to
+     * this.
+     *
+     * Don't use this string for logic, only use it when displaying the server
+     * version to the user. Prefer getServerVersionNum() for all logic
+     * purposes.
+     *
+     * @return the server version string from the server_version guc
      */
     String getServerVersion();
+
+    /**
+     * Get a machine-readable server version.
+     *
+     * This returns the value of the server_version_num GUC. If no such GUC exists, 
+     * it falls back on attempting to parse the text server version for the major version.
+     * If there's no minor version (e.g. a devel or beta release) then the
+     * minor version is set to zero. If the version could not be parsed, zero is returned.
+     *
+     * @return the server version in numeric XXYYZZ form, eg 090401, from server_version_num
+     */
+    int getServerVersionNum();
 
     /**
      * @return the current encoding in use by this connection

--- a/org/postgresql/core/Utils.java
+++ b/org/postgresql/core/Utils.java
@@ -15,6 +15,9 @@ import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.Charset;
 
+import java.text.NumberFormat;
+import java.text.ParsePosition;
+
 import org.postgresql.util.GT;
 import org.postgresql.util.PSQLException;
 import org.postgresql.util.PSQLState;
@@ -151,5 +154,101 @@ public class Utils {
         sbuf.append('"');
 
         return sbuf;
+    }
+
+    /**
+     * Attempt to parse the server version string into an XXYYZZ form version number.
+     *
+     * Returns 0 if the version could not be parsed.
+     *
+     * Returns minor version 0 if the minor version could not be determined, e.g. devel
+     * or beta releases.
+     *
+     * If a single major part like 90400 is passed, it's assumed to be a pre-parsed
+	 * version and returned verbatim. (Anything equal to or greater than 10000
+	 * is presumed to be this form).
+     *
+	 * The yy or zz version parts may be larger than 99. A
+	 * NumberFormatException is thrown if a version part is out of range.
+     */
+    public static int parseServerVersionStr(String serverVersion)
+		throws NumberFormatException
+ 	{
+        int vers;
+        NumberFormat numformat = NumberFormat.getIntegerInstance();
+        ParsePosition parsepos = new ParsePosition(0);
+        Long parsed;
+
+        if (serverVersion == null)
+            return 0;
+
+        /* Get first major version part */
+        parsed = (Long) numformat.parseObject(serverVersion, parsepos);
+        if (parsed == null) {
+            return 0;
+        }
+        if (parsed >= 10000)
+        {
+            /*
+             * PostgreSQL version 1000? I don't think so. We're seeing a version like
+             * 90401; return it verbatim, but only if there's nothing else in the version.
+             * If there is, treat it as a parse error.
+             */
+			if (parsepos.getIndex() == serverVersion.length())
+				return parsed.intValue();
+			else
+				throw new NumberFormatException("First major-version part equal to or greater than 10000 in invalid version string: " + serverVersion);
+        }
+
+        vers = parsed.intValue() * 10000;
+
+		/* Did we run out of string? */
+		if (parsepos.getIndex() == serverVersion.length())
+			return 0;
+
+        /* Skip the . */
+        if (serverVersion.charAt(parsepos.getIndex()) == '.')
+            parsepos.setIndex(parsepos.getIndex() + 1);
+        else
+            /* Unexpected version format */
+            return 0;
+
+        /*
+         * Get second major version part. If this isn't purely an integer,
+         * accept the integer part and return with a minor version of zero,
+         * so we cope with 8.1devel, etc.
+         */
+        parsed = (Long) numformat.parseObject(serverVersion, parsepos);
+        if (parsed == null) {
+            /*
+             * Failed to parse second part of minor version at all. Half
+             * a major version is useless, return 0.
+             */
+            return 0;
+        }
+		if (parsed > 99)
+			throw new NumberFormatException("Unsupported second part of major version > 99 in invalid version string: " + serverVersion);
+        vers = vers + parsed.intValue() * 100;
+
+		/* Did we run out of string? Return just the major. */
+		if (parsepos.getIndex() == serverVersion.length())
+			return vers;
+
+        /* Skip the . */
+        if (serverVersion.charAt(parsepos.getIndex()) == '.')
+            parsepos.setIndex(parsepos.getIndex() + 1);
+        else
+            /* Doesn't look like an x.y.z version, return what we have */
+            return vers;
+
+        /* Try to parse any remainder as a minor version */
+        parsed = (Long) numformat.parseObject(serverVersion, parsepos);
+        if (parsed != null) {
+			if (parsed > 99)
+				throw new NumberFormatException("Unsupported minor version value > 99 in invalid version string: " + serverVersion);
+            vers = vers + parsed.intValue();
+        }
+
+        return vers;
     }
 }

--- a/org/postgresql/core/v2/ProtocolConnectionImpl.java
+++ b/org/postgresql/core/v2/ProtocolConnectionImpl.java
@@ -49,6 +49,12 @@ class ProtocolConnectionImpl implements ProtocolConnection {
         return serverVersion;
     }
 
+    public int getServerVersionNum() {
+        if (serverVersionNum != 0)
+            return serverVersionNum;
+        return Utils.parseServerVersionStr(serverVersion);
+    }
+
     public synchronized boolean getStandardConformingStrings()
     {
         return standardConformingStrings;
@@ -163,6 +169,10 @@ class ProtocolConnectionImpl implements ProtocolConnection {
         this.serverVersion = serverVersion;
     }
 
+    void setServerVersionNum(int serverVersionNum) {
+        this.serverVersionNum = serverVersionNum;
+    }  
+
     void setBackendKeyData(int cancelPid, int cancelKey) {
         this.cancelPid = cancelPid;
         this.cancelKey = cancelKey;
@@ -226,6 +236,7 @@ class ProtocolConnectionImpl implements ProtocolConnection {
     }
 
     private String serverVersion;
+    private int serverVersionNum = 0;
     private int cancelPid;
     private int cancelKey;
 

--- a/org/postgresql/core/v2/V2Query.java
+++ b/org/postgresql/core/v2/V2Query.java
@@ -18,8 +18,7 @@ import org.postgresql.core.*;
 class V2Query implements Query {
     V2Query(String query, boolean withParameters, ProtocolConnection pconn) {
 
-        useEStringSyntax = pconn.getServerVersion() != null
-                && pconn.getServerVersion().compareTo("8.1") > 0;
+        useEStringSyntax = pconn.getServerVersionNum() >= 80100;
         boolean stdStrings = pconn.getStandardConformingStrings();
 
         if (!withParameters)

--- a/org/postgresql/core/v3/ProtocolConnectionImpl.java
+++ b/org/postgresql/core/v3/ProtocolConnectionImpl.java
@@ -54,6 +54,12 @@ class ProtocolConnectionImpl implements ProtocolConnection {
         return serverVersion;
     }
 
+    public int getServerVersionNum() {
+        if (serverVersionNum != 0)
+            return serverVersionNum;
+        return Utils.parseServerVersionStr(serverVersion);
+    }
+
     public synchronized boolean getStandardConformingStrings()
     {
         return standardConformingStrings;
@@ -163,6 +169,10 @@ class ProtocolConnectionImpl implements ProtocolConnection {
         this.serverVersion = serverVersion;
     }
 
+    void setServerVersionNum(int serverVersionNum) {
+        this.serverVersionNum = serverVersionNum;
+    }  
+
     void setBackendKeyData(int cancelPid, int cancelKey) {
         this.cancelPid = cancelPid;
         this.cancelKey = cancelKey;
@@ -246,6 +256,7 @@ class ProtocolConnectionImpl implements ProtocolConnection {
     */
     private final Set<Integer> useBinaryForOids = new HashSet<Integer>();
     private String serverVersion;
+    private int serverVersionNum = 0;
     private int cancelPid;
     private int cancelKey;
 

--- a/org/postgresql/core/v3/SimpleParameterList.java
+++ b/org/postgresql/core/v3/SimpleParameterList.java
@@ -189,7 +189,7 @@ class SimpleParameterList implements V3ParameterList {
             if (protoConnection != null)
             {
                 standardConformingStrings = protoConnection.getStandardConformingStrings();
-                supportsEStringSyntax = protoConnection.getServerVersion().compareTo("8.1") >= 0;
+                supportsEStringSyntax = protoConnection.getServerVersionNum() >= 80100;
             }
 
             if (hasBackslash && !standardConformingStrings && supportsEStringSyntax)

--- a/org/postgresql/test/jdbc2/Jdbc2TestSuite.java
+++ b/org/postgresql/test/jdbc2/Jdbc2TestSuite.java
@@ -44,6 +44,7 @@ public class Jdbc2TestSuite extends TestSuite
         suite.addTestSuite(EncodingTest.class);
         suite.addTestSuite(ColumnSanitiserDisabledTest.class);
         suite.addTestSuite(ColumnSanitiserEnabledTest.class);
+	suite.addTestSuite(VersionTest.class);
 
         // Connectivity/Protocols
 

--- a/org/postgresql/test/jdbc2/VersionTest.java
+++ b/org/postgresql/test/jdbc2/VersionTest.java
@@ -1,0 +1,72 @@
+package org.postgresql.test.jdbc2;
+
+import junit.framework.Assert;
+import junit.framework.TestCase;
+import org.postgresql.test.TestUtil;
+
+import org.postgresql.core.Utils;
+
+public class VersionTest extends TestCase {
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+    }
+
+    public void testVersionParsing() {
+		/* Boring versions */
+		assertEquals(70400, Utils.parseServerVersionStr("7.4.0"));
+		assertEquals(90001, Utils.parseServerVersionStr("9.0.1"));
+		assertEquals(90000, Utils.parseServerVersionStr("9.0.0"));
+		assertEquals(90201, Utils.parseServerVersionStr("9.2.1"));
+
+		/* Major-only versions */
+		assertEquals(70400, Utils.parseServerVersionStr("7.4"));
+		assertEquals(90000, Utils.parseServerVersionStr("9.0"));
+		assertEquals(90000, Utils.parseServerVersionStr("9.0"));
+		assertEquals(90200, Utils.parseServerVersionStr("9.2"));
+
+		/* Multi-digit versions */
+		assertEquals(90410, Utils.parseServerVersionStr("9.4.10"));
+		assertEquals(92010, Utils.parseServerVersionStr("9.20.10"));
+		assertEquals(100000, Utils.parseServerVersionStr("10.0.0"));
+		assertEquals(100103, Utils.parseServerVersionStr("10.1.3"));
+		assertEquals(102010, Utils.parseServerVersionStr("10.20.10"));
+
+		/* Out-of-range versions */
+		try {
+			Utils.parseServerVersionStr("9.20.100");
+			fail("Should've rejected three-digit minor version");
+		} catch (NumberFormatException ex) {}
+
+		try {
+			Utils.parseServerVersionStr("10.100.10");
+			fail("Should've rejected three-digit second part of major version");
+		} catch (NumberFormatException ex) {}
+
+		/* Big first part is OK */
+		assertEquals(1232010, Utils.parseServerVersionStr("123.20.10"));
+
+		/* But not too big */
+		try {
+			Utils.parseServerVersionStr("12345.1.1");
+			fail("Should've rejected five-digit second part of major version");
+		} catch (NumberFormatException ex) {}
+
+		/* Large numeric inputs are taken as already parsed */
+		assertEquals(90104, Utils.parseServerVersionStr("90104"));
+		assertEquals(90104, Utils.parseServerVersionStr("090104"));
+		assertEquals(70400, Utils.parseServerVersionStr("070400"));
+		assertEquals(100104, Utils.parseServerVersionStr("100104"));
+		assertEquals(10000, Utils.parseServerVersionStr("10000"));
+
+		/* --with-extra-version or beta/devel tags */
+		assertEquals(90400, Utils.parseServerVersionStr("9.4devel"));
+		assertEquals(90400, Utils.parseServerVersionStr("9.4beta1"));
+		assertEquals(100000, Utils.parseServerVersionStr("10.0devel"));
+		assertEquals(100000, Utils.parseServerVersionStr("10.0beta1"));
+		assertEquals(90401, Utils.parseServerVersionStr("9.4.1bobs"));
+		assertEquals(90401, Utils.parseServerVersionStr("9.4.1bobspatched9.4"));
+		assertEquals(90401, Utils.parseServerVersionStr("9.4.1-bobs-patched-postgres-v2.2"));
+	}
+}


### PR DESCRIPTION
PgJDBC does simple string comparisons on server_version instead of using `server_version_num` or even parsing `server_version`.

Fix this, so we use `server_version_num` if available (it was added in 8.2 by `04912899e792094ed00766b99b6c604cadf9edf7`) and fall back to really parsing `server_version` if `server_version_num` is not set.

Per github issue #167

A test suite is added to ensure versions are parsed as expected. Compatibility
code ensures that all the driver's existing tests for
`connection.haveMinimumServerVersion("8.0")` etc continue to work, though they
should be replaced.

This change breaks BC only in that it fixes buggy handling of two-digit
versions. If you connect to 9.0.11 and test
`connection.haveMinimumServerVersion("9.0.9")`, it will now report true, where
before it incorrectly reported false.
