### PR TITLE
docs: fix misleading statement on "can't use jdk5 features" in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,8 +154,7 @@ Remember to test proposed PgJDBC patches when running against older PostgreSQL
 versions where possible, not just against the PostgreSQL you use yourself.
 
 You also need to test your changes with older JDKs. PgJDBC must support JDK5
-("Java 1.5") and newer, which means you can't use annotations, auto-boxing, for
-(:), and numerous other features added since JDK 5. Code that's JDBC4 specific
+("Java 1.5") and newer. Code that's JDBC4 specific
 may use JDK6 features, and code that's JDBC4.1 specific may use JDK7 features.
 Common code and JDBC3 code needs to stick to Java 1.5.
 


### PR DESCRIPTION
Java 1.5 features can be used since it is the minimal supported version for PgJDBC.

closes #294