### PR TITLE
Add support for "currentSchema" connection property (in 9.3 branch).

### DIFF
--- a/doc/pgjdbc.xml
+++ b/doc/pgjdbc.xml
@@ -628,8 +628,8 @@ openssl pkcs8 -topk8 -in client.key -out client.pk8 -outform DER -v1 PBE-SHA1-3D
        <term><varname>charSet</varname> = <type>String</type></term>
        <listitem>
         <para>
-         The character set to use for data sent to the database or recieved
-         from the database.  This property is only relevent for server
+         The character set to use for data sent to the database or received
+         from the database.  This property is only relevant for server
          versions less than or equal to 7.2.  The 7.3 release was the first
          with multibyte support compiled by default and the driver uses
          its character set translation facilities instead of trying to do
@@ -846,6 +846,17 @@ openssl pkcs8 -topk8 -in client.key -out client.pk8 -outform DER -v1 PBE-SHA1-3D
         </para>
        </listitem>
       </varlistentry>
+
+      <varlistentry>
+       <term><varname>currentSchema</varname></term>
+       <listitem>
+        <para>
+         Specify the schema to be set in the search-path. This schema will be used
+         to resolve unqualified object names used in statements over this connection.
+        </para>
+       </listitem>
+      </varlistentry>
+
      </variablelist>
     </para>
 

--- a/org/postgresql/Driver.java.in
+++ b/org/postgresql/Driver.java.in
@@ -486,7 +486,9 @@ public class Driver implements java.sql.Driver
                 { "jaasApplicationName", Boolean.FALSE,
                   "Specifies the name of the JAAS system or application login configuration." },
                 { "disableColumnSanitiser", Boolean.FALSE,
-                  "Enable optimization that disables column name sanitiser." }
+                  "Enable optimization that disables column name sanitiser." },
+                { "currentSchema", Boolean.FALSE,
+                  "Specify the schema to set in the search_path to resolve unqualified object names." }
             };
 
     /**

--- a/org/postgresql/ds/common/BaseDataSource.java
+++ b/org/postgresql/ds/common/BaseDataSource.java
@@ -67,6 +67,7 @@ public abstract class BaseDataSource implements Referenceable
     private String stringType=null;
     private boolean logLevelSet = false;
     private boolean disableColumnSanitiser = false;
+    private String currentSchema;
 
     /**
      * Gets a connection to the PostgreSQL database.  The database is identified by the
@@ -517,6 +518,16 @@ public abstract class BaseDataSource implements Referenceable
 		this.disableColumnSanitiser = disableColumnSanitiser;
 	}
 
+    public String getCurrentSchema()
+    {
+        return currentSchema;
+    }
+
+    public void setCurrentSchema(String currentSchema)
+    {
+        this.currentSchema = currentSchema;
+    }
+
     /**
      * Generates a DriverManager URL from the other properties supplied.
      */
@@ -573,7 +584,10 @@ public abstract class BaseDataSource implements Referenceable
             sb.append("&binaryTransferDisable=").append(binaryTransferDisable);
         }
         sb.append("&disableColumnSanitiser=").append(disableColumnSanitiser);
-        
+
+        if (currentSchema != null) {
+            sb.append("&currentSchema=").append(currentSchema);
+        }
         return sb.toString();
     }
 
@@ -602,6 +616,7 @@ public abstract class BaseDataSource implements Referenceable
         stringType = p.getProperty("stringtype");
      	binaryTransfer = Boolean.parseBoolean(p.getProperty("binaryTransfer"));
      	disableColumnSanitiser = Boolean.parseBoolean(p.getProperty("disableColumnSanitiser"));
+     	currentSchema = p.getProperty("currentSchema");
     }
 
     /**
@@ -703,6 +718,7 @@ public abstract class BaseDataSource implements Referenceable
         out.writeObject(binaryTransferDisable);
         out.writeBoolean(logLevelSet);
         out.writeBoolean(disableColumnSanitiser);
+        out.writeObject(currentSchema);
     }
 
     protected void readBaseObject(ObjectInputStream in) throws IOException, ClassNotFoundException
@@ -731,6 +747,7 @@ public abstract class BaseDataSource implements Referenceable
         binaryTransferDisable = (String)in.readObject();
         logLevelSet = in.readBoolean();
         disableColumnSanitiser = in.readBoolean();
+        currentSchema = (String)in.readObject();
     }
 
     public void initializeFrom(BaseDataSource source) throws IOException, ClassNotFoundException {

--- a/org/postgresql/jdbc2/AbstractJdbc2Connection.java
+++ b/org/postgresql/jdbc2/AbstractJdbc2Connection.java
@@ -19,7 +19,6 @@ import org.postgresql.PGNotification;
 import org.postgresql.fastpath.Fastpath;
 import org.postgresql.largeobject.LargeObjectManager;
 import org.postgresql.util.*;
-import org.postgresql.util.HostSpec;
 import org.postgresql.copy.*;
 
 /**
@@ -270,6 +269,12 @@ public abstract class AbstractJdbc2Connection implements BaseConnection
         }
         this.disableColumnSanitiser = Boolean.valueOf(info.getProperty(""
                 + "disableColumnSanitiser", Boolean.FALSE.toString()));
+
+        String currentSchema = info.getProperty("currentSchema");
+        if (currentSchema != null)
+        {
+            setSchema(currentSchema);
+        }
     }
 
     private Set<Integer> getOidSet(String oidList) throws PSQLException {
@@ -1272,5 +1277,26 @@ public abstract class AbstractJdbc2Connection implements BaseConnection
     public void setDisableColumnSanitiser(boolean disableColumnSanitiser)
     {
         this.disableColumnSanitiser = disableColumnSanitiser;
+    }
+
+    public void setSchema(String schema) throws SQLException
+    {
+        checkClosed();
+        Statement stmt = createStatement();
+        try
+        {
+            if (schema != null)
+            {
+                stmt.executeUpdate("SET SESSION search_path TO '" + schema + "'");
+            }
+            else
+            {
+                stmt.executeUpdate("SET SESSION search_path TO DEFAULT");
+            }
+        }
+        finally
+        {
+            stmt.close();
+        }
     }
 }

--- a/org/postgresql/jdbc4/AbstractJdbc4Connection.java
+++ b/org/postgresql/jdbc4/AbstractJdbc4Connection.java
@@ -229,14 +229,42 @@ abstract class AbstractJdbc4Connection extends org.postgresql.jdbc3g.AbstractJdb
         throw org.postgresql.Driver.notImplemented(this.getClass(), "getParentLogger()");
     }
 
-    public void setSchema(String schema) throws SQLException
-    {
-        throw org.postgresql.Driver.notImplemented(this.getClass(), "setSchema(String)");
-    }
-
     public String getSchema() throws SQLException
     {
-        throw org.postgresql.Driver.notImplemented(this.getClass(), "getSchema()");
+        checkClosed();
+        String searchPath;
+        Statement stmt = createStatement();
+        try
+        {
+            ResultSet rs = stmt.executeQuery("SHOW search_path");
+            try
+            {
+                if (!rs.next())
+                {
+                    return null;
+                }
+                searchPath = rs.getString(1);
+            }
+            finally
+            {
+                rs.close();
+            }
+        }
+        finally
+        {
+            stmt.close();
+        }
+
+        // keep only the first schema of the search path if there are many
+        int commaIndex = searchPath.indexOf(',');
+        if (commaIndex == -1)
+        {
+            return searchPath;
+        }
+        else
+        {
+            return searchPath.substring(0, commaIndex);
+        }
     }
 
     public void abort(Executor executor) throws SQLException


### PR DESCRIPTION
Following the discussion in #156, here's a pull request targeted at the 9.3 branch.
I simply backported alexismeneses' code but I wasn't sure what to do in regard to JDBC 4 [g|s]etSchema() API (should it be supported or not?).
And also I didn't include the unit test for now, which depends on the previous question.
