### PR TITLE
perf: cache prepared statements across .prepareStatement calls

### DIFF
--- a/doc/pgjdbc.xml
+++ b/doc/pgjdbc.xml
@@ -737,6 +737,39 @@ openssl pkcs8 -topk8 -in client.key -out client.pk8 -outform DER -v1 PBE-SHA1-3D
        </listitem>
       </varlistentry>
 	  
+      <varlistentry>
+       <term><varname>preparedStatementCacheQueries</varname> = <type>int</type></term>
+       <listitem>
+        <para>
+         Determine the number of queries that are cached in each connection.
+         The default is 256, meaning if you use more than 256 different queries
+         in <function>prepareStatement()</function> calls, the least recently used ones
+         will be discarded. The cache allows application to benefit from <xref linkend="server-prepare" />
+         (see <varname>prepareThreshold</varname>) even if the prepared statement is
+         closed after each execution. The value of 0 disables the cache.
+         <note>
+          <para>
+           Each connection has its own statement cache.
+          </para>
+         </note>
+        </para>
+       </listitem>
+      </varlistentry>
+
+      <varlistentry>
+       <term><varname>preparedStatementCacheSizeMiB</varname> = <type>int</type></term>
+       <listitem>
+        <para>
+         Determine the maximum size (in mebibytes) of the prepared queries cache
+         (see <varname>preparedStatementCacheQueries</varname>).
+         The default is 5, meaning if you happen to cache more than 5 MiB of queries
+         the least recently used ones will be discarded.
+         The main aim of this setting is to prevent <classname>OutOfMemoryError</classname>.
+         The value of 0 disables the cache.
+        </para>
+       </listitem>
+      </varlistentry>
+
 	  <varlistentry>
        <term><varname>defaultRowFetchSize</varname> = <type>int</type></term>
        <listitem>

--- a/org/postgresql/PGProperty.java
+++ b/org/postgresql/PGProperty.java
@@ -62,6 +62,16 @@ public enum PGProperty
     PREPARE_THRESHOLD("prepareThreshold", "5", "Statement prepare threshold. A value of {@code -1} stands for forceBinary"),
 
     /**
+     * Specifies the maximum number of entries in cache of prepared statements. A value of {@code 0} disables the cache.
+     */
+    PREPARED_STATEMENT_CACHE_QUERIES("preparedStatementCacheQueries", "256", "Specifies the maximum number of entries in per-connection cache of prepared statements. A value of {@code 0} disables the cache."),
+
+    /**
+     * Specifies the maximum size (in megabytes) of the prepared statement cache. A value of {@code 0} disables the cache.
+     */
+    PREPARED_STATEMENT_CACHE_SIZE_MIB("preparedStatementCacheSizeMiB", "5", "Specifies the maximum size (in megabytes) of a per-connection prepared statement cache. A value of {@code 0} disables the cache."),
+
+    /**
      * Default parameter for {@link java.sql.Statement#getFetchSize()}. A value of {@code 0} means that need fetch all rows at once
      */
     DEFAULT_ROW_FETCH_SIZE("defaultRowFetchSize", "0", "Positive number of rows that should be fetched from the database when more rows are needed for ResultSet by each fetch iteration"),

--- a/org/postgresql/core/NativeQuery.java
+++ b/org/postgresql/core/NativeQuery.java
@@ -1,0 +1,77 @@
+/*-------------------------------------------------------------------------
+*
+* Copyright (c) 2003-2014, PostgreSQL Global Development Group
+* Copyright (c) 2004, Open Cloud Limited.
+*
+*
+*-------------------------------------------------------------------------
+*/
+package org.postgresql.core;
+
+/**
+ * Represents a query that is ready for execution by backend.
+ * The main difference from JDBC is ? are replaced with $1, $2, etc.
+ */
+public class NativeQuery {
+    private final static String[] BIND_NAMES = new String[128];
+    private final static int[] NO_BINDS = new int[0];
+
+    public final String nativeSql;
+    public final int[] bindPositions;
+
+    static
+    {
+        for (int i = 1; i < BIND_NAMES.length; i++)
+        {
+            BIND_NAMES[i] = "$" + i;
+        }
+    }
+
+    public NativeQuery(String nativeSql)
+    {
+        this(nativeSql, NO_BINDS);
+    }
+
+    public NativeQuery(String nativeSql, int[] bindPositions)
+    {
+        this.nativeSql = nativeSql;
+        this.bindPositions = bindPositions == null || bindPositions.length == 0 ? NO_BINDS : bindPositions;
+    }
+
+    /**
+     * Stringize this query to a human-readable form, substituting
+     * particular parameter values for parameter placeholders.
+     *
+     * @param parameters a ParameterList returned by this Query's
+     *  {@link Query#createParameterList} method, or <code>null</code> to
+     *  leave the parameter placeholders unsubstituted.
+     * @return a human-readable representation of this query
+     */
+    public String toString(ParameterList parameters)
+    {
+        if (bindPositions.length == 0)
+            return nativeSql;
+
+        StringBuilder sbuf = new StringBuilder(nativeSql.length());
+        sbuf.append(nativeSql, 0, bindPositions[0]);
+        for (int i = 1; i <= bindPositions.length; ++i)
+        {
+            if (parameters == null)
+                sbuf.append('?');
+            else
+                sbuf.append(parameters.toString(i));
+            int nextBind = i < bindPositions.length ? bindPositions[i] : nativeSql.length();
+            sbuf.append(nativeSql, bindPositions[i - 1] + bindName(i).length(), nextBind);
+        }
+        return sbuf.toString();
+    }
+
+    /**
+     * Returns $1, $2, etc names of bind variables used by backend.
+     * @param index index of a bind variable
+     * @return bind variable name
+     */
+    public static String bindName(int index) {
+        return index < BIND_NAMES.length ? BIND_NAMES[index] : "$" + index;
+    }
+}

--- a/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -30,17 +30,6 @@ import org.postgresql.copy.CopyOperation;
  * QueryExecutor implementation for the V3 protocol.
  */
 public class QueryExecutorImpl implements QueryExecutor {
-    /**
-     * Cache UTF8-encoded values for $1, $2, etc, so we do not have to repeatedly generate them for prepared statements.
-     */
-    private final static byte[][] BIND_NAMES = new byte[128][];
-
-    static {
-        for (int i = 1; i < BIND_NAMES.length; i++) {
-            BIND_NAMES[i] = Utils.encodeUTF8("$" + i);
-        }
-    }
-
     public QueryExecutorImpl(ProtocolConnectionImpl protoConnection, PGStream pgStream, Properties info, Logger logger) {
         this.protoConnection = protoConnection;
         this.pgStream = pgStream;
@@ -123,103 +112,24 @@ public class QueryExecutorImpl implements QueryExecutor {
     }
 
     private Query parseQuery(String query, boolean withParameters) {
-        // Parse query and find parameter placeholders;
-        // also break the query into separate statements.
 
-        ArrayList statementList = new ArrayList();
-        ArrayList fragmentList = new ArrayList(15);
-
-        int fragmentStart = 0;
-        int inParen = 0;
-
-        boolean standardConformingStrings = protoConnection.getStandardConformingStrings();
-        
-        char []aChars = query.toCharArray();
-
-        for (int i = 0; i < aChars.length; ++i)
-        {
-            switch (aChars[i])
-            {
-            case '\'': // single-quotes
-                i = Parser.parseSingleQuotes(aChars, i, standardConformingStrings);
-                break;
-
-            case '"': // double-quotes
-                i = Parser.parseDoubleQuotes(aChars, i);
-                break;
-
-            case '-': // possibly -- style comment
-                i = Parser.parseLineComment(aChars, i);
-                break;
-
-            case '/': // possibly /* */ style comment
-                i = Parser.parseBlockComment(aChars, i);
-                break;
-            
-            case '$': // possibly dollar quote start
-                i = Parser.parseDollarQuotes(aChars, i);
-                break;
-
-            case '(':
-                inParen++;
-                break;
-
-            case ')':
-                inParen--;
-                break;
-
-            case '?':
-                if (withParameters)
-                {
-                    if (i+1 < aChars.length && aChars[i+1] == '?') /* let '??' pass */
-                        i = i+1;
-                    else
-                    {
-                        fragmentList.add(query.substring(fragmentStart, i));
-                        fragmentStart = i + 1;
-                    }
-                }
-                break;
-
-            case ';':
-                if (inParen == 0)
-                {
-                    fragmentList.add(query.substring(fragmentStart, i));
-                    fragmentStart = i + 1;
-                    if (fragmentList.size() > 1 || ((String)fragmentList.get(0)).trim().length() > 0)
-                        statementList.add(fragmentList.toArray(new String[fragmentList.size()]));
-                    fragmentList.clear();
-                }
-                break;
-
-            default:
-                break;
-            }
-        }
-
-        fragmentList.add(query.substring(fragmentStart));
-        if (fragmentList.size() > 1 || ((String)fragmentList.get(0)).trim().length() > 0)
-            statementList.add(fragmentList.toArray(new String[fragmentList.size()]));
-
-        if (statementList.isEmpty())  // Empty query.
+        List<NativeQuery> queries = Parser.parseJdbcSql(query, protoConnection.getStandardConformingStrings(), withParameters, true);
+        if (queries.isEmpty())  // Empty query.
             return EMPTY_QUERY;
-
-        if (statementList.size() == 1)
-        {
-            // Only one statement.
-            return new SimpleQuery((String[]) statementList.get(0), protoConnection);
+        if (queries.size() == 1) {
+            return new SimpleQuery(queries.get(0), protoConnection);
         }
 
         // Multiple statements.
-        SimpleQuery[] subqueries = new SimpleQuery[statementList.size()];
-        int[] offsets = new int[statementList.size()];
+        SimpleQuery[] subqueries = new SimpleQuery[queries.size()];
+        int[] offsets = new int[subqueries.length];
         int offset = 0;
-        for (int i = 0; i < statementList.size(); ++i)
+        for (int i = 0; i < queries.size(); ++i)
         {
-            String[] fragments = (String[]) statementList.get(i);
+            NativeQuery nativeQuery = queries.get(i);
             offsets[i] = offset;
-            subqueries[i] = new SimpleQuery(fragments, protoConnection);
-            offset += fragments.length - 1;
+            subqueries[i] = new SimpleQuery(nativeQuery, protoConnection);
+            offset += nativeQuery.bindPositions.length;
         }
 
         return new CompositeQuery(subqueries, offsets);
@@ -1284,17 +1194,12 @@ public class QueryExecutorImpl implements QueryExecutor {
         }
 
         byte[] encodedStatementName = query.getEncodedStatementName();
-        String[] fragments = query.getFragments();
+        String nativeSql = query.getNativeSql();
 
         if (logger.logDebug())
         {
             StringBuilder sbuf = new StringBuilder(" FE=> Parse(stmt=" + statementName + ",query=\"");
-            for (int i = 0; i < fragments.length; ++i)
-            {
-                if (i > 0)
-                    sbuf.append("$").append(i);
-                sbuf.append(fragments[i]);
-            }
+            sbuf.append(nativeSql);
             sbuf.append("\",oids={");
             for (int i = 1; i <= params.getParameterCount(); ++i)
             {
@@ -1310,34 +1215,15 @@ public class QueryExecutorImpl implements QueryExecutor {
         // Send Parse.
         //
 
-        byte[][] parts = new byte[fragments.length * 2 - 1][];
-        int j = 0;
-        int encodedSize = 0;
+        byte[] queryUtf8 = Utils.encodeUTF8(nativeSql);
 
         // Total size = 4 (size field)
         //            + N + 1 (statement name, zero-terminated)
         //            + N + 1 (query, zero terminated)
         //            + 2 (parameter count) + N * 4 (parameter types)
-        // original query: "frag0 ? frag1 ? frag2"
-        // fragments: { "frag0", "frag1", "frag2" }
-        // output: "frag0 $1 frag1 $2 frag2"
-        for (int i = 0; i < fragments.length; ++i)
-        {
-            if (i != 0)
-            {
-                parts[j] = i < BIND_NAMES.length ? BIND_NAMES[i] : Utils.encodeUTF8("$" + i);
-                encodedSize += parts[j].length;
-                ++j;
-            }
-
-            parts[j] = Utils.encodeUTF8(fragments[i]);
-            encodedSize += parts[j].length;
-            ++j;
-        }
-
-        encodedSize = 4
+        int encodedSize = 4
                       + (encodedStatementName == null ? 0 : encodedStatementName.length) + 1
-                      + encodedSize + 1
+                      + queryUtf8.length + 1
                       + 2 + 4 * params.getParameterCount();
 
         pgStream.SendChar('P'); // Parse
@@ -1345,9 +1231,7 @@ public class QueryExecutorImpl implements QueryExecutor {
         if (encodedStatementName != null)
             pgStream.Send(encodedStatementName);
         pgStream.SendChar(0);   // End of statement name
-        for (byte[] part : parts) { // Query string
-            pgStream.Send(part);
-        }
+        pgStream.Send(queryUtf8); // Query string
         pgStream.SendChar(0);       // End of query string.
         pgStream.SendInteger2(params.getParameterCount());       // # of parameter types specified
         for (int i = 1; i <= params.getParameterCount(); ++i)
@@ -2401,7 +2285,7 @@ public class QueryExecutorImpl implements QueryExecutor {
      */
     private int estimatedReceiveBufferBytes = 0;
 
-    private final SimpleQuery beginTransactionQuery = new SimpleQuery(new String[] { "BEGIN" }, null);
+    private final SimpleQuery beginTransactionQuery = new SimpleQuery(new NativeQuery("BEGIN", new int[0]), null);
 
-    private final SimpleQuery EMPTY_QUERY = new SimpleQuery(new String[] { "" }, null);
+    private final SimpleQuery EMPTY_QUERY = new SimpleQuery(new NativeQuery("", new int[0]), null);
 }

--- a/org/postgresql/ds/common/BaseDataSource.java
+++ b/org/postgresql/ds/common/BaseDataSource.java
@@ -364,11 +364,43 @@ public abstract class BaseDataSource implements Referenceable
     }
 
     /**
-     * @see PGProperty#PREPARE_THRESHOLD 
+     * @see PGProperty#PREPARE_THRESHOLD
      */
     public int getPrepareThreshold()
     {
         return PGProperty.PREPARE_THRESHOLD.getIntNoCheck(properties);
+    }
+
+    /**
+     * @see PGProperty#PREPARED_STATEMENT_CACHE_QUERIES
+     */
+    public int getPreparedStatementCacheQueries()
+    {
+        return PGProperty.PREPARED_STATEMENT_CACHE_QUERIES.getIntNoCheck(properties);
+    }
+
+    /**
+     * @see PGProperty#PREPARED_STATEMENT_CACHE_QUERIES
+     */
+    public void setPreparedStatementCacheQueries(int cacheSize)
+    {
+        PGProperty.PREPARED_STATEMENT_CACHE_QUERIES.set(properties, cacheSize);
+    }
+
+    /**
+     * @see PGProperty#PREPARED_STATEMENT_CACHE_SIZE_MIB
+     */
+    public int getPreparedStatementCacheSizeMiB()
+    {
+        return PGProperty.PREPARED_STATEMENT_CACHE_SIZE_MIB.getIntNoCheck(properties);
+    }
+
+    /**
+     * @see PGProperty#PREPARED_STATEMENT_CACHE_SIZE_MIB
+     */
+    public void setPreparedStatementCacheSizeMiB(int cacheSize)
+    {
+        PGProperty.PREPARED_STATEMENT_CACHE_SIZE_MIB.set(properties, cacheSize);
     }
 
     /**

--- a/org/postgresql/jdbc2/CachedQueryCreateAction.java
+++ b/org/postgresql/jdbc2/CachedQueryCreateAction.java
@@ -1,0 +1,51 @@
+/*-------------------------------------------------------------------------
+*
+* Copyright (c) 2015, PostgreSQL Global Development Group
+*
+*
+*-------------------------------------------------------------------------
+*/
+package org.postgresql.jdbc2;
+
+import org.postgresql.core.CachedQuery;
+import org.postgresql.core.Parser;
+import org.postgresql.core.Query;
+import org.postgresql.util.LruCache;
+
+import java.sql.SQLException;
+
+/**
+ * Creates an instance of {@link CachedQuery} for a given connection.
+ */
+class CachedQueryCreateAction implements LruCache.CreateAction<Object, CachedQuery> {
+    private final int serverVersionNum;
+    private final AbstractJdbc2Connection connection;
+
+    public CachedQueryCreateAction(AbstractJdbc2Connection connection, int serverVersionNum)
+    {
+        this.connection = connection;
+        this.serverVersionNum = serverVersionNum;
+    }
+
+    @Override
+    public CachedQuery create(Object key) throws SQLException
+    {
+        String sql = key == null ? null : key.toString();
+        String parsedSql = AbstractJdbc2Statement.replaceProcessing(sql, true, connection.getStandardConformingStrings());
+        boolean isFunction;
+        boolean outParmBeforeFunc;
+        if (key instanceof CallableQueryKey)
+        {
+            Parser.JdbcCallParseInfo callInfo = Parser.modifyJdbcCall(parsedSql, connection.getStandardConformingStrings(), serverVersionNum, connection.getProtocolVersion());
+            parsedSql = callInfo.getSql();
+            isFunction = callInfo.isFunction();
+            outParmBeforeFunc = callInfo.isOutParmBeforeFunc();
+        } else
+        {
+            isFunction = false;
+            outParmBeforeFunc = false;
+        }
+        Query query = connection.getQueryExecutor().createParameterizedQuery(parsedSql);
+        return new CachedQuery(key, query, isFunction, outParmBeforeFunc);
+    }
+}

--- a/org/postgresql/jdbc2/CallableQueryKey.java
+++ b/org/postgresql/jdbc2/CallableQueryKey.java
@@ -1,0 +1,45 @@
+/*-------------------------------------------------------------------------
+*
+* Copyright (c) 2015, PostgreSQL Global Development Group
+*
+*
+*-------------------------------------------------------------------------
+*/
+package org.postgresql.jdbc2;
+
+/**
+ * Serves as a cache key for callable statements.
+ * For regular statements, just sql string is used as a key.
+ */
+class CallableQueryKey {
+    public final String sql;
+
+    public CallableQueryKey(String sql)
+    {
+        this.sql = sql;
+    }
+
+    @Override
+    public String toString()
+    {
+        return sql;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) return true;
+        if (!(o instanceof CallableQueryKey)) return false;
+
+        CallableQueryKey that = (CallableQueryKey) o;
+
+        return !(sql != null ? !sql.equals(that.sql) : that.sql != null);
+
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return sql != null ? sql.hashCode() : 0;
+    }
+}

--- a/org/postgresql/jdbc3/AbstractJdbc3Statement.java
+++ b/org/postgresql/jdbc3/AbstractJdbc3Statement.java
@@ -409,7 +409,7 @@ public abstract class AbstractJdbc3Statement extends org.postgresql.jdbc2.Abstra
     {
         int flags = QueryExecutor.QUERY_ONESHOT | QueryExecutor.QUERY_DESCRIBE_ONLY | QueryExecutor.QUERY_SUPPRESS_BEGIN;
         StatementResultHandler handler = new StatementResultHandler();
-        connection.getQueryExecutor().execute(preparedQuery, preparedParameters, handler, 0, 0, flags);
+        connection.getQueryExecutor().execute(preparedQuery.query, preparedParameters, handler, 0, 0, flags);
 
         int oids[] = preparedParameters.getTypeOIDs();
         if (oids != null)

--- a/org/postgresql/test/util/LruCacheTest.java
+++ b/org/postgresql/test/util/LruCacheTest.java
@@ -1,0 +1,152 @@
+/*-------------------------------------------------------------------------
+*
+* Copyright (c) 2015, PostgreSQL Global Development Group
+*
+*
+*-------------------------------------------------------------------------
+*/
+package org.postgresql.test.util;
+
+import junit.framework.TestCase;
+import org.postgresql.util.CanEstimateSize;
+import org.postgresql.util.LruCache;
+
+import java.sql.SQLException;
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Deque;
+
+/**
+ * Tests {@link org.postgresql.util.LruCache}
+ */
+public class LruCacheTest extends TestCase {
+    static class Entry implements CanEstimateSize {
+        private final int id;
+
+        Entry(int id)
+        {
+            this.id = id;
+        }
+
+
+        @Override
+        public long getSize()
+        {
+            return id;
+        }
+
+        @Override
+        public String toString()
+        {
+            return "Entry{" +
+                    "id=" + id +
+                    '}';
+        }
+    }
+
+    private final Integer[] expectCreate = new Integer[1];
+    private final Deque<Entry> expectEvict = new ArrayDeque<Entry>();
+    private final Entry dummy = new Entry(-999);
+    private LruCache<Integer, Entry> cache;
+
+    @Override
+    protected void setUp() throws Exception
+    {
+        cache = new LruCache<Integer, Entry>(3, 1000, new LruCache.CreateAction<Integer, Entry>() {
+            @Override
+            public Entry create(Integer key) throws SQLException
+            {
+                assertEquals("Unexpected create", expectCreate[0], key);
+                return new Entry(key);
+            }
+        }, new LruCache.EvictAction<Entry>() {
+            @Override
+            public void evict(Entry entry) throws SQLException
+            {
+                Entry expected = expectEvict.removeFirst();
+                assertEquals("Unexpected evict", expected, entry);
+            }
+        });
+    }
+
+    public void testEvictsByNumberOfEntries() throws SQLException
+    {
+        Entry a, b, c, d;
+
+        a = use(1, dummy);
+        b = use(2, dummy);
+        c = use(3, dummy);
+        d = use(4, a);
+    }
+
+    public void testEvictsBySize() throws SQLException
+    {
+        Entry a, b, c, d;
+
+        a = use(3, dummy);
+        b = use(5, dummy);
+        c = use((int) (1000 - a.getSize() - b.getSize()), dummy);
+        // Now cache holds exactly 1000 bytes.
+        // a and b should be evicted
+        d = use(4, a, b);
+    }
+
+    public void testEvictsLeastRecentlyUsed() throws SQLException
+    {
+        Entry a, b, c, d;
+
+        a = use(1, dummy);
+        b = use(2, dummy);
+        c = use(3, dummy);
+        a = use(1, dummy); // reuse a
+        d = use(4, b); // expect b to be evicted
+    }
+
+    public void testCyclicReplacement() throws SQLException
+    {
+        Entry a, b, c, d;
+
+        a = use(1, dummy);
+        b = use(2, dummy);
+        c = use(3, dummy);
+        d = use(4, a);
+
+        for (int i = 0; i < 100000; i++)
+        {
+            a = use(1, b);
+            b = use(2, c);
+            c = use(3, d);
+            d = use(4, a);
+        }
+    }
+
+    public void testCaching() throws SQLException
+    {
+        Entry a, b, c, d;
+
+        a = use(1, dummy);
+        b = use(2, dummy);
+        c = use(3, dummy);
+
+        for (int i = 0; i < 100000; i++)
+        {
+            b = use(-2, dummy);
+            a = use(-1, dummy);
+            d = use(4, c);
+            b = use(-2, dummy);
+            a = use(-1, dummy);
+            c = use(3, d);
+        }
+    }
+
+    private Entry use(int expectCreate, Entry... expectEvict) throws SQLException
+    {
+        Entry a;
+        this.expectCreate[0] = expectCreate <= 0 ? -1 : expectCreate;
+        this.expectEvict.clear();
+        this.expectEvict.addAll(Arrays.asList(expectEvict));
+        a = cache.borrow(Math.abs(expectCreate));
+        cache.put(a.id, a); // a
+        return a;
+    }
+}

--- a/org/postgresql/util/CanEstimateSize.java
+++ b/org/postgresql/util/CanEstimateSize.java
@@ -1,0 +1,12 @@
+/*-------------------------------------------------------------------------
+*
+* Copyright (c) 2015, PostgreSQL Global Development Group
+*
+*
+*-------------------------------------------------------------------------
+*/
+package org.postgresql.util;
+
+public interface CanEstimateSize {
+    long getSize();
+}

--- a/org/postgresql/util/LruCache.java
+++ b/org/postgresql/util/LruCache.java
@@ -1,0 +1,114 @@
+/*-------------------------------------------------------------------------
+*
+* Copyright (c) 2015, PostgreSQL Global Development Group
+*
+*
+*-------------------------------------------------------------------------
+*/
+package org.postgresql.util;
+
+import java.sql.SQLException;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Caches values in simple least-recently-accessed order.
+ */
+public class LruCache<Key, Value extends CanEstimateSize> {
+    /**
+     * Action that is invoked when the entry is removed from the cache.
+     * @param <Value> type of the cache entry
+     */
+    public interface EvictAction<Value> {
+        void evict(Value value) throws SQLException;
+    }
+
+    /**
+     * When the entry is not present in cache, this create action is used to create one.
+     * @param <Value> type of the cache entry
+     */
+    public interface CreateAction<Key, Value> {
+        Value create(Key key) throws SQLException;
+    }
+
+    private final EvictAction<Value> onEvict;
+    private final CreateAction<Key, Value> createAction;
+    private final int maxSizeEntries;
+    private final long maxSizeBytes;
+    private long currentSize;
+
+    private final Map<Key, Value> cache = new LinkedHashMap<Key, Value>() {
+        @Override
+        protected boolean removeEldestEntry(Map.Entry<Key, Value> eldest)
+        {
+            // Avoid creating iterators if size constraints not violated
+            if (size() <= maxSizeEntries && currentSize <= maxSizeBytes)
+                return false;
+
+            for (Iterator<Map.Entry<Key, Value>> it = entrySet().iterator(); it.hasNext(); )
+            {
+                if (size() <= maxSizeEntries && currentSize <= maxSizeBytes)
+                    return false;
+
+                Map.Entry<Key, Value> entry = it.next();
+                evictValue(entry.getValue());
+                long valueSize = entry.getValue().getSize();
+                if (valueSize > 0) // just in case
+                    currentSize -= valueSize;
+                it.remove();
+            }
+            return false;
+        }
+    };
+
+    private void evictValue(Value value)
+    {
+        try
+        {
+            onEvict.evict(value);
+        } catch (SQLException e)
+        {
+            /* ignore */
+        }
+    }
+
+    public LruCache(int maxSizeEntries, long maxSizeBytes, CreateAction<Key, Value> createAction, EvictAction<Value> onEvict)
+    {
+        this.maxSizeEntries = maxSizeEntries;
+        this.maxSizeBytes = maxSizeBytes;
+        this.createAction = createAction;
+        this.onEvict = onEvict;
+    }
+
+    /**
+     * Borrows an entry from the cache.
+     * @param key cache key
+     * @return entry from cache or newly created entry if cache does not contain given key.
+     * @throws SQLException if entry creation fails
+     */
+    public Value borrow(Key key) throws SQLException
+    {
+        Value value = cache.remove(key);
+        if (value == null)
+            return createAction.create(key);
+        currentSize -= value.getSize();
+        return value;
+    }
+
+    /**
+     * Returns given value to the cache
+     * @param key key
+     * @param value value
+     */
+    public void put(Key key, Value value)
+    {
+        if (maxSizeBytes == 0 || maxSizeEntries == 0) {
+            // Just destroy the value if cache is disabled
+            evictValue(value);
+            return;
+        }
+        currentSize += value.getSize();
+        cache.put(key, value);
+    }
+}

--- a/ubenchmark/src/main/java/org/postgresql/benchmark/statement/ParseStatement.java
+++ b/ubenchmark/src/main/java/org/postgresql/benchmark/statement/ParseStatement.java
@@ -26,9 +26,14 @@ public class ParseStatement {
     @Param({"0", "1", "10", "20"})
     private int bindCount;
 
+    @Param({"false"})
+    public boolean unique;
+
     private Connection connection;
 
     private String sql;
+
+    private int cntr;
 
     @Setup(Level.Trial)
     public void setUp() throws SQLException {
@@ -51,6 +56,8 @@ public class ParseStatement {
 
     @Benchmark
     public Statement bindExecuteFetch(Blackhole b) throws SQLException {
+        String sql = this.sql;
+        if (unique) sql += " -- " + cntr++;
         PreparedStatement ps = connection.prepareStatement(sql);
         for (int i = 1; i <= bindCount; i++) {
             ps.setInt(i, i);


### PR DESCRIPTION
This allows to use server-side prepared statements when application uses the same SQL multiple times.

Major difference from existing `setPrepareThreshold` is with current fix application does not have to reference exactly the same `PreparedStatement`. When a new statement is prepared, it is checked against existing statements in the cache. If there is a match, parsing result and server-side named query (!) are reused.

Note: this fix comes on top of https://github.com/pgjdbc/pgjdbc/pull/311.

### Note: I believe the code is feature complete

Cache size is configurable. It defaults to 256 queries and 5 MiB maximum per connection.
Feel free to review, add your comments, and merge.

Some measurements:
On a simple `select ?, ?, ?...` the response time is 20-40% better (78us -> 46us for 20 binds).
Execution of cached statements allocates 50% less garbage.

### Before

```
Benchmark                                           (bindCount)  Mode  Cnt     Score      Error   Units
ParseStatement.bindExecuteFetch                               0  avgt   10    42,883 ±    0,519   us/op
ParseStatement.bindExecuteFetch:·gc.alloc.rate.norm           0  avgt   10  1160,077 ±    0,255    B/op
ParseStatement.bindExecuteFetch                               1  avgt   10    48,658 ±    0,483   us/op
ParseStatement.bindExecuteFetch:·gc.alloc.rate.norm           1  avgt   10  1600,087 ±    0,289    B/op
ParseStatement.bindExecuteFetch                              10  avgt   10    64,844 ±    0,657   us/op
ParseStatement.bindExecuteFetch:·gc.alloc.rate.norm          10  avgt   10  3896,114 ±    0,379    B/op
ParseStatement.bindExecuteFetch                              20  avgt   10    78,440 ±    0,772   us/op
ParseStatement.bindExecuteFetch:·gc.alloc.rate.norm          20  avgt   10  6576,138 ±    0,458    B/op
```

### After

```
Benchmark                                           (bindCount)  Mode  Cnt     Score     Error   Units
ParseStatement.bindExecuteFetch                               0  avgt   10    32,450 ±   0,195   us/op
ParseStatement.bindExecuteFetch:·gc.alloc.rate.norm           0  avgt   10   608,057 ±   0,190    B/op
ParseStatement.bindExecuteFetch                               1  avgt   10    34,650 ±   0,907   us/op
ParseStatement.bindExecuteFetch:·gc.alloc.rate.norm           1  avgt   10   792,061 ±   0,201    B/op
ParseStatement.bindExecuteFetch                              10  avgt   10    41,341 ±   0,315   us/op
ParseStatement.bindExecuteFetch:·gc.alloc.rate.norm          10  avgt   10  1464,073 ±   0,241    B/op
ParseStatement.bindExecuteFetch                              20  avgt   10    46,994 ±   0,352   us/op
ParseStatement.bindExecuteFetch:·gc.alloc.rate.norm          20  avgt   10  2224,083 ±   0,275    B/op
```

Pathological case when `prepareStatement` is called with random sql texts.
1) Test passes, no out of memory happens
2) Response time is intact
3) Memory allocation is a bit higher than before 4496 -> 4560

### Before

```
Benchmark                                                         (bindCount)  (unique)  Mode  Cnt     Score      Error   Units
ParseStatement.bindExecuteFetch                                            10      true  avgt   10    64,710 ±    0,495   us/op
ParseStatement.bindExecuteFetch:·gc.alloc.rate.norm                        10      true  avgt   10  4496,114 ±    0,378    B/op
```

### After

```
Benchmark                                                         (bindCount)  (unique)  Mode  Cnt     Score      Error   Units
ParseStatement.bindExecuteFetch                                            10      true  avgt   10    65,289 ±    0,568   us/op
ParseStatement.bindExecuteFetch:·gc.alloc.rate.norm                        10      true  avgt   10  4560,115 ±    0,384    B/op
```