### PR TITLE
Update entries in lib/.gitignore

### DIFF
--- a/lib/.gitignore
+++ b/lib/.gitignore
@@ -1,7 +1,11 @@
 guava-18.0.jar
+hamcrest-core-1.3.jar
 jna-4.1.0.jar
 jna-platform-4.1.0.jar
-junit-4.0.jar
+junit-4.11.jar
+maven-ant-tasks-2.1.3.jar
+org.osgi.enterprise-4.2.0.jar
+org.osgi.core-4.3.1.jar
 slf4j-api-1.7.7.jar
-waffle-jna-1.7.jar
 slf4j-simple-1.7.7.jar
+waffle-jna-1.7.jar


### PR DESCRIPTION
Jar files downloaded from maven should be ignored in the code tree.