### PR TITLE
perf: improve sql parsing performance

### DIFF
--- a/org/postgresql/core/Parser.java
+++ b/org/postgresql/core/Parser.java
@@ -193,6 +193,7 @@ public class Parser {
     public static String unmarkDoubleQuestion(String query, boolean standardConformingStrings)
     {
         if (query == null) return query;
+        if (!query.contains("??")) return query;
 
         char[] aChars = query.toCharArray();
         StringBuilder buf = new StringBuilder(aChars.length);


### PR DESCRIPTION
It is likely double question marks are not used, so add short-circuit to Parser.unmarkDoubleQuestions.
Key observations:
 * when query does not have _double_ question marks, unmarkDoubleQuestion becomes 6 times faster, no java garbage is generated
 * For big query (6KiB) with "??" at the very end degradation is 18us -> 19us

Before:
```
Benchmark                                                     (literalLength)  (sqlSize)  (withDoubleQuestionmark)  Mode  Cnt      Score     Error   Units
Parser.unmarkDoubleQuestion                                                20          1                     false  avgt   10    175,338 ±   2,144   ns/op
Parser.unmarkDoubleQuestion:·gc.alloc.rate                                 20          1                     false  avgt   10   3132,534 ±  38,399  MB/sec
Parser.unmarkDoubleQuestion:·gc.alloc.rate.norm                            20          1                     false  avgt   10    576,000 ±   0,001    B/op
Parser.unmarkDoubleQuestion:·gc.churn.PS_Eden_Space                        20          1                     false  avgt   10   3135,615 ±  33,515  MB/sec
Parser.unmarkDoubleQuestion:·gc.churn.PS_Eden_Space.norm                   20          1                     false  avgt   10    576,575 ±   3,620    B/op
Parser.unmarkDoubleQuestion:·gc.churn.PS_Survivor_Space                    20          1                     false  avgt   10      0,687 ±   0,182  MB/sec
Parser.unmarkDoubleQuestion:·gc.churn.PS_Survivor_Space.norm               20          1                     false  avgt   10      0,126 ±   0,032    B/op
Parser.unmarkDoubleQuestion:·gc.count                                      20          1                     false  avgt   10    759,000            counts
Parser.unmarkDoubleQuestion:·gc.time                                       20          1                     false  avgt   10    255,000                ms
Parser.unmarkDoubleQuestion                                                20          1                      true  avgt   10    179,847 ±   3,631   ns/op
Parser.unmarkDoubleQuestion:·gc.alloc.rate                                 20          1                      true  avgt   10   3181,437 ±  63,227  MB/sec
Parser.unmarkDoubleQuestion:·gc.alloc.rate.norm                            20          1                      true  avgt   10    600,000 ±   0,001    B/op
Parser.unmarkDoubleQuestion:·gc.churn.PS_Eden_Space                        20          1                      true  avgt   10   3177,916 ±  69,012  MB/sec
Parser.unmarkDoubleQuestion:·gc.churn.PS_Eden_Space.norm                   20          1                      true  avgt   10    599,332 ±   3,912    B/op
Parser.unmarkDoubleQuestion:·gc.churn.PS_Survivor_Space                    20          1                      true  avgt   10      1,015 ±   0,597  MB/sec
Parser.unmarkDoubleQuestion:·gc.churn.PS_Survivor_Space.norm               20          1                      true  avgt   10      0,191 ±   0,112    B/op
Parser.unmarkDoubleQuestion:·gc.count                                      20          1                      true  avgt   10    770,000            counts
Parser.unmarkDoubleQuestion:·gc.time                                       20          1                      true  avgt   10    258,000                ms
Parser.unmarkDoubleQuestion                                                20         10                     false  avgt   10   1514,821 ±  15,977   ns/op
Parser.unmarkDoubleQuestion:·gc.alloc.rate                                 20         10                     false  avgt   10   2855,326 ±  29,978  MB/sec
Parser.unmarkDoubleQuestion:·gc.alloc.rate.norm                            20         10                     false  avgt   10   4536,003 ±   0,009    B/op
Parser.unmarkDoubleQuestion:·gc.churn.PS_Eden_Space                        20         10                     false  avgt   10   2859,159 ±  39,758  MB/sec
Parser.unmarkDoubleQuestion:·gc.churn.PS_Eden_Space.norm                   20         10                     false  avgt   10   4542,052 ±  27,794    B/op
Parser.unmarkDoubleQuestion:·gc.churn.PS_Survivor_Space                    20         10                     false  avgt   10      0,591 ±   0,157  MB/sec
Parser.unmarkDoubleQuestion:·gc.churn.PS_Survivor_Space.norm               20         10                     false  avgt   10      0,939 ±   0,250    B/op
Parser.unmarkDoubleQuestion:·gc.count                                      20         10                     false  avgt   10    692,000            counts
Parser.unmarkDoubleQuestion:·gc.time                                       20         10                     false  avgt   10    229,000                ms
Parser.unmarkDoubleQuestion                                                20         10                      true  avgt   10   1623,984 ±  36,587   ns/op
Parser.unmarkDoubleQuestion:·gc.alloc.rate                                 20         10                      true  avgt   10   2663,670 ±  59,828  MB/sec
Parser.unmarkDoubleQuestion:·gc.alloc.rate.norm                            20         10                      true  avgt   10   4536,003 ±   0,010    B/op
Parser.unmarkDoubleQuestion:·gc.churn.PS_Eden_Space                        20         10                      true  avgt   10   2659,881 ±  44,567  MB/sec
Parser.unmarkDoubleQuestion:·gc.churn.PS_Eden_Space.norm                   20         10                      true  avgt   10   4529,849 ±  47,702    B/op
Parser.unmarkDoubleQuestion:·gc.churn.PS_Survivor_Space                    20         10                      true  avgt   10      0,532 ±   0,107  MB/sec
Parser.unmarkDoubleQuestion:·gc.churn.PS_Survivor_Space.norm               20         10                      true  avgt   10      0,906 ±   0,192    B/op
Parser.unmarkDoubleQuestion:·gc.count                                      20         10                      true  avgt   10    646,000            counts
Parser.unmarkDoubleQuestion:·gc.time                                       20         10                      true  avgt   10    216,000                ms
Parser.unmarkDoubleQuestion                                                20        100                     false  avgt   10  14593,171 ± 178,610   ns/op
Parser.unmarkDoubleQuestion:·gc.alloc.rate                                 20        100                     false  avgt   10   2871,403 ±  34,741  MB/sec
Parser.unmarkDoubleQuestion:·gc.alloc.rate.norm                            20        100                     false  avgt   10  43944,024 ±   0,084    B/op
Parser.unmarkDoubleQuestion:·gc.churn.PS_Eden_Space                        20        100                     false  avgt   10   2904,066 ±  43,001  MB/sec
Parser.unmarkDoubleQuestion:·gc.churn.PS_Eden_Space.norm                   20        100                     false  avgt   10  44443,887 ± 378,369    B/op
Parser.unmarkDoubleQuestion:·gc.churn.PS_Survivor_Space                    20        100                     false  avgt   10      0,843 ±   0,092  MB/sec
Parser.unmarkDoubleQuestion:·gc.churn.PS_Survivor_Space.norm               20        100                     false  avgt   10     12,902 ±   1,424    B/op
Parser.unmarkDoubleQuestion:·gc.count                                      20        100                     false  avgt   10    704,000            counts
Parser.unmarkDoubleQuestion:·gc.time                                       20        100                     false  avgt   10    236,000                ms
Parser.unmarkDoubleQuestion                                                20        100                      true  avgt   10  18082,468 ± 318,971   ns/op
Parser.unmarkDoubleQuestion:·gc.alloc.rate                                 20        100                      true  avgt   10   2318,366 ±  40,813  MB/sec
Parser.unmarkDoubleQuestion:·gc.alloc.rate.norm                            20        100                      true  avgt   10  43960,030 ±   0,106    B/op
Parser.unmarkDoubleQuestion:·gc.churn.PS_Eden_Space                        20        100                      true  avgt   10   2346,707 ±  26,172  MB/sec
Parser.unmarkDoubleQuestion:·gc.churn.PS_Eden_Space.norm                   20        100                      true  avgt   10  44500,914 ± 647,678    B/op
Parser.unmarkDoubleQuestion:·gc.churn.PS_Survivor_Space                    20        100                      true  avgt   10      0,436 ±   0,127  MB/sec
Parser.unmarkDoubleQuestion:·gc.churn.PS_Survivor_Space.norm               20        100                      true  avgt   10      8,262 ±   2,448    B/op
Parser.unmarkDoubleQuestion:·gc.count                                      20        100                      true  avgt   10    568,000            counts
Parser.unmarkDoubleQuestion:·gc.time                                       20        100                      true  avgt   10    190,000                ms
```

After:
```
Benchmark                                                     (literalLength)  (sqlSize)  (withDoubleQuestionmark)  Mode  Cnt      Score     Error   Units
Parser.unmarkDoubleQuestion                                                20          1                     false  avgt   10     29,972 ±   1,185   ns/op
Parser.unmarkDoubleQuestion:·gc.alloc.rate                                 20          1                     false  avgt   10      0,002 ±   0,005  MB/sec
Parser.unmarkDoubleQuestion:·gc.alloc.rate.norm                            20          1                     false  avgt   10     ≈ 10⁻⁴              B/op
Parser.unmarkDoubleQuestion:·gc.count                                      20          1                     false  avgt   10        ≈ 0            counts
Parser.unmarkDoubleQuestion                                                20          1                      true  avgt   10    199,031 ±  10,507   ns/op
Parser.unmarkDoubleQuestion:·gc.alloc.rate                                 20          1                      true  avgt   10   2877,400 ± 142,901  MB/sec
Parser.unmarkDoubleQuestion:·gc.alloc.rate.norm                            20          1                      true  avgt   10    600,000 ±   0,001    B/op
Parser.unmarkDoubleQuestion:·gc.churn.PS_Eden_Space                        20          1                      true  avgt   10   2880,028 ± 139,885  MB/sec
Parser.unmarkDoubleQuestion:·gc.churn.PS_Eden_Space.norm                   20          1                      true  avgt   10    600,564 ±   2,614    B/op
Parser.unmarkDoubleQuestion:·gc.churn.PS_Survivor_Space                    20          1                      true  avgt   10      1,058 ±   0,528  MB/sec
Parser.unmarkDoubleQuestion:·gc.churn.PS_Survivor_Space.norm               20          1                      true  avgt   10      0,221 ±   0,112    B/op
Parser.unmarkDoubleQuestion:·gc.count                                      20          1                      true  avgt   10    697,000            counts
Parser.unmarkDoubleQuestion:·gc.time                                       20          1                      true  avgt   10    253,000                ms
Parser.unmarkDoubleQuestion                                                20         10                     false  avgt   10    237,874 ±   7,262   ns/op
Parser.unmarkDoubleQuestion:·gc.alloc.rate                                 20         10                     false  avgt   10      0,002 ±   0,005  MB/sec
Parser.unmarkDoubleQuestion:·gc.alloc.rate.norm                            20         10                     false  avgt   10     ≈ 10⁻³              B/op
Parser.unmarkDoubleQuestion:·gc.count                                      20         10                     false  avgt   10        ≈ 0            counts
Parser.unmarkDoubleQuestion                                                20         10                      true  avgt   10   1820,782 ±  39,059   ns/op
Parser.unmarkDoubleQuestion:·gc.alloc.rate                                 20         10                      true  avgt   10   2375,811 ±  50,699  MB/sec
Parser.unmarkDoubleQuestion:·gc.alloc.rate.norm                            20         10                      true  avgt   10   4536,003 ±   0,011    B/op
Parser.unmarkDoubleQuestion:·gc.churn.PS_Eden_Space                        20         10                      true  avgt   10   2380,343 ±  66,345  MB/sec
Parser.unmarkDoubleQuestion:·gc.churn.PS_Eden_Space.norm                   20         10                      true  avgt   10   4544,440 ±  41,137    B/op
Parser.unmarkDoubleQuestion:·gc.churn.PS_Survivor_Space                    20         10                      true  avgt   10      0,495 ±   0,147  MB/sec
Parser.unmarkDoubleQuestion:·gc.churn.PS_Survivor_Space.norm               20         10                      true  avgt   10      0,945 ±   0,286    B/op
Parser.unmarkDoubleQuestion:·gc.count                                      20         10                      true  avgt   10    576,000            counts
Parser.unmarkDoubleQuestion:·gc.time                                       20         10                      true  avgt   10    195,000                ms
Parser.unmarkDoubleQuestion                                                20        100                     false  avgt   10   2327,500 ±  29,070   ns/op
Parser.unmarkDoubleQuestion:·gc.alloc.rate                                 20        100                     false  avgt   10      0,002 ±   0,005  MB/sec
Parser.unmarkDoubleQuestion:·gc.alloc.rate.norm                            20        100                     false  avgt   10      0,004 ±   0,013    B/op
Parser.unmarkDoubleQuestion:·gc.count                                      20        100                     false  avgt   10        ≈ 0            counts
Parser.unmarkDoubleQuestion                                                20        100                      true  avgt   10  19166,072 ± 258,423   ns/op
Parser.unmarkDoubleQuestion:·gc.alloc.rate                                 20        100                      true  avgt   10   2187,152 ±  29,640  MB/sec
Parser.unmarkDoubleQuestion:·gc.alloc.rate.norm                            20        100                      true  avgt   10  43960,032 ±   0,112    B/op
Parser.unmarkDoubleQuestion:·gc.churn.PS_Eden_Space                        20        100                      true  avgt   10   2211,443 ±  42,896  MB/sec
Parser.unmarkDoubleQuestion:·gc.churn.PS_Eden_Space.norm                   20        100                      true  avgt   10  44447,615 ± 482,793    B/op
Parser.unmarkDoubleQuestion:·gc.churn.PS_Survivor_Space                    20        100                      true  avgt   10      0,464 ±   0,165  MB/sec
Parser.unmarkDoubleQuestion:·gc.churn.PS_Survivor_Space.norm               20        100                      true  avgt   10      9,330 ±   3,361    B/op
Parser.unmarkDoubleQuestion:·gc.count                                      20        100                      true  avgt   10    535,000            counts
Parser.unmarkDoubleQuestion:·gc.time                                       20        100                      true  avgt   10    179,000                ms
```
Tiny performance regression might be noticeable for queries involving double questionmarks