### PR TITLE
feat: add escapeLiteral(...) and escapeIdentifier(...) to PGConnection

### DIFF
--- a/org/postgresql/PGConnection.java
+++ b/org/postgresql/PGConnection.java
@@ -116,4 +116,22 @@ public interface PGConnection
      * @return PID of backend server process. 
      */
     public int getBackendPID();
+
+    /**
+     * Return the given string suitably quoted to be used as an identifier in an SQL statement string.
+     * Quotes are added only if necessary (i.e., if the string contains non-identifier characters or would be case-folded).
+     * Embedded quotes are properly doubled.
+     *
+     * @return the escaped identifier
+     */
+    public String escapeIdentifier(String identifier) throws SQLException;
+
+    /**
+     * Return the given string suitably quoted to be used as a string literal in an SQL statement string.
+     * Embedded single-quotes and backslashes are properly doubled.
+     * Note that quote_literal returns null on null input.
+     *
+     * @return the quoted literal
+     */
+    public String escapeLiteral(String literal) throws SQLException;
 }

--- a/org/postgresql/jdbc2/AbstractJdbc2Connection.java
+++ b/org/postgresql/jdbc2/AbstractJdbc2Connection.java
@@ -1325,4 +1325,12 @@ public abstract class AbstractJdbc2Connection implements BaseConnection
             timer.purge();
         }
     }
+
+    public String escapeIdentifier(String identifier) throws SQLException {
+        return Utils.escapeIdentifier(null, identifier).toString();
+    }
+
+    public String escapeLiteral(String literal) throws SQLException {
+        return Utils.escapeLiteral(null, literal, protoConnection.getStandardConformingStrings()).toString();
+    }
 }


### PR DESCRIPTION
Add methods for escaping identifiers and literals to public PGConnection interface. The methods are added there, rather then exposing the static versions publicly, so that the connection specific standard_conforming_strings property is used.

Closes #198 

This is a pretty straight forward PR ... the only thing that's kind of odd is the `throws SQLException` but that's the contract of the underlying static methods. Both reject zero bytes within strings and throw a `PSQLException` if they encounter one in the string to be escaped.

The descriptions for the javadocs for the two new methods were take from PG docs for `quote_ident(...)` and `quote_literal(...)`.