### PR TITLE
isValid has no impact on transaction state

### DIFF
--- a/org/postgresql/core/Query.java
+++ b/org/postgresql/core/Query.java
@@ -54,4 +54,6 @@ public interface Query {
     void close();
 
     boolean isStatementDescribed();
+
+    boolean isEmpty();
 }

--- a/org/postgresql/core/v2/V2Query.java
+++ b/org/postgresql/core/v2/V2Query.java
@@ -106,6 +106,11 @@ class V2Query implements Query {
         return false;
     }
 
+    public boolean isEmpty()
+    {
+        return fragments.length == 1 && "".equals(fragments[0]);
+    }
+
     private static final ParameterList NO_PARAMETERS = new SimpleParameterList(0, false);
 
     private final String[] fragments;      // Query fragments, length == # of parameters + 1

--- a/org/postgresql/core/v3/CompositeQuery.java
+++ b/org/postgresql/core/v3/CompositeQuery.java
@@ -62,6 +62,15 @@ class CompositeQuery implements V3Query {
         return true;
     }
 
+    public boolean isEmpty()
+    {
+        for (int i = 0; i < subqueries.length; ++i)
+            if (!subqueries[i].isEmpty()) {
+                return false;
+            }
+        return true;
+    }
+
     private final SimpleQuery[] subqueries;
     private final int[] offsets;
 }

--- a/org/postgresql/core/v3/SimpleQuery.java
+++ b/org/postgresql/core/v3/SimpleQuery.java
@@ -154,6 +154,11 @@ class SimpleQuery implements V3Query {
         this.statementDescribed = statementDescribed;
     }
 
+    public boolean isEmpty()
+    {
+        return fragments.length == 1 && "".equals(fragments[0]);
+    }
+
     void setCleanupRef(PhantomReference cleanupRef) {
         if (this.cleanupRef != null) {
             this.cleanupRef.clear();

--- a/org/postgresql/jdbc2/AbstractJdbc2Statement.java
+++ b/org/postgresql/jdbc2/AbstractJdbc2Statement.java
@@ -547,6 +547,11 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
         if (concurrency != ResultSet.CONCUR_READ_ONLY)
             flags |= QueryExecutor.QUERY_NO_BINARY_TRANSFER;
 
+        if (queryToExecute.isEmpty())
+        {
+            flags |= QueryExecutor.QUERY_SUPPRESS_BEGIN;
+        }
+
         if (!queryToExecute.isStatementDescribed() && forceBinaryTransfers) {
                 int flags2 = flags | QueryExecutor.QUERY_DESCRIBE_ONLY;
                 StatementResultHandler handler2 = new StatementResultHandler();

--- a/org/postgresql/jdbc4/AbstractJdbc4Connection.java
+++ b/org/postgresql/jdbc4/AbstractJdbc4Connection.java
@@ -126,13 +126,11 @@ abstract class AbstractJdbc4Connection extends org.postgresql.jdbc3g.AbstractJdb
         }
     	boolean valid = false;
         Statement stmt = null;
-		ResultSet rs;
     	try {
     		if (!isClosed()) {
             	stmt = createStatement();
             	stmt.setQueryTimeout( timeout );
-            	rs = stmt.executeQuery( "SELECT 1" );
-				rs.close();
+            	stmt.executeUpdate( "" );
             	valid = true;
     	    }
     	}

--- a/org/postgresql/test/jdbc4/IsValidTest.java
+++ b/org/postgresql/test/jdbc4/IsValidTest.java
@@ -1,11 +1,19 @@
 package org.postgresql.test.jdbc4;
 
 import java.sql.*;
+
 import junit.framework.TestCase;
 
+import org.junit.Assert;
+import org.postgresql.jdbc2.AbstractJdbc2Connection;
 import org.postgresql.test.TestUtil;
 
 public class IsValidTest  extends TestCase {
+
+    private int getTransactionState(Connection conn)
+    {
+        return ((AbstractJdbc2Connection) conn).getTransactionState();
+    }
 
     public void testIsValid() throws Exception {
         Connection _conn = TestUtil.openDB();
@@ -15,6 +23,54 @@ public class IsValidTest  extends TestCase {
             TestUtil.closeDB(_conn);
         }
         assertFalse(_conn.isValid(0));
+    }
+
+    /**
+     * Test that the transaction state is left unchanged
+     */
+    public void testTransactionState() throws Exception
+    {
+        Connection conn = TestUtil.openDB();
+        try
+        {
+            int transactionState;
+            transactionState = getTransactionState(conn);
+            conn.isValid(0);
+            Assert.assertEquals("Transaction state has been changed",
+                                transactionState,
+                                getTransactionState(conn));
+            
+            conn.setTransactionIsolation(Connection.TRANSACTION_READ_COMMITTED);
+            conn.setAutoCommit(false);
+            try
+            {
+                transactionState = getTransactionState(conn);
+                conn.isValid(0);
+                Assert.assertEquals("Transaction state has been changed",
+                                    transactionState,
+                                    getTransactionState(conn));
+
+                Statement stmt = conn.createStatement();
+                stmt.execute("SELECT 1");
+                transactionState = getTransactionState(conn);
+                conn.isValid(0);
+                Assert.assertEquals("Transaction state has been changed",
+                                    transactionState,
+                                    getTransactionState(conn));
+            }
+            finally
+            {
+                try
+                {
+                    conn.setAutoCommit(true);
+                }
+                catch (final Exception e) {}
+            }
+        }
+        finally
+        {
+            TestUtil.closeDB(conn);
+        }
     }
 
 }


### PR DESCRIPTION
Proposed fix for #214 

As suggested by @ringerc, `isValid()` now sends an empty statement.

Empty statements are then detected at lower level to prevent a BEGIN to be sent to the backend.
