### PR TITLE
perf: Remove expensive finalize methods from Statement and Connection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ nbproject
 *.iml
 build.local.properties
 *-dist.zip
+
+ubenchmark/target

--- a/doc/pgjdbc.xml
+++ b/doc/pgjdbc.xml
@@ -681,6 +681,28 @@ openssl pkcs8 -topk8 -in client.key -out client.pk8 -outform DER -v1 PBE-SHA1-3D
       </varlistentry>
 
       <varlistentry>
+       <term><varname>autoCloseUnclosedStatements</varname> = <type>boolean</type></term>
+       <listitem>
+        <para>
+	 Clients may leak <classname>Statement</classname> objects by
+	 failing to call its <function>close()</function> method.
+   If <literal>autoCloseUnclosedStatements</literal> is set to true, then
+   finalizer will be used as a stopgap solution to <function>close()</function>
+   the resource.
+        </para>
+		 <note>
+			<para>
+				Creating finalizable objects is very expensive in lots of JVM.
+				It dramatically impacts <classname>Statement</classname> instantiation
+				and increases time spent in garbage collection, so avoid using autoCloseUnclosedStatements=true
+        for highly loaded applications unless you are sure your JVM can crater
+        finalizer traffic.
+			</para>
+		 </note>
+       </listitem>
+      </varlistentry>
+
+      <varlistentry>
        <term><varname>binaryTransfer</varname> = <type>boolean</type></term>
        <listitem>
         <para>

--- a/org/postgresql/PGConnection.java
+++ b/org/postgresql/PGConnection.java
@@ -134,4 +134,19 @@ public interface PGConnection
      * @return the quoted literal
      */
     public String escapeLiteral(String literal) throws SQLException;
+
+    /**
+     * @see PGProperty#AUTO_CLOSE_UNCLOSED_STATEMENTS
+     * @return true if new Statement instance should be wrap to finalizer and close own resources on GC phase
+     */
+    boolean isAutoCloseUnclosedStatements();
+
+    /**
+     * Define necessary create finalizer wrapper for Statement instance for close resources
+     * on GC phase
+     * @param flag true if statement
+     *
+     * @see PGProperty#AUTO_CLOSE_UNCLOSED_STATEMENTS
+     */
+    void setAutoCloseUnclosedStatements(boolean flag);
 }

--- a/org/postgresql/PGProperty.java
+++ b/org/postgresql/PGProperty.java
@@ -7,7 +7,9 @@
 */
 package org.postgresql;
 
+import java.sql.Connection;
 import java.sql.DriverPropertyInfo;
+import java.sql.Statement;
 import java.util.Properties;
 
 import org.postgresql.util.GT;
@@ -100,6 +102,19 @@ public enum PGProperty
      * When connections that are not explicitly closed are garbage collected, log the stacktrace from the opening of the connection to trace the leak source.
      */
     LOG_UNCLOSED_CONNECTIONS("logUnclosedConnections", "false", "When connections that are not explicitly closed are garbage collected, log the stacktrace from the opening of the connection to trace the leak source"),
+
+    /**
+     * <p>
+     *     When {@link Statement} without explicitly close leaks critical resources remain busy,
+     *     it parameter allow during finalize() release critical resources. By default all resources should be close manually.
+     * </p>
+     * <p>
+     *     <b>Note:</b> Parameter affect performance(increase GC time, creation instance time) and should be use only for debugging
+     * </p>
+     * @see Statement#close()
+     * @see Object#finalize()
+     */
+    AUTO_CLOSE_UNCLOSED_STATEMENTS("autoCloseUnclosedStatements", "false", "When Statement without explicitly close leaks critical resources remain busy, it parameter allow during finalize() release critical resources. Parameter affect application performance and should be use only for debugging"),
 
     /**
      * Enable optimization that disables column name sanitiser.

--- a/org/postgresql/ds/common/BaseDataSource.java
+++ b/org/postgresql/ds/common/BaseDataSource.java
@@ -788,6 +788,22 @@ public abstract class BaseDataSource implements Referenceable
     }
 
     /**
+     * @see PGProperty#AUTO_CLOSE_UNCLOSED_STATEMENTS
+     */
+    public boolean getAutoCloseUnclosedStatements()
+    {
+        return PGProperty.AUTO_CLOSE_UNCLOSED_STATEMENTS.getBoolean(properties);
+    }
+
+    /**
+     * @see PGProperty#AUTO_CLOSE_UNCLOSED_STATEMENTS
+     */
+    public void setAutoCloseUnclosedStatements(boolean enable)
+    {
+        PGProperty.AUTO_CLOSE_UNCLOSED_STATEMENTS.set(properties, enable);
+    }
+
+    /**
      * @see PGProperty#ASSUME_MIN_SERVER_VERSION
      */
     public String getAssumeMinServerVersion()

--- a/org/postgresql/jdbc2/AbstractJdbc2Connection.java
+++ b/org/postgresql/jdbc2/AbstractJdbc2Connection.java
@@ -88,6 +88,11 @@ public abstract class AbstractJdbc2Connection implements BaseConnection
     // Only instantiated if a task is actually scheduled.
     private volatile Timer cancelTimer = null;
 
+    /**
+     * True if cleanup-in-finalizer is required for the statements of this connection.
+     */
+    private boolean autoCloseUnclosedStatements;
+
     //
     // Ctor.
     //
@@ -246,6 +251,8 @@ public abstract class AbstractJdbc2Connection implements BaseConnection
             enableDriverManagerLogging();
         }
         this.disableColumnSanitiser = PGProperty.DISABLE_COLUMN_SANITISER.getBoolean(info);
+
+        this.autoCloseUnclosedStatements = PGProperty.AUTO_CLOSE_UNCLOSED_STATEMENTS.getBoolean(info);
     }
 
     private Set<Integer> getOidSet(String oidList) throws PSQLException {
@@ -1332,5 +1339,15 @@ public abstract class AbstractJdbc2Connection implements BaseConnection
 
     public String escapeLiteral(String literal) throws SQLException {
         return Utils.escapeLiteral(null, literal, protoConnection.getStandardConformingStrings()).toString();
+    }
+
+    public void setAutoCloseUnclosedStatements(boolean flag)
+    {
+        autoCloseUnclosedStatements = flag;
+    }
+
+    public boolean isAutoCloseUnclosedStatements()
+    {
+        return autoCloseUnclosedStatements;
     }
 }

--- a/org/postgresql/jdbc2/AbstractJdbc2Statement.java
+++ b/org/postgresql/jdbc2/AbstractJdbc2Statement.java
@@ -134,6 +134,11 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
     protected Object []callResult;
     protected int maxfieldSize = 0;
 
+    /**
+     * Finalizer that close resources if they was leak
+     */
+    private final StatementFinalizer statementFinalizer;
+
     public ResultSet createDriverResultSet(Field[] fields, List tuples)
     throws SQLException
     {
@@ -149,6 +154,7 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
         forceBinaryTransfers |= c.getForceBinary();
         resultsettype = rsType;
         concurrency = rsConcurrency;
+        statementFinalizer = getFinalizer(c);
     }
 
     public AbstractJdbc2Statement(AbstractJdbc2Connection connection, String sql, boolean isCallable, int rsType, int rsConcurrency) throws SQLException
@@ -171,6 +177,16 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
 
         resultsettype = rsType;
         concurrency = rsConcurrency;
+
+        statementFinalizer = getFinalizer(connection);
+    }
+
+    private StatementFinalizer getFinalizer(AbstractJdbc2Connection connection) {
+        if(!connection.isAutoCloseUnclosedStatements())
+        {
+            return null;
+        }
+        return new StatementFinalizer(this);
     }
 
     public abstract ResultSet createResultSet(Query originalQuery, Field[] fields, List tuples, ResultCursor cursor)
@@ -848,6 +864,18 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
         if (isClosed)
             return ;
 
+        if (statementFinalizer != null)
+        {
+            Statement statement = statementFinalizer.shouldClose();
+            statementFinalizer.cleanup();
+            if (statement != null)
+            {
+                // This connection was just closed by the finalizer.
+                // No extra work to be done.
+                return;
+            }
+        }
+
         killTimerTask();
         
         closeForNextExecution();
@@ -856,24 +884,6 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
             preparedQuery.close();
 
         isClosed = true;
-    }
-
-    /**
-     * This finalizer ensures that statements that have allocated server-side
-     * resources free them when they become unreferenced.
-     */
-    protected void finalize() throws Throwable {
-        try
-        {
-            close();
-        }
-        catch (SQLException e)
-        {
-        }
-        finally
-        {
-            super.finalize();
-        }
     }
 
     /*

--- a/org/postgresql/jdbc2/StatementFinalizer.java
+++ b/org/postgresql/jdbc2/StatementFinalizer.java
@@ -1,0 +1,70 @@
+package org.postgresql.jdbc2;
+
+import java.sql.Statement;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+
+/**
+ * This class closes the statements that were not closed by the application.
+ * The idea of using a separate class for handling finalization is to avoid usage
+ * of finalizer in the base connection class since finalizers retain garbage longer
+ * than regular objects and finalization is not scalable yet in all the JMVs.
+ */
+/* package */ class StatementFinalizer
+{
+    /**
+     * The updater is used to implement compare and swap on the {@link #statement} field.
+     * We could use {@link java.util.concurrent.atomic.AtomicReference}, however it would
+     * increase heap size retained by the finalizer.
+     */
+    private AtomicReferenceFieldUpdater<StatementFinalizer, Statement> STATEMENT_UPDATER =
+        AtomicReferenceFieldUpdater.newUpdater(StatementFinalizer.class, Statement.class, "statement");
+
+    private volatile Statement statement;
+
+    /**
+     * @param statement not null resource that should be close when Statement leak
+     */
+    public StatementFinalizer(Statement statement)
+    {
+        this.statement = statement;
+    }
+
+    protected void finalize() throws Throwable
+    {
+        try
+        {
+            Statement statement = shouldClose();
+            if(statement != null && !statement.isClosed())
+            {
+                statement.close();
+            }
+        }
+        finally
+        {
+            super.finalize();
+        }
+    }
+
+    /**
+     * Returns {@code true} non-null {@link Statement} if {@link #shouldClose()} was never yet called.
+     *
+     * <p>Note: in general finalizer thread might compete with application thread
+     * trying to close the connection, so we need at least some race condition prevention
+     * logic here. The idea behind {@link #shouldClose()} is to make sure only first caller would get
+     * non-null reference.
+     * @return non-null {@link Statement} if {@link #shouldClose()} was never yet called.
+     */
+    public Statement shouldClose()
+    {
+        return STATEMENT_UPDATER.getAndSet(this, null);
+    }
+
+    /**
+     * Cleanups the finalizer in order to minimize garbage used by the finalizer when
+     * the {@link Statement} is closed in a regular way.
+     */
+    public void cleanup()
+    {
+        statement = null;
+    }
+}

--- a/ubenchmark/pom.xml
+++ b/ubenchmark/pom.xml
@@ -1,0 +1,167 @@
+<!--
+Copyright (c) 1997-2011, PostgreSQL Global Development Group
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+3. Neither the name of the PostgreSQL Global Development Group nor the names
+   of its contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.postgresql</groupId>
+    <artifactId>pgjdbc-benchmark</artifactId>
+    <version>1.0</version>
+    <packaging>jar</packaging>
+
+    <name>JDBC driver performance benchmarks</name>
+
+    <!--
+       This is the demo/sample template build script for building Java benchmarks with JMH.
+       Edit as needed.
+    -->
+
+    <prerequisites>
+        <maven>3.0</maven>
+    </prerequisites>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <version>${jmh.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <version>${jmh.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>9.4-1201-jdbc41</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <jmh.version>1.9.3</jmh.version>
+        <javac.target>1.6</javac.target>
+        <uberjar.name>benchmarks</uberjar.name>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.1</version>
+                <configuration>
+                    <compilerVersion>${javac.target}</compilerVersion>
+                    <source>${javac.target}</source>
+                    <target>${javac.target}</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>2.2</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <finalName>${uberjar.name}</finalName>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>org.openjdk.jmh.Main</mainClass>
+                                </transformer>
+                            </transformers>
+                            <filters>
+                                <filter>
+                                    <!--
+                                        Shading signed JARs will fail without this.
+                                        http://stackoverflow.com/questions/999489/invalid-signature-file-when-attempting-to-run-a-jar
+                                    -->
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-clean-plugin</artifactId>
+                    <version>2.5</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>2.8.1</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>2.5.1</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>2.4</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>2.9.1</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>2.6</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-site-plugin</artifactId>
+                    <version>3.3</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-source-plugin</artifactId>
+                    <version>2.2.1</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>2.17</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+
+</project>

--- a/ubenchmark/src/main/java/org/postgresql/benchmark/connection/FinalizeConnection.java
+++ b/ubenchmark/src/main/java/org/postgresql/benchmark/connection/FinalizeConnection.java
@@ -1,0 +1,80 @@
+package org.postgresql.benchmark.connection;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.postgresql.util.ConnectionUtil;
+
+import java.sql.*;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Tests the time and memory required to create a connection.
+ * Note: due to TCP socket's turning into TIME_WAIT state on close, it is
+ * rather hard to test lots of connection creations.
+ *
+ * <p>To run this and other benchmarks:
+ *
+ * <blockquote>
+ *   <code>mvn package &amp;&amp;
+ *   java -classpath postgresql-driver.jar;target\benchmarks.jar -Duser=postgres -Dpassword=postgres -Dport=5433  -wi 10 -i 10 -f 1</code>
+ * </blockquote>
+ *
+ * <p>To run with profiling:
+ *
+ * <blockquote>
+ *   <code>java -classpath postgresql-driver.jar;target\benchmarks.jar
+ *     -prof gc -f 1 -wi 10 -i 10</code>
+ * </blockquote>
+ */
+@Fork(1)
+@Measurement(iterations = 50)
+@Warmup(iterations = 10)
+@State(Scope.Thread)
+@Threads(1)
+@BenchmarkMode(Mode.SingleShotTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+public class FinalizeConnection
+{
+    private Properties connectionProperties;
+    private String connectionUrl;
+    private Driver driver;
+
+    @Setup(Level.Trial)
+    public void setUp() throws SQLException
+    {
+        Properties props = ConnectionUtil.getProperties();
+
+        connectionProperties = props;
+        connectionUrl = ConnectionUtil.getURL();
+        driver = DriverManager.getDriver(connectionUrl);
+    }
+
+    @Benchmark
+    public void baseline() throws SQLException
+    {
+    }
+
+    @Benchmark
+    public Connection createConnection() throws SQLException
+    {
+        Connection connection = driver.connect(connectionUrl, connectionProperties);
+        connection.close();
+        return connection;
+    }
+
+    public static void main(String[] args) throws RunnerException
+    {
+        Options opt = new OptionsBuilder()
+            .include(FinalizeConnection.class.getSimpleName())
+            .addProfiler(GCProfiler.class)
+            .detectJvmArgs()
+            .build();
+
+        new Runner(opt).run();
+    }
+}

--- a/ubenchmark/src/main/java/org/postgresql/benchmark/statement/FinalizeStatement.java
+++ b/ubenchmark/src/main/java/org/postgresql/benchmark/statement/FinalizeStatement.java
@@ -1,0 +1,85 @@
+package org.postgresql.benchmark.statement;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.postgresql.PGProperty;
+import org.postgresql.util.ConnectionUtil;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Compares {@link java.sql.Statement} with finalizer and without it.
+ *
+ * <p>This package contains micro-benchmarks to test postgresql jdbc driver performance.
+ *
+ * <p>To run this and other benchmarks:
+ *
+ * <blockquote>
+ *   <code>mvn package &amp;&amp;
+ *   java -classpath postgresql-driver.jar;target\benchmarks.jar -Duser=postgres -Dpassword=postgres -Dport=5433  -wi 10 -i 10 -f 1</code>
+ * </blockquote>
+ *
+ * <p>To run with profiling:
+ *
+ * <blockquote>
+ *   <code>java -classpath postgresql-driver.jar;target\benchmarks.jar
+ *     -prof gc -f 1 -wi 10 -i 10</code>
+ * </blockquote>
+ */
+@Fork(1)
+@Measurement(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class FinalizeStatement
+{
+    @Param({"true", "false"})
+    private boolean autoCloseStatements;
+
+    private Connection connection;
+
+    @Setup(Level.Trial)
+    public void setUp() throws SQLException
+    {
+        Properties props = ConnectionUtil.getProperties();
+        //not uses PGProperty.AUTO_CLOSE_UNCLOSED_STATEMENTS for run benchmark with old driver version
+        props.setProperty("autoCloseUnclosedStatements", String.valueOf(autoCloseStatements));
+
+        connection = DriverManager.getConnection(ConnectionUtil.getURL(), props);
+    }
+
+    @TearDown(Level.Trial)
+    public void tearDown() throws SQLException
+    {
+        connection.close();
+    }
+
+    @Benchmark
+    public Statement createStatement() throws SQLException
+    {
+        Statement statement = connection.createStatement();
+        statement.close();
+        return statement;
+    }
+
+    public static void main(String[] args) throws RunnerException
+    {
+        Options opt = new OptionsBuilder()
+            .include(FinalizeStatement.class.getSimpleName())
+            .addProfiler(GCProfiler.class)
+            .detectJvmArgs()
+            .build();
+
+        new Runner(opt).run();
+    }
+}

--- a/ubenchmark/src/main/java/org/postgresql/util/ConnectionUtil.java
+++ b/ubenchmark/src/main/java/org/postgresql/util/ConnectionUtil.java
@@ -1,0 +1,75 @@
+package org.postgresql.util;
+
+import org.postgresql.PGProperty;
+
+import java.util.Properties;
+
+public class ConnectionUtil
+{
+    /**
+    * @return the Postgresql username
+    */
+    public static String getUser()
+    {
+        return System.getProperty("user", "test");
+    }
+
+    /**
+     * @return the user's password
+     */
+    public static String getPassword()
+    {
+        return System.getProperty("password", "password");
+    }
+
+
+    /**
+     * @return the test server
+     */
+    public static String getServer()
+    {
+        return System.getProperty("server", "localhost");
+    }
+
+    /**
+     * @return the test port
+     */
+    public static int getPort()
+    {
+        return Integer.parseInt(System.getProperty("port", System.getProperty("def_pgport", "5432")));
+    }
+
+    /**
+     * @return the Test database
+     */
+    public static String getDatabase()
+    {
+        return System.getProperty("database", "test");
+    }
+
+    /**
+     * @return connection url to server
+     */
+    public static String getURL()
+    {
+        return "jdbc:postgresql://"+ ConnectionUtil.getServer()+":"+ ConnectionUtil.getPort()+"/"+ ConnectionUtil
+                .getDatabase();
+    }
+
+
+    /**
+     * @return merged with default property list
+     */
+    public static Properties getProperties()
+    {
+        Properties properties = new Properties(System.getProperties());
+
+        PGProperty.USER.set(properties, getUser());
+        PGProperty.PASSWORD.set(properties, getPassword());
+        PGProperty.PG_PORT.set(properties, getPort());
+        properties.setProperty("database", getDatabase());
+        properties.setProperty("server", getServer());
+
+        return properties;
+    }
+}


### PR DESCRIPTION
Finalize method on Statement was move to a saparete class that is lazily created if user sets "autoCloseUnclosedStatements"="true".

Parameters in state "autoCloseUnclosedStatements"="false" dramatically improves the performance of statement instantiation and reduces garbage collection overhead on several wildly used JMVs.

For demonstrate finalize overhed was add jmh benchmark like disscussed in issue  #289
The added jmh benchmark validates the performance of statement creation.

```java
    @Benchmark
    public Statement createStatement() throws SQLException
    {
        Statement statement = connection.createStatement();
        statement.close();
        return statement;
    }
```

I get next result on my mashin(full report: https://gist.github.com/Gordiychuk/72791b7ff5677d11117e)
```
Benchmark                                                           (autoCloseStatements)  Mode  Cnt     Score     Error   Units
FinalizeStatement.createStatement                                                    true  avgt   10  1736,304 ? 635,108   ns/op
FinalizeStatement.createStatement:ъgc.alloc.rate                                     true  avgt   10   189,397 ?  66,900  MB/sec
FinalizeStatement.createStatement:ъgc.alloc.rate.norm                                true  avgt   10   328,004 ?   0,014    B/op
FinalizeStatement.createStatement:ъgc.churn.PS_Eden_Space                            true  avgt   10   179,187 ? 288,014  MB/sec
FinalizeStatement.createStatement:ъgc.churn.PS_Eden_Space.norm                       true  avgt   10   395,423 ? 650,689    B/op
FinalizeStatement.createStatement:ъgc.count                                          true  avgt   10     6,000            counts
FinalizeStatement.createStatement:ъgc.time                                           true  avgt   10  1716,000                ms
FinalizeStatement.createStatement                                                   false  avgt   10    65,483 ?   3,334   ns/op
FinalizeStatement.createStatement:ъgc.alloc.rate                                    false  avgt   10  1981,967 ?  99,278  MB/sec
FinalizeStatement.createStatement:ъgc.alloc.rate.norm                               false  avgt   10   136,000 ?   0,001    B/op
FinalizeStatement.createStatement:ъgc.churn.PS_Eden_Space                           false  avgt   10  1983,006 ? 217,843  MB/sec
FinalizeStatement.createStatement:ъgc.churn.PS_Eden_Space.norm                      false  avgt   10   136,111 ?  14,225    B/op
FinalizeStatement.createStatement:ъgc.churn.PS_Survivor_Space                       false  avgt   10     0,044 ?   0,033  MB/sec
FinalizeStatement.createStatement:ъgc.churn.PS_Survivor_Space.norm                  false  avgt   10     0,003 ?   0,002    B/op
FinalizeStatement.createStatement:ъgc.count                                         false  avgt   10    97,000            counts
FinalizeStatement.createStatement:ъgc.time                                          false  avgt   10    86,000                ms
```

As you can see, in that simple benchmark  we spend 20 times less GC time(86ms/1716ms) use less memory(136,111b/189,397b) and also improve in 20 times for create instance