### PR TITLE
Enhance connection fail-over with master/slave restriction and loadbalancing

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -43,6 +43,7 @@
     <include name="${package}/fastpath/**" />
     <include name="${package}/geometric/**" />
     <include name="${package}/largeobject/**" />
+    <include name="${package}/hostchooser/**" />
     <include name="${package}/util/**" />
 
     <!--
@@ -699,6 +700,7 @@
       <test name="org.postgresql.test.extensions.ExtensionsSuite" outfile="${testResultsDir}/extensions"/>
       <test name="org.postgresql.test.jdbc4.Jdbc4TestSuite" if="jdbc4tests" outfile="${testResultsDir}/jdbc4"/>
       <test name="org.postgresql.test.jdbc4.jdbc41.Jdbc41TestSuite" if="jdbc41tests" outfile="${testResultsDir}/jdbc41"/>
+      <test name="org.postgresql.test.hostchooser.MultiHostSuite" outfile="${testResultsDir}/hostchooser"/>
       <test name="org.postgresql.test.ssl.SslTestSuite" if="jdbc4tests" outfile="${testResultsDir}/ssl"/>
       <test name="org.postgresql.test.ssl.SingleCertValidatingFactoryTest" if="jdbc4tests" outfile="${testResultsDir}/scsf-ssl"/>
     </junit>

--- a/doc/pgjdbc.xml
+++ b/doc/pgjdbc.xml
@@ -973,6 +973,37 @@ openssl pkcs8 -topk8 -in client.key -out client.pk8 -outform DER -v1 PBE-SHA1-3D
        </listitem>
       </varlistentry>
 
+      <varlistentry>
+       <term><varname>targetServerType</varname></term>
+       <listitem>
+        <para>
+         Allows opening connections to only servers with required state, the allowed values are
+         <literal>any</literal>, <literal>master</literal>, <literal>slave</literal> and <literal>preferSlave</literal>.
+         The master/slave distinction is currently done by observing if the server allows writes.
+         The value <literal>preferSlave</literal> tries to connect to slaves if any are available,
+         otherwise allows falls back to connecting also to master.
+        </para>
+       </listitem>
+      </varlistentry>
+
+      <varlistentry>
+       <term><varname>hostRecheckSeconds</varname> = <type>int</type></term>
+       <listitem>
+        <para>
+          Controls how long in seconds the knowledge about a host state is cached in JVM wide global cache. The default value is 10 seconds.
+        </para>
+       </listitem>
+      </varlistentry>
+
+      <varlistentry>
+       <term><varname>loadBalanceHosts</varname> = <type>boolean</type></term>
+       <listitem>
+        <para>
+          In default mode (disabled) hosts are connected in the given order. If enabled hosts are chosen randomly from the set of suitable candidates.
+        </para>
+       </listitem>
+      </varlistentry>
+
      </variablelist>
     </para>
 
@@ -998,8 +1029,17 @@ jdbc:postgresql://<replaceable class="parameter">host1</replaceable>:<replaceabl
     <para>
       The simple connection fail-over is useful when running against
       a high availability postgres installation that has identical data on each node.
-      For example streaming replication postgres that only accepts connection on the master
-      node or postgres-xc cluster.
+      For example streaming replication postgres or postgres-xc cluster.
+    </para>
+
+    <para>
+      For example an application can create two connection pools. One data source is for writes, another for reads.
+
+      The write pool limits connections only to master node:
+      <programlisting>jdbc:postgresql://node1,node2,node3/accounting?targetServerType=master</programlisting>.
+
+      And read pool balances connections between slaves nodes, but allows connections also to master if no slaves are available:
+      <programlisting>jdbc:postgresql://node1,node2,node3/accounting?targetServerType=preferSlave&amp;loadBalanceHosts=true</programlisting>.
     </para>
    </sect2>
 

--- a/org/postgresql/PGProperty.java
+++ b/org/postgresql/PGProperty.java
@@ -262,7 +262,13 @@ public enum PGProperty
      * Specify the schema to be set in the search-path. This schema will be used
      * to resolve unqualified object names used in statements over this connection.
      */
-    CURRENT_SCHEMA("currentSchema", null, "Specify the schema to be set in the search-path");
+    CURRENT_SCHEMA("currentSchema", null, "Specify the schema to be set in the search-path"),
+
+    TARGET_SERVER_TYPE("targetServerType", "any", "Specifies what kind of server to connect", false, "any", "master", "slave", "preferSlave"),
+
+    LOAD_BALANCE_HOSTS("loadBalanceHosts", "false", "If disabled hosts are connected in the given order. If enabled hosts are chosen randomly from the set of suitable candidates"),
+
+    HOST_RECHECK_SECONDS("hostRecheckSeconds", "10", "Specifies period (seconds) after host statuses are checked again in case they have changed");
 
     private String _name;
     private String _defaultValue;

--- a/org/postgresql/core/ConnectionFactory.java
+++ b/org/postgresql/core/ConnectionFactory.java
@@ -9,6 +9,7 @@
 package org.postgresql.core;
 
 import java.util.Properties;
+import java.io.IOException;
 import java.sql.SQLException;
 
 import org.postgresql.PGProperty;
@@ -87,4 +88,22 @@ public abstract class ConnectionFactory {
      *    than protocol version incompatibility.
      */
     public abstract ProtocolConnection openConnectionImpl(HostSpec[] hostSpecs, String user, String database, Properties info, Logger logger) throws SQLException;
+
+    /**
+     * Safely close the given stream.
+     *
+     * @param newStream The stream to close.
+     */
+    protected void closeStream(PGStream newStream) {
+        if (newStream != null)
+        {
+            try
+            {
+                newStream.close();
+            }
+            catch (IOException e)
+            {
+            }
+        }
+    }
 }

--- a/org/postgresql/ds/common/BaseDataSource.java
+++ b/org/postgresql/ds/common/BaseDataSource.java
@@ -586,6 +586,54 @@ public abstract class BaseDataSource implements Referenceable
     }
 
     /**
+     * @see PGProperty#TARGET_SERVER_TYPE
+     */
+    public void setTargetServerType(String targetServerType)
+    {
+        PGProperty.TARGET_SERVER_TYPE.set(properties, targetServerType);
+    }
+
+    /**
+     * @see PGProperty#TARGET_SERVER_TYPE
+     */
+    public String getTargetServerType()
+    {
+        return PGProperty.TARGET_SERVER_TYPE.get(properties);
+    }
+
+    /**
+     * @see PGProperty#LOAD_BALANCE_HOSTS
+     */
+    public void setLoadBalanceHosts(boolean loadBalanceHosts)
+    {
+        PGProperty.LOAD_BALANCE_HOSTS.set(properties, loadBalanceHosts);
+    }
+
+    /**
+     * @see PGProperty#LOAD_BALANCE_HOSTS
+     */
+    public boolean getLoadBalanceHosts()
+    {
+        return PGProperty.LOAD_BALANCE_HOSTS.isPresent(properties);
+    }
+
+    /**
+     * @see PGProperty#HOST_RECHECK_SECONDS
+     */
+    public void setHostRecheckSeconds(int hostRecheckSeconds)
+    {
+        PGProperty.HOST_RECHECK_SECONDS.set(properties, hostRecheckSeconds);
+    }
+
+    /**
+     * @see PGProperty#HOST_RECHECK_SECONDS
+     */
+    public int getHostRecheckSeconds()
+    {
+        return PGProperty.HOST_RECHECK_SECONDS.getIntNoCheck(properties);
+    }
+
+    /**
      * @see PGProperty#TCP_KEEP_ALIVE
      */
     public void setTcpKeepAlive(boolean enabled)

--- a/org/postgresql/hostchooser/GlobalHostStatusTracker.java
+++ b/org/postgresql/hostchooser/GlobalHostStatusTracker.java
@@ -1,0 +1,97 @@
+/*-------------------------------------------------------------------------
+ *
+ * Copyright (c) 2014, PostgreSQL Global Development Group
+ *
+ *
+ *-------------------------------------------------------------------------
+ */
+package org.postgresql.hostchooser;
+
+import static java.lang.System.currentTimeMillis;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.postgresql.util.HostSpec;
+
+/**
+ * Keeps track of HostSpec targets in a global map.
+ */
+public class GlobalHostStatusTracker {
+    private static final Map<HostSpec, HostSpecStatus> hostStatusMap = new HashMap<HostSpec, HostSpecStatus>();
+
+    /**
+     * Store the actual observed host status. 
+     *
+     * @param hostSpec The host whose status is known.
+     * @param hostStatus Latest known status for the host.
+     */
+    public static void reportHostStatus(HostSpec hostSpec, HostStatus hostStatus) {
+        long now = currentTimeMillis();
+        synchronized (hostStatusMap) {
+            HostSpecStatus oldStatus = hostStatusMap.get(hostSpec);
+            if (oldStatus == null || updateStatusFromTo(oldStatus.status, hostStatus)) {
+                hostStatusMap.put(hostSpec, new HostSpecStatus(hostSpec, hostStatus, now));
+            }
+        }
+    }
+
+    private static boolean updateStatusFromTo(HostStatus oldStatus, HostStatus newStatus) {
+        if (oldStatus == null) {
+            return true;
+        }
+        if (newStatus == HostStatus.ConnectOK) {
+            return oldStatus != HostStatus.Master && oldStatus != HostStatus.Slave;
+        }
+        return true;
+    }
+
+    /**
+     * Returns a list of candidate hosts that have the required targetServerType.
+     *
+     * @param hostSpecs The potential list of hosts.
+     * @param targetServerType The required target server type.
+     * @param hostRecheckMillis How stale information is allowed.
+     * @return candidate hosts to connect to.
+     */
+    static List<HostSpecStatus> getCandidateHosts(HostSpec[] hostSpecs, HostRequirement targetServerType, long hostRecheckMillis) {
+        List<HostSpecStatus> candidates = new ArrayList<HostSpecStatus>(hostSpecs.length);
+        long latestAllowedUpdate = currentTimeMillis() - hostRecheckMillis;
+        synchronized (hostStatusMap) {
+            for (HostSpec hostSpec : hostSpecs) {
+                HostSpecStatus hostInfo = hostStatusMap.get(hostSpec);
+                // return null status wrapper if if the current value is not known or is too old
+                if (hostInfo == null || hostInfo.lastUpdated < latestAllowedUpdate) {
+                    hostInfo = new HostSpecStatus(hostSpec, null, Long.MAX_VALUE);
+                }
+                // candidates are nodes we do not know about and the nodes with correct type
+                if (hostInfo.status == null || targetServerType.allowConnectingTo(hostInfo.status)) {
+                    candidates.add(hostInfo);
+                }
+            }
+        }
+        return candidates;
+    }
+
+    /**
+     * Immutable structure of known status of one HostSpec.
+     */
+    static class HostSpecStatus {
+        final HostSpec host;
+        final HostStatus status;
+        final long lastUpdated;
+
+        HostSpecStatus(HostSpec host, HostStatus hostStatus, long lastUpdated) {
+            this.host = host;
+            this.status = hostStatus;
+            this.lastUpdated = lastUpdated;
+        }
+
+        @Override
+        public String toString() {
+            return host.toString() + '=' + status;
+        }
+    }
+}

--- a/org/postgresql/hostchooser/HostChooser.java
+++ b/org/postgresql/hostchooser/HostChooser.java
@@ -1,0 +1,24 @@
+/*-------------------------------------------------------------------------
+ *
+ * Copyright (c) 2014, PostgreSQL Global Development Group
+ *
+ *
+ *-------------------------------------------------------------------------
+ */
+package org.postgresql.hostchooser;
+
+import java.util.Iterator;
+
+import org.postgresql.util.HostSpec;
+
+/**
+ * Lists connections in preferred order.
+ */
+public interface HostChooser {
+    /**
+     * Lists connection hosts in preferred order.
+     *
+     * @return connection hosts in preferred order.
+     */
+    Iterator<HostSpec> iterator();
+}

--- a/org/postgresql/hostchooser/HostChooserFactory.java
+++ b/org/postgresql/hostchooser/HostChooserFactory.java
@@ -1,0 +1,25 @@
+/*-------------------------------------------------------------------------
+ *
+ * Copyright (c) 2014, PostgreSQL Global Development Group
+ *
+ *
+ *-------------------------------------------------------------------------
+ */
+package org.postgresql.hostchooser;
+
+import java.util.Properties;
+
+import org.postgresql.util.HostSpec;
+
+/**
+ * Chooses a {@link HostChooser} instance based on the number of hosts and properties.
+ */
+public class HostChooserFactory {
+
+    public static HostChooser createHostChooser(HostSpec[] hostSpecs, HostRequirement targetServerType, Properties info) {
+        if (hostSpecs.length == 1) {
+            return new SingleHostChooser(hostSpecs[0]);
+        }
+        return new MultiHostChooser(hostSpecs, targetServerType, info);
+    }
+}

--- a/org/postgresql/hostchooser/HostRequirement.java
+++ b/org/postgresql/hostchooser/HostRequirement.java
@@ -1,0 +1,36 @@
+/*-------------------------------------------------------------------------
+ *
+ * Copyright (c) 2014, PostgreSQL Global Development Group
+ *
+ *
+ *-------------------------------------------------------------------------
+ */
+package org.postgresql.hostchooser;
+
+/**
+ * Describes the required server type.
+ */
+public enum HostRequirement {
+    any {
+        public boolean allowConnectingTo(HostStatus status) {
+            return status != HostStatus.ConnectFail;
+        }
+    },
+    master {
+        public boolean allowConnectingTo(HostStatus status) {
+            return status == HostStatus.Master || status == HostStatus.ConnectOK;
+        }
+    },
+    slave {
+        public boolean allowConnectingTo(HostStatus status) {
+            return status == HostStatus.Slave || status == HostStatus.ConnectOK;
+        }
+    },
+    preferSlave {
+        public boolean allowConnectingTo(HostStatus status) {
+            return status != HostStatus.ConnectFail;
+        }
+    };
+
+    public abstract boolean allowConnectingTo(HostStatus status);
+}

--- a/org/postgresql/hostchooser/HostStatus.java
+++ b/org/postgresql/hostchooser/HostStatus.java
@@ -1,0 +1,18 @@
+/*-------------------------------------------------------------------------
+*
+* Copyright (c) 2014, PostgreSQL Global Development Group
+*
+*
+*-------------------------------------------------------------------------
+*/
+package org.postgresql.hostchooser;
+
+/**
+ * Known state of a server.
+ */
+public enum HostStatus {
+    ConnectFail,
+    ConnectOK,
+    Master,
+    Slave
+}

--- a/org/postgresql/hostchooser/MultiHostChooser.java
+++ b/org/postgresql/hostchooser/MultiHostChooser.java
@@ -1,0 +1,112 @@
+/*-------------------------------------------------------------------------
+ *
+ * Copyright (c) 2014, PostgreSQL Global Development Group
+ *
+ *
+ *-------------------------------------------------------------------------
+ */
+package org.postgresql.hostchooser;
+
+import static java.lang.Boolean.parseBoolean;
+import static java.lang.Integer.parseInt;
+import static java.util.Arrays.asList;
+import static java.util.Collections.shuffle;
+import static java.util.Collections.sort;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Properties;
+
+import org.postgresql.hostchooser.GlobalHostStatusTracker.HostSpecStatus;
+import org.postgresql.util.HostSpec;
+
+/**
+ * HostChooser that keeps track of known host statuses.
+ */
+public class MultiHostChooser implements HostChooser {
+    private HostSpec[] hostSpecs;
+    private final HostRequirement targetServerType;
+    private int hostRecheckTime;
+    private boolean loadBalance;
+
+    protected MultiHostChooser(HostSpec[] hostSpecs, HostRequirement targetServerType, Properties info) {
+        this.hostSpecs = hostSpecs;
+        this.targetServerType = targetServerType;
+        hostRecheckTime = parseInt(info.getProperty("hostRecheckSeconds", "10")) * 1000;
+        loadBalance = parseBoolean(info.getProperty("loadBalanceHosts", "false"));
+    }
+
+    public Iterator<HostSpec> iterator() {
+        List<HostSpecStatus> candidates = GlobalHostStatusTracker.getCandidateHosts(hostSpecs, targetServerType, hostRecheckTime);
+        // if no candidates are suitable (all wrong type or unavailable) then we try original list in order
+        if (candidates.isEmpty()) {
+            return asList(hostSpecs).iterator();
+        }
+        if (candidates.size() == 1) {
+            return asList(candidates.get(0).host).iterator();
+        }
+        sortCandidates(candidates);
+        shuffleGoodHosts(candidates);
+        return extractHostSpecs(candidates).iterator();
+    }
+
+    private void sortCandidates(List<HostSpecStatus> candidates) {
+        if (targetServerType == HostRequirement.any) {
+            return;
+        }
+        sort(candidates, new HostSpecByTargetServerTypeComparator());
+    }
+
+    private void shuffleGoodHosts(List<HostSpecStatus> candidates) {
+        if (!loadBalance) {
+            return;
+        }
+        int count;
+        for (count = 1; count < candidates.size(); count++) {
+            HostSpecStatus hostSpecStatus = candidates.get(count);
+            if (hostSpecStatus.status != null && !targetServerType.allowConnectingTo(hostSpecStatus.status)) {
+                break;
+            }
+        }
+        if (count == 1) {
+            return;
+        }
+        List<HostSpecStatus> goodHosts = candidates.subList(0, count);
+        shuffle(goodHosts);
+    }
+
+    private List<HostSpec> extractHostSpecs(List<HostSpecStatus> hostSpecStatuses) {
+        List<HostSpec> hostSpecs = new ArrayList<HostSpec>(hostSpecStatuses.size());
+        for (HostSpecStatus hostSpecStatus : hostSpecStatuses) {
+            hostSpecs.add(hostSpecStatus.host);
+        }
+        return hostSpecs;
+    }
+
+    class HostSpecByTargetServerTypeComparator implements Comparator<HostSpecStatus> {
+        @Override
+        public int compare(HostSpecStatus o1, HostSpecStatus o2) {
+            int r1 = rank(o1.status, targetServerType);
+            int r2 = rank(o2.status, targetServerType);
+            return r1 == r2 ? 0 : r1 > r2 ? -1 : 1;
+        }
+
+        private int rank(HostStatus status, HostRequirement targetServerType) {
+            if (status == HostStatus.ConnectFail) {
+                return -1;
+            }
+            switch (targetServerType) {
+            case master:
+                return status == HostStatus.Master || status == null ? 1 : 0;
+            case slave:
+                return status == HostStatus.Slave || status == null ? 1 : 0;
+            case preferSlave:
+                return status == HostStatus.Slave || status == null ? 2 : status == HostStatus.Master ? 1 : 0;
+            default:
+                return 0;
+            }
+        }
+    }
+}

--- a/org/postgresql/hostchooser/SingleHostChooser.java
+++ b/org/postgresql/hostchooser/SingleHostChooser.java
@@ -1,0 +1,29 @@
+/*-------------------------------------------------------------------------
+*
+* Copyright (c) 2014, PostgreSQL Global Development Group
+*
+*
+*-------------------------------------------------------------------------
+*/
+package org.postgresql.hostchooser;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+
+import org.postgresql.util.HostSpec;
+
+/**
+ * Host chooser that returns the single host.
+ */
+public class SingleHostChooser implements HostChooser {
+    private final Collection<HostSpec> hostSpec;
+
+    public SingleHostChooser(HostSpec hostSpec) {
+        this.hostSpec = Collections.singletonList(hostSpec);
+    }
+
+    public Iterator<HostSpec> iterator() {
+        return hostSpec.iterator();
+    }
+}

--- a/org/postgresql/test/TestUtil.java
+++ b/org/postgresql/test/TestUtil.java
@@ -7,7 +7,6 @@
 */
 package org.postgresql.test;
 
-import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.sql.*;
@@ -24,6 +23,11 @@ public class TestUtil
      * Returns the Test database JDBC URL
      */
     public static String getURL()
+    {
+        return getURL(getServer(), getPort());
+    }
+
+    public static String getURL(String server, int port)
     {
         String protocolVersion = "";
         if (getProtocolVersion() != 0) {
@@ -46,8 +50,8 @@ public class TestUtil
 		}
 		
         return "jdbc:postgresql://"
-                                + getServer() + ":" 
-                                + getPort() + "/" 
+                                + server + ":"
+                                + port + "/"
                                 + getDatabase() 
                                 + "?prepareThreshold=" + getPrepareThreshold()
                                 + "&loglevel=" + getLogLevel()

--- a/org/postgresql/test/hostchooser/MultiHostSuite.java
+++ b/org/postgresql/test/hostchooser/MultiHostSuite.java
@@ -1,0 +1,85 @@
+/*-------------------------------------------------------------------------
+*
+* Copyright (c) 2007-2014, PostgreSQL Global Development Group
+*
+*
+*-------------------------------------------------------------------------
+*/
+package org.postgresql.test.hostchooser;
+
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
+
+import java.sql.*;
+import java.util.Properties;
+
+import org.postgresql.test.TestUtil;
+import org.postgresql.util.PSQLException;
+
+/*
+ * Executes multi host tests (aka master/slave connectivity selection).
+ */
+public class MultiHostSuite extends TestSuite
+{
+
+    public static java.sql.Connection openSlaveDB() throws Exception
+    {
+        TestUtil.initDriver();
+
+        Properties props = new Properties();
+
+        props.setProperty("user", TestUtil.getUser());
+        props.setProperty("password", TestUtil.getPassword());
+
+        return DriverManager.getConnection(TestUtil.getURL(getSlaveServer(), getSlavePort()), props);
+    }
+
+    /*
+     * Returns the Test server
+     */
+    public static String getSlaveServer()
+    {
+        return System.getProperty("slaveServer", TestUtil.getServer());
+    }
+
+    /*
+     * Returns the Test port
+     */
+    public static int getSlavePort()
+    {
+        return Integer.parseInt(System.getProperty("slavePort", String.valueOf(TestUtil.getPort() + 1)));
+    }
+
+    /*
+     * The main entry point for JUnit
+     */
+    public static TestSuite suite() throws Exception
+    {
+        Class.forName("org.postgresql.Driver");
+        TestSuite suite = new TestSuite();
+
+        try
+        {
+            Connection connection = openSlaveDB();
+            TestUtil.closeDB(connection);
+        }
+        catch (PSQLException ex)
+        {
+            // replication instance is not available, but suite must have at lest one test case
+            suite.addTestSuite(DummyTest.class);
+            return suite;
+        }
+
+        suite.addTestSuite(MultiHostsConnectionTest.class);
+        return suite;
+    }
+
+    public static class DummyTest extends TestCase {
+        public DummyTest(String name) {
+			super(name);
+		}
+    	public void testDummy() {
+    	}
+    }
+}
+

--- a/org/postgresql/test/hostchooser/MultiHostsConnectionTest.java
+++ b/org/postgresql/test/hostchooser/MultiHostsConnectionTest.java
@@ -1,0 +1,250 @@
+package org.postgresql.test.hostchooser;
+
+import static java.lang.Integer.parseInt;
+import static java.util.Arrays.asList;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.postgresql.hostchooser.HostRequirement.any;
+import static org.postgresql.hostchooser.HostRequirement.master;
+import static org.postgresql.hostchooser.HostRequirement.preferSlave;
+import static org.postgresql.hostchooser.HostRequirement.slave;
+import static org.postgresql.hostchooser.HostStatus.ConnectFail;
+import static org.postgresql.hostchooser.HostStatus.Slave;
+import static org.postgresql.test.TestUtil.closeDB;
+
+import java.lang.reflect.Field;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+
+import junit.framework.TestCase;
+
+import org.postgresql.hostchooser.GlobalHostStatusTracker;
+import org.postgresql.hostchooser.HostRequirement;
+import org.postgresql.test.TestUtil;
+import org.postgresql.util.HostSpec;
+import org.postgresql.util.PSQLException;
+
+public class MultiHostsConnectionTest extends TestCase {
+
+    static final String user = TestUtil.getUser();
+    static final String password = TestUtil.getPassword();
+    static final String master1 = TestUtil.getServer() + ":" + TestUtil.getPort();
+    static final String slave1 = MultiHostSuite.getSlaveServer() + ":" + MultiHostSuite.getSlavePort();
+    static final String fake1 = "127.127.217.217:1";
+    static String masterIp;
+    static String slaveIp;
+    static String fakeIp = fake1;
+
+    static Connection con;
+    private static Map<HostSpec, Object> hostStatusMap;
+
+    static {
+        Field field;
+        try {
+            field = GlobalHostStatusTracker.class.getDeclaredField("hostStatusMap");
+            field.setAccessible(true);
+            hostStatusMap = (Map<HostSpec, Object>) field.get(null);
+
+            con = TestUtil.openDB();
+            masterIp = getRemoteHostSpec();
+            closeDB(con);
+
+            con = MultiHostSuite.openSlaveDB();
+            slaveIp = getRemoteHostSpec();
+            closeDB(con);
+
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static Connection getConnection(HostRequirement hostType, String... targets) throws SQLException {
+        return getConnection(hostType, true, targets);
+    }
+
+    private static HostSpec hostSpec(String host) {
+        int split = host.indexOf(':');
+        return new HostSpec(host.substring(0, split), parseInt(host.substring(split + 1)));
+    }
+
+    private static Connection getConnection(HostRequirement hostType, boolean reset, String... targets) throws SQLException {
+        return getConnection(hostType, reset, false, targets);
+    }
+
+    private static Connection getConnection(HostRequirement hostType, boolean reset, boolean lb, String... targets) throws SQLException {
+        TestUtil.closeDB(con);
+
+        if (reset) {
+            resetGlobalState();
+        }
+
+        Properties props = new Properties();
+        props.setProperty("user", user);
+        props.setProperty("password", password);
+        props.setProperty("targetServerType", hostType.name());
+        props.setProperty("hostRecheckSeconds", "2");
+        if (lb) {
+            props.setProperty("loadBalanceHosts", "true");
+        }
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("jdbc:postgresql://");
+        for (String target : targets) {
+            sb.append(target).append(',');
+        }
+        sb.setLength(sb.length() - 1);
+        sb.append("/test");
+
+        return con = DriverManager.getConnection(sb.toString(), props);
+    }
+
+    private static void assertRemote(String expectedHost) throws SQLException {
+        assertEquals(expectedHost, getRemoteHostSpec());
+    }
+
+    private static String getRemoteHostSpec() throws SQLException {
+        ResultSet rs = con.createStatement().executeQuery("select inet_server_addr() || ':' || inet_server_port()");
+        rs.next();
+        return rs.getString(1);
+    }
+
+    public static boolean isMaster(Connection con) throws SQLException {
+        ResultSet rs = con.createStatement().executeQuery("show transaction_read_only");
+        rs.next();
+        return "off".equals(rs.getString(1));
+    }
+
+    private static void assertGlobalState(String host, String status) {
+        HostSpec spec = hostSpec(host);
+        if (status == null) {
+            assertNull(hostStatusMap.get(spec));
+        } else {
+            assertEquals(host + "=" + status, hostStatusMap.get(spec).toString());
+        }
+    }
+
+    private static void resetGlobalState() {
+        hostStatusMap.clear();
+    }
+
+    public static void testConnectToAny() throws SQLException {
+        getConnection(any, fake1, master1);
+        assertRemote(masterIp);
+        assertGlobalState(master1, "ConnectOK");
+        assertGlobalState(fake1, "ConnectFail");
+
+        getConnection(any, fake1, slave1);
+        assertRemote(slaveIp);
+        assertGlobalState(slave1, "ConnectOK");
+
+        getConnection(any, fake1, master1);
+        assertRemote(masterIp);
+        assertGlobalState(master1, "ConnectOK");
+        assertGlobalState(fake1, "ConnectFail");
+    }
+
+    public static void testConnectToMaster() throws SQLException {
+        getConnection(master, true, fake1, master1, slave1);
+        assertRemote(masterIp);
+        assertGlobalState(fake1, "ConnectFail");
+        assertGlobalState(master1, "Master");
+        assertGlobalState(slave1, null);
+
+        getConnection(master, false, fake1, slave1, master1);
+        assertRemote(masterIp);
+        assertGlobalState(fake1, "ConnectFail");
+        assertGlobalState(master1, "Master");
+        assertGlobalState(slave1, "Slave");
+    }
+
+    public static void testConnectToSlave() throws SQLException {
+        getConnection(slave, true, fake1, slave1, master1);
+        assertRemote(slaveIp);
+        assertGlobalState(fake1, "ConnectFail");
+        assertGlobalState(slave1, "Slave");
+        assertGlobalState(master1, null);
+
+        getConnection(slave, false, fake1, master1, slave1);
+        assertRemote(slaveIp);
+        assertGlobalState(fake1, "ConnectFail");
+        assertGlobalState(slave1, "Slave");
+        assertGlobalState(master1, "Master");
+    }
+
+    public static void testConnectToSlaveFirst() throws SQLException {
+        getConnection(preferSlave, true, fake1, slave1, master1);
+        assertRemote(slaveIp);
+        assertGlobalState(fake1, "ConnectFail");
+        assertGlobalState(slave1, "Slave");
+        assertGlobalState(master1, null);
+
+        getConnection(preferSlave, false, fake1, master1, slave1);
+        assertRemote(masterIp);
+        assertGlobalState(fake1, "ConnectFail");
+        assertGlobalState(slave1, "Slave");
+        assertGlobalState(master1, "Master");
+
+        getConnection(preferSlave, false, fake1, master1, slave1);
+        assertRemote(slaveIp);
+        assertGlobalState(fake1, "ConnectFail");
+        assertGlobalState(slave1, "Slave");
+        assertGlobalState(master1, "Master");
+    }
+
+    public static void testFailedConnection() throws SQLException {
+        try {
+            getConnection(any, true, fake1);
+            fail();
+        } catch (PSQLException ex) {
+        }
+    }
+
+    public static void testLoadBalancing() throws SQLException {
+        Set<String> connectedHosts = new HashSet<String>();
+        boolean fake1FoundTried = false;
+        for (int i=0; i<20; ++i) {
+            getConnection(any, true, true, fake1,  master1, slave1);
+            connectedHosts.add(getRemoteHostSpec());
+            fake1FoundTried |= hostStatusMap.containsKey(hostSpec(fake1));
+            if (connectedHosts.size() == 2 && fake1FoundTried)
+                break;
+        }
+        assertEquals("Never connected to all hosts", new HashSet<String>(asList(masterIp, slaveIp)), connectedHosts);
+        assertTrue("Never tried to connect to fake node", fake1FoundTried);
+    }
+
+    public static void testHostRechecks() throws SQLException, InterruptedException {
+        getConnection(master, true, fake1,  master1, slave1);
+        assertRemote(masterIp);
+        assertGlobalState(fake1, "ConnectFail");
+        assertGlobalState(slave1, null);
+
+        GlobalHostStatusTracker.reportHostStatus(hostSpec(master1), ConnectFail);
+        assertGlobalState(master1, "ConnectFail");
+
+        try {
+            getConnection(master, false, fake1, slave1, master1);
+            fail();
+        } catch (SQLException ex) {
+        }
+
+        SECONDS.sleep(3);
+
+        getConnection(master, false, slave1, fake1, master1);
+        assertRemote(masterIp);
+    }
+
+    public static void testNoGoodHostsRechecksEverything() throws SQLException, InterruptedException {
+        GlobalHostStatusTracker.reportHostStatus(hostSpec(master1), Slave);
+        GlobalHostStatusTracker.reportHostStatus(hostSpec(slave1), Slave);
+        GlobalHostStatusTracker.reportHostStatus(hostSpec(fake1), Slave);
+
+        getConnection(master, false, slave1, fake1, master1);
+        assertRemote(masterIp);
+    }
+}

--- a/org/postgresql/util/HostSpec.java
+++ b/org/postgresql/util/HostSpec.java
@@ -31,4 +31,14 @@ public class HostSpec {
     public String toString() {
         return host + ":" + port;
     }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj instanceof HostSpec && port == ((HostSpec) obj).port && host.equals(((HostSpec) obj).host);
+    }
+
+    @Override
+    public int hashCode() {
+        return port ^ host.hashCode();
+    }
 }


### PR DESCRIPTION
If multiple hosts are specified in the jdbc connection url then:
- Adds querying of node writability and possibility to restrict connections to writable or read-only nodes.
- Adds load balancing of connections.
- Uses a JVM global cache of known node states.

Based on work by chenhj@cn.fujitsu.com from 2011. I rewrote most of the code, added more documentation and integrated properly the tests.
