### PR TITLE
Add PostgreSQL 9.4 to Travis-CI Matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: java
 before_script:
   - psql -U postgres -c "create user test with password 'test';"
   - psql -c 'create database test owner test;' -U postgres
- 
 
 script: ant test
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ matrix:
         postgresql: "9.2"
     - jdk: oraclejdk8
       addons:
-        postgresql: "9.3"
+        postgresql: "9.2"
     - jdk: openjdk7
       addons:
         postgresql: "9.3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,10 @@ script: ant test
 
 matrix:
   include:
-    - jdk: openjdk7
+    - jdk: openjdk6
       addons:
         postgresql: "9.1"
-    - jdk: openjdk6
+    - jdk: openjdk7
       addons:
         postgresql: "9.1"
     - jdk: oraclejdk7
@@ -20,10 +20,10 @@ matrix:
     - jdk: oraclejdk8
       addons:
         postgresql: "9.1"
-    - jdk: openjdk7
+    - jdk: openjdk6
       addons:
         postgresql: "9.2"
-    - jdk: openjdk6
+    - jdk: openjdk7
       addons:
         postgresql: "9.2"
     - jdk: oraclejdk7
@@ -32,10 +32,10 @@ matrix:
     - jdk: oraclejdk8
       addons:
         postgresql: "9.2"
-    - jdk: openjdk7
+    - jdk: openjdk6
       addons:
         postgresql: "9.3"
-    - jdk: openjdk6
+    - jdk: openjdk7
       addons:
         postgresql: "9.3"
     - jdk: oraclejdk7

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,3 +44,15 @@ matrix:
     - jdk: oraclejdk8
       addons:
         postgresql: "9.3"
+    - jdk: openjdk6
+      addons:
+        postgresql: "9.4"
+    - jdk: openjdk7
+      addons:
+        postgresql: "9.4"
+    - jdk: oraclejdk7
+      addons:
+        postgresql: "9.4"
+    - jdk: oraclejdk8
+      addons:
+        postgresql: "9.4"


### PR DESCRIPTION
This PR adds testing against PostgreSQL 9.4 to the Travis-CI matrix. I did it in a couple of separate commits that first clean up the order of the order of the JDK versions (openjdk7 was before openjdk6). 

Also, this fixes an bug in the config as it wasn't testing against oraclejdk8/9.2 (9.3 was erroneously included twice).