### PR TITLE
Unescape/unquote result of getSchema

### DIFF
--- a/org/postgresql/test/jdbc4/jdbc41/SchemaTest.java
+++ b/org/postgresql/test/jdbc4/jdbc41/SchemaTest.java
@@ -34,6 +34,7 @@ public class SchemaTest extends TestCase
         stmt.execute("CREATE SCHEMA \"schema 3\"");
         stmt.execute("CREATE SCHEMA \"schema \"\"4\"");
         stmt.execute("CREATE SCHEMA \"schema '5\"");
+        stmt.execute("CREATE SCHEMA \"schema ,6\"");
         stmt.execute("CREATE SCHEMA \"UpperCase\"");
         TestUtil.createTable(_conn, "schema1.table1", "id integer");
         TestUtil.createTable(_conn, "schema2.table2", "id integer");
@@ -49,6 +50,7 @@ public class SchemaTest extends TestCase
         stmt.execute("DROP SCHEMA \"schema 3\" CASCADE");
         stmt.execute("DROP SCHEMA \"schema \"\"4\" CASCADE");
         stmt.execute("DROP SCHEMA \"schema '5\" CASCADE");
+        stmt.execute("DROP SCHEMA \"schema ,6\"");
         stmt.execute("DROP SCHEMA \"UpperCase\" CASCADE");
         TestUtil.closeDB(_conn);
     }
@@ -63,13 +65,13 @@ public class SchemaTest extends TestCase
         _conn.setSchema("schema2");
         assertEquals("schema2", _conn.getSchema());
         _conn.setSchema("schema 3");
-        assertEquals("\"schema 3\"", _conn.getSchema());
+        assertEquals("schema 3", _conn.getSchema());
         _conn.setSchema("schema \"4");
-        assertEquals("\"schema \"\"4\"", _conn.getSchema());
+        assertEquals("schema \"4", _conn.getSchema());
         _conn.setSchema("schema '5");
-        assertEquals("\"schema '5\"", _conn.getSchema());
+        assertEquals("schema '5", _conn.getSchema());
         _conn.setSchema("UpperCase");
-        assertEquals("\"UpperCase\"", _conn.getSchema());
+        assertEquals("UpperCase", _conn.getSchema());
     }
 
     /**
@@ -162,6 +164,23 @@ public class SchemaTest extends TestCase
             }
         }
         assertEquals("schema1", _conn.getSchema());
+
+        stmt = _conn.createStatement();
+        try
+        {
+            stmt.execute("SET search_path TO \"schema ,6\",schema2");
+        }
+        finally
+        {
+            try
+            {
+                stmt.close();
+            }
+            catch (SQLException e)
+            {
+            }
+        }
+        assertEquals("schema ,6", _conn.getSchema());
     }
 
     public void testSchemaInProperties() throws Exception


### PR DESCRIPTION
Followup of my comment on #207 (november 21st)

This PR unquotes getSchema the same way setSchema is quoting it.
