### PR TITLE
Make Pgjdbc an OSGi bundle

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -8,6 +8,8 @@ fullversion=9.4
 def_pgport=5432
 enable_debug=yes
 
+osgi.version=9.4.0.build-1200
+
 maven.group.id=org.postgresql
 maven.artifact.id=postgresql
 maven.artifact.version=9.4-1200

--- a/build.xml
+++ b/build.xml
@@ -423,6 +423,7 @@
       <attribute name="Bundle-DocURL" value="http://jdbc.postgresql.org/" />
 
       <attribute name="Bundle-Classpath" value="." />
+      <attribute name="Bundle-Activator" value="org.postgresql.osgi.PGBundleActivator" />
       <attribute name="Export-Package" value="org.postgresql*; version=${fullversion}" />
       <attribute name="Import-Package" value="javax.sql, javax.transaction.xa, javax.naming, *;resolution:=optional" />
     </manifest>
@@ -760,6 +761,7 @@
       <test name="org.postgresql.test.jdbc3.Jdbc3TestSuite" outfile="${testResultsDir}/jdbc3"/>
       <test name="org.postgresql.test.xa.XATestSuite" outfile="${testResultsDir}/xa"/>
       <test name="org.postgresql.test.extensions.ExtensionsSuite" outfile="${testResultsDir}/extensions"/>
+      <test name="org.postgresql.test.osgi.OsgiTestSuite" outfile="${testResultsDir}/osgi"/>
       <test name="org.postgresql.test.jdbc4.Jdbc4TestSuite" if="jdbc4tests" outfile="${testResultsDir}/jdbc4"/>
       <test name="org.postgresql.test.jdbc4.jdbc41.Jdbc41TestSuite" if="jdbc41tests" outfile="${testResultsDir}/jdbc41"/>
       <test name="org.postgresql.test.hostchooser.MultiHostSuite" outfile="${testResultsDir}/hostchooser"/>

--- a/build.xml
+++ b/build.xml
@@ -107,6 +107,9 @@
     <include name="${package}/xa/*.java"/>
     <include name="${package}/xa/jdbc3/*.java"/>
     <include name="${package}/xa/jdbc4/*.java" if="jdbc4any"/>
+
+    <!-- OSGi package -->
+    <include name="${package}/osgi/*.java"/>
   </patternset>
 
   <property name="waffle-jna.version" value="1.7" />
@@ -211,7 +214,7 @@
       <dependency groupId="junit" artifactId="junit" version="4.11"
                   scope="test"/>
 
-      <dependency groupId="org.osgi" artifactId="org.osgi.core" version="4.2.0"
+      <dependency groupId="org.osgi" artifactId="org.osgi.core" version="4.3.1"
                   scope="provided"/>
       <dependency groupId="org.osgi" artifactId="org.osgi.enterprise" version="4.2.0"
                   scope="provided"/>
@@ -254,7 +257,7 @@
       These are used for building only and are only exposed for ant script
     -->
     <artifact:dependencies pathId="dependency.build.classpath">
-      <dependency groupId="biz.aQute" artifactId="bnd" version="1.50.0"/>
+      <dependency groupId="biz.aQute.bnd" artifactId="bnd" version="2.4.0"/>
     </artifact:dependencies>
 
     <!-- To make life easier for IDE users, copy dependencies to lib/ -->
@@ -410,23 +413,24 @@
     <mkdir dir="${osgidir}"/>
 
     <!--   create a bnd file named after the JAR file so that bnd wrap tool find it -->
-    <manifest file="${osgidir}/${artifact.version.string}.bnd" mode="replace">
-      <attribute name="Bundle-ManifestVersion" value="2" />
+    <echo file="${osgidir}/${artifact.version.string}.bnd">
+Bundle-ManifestVersion: 2
 
-      <attribute name="Bundle-Name" value="PostgreSQL JDBC Driver ${jdbc.version.upper}" />
-      <attribute name="Bundle-SymbolicName" value="org.postgresql.${jdbc.version}" />
-      <attribute name="Bundle-Version" value="${osgi.version}" />
+Bundle-Name: PostgreSQL JDBC Driver ${jdbc.version.upper}
+Bundle-SymbolicName: org.postgresql.${jdbc.version}
+Bundle-Version: ${osgi.version}
 
-      <attribute name="Bundle-Vendor" value="PostgreSQL Global Development Group" />
-      <attribute name="Bundle-Copyright" value="Copyright (c) 2003-2015, PostgreSQL Global Development Group" />
-      <attribute name="Bundle-License" value="http://www.postgresql.org/about/licence/" />
-      <attribute name="Bundle-DocURL" value="http://jdbc.postgresql.org/" />
+Bundle-Vendor: PostgreSQL Global Development Group
+Bundle-Copyright: Copyright (c) 2003-2015, PostgreSQL Global Development Group
+Bundle-License: http://www.postgresql.org/about/licence/
+Bundle-DocURL: http://jdbc.postgresql.org/
 
-      <attribute name="Bundle-Classpath" value="." />
-      <attribute name="Bundle-Activator" value="org.postgresql.osgi.PGBundleActivator" />
-      <attribute name="Export-Package" value="org.postgresql*; version=${fullversion}" />
-      <attribute name="Import-Package" value="javax.sql, javax.transaction.xa, javax.naming, *;resolution:=optional" />
-    </manifest>
+Bundle-Classpath: .
+Bundle-Activator: org.postgresql.osgi.PGBundleActivator
+Require-Capability: osgi.ee;filter:="(&amp;(|(osgi.ee=J2SE)(osgi.ee=JavaSE))(version>=${java.specification.version}))"
+Export-Package: org.postgresql*; version=${fullversion}
+Import-Package: javax.sql, javax.transaction.xa, javax.naming, *;resolution:=optional
+    </echo>
 
     <!--   run wrap task from bnd -->
     <taskdef resource="aQute/bnd/ant/taskdef.properties" classpathref="dependency.build.classpath"/> 

--- a/build.xml
+++ b/build.xml
@@ -211,6 +211,10 @@
       <dependency groupId="junit" artifactId="junit" version="4.11"
                   scope="test"/>
 
+      <dependency groupId="org.osgi" artifactId="org.osgi.core" version="4.2.0"
+                  scope="provided"/>
+      <dependency groupId="org.osgi" artifactId="org.osgi.enterprise" version="4.2.0"
+                  scope="provided"/>
     </artifact:pom>
 
     <!--
@@ -246,6 +250,13 @@
                         url="${maven.remote.repository.url}"/>
     </artifact:dependencies>
 
+    <!--
+      These are used for building only and are only exposed for ant script
+    -->
+    <artifact:dependencies pathId="dependency.build.classpath">
+      <dependency groupId="biz.aQute" artifactId="bnd" version="1.50.0"/>
+    </artifact:dependencies>
+
     <!-- To make life easier for IDE users, copy dependencies to lib/ -->
     <copy todir="lib/">
       <fileset refid="dependency.compile.fileset"/>
@@ -255,9 +266,6 @@
     </copy>
 
   </target>
-  <artifact:dependencies pathId="dependency.classpath" useScope="test">
-    <dependency groupId="junit" artifactId="junit" version="4.11" scope="test"/>
-  </artifact:dependencies>
 
   <target name="check_versions">
     <condition property="jdbc2">
@@ -346,6 +354,18 @@
     <condition property="jdbc.version.upper" value="JDBC41">
       <isset property="jdbc41" />
     </condition>
+
+    <condition property="jdbc.version.numeric" value="3.0">
+      <isset property="jdbc3any" />
+    </condition>
+
+    <condition property="jdbc.version.numeric" value="4.0">
+      <isset property="jdbc4" />
+    </condition>
+
+    <condition property="jdbc.version.numeric" value="4.1">
+      <isset property="jdbc41" />
+    </condition>
   </target>
 
   <!-- default target -->
@@ -355,8 +375,13 @@
 
   <!-- create the jar file -->
   <target name="jar" depends="compile, artifact-version">
+    <property name="temp.jar.dir" value="${builddir}/${jardir}"/>
     <property name="artifact.jar" value="${jardir}/${artifact.version.string}.jar"/>
-    <jar jarfile="${artifact.jar}">
+    <property name="artifact.jar.build" value="${temp.jar.dir}/${artifact.version.string}.jar"/>
+
+    <mkdir dir="${temp.jar.dir}" />
+
+    <jar jarfile="${artifact.jar.build}">
       <fileset dir="${builddir}">
         <include name="${package}/**/*.class" />
       </fileset>
@@ -369,8 +394,42 @@
       </metainf>
       <manifest>
         <attribute name="Main-Class" value="org.postgresql.util.PGJDBCMain"/>
+
+        <attribute name="Specification-Title" value="JDBC" />
+        <attribute name="Specification-Version" value="${jdbc.version.numeric}" />
+        <attribute name="Specification-Vendor" value="Oracle Corporation" />
+
+        <attribute name="Implementation-Title" value="PostgreSQL JDBC Driver" />
+        <attribute name="Implementation-Version" value="${fullversion}" />
+        <attribute name="Implementation-Vendor" value="PostgreSQL Global Development Group" />
       </manifest>
     </jar>
+
+    <!-- add OSGi meta information -->
+    <property name="osgidir" value="${builddir}/osgi"/>
+    <mkdir dir="${osgidir}"/>
+
+    <!--   create a bnd file named after the JAR file so that bnd wrap tool find it -->
+    <manifest file="${osgidir}/${artifact.version.string}.bnd" mode="replace">
+      <attribute name="Bundle-ManifestVersion" value="2" />
+
+      <attribute name="Bundle-Name" value="PostgreSQL JDBC Driver ${jdbc.version.upper}" />
+      <attribute name="Bundle-SymbolicName" value="org.postgresql.${jdbc.version}" />
+      <attribute name="Bundle-Version" value="${osgi.version}" />
+
+      <attribute name="Bundle-Vendor" value="PostgreSQL Global Development Group" />
+      <attribute name="Bundle-Copyright" value="Copyright (c) 2003-2015, PostgreSQL Global Development Group" />
+      <attribute name="Bundle-License" value="http://www.postgresql.org/about/licence/" />
+      <attribute name="Bundle-DocURL" value="http://jdbc.postgresql.org/" />
+
+      <attribute name="Bundle-Classpath" value="." />
+      <attribute name="Export-Package" value="org.postgresql*; version=${fullversion}" />
+      <attribute name="Import-Package" value="javax.sql, javax.transaction.xa, javax.naming, *;resolution:=optional" />
+    </manifest>
+
+    <!--   run wrap task from bnd -->
+    <taskdef resource="aQute/bnd/ant/taskdef.properties" classpathref="dependency.build.classpath"/> 
+    <bndwrap jars="${artifact.jar.build}" output="${artifact.jar}" definitions="${osgidir}"/>
   </target>
 
   <!-- create a distribution with docs, dependencies, and driver jar -->

--- a/org/postgresql/Driver.java.in
+++ b/org/postgresql/Driver.java.in
@@ -52,7 +52,8 @@ public class Driver implements java.sql.Driver
     public static final int DEBUG = 2;
     public static final int INFO = 1;
     public static final int OFF = 0;
-    
+
+    private static Driver registeredDriver;
     private static final Logger logger = new Logger();
     private static boolean logLevelSet = false;
     private static SharedTimer sharedTimer = new SharedTimer(logger);
@@ -65,11 +66,11 @@ public class Driver implements java.sql.Driver
             // because some clients call the driver themselves (I know, as
             // my early jdbc work did - and that was based on other examples).
             // Placing it here, means that the driver is registered once only.
-            java.sql.DriverManager.registerDriver(new Driver());
+            register();
         }
         catch (SQLException e)
         {
-            e.printStackTrace();
+            throw new ExceptionInInitializerError(e);
         }
     }
 
@@ -700,5 +701,49 @@ public class Driver implements java.sql.Driver
 
     public static SharedTimer getSharedTimer() {
         return sharedTimer;
+    }
+
+    /**
+     * Register the driver against {@link DriverManager}. This is done automatically when the class is loaded.
+     * Dropping the driver from DriverManager's list is possible using {@link #deregister()} method. 
+     * 
+     * @throws IllegalStateException if the driver is already registered
+     * @throws SQLException if registering the driver fails
+     */
+    public static void register() throws SQLException
+    {
+        if (isRegistered())
+        {
+            throw new IllegalStateException("Driver is already registered. It can only be registered once.");
+        }
+        Driver registeredDriver = new Driver();
+        DriverManager.registerDriver(registeredDriver);
+        Driver.registeredDriver = registeredDriver;
+    }
+
+    /**
+     * According to JDBC specification, this driver is registered against {@link DriverManager}
+     * when the class is loaded. To avoid leaks, this method allow unregistering the driver
+     * so that the class can be gc'ed if necessary.
+     * @throws IllegalStateException if the driver is not registered
+     * @throws SQLException if deregistering the driver fails
+     */
+    public static void deregister() throws SQLException
+    {
+        if (!isRegistered())
+        {
+            throw new IllegalStateException("Driver is not registered (or it has not been registered using Driver.register() method)");
+        }
+        DriverManager.deregisterDriver(registeredDriver);
+        registeredDriver = null;
+    }
+
+    /**
+     * 
+     * @return {@code true} if the driver is registered against {@link DriverManager}
+     */
+    public static boolean isRegistered()
+    {
+        return registeredDriver != null;
     }
 }

--- a/org/postgresql/ds/common/BaseDataSource.java
+++ b/org/postgresql/ds/common/BaseDataSource.java
@@ -10,7 +10,9 @@ package org.postgresql.ds.common;
 import javax.naming.*;
 
 import org.postgresql.PGProperty;
+import org.postgresql.util.GT;
 import org.postgresql.util.PSQLException;
+import org.postgresql.util.PSQLState;
 
 import java.sql.*;
 import java.io.IOException;
@@ -959,33 +961,73 @@ public abstract class BaseDataSource implements Referenceable
         
         for (PGProperty property: PGProperty.values())
         {
-            switch(property)
-            {
-                case PG_HOST:
-                    serverName = property.get(properties);
-                    break;
-                case PG_PORT:
-                    try
-                    {
-                        portNumber = property.getInt(properties);
-                    }
-                    catch (PSQLException e)
-                    {
-                        portNumber = 0;
-                    }
-                    break;
-                case PG_DBNAME:
-                    databaseName = property.get(properties);
-                    break;
-                case USER:
-                    user = property.get(properties);
-                    break;
-                case PASSWORD:
-                    password = property.get(properties);
-                    break;
-                default:
-                    properties.setProperty(property.getName(), property.get(properties));
-            }
+            setProperty(property, property.get(p));
+        }
+    }
+
+    public String getProperty(String name)
+      throws SQLException
+    {
+        PGProperty pgProperty = PGProperty.forName(name);
+        if (pgProperty != null)
+        {
+            return getProperty(pgProperty);
+        }
+        else
+        {
+            throw new PSQLException(GT.tr("Unsupported property name: {0}", name),
+                                    PSQLState.INVALID_PARAMETER_VALUE);
+        }
+    }
+
+    public void setProperty(String name, String value)
+      throws SQLException
+    {
+        PGProperty pgProperty = PGProperty.forName(name);
+        if (pgProperty != null)
+        {
+            setProperty(pgProperty, value);
+        }
+        else
+        {
+            throw new PSQLException(GT.tr("Unsupported property name: {0}", name),
+                                    PSQLState.INVALID_PARAMETER_VALUE);
+        }
+    }
+
+    public String getProperty(PGProperty property)
+    {
+        return property.get(properties);
+    }
+
+    public void setProperty(PGProperty property, String value)
+    {
+        switch(property)
+        {
+            case PG_HOST:
+                serverName = value;
+                break;
+            case PG_PORT:
+                try
+                {
+                    portNumber = Integer.parseInt(value);
+                }
+                catch (NumberFormatException e)
+                {
+                    portNumber = 0;
+                }
+                break;
+            case PG_DBNAME:
+                databaseName = value;
+                break;
+            case USER:
+                user = value;
+                break;
+            case PASSWORD:
+                password = value;
+                break;
+            default:
+                properties.setProperty(property.getName(), value);
         }
     }
 

--- a/org/postgresql/osgi/PGBundleActivator.java
+++ b/org/postgresql/osgi/PGBundleActivator.java
@@ -1,0 +1,48 @@
+/*-------------------------------------------------------------------------
+*
+* Copyright (c) 2003-2015, PostgreSQL Global Development Group
+*
+*
+*-------------------------------------------------------------------------
+*/
+package org.postgresql.osgi;
+
+import java.util.Properties;
+
+import org.osgi.framework.BundleActivator;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.jdbc.DataSourceFactory;
+import org.postgresql.Driver;
+
+/**
+ * This class is an OSGi Bundle Activator and should only be used internally by the OSGi Framework
+ */
+public class PGBundleActivator implements BundleActivator
+{
+    private ServiceRegistration _registration;
+
+    public void start(BundleContext context) throws Exception
+    {
+        Properties properties = new Properties();
+        properties.put(DataSourceFactory.OSGI_JDBC_DRIVER_CLASS, Driver.class.getName());
+        properties.put(DataSourceFactory.OSGI_JDBC_DRIVER_NAME, "Postgresql JDBC Driver");
+        properties.put(DataSourceFactory.OSGI_JDBC_DRIVER_VERSION, Driver.getVersion());
+        _registration = context.registerService(DataSourceFactory.class.getName(),
+                                                new PGDataSourceFactory(),
+                                                properties);
+    }
+
+    public void stop(BundleContext context) throws Exception
+    {
+        if (_registration != null)
+        {
+            _registration.unregister();
+        }
+
+        if (Driver.isRegistered())
+        {
+            Driver.deregister();
+        }
+    }
+}

--- a/org/postgresql/osgi/PGBundleActivator.java
+++ b/org/postgresql/osgi/PGBundleActivator.java
@@ -7,7 +7,8 @@
 */
 package org.postgresql.osgi;
 
-import java.util.Properties;
+import java.util.Dictionary;
+import java.util.Hashtable;
 
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
@@ -24,9 +25,9 @@ public class PGBundleActivator implements BundleActivator
 
     public void start(BundleContext context) throws Exception
     {
-        Properties properties = new Properties();
+        Dictionary<String,Object> properties = new Hashtable<String,Object>();
         properties.put(DataSourceFactory.OSGI_JDBC_DRIVER_CLASS, Driver.class.getName());
-        properties.put(DataSourceFactory.OSGI_JDBC_DRIVER_NAME, "Postgresql JDBC Driver");
+        properties.put(DataSourceFactory.OSGI_JDBC_DRIVER_NAME, "PostgreSQL JDBC Driver");
         properties.put(DataSourceFactory.OSGI_JDBC_DRIVER_VERSION, Driver.getVersion());
         _registration = context.registerService(DataSourceFactory.class.getName(),
                                                 new PGDataSourceFactory(),
@@ -38,6 +39,7 @@ public class PGBundleActivator implements BundleActivator
         if (_registration != null)
         {
             _registration.unregister();
+            _registration = null;
         }
 
         if (Driver.isRegistered())

--- a/org/postgresql/osgi/PGDataSourceFactory.java
+++ b/org/postgresql/osgi/PGDataSourceFactory.java
@@ -1,0 +1,170 @@
+/*-------------------------------------------------------------------------
+*
+* Copyright (c) 2003-2015, PostgreSQL Global Development Group
+*
+*
+*-------------------------------------------------------------------------
+*/
+package org.postgresql.osgi;
+
+import java.sql.SQLException;
+import java.util.Map.Entry;
+import java.util.Properties;
+
+import javax.sql.ConnectionPoolDataSource;
+import javax.sql.DataSource;
+import javax.sql.XADataSource;
+
+import org.osgi.service.jdbc.DataSourceFactory;
+import org.postgresql.ds.common.BaseDataSource;
+import org.postgresql.jdbc2.optional.ConnectionPool;
+import org.postgresql.jdbc2.optional.PoolingDataSource;
+import org.postgresql.jdbc2.optional.SimpleDataSource;
+import org.postgresql.util.GT;
+import org.postgresql.util.PSQLException;
+import org.postgresql.util.PSQLState;
+import org.postgresql.xa.PGXADataSource;
+
+/**
+ * This factory service is designed to be used in OSGi Enterprise environments 
+ * to create and configure JDBC data-sources.
+ */
+public class PGDataSourceFactory implements DataSourceFactory
+{
+
+    /**
+     * A class that removes properties as they are used (without modifying the supplied initial Properties)
+     */
+    private static class SingleUseProperties extends Properties
+    {
+        private static final long serialVersionUID = 1L;
+
+        public SingleUseProperties(Properties initialProperties)
+        {
+            super();
+            if (initialProperties != null)
+            {
+                putAll(initialProperties);
+            }
+        }
+
+        @Override
+        public String getProperty(String key)
+        {
+            String value = super.getProperty(key);
+            remove(key);
+            return value;
+        }
+    }
+
+    private void configureBaseDataSource(BaseDataSource ds, Properties props)
+      throws SQLException
+    {
+        if (props.containsKey(JDBC_URL))
+        {
+            ds.setUrl(props.getProperty(JDBC_URL));
+        }
+        if (props.containsKey(JDBC_SERVER_NAME))
+        {
+            ds.setServerName(props.getProperty(JDBC_SERVER_NAME));
+        }
+        if (props.containsKey(JDBC_PORT_NUMBER))
+        {
+            ds.setPortNumber(Integer.parseInt(props.getProperty(JDBC_PORT_NUMBER)));
+        }
+        if (props.containsKey(JDBC_DATABASE_NAME))
+        {
+            ds.setDatabaseName(props.getProperty(JDBC_DATABASE_NAME));
+        }
+        if (props.containsKey(JDBC_USER))
+        {
+            ds.setUser(props.getProperty(JDBC_USER));
+        }
+        if (props.containsKey(JDBC_PASSWORD))
+        {
+            ds.setPassword(props.getProperty(JDBC_PASSWORD));
+        }
+
+        for (Entry<Object, Object> entry : props.entrySet())
+        {
+            ds.setProperty((String) entry.getKey(), (String) entry.getValue());
+        }
+    }
+
+    public java.sql.Driver createDriver(Properties props) throws SQLException
+    {
+        if (props != null && !props.isEmpty())
+        {
+            throw new PSQLException(GT.tr("Unsupported properties: {0}", props.stringPropertyNames()),
+                                          PSQLState.INVALID_PARAMETER_VALUE);
+        }
+        org.postgresql.Driver driver = new org.postgresql.Driver();
+        return driver;
+    }
+
+    private DataSource createPoolingDataSource(Properties props) throws SQLException
+    {
+        PoolingDataSource dataSource = new PoolingDataSource();
+        if (props.containsKey(JDBC_INITIAL_POOL_SIZE))
+        {
+            dataSource.setInitialConnections(Integer.parseInt(props.getProperty(JDBC_INITIAL_POOL_SIZE)));
+        }
+        if (props.containsKey(JDBC_MAX_POOL_SIZE))
+        {
+            dataSource.setMaxConnections(Integer.parseInt(props.getProperty(JDBC_MAX_POOL_SIZE)));
+        }
+        if (props.containsKey(JDBC_DATASOURCE_NAME))
+        {
+            dataSource.setDataSourceName(props.getProperty(JDBC_DATASOURCE_NAME)); 
+        }
+        configureBaseDataSource(dataSource, props);
+        return dataSource;
+    }
+
+    private DataSource createSimpleDataSource(Properties props) throws SQLException
+    {
+        SimpleDataSource dataSource = new SimpleDataSource();
+        configureBaseDataSource(dataSource, props);
+        return dataSource;
+    }
+
+    /**
+     * Will create and return either a {@link SimpleDataSource} or a {@link PoolingDataSource} depending 
+     * on the presence in the supplied properties of any pool-related property
+     * (eg.: {@code JDBC_INITIAL_POOL_SIZE} or {@code JDBC_MAX_POOL_SIZE})
+     */
+    public DataSource createDataSource(Properties props) throws SQLException
+    {
+        props = new SingleUseProperties(props);
+        if (props.containsKey(JDBC_INITIAL_POOL_SIZE) ||
+            props.containsKey(JDBC_MIN_POOL_SIZE) ||
+            props.containsKey(JDBC_MAX_POOL_SIZE) ||
+            props.containsKey(JDBC_MAX_IDLE_TIME) ||
+            props.containsKey(JDBC_MAX_STATEMENTS))
+        {
+            return createPoolingDataSource(props);
+        }
+        else
+        {
+            return createSimpleDataSource(props);
+        }
+    }
+
+    public ConnectionPoolDataSource createConnectionPoolDataSource(Properties props)
+        throws SQLException
+    {
+        props = new SingleUseProperties(props);
+        ConnectionPool dataSource = new ConnectionPool();
+        configureBaseDataSource(dataSource, props);
+        return dataSource;
+    }
+
+    public XADataSource createXADataSource(Properties props)
+        throws SQLException
+    {
+        props = new SingleUseProperties(props);
+        PGXADataSource dataSource = new PGXADataSource();
+        configureBaseDataSource(dataSource, props);
+        return dataSource;
+    }
+}

--- a/org/postgresql/test/osgi/OsgiTestSuite.java
+++ b/org/postgresql/test/osgi/OsgiTestSuite.java
@@ -1,0 +1,19 @@
+/*-------------------------------------------------------------------------
+*
+* Copyright (c) 2003-2015, PostgreSQL Global Development Group
+*
+*
+*-------------------------------------------------------------------------
+*/
+package org.postgresql.test.osgi;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+@RunWith(Suite.class)
+@SuiteClasses({PGDataSourceFactoryTest.class})
+public class OsgiTestSuite
+{
+
+}

--- a/org/postgresql/test/osgi/PGDataSourceFactoryTest.java
+++ b/org/postgresql/test/osgi/PGDataSourceFactoryTest.java
@@ -1,0 +1,127 @@
+/*-------------------------------------------------------------------------
+*
+* Copyright (c) 2003-2015, PostgreSQL Global Development Group
+*
+*
+*-------------------------------------------------------------------------
+*/
+package org.postgresql.test.osgi;
+
+import java.sql.Driver;
+import java.util.Properties;
+
+import javax.sql.ConnectionPoolDataSource;
+import javax.sql.DataSource;
+import javax.sql.XADataSource;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.osgi.service.jdbc.DataSourceFactory;
+import org.postgresql.jdbc2.optional.ConnectionPool;
+import org.postgresql.jdbc2.optional.PoolingDataSource;
+import org.postgresql.jdbc2.optional.SimpleDataSource;
+import org.postgresql.osgi.PGDataSourceFactory;
+import org.postgresql.xa.PGXADataSource;
+
+public class PGDataSourceFactoryTest
+{
+
+    private DataSourceFactory _dataSourceFactory;
+
+    @Before
+    public void createFactory()
+    {
+        _dataSourceFactory = new PGDataSourceFactory();
+    }
+
+    @Test
+    public void testCreateDriverDefault()
+      throws Exception
+    {
+        Driver driver = _dataSourceFactory.createDriver(null);
+        Assert.assertTrue(driver instanceof org.postgresql.Driver);
+    }
+
+    @Test
+    public void testCreateDataSourceDefault()
+      throws Exception
+    {
+        DataSource dataSource = _dataSourceFactory.createDataSource(null);
+        Assert.assertNotNull(dataSource);
+    }
+
+    @Test
+    public void testCreateDataSourceSimple()
+      throws Exception
+    {
+        Properties properties = new Properties();
+        properties.put(DataSourceFactory.JDBC_DATABASE_NAME, "db");
+        properties.put("currentSchema", "schema");
+        DataSource dataSource = _dataSourceFactory.createDataSource(properties);
+        Assert.assertNotNull(dataSource);
+        Assert.assertTrue(dataSource instanceof SimpleDataSource);
+        SimpleDataSource simpleDataSource = (SimpleDataSource) dataSource;
+        Assert.assertEquals("db", simpleDataSource.getDatabaseName());
+        Assert.assertEquals("schema", simpleDataSource.getCurrentSchema());
+    }
+
+    @Test
+    public void testCreateDataSourcePooling()
+      throws Exception
+    {
+        Properties properties = new Properties();
+        properties.put(DataSourceFactory.JDBC_DATABASE_NAME, "db");
+        properties.put(DataSourceFactory.JDBC_INITIAL_POOL_SIZE, "5");
+        properties.put(DataSourceFactory.JDBC_MAX_POOL_SIZE, "10");
+        DataSource dataSource = _dataSourceFactory.createDataSource(properties);
+        Assert.assertNotNull(dataSource);
+        Assert.assertTrue(dataSource instanceof PoolingDataSource);
+        PoolingDataSource poolingDataSource = (PoolingDataSource) dataSource;
+        Assert.assertEquals("db", poolingDataSource.getDatabaseName());
+        Assert.assertEquals(5, poolingDataSource.getInitialConnections());
+        Assert.assertEquals(10, poolingDataSource.getMaxConnections());
+    }
+
+    @Test
+    public void testCreateConnectionPoolDataSourceDefault()
+      throws Exception
+    {
+        ConnectionPoolDataSource dataSource = _dataSourceFactory.createConnectionPoolDataSource(null);
+        Assert.assertNotNull(dataSource);
+    }
+
+    @Test
+    public void testCreateConnectionPoolDataSourceConfigured()
+      throws Exception
+    {
+        Properties properties = new Properties();
+        properties.put(DataSourceFactory.JDBC_DATABASE_NAME, "db");
+        ConnectionPoolDataSource dataSource = _dataSourceFactory.createConnectionPoolDataSource(properties);
+        Assert.assertNotNull(dataSource);
+        Assert.assertTrue(dataSource instanceof ConnectionPool);
+        ConnectionPool connectionPoolDataSource = (ConnectionPool) dataSource;
+        Assert.assertEquals("db", connectionPoolDataSource.getDatabaseName());
+    }
+
+    @Test
+    public void testCreateXADataSourceDefault()
+      throws Exception
+    {
+        XADataSource dataSource = _dataSourceFactory.createXADataSource(null);
+        Assert.assertNotNull(dataSource);
+    }
+
+    @Test
+    public void testCreateXADataSourceConfigured()
+      throws Exception
+    {
+        Properties properties = new Properties();
+        properties.put(DataSourceFactory.JDBC_DATABASE_NAME, "db");
+        XADataSource dataSource = _dataSourceFactory.createXADataSource(properties);
+        Assert.assertNotNull(dataSource);
+        Assert.assertTrue(dataSource instanceof PGXADataSource);
+        PGXADataSource xaDataSource = (PGXADataSource) dataSource;
+        Assert.assertEquals("db", xaDataSource.getDatabaseName());
+    }
+}


### PR DESCRIPTION
Added OSGi metadata and expose the driver as a JDBC service using dedicated `DataSourceFactory` of OSGi Enterprise.

This fixes enlarged scope of issue #71 and [a related conversation thread](http://www.postgresql.org/message-id/CAHL_zcPSif+Z7ZcpROYN28LOQA=CWU431fDfHYNbkj2x=_xJTA@mail.gmail.com)

The bundle version is defined in `build.properties` file. We may need to do something more generic concerning version computation so as to keep all versions aligned (maven version, osgi version, ant tokens, ...).

Imported and exported packages are computed automatically using `bnd` tool so as to reduce the maintenance cost of metadatas.

For the need of the bundle activator, the driver is now able to deregister from the driver manager (in case the bundle is stopped/unloaded). In addition to this case, deregistering methods may be used in some other situations where class unloading is expected (JEE containers for example).

There is now a compile time dependency with osgi-core and osgi-enterprise, added in the maven pom as a 'provided' dependency.