### PR TITLE
Add path for custom source repository of mvn dependencies

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -18,3 +18,5 @@ maven.snapshots.repository.id=sonatype-nexus-snapshots
 maven.snapshots.repository.url=https://oss.sonatype.org/content/repositories/snapshots
 maven.staging.repository.id=sonatype-nexus-staging
 maven.staging.repository.url=https://oss.sonatype.org/service/local/staging/deploy/maven2
+maven.remote.repository.id=central
+maven.remote.repository.url=http://repo1.maven.org/maven2

--- a/build.xml
+++ b/build.xml
@@ -125,6 +125,8 @@
     <artifact:dependencies>
       <dependency groupId="com.github.dblock.waffle" artifactId="waffle-jna"
                   version="${waffle-jna.version}" type="pom"/>
+      <remoteRepository id="${maven.remote.repository.id}"
+			url="${maven.remote.repository.url}" />
     </artifact:dependencies>
 
     <!-- Import Waffle's pom so we can reference its properties -->
@@ -217,13 +219,19 @@
     -->
     <artifact:dependencies pathId="dependency.compile.classpath"
                            filesetId="dependency.compile.fileset"
-                           pomRefId="org.postgresql:postgresql:pom"/>
+                           pomRefId="org.postgresql:postgresql:pom">
+      <remoteRepository id="${maven.remote.repository.id}"
+                        url="${maven.remote.repository.url}"/>
+    </artifact:dependencies>
 
     <!-- These libraries should be bundled for use at runtime and added to the
          classpath when running tests-->
     <artifact:dependencies pathId="dependency.runtime.classpath"
                            filesetId="dependency.runtime.fileset"
-                           pomRefId="org.postgresql:postgresql:pom"/>
+                           pomRefId="org.postgresql:postgresql:pom">
+      <remoteRepository id="${maven.remote.repository.id}"
+                        url="${maven.remote.repository.url}"/>
+    </artifact:dependencies>
 
     <!--
       These are used for test compilation and for test running only. They aren't
@@ -232,7 +240,10 @@
     <artifact:dependencies pathId="dependency.test.classpath"
                            filesetId="dependency.test.fileset"
                            useScope="test"
-                           pomRefId="org.postgresql:postgresql:pom"/>
+                           pomRefId="org.postgresql:postgresql:pom">
+      <remoteRepository id="${maven.remote.repository.id}"
+                        url="${maven.remote.repository.url}"/>
+    </artifact:dependencies>
 
     <!-- To make life easier for IDE users, copy dependencies to lib/ -->
     <copy todir="lib/">


### PR DESCRIPTION
This commit adds two parameters making possible to specify a custom
remote repository from which are fetched dependent packages needed
for the build:
- maven.remote.repository.id to define the id of the remote repository
- maven.remote.repository.url to define the URL of the remote repository
  Default values make process point to the central Maven repository, but
  those values can be enforced using build.local.properties.
