### PR TITLE
Fix connection URL generation for 'stringtype' parameter in BaseDataSour...

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -493,6 +493,7 @@
       <test name="org.postgresql.test.extensions.ExtensionsSuite" outfile="${testResultsDir}/extensions"/>
       <test name="org.postgresql.test.jdbc4.Jdbc4TestSuite" if="jdbc4tests" outfile="${testResultsDir}/jdbc4"/>
       <test name="org.postgresql.test.jdbc4.jdbc41.Jdbc41TestSuite" if="jdbc41tests" outfile="${testResultsDir}/jdbc41"/>
+      <test name="org.postgresql.test.ds.common.DataSourceTestSuite" outfile="${testResultsDir}/dscommon"/>
       <test name="org.postgresql.test.ssl.SslTestSuite" if="jdbc4tests" outfile="${testResultsDir}/ssl"/>
     </junit>
   </target>

--- a/org/postgresql/ds/common/BaseDataSource.java
+++ b/org/postgresql/ds/common/BaseDataSource.java
@@ -573,7 +573,7 @@ public abstract class BaseDataSource implements Referenceable
         sb.append("&binaryTransfer=").append(binaryTransfer);
 
         if ( stringType != null ) {
-            sb.append("&stringtype");
+            sb.append("&stringtype=");
             sb.append(stringType);
         }
 

--- a/org/postgresql/test/ds/common/BaseDataSourceParameterTest.java
+++ b/org/postgresql/test/ds/common/BaseDataSourceParameterTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 1997-2014, PostgreSQL Global Development Group
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. Neither the name of the PostgreSQL Global Development Group nor the names
+ *    of its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.postgresql.test.ds.common;
+
+import org.postgresql.ds.common.BaseDataSource;
+
+import junit.framework.TestCase;
+
+/**
+ * Test case for parameter handling in {@linkplain BaseDataSource}.
+ *
+ * @author Ancoron <ancoron.luciferis@gmail.com>
+ */
+public class BaseDataSourceParameterTest extends TestCase {
+
+    private BaseDataSource ds;
+
+    public BaseDataSourceParameterTest(String name) {
+        super(name);
+    }
+
+    protected void setUp() throws Exception {
+        ds = new BaseDataSource() {
+
+            public String getDescription() {
+                return "I am a test dummy";
+            }
+        };
+    }
+
+    protected void tearDown() throws Exception {
+        ds = null;
+    }
+
+    protected void assertContains(String str, String value) {
+        assertTrue("Expected '" + value
+                + "' to find inside the following string: " + str,
+                str.contains(value));
+    }
+
+    public void testStringtype() {
+        final String value = "unspecified";
+        ds.setStringType(value);
+
+        assertContains(ds.getUrl(), "&stringtype=" + value);
+    }
+}

--- a/org/postgresql/test/ds/common/DataSourceTestSuite.java
+++ b/org/postgresql/test/ds/common/DataSourceTestSuite.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 1997-2014, PostgreSQL Global Development Group
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. Neither the name of the PostgreSQL Global Development Group nor the names
+ *    of its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.postgresql.test.ds.common;
+
+import junit.framework.TestSuite;
+
+/**
+ * Executes all known tests for DataStore handling.
+ * 
+ * @author Ancoron <ancoron.luciferis@gmail.com>
+ */
+public class DataSourceTestSuite extends TestSuite
+{
+
+    /*
+     * The main entry point for JUnit
+     */
+    public static TestSuite suite() throws Exception
+    {
+        TestSuite suite = new TestSuite();
+        suite.addTestSuite(BaseDataSourceParameterTest.class);
+        return suite;
+    }
+}


### PR DESCRIPTION
...ce

Since commit e55ef21 introduced support for configuring the "stringtype" connection parameter also for DataSource instances, the resulting connection URL contained a type-o ("=" was missing betwwen parameter and value), resulting in the configured parameter not bein effective at all.

I've also included a test to verify the URL contains what it should contain (without involving a real connection though).