### PR TITLE
Fix the test code of testUpdateWithPGobject, for cannot update ResultSet

### DIFF
--- a/org/postgresql/test/jdbc2/ResultSetTest.java
+++ b/org/postgresql/test/jdbc2/ResultSetTest.java
@@ -94,7 +94,7 @@ public class ResultSetTest extends TestCase
         stmt.executeUpdate("INSERT INTO testnumeric VALUES('9223372036854775808')");
         stmt.executeUpdate("INSERT INTO testnumeric VALUES('-9223372036854775809')");
 
-        TestUtil.createTable(con, "testpgobject", "id integer, d date");
+        TestUtil.createTable(con, "testpgobject", "id integer NOT NULL, d date, PRIMARY KEY (id)");
         stmt.execute("INSERT INTO testpgobject VALUES(1, '2010-11-3')");
 
         stmt.close();
@@ -731,7 +731,8 @@ public class ResultSetTest extends TestCase
 
     public void testUpdateWithPGobject() throws SQLException
     {
-        Statement stmt = con.createStatement();
+        Statement stmt = con.createStatement(ResultSet.TYPE_SCROLL_INSENSITIVE,
+                                             ResultSet.CONCUR_UPDATABLE);
 
         ResultSet rs = stmt.executeQuery("select * from testpgobject where id = 1");
         assertTrue(rs.next());


### PR DESCRIPTION
The test testUpdateWithPGobject still failed due to other 2 issues below:

The ResultSet cannot be updated.
Fixed by initialize statement with flag "CONCUR_UPDATABLE".

```
[junit] Testcase: testUpdateWithPGobject(org.postgresql.test.jdbc2.ResultSetTest):  Caused an ERROR
[junit] ResultSets with concurrency CONCUR_READ_ONLY cannot be updated.
[junit] org.postgresql.util.PSQLException: ResultSets with concurrency CONCUR_READ_ONLY cannot be updated.
[junit]     at org.postgresql.jdbc2.AbstractJdbc2ResultSet.isUpdateable(AbstractJdbc2ResultSet.java:1583)
[junit]     at org.postgresql.jdbc2.AbstractJdbc2ResultSet.checkUpdateable(AbstractJdbc2ResultSet.java:2840)
[junit]     at org.postgresql.jdbc2.AbstractJdbc2ResultSet.updateValue(AbstractJdbc2ResultSet.java:3208)
[junit]     at org.postgresql.jdbc2.AbstractJdbc2ResultSet.updateObject(AbstractJdbc2ResultSet.java:1244)
[junit]     at org.postgresql.jdbc2.AbstractJdbc2ResultSet.updateObject(AbstractJdbc2ResultSet.java:1570)
[junit]     at org.postgresql.test.jdbc2.ResultSetTest.testUpdateWithPGobject(ResultSetTest.java:743)
[junit]
```

After issue above was fixed, will encounter "No primary key" issue when trying to update the table.
Fixed by setting primary key for test table "testpgobject".

```
[junit] Testcase: testUpdateWithPGobject(org.postgresql.test.jdbc2.ResultSetTest):  Caused an ERROR
[junit] No primary key found for table testpgobject.
[junit] org.postgresql.util.PSQLException: No primary key found for table testpgobject.
[junit]     at org.postgresql.jdbc2.AbstractJdbc2ResultSet.isUpdateable(AbstractJdbc2ResultSet.java:1651)
[junit]     at org.postgresql.jdbc2.AbstractJdbc2ResultSet.checkUpdateable(AbstractJdbc2ResultSet.java:2840)
[junit]     at org.postgresql.jdbc2.AbstractJdbc2ResultSet.updateValue(AbstractJdbc2ResultSet.java:3208)
[junit]     at org.postgresql.jdbc2.AbstractJdbc2ResultSet.updateObject(AbstractJdbc2ResultSet.java:1244)
[junit]     at org.postgresql.jdbc2.AbstractJdbc2ResultSet.updateObject(AbstractJdbc2ResultSet.java:1570)
[junit]     at org.postgresql.test.jdbc2.ResultSetTest.testUpdateWithPGobject(ResultSetTest.java:744)
[junit]
```

The  Jdbc2TestSuite can finally full pass now.

```
runtest:
      [mkdir] Created dir: /home/kingter/pgjdbc/build/testresults
      [junit] Testsuite: org.postgresql.test.jdbc2.Jdbc2TestSuite
      [junit] Tests run: 337, Failures: 0, Errors: 0, Time elapsed: 67.633 sec
```
