### PR TITLE
Implement hashcode in PGObject

### DIFF
--- a/org/postgresql/util/PGobject.java
+++ b/org/postgresql/util/PGobject.java
@@ -8,6 +8,7 @@
 package org.postgresql.util;
 
 import java.io.Serializable;
+import java.lang.Object;
 import java.lang.Override;
 import java.sql.SQLException;
 
@@ -108,10 +109,10 @@ public class PGobject implements Serializable, Cloneable
 
     /**
      * Compute hash. As equals() use only value. Return the same hash for the same value.
-     * @return Value hashcode
+     * @return Value hashcode, 0 if value is null {@link java.util.Objects#hashCode(Object)}
      */
     @Override
     public int hashCode() {
-        return getValue().hashCode();
+        return getValue() != null ? getValue().hashCode() : 0;
     }
 }


### PR DESCRIPTION
equals have been overloaded but not hashcode.We need hashcode for usage in map. Thank you.
