### PR TITLE
refactor: cleanup constructors of JDBC4 and JDBC42 connections/statements

### DIFF
--- a/org/postgresql/jdbc2/AbstractJdbc2Statement.java
+++ b/org/postgresql/jdbc2/AbstractJdbc2Statement.java
@@ -154,6 +154,8 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
         forceBinaryTransfers |= c.getForceBinary();
         resultsettype = rsType;
         concurrency = rsConcurrency;
+        setFetchSize(c.getDefaultFetchSize());
+        setPrepareThreshold(c.getPrepareThreshold());
     }
 
     public AbstractJdbc2Statement(AbstractJdbc2Connection connection, String sql, boolean isCallable, int rsType, int rsConcurrency) throws SQLException
@@ -176,6 +178,8 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
 
         resultsettype = rsType;
         concurrency = rsConcurrency;
+        setFetchSize(connection.getDefaultFetchSize());
+        setPrepareThreshold(connection.getPrepareThreshold());
     }
 
     public abstract ResultSet createResultSet(Query originalQuery, Field[] fields, List tuples, ResultCursor cursor)

--- a/org/postgresql/jdbc4/AbstractJdbc4Statement.java
+++ b/org/postgresql/jdbc4/AbstractJdbc4Statement.java
@@ -26,12 +26,12 @@ public abstract class AbstractJdbc4Statement extends org.postgresql.jdbc3g.Abstr
     protected AbstractJdbc4Statement (AbstractJdbc4Connection c, int rsType, int rsConcurrency, int rsHoldability) throws SQLException
     {
         super(c, rsType, rsConcurrency, rsHoldability);
-        poolable = true;
     }
 
     protected AbstractJdbc4Statement(AbstractJdbc4Connection connection, String sql, boolean isCallable, int rsType, int rsConcurrency, int rsHoldability) throws SQLException
     {
         super(connection, sql, isCallable, rsType, rsConcurrency, rsHoldability);
+        poolable = true; // As per JDBC spec: prepared and callable statements are poolable by default
     }
 
     public boolean isClosed() throws SQLException

--- a/org/postgresql/jdbc4/Jdbc4Connection.java
+++ b/org/postgresql/jdbc4/Jdbc4Connection.java
@@ -33,28 +33,19 @@ public class Jdbc4Connection extends AbstractJdbc4Connection implements java.sql
     public java.sql.Statement createStatement(int resultSetType, int resultSetConcurrency, int resultSetHoldability) throws SQLException
     {
         checkClosed();
-        Jdbc4Statement s = new Jdbc4Statement(this, resultSetType, resultSetConcurrency, resultSetHoldability);
-        s.setPrepareThreshold(getPrepareThreshold());
-        s.setFetchSize(getDefaultFetchSize());
-        return s;
+        return new Jdbc4Statement(this, resultSetType, resultSetConcurrency, resultSetHoldability);
     }
 
     public java.sql.PreparedStatement prepareStatement(String sql, int resultSetType, int resultSetConcurrency, int resultSetHoldability) throws SQLException
     {
         checkClosed();
-        Jdbc4PreparedStatement s = new Jdbc4PreparedStatement(this, sql, resultSetType, resultSetConcurrency, resultSetHoldability);
-        s.setPrepareThreshold(getPrepareThreshold());
-        s.setFetchSize(getDefaultFetchSize());
-        return s;
+        return new Jdbc4PreparedStatement(this, sql, resultSetType, resultSetConcurrency, resultSetHoldability);
     }
 
     public java.sql.CallableStatement prepareCall(String sql, int resultSetType, int resultSetConcurrency, int resultSetHoldability) throws SQLException
     {
         checkClosed();
-        Jdbc4CallableStatement s = new Jdbc4CallableStatement(this, sql, resultSetType, resultSetConcurrency, resultSetHoldability);
-        s.setPrepareThreshold(getPrepareThreshold());
-        s.setFetchSize(getDefaultFetchSize());
-        return s;
+        return new Jdbc4CallableStatement(this, sql, resultSetType, resultSetConcurrency, resultSetHoldability);
     }
 
     public java.sql.DatabaseMetaData getMetaData() throws SQLException

--- a/org/postgresql/jdbc42/AbstractJdbc42Statement.java
+++ b/org/postgresql/jdbc42/AbstractJdbc42Statement.java
@@ -17,16 +17,14 @@ import org.postgresql.jdbc4.AbstractJdbc4Statement;
 public abstract class AbstractJdbc42Statement extends AbstractJdbc4Statement
 {
 
-    protected AbstractJdbc42Statement(AbstractJdbc4Connection c, int rsType, int rsConcurrency, int rsHoldability, int prepareThreshold) throws SQLException
+    protected AbstractJdbc42Statement(AbstractJdbc4Connection c, int rsType, int rsConcurrency, int rsHoldability) throws SQLException
     {
         super(c, rsType, rsConcurrency, rsHoldability);
-        setPrepareThreshold(prepareThreshold);
     }
 
-    protected AbstractJdbc42Statement(AbstractJdbc42Connection connection, String sql, boolean isCallable, int rsType, int rsConcurrency, int rsHoldability, int prepareThreshold) throws SQLException
+    protected AbstractJdbc42Statement(AbstractJdbc42Connection connection, String sql, boolean isCallable, int rsType, int rsConcurrency, int rsHoldability) throws SQLException
     {
         super(connection, sql, isCallable, rsType, rsConcurrency, rsHoldability);
-        setPrepareThreshold(prepareThreshold);
     }
 
     public long getLargeUpdateCount() throws SQLException

--- a/org/postgresql/jdbc42/Jdbc42CallableStatement.java
+++ b/org/postgresql/jdbc42/Jdbc42CallableStatement.java
@@ -12,9 +12,9 @@ import java.util.Map;
 
 class Jdbc42CallableStatement extends Jdbc42PreparedStatement implements CallableStatement
 {
-    Jdbc42CallableStatement(Jdbc42Connection connection, String sql, int rsType, int rsConcurrency, int rsHoldability, int prepareThreshold) throws SQLException
+    Jdbc42CallableStatement(Jdbc42Connection connection, String sql, int rsType, int rsConcurrency, int rsHoldability) throws SQLException
     {
-        super(connection, sql, true, rsType, rsConcurrency, rsHoldability, prepareThreshold);
+        super(connection, sql, true, rsType, rsConcurrency, rsHoldability);
     }
 
     public Object getObject(int i, Map < String, Class < ? >> map) throws SQLException

--- a/org/postgresql/jdbc42/Jdbc42Connection.java
+++ b/org/postgresql/jdbc42/Jdbc42Connection.java
@@ -31,25 +31,19 @@ public class Jdbc42Connection extends AbstractJdbc42Connection
     public Statement createStatement(int resultSetType, int resultSetConcurrency, int resultSetHoldability) throws SQLException
     {
         checkClosed();
-        Jdbc42Statement s = new Jdbc42Statement(this, resultSetType, resultSetConcurrency, resultSetHoldability, getPrepareThreshold());
-        s.setFetchSize(getDefaultFetchSize());
-        return s;
+        return new Jdbc42Statement(this, resultSetType, resultSetConcurrency, resultSetHoldability);
     }
 
     public PreparedStatement prepareStatement(String sql, int resultSetType, int resultSetConcurrency, int resultSetHoldability) throws SQLException
     {
         checkClosed();
-        Jdbc42PreparedStatement s = new Jdbc42PreparedStatement(this, sql, resultSetType, resultSetConcurrency, resultSetHoldability, getPrepareThreshold());
-        s.setFetchSize(getDefaultFetchSize());
-        return s;
+        return new Jdbc42PreparedStatement(this, sql, resultSetType, resultSetConcurrency, resultSetHoldability);
     }
 
     public CallableStatement prepareCall(String sql, int resultSetType, int resultSetConcurrency, int resultSetHoldability) throws SQLException
     {
         checkClosed();
-        Jdbc42CallableStatement s = new Jdbc42CallableStatement(this, sql, resultSetType, resultSetConcurrency, resultSetHoldability, getPrepareThreshold());
-        s.setFetchSize(getDefaultFetchSize());
-        return s;
+        return new Jdbc42CallableStatement(this, sql, resultSetType, resultSetConcurrency, resultSetHoldability);
     }
 
     public DatabaseMetaData getMetaData() throws SQLException

--- a/org/postgresql/jdbc42/Jdbc42PreparedStatement.java
+++ b/org/postgresql/jdbc42/Jdbc42PreparedStatement.java
@@ -11,13 +11,13 @@ import java.sql.*;
 
 class Jdbc42PreparedStatement extends Jdbc42Statement implements PreparedStatement
 {
-    Jdbc42PreparedStatement(Jdbc42Connection connection, String sql, int rsType, int rsConcurrency, int rsHoldability, int prepareThreshold) throws SQLException
+    Jdbc42PreparedStatement(Jdbc42Connection connection, String sql, int rsType, int rsConcurrency, int rsHoldability) throws SQLException
     {
-        this(connection, sql, false, rsType, rsConcurrency, rsHoldability, prepareThreshold);
+        this(connection, sql, false, rsType, rsConcurrency, rsHoldability);
     }
 
-    Jdbc42PreparedStatement(Jdbc42Connection connection, String sql, boolean isCallable, int rsType, int rsConcurrency, int rsHoldability, int prepareThreshold) throws SQLException
+    Jdbc42PreparedStatement(Jdbc42Connection connection, String sql, boolean isCallable, int rsType, int rsConcurrency, int rsHoldability) throws SQLException
     {
-        super(connection, sql, isCallable, rsType, rsConcurrency, rsHoldability, prepareThreshold);
+        super(connection, sql, isCallable, rsType, rsConcurrency, rsHoldability);
     }
 }

--- a/org/postgresql/jdbc42/Jdbc42Statement.java
+++ b/org/postgresql/jdbc42/Jdbc42Statement.java
@@ -21,14 +21,14 @@ import org.postgresql.jdbc4.AbstractJdbc4Connection;
 public class Jdbc42Statement extends AbstractJdbc42Statement
 {
 
-    Jdbc42Statement(AbstractJdbc4Connection c, int rsType, int rsConcurrency, int rsHoldability, int prepareThreshold) throws SQLException
+    Jdbc42Statement(AbstractJdbc4Connection c, int rsType, int rsConcurrency, int rsHoldability) throws SQLException
     {
-        super(c, rsType, rsConcurrency, rsHoldability, prepareThreshold);
+        super(c, rsType, rsConcurrency, rsHoldability);
     }
 
-    Jdbc42Statement(AbstractJdbc42Connection connection, String sql, boolean isCallable, int rsType, int rsConcurrency, int rsHoldability, int prepareThreshold) throws SQLException
+    Jdbc42Statement(AbstractJdbc42Connection connection, String sql, boolean isCallable, int rsType, int rsConcurrency, int rsHoldability) throws SQLException
     {
-        super(connection, sql, isCallable, rsType, rsConcurrency, rsHoldability, prepareThreshold);
+        super(connection, sql, isCallable, rsType, rsConcurrency, rsHoldability);
     }
 
     public ResultSet createResultSet (Query originalQuery, Field[] fields, List tuples, ResultCursor cursor)


### PR DESCRIPTION
Move `setPrepareThreshold(getPrepareThreshold())` and `setFetchSize(getDefaultFetchSize())` to base `AbstractJdbc2Statement`.