### PR TITLE
Fix recovery function to return only xa transactions which belongs to current db

### DIFF
--- a/org/postgresql/xa/PGXAConnection.java
+++ b/org/postgresql/xa/PGXAConnection.java
@@ -363,7 +363,7 @@ public class PGXAConnection extends PGPooledConnection implements XAConnection, 
                     // except if the transaction is in abort-only state and the
                     // backed refuses to process new queries. Hopefully not a problem
                     // in practise.
-                    ResultSet rs = stmt.executeQuery("SELECT gid FROM pg_prepared_xacts");
+                    ResultSet rs = stmt.executeQuery("SELECT gid FROM pg_prepared_xacts where database = current_database()");
                     LinkedList l = new LinkedList();
                     while (rs.next())
                     {


### PR DESCRIPTION
There is a problem with recover method of PGXAConnection. It returns XID's for all prepared transactions that exists in postgres cluster. 
- But you can commit or rollback only those transactions, that belongs to current database. 
- And there is no way to understand which XID belongs to what database. 
- And the XA transaction managers, which call recover() and commit()/rollback() functions, according to the contract should recover only one database not the whole cluster. There is no reason why it should get not relevant XIDs from recover() call. 

The fix would be to return only relevant transactions from recover() function.  
