### PR TITLE
Replace StringBuffer with StringBuilder

### DIFF
--- a/org/postgresql/Driver.java.in
+++ b/org/postgresql/Driver.java.in
@@ -550,8 +550,8 @@ public class Driver implements java.sql.Driver
             urlProps.setProperty("PGDBNAME", l_urlServer.substring(slash + 1));
 
             String[] addresses = l_urlServer.substring(0, slash).split(",");
-            StringBuffer hosts = new StringBuffer();
-            StringBuffer ports = new StringBuffer();
+            StringBuilder hosts = new StringBuilder();
+            StringBuilder ports = new StringBuilder();
             for (int addr = 0; addr < addresses.length; ++addr) {
                 String address = addresses[addr];
                 

--- a/org/postgresql/core/Parser.java
+++ b/org/postgresql/core/Parser.java
@@ -195,7 +195,7 @@ public class Parser {
         if (query == null) return query;
 
         char[] aChars = query.toCharArray();
-        StringBuffer buf = new StringBuffer(aChars.length);
+        StringBuilder buf = new StringBuilder(aChars.length);
         for(int i=0, j=-1; i< aChars.length; i++)
         {
             switch (aChars[i])

--- a/org/postgresql/core/v2/ConnectionFactoryImpl.java
+++ b/org/postgresql/core/v2/ConnectionFactoryImpl.java
@@ -485,8 +485,8 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
         String appName = PGProperty.APPLICATION_NAME.get(info);
         if (appName != null && dbVersion.compareTo("9.0") >= 0)
         {
-            StringBuffer sb = new StringBuffer("SET application_name = '");
-            Utils.appendEscapedLiteral(sb, appName, protoConnection.getStandardConformingStrings());
+            StringBuilder sb = new StringBuilder("SET application_name = '");
+            Utils.escapeLiteral(sb, appName, protoConnection.getStandardConformingStrings());
             sb.append("'");
             SetupQueryRunner.run(protoConnection, sb.toString(), false);
         }
@@ -494,8 +494,8 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
         String currentSchema = PGProperty.CURRENT_SCHEMA.get(info);
         if (currentSchema != null)
         {
-            StringBuffer sb = new StringBuffer("SET search_path = '");
-            Utils.appendEscapedLiteral(sb, appName, protoConnection.getStandardConformingStrings());
+            StringBuilder sb = new StringBuilder("SET search_path = '");
+            Utils.escapeLiteral(sb, appName, protoConnection.getStandardConformingStrings());
             sb.append("'");
             SetupQueryRunner.run(protoConnection, sb.toString(), false);
         }

--- a/org/postgresql/core/v2/SimpleParameterList.java
+++ b/org/postgresql/core/v2/SimpleParameterList.java
@@ -60,12 +60,12 @@ class SimpleParameterList implements ParameterList {
     }
 
     public void setStringParameter(int index, String value, int oid) throws SQLException {
-        StringBuffer sbuf = new StringBuffer(2 + value.length() * 11 / 10); // Add 10% for escaping.
+        StringBuilder sbuf = new StringBuilder(2 + value.length() * 11 / 10); // Add 10% for escaping.
 
         if (useEStringSyntax)
             sbuf.append(' ').append('E');
         sbuf.append('\'');
-        Utils.appendEscapedLiteral(sbuf, value, false);
+        Utils.escapeLiteral(sbuf, value, false);
         sbuf.append('\'');
 
         setLiteralParameter(index, sbuf.toString(), oid);

--- a/org/postgresql/core/v2/V2Query.java
+++ b/org/postgresql/core/v2/V2Query.java
@@ -88,7 +88,7 @@ class V2Query implements Query {
     }
 
     public String toString(ParameterList parameters) {
-        StringBuffer sbuf = new StringBuffer(fragments[0]);
+        StringBuilder sbuf = new StringBuilder(fragments[0]);
         for (int i = 1; i < fragments.length; ++i)
         {
             if (parameters == null)

--- a/org/postgresql/core/v3/CompositeQuery.java
+++ b/org/postgresql/core/v3/CompositeQuery.java
@@ -32,7 +32,7 @@ class CompositeQuery implements V3Query {
     }
 
     public String toString(ParameterList parameters) {
-        StringBuffer sbuf = new StringBuffer(subqueries[0].toString());
+        StringBuilder sbuf = new StringBuilder(subqueries[0].toString());
         for (int i = 1; i < subqueries.length; ++i)
         {
             sbuf.append(';');

--- a/org/postgresql/core/v3/ConnectionFactoryImpl.java
+++ b/org/postgresql/core/v3/ConnectionFactoryImpl.java
@@ -339,7 +339,7 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
     private void sendStartupPacket(PGStream pgStream, String[][] params, Logger logger) throws IOException {
         if (logger.logDebug())
         {
-            StringBuffer details = new StringBuffer();
+            StringBuilder details = new StringBuilder();
             for (int i = 0; i < params.length; ++i)
             {
                 if (i != 0)
@@ -758,9 +758,9 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
 
         String appName = PGProperty.APPLICATION_NAME.get(info);
         if (appName != null && dbVersion >= 90000) {
-            StringBuffer sql = new StringBuffer();
+            StringBuilder sql = new StringBuilder();
             sql.append("SET application_name = '");
-            Utils.appendEscapedLiteral(sql, appName, protoConnection.getStandardConformingStrings());
+            Utils.escapeLiteral(sql, appName, protoConnection.getStandardConformingStrings());
             sql.append("'");
             SetupQueryRunner.run(protoConnection, sql.toString(), false);
         }

--- a/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -1276,7 +1276,7 @@ public class QueryExecutorImpl implements QueryExecutor {
 
         if (logger.logDebug())
         {
-            StringBuffer sbuf = new StringBuffer(" FE=> Parse(stmt=" + statementName + ",query=\"");
+            StringBuilder sbuf = new StringBuilder(" FE=> Parse(stmt=" + statementName + ",query=\"");
             for (int i = 0; i < fragments.length; ++i)
             {
                 if (i > 0)
@@ -1357,7 +1357,7 @@ public class QueryExecutorImpl implements QueryExecutor {
 
         if (logger.logDebug())
         {
-            StringBuffer sbuf = new StringBuffer(" FE=> Bind(stmt=" + statementName + ",portal=" + portal);
+            StringBuilder sbuf = new StringBuilder(" FE=> Bind(stmt=" + statementName + ",portal=" + portal);
             for (int i = 1; i <= params.getParameterCount(); ++i)
             {
                 sbuf.append(",$").append(i).append("=<").append(params.toString(i)).append(">");

--- a/org/postgresql/core/v3/SimpleParameterList.java
+++ b/org/postgresql/core/v3/SimpleParameterList.java
@@ -187,7 +187,7 @@ class SimpleParameterList implements V3ParameterList {
             boolean hasBackslash = param.indexOf('\\') != -1;
 
             // add room for quotes + potential escaping.
-            StringBuffer p = new StringBuffer(3 + param.length() * 11 / 10);
+            StringBuilder p = new StringBuilder(3 + param.length() * 11 / 10);
 
             boolean standardConformingStrings = false;
             boolean supportsEStringSyntax = false;
@@ -203,7 +203,7 @@ class SimpleParameterList implements V3ParameterList {
             p.append('\'');
             try
             {
-                p = Utils.appendEscapedLiteral(p, param, standardConformingStrings);
+                p = Utils.escapeLiteral(p, param, standardConformingStrings);
             }
             catch (SQLException sqle)
             {

--- a/org/postgresql/core/v3/SimpleQuery.java
+++ b/org/postgresql/core/v3/SimpleQuery.java
@@ -36,7 +36,7 @@ class SimpleQuery implements V3Query {
     }
 
     public String toString(ParameterList parameters) {
-        StringBuffer sbuf = new StringBuffer(fragments[0]);
+        StringBuilder sbuf = new StringBuilder(fragments[0]);
         for (int i = 1; i < fragments.length; ++i)
         {
             if (parameters == null)

--- a/org/postgresql/geometric/PGpath.java
+++ b/org/postgresql/geometric/PGpath.java
@@ -139,7 +139,7 @@ public class PGpath extends PGobject implements Serializable, Cloneable
      */
     public String getValue()
     {
-        StringBuffer b = new StringBuffer(open ? "[" : "(");
+        StringBuilder b = new StringBuilder(open ? "[" : "(");
 
         for (int p = 0;p < points.length;p++)
         {

--- a/org/postgresql/geometric/PGpolygon.java
+++ b/org/postgresql/geometric/PGpolygon.java
@@ -114,7 +114,7 @@ public class PGpolygon extends PGobject implements Serializable, Cloneable
      */
     public String getValue()
     {
-        StringBuffer b = new StringBuffer();
+        StringBuilder b = new StringBuilder();
         b.append("(");
         for (int p = 0;p < points.length;p++)
         {

--- a/org/postgresql/jdbc2/AbstractJdbc2Array.java
+++ b/org/postgresql/jdbc2/AbstractJdbc2Array.java
@@ -385,7 +385,7 @@ public abstract class AbstractJdbc2Array
         {
 
             char[] chars = fieldString.toCharArray();
-            StringBuffer buffer = null;
+            StringBuilder buffer = null;
             boolean insideString = false;
             boolean wasInsideString = false; // needed for checking if NULL
             // value occured
@@ -446,7 +446,7 @@ public abstract class AbstractJdbc2Array
                         }
                     }
 
-                    buffer = new StringBuffer();
+                    buffer = new StringBuilder();
                     continue;
                 }
 
@@ -483,7 +483,7 @@ public abstract class AbstractJdbc2Array
                     }
 
                     wasInsideString = false;
-                    buffer = new StringBuffer();
+                    buffer = new StringBuilder();
 
                     // when end of an array
                     if (chars[i] == '}')
@@ -887,7 +887,7 @@ public abstract class AbstractJdbc2Array
      */
     private String toString(PgArrayList list) throws SQLException
     {
-        StringBuffer b = new StringBuffer().append('{');
+        StringBuilder b = new StringBuilder().append('{');
 
         char delim = connection.getTypeInfo().getArrayDelimiter(oid);
 
@@ -913,7 +913,7 @@ public abstract class AbstractJdbc2Array
         return b.toString();
     }
 
-    public static void escapeArrayElement(StringBuffer b, String s)
+    public static void escapeArrayElement(StringBuilder b, String s)
     {
         b.append('"');
         for (int j = 0; j < s.length(); j++) {

--- a/org/postgresql/jdbc2/AbstractJdbc2Connection.java
+++ b/org/postgresql/jdbc2/AbstractJdbc2Connection.java
@@ -259,7 +259,7 @@ public abstract class AbstractJdbc2Connection implements BaseConnection
     }
 
     private String oidsToString(Set<Integer> oids) {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         for (Integer oid : oids) {
             sb.append(Oid.toString(oid));
             sb.append(',');
@@ -658,7 +658,7 @@ public abstract class AbstractJdbc2Connection implements BaseConnection
     public String nativeSQL(String sql) throws SQLException
     {
         checkClosed();
-        StringBuffer buf = new StringBuffer(sql.length());
+        StringBuilder buf = new StringBuilder(sql.length());
         AbstractJdbc2Statement.parseSql(sql,0,buf,false,getStandardConformingStrings());
         return buf.toString();
     }
@@ -1129,7 +1129,7 @@ public abstract class AbstractJdbc2Connection implements BaseConnection
     }
 
     public String escapeString(String str) throws SQLException {
-        return Utils.appendEscapedLiteral(null, str,
+        return Utils.escapeLiteral(null, str,
                 protoConnection.getStandardConformingStrings()).toString();
     }
 
@@ -1278,9 +1278,9 @@ public abstract class AbstractJdbc2Connection implements BaseConnection
         {
             if (schema != null)
             {
-                StringBuffer sb = new StringBuffer();
+                StringBuilder sb = new StringBuilder();
                 sb.append("SET SESSION search_path TO '");
-                Utils.appendEscapedLiteral(sb, schema, protoConnection.getStandardConformingStrings());
+                Utils.escapeLiteral(sb, schema, protoConnection.getStandardConformingStrings());
                 sb.append("'");
                 stmt.executeUpdate(sb.toString());
             }

--- a/org/postgresql/jdbc2/AbstractJdbc2DatabaseMetaData.java
+++ b/org/postgresql/jdbc2/AbstractJdbc2DatabaseMetaData.java
@@ -1576,7 +1576,7 @@ public abstract class AbstractJdbc2DatabaseMetaData
      * needed around it.
      */
     protected String escapeQuotes(String s) throws SQLException {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         if (!connection.getStandardConformingStrings() && connection.haveMinimumServerVersion("8.1")) {
             sb.append("E");
         }

--- a/org/postgresql/jdbc2/AbstractJdbc2ResultSet.java
+++ b/org/postgresql/jdbc2/AbstractJdbc2ResultSet.java
@@ -191,8 +191,8 @@ public abstract class AbstractJdbc2ResultSet implements BaseResultSet, org.postg
                 // Fetch all results.
                 String cursorName = getString(columnIndex);
 
-                StringBuffer sb = new StringBuffer("FETCH ALL IN ");
-                Utils.appendEscapedIdentifier(sb, cursorName);
+                StringBuilder sb = new StringBuilder("FETCH ALL IN ");
+                Utils.escapeIdentifier(sb, cursorName);
 
                 // nb: no BEGIN triggered here. This is fine. If someone
                 // committed, and the cursor was not holdable (closing the
@@ -212,7 +212,7 @@ public abstract class AbstractJdbc2ResultSet implements BaseResultSet, org.postg
 
                 sb.setLength(0);
                 sb.append("CLOSE ");
-                Utils.appendEscapedIdentifier(sb, cursorName);
+                Utils.escapeIdentifier(sb, cursorName);
                 connection.execSQLUpdate(sb.toString());
                 ((AbstractJdbc2ResultSet)rs).setRefCursor(cursorName);
                 return rs;
@@ -846,11 +846,11 @@ public abstract class AbstractJdbc2ResultSet implements BaseResultSet, org.postg
         {
 
 
-            StringBuffer deleteSQL = new StringBuffer("DELETE FROM " ).append(onlyTable).append(tableName).append(" where " );
+            StringBuilder deleteSQL = new StringBuilder("DELETE FROM " ).append(onlyTable).append(tableName).append(" where " );
 
             for ( int i = 0; i < numKeys; i++ )
             {
-                Utils.appendEscapedIdentifier(deleteSQL, ((PrimaryKey)primaryKeys.get(i)).name);
+                Utils.escapeIdentifier(deleteSQL, ((PrimaryKey)primaryKeys.get(i)).name);
                 deleteSQL.append(" = ?");
                 if ( i < numKeys - 1 )
                 {
@@ -897,8 +897,8 @@ public abstract class AbstractJdbc2ResultSet implements BaseResultSet, org.postg
             // we have to create the sql every time since the user could insert different
             // columns each time
 
-            StringBuffer insertSQL = new StringBuffer("INSERT INTO ").append(tableName).append(" (");
-            StringBuffer paramSQL = new StringBuffer(") values (" );
+            StringBuilder insertSQL = new StringBuilder("INSERT INTO ").append(tableName).append(" (");
+            StringBuilder paramSQL = new StringBuilder(") values (" );
 
             Iterator columnNames = updateValues.keySet().iterator();
             int numColumns = updateValues.size();
@@ -907,7 +907,7 @@ public abstract class AbstractJdbc2ResultSet implements BaseResultSet, org.postg
             {
                 String columnName = (String) columnNames.next();
 
-                Utils.appendEscapedIdentifier(insertSQL, columnName);
+                Utils.escapeIdentifier(insertSQL, columnName);
                 if ( i < numColumns - 1 )
                 {
                     insertSQL.append(", ");
@@ -1263,7 +1263,7 @@ public abstract class AbstractJdbc2ResultSet implements BaseResultSet, org.postg
         if (isBeforeFirst() || isAfterLast() || rows.size() == 0)
             return ;
 
-        StringBuffer selectSQL = new StringBuffer( "select ");
+        StringBuilder selectSQL = new StringBuilder( "select ");
 
         ResultSetMetaData rsmd = getMetaData();
         PGResultSetMetaData pgmd = (PGResultSetMetaData)rsmd;
@@ -1338,7 +1338,7 @@ public abstract class AbstractJdbc2ResultSet implements BaseResultSet, org.postg
         if (!doingUpdates)
             return; // No work pending.
 
-        StringBuffer updateSQL = new StringBuffer("UPDATE " + onlyTable + tableName + " SET  ");
+        StringBuilder updateSQL = new StringBuilder("UPDATE " + onlyTable + tableName + " SET  ");
         
         int numColumns = updateValues.size();
         Iterator columns = updateValues.keySet().iterator();
@@ -1346,7 +1346,7 @@ public abstract class AbstractJdbc2ResultSet implements BaseResultSet, org.postg
         for (int i = 0; columns.hasNext(); i++ )
         {
             String column = (String) columns.next();
-            Utils.appendEscapedIdentifier(updateSQL, column);
+            Utils.escapeIdentifier(updateSQL, column);
             updateSQL.append(" = ?");
             
             if ( i < numColumns - 1 )
@@ -1360,7 +1360,7 @@ public abstract class AbstractJdbc2ResultSet implements BaseResultSet, org.postg
         for ( int i = 0; i < numKeys; i++ )
         {                
             PrimaryKey primaryKey = ((PrimaryKey) primaryKeys.get(i));
-            Utils.appendEscapedIdentifier(updateSQL, primaryKey.name);
+            Utils.escapeIdentifier(updateSQL, primaryKey.name);
             updateSQL.append(" = ?");
             
             if ( i < numKeys - 1 )
@@ -1676,7 +1676,7 @@ public abstract class AbstractJdbc2ResultSet implements BaseResultSet, org.postg
     public static String[] quotelessTableName(String fullname) {
 
         String[] parts = new String[] {null, ""};
-        StringBuffer acc = new StringBuffer();
+        StringBuilder acc = new StringBuilder();
         boolean betweenQuotes = false;
         for (int i = 0; i < fullname.length(); i++)
         {
@@ -1703,7 +1703,7 @@ public abstract class AbstractJdbc2ResultSet implements BaseResultSet, org.postg
                 else
                 {    // Have schema name
                     parts[1] = acc.toString();
-                    acc = new StringBuffer();
+                    acc = new StringBuilder();
                 }
                 break;
             default:

--- a/org/postgresql/jdbc2/AbstractJdbc2ResultSetMetaData.java
+++ b/org/postgresql/jdbc2/AbstractJdbc2ResultSetMetaData.java
@@ -205,7 +205,7 @@ public abstract class AbstractJdbc2ResultSetMetaData implements PGResultSetMetaD
 
         fieldInfoFetched = true;
 
-        StringBuffer sql = new StringBuffer();
+        StringBuilder sql = new StringBuilder();
         sql.append("SELECT c.oid, a.attnum, a.attname, c.relname, n.nspname, ");
         sql.append("a.attnotnull OR (t.typtype = 'd' AND t.typnotnull), ");
         sql.append("pg_catalog.pg_get_expr(d.adbin, d.adrelid) LIKE '%nextval(%' ");

--- a/org/postgresql/jdbc2/AbstractJdbc2Statement.java
+++ b/org/postgresql/jdbc2/AbstractJdbc2Statement.java
@@ -894,7 +894,7 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
             // Since escape codes can only appear in SQL CODE, we keep track
             // of if we enter a string or not.
             int len = p_sql.length();
-            StringBuffer newsql = new StringBuffer(len);
+            StringBuilder newsql = new StringBuilder(len);
             int i=0;
             while (i<len){
                 i=parseSql(p_sql,i,newsql,false,connection.getStandardConformingStrings());
@@ -929,7 +929,7 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
      * @param stdStrings whether standard_conforming_strings is on
      * @return the position we stopped processing at
      */
-    protected static int parseSql(String p_sql,int i,StringBuffer newsql, boolean stopOnComma,
+    protected static int parseSql(String p_sql,int i,StringBuilder newsql, boolean stopOnComma,
                                   boolean stdStrings)throws SQLException{
         short state = IN_SQLCODE;
         int len = p_sql.length();
@@ -1036,7 +1036,7 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
                     functionName=p_sql.substring(i,posArgs).trim();
                     // extract arguments
                     i= posArgs+1;// we start the scan after the first (
-                    StringBuffer args=new StringBuffer();
+                    StringBuilder args=new StringBuilder();
                     i = parseSql(p_sql,i,args,false,stdStrings);
                     // translate the function and parse arguments
                     newsql.append(escapeFunction(functionName,args.toString(),stdStrings));
@@ -1073,7 +1073,7 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
         int i=0;
         ArrayList parsedArgs = new ArrayList();
         while (i<len){
-            StringBuffer arg = new StringBuffer();
+            StringBuilder arg = new StringBuilder();
             int lastPos=i;
             i=parseSql(args,i,arg,true,stdStrings);
             if (lastPos!=i){
@@ -1093,7 +1093,7 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
                                         PSQLState.SYSTEM_ERROR);
         }catch (Exception e){
             // by default the function name is kept unchanged
-            StringBuffer buf = new StringBuffer();
+            StringBuilder buf = new StringBuilder();
             buf.append(functionName).append('(');
             for (int iArg = 0;iArg<parsedArgs.size();iArg++){
                 buf.append(parsedArgs.get(iArg));
@@ -2531,7 +2531,7 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
         if (connection.haveMinimumServerVersion("8.1") && ((AbstractJdbc2Connection)connection).getProtocolVersion() == 3)
         {
             String s = p_sql.substring(startIndex, endIndex );
-            StringBuffer sb = new StringBuffer(s);
+            StringBuilder sb = new StringBuilder(s);
             if ( outParmBeforeFunc )
             {
 	    	        // move the single out parameter into the function call 

--- a/org/postgresql/jdbc2/CacheMetadata.java
+++ b/org/postgresql/jdbc2/CacheMetadata.java
@@ -37,7 +37,7 @@ public class CacheMetadata {
   }
   
   protected String getIdFields(Field[] fields) {
-    StringBuffer sb = new StringBuffer();
+    StringBuilder sb = new StringBuilder();
     
     for (int i = 0 ; i < fields.length ; i++) {
       sb.append(getIdField(fields[i])).append('/');

--- a/org/postgresql/jdbc2/EscapedFunctions.java
+++ b/org/postgresql/jdbc2/EscapedFunctions.java
@@ -139,7 +139,7 @@ public class EscapedFunctions {
     // ** numeric functions translations **
     /** ceiling to ceil translation */
     public static String sqlceiling(List parsedArgs) throws SQLException{
-        StringBuffer buf = new StringBuffer();
+        StringBuilder buf = new StringBuilder();
         buf.append("ceil(");
         if (parsedArgs.size()!=1){
             throw new PSQLException(GT.tr("{0} function takes one and only one argument.","ceiling"),
@@ -151,7 +151,7 @@ public class EscapedFunctions {
     
     /** log to ln translation */
     public static String sqllog(List parsedArgs) throws SQLException{
-        StringBuffer buf = new StringBuffer();
+        StringBuilder buf = new StringBuilder();
         buf.append("ln(");
         if (parsedArgs.size()!=1){
             throw new PSQLException(GT.tr("{0} function takes one and only one argument.","log"),
@@ -163,7 +163,7 @@ public class EscapedFunctions {
     
     /** log10 to log translation */
     public static String sqllog10(List parsedArgs) throws SQLException{
-        StringBuffer buf = new StringBuffer();
+        StringBuilder buf = new StringBuilder();
         buf.append("log(");
         if (parsedArgs.size()!=1){
             throw new PSQLException(GT.tr("{0} function takes one and only one argument.","log10"),
@@ -175,7 +175,7 @@ public class EscapedFunctions {
     
     /** power to pow translation */
     public static String sqlpower(List parsedArgs) throws SQLException{
-        StringBuffer buf = new StringBuffer();
+        StringBuilder buf = new StringBuilder();
         buf.append("pow(");
         if (parsedArgs.size()!=2){
             throw new PSQLException(GT.tr("{0} function takes two and only two arguments.","power"),
@@ -187,7 +187,7 @@ public class EscapedFunctions {
     
     /** truncate to trunc translation */
     public static String sqltruncate(List parsedArgs) throws SQLException{
-        StringBuffer buf = new StringBuffer();
+        StringBuilder buf = new StringBuilder();
         buf.append("trunc(");
         if (parsedArgs.size()!=2){
             throw new PSQLException(GT.tr("{0} function takes two and only two arguments.","truncate"),
@@ -200,7 +200,7 @@ public class EscapedFunctions {
     // ** string functions translations **
     /** char to chr translation */
     public static String sqlchar(List parsedArgs) throws SQLException{
-        StringBuffer buf = new StringBuffer();
+        StringBuilder buf = new StringBuilder();
         buf.append("chr(");
         if (parsedArgs.size()!=1){
             throw new PSQLException(GT.tr("{0} function takes one and only one argument.","char"),
@@ -212,7 +212,7 @@ public class EscapedFunctions {
 
     /** concat translation */
     public static String sqlconcat(List parsedArgs){
-        StringBuffer buf = new StringBuffer();
+        StringBuilder buf = new StringBuilder();
         buf.append('(');
         for (int iArg = 0;iArg<parsedArgs.size();iArg++){
             buf.append(parsedArgs.get(iArg));
@@ -224,7 +224,7 @@ public class EscapedFunctions {
 
     /** insert to overlay translation */
     public static String sqlinsert(List parsedArgs) throws SQLException{
-        StringBuffer buf = new StringBuffer();
+        StringBuilder buf = new StringBuilder();
         buf.append("overlay(");
         if (parsedArgs.size()!=4){
             throw new PSQLException(GT.tr("{0} function takes four and only four argument.","insert"),
@@ -237,7 +237,7 @@ public class EscapedFunctions {
 
     /** lcase to lower translation */
     public static String sqllcase(List parsedArgs) throws SQLException{
-        StringBuffer buf = new StringBuffer();
+        StringBuilder buf = new StringBuilder();
         buf.append("lower(");
         if (parsedArgs.size()!=1){
             throw new PSQLException(GT.tr("{0} function takes one and only one argument.","lcase"),
@@ -249,7 +249,7 @@ public class EscapedFunctions {
 
     /** left to substring translation */
     public static String sqlleft(List parsedArgs) throws SQLException{
-        StringBuffer buf = new StringBuffer();
+        StringBuilder buf = new StringBuilder();
         buf.append("substring(");
         if (parsedArgs.size()!=2){
             throw new PSQLException(GT.tr("{0} function takes two and only two arguments.","left"),
@@ -261,7 +261,7 @@ public class EscapedFunctions {
 
     /** length translation */
     public static String sqllength(List parsedArgs) throws SQLException{
-        StringBuffer buf = new StringBuffer();
+        StringBuilder buf = new StringBuilder();
         buf.append("length(trim(trailing from ");
         if (parsedArgs.size()!=1){
             throw new PSQLException(GT.tr("{0} function takes one and only one argument.","length"),
@@ -286,7 +286,7 @@ public class EscapedFunctions {
 
     /** ltrim translation */
     public static String sqlltrim(List parsedArgs) throws SQLException{
-        StringBuffer buf = new StringBuffer();
+        StringBuilder buf = new StringBuilder();
         buf.append("trim(leading from ");
         if (parsedArgs.size()!=1){
             throw new PSQLException(GT.tr("{0} function takes one and only one argument.","ltrim"),
@@ -298,7 +298,7 @@ public class EscapedFunctions {
 
     /** right to substring translation */
     public static String sqlright(List parsedArgs) throws SQLException{
-        StringBuffer buf = new StringBuffer();
+        StringBuilder buf = new StringBuilder();
         buf.append("substring(");
         if (parsedArgs.size()!=2){
             throw new PSQLException(GT.tr("{0} function takes two and only two arguments.","right"),
@@ -310,7 +310,7 @@ public class EscapedFunctions {
 
     /** rtrim translation */
     public static String sqlrtrim(List parsedArgs) throws SQLException{
-        StringBuffer buf = new StringBuffer();
+        StringBuilder buf = new StringBuilder();
         buf.append("trim(trailing from ");
         if (parsedArgs.size()!=1){
             throw new PSQLException(GT.tr("{0} function takes one and only one argument.","rtrim"),
@@ -322,7 +322,7 @@ public class EscapedFunctions {
 
     /** space translation */
     public static String sqlspace(List parsedArgs) throws SQLException{
-        StringBuffer buf = new StringBuffer();
+        StringBuilder buf = new StringBuilder();
         buf.append("repeat(' ',");
         if (parsedArgs.size()!=1){
             throw new PSQLException(GT.tr("{0} function takes one and only one argument.","space"),
@@ -346,7 +346,7 @@ public class EscapedFunctions {
 
     /** ucase to upper translation */
     public static String sqlucase(List parsedArgs) throws SQLException{
-        StringBuffer buf = new StringBuffer();
+        StringBuilder buf = new StringBuilder();
         buf.append("upper(");
         if (parsedArgs.size()!=1){
             throw new PSQLException(GT.tr("{0} function takes one and only one argument.","ucase"),
@@ -490,7 +490,7 @@ public class EscapedFunctions {
                                     PSQLState.SYNTAX_ERROR);
         }
         String interval = EscapedFunctions.constantToInterval(parsedArgs.get(0).toString(),parsedArgs.get(1).toString());
-        StringBuffer buf = new StringBuffer();
+        StringBuilder buf = new StringBuilder();
         buf.append("(").append(interval).append("+");
         buf.append(parsedArgs.get(2)).append(")");
         return buf.toString();
@@ -532,7 +532,7 @@ public class EscapedFunctions {
                                     PSQLState.SYNTAX_ERROR);
         }
         String datePart = EscapedFunctions.constantToDatePart(parsedArgs.get(0).toString());
-        StringBuffer buf = new StringBuffer();
+        StringBuilder buf = new StringBuilder();
         buf.append("extract( ").append(datePart)
         .append(" from (").append(parsedArgs.get(2)).append("-").append(parsedArgs.get(1)).append("))");
         return buf.toString();

--- a/org/postgresql/jdbc3/AbstractJdbc3Statement.java
+++ b/org/postgresql/jdbc3/AbstractJdbc3Statement.java
@@ -154,7 +154,7 @@ public abstract class AbstractJdbc3Statement extends org.postgresql.jdbc2.Abstra
         if (sql.endsWith(";"))
             sql = sql.substring(0, sql.length()-1);
 
-        StringBuffer sb = new StringBuffer(sql);
+        StringBuilder sb = new StringBuilder(sql);
         sb.append(" RETURNING ");
         for (int i=0; i<columns.length; i++) {
             if (i != 0)
@@ -165,7 +165,7 @@ public abstract class AbstractJdbc3Statement extends org.postgresql.jdbc2.Abstra
             // DatabaseMetaData.getColumns and is necessary for the same
             // reasons.
             if (escape)
-                Utils.appendEscapedIdentifier(sb, columns[i]);
+                Utils.escapeIdentifier(sb, columns[i]);
             else
                 sb.append(columns[i]);
         }

--- a/org/postgresql/jdbc3/PSQLSavepoint.java
+++ b/org/postgresql/jdbc3/PSQLSavepoint.java
@@ -71,7 +71,7 @@ public class PSQLSavepoint implements Savepoint {
             // We need to quote and escape the name in case it
             // contains spaces/quotes/etc.
             //
-            return Utils.appendEscapedIdentifier(null, _name).toString();
+            return Utils.escapeIdentifier(null, _name).toString();
         }
 
         return "JDBC_SAVEPOINT_" + _id;

--- a/org/postgresql/jdbc4/AbstractJdbc4Connection.java
+++ b/org/postgresql/jdbc4/AbstractJdbc4Connection.java
@@ -93,7 +93,7 @@ abstract class AbstractJdbc4Connection extends org.postgresql.jdbc3g.AbstractJdb
             throw new PSQLException(GT.tr("Unable to find server array type for provided name {0}.", typeName), PSQLState.INVALID_NAME);
 
         char delim = getTypeInfo().getArrayDelimiter(oid);
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         appendArray(sb, elements, delim);
 
         // This will not work once we have a JDBC 5,
@@ -101,7 +101,7 @@ abstract class AbstractJdbc4Connection extends org.postgresql.jdbc3g.AbstractJdb
         return new Jdbc4Array(this, oid, sb.toString());
     }
 
-    private static void appendArray(StringBuffer sb, Object elements, char delim)
+    private static void appendArray(StringBuilder sb, Object elements, char delim)
     {
         sb.append('{');
 
@@ -172,8 +172,8 @@ abstract class AbstractJdbc4Connection extends org.postgresql.jdbc3g.AbstractJdb
                 value = "";
 
             try {
-                StringBuffer sql = new StringBuffer("SET application_name = '");
-                Utils.appendEscapedLiteral(sql, value, getStandardConformingStrings());
+                StringBuilder sql = new StringBuilder("SET application_name = '");
+                Utils.escapeLiteral(sql, value, getStandardConformingStrings());
                 sql.append("'");
                 execSQLUpdate(sql.toString());
             } catch (SQLException sqle) {

--- a/org/postgresql/util/HStoreConverter.java
+++ b/org/postgresql/util/HStoreConverter.java
@@ -67,7 +67,7 @@ public class HStoreConverter {
        if (map.isEmpty()) {
            return "";
        }
-       StringBuffer sb = new StringBuffer(map.size() * 8);
+       StringBuilder sb = new StringBuilder(map.size() * 8);
        for (Iterator i = map.entrySet().iterator(); i.hasNext(); ) {
            Entry e = (Entry) i.next();
            appendEscaped(sb, e.getKey());
@@ -79,7 +79,7 @@ public class HStoreConverter {
        return sb.toString();
    }
 
-   private static void appendEscaped(StringBuffer sb, Object val) {
+   private static void appendEscaped(StringBuilder sb, Object val) {
       if (val != null) {
           sb.append('"');
           String s = val.toString();
@@ -99,7 +99,7 @@ public class HStoreConverter {
    public static Map fromString(String s) {
        Map m = new HashMap();
        int pos = 0;
-       StringBuffer sb = new StringBuffer();
+       StringBuilder sb = new StringBuilder();
        while (pos < s.length()) {
            sb.setLength(0);
            int start = s.indexOf('"', pos);
@@ -123,7 +123,7 @@ public class HStoreConverter {
        return m;
    }
 
-   private static int appendUntilQuote(StringBuffer sb, String s, int pos) {
+   private static int appendUntilQuote(StringBuilder sb, String s, int pos) {
        for (pos += 1; pos < s.length(); pos++) {
            char ch = s.charAt(pos);
            if (ch == '"') {

--- a/org/postgresql/util/PGbytea.java
+++ b/org/postgresql/util/PGbytea.java
@@ -136,7 +136,7 @@ public class PGbytea
     {
         if (p_buf == null)
             return null;
-        StringBuffer l_strbuf = new StringBuffer(2 * p_buf.length);
+        StringBuilder l_strbuf = new StringBuilder(2 * p_buf.length);
         for (int i = 0; i < p_buf.length; i++)
         {
             int l_int = (int)p_buf[i];

--- a/org/postgresql/util/ServerErrorMessage.java
+++ b/org/postgresql/util/ServerErrorMessage.java
@@ -173,7 +173,7 @@ public class ServerErrorMessage implements Serializable
         //included.  If DEBUG level logging is enabled then all information
         //is included.
 
-        StringBuffer l_totalMessage = new StringBuffer();
+        StringBuilder l_totalMessage = new StringBuilder();
         String l_message = (String)m_mesgParts.get(SEVERITY);
         if (l_message != null)
             l_totalMessage.append(l_message).append(": ");


### PR DESCRIPTION
Take advantage of Java 5 using StringBuilder where applicable

 - replacement is done when `StringBuffer` is used as a local variable

 - public methods using `StringBuffer` are kept but deprecated in favor of the same using `StringBuilder`. Cases can be found in `org.postgresql.core.Utils`. New public methods using `StringBuilder` do not use the same name as their `StringBuffer` counterpart otherwise it would prevent existing code using `null` as a method argument to compile.
