### PR TITLE
fix: regression of `ssl` parameter processing when used in additional Properties

### DIFF
--- a/org/postgresql/PGProperty.java
+++ b/org/postgresql/PGProperty.java
@@ -448,7 +448,7 @@ public enum PGProperty
      */
     public boolean isPresent(Properties properties)
     {
-        return properties.containsKey(_name) && get(properties) != null;
+        return get(properties) != null;
     }
 
     /**

--- a/org/postgresql/test/jdbc2/PGPropertyTest.java
+++ b/org/postgresql/test/jdbc2/PGPropertyTest.java
@@ -22,6 +22,7 @@ import org.postgresql.Driver;
 import org.postgresql.PGProperty;
 import org.postgresql.ds.PGSimpleDataSource;
 import org.postgresql.ds.common.BaseDataSource;
+import org.postgresql.test.TestUtil;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -188,5 +189,29 @@ public class PGPropertyTest extends TestCase
             PGProperty enumProperty = PGProperty.forName(propertyName);
             Assert.assertNotNull("Connection parameter [" + propertyName + "] documented in [" + DOCUMENTATION_FILE + "] does not exist in the code (see PGProperty enum)", enumProperty);
         }
+    }
+
+    /**
+     * Test that {@link PGProperty#isPresent(Properties)} returns a correct result in all cases
+     */
+    public void testIsPresentWithParseURLResult() throws Exception
+    {
+        Properties givenProperties = new Properties();
+        givenProperties.setProperty("user", TestUtil.getUser());
+        givenProperties.setProperty("password", TestUtil.getPassword());
+
+        Properties parsedProperties = Driver.parseURL(TestUtil.getURL(), givenProperties);
+        Assert.assertFalse("SSL property should not be present", PGProperty.SSL.isPresent(parsedProperties));
+
+        givenProperties.setProperty("ssl", "true");
+        parsedProperties = Driver.parseURL(TestUtil.getURL(), givenProperties);
+        Assert.assertTrue("SSL property should be present", PGProperty.SSL.isPresent(parsedProperties));
+
+        givenProperties.setProperty("ssl", "anotherValue");
+        parsedProperties = Driver.parseURL(TestUtil.getURL(), givenProperties);
+        Assert.assertTrue("SSL property should be present", PGProperty.SSL.isPresent(parsedProperties));
+
+        parsedProperties = Driver.parseURL(TestUtil.getURL() + "&ssl=true" , null);
+        Assert.assertTrue("SSL property should be present", PGProperty.SSL.isPresent(parsedProperties));
     }
 }


### PR DESCRIPTION
When a Properties object is initialized with default properties using its one-arg constructor (what Driver#parseURL does), the method [PGProperty#isPresent](https://github.com/alexismeneses/pgjdbc/commit/33d55af9354743903fbc211e0413e4840d0f08a7#diff-ba5d8e206f51468b12a3cb8d32391a62L449) was returning incorrect result for these default properties.

`ssl` parameter is checked using aforementioned method hence the issue.

This fixes #259