### PR TITLE
bug: equals on an array does not return true when values are equal

### DIFF
--- a/org/postgresql/jdbc2/AbstractJdbc2Array.java
+++ b/org/postgresql/jdbc2/AbstractJdbc2Array.java
@@ -934,4 +934,26 @@ public abstract class AbstractJdbc2Array
     public byte[] toBytes() {
         return fieldBytes;
     }
+
+    public int hashCode() {
+        if (fieldBytes != null)
+            return fieldBytes.hashCode();
+
+        return fieldString.hashCode();
+    }
+
+    public boolean equals(Object other) {
+        if (!(other instanceof AbstractJdbc2Array))
+            return false;
+
+        if (other == this)
+            return true;
+
+        AbstractJdbc2Array otherArray = (AbstractJdbc2Array) other;
+
+        if (fieldBytes != null)
+            return fieldBytes == otherArray.fieldBytes;
+
+        return fieldString.equals(otherArray.fieldString);
+    }
 }


### PR DESCRIPTION
All fields returned by the JDBC driver are expected to return true with
the equals function when the values are the same.  This commit
overrides the equals function on the array object so that the state is
compared as opposed to just the identity.

It is assumed that both fieldBytes and fieldString cannot be null at
the same time.  Breaking that assumption would require that a null is
passed into the constructor.