### PR TITLE
Use language features from Java 5

### DIFF
--- a/org/postgresql/PGProperty.java
+++ b/org/postgresql/PGProperty.java
@@ -358,7 +358,7 @@ public enum PGProperty
      */
     public boolean getBoolean(Properties properties)
     {
-        return Boolean.valueOf(get(properties)).booleanValue();
+        return Boolean.valueOf(get(properties));
     }
 
     /**

--- a/org/postgresql/copy/PGCopyOutputStream.java
+++ b/org/postgresql/copy/PGCopyOutputStream.java
@@ -65,7 +65,7 @@ public class PGCopyOutputStream extends OutputStream implements CopyIn {
     public void write(int b) throws IOException {
         checkClosed();
         if(b<0 || b>255)
-            throw new IOException(GT.tr("Cannot write to copy a byte of value {0}", new Integer(b)));
+            throw new IOException(GT.tr("Cannot write to copy a byte of value {0}", b));
         singleByteBuffer[0] = (byte)b;
         write(singleByteBuffer, 0, 1);
     }

--- a/org/postgresql/core/ConnectionFactory.java
+++ b/org/postgresql/core/ConnectionFactory.java
@@ -56,13 +56,12 @@ public abstract class ConnectionFactory {
     public static ProtocolConnection openConnection(HostSpec[] hostSpecs, String user, String database, Properties info, Logger logger) throws SQLException {
         String protoName = PGProperty.PROTOCOL_VERSION.get(info);
 
-        for (int i = 0; i < versions.length; ++i)
-        {
-            String versionProtoName = (String) versions[i][0];
+        for (Object[] version : versions) {
+            String versionProtoName = (String) version[0];
             if (protoName != null && !protoName.equals(versionProtoName))
                 continue;
 
-            ConnectionFactory factory = (ConnectionFactory) versions[i][1];
+            ConnectionFactory factory = (ConnectionFactory) version[1];
             ProtocolConnection connection = factory.openConnectionImpl(hostSpecs, user, database, info, logger);
             if (connection != null)
                 return connection;

--- a/org/postgresql/core/Encoding.java
+++ b/org/postgresql/core/Encoding.java
@@ -128,11 +128,9 @@ public class Encoding
         String[] candidates = (String[]) encodings.get(databaseEncoding);
         if (candidates != null)
         {
-            for (int i = 0; i < candidates.length; i++)
-            {
-                if (isAvailable(candidates[i]))
-                {
-                    return new Encoding(candidates[i]);
+            for (String candidate : candidates) {
+                if (isAvailable(candidate)) {
+                    return new Encoding(candidate);
                 }
             }
         }

--- a/org/postgresql/core/Oid.java
+++ b/org/postgresql/core/Oid.java
@@ -83,9 +83,9 @@ public class Oid {
     public static String toString(int oid) {
         try {
             Field[] fields = Oid.class.getFields();
-            for (int i = 0; i < fields.length; ++i) {
-                if (fields[i].getInt(null) == oid) {
-                    return fields[i].getName();
+            for (Field field : fields) {
+                if (field.getInt(null) == oid) {
+                    return field.getName();
                 }
             }
         } catch (IllegalAccessException e) {
@@ -102,9 +102,9 @@ public class Oid {
         try {
             oid = oid.toUpperCase();
             Field[] fields = Oid.class.getFields();
-            for (int i = 0; i < fields.length; ++i) {
-                if (fields[i].getName().toUpperCase().equals(oid)) {
-                    return fields[i].getInt(null);
+            for (Field field : fields) {
+                if (field.getName().toUpperCase().equals(oid)) {
+                    return field.getInt(null);
                 }
             }
         } catch (IllegalAccessException e) {

--- a/org/postgresql/core/PGStream.java
+++ b/org/postgresql/core/PGStream.java
@@ -500,7 +500,7 @@ public class PGStream
             {
                 readCount = inStream.read(streamBuffer, 0, count);
                 if (readCount < 0)
-                    throw new EOFException(GT.tr("Premature end of input stream, expected {0} bytes, but only read {1}.", new Object[]{new Integer(expectedLength), new Integer(expectedLength - remaining)}));
+                    throw new EOFException(GT.tr("Premature end of input stream, expected {0} bytes, but only read {1}.", new Object[]{expectedLength, expectedLength - remaining}));
             }
             catch (IOException ioe)
             {
@@ -540,7 +540,7 @@ public class PGStream
         int c = pg_input.read();
         if (c < 0)
             return;
-        throw new PSQLException(GT.tr("Expected an EOF from server, got: {0}", new Integer(c)), PSQLState.COMMUNICATION_ERROR);
+        throw new PSQLException(GT.tr("Expected an EOF from server, got: {0}", c), PSQLState.COMMUNICATION_ERROR);
     }
 
     /**

--- a/org/postgresql/core/UTF8Encoding.java
+++ b/org/postgresql/core/UTF8Encoding.java
@@ -26,7 +26,7 @@ class UTF8Encoding extends Encoding {
     private final static void checkByte(int ch, int pos, int len) throws IOException {
         if ((ch & 0xc0) != 0x80)
             throw new IOException(GT.tr("Illegal UTF-8 sequence: byte {0} of {1} byte sequence is not 10xxxxxx: {2}",
-                                        new Object[] { new Integer(pos), new Integer(len), new Integer(ch) }));
+                                        new Object[] {pos, len, ch}));
     }    
 
     private final static void checkMinimal(int ch, int minValue) throws IOException {
@@ -59,7 +59,7 @@ class UTF8Encoding extends Encoding {
             throw new IllegalArgumentException("unexpected ch passed to checkMinimal: " + ch);
         
         throw new IOException(GT.tr("Illegal UTF-8 sequence: {0} bytes used to encode a {1} byte value: {2}",
-                                    new Object[] { new Integer(actualLen), new Integer(expectedLen), new Integer(ch) }));
+                                    new Object[] {actualLen, expectedLen, ch}));
     }
 
     /**
@@ -96,7 +96,7 @@ class UTF8Encoding extends Encoding {
                 } else if (ch < 0xc0) {
                     // 10xxxxxx -- illegal!
                     throw new IOException(GT.tr("Illegal UTF-8 sequence: initial byte is {0}: {1}",
-                                                new Object[] { "10xxxxxx", new Integer(ch) }));
+                                                new Object[] { "10xxxxxx", ch}));
                 } else if (ch < 0xe0) { 
                     // 110xxxxx 10xxxxxx
                     ch = ((ch & 0x1f) << 6);
@@ -123,12 +123,12 @@ class UTF8Encoding extends Encoding {
                     checkMinimal(ch, MIN_4_BYTES);
                 } else {
                     throw new IOException(GT.tr("Illegal UTF-8 sequence: initial byte is {0}: {1}",
-                                                new Object[] { "11111xxx", new Integer(ch) }));
+                                                new Object[] { "11111xxx", ch}));
                 }
                 
                 if (ch > MAX_CODE_POINT)
                     throw new IOException(GT.tr("Illegal UTF-8 sequence: final value is out of range: {0}",
-                                                new Integer(ch)));
+                            ch));
 
                 // Convert 21-bit codepoint to Java chars:
                 //   0..ffff are represented directly as a single char
@@ -143,7 +143,7 @@ class UTF8Encoding extends Encoding {
                 } else if (ch >= 0xd800 && ch < 0xe000) {
                     // Not allowed to encode the surrogate range directly.
                     throw new IOException(GT.tr("Illegal UTF-8 sequence: final value is a surrogate value: {0}",
-                                                new Integer(ch)));
+                            ch));
                 } else {
                     // Normal case.
                     cdata[out++] = (char) ch;

--- a/org/postgresql/core/Utils.java
+++ b/org/postgresql/core/Utils.java
@@ -34,10 +34,9 @@ public class Utils {
      */
     public static String toHexString(byte[] data) {
         StringBuilder sb = new StringBuilder(data.length * 2);
-        for (int i = 0; i < data.length; ++i)
-        {
-            sb.append(Integer.toHexString((data[i] >> 4) & 15));
-            sb.append(Integer.toHexString(data[i] & 15));
+        for (byte aData : data) {
+            sb.append(Integer.toHexString((aData >> 4) & 15));
+            sb.append(Integer.toHexString(aData & 15));
         }
         return sb.toString();
     }

--- a/org/postgresql/core/types/PGBigDecimal.java
+++ b/org/postgresql/core/types/PGBigDecimal.java
@@ -39,12 +39,12 @@ public class PGBigDecimal implements PGType
 	            case Types.BIT:
 	                return new PGBoolean( val.doubleValue() == 0?Boolean.FALSE:Boolean.TRUE );            
 	            case Types.BIGINT:
-	                return new PGLong( new Long( val.longValue() ) );
+	                return new PGLong(val.longValue());
 	            case Types.INTEGER:
-	                return new PGInteger( new Integer( val.intValue() ) ) ;
+	                return new PGInteger(val.intValue()) ;
 	            case Types.SMALLINT:
 	            case Types.TINYINT:
-	                return new PGShort( new Short( val.shortValue() ) );
+	                return new PGShort(val.shortValue());
 	            case Types.VARCHAR:
 	            case Types.LONGVARCHAR:
 	                return new PGString( val.toString() );

--- a/org/postgresql/core/types/PGBoolean.java
+++ b/org/postgresql/core/types/PGBoolean.java
@@ -33,23 +33,23 @@ public class PGBoolean implements PGType
         switch ( targetType )
         {
             case Types.BIGINT:
-                return new PGLong(new Long( val.booleanValue()==true?1:0 ));
+                return new PGLong((long) (val == true ? 1 : 0));
             case Types.INTEGER:
-                return new PGInteger( new Integer(  val.booleanValue()==true?1:0  ) );
+                return new PGInteger(val == true ? 1 : 0);
             case Types.SMALLINT:
             case Types.TINYINT:
-                return new PGShort( new Short( val.booleanValue()==true?(short)1:(short)0  ) );
+                return new PGShort(val == true ? (short) 1 : (short) 0);
             case Types.VARCHAR:
             case Types.LONGVARCHAR:                
-                return new PGString( val.booleanValue()==true?"true":"false" );
+                return new PGString(val ==true?"true":"false" );
             case Types.DOUBLE:
             case Types.FLOAT:
-            		return new PGDouble( new Double(val.booleanValue()==true?1:0));
+            		return new PGDouble((double) (val == true ? 1 : 0));
             case Types.REAL:
-        		return new PGFloat( new Float(val.booleanValue()==true?1:0));
+        		return new PGFloat((float) (val == true ? 1 : 0));
             case Types.NUMERIC:
             case Types.DECIMAL:
-                return new PGBigDecimal( new java.math.BigDecimal(val.booleanValue()==true?1:0));
+                return new PGBigDecimal( new java.math.BigDecimal(val ==true?1:0));
             
             case Types.BIT:
                 return new PGBoolean( val );
@@ -64,7 +64,7 @@ public class PGBoolean implements PGType
     }
     public String toString()
     {
-        return val.booleanValue()==true?"true":"false";
+        return val ==true?"true":"false";
     }
     
 }

--- a/org/postgresql/core/types/PGByte.java
+++ b/org/postgresql/core/types/PGByte.java
@@ -38,16 +38,16 @@ public class PGByte implements PGType
             switch ( targetType )
             {
 	            case Types.BIT:
-	                return new PGBoolean( val.byteValue() == 0?Boolean.FALSE:Boolean.TRUE );
+	                return new PGBoolean(val == 0?Boolean.FALSE:Boolean.TRUE );
 	            
 	            case Types.SMALLINT:
 	            case Types.TINYINT:
 	                return new PGByte( val );
 	            case Types.REAL:
-	                return new PGFloat( new Float( val.floatValue() ) ); 
+	                return new PGFloat(val.floatValue());
 	            case Types.DOUBLE:
 	            case Types.FLOAT:
-	                return new PGDouble( new Double( val.doubleValue() ) );
+	                return new PGDouble(val.doubleValue());
 	            case Types.NUMERIC:
 	            case Types.DECIMAL:
 	                return new PGBigDecimal( new BigDecimal(val.toString()) );

--- a/org/postgresql/core/types/PGDouble.java
+++ b/org/postgresql/core/types/PGDouble.java
@@ -35,15 +35,15 @@ public class PGDouble implements PGType
             switch ( targetType )
             {
 	            case Types.BIT:
-	                return new PGBoolean( val.doubleValue() == 0?Boolean.FALSE:Boolean.TRUE );
+	                return new PGBoolean(val == 0?Boolean.FALSE:Boolean.TRUE );
 	            
 	            case Types.BIGINT:
-	                return new PGLong( new Long( val.longValue() ) );
+	                return new PGLong(val.longValue());
 	            case Types.INTEGER:
-	                return new PGInteger( new Integer( val.intValue() ) ) ;
+	                return new PGInteger(val.intValue()) ;
 	            case Types.SMALLINT:
 	            case Types.TINYINT:
-	                return new PGShort( new Short( val.shortValue() ) );
+	                return new PGShort(val.shortValue());
 	            case Types.VARCHAR:
 	            case Types.LONGVARCHAR:                
 	                return new PGString( val.toString() );
@@ -51,7 +51,7 @@ public class PGDouble implements PGType
 	            case Types.FLOAT:
 	                return new PGDouble( val );
 	            case Types.REAL:
-	                return new PGFloat( new Float( val.floatValue()));
+	                return new PGFloat(val.floatValue());
 	            case Types.DECIMAL:
 	            case Types.NUMERIC:
 	                return new PGBigDecimal( new BigDecimal( val.toString()));

--- a/org/postgresql/core/types/PGFloat.java
+++ b/org/postgresql/core/types/PGFloat.java
@@ -35,21 +35,21 @@ public class PGFloat implements PGType
             switch ( targetType )
             {
 	            case Types.BIT:
-	                return new PGBoolean( val.floatValue() == 0?Boolean.FALSE:Boolean.TRUE );
+	                return new PGBoolean(val == 0?Boolean.FALSE:Boolean.TRUE );
 	            
 	            case Types.BIGINT:
-	                return new PGLong(new Long( val.longValue() ));
+	                return new PGLong(val.longValue());
 	            case Types.INTEGER:
-	                return new PGInteger(new Integer( val.intValue() ) );
+	                return new PGInteger(val.intValue());
 	            case Types.SMALLINT:
 	            case Types.TINYINT:
-	                return new PGShort(new Short( val.shortValue() ));
+	                return new PGShort(val.shortValue());
 	            case Types.VARCHAR:
 	            case Types.LONGVARCHAR:                
 	                return new PGString( val.toString() );
 	            case Types.DOUBLE:
 	            case Types.FLOAT:
-	                return( new PGDouble( new Double( val.doubleValue())));
+	                return( new PGDouble(val.doubleValue()));
 	            case Types.REAL:
 	                return new PGFloat( val );
 	            case Types.DECIMAL:

--- a/org/postgresql/core/types/PGInteger.java
+++ b/org/postgresql/core/types/PGInteger.java
@@ -35,18 +35,18 @@ public class PGInteger implements PGType
             switch ( targetType )
             {
 	            case Types.BIT:
-	                return new PGBoolean( val.intValue() == 0?Boolean.FALSE:Boolean.TRUE );
+	                return new PGBoolean(val == 0?Boolean.FALSE:Boolean.TRUE );
 	            case Types.REAL:
-	                return new PGFloat( new Float( val.floatValue() ) );
+	                return new PGFloat(val.floatValue());
 	            case Types.DOUBLE:
 	            case Types.FLOAT:
-	                return new PGDouble(new Double( val.doubleValue() ));
+	                return new PGDouble(val.doubleValue());
 	            case Types.VARCHAR:
 	            case Types.LONGVARCHAR:                
 	                return new PGString( val.toString() );
 	            case Types.SMALLINT:
 	            case Types.TINYINT:
-	                return new PGShort( new Short( val.shortValue() ));
+	                return new PGShort(val.shortValue());
 	            case Types.INTEGER:
 	                return new PGInteger( val );
 	            case Types.DECIMAL:

--- a/org/postgresql/core/types/PGLong.java
+++ b/org/postgresql/core/types/PGLong.java
@@ -34,22 +34,22 @@ public class PGLong implements PGType
             switch ( targetType )
             {
 	            case Types.BIT:
-	                return new PGBoolean(val.longValue()==0?Boolean.FALSE:Boolean.TRUE);
+	                return new PGBoolean(val ==0?Boolean.FALSE:Boolean.TRUE);
 	            case Types.REAL:
-	                return new PGFloat( new Float(val.floatValue()) );
+	                return new PGFloat(val.floatValue());
 	            case Types.FLOAT:
 	            case Types.DOUBLE:
-	                return new PGDouble( new Double(val.doubleValue()) );
+	                return new PGDouble(val.doubleValue());
 	            case Types.VARCHAR:
 	            case Types.LONGVARCHAR:                
 	                return new PGString(val.toString());
 	            case Types.BIGINT:
 	                return new PGLong( val );
 	            case Types.INTEGER:
-	                return new PGInteger( new Integer( val.intValue()));
+	                return new PGInteger(val.intValue());
 	            case Types.SMALLINT:
 	            case Types.TINYINT:
-	                return new PGShort( new Short( val.shortValue() ));
+	                return new PGShort(val.shortValue());
 	            case Types.DECIMAL:
 	            case Types.NUMERIC:
 	                return new PGBigDecimal( new BigDecimal( val.toString())); 

--- a/org/postgresql/core/types/PGNumber.java
+++ b/org/postgresql/core/types/PGNumber.java
@@ -36,20 +36,20 @@ public class PGNumber implements PGType
 	                return new PGBoolean( val.doubleValue() == 0?Boolean.FALSE:Boolean.TRUE );
 	            
 	            case Types.BIGINT:
-	                return new PGLong(new Long( val.longValue() ));
+	                return new PGLong(val.longValue());
 	            case Types.INTEGER:
-	                return new PGInteger(new Integer( val.intValue() ) );
+	                return new PGInteger(val.intValue());
 	            case Types.TINYINT:
 	            case Types.SMALLINT:
-	                return new PGShort(new Short( val.shortValue() ));
+	                return new PGShort(val.shortValue());
 	            case Types.VARCHAR:
 	            case Types.LONGVARCHAR:                
 	                return new PGString( val.toString() );
 	            case Types.DOUBLE:
 	            case Types.FLOAT:
-	                return( new PGDouble( new Double( val.doubleValue())));
+	                return( new PGDouble(val.doubleValue()));
 	            case Types.REAL:
-	                return (new PGFloat( new Float( val.floatValue())));
+	                return (new PGFloat(val.floatValue()));
 	            case Types.DECIMAL:
 	            case Types.NUMERIC:
 	                return new PGNumber( val );

--- a/org/postgresql/core/types/PGShort.java
+++ b/org/postgresql/core/types/PGShort.java
@@ -33,16 +33,16 @@ public class PGShort implements PGType
             switch ( targetType )
             {
 	            case Types.BIT:
-	                return new PGBoolean( val.shortValue() == 0?Boolean.FALSE:Boolean.TRUE );
+	                return new PGBoolean(val == 0?Boolean.FALSE:Boolean.TRUE );
 	            
 	            case Types.SMALLINT:
 	            case Types.TINYINT:
 	                return new PGShort(val);
 	            case Types.REAL:
-	                return new PGFloat( new Float( val.floatValue() ) ); 
+	                return new PGFloat(val.floatValue());
 	            case Types.DOUBLE:
 	            case Types.FLOAT:
-	                return new PGDouble( new Double( val.doubleValue() ) );
+	                return new PGDouble(val.doubleValue());
 	            case Types.VARCHAR:
 	            case Types.LONGVARCHAR:                
 	                return new PGString ( val.toString() );

--- a/org/postgresql/core/types/PGString.java
+++ b/org/postgresql/core/types/PGString.java
@@ -50,16 +50,16 @@ public class PGString implements PGType
 	            case Types.LONGVARCHAR:                
 	                return new PGString(val);
 	            case Types.BIGINT:
-	                return new PGLong( new Long(Long.parseLong( val )));
+	                return new PGLong(Long.parseLong(val));
 	            case Types.INTEGER:
-	                return new PGInteger( new Integer(Integer.parseInt( val )));
+	                return new PGInteger(Integer.parseInt(val));
 	            case Types.TINYINT:
-	                return new PGShort( new Short( Short.parseShort( val )));
+	                return new PGShort(Short.parseShort(val));
 	            case Types.FLOAT:
 	            case Types.DOUBLE:
-	                return new PGDouble( new Double(Double.parseDouble( val )));
+	                return new PGDouble(Double.parseDouble(val));
 	            case Types.REAL:
-	                return new PGFloat( new Float( Float.parseFloat( val )));
+	                return new PGFloat(Float.parseFloat(val));
 	            case Types.NUMERIC:
 	            case Types.DECIMAL:
 	                return new PGBigDecimal( new BigDecimal( val));

--- a/org/postgresql/core/v2/ConnectionFactoryImpl.java
+++ b/org/postgresql/core/v2/ConnectionFactoryImpl.java
@@ -359,7 +359,7 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
                     if (logger.logDebug())
                         logger.debug(" <=BE AuthenticationReq (unsupported type " + ((int)areq) + ")");
 
-                    throw new PSQLException(GT.tr("The authentication type {0} is not supported. Check that you have configured the pg_hba.conf file to include the client''s IP address or subnet, and that it is using an authentication scheme supported by the driver.", new Integer(areq)), PSQLState.CONNECTION_REJECTED);
+                    throw new PSQLException(GT.tr("The authentication type {0} is not supported. Check that you have configured the pg_hba.conf file to include the client''s IP address or subnet, and that it is using an authentication scheme supported by the driver.", areq), PSQLState.CONNECTION_REJECTED);
                 }
 
                 break;

--- a/org/postgresql/core/v2/FastpathParameterList.java
+++ b/org/postgresql/core/v2/FastpathParameterList.java
@@ -52,7 +52,7 @@ class FastpathParameterList implements ParameterList {
     
     public void setIntParameter(int index, int value) throws SQLException {
         if (index < 1 || index > paramValues.length)
-            throw new PSQLException(GT.tr("The column index is out of range: {0}, number of columns: {1}.", new Object[]{new Integer(index), new Integer(paramValues.length)}), PSQLState.INVALID_PARAMETER_VALUE );
+            throw new PSQLException(GT.tr("The column index is out of range: {0}, number of columns: {1}.", new Object[]{index, paramValues.length}), PSQLState.INVALID_PARAMETER_VALUE );
 
         byte[] data = new byte[4];
         data[3] = (byte)value;
@@ -74,14 +74,14 @@ class FastpathParameterList implements ParameterList {
 
     public void setBytea(int index, byte[] data, int offset, int length) throws SQLException {
         if (index < 1 || index > paramValues.length)
-            throw new PSQLException(GT.tr("The column index is out of range: {0}, number of columns: {1}.", new Object[]{new Integer(index), new Integer(paramValues.length)}), PSQLState.INVALID_PARAMETER_VALUE );
+            throw new PSQLException(GT.tr("The column index is out of range: {0}, number of columns: {1}.", new Object[]{index, paramValues.length}), PSQLState.INVALID_PARAMETER_VALUE );
 
         paramValues[index - 1] = new StreamWrapper(data, offset, length);
     }
 
     public void setBytea(int index, final InputStream stream, final int length) throws SQLException {
         if (index < 1 || index > paramValues.length)
-            throw new PSQLException(GT.tr("The column index is out of range: {0}, number of columns: {1}.", new Object[]{new Integer(index), new Integer(paramValues.length)}), PSQLState.INVALID_PARAMETER_VALUE );
+            throw new PSQLException(GT.tr("The column index is out of range: {0}, number of columns: {1}.", new Object[]{index, paramValues.length}), PSQLState.INVALID_PARAMETER_VALUE );
 
         paramValues[index - 1] = new StreamWrapper(stream, length);
     }
@@ -89,7 +89,7 @@ class FastpathParameterList implements ParameterList {
     public void setBytea(int index, InputStream stream) throws SQLException
     {
         if (index < 1 || index > paramValues.length)
-            throw new PSQLException(GT.tr("The column index is out of range: {0}, number of columns: {1}.", new Object[]{new Integer(index), new Integer(paramValues.length)}), PSQLState.INVALID_PARAMETER_VALUE );
+            throw new PSQLException(GT.tr("The column index is out of range: {0}, number of columns: {1}.", new Object[]{index, paramValues.length}), PSQLState.INVALID_PARAMETER_VALUE );
 
         paramValues[index - 1] = new StreamWrapper(stream);
     }
@@ -147,7 +147,7 @@ class FastpathParameterList implements ParameterList {
         for (int i = 0; i < paramValues.length; i++)
         {
             if (paramValues[i] == null)
-                throw new PSQLException(GT.tr("No value specified for parameter {0}.", new Integer(i + 1)), PSQLState.INVALID_PARAMETER_VALUE);
+                throw new PSQLException(GT.tr("No value specified for parameter {0}.", i + 1), PSQLState.INVALID_PARAMETER_VALUE);
         }
     }
 

--- a/org/postgresql/core/v2/QueryExecutorImpl.java
+++ b/org/postgresql/core/v2/QueryExecutorImpl.java
@@ -167,7 +167,7 @@ public class QueryExecutorImpl implements QueryExecutor {
                     protoConnection.addWarning(receiveNotification());
                     break;
                 default:
-                    throw new PSQLException(GT.tr("Unknown Response Type {0}.", new Character((char) c)), PSQLState.CONNECTION_FAILURE);
+                    throw new PSQLException(GT.tr("Unknown Response Type {0}.", (char) c), PSQLState.CONNECTION_FAILURE);
                 }
             }
         } catch (IOException ioe) {
@@ -222,7 +222,7 @@ public class QueryExecutorImpl implements QueryExecutor {
                 }
 
                 if (c != '0')
-                    throw new PSQLException(GT.tr("Unknown Response Type {0}.", new Character((char) c)), PSQLState.CONNECTION_FAILURE);
+                    throw new PSQLException(GT.tr("Unknown Response Type {0}.", (char) c), PSQLState.CONNECTION_FAILURE);
 
                 break;
 
@@ -233,7 +233,7 @@ public class QueryExecutorImpl implements QueryExecutor {
                 break;
 
             default:
-                throw new PSQLException(GT.tr("Unknown Response Type {0}.", new Character((char) c)), PSQLState.CONNECTION_FAILURE);
+                throw new PSQLException(GT.tr("Unknown Response Type {0}.", (char) c), PSQLState.CONNECTION_FAILURE);
             }
 
         }
@@ -431,8 +431,7 @@ public class QueryExecutorImpl implements QueryExecutor {
                         }
                     }
 
-                    for (int i = 0; i < fields.length; i++)
-                        fields[i].setFormat(Field.BINARY_FORMAT); //Set the field to binary format
+                    for (Field field : fields) field.setFormat(Field.BINARY_FORMAT); //Set the field to binary format
                     if (maxRows == 0 || tuples.size() < maxRows)
                         tuples.add(tuple);
                 }

--- a/org/postgresql/core/v2/SimpleParameterList.java
+++ b/org/postgresql/core/v2/SimpleParameterList.java
@@ -54,7 +54,7 @@ class SimpleParameterList implements ParameterList {
 
     public void setLiteralParameter(int index, String value, int oid) throws SQLException {
         if (index < 1 || index > paramValues.length)
-            throw new PSQLException(GT.tr("The column index is out of range: {0}, number of columns: {1}.", new Object[]{new Integer(index), new Integer(paramValues.length)}), PSQLState.INVALID_PARAMETER_VALUE );
+            throw new PSQLException(GT.tr("The column index is out of range: {0}, number of columns: {1}.", new Object[]{index, paramValues.length}), PSQLState.INVALID_PARAMETER_VALUE );
 
         paramValues[index - 1] = value;
     }
@@ -73,14 +73,14 @@ class SimpleParameterList implements ParameterList {
 
     public void setBytea(int index, byte[] data, int offset, int length) throws SQLException {
         if (index < 1 || index > paramValues.length)
-            throw new PSQLException(GT.tr("The column index is out of range: {0}, number of columns: {1}.", new Object[]{new Integer(index), new Integer(paramValues.length)}), PSQLState.INVALID_PARAMETER_VALUE );
+            throw new PSQLException(GT.tr("The column index is out of range: {0}, number of columns: {1}.", new Object[]{index, paramValues.length}), PSQLState.INVALID_PARAMETER_VALUE );
 
         paramValues[index - 1] = new StreamWrapper(data, offset, length);
     }
 
     public void setBytea(int index, final InputStream stream, final int length) throws SQLException {
         if (index < 1 || index > paramValues.length)
-            throw new PSQLException(GT.tr("The column index is out of range: {0}, number of columns: {1}.", new Object[]{new Integer(index), new Integer(paramValues.length)}), PSQLState.INVALID_PARAMETER_VALUE );
+            throw new PSQLException(GT.tr("The column index is out of range: {0}, number of columns: {1}.", new Object[]{index, paramValues.length}), PSQLState.INVALID_PARAMETER_VALUE );
 
         paramValues[index - 1] = new StreamWrapper(stream, length);
     }
@@ -88,14 +88,14 @@ class SimpleParameterList implements ParameterList {
     public void setBytea(int index, InputStream stream) throws SQLException
     {
         if (index < 1 || index > paramValues.length)
-            throw new PSQLException(GT.tr("The column index is out of range: {0}, number of columns: {1}.", new Object[]{new Integer(index), new Integer(paramValues.length)}), PSQLState.INVALID_PARAMETER_VALUE );
+            throw new PSQLException(GT.tr("The column index is out of range: {0}, number of columns: {1}.", new Object[]{index, paramValues.length}), PSQLState.INVALID_PARAMETER_VALUE );
 
         paramValues[index - 1] = new StreamWrapper(stream);
     }
 
     public void setNull(int index, int oid) throws SQLException {
         if (index < 1 || index > paramValues.length)
-            throw new PSQLException(GT.tr("The column index is out of range: {0}, number of columns: {1}.", new Object[]{new Integer(index), new Integer(paramValues.length)}), PSQLState.INVALID_PARAMETER_VALUE );
+            throw new PSQLException(GT.tr("The column index is out of range: {0}, number of columns: {1}.", new Object[]{index, paramValues.length}), PSQLState.INVALID_PARAMETER_VALUE );
 
         paramValues[index - 1] = NULL_OBJECT;
     }
@@ -160,7 +160,7 @@ class SimpleParameterList implements ParameterList {
         for (int i = 0; i < paramValues.length; i++)
         {
             if (paramValues[i] == null)
-                throw new PSQLException(GT.tr("No value specified for parameter {0}.", new Integer(i + 1)), PSQLState.INVALID_PARAMETER_VALUE);
+                throw new PSQLException(GT.tr("No value specified for parameter {0}.", i + 1), PSQLState.INVALID_PARAMETER_VALUE);
         }
     }
 

--- a/org/postgresql/core/v3/CompositeParameterList.java
+++ b/org/postgresql/core/v3/CompositeParameterList.java
@@ -32,7 +32,7 @@ class CompositeParameterList implements V3ParameterList {
 
     private final int findSubParam(int index) throws SQLException {
         if (index < 1 || index > total)
-            throw new PSQLException(GT.tr("The column index is out of range: {0}, number of columns: {1}.", new Object[]{new Integer(index), new Integer(total)}), PSQLState.INVALID_PARAMETER_VALUE );
+            throw new PSQLException(GT.tr("The column index is out of range: {0}, number of columns: {1}.", new Object[]{index, total}), PSQLState.INVALID_PARAMETER_VALUE );
 
         for (int i = offsets.length - 1; i >= 0; --i)
             if (offsets[i] < index)
@@ -129,9 +129,8 @@ class CompositeParameterList implements V3ParameterList {
     }
 
     public void clear() {
-        for (int sub = 0; sub < subparams.length; ++sub)
-        {
-            subparams[sub].clear();
+        for (SimpleParameterList subparam : subparams) {
+            subparam.clear();
         }
     }
 
@@ -140,14 +139,16 @@ class CompositeParameterList implements V3ParameterList {
     }
 
     public void checkAllParametersSet() throws SQLException {
-        for (int sub = 0; sub < subparams.length; ++sub)
-            subparams[sub].checkAllParametersSet();
+        for (SimpleParameterList subparam : subparams) {
+            subparam.checkAllParametersSet();
+        }
     }
 
     public void convertFunctionOutParameters()
     {
-        for (int sub = 0; sub < subparams.length; ++sub)
-            subparams[sub].convertFunctionOutParameters();
+        for (SimpleParameterList subparam : subparams) {
+            subparam.convertFunctionOutParameters();
+        }
     }
 
     private final int total;

--- a/org/postgresql/core/v3/CompositeQuery.java
+++ b/org/postgresql/core/v3/CompositeQuery.java
@@ -46,8 +46,9 @@ class CompositeQuery implements V3Query {
     }
 
     public void close() {
-        for (int i = 0; i < subqueries.length; ++i)
-            subqueries[i].close();
+        for (SimpleQuery subquery : subqueries) {
+            subquery.close();
+        }
     }
 
     public SimpleQuery[] getSubqueries() {
@@ -55,8 +56,8 @@ class CompositeQuery implements V3Query {
     }
 
     public boolean isStatementDescribed() {
-        for (int i = 0; i < subqueries.length; ++i)
-            if (!subqueries[i].isStatementDescribed()) {
+        for (SimpleQuery subquery : subqueries)
+            if (!subquery.isStatementDescribed()) {
                 return false;
             }
         return true;
@@ -64,8 +65,8 @@ class CompositeQuery implements V3Query {
 
     public boolean isEmpty()
     {
-        for (int i = 0; i < subqueries.length; ++i)
-            if (!subqueries[i].isEmpty()) {
+        for (SimpleQuery subquery : subqueries)
+            if (!subquery.isEmpty()) {
                 return false;
             }
         return true;

--- a/org/postgresql/core/v3/ConnectionFactoryImpl.java
+++ b/org/postgresql/core/v3/ConnectionFactoryImpl.java
@@ -371,9 +371,8 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
         pgStream.SendInteger4(length);
         pgStream.SendInteger2(3); // protocol major
         pgStream.SendInteger2(0); // protocol minor
-        for (int i = 0; i < encodedParams.length; ++i)
-        {
-            pgStream.Send(encodedParams[i]);
+        for (byte[] encodedParam : encodedParams) {
+            pgStream.Send(encodedParam);
             pgStream.SendChar(0);
         }
 
@@ -600,7 +599,7 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
 	                    if (logger.logDebug())
 	                        logger.debug(" <=BE AuthenticationReq (unsupported type " + ((int)areq) + ")");
 	
-	                    throw new PSQLException(GT.tr("The authentication type {0} is not supported. Check that you have configured the pg_hba.conf file to include the client''s IP address or subnet, and that it is using an authentication scheme supported by the driver.", new Integer(areq)), PSQLState.CONNECTION_REJECTED);
+	                    throw new PSQLException(GT.tr("The authentication type {0} is not supported. Check that you have configured the pg_hba.conf file to include the client''s IP address or subnet, and that it is using an authentication scheme supported by the driver.", areq), PSQLState.CONNECTION_REJECTED);
 	                }
 	
 	                break;

--- a/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -389,10 +389,9 @@ public class QueryExecutorImpl implements QueryExecutor {
         boolean describeOnly = (QUERY_DESCRIBE_ONLY & flags) != 0;
         // Check parameters and resolve OIDs.
         if (!describeOnly) {
-            for (int i = 0; i < parameterLists.length; ++i)
-            {
-                if (parameterLists[i] != null)
-                    ((V3ParameterList)parameterLists[i]).checkAllParametersSet();
+            for (ParameterList parameterList : parameterLists) {
+                if (parameterList != null)
+                    ((V3ParameterList) parameterList).checkAllParametersSet();
             }
         }
 
@@ -646,7 +645,7 @@ public class QueryExecutorImpl implements QueryExecutor {
                     protoConnection.addWarning(warning);
                     break;
                 default:
-                    throw new PSQLException(GT.tr("Unknown Response Type {0}.", new Character((char) c)), PSQLState.CONNECTION_FAILURE);
+                    throw new PSQLException(GT.tr("Unknown Response Type {0}.", (char) c), PSQLState.CONNECTION_FAILURE);
                 }
             }
         } catch (IOException ioe) {
@@ -704,7 +703,7 @@ public class QueryExecutorImpl implements QueryExecutor {
                 break;
 
             default:
-                throw new PSQLException(GT.tr("Unknown Response Type {0}.", new Character((char) c)), PSQLState.CONNECTION_FAILURE);
+                throw new PSQLException(GT.tr("Unknown Response Type {0}.", (char) c), PSQLState.CONNECTION_FAILURE);
             }
 
         }
@@ -1333,9 +1332,8 @@ public class QueryExecutorImpl implements QueryExecutor {
         if (encodedStatementName != null)
             pgStream.Send(encodedStatementName);
         pgStream.SendChar(0);   // End of statement name
-        for (int i = 0; i < parts.length; ++i)
-        { // Query string
-            pgStream.Send(parts[i]);
+        for (byte[] part : parts) { // Query string
+            pgStream.Send(part);
         }
         pgStream.SendChar(0);       // End of query string.
         pgStream.SendInteger2(params.getParameterCount());       // # of parameter types specified
@@ -1387,9 +1385,9 @@ public class QueryExecutorImpl implements QueryExecutor {
         int numBinaryFields = 0;
         Field[] fields = query.getFields();
         if (!noBinaryTransfer && fields != null) {
-            for (int i = 0; i < fields.length; ++i) {
-                if (useBinary(fields[i])) {
-                    fields[i].setFormat(Field.BINARY_FORMAT);
+            for (Field field : fields) {
+                if (useBinary(field)) {
+                    field.setFormat(Field.BINARY_FORMAT);
                     numBinaryFields = fields.length;
                 }
             }
@@ -1410,7 +1408,7 @@ public class QueryExecutorImpl implements QueryExecutor {
         //
         if (encodedSize > 0x3fffffff)
         {
-            throw new PGBindException(new IOException(GT.tr("Bind message length {0} too long.  This can be caused by very large or incorrect length specifications on InputStream parameters.", new Long(encodedSize))));
+            throw new PGBindException(new IOException(GT.tr("Bind message length {0} too long.  This can be caused by very large or incorrect length specifications on InputStream parameters.", encodedSize)));
         }
 
         pgStream.SendChar('B');                  // Bind
@@ -1527,7 +1525,7 @@ public class QueryExecutorImpl implements QueryExecutor {
             pgStream.Send(encodedStatementName);    // Statement name
         pgStream.SendChar(0);                       // end message
 
-        pendingDescribeStatementQueue.add(new Object[]{query, params, new Boolean(describeOnly), query.getStatementName()});
+        pendingDescribeStatementQueue.add(new Object[]{query, params, describeOnly, query.getStatementName()});
         pendingDescribePortalQueue.add(query);
         query.setStatementDescribed(true);
         query.setPortalDescribed(true);
@@ -1831,7 +1829,7 @@ public class QueryExecutorImpl implements QueryExecutor {
                     Object describeData[] = (Object[])pendingDescribeStatementQueue.get(describeIndex);
                     SimpleQuery query = (SimpleQuery)describeData[0];
                     SimpleParameterList params = (SimpleParameterList)describeData[1];
-                    boolean describeOnly = ((Boolean)describeData[2]).booleanValue();
+                    boolean describeOnly = (Boolean) describeData[2];
                     String origStatementName = (String)describeData[3];
 
                     int numParams = pgStream.ReceiveInteger2();
@@ -1975,9 +1973,9 @@ public class QueryExecutorImpl implements QueryExecutor {
                         length = -1;
                     } else {
                         length = 0;
-                        for (int i=0; i< tuple.length; ++i) {
-                            if (tuple[i] == null) continue;
-                            length += tuple[i].length;
+                        for (byte[] aTuple : tuple) {
+                            if (aTuple == null) continue;
+                            length += aTuple.length;
                         }
                     }
                     logger.debug(" <=BE DataRow(len=" + length + ")");

--- a/org/postgresql/core/v3/SimpleParameterList.java
+++ b/org/postgresql/core/v3/SimpleParameterList.java
@@ -46,14 +46,14 @@ class SimpleParameterList implements V3ParameterList {
     public void registerOutParameter( int index, int sqlType ) throws SQLException
     {
         if (index < 1 || index > paramValues.length)
-            throw new PSQLException(GT.tr("The column index is out of range: {0}, number of columns: {1}.", new Object[]{new Integer(index), new Integer(paramValues.length)}), PSQLState.INVALID_PARAMETER_VALUE);
+            throw new PSQLException(GT.tr("The column index is out of range: {0}, number of columns: {1}.", new Object[]{index, paramValues.length}), PSQLState.INVALID_PARAMETER_VALUE);
 
         flags[index-1] |= OUT;
     }
 
     private void bind(int index, Object value, int oid, int binary) throws SQLException {
         if (index < 1 || index > paramValues.length)
-            throw new PSQLException(GT.tr("The column index is out of range: {0}, number of columns: {1}.", new Object[]{new Integer(index), new Integer(paramValues.length)}), PSQLState.INVALID_PARAMETER_VALUE);
+            throw new PSQLException(GT.tr("The column index is out of range: {0}, number of columns: {1}.", new Object[]{index, paramValues.length}), PSQLState.INVALID_PARAMETER_VALUE);
 
         --index;
 
@@ -225,7 +225,7 @@ class SimpleParameterList implements V3ParameterList {
         for (int i = 0; i < paramTypes.length; ++i)
         {
             if (direction(i) != OUT && paramValues[i] == null)
-                throw new PSQLException(GT.tr("No value specified for parameter {0}.", new Integer(i + 1)), PSQLState.INVALID_PARAMETER_VALUE);
+                throw new PSQLException(GT.tr("No value specified for parameter {0}.", i + 1), PSQLState.INVALID_PARAMETER_VALUE);
             }
         }
 
@@ -269,10 +269,10 @@ class SimpleParameterList implements V3ParameterList {
     }
 
     boolean hasUnresolvedTypes() {
-        for (int i=0; i< paramTypes.length; i++) {
-            if (paramTypes[i] == Oid.UNSPECIFIED)
+        for (int paramType : paramTypes) {
+            if (paramType == Oid.UNSPECIFIED)
                 return true;
-            }
+        }
         return false;
     }
 

--- a/org/postgresql/core/v3/SimpleQuery.java
+++ b/org/postgresql/core/v3/SimpleQuery.java
@@ -77,7 +77,7 @@ class SimpleQuery implements V3Query {
 	 */
 	public int getMaxResultRowSize() {
 		if (cachedMaxResultRowSize != null) {
-			return cachedMaxResultRowSize.intValue();
+			return cachedMaxResultRowSize;
 		}
 		if (!this.statementDescribed) {
 			throw new IllegalStateException(
@@ -85,20 +85,19 @@ class SimpleQuery implements V3Query {
 		}
 		int maxResultRowSize = 0;
 		if (fields != null) {
-			for (int i = 0; i < fields.length; i++) {
-				Field f = fields[i];
-				final int fieldLength = f.getLength();
-				if (fieldLength < 1 || fieldLength >= 65535) {
-					/*
+            for (Field f : fields) {
+                final int fieldLength = f.getLength();
+                if (fieldLength < 1 || fieldLength >= 65535) {
+                    /*
 					 * Field length unknown or large; we can't make any safe
 					 * estimates about the result size, so we have to fall back to
 					 * sending queries individually.
 					 */
-					maxResultRowSize = -1;
-					break;
-				}
-				maxResultRowSize += fieldLength;
-			}
+                    maxResultRowSize = -1;
+                    break;
+                }
+                maxResultRowSize += fieldLength;
+            }
 		}
 		cachedMaxResultRowSize = maxResultRowSize;
 		return maxResultRowSize;
@@ -161,8 +160,8 @@ class SimpleQuery implements V3Query {
         if (preparedTypes == null)
             return true;
 
-        for (int i=0; i<preparedTypes.length; i++) {
-            if (preparedTypes[i] == Oid.UNSPECIFIED)
+        for (int preparedType : preparedTypes) {
+            if (preparedType == Oid.UNSPECIFIED)
                 return true;
         }
 

--- a/org/postgresql/fastpath/Fastpath.java
+++ b/org/postgresql/fastpath/Fastpath.java
@@ -75,15 +75,15 @@ public class Fastpath
 
         if (returnValue.length == 4)
         {
-            return new Integer(ByteConverter.int4(returnValue, 0));
+            return ByteConverter.int4(returnValue, 0);
         }
         else if (returnValue.length == 8)
         {
-            return new Long(ByteConverter.int8(returnValue, 0));
+            return ByteConverter.int8(returnValue, 0);
         }
         else
         {
-            throw new PSQLException(GT.tr("Fastpath call {0} - No result was returned and we expected a numeric.", new Integer(fnId)),
+            throw new PSQLException(GT.tr("Fastpath call {0} - No result was returned and we expected a numeric.", fnId),
                                     PSQLState.NO_DATA);
         }
     }
@@ -251,7 +251,7 @@ public class Fastpath
      */
     public void addFunction(String name, int fnid)
     {
-        func.put(name, new Integer(fnid));
+        func.put(name, fnid);
     }
 
     /**
@@ -290,7 +290,7 @@ public class Fastpath
     {
         while (rs.next())
         {
-            func.put(rs.getString(1), new Integer(rs.getInt(2)));
+            func.put(rs.getString(1), rs.getInt(2));
         }
     }
 
@@ -318,7 +318,7 @@ public class Fastpath
         if (id == null)
             throw new PSQLException(GT.tr("The fastpath function {0} is unknown.", name), PSQLState.UNEXPECTED_ERROR);
 
-        return id.intValue();
+        return id;
     }
 
     /**

--- a/org/postgresql/gss/GSSCallbackHandler.java
+++ b/org/postgresql/gss/GSSCallbackHandler.java
@@ -24,9 +24,9 @@ public class GSSCallbackHandler implements CallbackHandler {
 
     public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException
     {
-        for (int i=0; i<callbacks.length; i++) {
-            if (callbacks[i] instanceof TextOutputCallback) {
-                TextOutputCallback toc = (TextOutputCallback)callbacks[i];
+        for (Callback callback : callbacks) {
+            if (callback instanceof TextOutputCallback) {
+                TextOutputCallback toc = (TextOutputCallback) callback;
                 switch (toc.getMessageType()) {
                     case TextOutputCallback.INFORMATION:
                         System.out.println("INFO: " + toc.getMessage());
@@ -40,17 +40,17 @@ public class GSSCallbackHandler implements CallbackHandler {
                     default:
                         throw new IOException("Unsupported message type: " + toc.getMessageType());
                 }
-            } else if (callbacks[i] instanceof NameCallback) {
-                NameCallback nc = (NameCallback)callbacks[i];
+            } else if (callback instanceof NameCallback) {
+                NameCallback nc = (NameCallback) callback;
                 nc.setName(user);
-            } else if (callbacks[i] instanceof PasswordCallback) {
-                PasswordCallback pc = (PasswordCallback)callbacks[i];
+            } else if (callback instanceof PasswordCallback) {
+                PasswordCallback pc = (PasswordCallback) callback;
                 if (password == null) {
                     throw new IOException("No cached kerberos ticket found and no password supplied.");
                 }
                 pc.setPassword(password.toCharArray());
             } else {
-                throw new UnsupportedCallbackException(callbacks[i], "Unrecognized Callback");
+                throw new UnsupportedCallbackException(callback, "Unrecognized Callback");
             }
         }
     }

--- a/org/postgresql/gss/MakeGSS.java
+++ b/org/postgresql/gss/MakeGSS.java
@@ -101,8 +101,8 @@ class GssAction implements PrivilegedAction
         org.ietf.jgss.Oid spnego = new org.ietf.jgss.Oid("1.3.6.1.5.5.2");
         org.ietf.jgss.Oid mechs[] = manager.getMechs();
 
-        for (int i = 0; i < mechs.length; ++i) {
-            if (mechs[i].equals(spnego)) {
+        for (Oid mech : mechs) {
+            if (mech.equals(spnego)) {
                 return true;
             }
         }

--- a/org/postgresql/jdbc2/AbstractJdbc2Array.java
+++ b/org/postgresql/jdbc2/AbstractJdbc2Array.java
@@ -150,7 +150,7 @@ public abstract class AbstractJdbc2Array
         // array index is out of range
         if (index < 1)
         {
-            throw new PSQLException(GT.tr("The array index is out of range: {0}", new Long(index)), PSQLState.DATA_ERROR);
+            throw new PSQLException(GT.tr("The array index is out of range: {0}", index), PSQLState.DATA_ERROR);
         }
 
         if (fieldBytes != null) {
@@ -165,7 +165,7 @@ public abstract class AbstractJdbc2Array
         // array index out of range
         if ((--index) + count > arrayList.size())
         {
-            throw new PSQLException(GT.tr("The array index is out of range: {0}, number of elements: {1}.", new Object[] { new Long(index + count), new Long(arrayList.size()) }), PSQLState.DATA_ERROR);
+            throw new PSQLException(GT.tr("The array index is out of range: {0}, number of elements: {1}.", new Object[] {index + count, (long) arrayList.size()}), PSQLState.DATA_ERROR);
         }
 
         return buildArray(arrayList, (int) index, count);
@@ -213,19 +213,19 @@ public abstract class AbstractJdbc2Array
                 }
                 switch (elementOid) {
                     case Oid.INT2:
-                        arr[i] = new Short(ByteConverter.int2(fieldBytes, pos));
+                        arr[i] = ByteConverter.int2(fieldBytes, pos);
                         break;
                     case Oid.INT4:
-                        arr[i] = new Integer(ByteConverter.int4(fieldBytes, pos));
+                        arr[i] = ByteConverter.int4(fieldBytes, pos);
                         break;
                     case Oid.INT8:
-                        arr[i] = new Long(ByteConverter.int8(fieldBytes, pos));
+                        arr[i] = ByteConverter.int8(fieldBytes, pos);
                         break;
                     case Oid.FLOAT4:
-                        arr[i] = new Float(ByteConverter.float4(fieldBytes, pos));
+                        arr[i] = ByteConverter.float4(fieldBytes, pos);
                         break;
                     case Oid.FLOAT8:
-                        arr[i] = new Double(ByteConverter.float8(fieldBytes, pos));
+                        arr[i] = ByteConverter.float8(fieldBytes, pos);
                         break;
                     case Oid.TEXT:
                     case Oid.VARCHAR:
@@ -813,7 +813,7 @@ public abstract class AbstractJdbc2Array
         // array index is out of range
         if (index < 1)
         {
-            throw new PSQLException(GT.tr("The array index is out of range: {0}", new Long(index)), PSQLState.DATA_ERROR);
+            throw new PSQLException(GT.tr("The array index is out of range: {0}", index), PSQLState.DATA_ERROR);
         }
 
         if (fieldBytes != null) {
@@ -830,7 +830,7 @@ public abstract class AbstractJdbc2Array
         // array index out of range
         if ((--index) + count > arrayList.size())
         {
-            throw new PSQLException(GT.tr("The array index is out of range: {0}, number of elements: {1}.", new Object[] { new Long(index + count), new Long(arrayList.size()) }), PSQLState.DATA_ERROR);
+            throw new PSQLException(GT.tr("The array index is out of range: {0}, number of elements: {1}.", new Object[] {index + count, (long) arrayList.size()}), PSQLState.DATA_ERROR);
         }
 
         List rows = new ArrayList();

--- a/org/postgresql/jdbc2/AbstractJdbc2BlobClob.java
+++ b/org/postgresql/jdbc2/AbstractJdbc2BlobClob.java
@@ -103,7 +103,7 @@ public abstract class AbstractJdbc2BlobClob
             }
             else
             {
-                throw new PSQLException(GT.tr("PostgreSQL LOBs can only index to: {0}", new Integer(Integer.MAX_VALUE)), PSQLState.INVALID_PARAMETER_VALUE);
+                throw new PSQLException(GT.tr("PostgreSQL LOBs can only index to: {0}", Integer.MAX_VALUE), PSQLState.INVALID_PARAMETER_VALUE);
             }
         }
         else
@@ -267,7 +267,7 @@ public abstract class AbstractJdbc2BlobClob
         }
         if (pos + len - 1 > Integer.MAX_VALUE)
         {
-            throw new PSQLException(GT.tr("PostgreSQL LOBs can only index to: {0}", new Integer(Integer.MAX_VALUE)), PSQLState.INVALID_PARAMETER_VALUE);
+            throw new PSQLException(GT.tr("PostgreSQL LOBs can only index to: {0}", Integer.MAX_VALUE), PSQLState.INVALID_PARAMETER_VALUE);
         }
     }
 

--- a/org/postgresql/jdbc2/AbstractJdbc2Connection.java
+++ b/org/postgresql/jdbc2/AbstractJdbc2Connection.java
@@ -102,7 +102,7 @@ public abstract class AbstractJdbc2Connection implements BaseConnection
         int logLevel = Driver.getLogLevel();
         Integer connectionLogLevel = PGProperty.LOG_LEVEL.getInteger(info);
         if (connectionLogLevel != null) {
-            logLevel = connectionLogLevel.intValue();
+            logLevel = connectionLogLevel;
         }
 
         synchronized (AbstractJdbc2Connection.class) {
@@ -894,13 +894,13 @@ public abstract class AbstractJdbc2Connection implements BaseConnection
             return Connection.TRANSACTION_READ_COMMITTED; // Best guess.
 
         level = level.toUpperCase(Locale.US);
-        if (level.indexOf("READ COMMITTED") != -1)
+        if (level.contains("READ COMMITTED"))
             return Connection.TRANSACTION_READ_COMMITTED;
-        if (level.indexOf("READ UNCOMMITTED") != -1)
+        if (level.contains("READ UNCOMMITTED"))
             return Connection.TRANSACTION_READ_UNCOMMITTED;
-        if (level.indexOf("REPEATABLE READ") != -1)
+        if (level.contains("REPEATABLE READ"))
             return Connection.TRANSACTION_REPEATABLE_READ;
-        if (level.indexOf("SERIALIZABLE") != -1)
+        if (level.contains("SERIALIZABLE"))
             return Connection.TRANSACTION_SERIALIZABLE;
 
         return Connection.TRANSACTION_READ_COMMITTED; // Best guess.
@@ -929,7 +929,7 @@ public abstract class AbstractJdbc2Connection implements BaseConnection
 
         String isolationLevelName = getIsolationLevelName(level);
         if (isolationLevelName == null)
-            throw new PSQLException(GT.tr("Transaction isolation level {0} not supported.", new Integer(level)), PSQLState.NOT_IMPLEMENTED);
+            throw new PSQLException(GT.tr("Transaction isolation level {0} not supported.", level), PSQLState.NOT_IMPLEMENTED);
 
         String isolationLevelSQL = "SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL " + isolationLevelName;
         execSQLUpdate(isolationLevelSQL); // nb: no BEGIN triggered

--- a/org/postgresql/jdbc2/AbstractJdbc2DatabaseMetaData.java
+++ b/org/postgresql/jdbc2/AbstractJdbc2DatabaseMetaData.java
@@ -1846,7 +1846,7 @@ public abstract class AbstractJdbc2DatabaseMetaData
                     long tempAllArgTypes[] = (long[])allArgTypesArray.getArray();
                     allArgTypes = new Long[tempAllArgTypes.length];
                     for (int i=0; i<tempAllArgTypes.length; i++) {
-                        allArgTypes[i] = new Long(tempAllArgTypes[i]);
+                        allArgTypes[i] = tempAllArgTypes[i];
                     }
                 }
                 numArgs = allArgTypes.length;
@@ -2124,12 +2124,10 @@ public abstract class AbstractJdbc2DatabaseMetaData
         }
         if (types != null) {
             select += " AND (false ";
-            for (int i = 0; i < types.length; i++)
-            {
-                Map clauses = (Map)tableTypeClauses.get(types[i]);
-                if (clauses != null)
-                {
-                    String clause = (String)clauses.get(useSchemas);
+            for (String type : types) {
+                Map clauses = (Map) tableTypeClauses.get(type);
+                if (clauses != null) {
+                    String clause = (String) clauses.get(useSchemas);
                     select += " OR ( " + clause + " ) ";
                 }
             }
@@ -2495,12 +2493,12 @@ public abstract class AbstractJdbc2DatabaseMetaData
             {
                 if ( pgType.equals("int4") )
                 {
-                    if (defval.indexOf("nextval(") != -1)
+                    if (defval.contains("nextval("))
                         tuple[5] = connection.encodeString("serial"); // Type name == serial
                 }
                 else if ( pgType.equals("int8") )
                 {
-                    if (defval.indexOf("nextval(") != -1)
+                    if (defval.contains("nextval("))
                         tuple[5] = connection.encodeString("bigserial"); // Type name == bigserial
                 }
             }
@@ -2542,7 +2540,7 @@ public abstract class AbstractJdbc2DatabaseMetaData
 
             if (jdbcVersion >= 4) {
                 String autoinc = "NO";
-                if (defval != null && defval.indexOf("nextval(") != -1) {
+                if (defval != null && defval.contains("nextval(")) {
                     autoinc = "YES";
                 }
                 tuple[22] = connection.encodeString(autoinc);
@@ -2742,20 +2740,20 @@ public abstract class AbstractJdbc2DatabaseMetaData
                 {
                 	List grantor = (List)grantees.get(granteeUsers[j]);
                 	String grantee = (String)granteeUsers[j];
-                	for (int l = 0; l < grantor.size(); l++) {
-                		String[] grants = (String[])grantor.get(l);                	
-	                    String grantable = owner.equals(grantee) ? "YES" : grants[1];
-                    byte[][] tuple = new byte[8][];
-                    tuple[0] = null;
-                    tuple[1] = schemaName;
-                    tuple[2] = tableName;
-                    tuple[3] = column;
-	                    tuple[4] = connection.encodeString(grants[0]);
-                    tuple[5] = connection.encodeString(grantee);
-                    tuple[6] = privilege;
-                    tuple[7] = connection.encodeString(grantable);
-                    v.add(tuple);
-                }
+                    for (Object aGrantor : grantor) {
+                        String[] grants = (String[]) aGrantor;
+                        String grantable = owner.equals(grantee) ? "YES" : grants[1];
+                        byte[][] tuple = new byte[8][];
+                        tuple[0] = null;
+                        tuple[1] = schemaName;
+                        tuple[2] = tableName;
+                        tuple[3] = column;
+                        tuple[4] = connection.encodeString(grants[0]);
+                        tuple[5] = connection.encodeString(grantee);
+                        tuple[6] = privilege;
+                        tuple[7] = connection.encodeString(grantable);
+                        v.add(tuple);
+                    }
             }
         }
 	}
@@ -2862,27 +2860,26 @@ public abstract class AbstractJdbc2DatabaseMetaData
                 while (g.hasNext()){
                 	granteeUsers[k++] = (String)g.next();
                 }
-                for (int j = 0; j < granteeUsers.length; j++)
-                {
-                	List grants = (List)grantees.get(granteeUsers[j]);
-                	String grantee = (String)granteeUsers[j];
-                	for (int l = 0; l < grants.size(); l++) {
-                		String[] grantTuple = (String[])grants.get(l);
-                		// report the owner as grantor if it's missing
+                for (String granteeUser : granteeUsers) {
+                    List grants = (List) grantees.get(granteeUser);
+                    String grantee = (String) granteeUser;
+                    for (Object grant : grants) {
+                        String[] grantTuple = (String[]) grant;
+                        // report the owner as grantor if it's missing
                         String grantor = grantTuple[0].equals(null) ? owner : grantTuple[0];
                         // owner always has grant privileges
                         String grantable = owner.equals(grantee) ? "YES" : grantTuple[1];
-                    	byte[][] tuple = new byte[7][];
-                    	tuple[0] = null;
-                    	tuple[1] = schema;
-                    	tuple[2] = table;
+                        byte[][] tuple = new byte[7][];
+                        tuple[0] = null;
+                        tuple[1] = schema;
+                        tuple[2] = table;
                         tuple[3] = connection.encodeString(grantor);
-                    	tuple[4] = connection.encodeString(grantee);
-                    	tuple[5] = privilege;
-                    	tuple[6] = connection.encodeString(grantable);
-                    	v.add(tuple);
-                    		
-                	}
+                        tuple[4] = connection.encodeString(grantee);
+                        tuple[5] = privilege;
+                        tuple[6] = connection.encodeString(grantable);
+                        v.add(tuple);
+
+                    }
                 }
             }
         }
@@ -3075,9 +3072,8 @@ public abstract class AbstractJdbc2DatabaseMetaData
 
         List acls = parseACLArray(aclArray);
         Map privileges = new HashMap();
-        for (int i = 0; i < acls.size(); i++)
-        {
-            String acl = (String)acls.get(i);
+        for (Object acl1 : acls) {
+            String acl = (String) acl1;
             addACLPrivileges(acl, privileges);
         }
         return privileges;
@@ -4392,16 +4388,14 @@ public abstract class AbstractJdbc2DatabaseMetaData
         if ( types != null )
         {
             toAdd += " and (false ";
-            for (int i = 0; i < types.length; i++)
-            {
-                switch (types[i] )
-                {
-                case java.sql.Types.STRUCT:
-                    toAdd += " or t.typtype = 'c'";
-                    break;
-                case java.sql.Types.DISTINCT:
-                    toAdd += " or t.typtype = 'd'";
-                    break;
+            for (int type : types) {
+                switch (type) {
+                    case Types.STRUCT:
+                        toAdd += " or t.typtype = 'c'";
+                        break;
+                    case Types.DISTINCT:
+                        toAdd += " or t.typtype = 'd'";
+                        break;
                 }
             }
             toAdd += " ) ";

--- a/org/postgresql/jdbc2/AbstractJdbc2ResultSet.java
+++ b/org/postgresql/jdbc2/AbstractJdbc2ResultSet.java
@@ -138,18 +138,18 @@ public abstract class AbstractJdbc2ResultSet implements BaseResultSet, org.postg
         case Types.TINYINT:
         case Types.SMALLINT:
         case Types.INTEGER:
-            return new Integer(getInt(columnIndex));
+            return getInt(columnIndex);
         case Types.BIGINT:
-            return new Long(getLong(columnIndex));
+            return getLong(columnIndex);
         case Types.NUMERIC:
         case Types.DECIMAL:
             return getBigDecimal
                    (columnIndex, (field.getMod() == -1) ? -1 : ((field.getMod() - 4) & 0xffff));
         case Types.REAL:
-            return new Float(getFloat(columnIndex));
+            return getFloat(columnIndex);
         case Types.FLOAT:
         case Types.DOUBLE:
-            return new Double(getDouble(columnIndex));
+            return getDouble(columnIndex);
         case Types.CHAR:
         case Types.VARCHAR:
         case Types.LONGVARCHAR:
@@ -786,7 +786,7 @@ public abstract class AbstractJdbc2ResultSet implements BaseResultSet, org.postg
             checkScrollable();
             break;
         default:
-            throw new PSQLException(GT.tr("Invalid fetch direction constant: {0}.", new Integer(direction)),
+            throw new PSQLException(GT.tr("Invalid fetch direction constant: {0}.", direction),
                                     PSQLState.INVALID_PARAMETER_VALUE);
         }
 
@@ -940,7 +940,7 @@ public abstract class AbstractJdbc2ResultSet implements BaseResultSet, org.postg
 
                 long insertedOID = ((AbstractJdbc2Statement) insertStatement).getLastOID();
 
-                updateValues.put("oid", new Long(insertedOID) );
+                updateValues.put("oid", insertedOID);
 
             }
 
@@ -1140,7 +1140,7 @@ public abstract class AbstractJdbc2ResultSet implements BaseResultSet, org.postg
     public synchronized void updateBoolean(int columnIndex, boolean x)
     throws SQLException
     {
-        updateValue(columnIndex, new Boolean(x));
+        updateValue(columnIndex, x);
     }
 
 
@@ -1204,28 +1204,28 @@ public abstract class AbstractJdbc2ResultSet implements BaseResultSet, org.postg
     public synchronized void updateDouble(int columnIndex, double x)
     throws SQLException
     {
-        updateValue(columnIndex, new Double(x));
+        updateValue(columnIndex, x);
     }
 
 
     public synchronized void updateFloat(int columnIndex, float x)
     throws SQLException
     {
-        updateValue(columnIndex, new Float(x));
+        updateValue(columnIndex, x);
     }
 
 
     public synchronized void updateInt(int columnIndex, int x)
     throws SQLException
     {
-        updateValue(columnIndex, new Integer(x));
+        updateValue(columnIndex, x);
     }
 
 
     public synchronized void updateLong(int columnIndex, long x)
     throws SQLException
     {
-        updateValue(columnIndex, new Long(x));
+        updateValue(columnIndex, x);
     }
 
 
@@ -1403,7 +1403,7 @@ public abstract class AbstractJdbc2ResultSet implements BaseResultSet, org.postg
     public synchronized void updateShort(int columnIndex, short x)
     throws SQLException
     {
-        updateValue(columnIndex, new Short(x));
+        updateValue(columnIndex, x);
     }
 
 
@@ -2743,9 +2743,9 @@ public abstract class AbstractJdbc2ResultSet implements BaseResultSet, org.postg
             for (int i = fields.length - 1; i >= 0; i--)
             {
                 if (isSanitiserDisabled){
-                    columnNameIndexMap.put(fields[i].getColumnLabel(), new Integer(i + 1));
+                    columnNameIndexMap.put(fields[i].getColumnLabel(), i + 1);
                 } else {
-                    columnNameIndexMap.put(fields[i].getColumnLabel().toLowerCase(Locale.US), new Integer(i + 1));
+                    columnNameIndexMap.put(fields[i].getColumnLabel().toLowerCase(Locale.US), i + 1);
                 }
             }
         }
@@ -2753,21 +2753,21 @@ public abstract class AbstractJdbc2ResultSet implements BaseResultSet, org.postg
         Integer index = (Integer)columnNameIndexMap.get(columnName);
         if (index != null)
         {
-            return index.intValue();
+            return index;
         }
         
         index = (Integer)columnNameIndexMap.get(columnName.toLowerCase(Locale.US));
         if (index != null)
         {
             columnNameIndexMap.put(columnName, index);
-            return index.intValue();
+            return index;
         }
 
         index = (Integer)columnNameIndexMap.get(columnName.toUpperCase(Locale.US));
         if (index != null)
         {
             columnNameIndexMap.put(columnName, index);
-            return index.intValue();
+            return index;
         }
     
         return 0;
@@ -2864,7 +2864,7 @@ public abstract class AbstractJdbc2ResultSet implements BaseResultSet, org.postg
     protected void checkColumnIndex(int column) throws SQLException
     {
         if ( column < 1 || column > fields.length )
-            throw new PSQLException(GT.tr("The column index is out of range: {0}, number of columns: {1}.", new Object[]{new Integer(column), new Integer(fields.length)}), PSQLState.INVALID_PARAMETER_VALUE );
+            throw new PSQLException(GT.tr("The column index is out of range: {0}, number of columns: {1}.", new Object[]{column, fields.length}), PSQLState.INVALID_PARAMETER_VALUE );
     }
 
     /**
@@ -3198,7 +3198,7 @@ public abstract class AbstractJdbc2ResultSet implements BaseResultSet, org.postg
                     PSQLState.DATA_TYPE_MISMATCH);
         }
         if (val < minVal || val > maxVal) {
-            throw new PSQLException(GT.tr("Bad value for type {0} : {1}", new Object[]{targetType, new Long(val)}),
+            throw new PSQLException(GT.tr("Bad value for type {0} : {1}", new Object[]{targetType, val}),
                                     PSQLState.NUMERIC_VALUE_OUT_OF_RANGE);
         }
         return val;

--- a/org/postgresql/jdbc2/AbstractJdbc2ResultSetMetaData.java
+++ b/org/postgresql/jdbc2/AbstractJdbc2ResultSetMetaData.java
@@ -220,19 +220,19 @@ public abstract class AbstractJdbc2ResultSetMetaData implements PGResultSetMetaD
         // so we've got to fake that with a JOIN here.
         //
         boolean hasSourceInfo = false;
-        for (int i=0; i<fields.length; i++) {
-            if (fields[i].getTableOid() == 0)
+        for (Field field : fields) {
+            if (field.getTableOid() == 0)
                 continue;
 
             if (hasSourceInfo)
                 sql.append(" UNION ALL ");
 
             sql.append("SELECT ");
-            sql.append(fields[i].getTableOid());
+            sql.append(field.getTableOid());
             if (!hasSourceInfo)
                 sql.append(" AS oid ");
             sql.append(", ");
-            sql.append(fields[i].getPositionInTable());
+            sql.append(field.getPositionInTable());
             if (!hasSourceInfo)
                 sql.append(" AS attnum");
 
@@ -254,13 +254,13 @@ public abstract class AbstractJdbc2ResultSetMetaData implements PGResultSetMetaD
             String schemaName = rs.getString(5);
             int nullable = rs.getBoolean(6) ? ResultSetMetaData.columnNoNulls : ResultSetMetaData.columnNullable;
             boolean autoIncrement = rs.getBoolean(7);
-            for (int i=0; i<fields.length; i++) {
-                if (fields[i].getTableOid() == table && fields[i].getPositionInTable() == column) {
-                    fields[i].setColumnName(columnName);
-                    fields[i].setTableName(tableName);
-                    fields[i].setSchemaName(schemaName);
-                    fields[i].setNullable(nullable);
-                    fields[i].setAutoIncrement(autoIncrement);
+            for (Field field : fields) {
+                if (field.getTableOid() == table && field.getPositionInTable() == column) {
+                    field.setColumnName(columnName);
+                    field.setTableName(tableName);
+                    field.setSchemaName(schemaName);
+                    field.setNullable(nullable);
+                    field.setAutoIncrement(autoIncrement);
                 }
             }
         }
@@ -442,7 +442,7 @@ public abstract class AbstractJdbc2ResultSetMetaData implements PGResultSetMetaD
     protected Field getField(int columnIndex) throws SQLException
     {
         if (columnIndex < 1 || columnIndex > fields.length)
-            throw new PSQLException(GT.tr("The column index is out of range: {0}, number of columns: {1}.", new Object[]{new Integer(columnIndex), new Integer(fields.length)}), PSQLState.INVALID_PARAMETER_VALUE );
+            throw new PSQLException(GT.tr("The column index is out of range: {0}, number of columns: {1}.", new Object[]{columnIndex, fields.length}), PSQLState.INVALID_PARAMETER_VALUE );
         return fields[columnIndex - 1];
     }
 

--- a/org/postgresql/jdbc2/AbstractJdbc2Statement.java
+++ b/org/postgresql/jdbc2/AbstractJdbc2Statement.java
@@ -464,12 +464,12 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
                     {
                         // return it as a float
                         if ( callResult[j] != null)
-                            callResult[j] = new Float(((Double)callResult[j]).floatValue());
+                            callResult[j] = ((Double) callResult[j]).floatValue();
                     }
                     else
                     {    
 	                    throw new PSQLException (GT.tr("A CallableStatement function was executed and the out parameter {0} was of type {1} however type {2} was registered.",
-	                            new Object[]{new Integer(i+1),
+	                            new Object[]{i + 1,
 	                                "java.sql.Types=" + columnType, "java.sql.Types=" + functionReturnType[j] }),
 	                      PSQLState.DATA_TYPE_MISMATCH);
                     }
@@ -1494,7 +1494,7 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
             return ;
         }
         if (length < 0)
-            throw new PSQLException(GT.tr("Invalid stream length {0}.", new Integer(length)),
+            throw new PSQLException(GT.tr("Invalid stream length {0}.", length),
                                     PSQLState.INVALID_PARAMETER_VALUE);
 
 
@@ -1619,7 +1619,7 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
         }
 
         if (length < 0)
-            throw new PSQLException(GT.tr("Invalid stream length {0}.", new Integer(length)),
+            throw new PSQLException(GT.tr("Invalid stream length {0}.", length),
                                     PSQLState.INVALID_PARAMETER_VALUE);
 
         if (connection.haveMinimumCompatibleVersion("7.2"))
@@ -1873,7 +1873,7 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
                     bindString(parameterIndex, in.toString(), Oid.UNSPECIFIED);
 	            break;
 	        default:
-	            throw new PSQLException(GT.tr("Unsupported Types value: {0}", new Integer(targetSqlType)), PSQLState.INVALID_PARAMETER_TYPE);
+	            throw new PSQLException(GT.tr("Unsupported Types value: {0}", targetSqlType), PSQLState.INVALID_PARAMETER_TYPE);
         }
     }
 
@@ -1895,15 +1895,15 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
         else if (x instanceof BigDecimal)
             setBigDecimal(parameterIndex, (BigDecimal)x);
         else if (x instanceof Short)
-            setShort(parameterIndex, ((Short)x).shortValue());
+            setShort(parameterIndex, (Short) x);
         else if (x instanceof Integer)
-            setInt(parameterIndex, ((Integer)x).intValue());
+            setInt(parameterIndex, (Integer) x);
         else if (x instanceof Long)
-            setLong(parameterIndex, ((Long)x).longValue());
+            setLong(parameterIndex, (Long) x);
         else if (x instanceof Float)
-            setFloat(parameterIndex, ((Float)x).floatValue());
+            setFloat(parameterIndex, (Float) x);
         else if (x instanceof Double)
-            setDouble(parameterIndex, ((Double)x).doubleValue());
+            setDouble(parameterIndex, (Double) x);
         else if (x instanceof byte[])
             setBytes(parameterIndex, (byte[])x);
         else if (x instanceof java.sql.Date)
@@ -1913,9 +1913,9 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
         else if (x instanceof Timestamp)
             setTimestamp(parameterIndex, (Timestamp)x);
         else if (x instanceof Boolean)
-            setBoolean(parameterIndex, ((Boolean)x).booleanValue());
+            setBoolean(parameterIndex, (Boolean) x);
         else if (x instanceof Byte)
-            setByte(parameterIndex, ((Byte)x).byteValue());
+            setByte(parameterIndex, (Byte) x);
         else if (x instanceof Blob)
             setBlob(parameterIndex, (Blob)x);
         else if (x instanceof Clob)
@@ -2065,7 +2065,7 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
         if (callResult[parameterIndex-1] == null)
             return false;
         
-        return ((Boolean)callResult[parameterIndex-1]).booleanValue ();
+        return (Boolean) callResult[parameterIndex - 1];
     }
 
     /*
@@ -2119,7 +2119,7 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
         if (callResult[parameterIndex-1] == null)
             return 0;
         
-        return ((Integer)callResult[parameterIndex-1]).intValue ();
+        return (Integer) callResult[parameterIndex - 1];
     }
 
     /*
@@ -2136,7 +2136,7 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
         if (callResult[parameterIndex-1] == null)
             return 0;
         
-        return ((Long)callResult[parameterIndex-1]).longValue ();
+        return (Long) callResult[parameterIndex - 1];
     }
 
     /*
@@ -2153,7 +2153,7 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
         if (callResult[parameterIndex-1] == null)
             return 0;
 
-        return ((Float)callResult[parameterIndex-1]).floatValue ();
+        return (Float) callResult[parameterIndex - 1];
     }
 
     /*
@@ -2170,7 +2170,7 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
         if (callResult[parameterIndex-1] == null)
             return 0;
         
-        return ((Double)callResult[parameterIndex-1]).doubleValue ();
+        return (Double) callResult[parameterIndex - 1];
     }
 
     /*
@@ -2525,7 +2525,7 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
         }
 
         if (syntaxError)
-            throw new PSQLException (GT.tr("Malformed function or procedure escape syntax at offset {0}.", new Integer(i)),
+            throw new PSQLException (GT.tr("Malformed function or procedure escape syntax at offset {0}.", i),
                                      PSQLState.STATEMENT_NOT_ALLOWED_IN_FUNCTION_CALL);
 
         if (connection.haveMinimumServerVersion("8.1") && ((AbstractJdbc2Connection)connection).getProtocolVersion() == 3)
@@ -2760,7 +2760,7 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
                     queryString = queries[resultIndex].toString(parameterLists[resultIndex]);
 
                 batchException = new BatchUpdateException(GT.tr("Batch entry {0} {1} was aborted.  Call getNextException to see the cause.",
-                                 new Object[]{ new Integer(resultIndex),
+                                 new Object[]{resultIndex,
                                                queryString}),
                                  newError.getSQLState(),
                                  successCounts);
@@ -2830,7 +2830,7 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
                     queryString = queries[resultIndex].toString(parameterLists[resultIndex]);
 
                 batchException = new BatchUpdateException(GT.tr("Batch entry {0} {1} was aborted.  Call getNextException to see the cause.",
-                                 new Object[]{ new Integer(resultIndex),
+                                 new Object[]{resultIndex,
                                                queryString}),
                                  newError.getSQLState(),
                                  successCounts);
@@ -2985,7 +2985,7 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
             fetchdirection = direction;
             break;
         default:
-            throw new PSQLException(GT.tr("Invalid fetch direction constant: {0}.", new Integer(direction)),
+            throw new PSQLException(GT.tr("Invalid fetch direction constant: {0}.", direction),
                                     PSQLState.INVALID_PARAMETER_VALUE);
         }
     }
@@ -3158,7 +3158,7 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
         }
 
         if (length < 0)
-            throw new PSQLException(GT.tr("Invalid stream length {0}.", new Integer(length)),
+            throw new PSQLException(GT.tr("Invalid stream length {0}.", length),
                                     PSQLState.INVALID_PARAMETER_VALUE);
 
         if (connection.haveMinimumCompatibleVersion("7.2"))

--- a/org/postgresql/jdbc2/ArrayAssistantRegistry.java
+++ b/org/postgresql/jdbc2/ArrayAssistantRegistry.java
@@ -12,11 +12,11 @@ public class ArrayAssistantRegistry {
     private static Map arrayAssistantMap = new HashMap();
 
     public static ArrayAssistant getAssistant(int oid) {
-        return (ArrayAssistant) arrayAssistantMap.get(new Integer(oid));
+        return (ArrayAssistant) arrayAssistantMap.get(oid);
     }
 
     ////
     public static void register(int oid, ArrayAssistant assistant) {
-        arrayAssistantMap.put(new Integer(oid), assistant);
+        arrayAssistantMap.put(oid, assistant);
     }
 }

--- a/org/postgresql/jdbc2/CacheMetadata.java
+++ b/org/postgresql/jdbc2/CacheMetadata.java
@@ -27,9 +27,9 @@ public class CacheMetadata {
   
   protected void setCache(String idFields, Field[] fields) {
     List<CacheMetadataField> liste = new LinkedList<CacheMetadataField>();
-    
-    for (int i = 0 ; i < fields.length ; i++) {
-      CacheMetadataField c = new CacheMetadataField(fields[i]);
+
+    for (Field field : fields) {
+      CacheMetadataField c = new CacheMetadataField(field);
       liste.add(c);
     }
     
@@ -38,9 +38,9 @@ public class CacheMetadata {
   
   protected String getIdFields(Field[] fields) {
     StringBuilder sb = new StringBuilder();
-    
-    for (int i = 0 ; i < fields.length ; i++) {
-      sb.append(getIdField(fields[i])).append('/');
+
+    for (Field field : fields) {
+      sb.append(getIdField(field)).append('/');
     }
     
     return sb.toString();

--- a/org/postgresql/jdbc2/EscapedFunctions.java
+++ b/org/postgresql/jdbc2/EscapedFunctions.java
@@ -119,10 +119,9 @@ public class EscapedFunctions {
     private static Map createFunctionMap() {
     	Method[] arrayMeths = EscapedFunctions.class.getDeclaredMethods();
         Map functionMap = new HashMap(arrayMeths.length*2);
-        for (int i=0;i<arrayMeths.length;i++){
-            Method meth = arrayMeths[i];
+        for (Method meth : arrayMeths) {
             if (meth.getName().startsWith("sql"))
-                functionMap.put(meth.getName().toLowerCase(Locale.US),meth);
+                functionMap.put(meth.getName().toLowerCase(Locale.US), meth);
         }
 	return functionMap;
     }

--- a/org/postgresql/jdbc2/TimestampUtils.java
+++ b/org/postgresql/jdbc2/TimestampUtils.java
@@ -58,7 +58,7 @@ public class TimestampUtils {
         if (calCache != null && calCacheZone == rawOffset)
             return calCache;
                 
-        StringBuffer zoneID = new StringBuffer("GMT");
+        StringBuilder zoneID = new StringBuilder("GMT");
         zoneID.append(sign < 0 ? '-' : '+');
         if (hr < 10) zoneID.append('0');
         zoneID.append(hr);

--- a/org/postgresql/jdbc2/TypeInfoCache.java
+++ b/org/postgresql/jdbc2/TypeInfoCache.java
@@ -67,27 +67,27 @@ public class TypeInfoCache implements TypeInfo {
     // 5 - conditional minimum server version
     // 6 - conditional minimum JDK build version
     private static final Object types[][] = {
-        {"int2", new Integer(Oid.INT2), new Integer(Types.SMALLINT), "java.lang.Integer", new Integer(Oid.INT2_ARRAY)},
-        {"int4", new Integer(Oid.INT4), new Integer(Types.INTEGER), "java.lang.Integer", new Integer(Oid.INT4_ARRAY)},
-        {"oid", new Integer(Oid.OID), new Integer(Types.BIGINT), "java.lang.Long", new Integer(Oid.OID_ARRAY)},
-        {"int8", new Integer(Oid.INT8), new Integer(Types.BIGINT), "java.lang.Long", new Integer(Oid.INT8_ARRAY)},
-        {"money", new Integer(Oid.MONEY), new Integer(Types.DOUBLE), "java.lang.Double", new Integer(Oid.MONEY_ARRAY)},
-        {"numeric", new Integer(Oid.NUMERIC), new Integer(Types.NUMERIC), "java.math.BigDecimal", new Integer(Oid.NUMERIC_ARRAY)},
-        {"float4", new Integer(Oid.FLOAT4), new Integer(Types.REAL), "java.lang.Float", new Integer(Oid.FLOAT4_ARRAY)},
-        {"float8", new Integer(Oid.FLOAT8), new Integer(Types.DOUBLE), "java.lang.Double", new Integer(Oid.FLOAT8_ARRAY)},
-        {"char", new Integer(Oid.CHAR), new Integer(Types.CHAR), "java.lang.String", new Integer(Oid.CHAR_ARRAY)},
-        {"bpchar", new Integer(Oid.BPCHAR), new Integer(Types.CHAR), "java.lang.String", new Integer(Oid.BPCHAR_ARRAY)},
-        {"varchar", new Integer(Oid.VARCHAR), new Integer(Types.VARCHAR), "java.lang.String", new Integer(Oid.VARCHAR_ARRAY)},
-        {"text", new Integer(Oid.TEXT), new Integer(Types.VARCHAR), "java.lang.String", new Integer(Oid.TEXT_ARRAY)},
-        {"name", new Integer(Oid.NAME), new Integer(Types.VARCHAR), "java.lang.String", new Integer(Oid.NAME_ARRAY)},
-        {"bytea", new Integer(Oid.BYTEA), new Integer(Types.BINARY), "[B", new Integer(Oid.BYTEA_ARRAY)},
-        {"bool", new Integer(Oid.BOOL), new Integer(Types.BIT), "java.lang.Boolean", new Integer(Oid.BOOL_ARRAY)},
-        {"bit", new Integer(Oid.BIT), new Integer(Types.BIT), "java.lang.Boolean", new Integer(Oid.BIT_ARRAY)},
-        {"date", new Integer(Oid.DATE), new Integer(Types.DATE), "java.sql.Date", new Integer(Oid.DATE_ARRAY)},
-        {"time", new Integer(Oid.TIME), new Integer(Types.TIME), "java.sql.Time", new Integer(Oid.TIME_ARRAY)},
-        {"timetz", new Integer(Oid.TIMETZ), new Integer(Types.TIME), "java.sql.Time", new Integer(Oid.TIMETZ_ARRAY)},
-        {"timestamp", new Integer(Oid.TIMESTAMP), new Integer(Types.TIMESTAMP), "java.sql.Timestamp", new Integer(Oid.TIMESTAMP_ARRAY)},
-        {"timestamptz", new Integer(Oid.TIMESTAMPTZ), new Integer(Types.TIMESTAMP), "java.sql.Timestamp", new Integer(Oid.TIMESTAMPTZ_ARRAY)},
+        {"int2", Oid.INT2, Types.SMALLINT, "java.lang.Integer", Oid.INT2_ARRAY},
+        {"int4", Oid.INT4, Types.INTEGER, "java.lang.Integer", Oid.INT4_ARRAY},
+        {"oid", Oid.OID, Types.BIGINT, "java.lang.Long", Oid.OID_ARRAY},
+        {"int8", Oid.INT8, Types.BIGINT, "java.lang.Long", Oid.INT8_ARRAY},
+        {"money", Oid.MONEY, Types.DOUBLE, "java.lang.Double", Oid.MONEY_ARRAY},
+        {"numeric", Oid.NUMERIC, Types.NUMERIC, "java.math.BigDecimal", Oid.NUMERIC_ARRAY},
+        {"float4", Oid.FLOAT4, Types.REAL, "java.lang.Float", Oid.FLOAT4_ARRAY},
+        {"float8", Oid.FLOAT8, Types.DOUBLE, "java.lang.Double", Oid.FLOAT8_ARRAY},
+        {"char", Oid.CHAR, Types.CHAR, "java.lang.String", Oid.CHAR_ARRAY},
+        {"bpchar", Oid.BPCHAR, Types.CHAR, "java.lang.String", Oid.BPCHAR_ARRAY},
+        {"varchar", Oid.VARCHAR, Types.VARCHAR, "java.lang.String", Oid.VARCHAR_ARRAY},
+        {"text", Oid.TEXT, Types.VARCHAR, "java.lang.String", Oid.TEXT_ARRAY},
+        {"name", Oid.NAME, Types.VARCHAR, "java.lang.String", Oid.NAME_ARRAY},
+        {"bytea", Oid.BYTEA, Types.BINARY, "[B", Oid.BYTEA_ARRAY},
+        {"bool", Oid.BOOL, Types.BIT, "java.lang.Boolean", Oid.BOOL_ARRAY},
+        {"bit", Oid.BIT, Types.BIT, "java.lang.Boolean", Oid.BIT_ARRAY},
+        {"date", Oid.DATE, Types.DATE, "java.sql.Date", Oid.DATE_ARRAY},
+        {"time", Oid.TIME, Types.TIME, "java.sql.Time", Oid.TIME_ARRAY},
+        {"timetz", Oid.TIMETZ, Types.TIME, "java.sql.Time", Oid.TIMETZ_ARRAY},
+        {"timestamp", Oid.TIMESTAMP, Types.TIMESTAMP, "java.sql.Timestamp", Oid.TIMESTAMP_ARRAY},
+        {"timestamptz", Oid.TIMESTAMPTZ, Types.TIMESTAMP, "java.sql.Timestamp", Oid.TIMESTAMPTZ_ARRAY},
     };
 
     /**
@@ -122,12 +122,12 @@ public class TypeInfoCache implements TypeInfo {
         // from getPGTypeNamesWithSQLTypes()
         _pgNameToSQLType = Collections.synchronizedMap(new HashMap());
 
-        for (int i=0; i<types.length; i++) {
-            String pgTypeName = (String)types[i][0];
-            Integer oid = (Integer)types[i][1];
-            Integer sqlType = (Integer)types[i][2];
-            String javaClass = (String)types[i][3];
-            Integer arrayOid = (Integer)types[i][4];
+        for (Object[] type : types) {
+            String pgTypeName = (String) type[0];
+            Integer oid = (Integer) type[1];
+            Integer sqlType = (Integer) type[2];
+            String javaClass = (String) type[3];
+            Integer arrayOid = (Integer) type[4];
 
             addCoreType(pgTypeName, oid, sqlType, javaClass, arrayOid);
         }
@@ -147,12 +147,12 @@ public class TypeInfoCache implements TypeInfo {
         // to a comma.  In a stock install the only exception is
         // the box datatype and it's not a JDBC core type.
         //
-        Character delim = new Character(',');
+        Character delim = ',';
         _arrayOidToDelimiter.put(oid, delim);
 
         String pgArrayTypeName = "_" + pgTypeName;
         _pgNameToJavaClass.put(pgArrayTypeName, "java.sql.Array");
-        _pgNameToSQLType.put(pgArrayTypeName, new Integer(Types.ARRAY));
+        _pgNameToSQLType.put(pgArrayTypeName, Types.ARRAY);
     }
 
 
@@ -179,7 +179,7 @@ public class TypeInfoCache implements TypeInfo {
     {
         Integer i = (Integer)_pgNameToSQLType.get(pgTypeName);
         if (i != null)
-            return i.intValue();
+            return i;
 
         if (_getTypeInfoStatement == null) {
             // There's no great way of telling what's an array type.
@@ -226,32 +226,32 @@ public class TypeInfoCache implements TypeInfo {
             boolean isArray = rs.getBoolean(1);
             String typtype = rs.getString(2);
             if (isArray) {
-                type = new Integer(Types.ARRAY);
+                type = Types.ARRAY;
             } else if ("c".equals(typtype)) {
-                type = new Integer(Types.STRUCT);
+                type = Types.STRUCT;
             } else if ("d".equals(typtype)) {
-                type = new Integer(Types.DISTINCT);
+                type = Types.DISTINCT;
             } else if ("e".equals(typtype)) {
-                type = new Integer(Types.VARCHAR);
+                type = Types.VARCHAR;
             }
         }
 
         if (type == null) {
-             type = new Integer(Types.OTHER);
+             type = Types.OTHER;
         }
         rs.close();
 
         if ( pgTypeName != null ){            
             _pgNameToSQLType.put(pgTypeName, type);
         }
-        return type.intValue();
+        return type;
     }
 
     public synchronized int getPGType(String pgTypeName) throws SQLException
     {
         Integer oid = (Integer)_pgNameToOid.get(pgTypeName);
         if (oid != null)
-            return oid.intValue();
+            return oid;
 
         if (_getOidStatement == null) {
             String sql;
@@ -285,16 +285,16 @@ public class TypeInfoCache implements TypeInfo {
         if (!((BaseStatement)_getOidStatement).executeWithFlags(QueryExecutor.QUERY_SUPPRESS_BEGIN))
             throw new PSQLException(GT.tr("No results were returned by the query."), PSQLState.NO_DATA);
 
-        oid = new Integer(Oid.UNSPECIFIED);
+        oid = Oid.UNSPECIFIED;
         ResultSet rs = _getOidStatement.getResultSet();
         if (rs.next()) {
-            oid = new Integer((int)rs.getLong(1));
+            oid = (int) rs.getLong(1);
             _oidToPgName.put(oid, pgTypeName);
         }
         _pgNameToOid.put(pgTypeName, oid);
         rs.close();
 
-        return oid.intValue();
+        return oid;
     }
 
     public synchronized String getPGType(int oid) throws SQLException
@@ -302,7 +302,7 @@ public class TypeInfoCache implements TypeInfo {
         if (oid == Oid.UNSPECIFIED)
             return null;
 
-        String pgTypeName = (String)_oidToPgName.get(new Integer(oid));
+        String pgTypeName = (String)_oidToPgName.get(oid);
         if (pgTypeName != null)
             return pgTypeName;
 
@@ -326,8 +326,8 @@ public class TypeInfoCache implements TypeInfo {
         ResultSet rs = _getNameStatement.getResultSet();
         if (rs.next()) {
             pgTypeName = rs.getString(1);
-            _pgNameToOid.put(pgTypeName, new Integer(oid));
-            _oidToPgName.put(new Integer(oid), pgTypeName);
+            _pgNameToOid.put(pgTypeName, oid);
+            _oidToPgName.put(oid, pgTypeName);
         }
         rs.close();
 
@@ -349,10 +349,10 @@ public class TypeInfoCache implements TypeInfo {
      */
     protected synchronized int convertArrayToBaseOid(int oid)
     {
-        Integer i = (Integer)_pgArrayToPgType.get(new Integer(oid));
+        Integer i = (Integer)_pgArrayToPgType.get(oid);
         if (i == null)
             return oid;
-        return i.intValue();
+        return i;
     }
 
     public synchronized char getArrayDelimiter(int oid) throws SQLException
@@ -360,9 +360,9 @@ public class TypeInfoCache implements TypeInfo {
         if (oid == Oid.UNSPECIFIED)
             return ',';
 
-        Character delim = (Character) _arrayOidToDelimiter.get(new Integer(oid));
+        Character delim = (Character) _arrayOidToDelimiter.get(oid);
         if (delim != null)
-            return delim.charValue();
+            return delim;
 
         if (_getArrayDelimiterStatement == null) {
             String sql;
@@ -385,13 +385,13 @@ public class TypeInfoCache implements TypeInfo {
             throw new PSQLException(GT.tr("No results were returned by the query."), PSQLState.NO_DATA);
 
         String s = rs.getString(1);
-        delim = new Character(s.charAt(0));
+        delim = s.charAt(0);
 
-        _arrayOidToDelimiter.put(new Integer(oid), delim);
+        _arrayOidToDelimiter.put(oid, delim);
 
         rs.close();
 
-        return delim.charValue();
+        return delim;
     }
 
     public synchronized int getPGArrayElement (int oid) throws SQLException
@@ -399,10 +399,10 @@ public class TypeInfoCache implements TypeInfo {
         if (oid == Oid.UNSPECIFIED)
             return Oid.UNSPECIFIED;
 
-        Integer pgType = (Integer) _pgArrayToPgType.get(new Integer(oid));
+        Integer pgType = (Integer) _pgArrayToPgType.get(oid);
 
         if (pgType != null)
-            return pgType.intValue();
+            return pgType;
 
         if (_getArrayElementOidStatement == null) {
             String sql;
@@ -424,14 +424,14 @@ public class TypeInfoCache implements TypeInfo {
         if (!rs.next())
             throw new PSQLException(GT.tr("No results were returned by the query."), PSQLState.NO_DATA);
 
-        pgType = new Integer((int)rs.getLong(1));
-        _pgArrayToPgType.put(new Integer(oid), pgType);
+        pgType = (int) rs.getLong(1);
+        _pgArrayToPgType.put(oid, pgType);
         _pgNameToOid.put(rs.getString(2), pgType);
         _oidToPgName.put(pgType, rs.getString(2));
 
         rs.close();
 
-        return pgType.intValue();
+        return pgType;
     }
 
     public synchronized Class getPGobject(String type)

--- a/org/postgresql/jdbc3/AbstractJdbc3Connection.java
+++ b/org/postgresql/jdbc3/AbstractJdbc3Connection.java
@@ -57,7 +57,7 @@ public abstract class AbstractJdbc3Connection extends org.postgresql.jdbc2.Abstr
             rsHoldability = holdability;
             break;
         default:
-            throw new PSQLException(GT.tr("Unknown ResultSet holdability setting: {0}.", new Integer(holdability)),
+            throw new PSQLException(GT.tr("Unknown ResultSet holdability setting: {0}.", holdability),
                                     PSQLState.INVALID_PARAMETER_VALUE);
         }
     }

--- a/org/postgresql/jdbc3/AbstractJdbc3ParameterMetaData.java
+++ b/org/postgresql/jdbc3/AbstractJdbc3ParameterMetaData.java
@@ -78,7 +78,7 @@ public abstract class AbstractJdbc3ParameterMetaData {
 
     private void checkParamIndex(int param) throws PSQLException {
         if (param < 1 || param > _oids.length)
-            throw new PSQLException(GT.tr("The parameter index is out of range: {0}, number of parameters: {1}.", new Object[]{new Integer(param), new Integer(_oids.length)}), PSQLState.INVALID_PARAMETER_VALUE);
+            throw new PSQLException(GT.tr("The parameter index is out of range: {0}, number of parameters: {1}.", new Object[]{param, _oids.length}), PSQLState.INVALID_PARAMETER_VALUE);
     }
 
 }

--- a/org/postgresql/jdbc3/AbstractJdbc3ResultSet.java
+++ b/org/postgresql/jdbc3/AbstractJdbc3ResultSet.java
@@ -31,7 +31,7 @@ public abstract class AbstractJdbc3ResultSet extends org.postgresql.jdbc2.Abstra
     {
         switch (getSQLType(columnIndex)) {
         case Types.BOOLEAN:
-            return new Boolean(getBoolean(columnIndex));
+            return getBoolean(columnIndex);
         default:
             return super.internalGetObject(columnIndex, field);
         }

--- a/org/postgresql/jdbc4/AbstractJdbc4Statement.java
+++ b/org/postgresql/jdbc4/AbstractJdbc4Statement.java
@@ -172,7 +172,7 @@ abstract class AbstractJdbc4Statement extends org.postgresql.jdbc3g.AbstractJdbc
 
         if (length < 0)
         {
-            throw new PSQLException(GT.tr("Invalid stream length {0}.", new Long(length)),
+            throw new PSQLException(GT.tr("Invalid stream length {0}.", length),
                                     PSQLState.INVALID_PARAMETER_VALUE);
         }
 

--- a/org/postgresql/ssl/jdbc4/LazyKeyManager.java
+++ b/org/postgresql/ssl/jdbc4/LazyKeyManager.java
@@ -95,9 +95,10 @@ public class LazyKeyManager implements X509KeyManager {
         } else {
           X500Principal ourissuer = certchain[certchain.length-1].getIssuerX500Principal();
           boolean found = false;
-          for (int i=0; i<issuers.length; i++)
-          {
-            if (ourissuer.equals(issuers[i])) { found = true;}
+          for (Principal issuer : issuers) {
+            if (ourissuer.equals(issuer)) {
+              found = true;
+            }
           }
           return (found ? "user" : null);
         }

--- a/org/postgresql/ssl/jdbc4/LibPQFactory.java
+++ b/org/postgresql/ssl/jdbc4/LibPQFactory.java
@@ -65,7 +65,7 @@ public class LibPQFactory extends WrappedFactory implements HostnameVerifier {
         String pathsep = System.getProperty("file.separator");
         String defaultdir;
         boolean defaultfile = false;
-        if (System.getProperty("os.name").toLowerCase().indexOf("windows") > -1)
+        if (System.getProperty("os.name").toLowerCase().contains("windows"))
         { //It is Windows
           defaultdir = System.getenv("APPDATA")+pathsep+"postgresql"+pathsep;
         } else {
@@ -207,21 +207,18 @@ public class LibPQFactory extends WrappedFactory implements HostnameVerifier {
           UnsupportedCallbackException {
         Console cons = System.console();
         if (cons==null && password==null) {throw new UnsupportedCallbackException(callbacks[0], "Console is not available");}
-        for (int i=0; i<callbacks.length; i++)
-        {
-          if (callbacks[i] instanceof PasswordCallback)
-          {
-            if (password==null)
-            {
+        for (Callback callback : callbacks) {
+          if (callback instanceof PasswordCallback) {
+            if (password == null) {
               //It is used instead of cons.readPassword(prompt), because the prompt may contain '%' characters
-              ((PasswordCallback)callbacks[i]).setPassword(cons.readPassword("%s", new Object[]{((PasswordCallback)callbacks[i]).getPrompt()}));
+              ((PasswordCallback) callback).setPassword(cons.readPassword("%s", new Object[]{((PasswordCallback) callback).getPrompt()}));
             } else {
-              ((PasswordCallback)callbacks[i]).setPassword(password);
+              ((PasswordCallback) callback).setPassword(password);
             }
           } else {
-            throw new UnsupportedCallbackException(callbacks[i]);
+            throw new UnsupportedCallbackException(callback);
           }
-      }
+        }
       
     }
   }

--- a/org/postgresql/test/extensions/HStoreTest.java
+++ b/org/postgresql/test/extensions/HStoreTest.java
@@ -60,7 +60,7 @@ public class HStoreTest extends TestCase {
     }
 
     public void testHStoreSend() throws SQLException {
-        Map correct = Collections.singletonMap("a", new Integer(1));
+        Map correct = Collections.singletonMap("a", 1);
         PreparedStatement pstmt = _conn.prepareStatement("SELECT ?::text");
         pstmt.setObject(1, correct);
         ResultSet rs = pstmt.executeQuery();

--- a/org/postgresql/test/jdbc2/CopyTest.java
+++ b/org/postgresql/test/jdbc2/CopyTest.java
@@ -50,8 +50,9 @@ public class CopyTest extends TestCase {
     private byte[] getData(String[] origData) {
         ByteArrayOutputStream buf = new ByteArrayOutputStream();
         PrintStream ps = new PrintStream(buf);
-        for(int i=0; i<origData.length; i++)
-            ps.print(origData[i]);
+        for (String anOrigData : origData) {
+            ps.print(anOrigData);
+        }
         return buf.toByteArray();
     }
 
@@ -82,8 +83,8 @@ public class CopyTest extends TestCase {
     public void testCopyInByRow() throws SQLException {
         String sql = "COPY copytest FROM STDIN";
         CopyIn cp = copyAPI.copyIn(sql);
-        for(int i=0; i<origData.length; i++) {
-            byte[] buf = origData[i].getBytes();
+        for (String anOrigData : origData) {
+            byte[] buf = anOrigData.getBytes();
             cp.writeToCopy(buf, 0, buf.length);
         }
 
@@ -109,8 +110,8 @@ public class CopyTest extends TestCase {
     public void testCopyInAsOutputStream() throws SQLException, IOException {
         String sql = "COPY copytest FROM STDIN";
         OutputStream os = new PGCopyOutputStream((PGConnection)con, sql, 1000);
-        for(int i=0; i<origData.length; i++) {
-            byte[] buf = origData[i].getBytes();
+        for (String anOrigData : origData) {
+            byte[] buf = anOrigData.getBytes();
             os.write(buf);
         }
         os.close();
@@ -132,7 +133,7 @@ public class CopyTest extends TestCase {
                 public int read() { throw new RuntimeException("COPYTEST"); }
             }, 3 );
         } catch(Exception e) {
-            if(e.toString().indexOf("COPYTEST") == -1)
+            if(!e.toString().contains("COPYTEST"))
                 fail("should have failed trying to read from our bogus stream.");
         }
         int rowCount = getCount();
@@ -291,10 +292,10 @@ public class CopyTest extends TestCase {
         // I expect an SQLException 
         String sql = "COPY copytest FROM STDIN with xxx (format 'csv')";
         CopyIn cp = manager.copyIn(sql);
-        for(int i=0; i<origData.length; i++) {
-            byte[] buf = origData[i].getBytes();
-            cp.writeToCopy(buf, 0, buf.length);
-        }
+            for (String anOrigData : origData) {
+                byte[] buf = anOrigData.getBytes();
+                cp.writeToCopy(buf, 0, buf.length);
+            }
 
         long count1 = cp.endCopy();
         long count2 = cp.getHandledRowCount();

--- a/org/postgresql/test/jdbc2/CursorFetchTest.java
+++ b/org/postgresql/test/jdbc2/CursorFetchTest.java
@@ -59,22 +59,20 @@ public class CursorFetchTest extends TestCase
 
         PreparedStatement stmt = con.prepareStatement("select * from test_fetch order by value");
         int[] testSizes = { 0, 1, 49, 50, 51, 99, 100, 101 };
-        for (int i = 0; i < testSizes.length; ++i)
-        {
-            stmt.setFetchSize(testSizes[i]);
-            assertEquals(testSizes[i], stmt.getFetchSize());
+        for (int testSize : testSizes) {
+            stmt.setFetchSize(testSize);
+            assertEquals(testSize, stmt.getFetchSize());
 
             ResultSet rs = stmt.executeQuery();
-            assertEquals(testSizes[i], rs.getFetchSize());
+            assertEquals(testSize, rs.getFetchSize());
 
             int count = 0;
-            while (rs.next())
-            {
-                assertEquals("query value error with fetch size " + testSizes[i], count, rs.getInt(1));
+            while (rs.next()) {
+                assertEquals("query value error with fetch size " + testSize, count, rs.getInt(1));
                 ++count;
             }
 
-            assertEquals("total query size error with fetch size " + testSizes[i], 100, count);
+            assertEquals("total query size error with fetch size " + testSize, 100, count);
         }
     }
 
@@ -89,37 +87,30 @@ public class CursorFetchTest extends TestCase
                                  ResultSet.CONCUR_READ_ONLY);
 
         int[] testSizes = { 0, 1, 49, 50, 51, 99, 100, 101 };
-        for (int i = 0; i < testSizes.length; ++i)
-        {
-            stmt.setFetchSize(testSizes[i]);
-            assertEquals(testSizes[i], stmt.getFetchSize());
+        for (int testSize : testSizes) {
+            stmt.setFetchSize(testSize);
+            assertEquals(testSize, stmt.getFetchSize());
 
             ResultSet rs = stmt.executeQuery();
-            assertEquals(testSizes[i], rs.getFetchSize());
+            assertEquals(testSize, rs.getFetchSize());
 
-            for (int j = 0; j <= 50; ++j)
-            {
-                assertTrue("ran out of rows at position " + j + " with fetch size " + testSizes[i], rs.next());
-                assertEquals("query value error with fetch size " + testSizes[i], j, rs.getInt(1));
+            for (int j = 0; j <= 50; ++j) {
+                assertTrue("ran out of rows at position " + j + " with fetch size " + testSize, rs.next());
+                assertEquals("query value error with fetch size " + testSize, j, rs.getInt(1));
             }
 
             int position = 50;
-            for (int j = 1; j < 100; ++j)
-            {
-                for (int k = 0; k < j; ++k)
-                {
-                    if (j % 2 == 0)
-                    {
+            for (int j = 1; j < 100; ++j) {
+                for (int k = 0; k < j; ++k) {
+                    if (j % 2 == 0) {
                         ++position;
-                        assertTrue("ran out of rows doing a forward fetch on iteration " + j + "/" + k + " at position " + position + " with fetch size " + testSizes[i], rs.next());
-                    }
-                    else
-                    {
+                        assertTrue("ran out of rows doing a forward fetch on iteration " + j + "/" + k + " at position " + position + " with fetch size " + testSize, rs.next());
+                    } else {
                         --position;
-                        assertTrue("ran out of rows doing a reverse fetch on iteration " + j + "/" + k + " at position " + position + " with fetch size " + testSizes[i], rs.previous());
+                        assertTrue("ran out of rows doing a reverse fetch on iteration " + j + "/" + k + " at position " + position + " with fetch size " + testSize, rs.previous());
                     }
 
-                    assertEquals("query value error on iteration " + j + "/" + k + " with fetch size " + testSizes[i], position, rs.getInt(1));
+                    assertEquals("query value error on iteration " + j + "/" + k + " with fetch size " + testSize, position, rs.getInt(1));
                 }
             }
         }
@@ -134,27 +125,25 @@ public class CursorFetchTest extends TestCase
                                  ResultSet.CONCUR_READ_ONLY);
 
         int[] testSizes = { 0, 1, 49, 50, 51, 99, 100, 101 };
-        for (int i = 0; i < testSizes.length; ++i)
-        {
-            stmt.setFetchSize(testSizes[i]);
-            assertEquals(testSizes[i], stmt.getFetchSize());
+        for (int testSize : testSizes) {
+            stmt.setFetchSize(testSize);
+            assertEquals(testSize, stmt.getFetchSize());
 
             ResultSet rs = stmt.executeQuery();
-            assertEquals(testSizes[i], rs.getFetchSize());
+            assertEquals(testSize, rs.getFetchSize());
 
             int position = 50;
-            assertTrue("ran out of rows doing an absolute fetch at " + position + " with fetch size " + testSizes[i], rs.absolute(position + 1));
-            assertEquals("query value error with fetch size " + testSizes[i], position, rs.getInt(1));
+            assertTrue("ran out of rows doing an absolute fetch at " + position + " with fetch size " + testSize, rs.absolute(position + 1));
+            assertEquals("query value error with fetch size " + testSize, position, rs.getInt(1));
 
-            for (int j = 1; j < 100; ++j)
-            {
+            for (int j = 1; j < 100; ++j) {
                 if (j % 2 == 0)
                     position += j;
                 else
                     position -= j;
 
-                assertTrue("ran out of rows doing an absolute fetch at " + position + " on iteration " + j + " with fetchsize" + testSizes[i], rs.absolute(position + 1));
-                assertEquals("query value error with fetch size " + testSizes[i], position, rs.getInt(1));
+                assertTrue("ran out of rows doing an absolute fetch at " + position + " on iteration " + j + " with fetchsize" + testSize, rs.absolute(position + 1));
+                assertEquals("query value error with fetch size " + testSize, position, rs.getInt(1));
             }
         }
     }
@@ -278,21 +267,20 @@ public class CursorFetchTest extends TestCase
         createRows(1);
 
         int[] sizes = { 0, 1, 10 };
-        for (int i = 0; i < sizes.length; ++i)
-        {
+        for (int size : sizes) {
             Statement stmt = con.createStatement(ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_UPDATABLE);
-            stmt.setFetchSize(sizes[i]);
+            stmt.setFetchSize(size);
 
             // Create a one row result set.
             ResultSet rs = stmt.executeQuery("select * from test_fetch order by value");
 
-            msg = "before-first row positioning error with fetchsize=" + sizes[i];
+            msg = "before-first row positioning error with fetchsize=" + size;
             assertTrue(msg, rs.isBeforeFirst());
             assertTrue(msg, !rs.isAfterLast());
             assertTrue(msg, !rs.isFirst());
             assertTrue(msg, !rs.isLast());
 
-            msg = "row 1 positioning error with fetchsize=" + sizes[i];
+            msg = "row 1 positioning error with fetchsize=" + size;
             assertTrue(msg, rs.next());
 
             assertTrue(msg, !rs.isBeforeFirst());
@@ -301,7 +289,7 @@ public class CursorFetchTest extends TestCase
             assertTrue(msg, rs.isLast());
             assertEquals(msg, 0, rs.getInt(1));
 
-            msg = "after-last row positioning error with fetchsize=" + sizes[i];
+            msg = "after-last row positioning error with fetchsize=" + size;
             assertTrue(msg, !rs.next());
 
             assertTrue(msg, !rs.isBeforeFirst());
@@ -321,21 +309,19 @@ public class CursorFetchTest extends TestCase
         createRows(100);
 
         int[] sizes = { 0, 1, 10, 100 };
-        for (int i = 0; i < sizes.length; ++i)
-        {
+        for (int size : sizes) {
             Statement stmt = con.createStatement(ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_UPDATABLE);
-            stmt.setFetchSize(sizes[i]);
+            stmt.setFetchSize(size);
 
             ResultSet rs = stmt.executeQuery("select * from test_fetch order by value");
-            msg = "before-first row positioning error with fetchsize=" + sizes[i];
+            msg = "before-first row positioning error with fetchsize=" + size;
             assertTrue(msg, rs.isBeforeFirst());
             assertTrue(msg, !rs.isAfterLast());
             assertTrue(msg, !rs.isFirst());
             assertTrue(msg, !rs.isLast());
 
-            for (int j = 0; j < 100; ++j)
-            {
-                msg = "row " + j + " positioning error with fetchsize=" + sizes[i];
+            for (int j = 0; j < 100; ++j) {
+                msg = "row " + j + " positioning error with fetchsize=" + size;
                 assertTrue(msg, rs.next());
                 assertEquals(msg, j, rs.getInt(1));
 
@@ -352,7 +338,7 @@ public class CursorFetchTest extends TestCase
                     assertTrue(msg, !rs.isLast());
             }
 
-            msg = "after-last row positioning error with fetchsize=" + sizes[i];
+            msg = "after-last row positioning error with fetchsize=" + size;
             assertTrue(msg, !rs.next());
 
             assertTrue(msg, !rs.isBeforeFirst());

--- a/org/postgresql/test/jdbc2/DatabaseEncodingTest.java
+++ b/org/postgresql/test/jdbc2/DatabaseEncodingTest.java
@@ -54,7 +54,7 @@ public class DatabaseEncodingTest extends TestCase
     }
 
     private static String dumpString(String s) {
-        StringBuffer sb = new StringBuffer(s.length() * 6);
+        StringBuilder sb = new StringBuilder(s.length() * 6);
         for (int i = 0; i < s.length(); ++i)
         {
             sb.append("\\u");

--- a/org/postgresql/test/jdbc2/EncodingTest.java
+++ b/org/postgresql/test/jdbc2/EncodingTest.java
@@ -33,7 +33,7 @@ public class EncodingTest extends TestCase
         encoding = Encoding.getDatabaseEncoding("UTF8");
         assertEquals("UTF", encoding.name().substring(0, 3).toUpperCase(Locale.US));
         encoding = Encoding.getDatabaseEncoding("SQL_ASCII");
-        assertTrue(encoding.name().toUpperCase(Locale.US).indexOf("ASCII") != -1);
+        assertTrue(encoding.name().toUpperCase(Locale.US).contains("ASCII"));
         assertEquals("When encoding is unknown the default encoding should be used",
                      Encoding.defaultEncoding(),
                      Encoding.getDatabaseEncoding("UNKNOWN"));

--- a/org/postgresql/test/jdbc2/IntervalTest.java
+++ b/org/postgresql/test/jdbc2/IntervalTest.java
@@ -75,7 +75,7 @@ public class IntervalTest extends TestCase
         PreparedStatement pstmt = _conn
             .prepareStatement("SELECT v FROM testdate WHERE v < (?::timestamp with time zone + ? * ?::interval) ORDER BY v");
         pstmt.setObject(1, makeDate(2010, 1, 1));
-        pstmt.setObject(2, Integer.valueOf(2));
+        pstmt.setObject(2, 2);
         pstmt.setObject(3, "1 day");
         ResultSet rs = pstmt.executeQuery();
 

--- a/org/postgresql/test/jdbc2/PreparedStatementTest.java
+++ b/org/postgresql/test/jdbc2/PreparedStatementTest.java
@@ -349,13 +349,12 @@ public class PreparedStatementTest extends TestCase
                                    "no backslash interpretation here: \\",
                                };
 
-        for (int i = 0; i < testStrings.length; ++i)
-        {
-            PreparedStatement pstmt = conn.prepareStatement("CREATE TABLE \"" + testStrings[i] + "\" (i integer)");
+        for (String testString : testStrings) {
+            PreparedStatement pstmt = conn.prepareStatement("CREATE TABLE \"" + testString + "\" (i integer)");
             pstmt.executeUpdate();
             pstmt.close();
 
-            pstmt = conn.prepareStatement("DROP TABLE \"" + testStrings[i] + "\"");
+            pstmt = conn.prepareStatement("DROP TABLE \"" + testString + "\"");
             pstmt.executeUpdate();
             pstmt.close();
         }
@@ -549,9 +548,9 @@ public class PreparedStatementTest extends TestCase
         pstmt.executeUpdate();
         pstmt.close();
         
-        Integer maxInteger= new Integer(2147483647), minInteger = new Integer(-2147483648);
+        Integer maxInteger= 2147483647, minInteger = -2147483648;
         
-        Double maxFloat=new Double( 2147483647), minFloat = new Double( -2147483648 );
+        Double maxFloat= (double) 2147483647, minFloat = (double) -2147483648;
         
         pstmt = conn.prepareStatement( "insert into float_tab values (?,?,?)");
         pstmt.setObject(1,maxInteger,Types.FLOAT );
@@ -579,7 +578,7 @@ public class PreparedStatementTest extends TestCase
         pstmt.close();
         
         String maxStringFloat = new String("1.0E37"), minStringFloat = new String("1.0E-37");
-        Double maxFloat=new Double(1.0E37), minFloat = new Double( 1.0E-37 );
+        Double maxFloat= 1.0E37, minFloat = 1.0E-37;
         
         pstmt = conn.prepareStatement( "insert into float_tab values (?,?,?)");
         pstmt.setObject(1,maxStringFloat,Types.FLOAT );
@@ -608,7 +607,7 @@ public class PreparedStatementTest extends TestCase
         pstmt.close();
         
         BigDecimal maxBigDecimalFloat = new BigDecimal("1.0E37"), minBigDecimalFloat = new BigDecimal("1.0E-37");
-        Double maxFloat=new Double(1.0E37), minFloat = new Double( 1.0E-37 );
+        Double maxFloat= 1.0E37, minFloat = 1.0E-37;
         
         pstmt = conn.prepareStatement( "insert into float_tab values (?,?,?)");
         pstmt.setObject(1,maxBigDecimalFloat,Types.FLOAT );
@@ -635,8 +634,8 @@ public class PreparedStatementTest extends TestCase
         pstmt.executeUpdate();
         pstmt.close();
         
-        Integer maxInt = new Integer( 127 ), minInt = new Integer(-127);
-        Float maxIntFloat = new Float( 127 ), minIntFloat = new Float( -127 ); 
+        Integer maxInt = 127, minInt = -127;
+        Float maxIntFloat = (float) 127, minIntFloat = (float) -127;
         
         pstmt = conn.prepareStatement( "insert into tiny_int values (?,?,?)");
         pstmt.setObject(1,maxIntFloat,Types.TINYINT );
@@ -664,8 +663,8 @@ public class PreparedStatementTest extends TestCase
         pstmt.executeUpdate();
         pstmt.close();
         
-        Integer maxInt = new Integer( 32767 ), minInt = new Integer(-32768);
-        Float maxIntFloat = new Float( 32767 ), minIntFloat = new Float( -32768 ); 
+        Integer maxInt = 32767, minInt = -32768;
+        Float maxIntFloat = (float) 32767, minIntFloat = (float) -32768;
         
         pstmt = conn.prepareStatement( "insert into small_int values (?,?,?)");
         pstmt.setObject(1,maxIntFloat,Types.SMALLINT );
@@ -692,8 +691,8 @@ public class PreparedStatementTest extends TestCase
         pstmt.executeUpdate();
         pstmt.close();
         
-        Integer maxInt = new Integer( 1000 ), minInt = new Integer(-1000);
-        Float maxIntFloat = new Float( 1000 ), minIntFloat = new Float( -1000 ); 
+        Integer maxInt = 1000, minInt = -1000;
+        Float maxIntFloat = (float) 1000, minIntFloat = (float) -1000;
         
         pstmt = conn.prepareStatement( "insert into int_tab values (?,?,?)");
         pstmt.setObject(1,maxIntFloat,Types.INTEGER );
@@ -721,7 +720,7 @@ public class PreparedStatementTest extends TestCase
         pstmt.close();
         
         Boolean trueVal = Boolean.TRUE, falseVal = Boolean.FALSE;
-        Double dBooleanTrue = new Double(1), dBooleanFalse = new Double( 0 ); 
+        Double dBooleanTrue = (double) 1, dBooleanFalse = (double) 0;
         
         pstmt = conn.prepareStatement( "insert into double_tab values (?,?,?)");
         pstmt.setObject(1,trueVal,Types.DOUBLE );
@@ -824,7 +823,7 @@ public class PreparedStatementTest extends TestCase
     public void testSetObjectCharacter() throws SQLException
     {
         PreparedStatement ps = conn.prepareStatement("INSERT INTO texttable(te) VALUES (?)");
-        ps.setObject(1, new Character('z'));
+        ps.setObject(1, 'z');
         ps.executeUpdate();
         ps.close();
     }
@@ -838,7 +837,7 @@ public class PreparedStatementTest extends TestCase
     public void testStatementDescribe() throws SQLException
     {
         PreparedStatement pstmt = conn.prepareStatement("SELECT ?::int");
-        pstmt.setObject(1, new Integer(2), Types.OTHER);
+        pstmt.setObject(1, 2, Types.OTHER);
         for (int i=0; i<10; i++) {
             ResultSet rs = pstmt.executeQuery();
             assertTrue(rs.next());

--- a/org/postgresql/test/jdbc2/ResultSetTest.java
+++ b/org/postgresql/test/jdbc2/ResultSetTest.java
@@ -191,10 +191,10 @@ public class ResultSetTest extends TestCase
         if (useServerPrepare)
             ((org.postgresql.PGStatement)pstmt).setUseServerPrepare(true);
 
-        pstmt.setObject(1, new Float(0), java.sql.Types.BIT);
+        pstmt.setObject(1, (float) 0, java.sql.Types.BIT);
         pstmt.executeUpdate();
 
-        pstmt.setObject(1, new Float(1), java.sql.Types.BIT);
+        pstmt.setObject(1, (float) 1, java.sql.Types.BIT);
         pstmt.executeUpdate();
 
         pstmt.setObject(1, "False", java.sql.Types.BIT);

--- a/org/postgresql/test/jdbc2/ServerPreparedStmtTest.java
+++ b/org/postgresql/test/jdbc2/ServerPreparedStmtTest.java
@@ -153,7 +153,7 @@ public class ServerPreparedStmtTest extends TestCase
         ((PGStatement)pstmt).setUseServerPrepare(true);
         assertTrue(((PGStatement)pstmt).isUseServerPrepare());
 
-        pstmt.setObject(1, new Boolean(false), java.sql.Types.BIT);
+        pstmt.setObject(1, false, java.sql.Types.BIT);
         ResultSet rs = pstmt.executeQuery();
         assertTrue(rs.next());
         assertEquals(9, rs.getInt(1));
@@ -167,7 +167,7 @@ public class ServerPreparedStmtTest extends TestCase
         ((PGStatement)pstmt).setUseServerPrepare(true);
         assertTrue(((PGStatement)pstmt).isUseServerPrepare());
 
-        pstmt.setObject(1, new Boolean(true), java.sql.Types.INTEGER);
+        pstmt.setObject(1, true, java.sql.Types.INTEGER);
         ResultSet rs = pstmt.executeQuery();
         assertTrue(rs.next());
         assertEquals(1, rs.getInt(1));

--- a/org/postgresql/test/jdbc2/optional/ConnectionPoolTest.java
+++ b/org/postgresql/test/jdbc2/optional/ConnectionPoolTest.java
@@ -53,8 +53,8 @@ public class ConnectionPoolTest extends BaseDataSourceTest
     
     protected void tearDown() throws Exception
     {
-        for (Iterator i = connections.iterator(); i.hasNext(); ) {
-            PooledConnection c = (PooledConnection) i.next();
+        for (Object connection : connections) {
+            PooledConnection c = (PooledConnection) connection;
             try {
                 c.close();
             } catch (Exception ex) {

--- a/org/postgresql/test/jdbc3/Jdbc3CallableStatementTest.java
+++ b/org/postgresql/test/jdbc3/Jdbc3CallableStatementTest.java
@@ -586,10 +586,10 @@ public class Jdbc3CallableStatementTest extends TestCase
             cstmt.close();
             ResultSet rs = con.createStatement().executeQuery("select * from real_tab");
             assertTrue ( rs.next() );
-            Float oVal = new Float( intValues[0]);
+            Float oVal = (float) intValues[0];
             Float rVal = new Float(rs.getObject(1).toString());
             assertTrue ( oVal.equals(rVal) );
-            oVal = new Float( intValues[1] );
+            oVal = (float) intValues[1];
             rVal = new Float(rs.getObject(2).toString());
             assertTrue ( oVal.equals(rVal) );
             rs.close();
@@ -738,10 +738,10 @@ public class Jdbc3CallableStatementTest extends TestCase
             cstmt.registerOutParameter(3,java.sql.Types.FLOAT);
             cstmt.executeUpdate();
             Double val = (Double)cstmt.getObject(1);
-            assertTrue( val.doubleValue() == doubleValues[0] );
+            assertTrue(val == doubleValues[0] );
             
             val = (Double)cstmt.getObject(2);
-            assertTrue( val.doubleValue() == doubleValues[1]);
+            assertTrue(val == doubleValues[1]);
             
             val = (Double)cstmt.getObject(3);            
             assertTrue( cstmt.wasNull() );

--- a/org/postgresql/test/jdbc3/TypesTest.java
+++ b/org/postgresql/test/jdbc3/TypesTest.java
@@ -58,14 +58,14 @@ public class TypesTest extends TestCase {
         // any better.
         if (TestUtil.isProtocolVersion(_conn, 3))
         {
-            assertTrue(!((Boolean)rs.getObject(4)).booleanValue());
+            assertTrue(!(Boolean) rs.getObject(4));
         }
     }
 
     public void testPreparedByte() throws SQLException {
         PreparedStatement pstmt = _conn.prepareStatement("SELECT ?,?");
         pstmt.setByte(1, (byte)1);
-        pstmt.setObject(2, new Byte((byte)2));
+        pstmt.setObject(2, (byte) 2);
         ResultSet rs = pstmt.executeQuery();
         assertTrue(rs.next());
         assertEquals((byte)1, rs.getByte(1));

--- a/org/postgresql/test/ssl/SslTest.java
+++ b/org/postgresql/test/ssl/SslTest.java
@@ -93,14 +93,13 @@ public class SslTest extends TestCase {
     Map expected = (Map)expectedmap.get(param);
     if (expected == null) {;expected = defaultexpected;}
     int j=0;
-    for (int i=0; i<csslmode.length; i++)
-    {
-      suite.addTest(new SslTest(param + "-"+csslmode[i]+"GG2",certdir,sconnstr,csslmode[i],2,true, true,sprefix,(Object[])expected.get(csslmode[i]+"GG")));
-      suite.addTest(new SslTest(param + "-"+csslmode[i]+"GG3",certdir,sconnstr,csslmode[i],3,true, true,sprefix,(Object[])expected.get(csslmode[i]+"GG")));
-      suite.addTest(new SslTest(param + "-"+csslmode[i]+"GB2",certdir,sconnstr,csslmode[i],2,true,false,sprefix,(Object[])expected.get(csslmode[i]+"GB")));
-      suite.addTest(new SslTest(param + "-"+csslmode[i]+"GB3",certdir,sconnstr,csslmode[i],3,true,false,sprefix,(Object[])expected.get(csslmode[i]+"GB")));
-      suite.addTest(new SslTest(param + "-"+csslmode[i]+"BG2",certdir,sconnstr,csslmode[i],2,false,true,sprefix,(Object[])expected.get(csslmode[i]+"BG")));
-      suite.addTest(new SslTest(param + "-"+csslmode[i]+"BG3",certdir,sconnstr,csslmode[i],3,false,true,sprefix,(Object[])expected.get(csslmode[i]+"BG")));
+    for (String aCsslmode : csslmode) {
+      suite.addTest(new SslTest(param + "-" + aCsslmode + "GG2", certdir, sconnstr, aCsslmode, 2, true, true, sprefix, (Object[]) expected.get(aCsslmode + "GG")));
+      suite.addTest(new SslTest(param + "-" + aCsslmode + "GG3", certdir, sconnstr, aCsslmode, 3, true, true, sprefix, (Object[]) expected.get(aCsslmode + "GG")));
+      suite.addTest(new SslTest(param + "-" + aCsslmode + "GB2", certdir, sconnstr, aCsslmode, 2, true, false, sprefix, (Object[]) expected.get(aCsslmode + "GB")));
+      suite.addTest(new SslTest(param + "-" + aCsslmode + "GB3", certdir, sconnstr, aCsslmode, 3, true, false, sprefix, (Object[]) expected.get(aCsslmode + "GB")));
+      suite.addTest(new SslTest(param + "-" + aCsslmode + "BG2", certdir, sconnstr, aCsslmode, 2, false, true, sprefix, (Object[]) expected.get(aCsslmode + "BG")));
+      suite.addTest(new SslTest(param + "-" + aCsslmode + "BG3", certdir, sconnstr, aCsslmode, 3, false, true, sprefix, (Object[]) expected.get(aCsslmode + "BG")));
     }
     return suite;
   }

--- a/org/postgresql/test/ssl/SslTestSuite.java
+++ b/org/postgresql/test/ssl/SslTestSuite.java
@@ -38,14 +38,12 @@ public class SslTestSuite  extends TestSuite {
 
       String[] hostmode = {"sslhost","sslhostssl","sslhostsslcert","sslcert"};
       String[] certmode = {"gh","bh"};
-      
-      for (int i=0; i<hostmode.length; i++)
-      {
-        for (int j=0; j<certmode.length; j++)
-        {
-          add(suite,hostmode[i]+certmode[j]+"8");
-          add(suite,hostmode[i]+certmode[j]+"9");
-        }
+
+      for (String aHostmode : hostmode) {
+          for (String aCertmode : certmode) {
+              add(suite, aHostmode + aCertmode + "8");
+              add(suite, aHostmode + aCertmode + "9");
+          }
       }
       
       TestUtil.initDriver();

--- a/org/postgresql/test/xa/XADataSourceTest.java
+++ b/org/postgresql/test/xa/XADataSourceTest.java
@@ -192,10 +192,8 @@ public class XADataSourceTest extends TestCase {
 
             boolean recoveredXid = false;
 
-            for (int i = 0; i < recoveredXidArray.length; i++)
-            {
-                if (xid.equals(recoveredXidArray[i]))
-                {
+            for (Xid aRecoveredXidArray : recoveredXidArray) {
+                if (xid.equals(aRecoveredXidArray)) {
                     recoveredXid = true;
                     break;
                 }
@@ -212,10 +210,8 @@ public class XADataSourceTest extends TestCase {
 
             boolean recoveredXid = false;
 
-            for (int c = 0; c < recoveredXidArray.length; c++)
-            {
-                if (xaRes.equals(recoveredXidArray[c]))
-                {
+            for (Xid aRecoveredXidArray : recoveredXidArray) {
+                if (xaRes.equals(aRecoveredXidArray)) {
                     recoveredXid = true;
                     break;
                 }

--- a/org/postgresql/util/HStoreConverter.java
+++ b/org/postgresql/util/HStoreConverter.java
@@ -41,17 +41,20 @@ public class HStoreConverter {
        byte[] lenBuf = new byte[4];
        try {
            ByteConverter.int4(lenBuf, 0, m.size()); baos.write(lenBuf);
-           for (Iterator i = m.entrySet().iterator(); i.hasNext(); ) {
-               Entry e = (Entry) i.next();
+           for (Object o : m.entrySet()) {
+               Entry e = (Entry) o;
                byte[] key = encoding.encode(e.getKey().toString());
-               ByteConverter.int4(lenBuf, 0, key.length); baos.write(lenBuf);
+               ByteConverter.int4(lenBuf, 0, key.length);
+               baos.write(lenBuf);
                baos.write(key);
-               
+
                if (e.getValue() == null) {
-                   ByteConverter.int4(lenBuf, 0, -1); baos.write(lenBuf);
+                   ByteConverter.int4(lenBuf, 0, -1);
+                   baos.write(lenBuf);
                } else {
                    byte[] val = encoding.encode(e.getValue().toString());
-                   ByteConverter.int4(lenBuf, 0, val.length); baos.write(lenBuf);
+                   ByteConverter.int4(lenBuf, 0, val.length);
+                   baos.write(lenBuf);
                    baos.write(val);
                }
            }
@@ -68,8 +71,8 @@ public class HStoreConverter {
            return "";
        }
        StringBuilder sb = new StringBuilder(map.size() * 8);
-       for (Iterator i = map.entrySet().iterator(); i.hasNext(); ) {
-           Entry e = (Entry) i.next();
+       for (Object o : map.entrySet()) {
+           Entry e = (Entry) o;
            appendEscaped(sb, e.getKey());
            sb.append("=>");
            appendEscaped(sb, e.getValue());

--- a/org/postgresql/util/PGbytea.java
+++ b/org/postgresql/util/PGbytea.java
@@ -137,36 +137,29 @@ public class PGbytea
         if (p_buf == null)
             return null;
         StringBuilder l_strbuf = new StringBuilder(2 * p_buf.length);
-        for (int i = 0; i < p_buf.length; i++)
-        {
-            int l_int = (int)p_buf[i];
-            if (l_int < 0)
-            {
+        for (byte aP_buf : p_buf) {
+            int l_int = (int) aP_buf;
+            if (l_int < 0) {
                 l_int = 256 + l_int;
             }
             //we escape the same non-printable characters as the backend
             //we must escape all 8bit characters otherwise when convering
             //from java unicode to the db character set we may end up with
             //question marks if the character set is SQL_ASCII
-            if (l_int < 040 || l_int > 0176)
-            {
+            if (l_int < 040 || l_int > 0176) {
                 //escape charcter with the form \000, but need two \\ because of
                 //the Java parser
                 l_strbuf.append("\\");
-                l_strbuf.append((char)(((l_int >> 6) & 0x3) + 48));
-                l_strbuf.append((char)(((l_int >> 3) & 0x7) + 48));
-                l_strbuf.append((char)((l_int & 0x07) + 48));
-            }
-            else if (p_buf[i] == (byte)'\\')
-            {
+                l_strbuf.append((char) (((l_int >> 6) & 0x3) + 48));
+                l_strbuf.append((char) (((l_int >> 3) & 0x7) + 48));
+                l_strbuf.append((char) ((l_int & 0x07) + 48));
+            } else if (aP_buf == (byte) '\\') {
                 //escape the backslash character as \\, but need four \\\\ because
                 //of the Java parser
                 l_strbuf.append("\\\\");
-            }
-            else
-            {
+            } else {
                 //other characters are left alone
-                l_strbuf.append((char)p_buf[i]);
+                l_strbuf.append((char) aP_buf);
             }
         }
         return l_strbuf.toString();

--- a/org/postgresql/util/ServerErrorMessage.java
+++ b/org/postgresql/util/ServerErrorMessage.java
@@ -14,23 +14,23 @@ import java.io.Serializable;
 public class ServerErrorMessage implements Serializable
 {
 
-    private static final Character SEVERITY = new Character('S');
-    private static final Character MESSAGE = new Character('M');
-    private static final Character DETAIL = new Character('D');
-    private static final Character HINT = new Character('H');
-    private static final Character POSITION = new Character('P');
-    private static final Character WHERE = new Character('W');
-    private static final Character FILE = new Character('F');
-    private static final Character LINE = new Character('L');
-    private static final Character ROUTINE = new Character('R');
-    private static final Character SQLSTATE = new Character('C');
-    private static final Character INTERNAL_POSITION = new Character('p');
-    private static final Character INTERNAL_QUERY = new Character('q');
-    private static final Character SCHEMA = new Character('s');
-    private static final Character TABLE = new Character('t');
-    private static final Character COLUMN = new Character('c');
-    private static final Character DATATYPE = new Character('d');
-    private static final Character CONSTRAINT = new Character('n');
+    private static final Character SEVERITY = 'S';
+    private static final Character MESSAGE = 'M';
+    private static final Character DETAIL = 'D';
+    private static final Character HINT = 'H';
+    private static final Character POSITION = 'P';
+    private static final Character WHERE = 'W';
+    private static final Character FILE = 'F';
+    private static final Character LINE = 'L';
+    private static final Character ROUTINE = 'R';
+    private static final Character SQLSTATE = 'C';
+    private static final Character INTERNAL_POSITION = 'p';
+    private static final Character INTERNAL_QUERY = 'q';
+    private static final Character SCHEMA = 's';
+    private static final Character TABLE = 't';
+    private static final Character COLUMN = 'c';
+    private static final Character DATATYPE = 'd';
+    private static final Character CONSTRAINT = 'n';
 
     private final Map m_mesgParts = new HashMap();
     private final int verbosity;
@@ -55,7 +55,7 @@ public class ServerErrorMessage implements Serializable
                     l_pos++;
                 }
                 String l_mesgPart = new String(l_chars, l_startString, l_pos - l_startString);
-                m_mesgParts.put(new Character(l_mesgType), l_mesgPart);
+                m_mesgParts.put(l_mesgType, l_mesgPart);
             }
             l_pos++;
         }

--- a/org/postgresql/xa/PGXAConnection.java
+++ b/org/postgresql/xa/PGXAConnection.java
@@ -143,7 +143,7 @@ public class PGXAConnection extends PGPooledConnection implements XAConnection, 
                 if (methodName.equals("commit") ||
                     methodName.equals("rollback") ||
                     methodName.equals("setSavePoint") ||
-                    (methodName.equals("setAutoCommit") && ((Boolean) args[0]).booleanValue()))
+                    (methodName.equals("setAutoCommit") && (Boolean) args[0]))
                 {
 		    throw new PSQLException(GT.tr("Transaction control methods setAutoCommit(true), commit, rollback and setSavePoint not allowed while an XA transaction is active."),
 					    PSQLState.OBJECT_NOT_IN_STATE);


### PR DESCRIPTION
This PR uses some language features from Java 5 to reduce boiler plate and enhance readability of the code.
The changes include:
* Replace for loops with Java 5-style for loops.
* Replace String.indexOf with String.contains.
* Replace StringBuffer with StringBuilder.
* Remove boxing/unboxing of primitives.