### PR TITLE
Expand query param count limit

### DIFF
--- a/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -1338,7 +1338,7 @@ public class QueryExecutorImpl implements QueryExecutor {
             pgStream.Send(parts[i]);
         }
         pgStream.SendChar(0);       // End of query string.
-        pgStream.SendInteger2(params.getParameterCount());       // # of parameter types specified
+        pgStream.SendInteger4(params.getParameterCount());       // # of parameter types specified
         for (int i = 1; i <= params.getParameterCount(); ++i)
             pgStream.SendInteger4(params.getTypeOID(i));
 


### PR DESCRIPTION
when I run like this query , occur IO Exception.

select count(1) from one_table ;

```

 count
-------
   35000
(1 row)


```

select * from two_table where id in (select id from one_table );

```

Caused by: org.postgresql.util.PSQLException: An I/O error occurred while sending to the backend.
        at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:283)
        at org.postgresql.jdbc2.AbstractJdbc2Statement.execute(AbstractJdbc2Statement.java:500)
        at org.postgresql.jdbc2.AbstractJdbc2Statement.executeWithFlags(AbstractJdbc2Statement.java:388)
        at org.postgresql.jdbc2.AbstractJdbc2Statement.executeQuery(AbstractJdbc2Statement.java:273)
        at org.seasar.extension.jdbc.impl.PreparedStatementWrapper.executeQuery(PreparedStatementWrapper.java:81)
        ... 94 more

Caused by: java.io.IOException: Tried to send an out-of-range integer as a 2-byte value: 33559
        at org.postgresql.core.PGStream.SendInteger2(PGStream.java:201)
        at org.postgresql.core.v3.QueryExecutorImpl.sendParse(QueryExecutorImpl.java:1236)
        at org.postgresql.core.v3.QueryExecutorImpl.sendOneQuery(QueryExecutorImpl.java:1508)
        at org.postgresql.core.v3.QueryExecutorImpl.sendQuery(QueryExecutorImpl.java:1097)
        at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:255)
        ... 98 more

```


Query parameter does not accept only　out range of smallint.

I fixed it, sorry my poor english.