### PR TITLE
Resolving Duplicate Column Names

### DIFF
--- a/org/postgresql/jdbc2/AbstractJdbc2ResultSet.java
+++ b/org/postgresql/jdbc2/AbstractJdbc2ResultSet.java
@@ -2730,10 +2730,11 @@ public abstract class AbstractJdbc2ResultSet implements BaseResultSet, org.postg
         return col;
     }
 
-    private int findColumnIndex(String columnName)
+    private int findColumnIndex(String columnName) throws SQLException
     {
     	if (columnNameIndexMap == null)
         {
+            ResultSetMetaData metaData = getMetaData();
             columnNameIndexMap = new HashMap(fields.length * 2);
             // The JDBC spec says when you have duplicate columns names,
             // the first one should be returned.  So load the map in
@@ -2743,8 +2744,10 @@ public abstract class AbstractJdbc2ResultSet implements BaseResultSet, org.postg
             {
                 if (isSanitiserDisabled){
                     columnNameIndexMap.put(fields[i].getColumnLabel(), new Integer(i + 1));
+                    columnNameIndexMap.put(metaData.getTableName(i+1) + "." +  fields[i].getColumnLabel(), new Integer(i + 1));
                 } else {
                     columnNameIndexMap.put(fields[i].getColumnLabel().toLowerCase(Locale.US), new Integer(i + 1));
+                    columnNameIndexMap.put(metaData.getTableName(i+1).toLowerCase(Locale.US) + "." +  fields[i].getColumnLabel().toLowerCase(Locale.US), new Integer(i + 1));
                 }
             }
         }

--- a/org/postgresql/test/jdbc2/ResultSetTest.java
+++ b/org/postgresql/test/jdbc2/ResultSetTest.java
@@ -34,6 +34,7 @@ public class ResultSetTest extends TestCase
         Statement stmt = con.createStatement();
 
         TestUtil.createTable(con, "testrs", "id integer");
+        TestUtil.createTable(con, "testrs_dup", "id integer");
 
         stmt.executeUpdate("INSERT INTO testrs VALUES (1)");
         stmt.executeUpdate("INSERT INTO testrs VALUES (2)");
@@ -41,6 +42,8 @@ public class ResultSetTest extends TestCase
         stmt.executeUpdate("INSERT INTO testrs VALUES (4)");
         stmt.executeUpdate("INSERT INTO testrs VALUES (6)");
         stmt.executeUpdate("INSERT INTO testrs VALUES (9)");
+        
+        stmt.executeUpdate("INSERT INTO testrs_dup VALUES (5)");
 
         TestUtil.createTable(con, "teststring", "a text");
         stmt.executeUpdate("INSERT INTO teststring VALUES ('12345')");
@@ -101,6 +104,7 @@ public class ResultSetTest extends TestCase
     protected void tearDown() throws SQLException
     {
         TestUtil.dropTable(con, "testrs");
+        TestUtil.dropTable(con, "testrs_dup");
         TestUtil.dropTable(con, "teststring");
         TestUtil.dropTable(con, "testint");
         TestUtil.dropTable(con, "testbool");
@@ -706,6 +710,18 @@ public class ResultSetTest extends TestCase
         assertEquals(1, rs.getInt("a"));
     }
 
+    /*
+     * Tests the improvement when there are duplicate column names that the
+     * client can distinguish one from the other by prepending the columna name.
+     */
+    public void testDuplicateColumnName() throws SQLException
+    {
+        Statement stmt = con.createStatement();
+        ResultSet rs = stmt.executeQuery("SELECT * FROM testrs, testrs_dup");
+        assertTrue(rs.next());
+        assertEquals(5, rs.getInt("testrs_dup.id"));
+    }
+    
     public void testTurkishLocale() throws SQLException
     {
         Locale current = Locale.getDefault();


### PR DESCRIPTION
The JDBC spec says when you have duplicate columns names, the first one should be returned but this behavior isn't useful to us. What we really need is the ability to resolve those ambiguous cases in the client code.

I propose adding an additional string  to the columnNameIndexMap that would be in the format of tablename.column similar to how you would reference the columns in SQL.

I've added a test case for this use case that shows that it works and doesn't affect any existing test cases.