### PR TITLE
feat: add equality support to PSQLState

### DIFF
--- a/org/postgresql/util/PSQLState.java
+++ b/org/postgresql/util/PSQLState.java
@@ -25,6 +25,18 @@ public class PSQLState implements java.io.Serializable
         this.state = state;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        PSQLState psqlState = (PSQLState) o;
+        return !(state != null ? !state.equals(psqlState.state) : psqlState.state != null);
+    }
+
+    @Override
+    public int hashCode() {
+        return state != null ? state.hashCode() : 0;
+    }
 
     // begin constant state codes
     public final static PSQLState UNKNOWN_STATE = new PSQLState("");


### PR DESCRIPTION
This commit adds support for equality comparison of PSQLState
instances by specializing the equals(...) and hashCode() methods.
Previously, two seemingly identical instances (e.g., `new
PSQLState("0100E")` and `new PSQLState("0100E")`) would not compare
equal.

This change is particularly useful to Scala developers. Pattern
matching can now be used against the predefined constant PSQLState
instances.