### PR TITLE
Fix for setStringType in DataSource

### DIFF
--- a/org/postgresql/ds/common/BaseDataSource.java
+++ b/org/postgresql/ds/common/BaseDataSource.java
@@ -573,7 +573,7 @@ public abstract class BaseDataSource implements Referenceable
         sb.append("&binaryTransfer=").append(binaryTransfer);
 
         if ( stringType != null ) {
-            sb.append("&stringtype");
+            sb.append("&stringtype=");
             sb.append(stringType);
         }
 


### PR DESCRIPTION
Integration of fix #192 submitted by @einavitamar
## 

In a more general way, I think we should use a class of constants grouping all supported driver properties instead of leaving strings a bit everywhere in the code where this kind of mistake is possible.
Making this change can introduce big diff between master and older branches but with the upcoming release of 9.4, we may have less need to backpatch, thus reducing the impact.
Any advice before I possibly work on that?
