### PR TITLE
Customize default fetchSize for statements

### DIFF
--- a/doc/pgjdbc.xml
+++ b/doc/pgjdbc.xml
@@ -736,6 +736,20 @@ openssl pkcs8 -topk8 -in client.key -out client.pk8 -outform DER -v1 PBE-SHA1-3D
         </para>
        </listitem>
       </varlistentry>
+	  
+	  <varlistentry>
+       <term><varname>defaultRowFetchSize</varname> = <type>int</type></term>
+       <listitem>
+        <para>
+         Determine the number of rows fetched in <classname>ResultSet</classname>
+		 by one fetch with trip to the database. Limiting the number of rows are fetch with 
+		 each trip to the database allow avoids unnecessary memory consumption 
+		 and as a consequence <classname>OutOfMemoryException</classname>.
+		 The default is zero, meaning that in <classname>ResultSet</classname>
+		 will be fetch all rows at once. Negative number is not available.
+        </para>
+       </listitem>
+      </varlistentry>
 
       <varlistentry>
        <term><varname>loginTimeout</varname> = <type>int</type></term>

--- a/org/postgresql/PGConnection.java
+++ b/org/postgresql/PGConnection.java
@@ -111,6 +111,27 @@ public interface PGConnection
     public int getPrepareThreshold();
 
     /**
+     * Set the default fetch size for statements created from this connection
+     *
+     * @param fetchSize new default fetch size
+     * @throws SQLException if specified negative <code>fetchSize</code> parameter
+     *
+     * @see Statement#setFetchSize(int)
+     *
+     */
+    public void setDefaultFetchSize(int fetchSize) throws SQLException;
+
+
+    /**
+     * Get the default fetch size for statements created from this connection
+     *
+     * @return current state for default fetch size
+     * @see PGProperty#DEFAULT_ROW_FETCH_SIZE
+     * @see Statement#getFetchSize()
+     */
+    public int getDefaultFetchSize();
+
+    /**
      * Return the process ID (PID) of the backend server process handling this connection.
      * 
      * @return PID of backend server process. 

--- a/org/postgresql/PGProperty.java
+++ b/org/postgresql/PGProperty.java
@@ -62,6 +62,11 @@ public enum PGProperty
     PREPARE_THRESHOLD("prepareThreshold", "5", "Statement prepare threshold. A value of {@code -1} stands for forceBinary"),
 
     /**
+     * Default parameter for {@link java.sql.Statement#getFetchSize()}. A value of {@code 0} means that need fetch all rows at once
+     */
+    DEFAULT_ROW_FETCH_SIZE("defaultRowFetchSize", "0", "Positive number of rows that should be fetched from the database when more rows are needed for ResultSet by each fetch iteration"),
+
+    /**
      * Use binary format for sending and receiving data if possible.
      */
     BINARY_TRANSFER("binaryTransfer", "true", "Use binary format for sending and receiving data if possible"),

--- a/org/postgresql/ds/common/BaseDataSource.java
+++ b/org/postgresql/ds/common/BaseDataSource.java
@@ -372,6 +372,22 @@ public abstract class BaseDataSource implements Referenceable
     }
 
     /**
+     * @see PGProperty#DEFAULT_ROW_FETCH_SIZE
+     */
+    public void setDefaultRowFetchSize(int fetchSize)
+    {
+        PGProperty.DEFAULT_ROW_FETCH_SIZE.set(properties, fetchSize);
+    }
+
+    /**
+     * @see PGProperty#DEFAULT_ROW_FETCH_SIZE
+     */
+    public int getDefaultRowFetchSize()
+    {
+        return PGProperty.DEFAULT_ROW_FETCH_SIZE.getIntNoCheck(properties);
+    }
+
+    /**
      * @see PGProperty#UNKNOWN_LENGTH 
      */
     public void setUnknownLength(int unknownLength)

--- a/org/postgresql/jdbc2/AbstractJdbc2Connection.java
+++ b/org/postgresql/jdbc2/AbstractJdbc2Connection.java
@@ -63,6 +63,12 @@ public abstract class AbstractJdbc2Connection implements BaseConnection
     // Default statement prepare threshold.
     protected int prepareThreshold;
 
+    /**
+     * Default fetch size for statement
+     * @see PGProperty#DEFAULT_ROW_FETCH_SIZE
+     */
+    protected int defaultFetchSize;
+
     // Default forcebinary option.
     protected boolean forcebinary = false;
 
@@ -112,6 +118,8 @@ public abstract class AbstractJdbc2Connection implements BaseConnection
 
         if (logLevel > 0)
             enableDriverManagerLogging();
+
+        setDefaultFetchSize(PGProperty.DEFAULT_ROW_FETCH_SIZE.getInt(info));
 
         prepareThreshold = PGProperty.PREPARE_THRESHOLD.getInt(info);
         if (prepareThreshold == -1)
@@ -1196,6 +1204,18 @@ public abstract class AbstractJdbc2Connection implements BaseConnection
 
     public int getPrepareThreshold() {
         return prepareThreshold;
+    }
+
+    public void setDefaultFetchSize(int fetchSize) throws SQLException {
+        if (fetchSize < 0)
+            throw new PSQLException(GT.tr("Fetch size must be a value greater to or equal to 0."),
+                                    PSQLState.INVALID_PARAMETER_VALUE);
+
+        this.defaultFetchSize = fetchSize;
+    }
+
+    public int getDefaultFetchSize() {
+        return defaultFetchSize;
     }
 
     public void setPrepareThreshold(int newThreshold) {

--- a/org/postgresql/jdbc4/Jdbc4Connection.java
+++ b/org/postgresql/jdbc4/Jdbc4Connection.java
@@ -35,6 +35,7 @@ public class Jdbc4Connection extends AbstractJdbc4Connection implements java.sql
         checkClosed();
         Jdbc4Statement s = new Jdbc4Statement(this, resultSetType, resultSetConcurrency, resultSetHoldability);
         s.setPrepareThreshold(getPrepareThreshold());
+        s.setFetchSize(getDefaultFetchSize());
         return s;
     }
 
@@ -43,6 +44,7 @@ public class Jdbc4Connection extends AbstractJdbc4Connection implements java.sql
         checkClosed();
         Jdbc4PreparedStatement s = new Jdbc4PreparedStatement(this, sql, resultSetType, resultSetConcurrency, resultSetHoldability);
         s.setPrepareThreshold(getPrepareThreshold());
+        s.setFetchSize(getDefaultFetchSize());
         return s;
     }
 
@@ -51,6 +53,7 @@ public class Jdbc4Connection extends AbstractJdbc4Connection implements java.sql
         checkClosed();
         Jdbc4CallableStatement s = new Jdbc4CallableStatement(this, sql, resultSetType, resultSetConcurrency, resultSetHoldability);
         s.setPrepareThreshold(getPrepareThreshold());
+        s.setFetchSize(getDefaultFetchSize());
         return s;
     }
 

--- a/org/postgresql/jdbc42/Jdbc42Connection.java
+++ b/org/postgresql/jdbc42/Jdbc42Connection.java
@@ -32,6 +32,7 @@ public class Jdbc42Connection extends AbstractJdbc42Connection
     {
         checkClosed();
         Jdbc42Statement s = new Jdbc42Statement(this, resultSetType, resultSetConcurrency, resultSetHoldability, getPrepareThreshold());
+        s.setFetchSize(getDefaultFetchSize());
         return s;
     }
 
@@ -39,6 +40,7 @@ public class Jdbc42Connection extends AbstractJdbc42Connection
     {
         checkClosed();
         Jdbc42PreparedStatement s = new Jdbc42PreparedStatement(this, sql, resultSetType, resultSetConcurrency, resultSetHoldability, getPrepareThreshold());
+        s.setFetchSize(getDefaultFetchSize());
         return s;
     }
 
@@ -46,6 +48,7 @@ public class Jdbc42Connection extends AbstractJdbc42Connection
     {
         checkClosed();
         Jdbc42CallableStatement s = new Jdbc42CallableStatement(this, sql, resultSetType, resultSetConcurrency, resultSetHoldability, getPrepareThreshold());
+        s.setFetchSize(getDefaultFetchSize());
         return s;
     }
 

--- a/org/postgresql/test/jdbc42/CustomizeDefaultFetchSizeTest.java
+++ b/org/postgresql/test/jdbc42/CustomizeDefaultFetchSizeTest.java
@@ -1,0 +1,84 @@
+package org.postgresql.test.jdbc42;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.After;
+import org.junit.Test;
+import org.postgresql.PGProperty;
+import org.postgresql.test.TestUtil;
+
+import java.sql.CallableStatement;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Properties;
+
+import static junit.framework.Assert.fail;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class CustomizeDefaultFetchSizeTest
+{
+
+    private Connection connection;
+
+    @After
+    public void tearDown() throws Exception
+    {
+        if(connection != null)
+        {
+            TestUtil.closeDB(connection);
+        }
+    }
+
+    @Test
+    public void testSetPredefineDefaultFetchSizeOnStatement() throws Exception
+    {
+        final int waitFetchSize = 13;
+        Properties properties = new Properties();
+        PGProperty.DEFAULT_ROW_FETCH_SIZE.set(properties, waitFetchSize);
+
+        connection = TestUtil.openDB(properties);
+
+        Statement statement = connection.createStatement();
+        int resultFetchSize = statement.getFetchSize();
+
+        statement.close();
+
+        assertThat("PGProperty.DEFAULT_ROW_FETCH_SIZE should be propagate to Statement that was create from connection " +
+                           "on that define it parameter",
+                   resultFetchSize, CoreMatchers.equalTo(waitFetchSize)
+        );
+    }
+
+
+    @Test
+    public void testSetPredefineDefaultFetchSizeOnPreparedStatement() throws Exception
+    {
+        final int waitFetchSize = 14;
+
+        Properties properties = new Properties();
+        PGProperty.DEFAULT_ROW_FETCH_SIZE.set(properties, waitFetchSize);
+
+        connection = TestUtil.openDB(properties);
+
+        CallableStatement statement = connection.prepareCall("{ call unnest(array[1, 2, 3, 5])}");
+        int resultFetchSize = statement.getFetchSize();
+
+        assertThat("PGProperty.DEFAULT_ROW_FETCH_SIZE should be propagate to CallableStatement that was create from connection " +
+                           "on that define it parameter",
+                   resultFetchSize, CoreMatchers.equalTo(waitFetchSize)
+        );
+    }
+
+    @Test(expected = SQLException.class)
+    public void testNotAvailableSpecifyNegativeFetchSize() throws Exception
+    {
+        Properties properties = new Properties();
+        PGProperty.DEFAULT_ROW_FETCH_SIZE.set(properties, Integer.MIN_VALUE);
+
+        connection = TestUtil.openDB(properties);
+
+        fail("On step initialize connection we know about not valid parameter PGProperty.DEFAULT_ROW_FETCH_SIZE they can't be negative, " +
+                     "so we should throw correspond exception about it rather than fall with exception in runtime for example during create statement"
+        );
+    }
+}

--- a/org/postgresql/test/jdbc42/Jdbc42TestSuite.java
+++ b/org/postgresql/test/jdbc42/Jdbc42TestSuite.java
@@ -12,7 +12,7 @@ import org.junit.runners.Suite.SuiteClasses;
 import org.junit.runner.RunWith;
 
 @RunWith(Suite.class)
-@SuiteClasses({SimpleJdbc42Test.class})
+@SuiteClasses({SimpleJdbc42Test.class, CustomizeDefaultFetchSizeTest.class})
 public class Jdbc42TestSuite
 {
 


### PR DESCRIPTION
After migration big application from Oracle to PostgreSQL we faced with problem that application use too many memory and as result it lead to OutOfMemoryException. The application that has been developing for more than one year which develops many developers usually there are several entry points to the database. It can be use manually Connection\Statements\etc or it can be Spring JdbcTemplate or some own implementation. Common points it's application server datasource in that configure connection to postgresql. And it's a good point for configure global parameters like default fetch size that allow facilitate migration from Oracle and its default value of 10 to PostgreSQL where by default fetches all records at once.

![postgresql_oom](https://cloud.githubusercontent.com/assets/10699594/7820949/3aaf3f3e-03f4-11e5-8274-1c36fba37392.png)

I add additional property 'defaultRowFetchSize' that can be specify on connection. It parameter means default value for fetch size on Statement. All statements creates via connection on that specify it property will have correspond value. It value can be override via explicit execute Statement#setFetchSize