### PR TITLE
Fix: ResultSet positioning methods in some particular cases

### DIFF
--- a/org/postgresql/jdbc2/AbstractJdbc2ResultSet.java
+++ b/org/postgresql/jdbc2/AbstractJdbc2ResultSet.java
@@ -645,7 +645,11 @@ public abstract class AbstractJdbc2ResultSet implements BaseResultSet, org.postg
             return false;
 
         final int rows_size = rows.size();
-        return (current_row >= rows_size && rows_size > 0);
+        if (row_offset + rows_size == 0)
+        {
+            return false;
+        }
+        return (current_row >= rows_size);
     }
 
 
@@ -664,6 +668,12 @@ public abstract class AbstractJdbc2ResultSet implements BaseResultSet, org.postg
         checkClosed();
         if (onInsertRow)
             return false;
+
+        final int rows_size = rows.size();
+        if (row_offset + rows_size == 0)
+        {
+            return false;
+        }
 
         return ((row_offset + current_row) == 0);
     }


### PR DESCRIPTION
Fixes status returned by ResultSet positioning methods (isFirst/isLast/isBeforeFirst/isAfterLast) in two particular cases:

 - fetchsize is non-zero and current position is at the boundary of a fetch (bug reported by Luis Michel Pinto Da Costa in [mailing list](http://www.postgresql.org/message-id/flat/OFF3D569C5.9BC4DC3D-ONC1257E1B.0045CF5C-C1257E1B.00472393@retraite.lan) )

 - the resultset is empty (ie. contains no row) as the jdbc spec require all positionning methods to return false
