### PR TITLE
Added setter method for logging level.

### DIFF
--- a/org/postgresql/ds/common/BaseDataSource.java
+++ b/org/postgresql/ds/common/BaseDataSource.java
@@ -1133,4 +1133,8 @@ public abstract class BaseDataSource implements Referenceable
         readBaseObject(ois);
     }
 
+    public void setLoglevel(int logLevel)
+    {
+        PGProperty.LOG_LEVEL.set(properties, logLevel);
+    }
 }

--- a/org/postgresql/ds/common/BaseDataSource.java
+++ b/org/postgresql/ds/common/BaseDataSource.java
@@ -1137,4 +1137,8 @@ public abstract class BaseDataSource implements Referenceable
     {
         PGProperty.LOG_LEVEL.set(properties, logLevel);
     }
+
+    public int getLoglevel() {
+        return PGProperty.LOG_LEVEL.getIntNoCheck(properties);
+    }
 }


### PR DESCRIPTION
The documentation shows the property name for the logging level is "loglevel". All lower case.
A method has been added to the base data source to work in cases where a user configures a datasource with exactly the same case. 