### PR TITLE
perf: Excessive time spent in Boolean.getBoolean("org.postgresql.forceBinary")

### DIFF
--- a/org/postgresql/jdbc2/AbstractJdbc2Statement.java
+++ b/org/postgresql/jdbc2/AbstractJdbc2Statement.java
@@ -39,8 +39,12 @@ import org.postgresql.util.GT;
  */
 public abstract class AbstractJdbc2Statement implements BaseStatement
 {
+    /**
+     * Default state for use or not binary transfers. Can use only for testing purposes
+     */
+    private static final boolean DEFAULT_FORCE_BINARY_TRANSFERS = Boolean.getBoolean("org.postgresql.forceBinary");
     // only for testing purposes. even single shot statements will use binary transfers
-    private boolean forceBinaryTransfers = Boolean.getBoolean("org.postgresql.forceBinary");
+    private boolean forceBinaryTransfers = DEFAULT_FORCE_BINARY_TRANSFERS;
 
     protected ArrayList batchStatements = null;
     protected ArrayList batchParameters = null;


### PR DESCRIPTION
It fix for issue https://github.com/pgjdbc/pgjdbc/issues/288

Property "org.postgresql.forceBinary" uses only only for testing purposes and not change in runtime, so, they can be cached to static variable for improve creating statement instance.

Benchmark for test changes was use from https://github.com/pgjdbc/pgjdbc/pull/290

JFR hot method before changes on my machine
![hot-method-old](https://cloud.githubusercontent.com/assets/10699594/7891306/53f74628-0654-11e5-96be-f8b2bf959e8d.png)

JFR hot method after chanages on my machine
![hot-method-new](https://cloud.githubusercontent.com/assets/10699594/7891375/d3f4fcd0-0654-11e5-941f-09ce200dcf29.png)

Benchmark that measure create Statement became more faster
```
Benchmark                                                           (autoCloseStatements)  Mode  Cnt     Score     Error   Units
FinalizeStatement.createStatement                                                   false  avgt   10    50,137 ?   1,228   ns/op
```
Previous result was
```
FinalizeStatement.createStatement                                                   false  avgt   10    65,483 ?   3,334   ns/op
```