### PR TITLE
Don't prevented VM shutdown if ConnectThread is blocked

### DIFF
--- a/org/postgresql/Driver.java.in
+++ b/org/postgresql/Driver.java.in
@@ -280,7 +280,9 @@ public class Driver implements java.sql.Driver
                 return makeConnection(url, props);
 
             ConnectThread ct = new ConnectThread(url, props);
-            new Thread(ct, "PostgreSQL JDBC driver connection thread").start();
+            Thread thread = new Thread(ct, "PostgreSQL JDBC driver connection thread");
+            thread.setDaemon(true); // Don't prevent the VM from shutting down
+            thread.start();
             return ct.getResult(timeout);
         }
         catch (PSQLException ex1)


### PR DESCRIPTION
ConnectThread prevented VM shutdown if the underlying socket operation was blocked and could not be interrupted.
Making the ConnectThread a daemon will allow a proper shutdown. 
The VM won't exit too early, as the Thread waiting for ConnectThread until the login timeout will keep the VM alive (because it shouldn't be a daemon).
