### PR TITLE
Setting search_path in startup packet

### DIFF
--- a/org/postgresql/core/v2/ConnectionFactoryImpl.java
+++ b/org/postgresql/core/v2/ConnectionFactoryImpl.java
@@ -490,5 +490,14 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
             sb.append("'");
             SetupQueryRunner.run(protoConnection, sb.toString(), false);
         }
+
+        String currentSchema = info.getProperty("currentSchema");
+        if (currentSchema != null)
+        {
+            StringBuffer sb = new StringBuffer("SET search_path = '");
+            Utils.appendEscapedLiteral(sb, appName, protoConnection.getStandardConformingStrings());
+            sb.append("'");
+            SetupQueryRunner.run(protoConnection, sb.toString(), false);
+        }
     }
 }

--- a/org/postgresql/core/v3/ConnectionFactoryImpl.java
+++ b/org/postgresql/core/v3/ConnectionFactoryImpl.java
@@ -185,6 +185,13 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
                 // User has not explicitly told us that this is a 9.0+ server so stick to old default:
                 paramList.add(new String[] {"extra_float_digits", "2"});
             }
+
+            String currentSchema = info.getProperty("currentSchema");
+            if (currentSchema != null)
+            {
+                paramList.add(new String[] {"search_path", currentSchema});
+            }
+
             String[][] params = paramList.toArray(new String[][]{});
 
             sendStartupPacket(newStream, params, logger);

--- a/org/postgresql/jdbc2/AbstractJdbc2Connection.java
+++ b/org/postgresql/jdbc2/AbstractJdbc2Connection.java
@@ -270,12 +270,6 @@ public abstract class AbstractJdbc2Connection implements BaseConnection
         }
         this.disableColumnSanitiser = Boolean.valueOf(info.getProperty(""
                 + "disableColumnSanitiser", Boolean.FALSE.toString()));
-
-        String currentSchema = info.getProperty("currentSchema");
-        if (currentSchema != null)
-        {
-            setSchema(currentSchema);
-        }
     }
 
     private Set<Integer> getOidSet(String oidList) throws PSQLException {


### PR DESCRIPTION
As pointed out by @sehrope on PR #156, setting the `search_path` can be done directly in the startup packet when using v3 protocol, saving a round-trip.
Dealing with `currentSchema` is now done this way.

On v2 protocol, it keeps being set in an sql query after the connection has been made.

Note : I would consider merging PR #207 at the same time because I expect special characters to be now taken in account that way. And I think the behavior of `currentSchema` and `setSchema()` should remain consistent.
