### PR TITLE
Fix test code problem of test case testUpdateWithPGobject

### DIFF
--- a/org/postgresql/test/jdbc2/ResultSetTest.java
+++ b/org/postgresql/test/jdbc2/ResultSetTest.java
@@ -734,6 +734,7 @@ public class ResultSetTest extends TestCase
         Statement stmt = con.createStatement();
 
         ResultSet rs = stmt.executeQuery("select * from testpgobject where id = 1");
+        assertTrue(rs.next());
         assertEquals("2010-11-3", rs.getDate("d").toString());
 
         PGobject pgobj = new PGobject();
@@ -744,6 +745,7 @@ public class ResultSetTest extends TestCase
         rs.close();
 
         ResultSet rs1 = stmt.executeQuery("select * from testpgobject where id = 1");
+        assertTrue(rs1.next());
         assertEquals("2014-12-23", rs1.getDate("d").toString());
         rs1.close();
 


### PR DESCRIPTION
Adding invocation of ResultSet.next() before getting data from the results set.

Found following error when runing the jdbc2TestSuite:

```
 [junit] Testcase: testUpdateWithPGobject took 0.351 sec
 [junit]    Caused an ERROR
 [junit] ResultSet not positioned properly, perhaps you need to call next.
 [junit] org.postgresql.util.PSQLException: ResultSet not positioned properly, perhaps you need to call next.
 [junit]    at org.postgresql.jdbc2.AbstractJdbc2ResultSet.checkResultSet(AbstractJdbc2ResultSet.java:2882)
 [junit]    at org.postgresql.jdbc2.AbstractJdbc2ResultSet.getDate(AbstractJdbc2ResultSet.java:449)
 [junit]    at org.postgresql.jdbc2.AbstractJdbc2ResultSet.getDate(AbstractJdbc2ResultSet.java:2620)
 [junit]    at org.postgresql.test.jdbc2.ResultSetTest.testUpdateWithPGobject(ResultSetTest.java:737)
```

The error due to the cursor of result had not been point to the first row while trying to get data from the result set.
Fixed the issue by invoking ResultSet.next() before get any data from it.
