### PR TITLE
Minor performance improvement in findColumnIndex

### DIFF
--- a/org/postgresql/jdbc2/AbstractJdbc2ResultSet.java
+++ b/org/postgresql/jdbc2/AbstractJdbc2ResultSet.java
@@ -2755,14 +2755,14 @@ public abstract class AbstractJdbc2ResultSet implements BaseResultSet, org.postg
             return index.intValue();
         }
         
-        index = (Integer)columnNameIndexMap.get(columnName.toUpperCase(Locale.US));
+        index = (Integer)columnNameIndexMap.get(columnName.toLowerCase(Locale.US));
         if (index != null)
         {
             columnNameIndexMap.put(columnName, index);
             return index.intValue();
         }
 
-        index = (Integer)columnNameIndexMap.get(columnName.toLowerCase(Locale.US));
+        index = (Integer)columnNameIndexMap.get(columnName.toUpperCase(Locale.US));
         if (index != null)
         {
             columnNameIndexMap.put(columnName, index);


### PR DESCRIPTION
The recent change in findColumnIndex to allow the disabling of the column sanitiser has introduced an extra call to `toUpperCase` on most calls to findColumnIndex, especially in the default case where the column sanitiser is still enabled.

This is easily addressed by always checking the lower cased version of the column name before checking the upper case version.
