### PR TITLE
perf: parse SQL to a single string, not a array of fragments

### DIFF
--- a/org/postgresql/core/NativeQuery.java
+++ b/org/postgresql/core/NativeQuery.java
@@ -1,0 +1,77 @@
+/*-------------------------------------------------------------------------
+*
+* Copyright (c) 2003-2014, PostgreSQL Global Development Group
+* Copyright (c) 2004, Open Cloud Limited.
+*
+*
+*-------------------------------------------------------------------------
+*/
+package org.postgresql.core;
+
+/**
+ * Represents a query that is ready for execution by backend.
+ * The main difference from JDBC is ? are replaced with $1, $2, etc.
+ */
+public class NativeQuery {
+    private final static String[] BIND_NAMES = new String[128];
+    private final static int[] NO_BINDS = new int[0];
+
+    public final String nativeSql;
+    public final int[] bindPositions;
+
+    static
+    {
+        for (int i = 1; i < BIND_NAMES.length; i++)
+        {
+            BIND_NAMES[i] = "$" + i;
+        }
+    }
+
+    public NativeQuery(String nativeSql)
+    {
+        this(nativeSql, NO_BINDS);
+    }
+
+    public NativeQuery(String nativeSql, int[] bindPositions)
+    {
+        this.nativeSql = nativeSql;
+        this.bindPositions = bindPositions == null || bindPositions.length == 0 ? NO_BINDS : bindPositions;
+    }
+
+    /**
+     * Stringize this query to a human-readable form, substituting
+     * particular parameter values for parameter placeholders.
+     *
+     * @param parameters a ParameterList returned by this Query's
+     *  {@link Query#createParameterList} method, or <code>null</code> to
+     *  leave the parameter placeholders unsubstituted.
+     * @return a human-readable representation of this query
+     */
+    public String toString(ParameterList parameters)
+    {
+        if (bindPositions.length == 0)
+            return nativeSql;
+
+        StringBuilder sbuf = new StringBuilder(nativeSql.length());
+        sbuf.append(nativeSql, 0, bindPositions[0]);
+        for (int i = 1; i <= bindPositions.length; ++i)
+        {
+            if (parameters == null)
+                sbuf.append('?');
+            else
+                sbuf.append(parameters.toString(i));
+            int nextBind = i < bindPositions.length ? bindPositions[i] : nativeSql.length();
+            sbuf.append(nativeSql, bindPositions[i - 1] + bindName(i).length(), nextBind);
+        }
+        return sbuf.toString();
+    }
+
+    /**
+     * Returns $1, $2, etc names of bind variables used by backend.
+     * @param index index of a bind variable
+     * @return bind variable name
+     */
+    public static String bindName(int index) {
+        return index < BIND_NAMES.length ? BIND_NAMES[index] : "$" + index;
+    }
+}

--- a/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -30,17 +30,6 @@ import org.postgresql.copy.CopyOperation;
  * QueryExecutor implementation for the V3 protocol.
  */
 public class QueryExecutorImpl implements QueryExecutor {
-    /**
-     * Cache UTF8-encoded values for $1, $2, etc, so we do not have to repeatedly generate them for prepared statements.
-     */
-    private final static byte[][] BIND_NAMES = new byte[128][];
-
-    static {
-        for (int i = 1; i < BIND_NAMES.length; i++) {
-            BIND_NAMES[i] = Utils.encodeUTF8("$" + i);
-        }
-    }
-
     public QueryExecutorImpl(ProtocolConnectionImpl protoConnection, PGStream pgStream, Properties info, Logger logger) {
         this.protoConnection = protoConnection;
         this.pgStream = pgStream;
@@ -123,103 +112,24 @@ public class QueryExecutorImpl implements QueryExecutor {
     }
 
     private Query parseQuery(String query, boolean withParameters) {
-        // Parse query and find parameter placeholders;
-        // also break the query into separate statements.
 
-        ArrayList statementList = new ArrayList();
-        ArrayList fragmentList = new ArrayList(15);
-
-        int fragmentStart = 0;
-        int inParen = 0;
-
-        boolean standardConformingStrings = protoConnection.getStandardConformingStrings();
-        
-        char []aChars = query.toCharArray();
-
-        for (int i = 0; i < aChars.length; ++i)
-        {
-            switch (aChars[i])
-            {
-            case '\'': // single-quotes
-                i = Parser.parseSingleQuotes(aChars, i, standardConformingStrings);
-                break;
-
-            case '"': // double-quotes
-                i = Parser.parseDoubleQuotes(aChars, i);
-                break;
-
-            case '-': // possibly -- style comment
-                i = Parser.parseLineComment(aChars, i);
-                break;
-
-            case '/': // possibly /* */ style comment
-                i = Parser.parseBlockComment(aChars, i);
-                break;
-            
-            case '$': // possibly dollar quote start
-                i = Parser.parseDollarQuotes(aChars, i);
-                break;
-
-            case '(':
-                inParen++;
-                break;
-
-            case ')':
-                inParen--;
-                break;
-
-            case '?':
-                if (withParameters)
-                {
-                    if (i+1 < aChars.length && aChars[i+1] == '?') /* let '??' pass */
-                        i = i+1;
-                    else
-                    {
-                        fragmentList.add(query.substring(fragmentStart, i));
-                        fragmentStart = i + 1;
-                    }
-                }
-                break;
-
-            case ';':
-                if (inParen == 0)
-                {
-                    fragmentList.add(query.substring(fragmentStart, i));
-                    fragmentStart = i + 1;
-                    if (fragmentList.size() > 1 || ((String)fragmentList.get(0)).trim().length() > 0)
-                        statementList.add(fragmentList.toArray(new String[fragmentList.size()]));
-                    fragmentList.clear();
-                }
-                break;
-
-            default:
-                break;
-            }
-        }
-
-        fragmentList.add(query.substring(fragmentStart));
-        if (fragmentList.size() > 1 || ((String)fragmentList.get(0)).trim().length() > 0)
-            statementList.add(fragmentList.toArray(new String[fragmentList.size()]));
-
-        if (statementList.isEmpty())  // Empty query.
+        List<NativeQuery> queries = Parser.parseJdbcSql(query, protoConnection.getStandardConformingStrings(), withParameters, true);
+        if (queries.isEmpty())  // Empty query.
             return EMPTY_QUERY;
-
-        if (statementList.size() == 1)
-        {
-            // Only one statement.
-            return new SimpleQuery((String[]) statementList.get(0), protoConnection);
+        if (queries.size() == 1) {
+            return new SimpleQuery(queries.get(0), protoConnection);
         }
 
         // Multiple statements.
-        SimpleQuery[] subqueries = new SimpleQuery[statementList.size()];
-        int[] offsets = new int[statementList.size()];
+        SimpleQuery[] subqueries = new SimpleQuery[queries.size()];
+        int[] offsets = new int[subqueries.length];
         int offset = 0;
-        for (int i = 0; i < statementList.size(); ++i)
+        for (int i = 0; i < queries.size(); ++i)
         {
-            String[] fragments = (String[]) statementList.get(i);
+            NativeQuery nativeQuery = queries.get(i);
             offsets[i] = offset;
-            subqueries[i] = new SimpleQuery(fragments, protoConnection);
-            offset += fragments.length - 1;
+            subqueries[i] = new SimpleQuery(nativeQuery, protoConnection);
+            offset += nativeQuery.bindPositions.length;
         }
 
         return new CompositeQuery(subqueries, offsets);
@@ -1284,17 +1194,12 @@ public class QueryExecutorImpl implements QueryExecutor {
         }
 
         byte[] encodedStatementName = query.getEncodedStatementName();
-        String[] fragments = query.getFragments();
+        String nativeSql = query.getNativeSql();
 
         if (logger.logDebug())
         {
             StringBuilder sbuf = new StringBuilder(" FE=> Parse(stmt=" + statementName + ",query=\"");
-            for (int i = 0; i < fragments.length; ++i)
-            {
-                if (i > 0)
-                    sbuf.append("$").append(i);
-                sbuf.append(fragments[i]);
-            }
+            sbuf.append(nativeSql);
             sbuf.append("\",oids={");
             for (int i = 1; i <= params.getParameterCount(); ++i)
             {
@@ -1310,34 +1215,15 @@ public class QueryExecutorImpl implements QueryExecutor {
         // Send Parse.
         //
 
-        byte[][] parts = new byte[fragments.length * 2 - 1][];
-        int j = 0;
-        int encodedSize = 0;
+        byte[] queryUtf8 = Utils.encodeUTF8(nativeSql);
 
         // Total size = 4 (size field)
         //            + N + 1 (statement name, zero-terminated)
         //            + N + 1 (query, zero terminated)
         //            + 2 (parameter count) + N * 4 (parameter types)
-        // original query: "frag0 ? frag1 ? frag2"
-        // fragments: { "frag0", "frag1", "frag2" }
-        // output: "frag0 $1 frag1 $2 frag2"
-        for (int i = 0; i < fragments.length; ++i)
-        {
-            if (i != 0)
-            {
-                parts[j] = i < BIND_NAMES.length ? BIND_NAMES[i] : Utils.encodeUTF8("$" + i);
-                encodedSize += parts[j].length;
-                ++j;
-            }
-
-            parts[j] = Utils.encodeUTF8(fragments[i]);
-            encodedSize += parts[j].length;
-            ++j;
-        }
-
-        encodedSize = 4
+        int encodedSize = 4
                       + (encodedStatementName == null ? 0 : encodedStatementName.length) + 1
-                      + encodedSize + 1
+                      + queryUtf8.length + 1
                       + 2 + 4 * params.getParameterCount();
 
         pgStream.SendChar('P'); // Parse
@@ -1345,9 +1231,7 @@ public class QueryExecutorImpl implements QueryExecutor {
         if (encodedStatementName != null)
             pgStream.Send(encodedStatementName);
         pgStream.SendChar(0);   // End of statement name
-        for (byte[] part : parts) { // Query string
-            pgStream.Send(part);
-        }
+        pgStream.Send(queryUtf8); // Query string
         pgStream.SendChar(0);       // End of query string.
         pgStream.SendInteger2(params.getParameterCount());       // # of parameter types specified
         for (int i = 1; i <= params.getParameterCount(); ++i)
@@ -2401,7 +2285,7 @@ public class QueryExecutorImpl implements QueryExecutor {
      */
     private int estimatedReceiveBufferBytes = 0;
 
-    private final SimpleQuery beginTransactionQuery = new SimpleQuery(new String[] { "BEGIN" }, null);
+    private final SimpleQuery beginTransactionQuery = new SimpleQuery(new NativeQuery("BEGIN", new int[0]), null);
 
-    private final SimpleQuery EMPTY_QUERY = new SimpleQuery(new String[] { "" }, null);
+    private final SimpleQuery EMPTY_QUERY = new SimpleQuery(new NativeQuery("", new int[0]), null);
 }


### PR DESCRIPTION
This saves a bit of cycles when encoding the query to UTF8 (the whole query can be encoded at once)

I've updated both V2 and V3 queries.
?? -> ? replacing is folded into the parse process.