### PR TITLE
Honor stringtype=unspecified when also saving null values

### DIFF
--- a/org/postgresql/jdbc2/AbstractJdbc2Statement.java
+++ b/org/postgresql/jdbc2/AbstractJdbc2Statement.java
@@ -1175,7 +1175,7 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
             break;
         case Types.VARCHAR:
         case Types.LONGVARCHAR:
-            oid = Oid.VARCHAR;
+            oid = connection.getStringVarcharFlag() ? Oid.VARCHAR : Oid.UNSPECIFIED;
             break;
         case Types.DATE:
             oid = Oid.DATE;


### PR DESCRIPTION
This change applies the `stringtype=unspecified` setting to null values when using JDBC's `setNull` method with a sqlType of `VARCHAR` in addition to the `setString` method.

Currently, saving a string with `setString` applies `oid.UNSPECIFIED`, but saving null with `setNull(index, java.sql.Types.VARCHAR)` saves with `oid.VARCHAR`.

This causes problem with ORM layers that are, for example, saving strings to timestamp columns, which works in the non-null case, but creates a postgresql error when null.
