### PR TITLE
NPE fix in org.postgresql.Driver.getPropertyInfo

### DIFF
--- a/org/postgresql/Driver.java.in
+++ b/org/postgresql/Driver.java.in
@@ -510,7 +510,8 @@ public class Driver implements java.sql.Driver
     public DriverPropertyInfo[] getPropertyInfo(String url, Properties info) throws SQLException
     {
         Properties copy = new Properties(info);
-        copy = parseURL(url, copy);
+        Properties parse = parseURL(url, copy);
+        if (parse != null) copy = parse;
 
         DriverPropertyInfo[] props = new DriverPropertyInfo[knownProperties.length];
         for (int i = 0; i < knownProperties.length; ++i)


### PR DESCRIPTION
When schema isn't specified in the URL I got an exception.
For some additional information please see http://youtrack.jetbrains.com/issue/DBE-615
