### PR TITLE
Build process improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_script:
   - psql -c 'create database test owner test;' -U postgres
  
 
-script: ant -lib lib test
+script: ant test
 
 matrix:
   include:

--- a/build.xml
+++ b/build.xml
@@ -676,6 +676,12 @@ Import-Package: javax.sql, javax.transaction.xa, javax.naming, *;resolution:=opt
     <delete quiet="true" file="${srcdir}/${package}/ds/PGConnectionPoolDataSource.java" />
     <delete quiet="true" file="${srcdir}/${package}/xa/PGXADataSource.java" />
     <delete quiet="true" file="${srcdir}/${package}/ssl/MakeSSL.java" />
+    <delete quiet="true">
+      <fileset dir="lib">
+        <include name="*"/>
+        <exclude name="maven-ant-tasks*.jar"/>
+      </fileset>
+    </delete>
   </target>
 
   <!-- This compiles and executes the JUnit tests -->

--- a/build.xml
+++ b/build.xml
@@ -30,6 +30,9 @@
   <property file="build.local.properties" />
   <property file="build.properties"/>
 
+  <taskdef uri="antlib:org.apache.maven.artifact.ant"
+           classpath="lib/maven-ant-tasks-2.1.3.jar"/>
+
  <!-- define artifacts' name, which follows the convention of Maven -->
   <property name="maven.jar" value="${jardir}/${maven.artifact.id}-${maven.artifact.version}.jar"/>
   <property name="maven.javadoc.jar" value="${jardir}/${maven.artifact.id}-${maven.artifact.version}-javadoc.jar"/>


### PR DESCRIPTION
- It is no longer necessary to run ant with `ant -lib lib <target>`, required libraries are automatically loaded by the build process (typically `ant all` is sufficient)

- ~~Documentation can be built without requiring prior installation of docbook stylesheet and saxon (saxon and XSLT stylesheets are retrieved from the nexus). The following command can be used to build documentation `ant snapshot-version doc` (fixes #226)~~

- The `clean` target delete the files added to the `lib` directory
