### PR TITLE
perf: improve statement instantiation by removing finalize

### DIFF
--- a/org/postgresql/jdbc2/AbstractJdbc2Statement.java
+++ b/org/postgresql/jdbc2/AbstractJdbc2Statement.java
@@ -22,6 +22,7 @@ import java.util.TimeZone;
 import java.util.Calendar;
 
 import org.postgresql.Driver;
+import org.postgresql.core.v3.QueryExecutorImpl;
 import org.postgresql.largeobject.*;
 import org.postgresql.core.*;
 import org.postgresql.core.types.*;
@@ -863,22 +864,9 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
     }
 
     /**
-     * This finalizer ensures that statements that have allocated server-side
-     * resources free them when they become unreferenced.
+     * Statement finalizer is not required as "statement" at the database side
+     * is managed by a {@link java.lang.ref.PhantomReference} in {@link QueryExecutorImpl#processDeadParsedQueries()}.
      */
-    protected void finalize() throws Throwable {
-        try
-        {
-            close();
-        }
-        catch (SQLException e)
-        {
-        }
-        finally
-        {
-            super.finalize();
-        }
-    }
 
     /*
      * Filter the SQL string of Java SQL Escape clauses.


### PR DESCRIPTION
AbstractJdbc2Statement.finalize is not required since server-side resources (if any) are managed in org.postgresql.core.v3.QueryExecutorImpl#processDeadParsedQueries.
Even though dead queries are processed at subsequent operations on the connection, since GC is still required to find dead statements (like with finalizers), and the dead statements would be processed right at the subsequent execute.

It is believed that scenario of "create lots of prepared statements, then stop any activity on the connection" would never happen, so no additional handling is implemented for that case.

Here's what `FinalizeStatement.createAndLeak` gives after the fix (-Xmx128m, OracleJDK 1.8u40, MacOS, 2.6GHz Core i7):
```
Benchmark                                                         (leakPct)  Mode  Cnt     Score     Error   Units
FinalizeStatement.createAndLeak                                           0  avgt   10    46,975 ±   2,649   ns/op
FinalizeStatement.createAndLeak:·gc.alloc.rate                            0  avgt   10  2763,767 ± 151,212  MB/sec
FinalizeStatement.createAndLeak:·gc.alloc.rate.norm                       0  avgt   10   136,000 ±   0,001    B/op
FinalizeStatement.createAndLeak:·gc.churn.PS_Eden_Space                   0  avgt   10  2765,761 ± 143,560  MB/sec
FinalizeStatement.createAndLeak:·gc.churn.PS_Eden_Space.norm              0  avgt   10   136,110 ±   1,689    B/op
FinalizeStatement.createAndLeak:·gc.churn.PS_Survivor_Space               0  avgt   10     0,093 ±   0,067  MB/sec
FinalizeStatement.createAndLeak:·gc.churn.PS_Survivor_Space.norm          0  avgt   10     0,005 ±   0,003    B/op
FinalizeStatement.createAndLeak:·gc.count                                 0  avgt   10   669,000            counts
FinalizeStatement.createAndLeak:·gc.time                                  0  avgt   10   230,000                ms
FinalizeStatement.createAndLeak                                           1  avgt   10    47,087 ±   3,693   ns/op
FinalizeStatement.createAndLeak:·gc.alloc.rate                            1  avgt   10  2760,372 ± 212,065  MB/sec
FinalizeStatement.createAndLeak:·gc.alloc.rate.norm                       1  avgt   10   136,000 ±   0,001    B/op
FinalizeStatement.createAndLeak:·gc.churn.PS_Eden_Space                   1  avgt   10  2760,047 ± 218,990  MB/sec
FinalizeStatement.createAndLeak:·gc.churn.PS_Eden_Space.norm              1  avgt   10   135,975 ±   1,062    B/op
FinalizeStatement.createAndLeak:·gc.churn.PS_Survivor_Space               1  avgt   10     0,137 ±   0,077  MB/sec
FinalizeStatement.createAndLeak:·gc.churn.PS_Survivor_Space.norm          1  avgt   10     0,007 ±   0,004    B/op
FinalizeStatement.createAndLeak:·gc.count                                 1  avgt   10   668,000            counts
FinalizeStatement.createAndLeak:·gc.time                                  1  avgt   10   240,000                ms
FinalizeStatement.createAndLeak                                          10  avgt   10    47,029 ±   2,382   ns/op
FinalizeStatement.createAndLeak:·gc.alloc.rate                           10  avgt   10  2760,006 ± 138,833  MB/sec
FinalizeStatement.createAndLeak:·gc.alloc.rate.norm                      10  avgt   10   136,000 ±   0,001    B/op
FinalizeStatement.createAndLeak:·gc.churn.PS_Eden_Space                  10  avgt   10  2761,202 ± 148,048  MB/sec
FinalizeStatement.createAndLeak:·gc.churn.PS_Eden_Space.norm             10  avgt   10   136,052 ±   1,352    B/op
FinalizeStatement.createAndLeak:·gc.churn.PS_Survivor_Space              10  avgt   10     0,115 ±   0,094  MB/sec
FinalizeStatement.createAndLeak:·gc.churn.PS_Survivor_Space.norm         10  avgt   10     0,006 ±   0,005    B/op
FinalizeStatement.createAndLeak:·gc.count                                10  avgt   10   668,000            counts
FinalizeStatement.createAndLeak:·gc.time                                 10  avgt   10   231,000                ms
FinalizeStatement.createAndLeak                                         100  avgt   10    35,882 ±   1,010   ns/op
FinalizeStatement.createAndLeak:·gc.alloc.rate                          100  avgt   10  3614,942 ± 101,382  MB/sec
FinalizeStatement.createAndLeak:·gc.alloc.rate.norm                     100  avgt   10   136,000 ±   0,001    B/op
FinalizeStatement.createAndLeak:·gc.churn.PS_Eden_Space                 100  avgt   10  3610,823 ± 111,232  MB/sec
FinalizeStatement.createAndLeak:·gc.churn.PS_Eden_Space.norm            100  avgt   10   135,843 ±   1,387    B/op
FinalizeStatement.createAndLeak:·gc.churn.PS_Survivor_Space             100  avgt   10     0,134 ±   0,077  MB/sec
FinalizeStatement.createAndLeak:·gc.churn.PS_Survivor_Space.norm        100  avgt   10     0,005 ±   0,003    B/op
FinalizeStatement.createAndLeak:·gc.count                               100  avgt   10   875,000            counts
FinalizeStatement.createAndLeak:·gc.time                                100  avgt   10   297,000                ms
```
This change should be completely transparent to the consumers of PgJDBC.