### PR TITLE
Fix setUrl method of BaseDataSource. 

### DIFF
--- a/org/postgresql/ds/common/BaseDataSource.java
+++ b/org/postgresql/ds/common/BaseDataSource.java
@@ -1002,6 +1002,9 @@ public abstract class BaseDataSource implements Referenceable
 
     public void setProperty(PGProperty property, String value)
     {
+        if (value == null) {
+            return;
+        }
         switch(property)
         {
             case PG_HOST:

--- a/org/postgresql/test/jdbc2/optional/OptionalTestSuite.java
+++ b/org/postgresql/test/jdbc2/optional/OptionalTestSuite.java
@@ -27,6 +27,7 @@ public class OptionalTestSuite extends TestSuite
         Class.forName("org.postgresql.Driver");
         TestSuite suite = new TestSuite();
         suite.addTestSuite(SimpleDataSourceTest.class);
+        suite.addTestSuite(SimpleDataSourceWithUrlTest.class);
         suite.addTestSuite(ConnectionPoolTest.class);
         suite.addTestSuite(PoolingDataSourceTest.class);
         suite.addTestSuite(CaseOptimiserDataSourceTest.class);

--- a/org/postgresql/test/jdbc2/optional/SimpleDataSourceWithUrlTest.java
+++ b/org/postgresql/test/jdbc2/optional/SimpleDataSourceWithUrlTest.java
@@ -1,0 +1,43 @@
+/*-------------------------------------------------------------------------
+*
+* Copyright (c) 2004-2014, PostgreSQL Global Development Group
+*
+*
+*-------------------------------------------------------------------------
+*/
+package org.postgresql.test.jdbc2.optional;
+
+import org.postgresql.test.TestUtil;
+import org.postgresql.jdbc2.optional.SimpleDataSource;
+
+/**
+ * Performs the basic tests defined in the superclass. Just adds the
+ * configuration logic.
+ *
+ * @author Aaron Mulder (ammulder@chariotsolutions.com)
+ */
+public class SimpleDataSourceWithUrlTest extends BaseDataSourceTest
+{
+    /**
+     * Constructor required by JUnit
+     */
+    public SimpleDataSourceWithUrlTest(String name)
+    {
+        super(name);
+    }
+
+    /**
+     * Creates and configures a new SimpleDataSource.
+     */
+    protected void initializeDataSource()
+    {
+        if (bds == null)
+        {
+            bds = new SimpleDataSource();
+            bds.setUrl("jdbc:postgresql://"+TestUtil.getServer() + ":" + TestUtil.getPort() + "/" + TestUtil.getDatabase() + "?prepareThreshold=" + TestUtil.getPrepareThreshold() + "&logLevel=" + TestUtil.getLogLevel());
+            bds.setUser(TestUtil.getUser());
+            bds.setPassword(TestUtil.getPassword());
+            bds.setProtocolVersion(TestUtil.getProtocolVersion());
+        }
+    }
+}


### PR DESCRIPTION
The latest 9.4 jdbc driver fails with NullPointerException when data source setUrl method is invoked.
Fix it and add test to make sure it does not break again.