### PR TITLE
Fixes parsing of server version for locales which use "." as grouping separator

### DIFF
--- a/org/postgresql/core/Utils.java
+++ b/org/postgresql/core/Utils.java
@@ -176,6 +176,7 @@ public class Utils {
  	{
         int vers;
         NumberFormat numformat = NumberFormat.getIntegerInstance();
+		numformat.setGroupingUsed(false);
         ParsePosition parsepos = new ParsePosition(0);
         Long parsed;
 
@@ -187,7 +188,7 @@ public class Utils {
         if (parsed == null) {
             return 0;
         }
-        if (parsed >= 10000)
+        if (parsed.intValue() >= 10000)
         {
             /*
              * PostgreSQL version 1000? I don't think so. We're seeing a version like
@@ -226,7 +227,7 @@ public class Utils {
              */
             return 0;
         }
-		if (parsed > 99)
+		if (parsed.intValue() > 99)
 			throw new NumberFormatException("Unsupported second part of major version > 99 in invalid version string: " + serverVersion);
         vers = vers + parsed.intValue() * 100;
 
@@ -244,7 +245,7 @@ public class Utils {
         /* Try to parse any remainder as a minor version */
         parsed = (Long) numformat.parseObject(serverVersion, parsepos);
         if (parsed != null) {
-			if (parsed > 99)
+			if (parsed.intValue() > 99)
 				throw new NumberFormatException("Unsupported minor version value > 99 in invalid version string: " + serverVersion);
             vers = vers + parsed.intValue();
         }


### PR DESCRIPTION
Fixes parsing of server version for locales which use "." as grouping separator, e.g. German locale, and removes unboxing. When I execute tests using German locale, then the VersionTest fails with the message:

```
[junit] Testcase: testVersionParsing(org.postgresql.test.jdbc2.VersionTest):    FAILED
[junit] expected:<70400> but was:<0>
[junit] junit.framework.AssertionFailedError: expected:<70400> but was:<0>
[junit]     at org.postgresql.test.jdbc2.VersionTest.testVersionParsing(VersionTest.java:16)
```

After applying this patch the test runs as expected.
