### PR TITLE
perf: use shared PGBoolean instances

### DIFF
--- a/org/postgresql/core/types/PGBigDecimal.java
+++ b/org/postgresql/core/types/PGBigDecimal.java
@@ -20,14 +20,22 @@ import org.postgresql.util.PSQLState;
  */
 public class PGBigDecimal implements PGType
 {
+    static final PGBigDecimal ZERO = new PGBigDecimal(BigDecimal.ZERO);
+    
+    static final PGBigDecimal ONE = new PGBigDecimal(BigDecimal.ONE);
+    
     private BigDecimal val;
     
-    protected PGBigDecimal( BigDecimal x )
+    private PGBigDecimal( BigDecimal x )
     {
         // ensure the value is a valid numeric value to avoid
         // sql injection attacks
         val = new BigDecimal(x.toString());
         
+    }
+    
+    static final PGBigDecimal valueOf(final BigDecimal value) {
+        return BigDecimal.ZERO.equals(value) ? PGBigDecimal.ZERO : BigDecimal.ONE.equals(value) ? PGBigDecimal.ONE : new PGBigDecimal(value);
     }
 
     public static PGType castToServerType( BigDecimal val, int targetType ) throws PSQLException
@@ -37,25 +45,25 @@ public class PGBigDecimal implements PGType
             switch ( targetType )
             {
 	            case Types.BIT:
-	                return new PGBoolean( val.doubleValue() == 0?Boolean.FALSE:Boolean.TRUE );            
+	                return PGBoolean.valueOf(val.doubleValue() != 0d);            
 	            case Types.BIGINT:
-	                return new PGLong(val.longValue());
+	                return PGLong.valueOf(val.longValue());
 	            case Types.INTEGER:
-	                return new PGInteger(val.intValue()) ;
+	                return PGInteger.valueOf(val.intValue()) ;
 	            case Types.SMALLINT:
 	            case Types.TINYINT:
-	                return new PGShort(val.shortValue());
+	                return PGShort.valueOf(val.shortValue());
 	            case Types.VARCHAR:
 	            case Types.LONGVARCHAR:
-	                return new PGString( val.toString() );
+	                return PGString.valueOf( val.toString() );
 	            case Types.DECIMAL:
 	            case Types.NUMERIC:
 	            case Types.DOUBLE:
 	            case Types.FLOAT:
 	            case Types.REAL:
-	                return new PGBigDecimal( val );
+	                return PGBigDecimal.valueOf( val );
 	            default:
-	                return new PGUnknown(val);            
+	                return PGUnknown.valueOf(val);            
             }
         }
         catch( Exception ex )

--- a/org/postgresql/core/types/PGBoolean.java
+++ b/org/postgresql/core/types/PGBoolean.java
@@ -18,14 +18,23 @@ import org.postgresql.util.PSQLState;
  * TODO To change the template for this generated type comment go to
  * Window - Preferences - Java - Code Style - Code Templates
  */
-public class PGBoolean implements PGType 
+public class PGBoolean implements PGType
 {
+    static final PGBoolean TRUE = new PGBoolean(Boolean.TRUE);
+
+    static final PGBoolean FALSE = new PGBoolean(Boolean.FALSE);
+
     private Boolean val;
-    
-    public PGBoolean(Boolean x)
+
+    private PGBoolean(Boolean x)
     {
         val = x;
     }
+
+    static final PGBoolean valueOf(final Boolean value) {
+        return Boolean.FALSE.equals(value) ? PGBoolean.FALSE : Boolean.TRUE.equals(value) ? PGBoolean.TRUE : new PGBoolean(value);
+    }
+
     public static PGType castToServerType( Boolean val, int targetType ) throws PSQLException
     {
         try
@@ -33,28 +42,28 @@ public class PGBoolean implements PGType
         switch ( targetType )
         {
             case Types.BIGINT:
-                return new PGLong((long) (val == true ? 1 : 0));
+                return val == true ? PGLong.ONE : PGLong.ZERO;
             case Types.INTEGER:
-                return new PGInteger(val == true ? 1 : 0);
+                return val == true ? PGInteger.ONE : PGInteger.ZERO;
             case Types.SMALLINT:
             case Types.TINYINT:
-                return new PGShort(val == true ? (short) 1 : (short) 0);
+                return val == true ? PGShort.ONE : PGShort.ZERO;
             case Types.VARCHAR:
-            case Types.LONGVARCHAR:                
-                return new PGString(val ==true?"true":"false" );
+            case Types.LONGVARCHAR:
+                return val == true ? PGString.TRUE : PGString.FALSE;
             case Types.DOUBLE:
             case Types.FLOAT:
-            		return new PGDouble((double) (val == true ? 1 : 0));
+            		return val == true ? PGDouble.ONE : PGDouble.ZERO;
             case Types.REAL:
-        		return new PGFloat((float) (val == true ? 1 : 0));
+        		return val == true ? PGFloat.ONE : PGFloat.ZERO;
             case Types.NUMERIC:
             case Types.DECIMAL:
-                return new PGBigDecimal( new java.math.BigDecimal(val ==true?1:0));
-            
+                return val == true ? PGBigDecimal.ONE : PGBigDecimal.ZERO;
+
             case Types.BIT:
-                return new PGBoolean( val );
+                return PGBoolean.valueOf(val);
             default:
-                return new PGUnknown( val );
+                return PGUnknown.valueOf( val );
         }
         }
         catch(Exception ex)
@@ -62,9 +71,10 @@ public class PGBoolean implements PGType
             throw new PSQLException(GT.tr("Cannot convert an instance of {0} to type {1}", new Object[]{val.getClass().getName(),"Types.OTHER"}), PSQLState.INVALID_PARAMETER_TYPE, ex);
         }
     }
+    @Override
     public String toString()
     {
         return val ==true?"true":"false";
     }
-    
+
 }

--- a/org/postgresql/core/types/PGByte.java
+++ b/org/postgresql/core/types/PGByte.java
@@ -21,13 +21,17 @@ import org.postgresql.util.PSQLState;
  */
 public class PGByte implements PGType
 {
-
     private Byte val;
     
-    public PGByte( Byte x )
+    private PGByte( Byte x )
     {
         val = x;
     }
+    
+    static final PGByte valueOf(final Byte value) {
+        return new PGByte(value);
+    }
+    
     /* (non-Javadoc)
      * @see org.postgresql.types.PGType#castToServerType(int)
      */
@@ -38,24 +42,24 @@ public class PGByte implements PGType
             switch ( targetType )
             {
 	            case Types.BIT:
-	                return new PGBoolean(val == 0?Boolean.FALSE:Boolean.TRUE );
+	                return PGBoolean.valueOf(val != (byte) 0);
 	            
 	            case Types.SMALLINT:
 	            case Types.TINYINT:
-	                return new PGByte( val );
+	                return PGByte.valueOf( val );
 	            case Types.REAL:
-	                return new PGFloat(val.floatValue());
+	                return PGFloat.valueOf(val.floatValue());
 	            case Types.DOUBLE:
 	            case Types.FLOAT:
-	                return new PGDouble(val.doubleValue());
+	                return PGDouble.valueOf(val.doubleValue());
 	            case Types.NUMERIC:
 	            case Types.DECIMAL:
-	                return new PGBigDecimal( new BigDecimal(val.toString()) );
+	                return PGBigDecimal.valueOf( new BigDecimal(val.toString()) );
 	            case Types.VARCHAR:
 	            case Types.LONGVARCHAR:                
-	                return new PGString ( val.toString() );
+	                return PGString.valueOf ( val.toString() );
 	            default:
-	                return new PGUnknown(val);
+	                return PGUnknown.valueOf(val);
             }
         }
         catch( Exception ex )

--- a/org/postgresql/core/types/PGDouble.java
+++ b/org/postgresql/core/types/PGDouble.java
@@ -19,44 +19,52 @@ import org.postgresql.util.PSQLState;
  * TODO To change the template for this generated type comment go to
  * Window - Preferences - Java - Code Style - Code Templates
  */
-public class PGDouble implements PGType
+public class PGDouble  implements PGType
 {
+    static final PGDouble ZERO = new PGDouble(0d);
+
+    static final PGDouble ONE = new PGDouble(1d);
+
     private Double val;
-    
-    protected PGDouble( Double x )
+
+    private PGDouble( Double x )
     {
         val = x;
     }
-        
+
+    static final PGDouble valueOf(final Double value) {
+        final double v = value; // Prevent double auto-unboxing
+        return v == 0d ? PGDouble.ZERO : v == 1d ? PGDouble.ONE : new PGDouble(value);
+    }
+
     public static PGType castToServerType( Double val, int targetType ) throws PSQLException
     {
         try
-        {	
+        {
             switch ( targetType )
             {
 	            case Types.BIT:
-	                return new PGBoolean(val == 0?Boolean.FALSE:Boolean.TRUE );
-	            
+	                return PGBoolean.valueOf(val != 0d);
 	            case Types.BIGINT:
-	                return new PGLong(val.longValue());
+	                return PGLong.valueOf(val.longValue());
 	            case Types.INTEGER:
-	                return new PGInteger(val.intValue()) ;
+	                return PGInteger.valueOf(val.intValue()) ;
 	            case Types.SMALLINT:
 	            case Types.TINYINT:
-	                return new PGShort(val.shortValue());
+	                return PGShort.valueOf(val.shortValue());
 	            case Types.VARCHAR:
-	            case Types.LONGVARCHAR:                
-	                return new PGString( val.toString() );
+	            case Types.LONGVARCHAR:
+	                return PGString.valueOf( val.toString() );
 	            case Types.DOUBLE:
 	            case Types.FLOAT:
-	                return new PGDouble( val );
+	                return PGDouble.valueOf( val );
 	            case Types.REAL:
-	                return new PGFloat(val.floatValue());
+	                return PGFloat.valueOf(val.floatValue());
 	            case Types.DECIMAL:
 	            case Types.NUMERIC:
-	                return new PGBigDecimal( new BigDecimal( val.toString()));
+	                return PGBigDecimal.valueOf( new BigDecimal( val.toString()));
 	            default:
-	                return new PGUnknown(val);
+	                return PGUnknown.valueOf(val);
             }
         }
         catch( Exception ex )
@@ -64,6 +72,7 @@ public class PGDouble implements PGType
             throw new PSQLException(GT.tr("Cannot convert an instance of {0} to type {1}", new Object[]{val.getClass().getName(),"Types.OTHER"}), PSQLState.INVALID_PARAMETER_TYPE, ex);
         }
     }
+    @Override
     public String toString()
     {
         return val.toString();

--- a/org/postgresql/core/types/PGFloat.java
+++ b/org/postgresql/core/types/PGFloat.java
@@ -21,13 +21,22 @@ import org.postgresql.util.PSQLState;
  */
 public class PGFloat implements PGType
 {
+    static final PGFloat ZERO = new PGFloat(0f);
+
+    static final PGFloat ONE = new PGFloat(1f);
+
     private Float val;
-    
-    protected PGFloat( Float x )
+
+    private PGFloat( Float x )
     {
         val = x;
     }
-        
+
+    static final PGFloat valueOf(final Float value) {
+        final float v = value; // Prevent double auto-unboxing
+        return v == 0f ? PGFloat.ZERO : v == 1f ? PGFloat.ONE : new PGFloat(value);
+    }
+
     public static PGType castToServerType( Float val, int targetType ) throws PSQLException
     {
         try
@@ -35,28 +44,28 @@ public class PGFloat implements PGType
             switch ( targetType )
             {
 	            case Types.BIT:
-	                return new PGBoolean(val == 0?Boolean.FALSE:Boolean.TRUE );
-	            
+	                return PGBoolean.valueOf(val != 0f);
+
 	            case Types.BIGINT:
-	                return new PGLong(val.longValue());
+	                return PGLong.valueOf(val.longValue());
 	            case Types.INTEGER:
-	                return new PGInteger(val.intValue());
+	                return PGInteger.valueOf(val.intValue());
 	            case Types.SMALLINT:
 	            case Types.TINYINT:
-	                return new PGShort(val.shortValue());
+	                return PGShort.valueOf(val.shortValue());
 	            case Types.VARCHAR:
-	            case Types.LONGVARCHAR:                
-	                return new PGString( val.toString() );
+	            case Types.LONGVARCHAR:
+	                return PGString.valueOf( val.toString() );
 	            case Types.DOUBLE:
 	            case Types.FLOAT:
-	                return( new PGDouble(val.doubleValue()));
+	                return PGDouble.valueOf(val.doubleValue());
 	            case Types.REAL:
-	                return new PGFloat( val );
+	                return PGFloat.valueOf( val );
 	            case Types.DECIMAL:
 	            case Types.NUMERIC:
-	                return new PGBigDecimal( new BigDecimal( val.toString()));
+	                return PGBigDecimal.valueOf( new BigDecimal( val.toString()));
 	            default:
-	                return new PGUnknown(val);            
+	                return PGUnknown.valueOf(val);
             }
         }
         catch( Exception ex)
@@ -64,6 +73,7 @@ public class PGFloat implements PGType
             throw new PSQLException(GT.tr("Cannot convert an instance of {0} to type {1}", new Object[]{val.getClass().getName(),"Types.OTHER"}), PSQLState.INVALID_PARAMETER_TYPE, ex);
         }
     }
+    @Override
     public String toString()
     {
         return val.toString();

--- a/org/postgresql/core/types/PGInteger.java
+++ b/org/postgresql/core/types/PGInteger.java
@@ -21,13 +21,22 @@ import org.postgresql.util.PSQLState;
  */
 public class PGInteger implements PGType
 {
+    static final PGInteger ZERO = new PGInteger(0);
+
+    static final PGInteger ONE = new PGInteger(1);
+
     private Integer val;
-    
+
     protected PGInteger( Integer x )
     {
         val = x;
     }
-    
+
+    static final PGInteger valueOf(final Integer value) {
+        final int v = value; // Prevent double auto-unboxing
+        return v == 0 ? PGInteger.ZERO : v == 1 ? PGInteger.ONE : new PGInteger(value);
+    }
+
     public static PGType castToServerType( Integer val, int targetType ) throws PSQLException
     {
         try
@@ -35,25 +44,25 @@ public class PGInteger implements PGType
             switch ( targetType )
             {
 	            case Types.BIT:
-	                return new PGBoolean(val == 0?Boolean.FALSE:Boolean.TRUE );
+                    return PGBoolean.valueOf(val != 0);
 	            case Types.REAL:
-	                return new PGFloat(val.floatValue());
+	                return PGFloat.valueOf(val.floatValue());
 	            case Types.DOUBLE:
 	            case Types.FLOAT:
-	                return new PGDouble(val.doubleValue());
+	                return PGDouble.valueOf(val.doubleValue());
 	            case Types.VARCHAR:
-	            case Types.LONGVARCHAR:                
-	                return new PGString( val.toString() );
+	            case Types.LONGVARCHAR:
+	                return PGString.valueOf( val.toString() );
 	            case Types.SMALLINT:
 	            case Types.TINYINT:
-	                return new PGShort(val.shortValue());
+	                return PGShort.valueOf(val.shortValue());
 	            case Types.INTEGER:
-	                return new PGInteger( val );
+	                return PGInteger.valueOf( val );
 	            case Types.DECIMAL:
 	            case Types.NUMERIC:
-	                return new PGBigDecimal( new BigDecimal( val.toString()));
+	                return PGBigDecimal.valueOf( new BigDecimal( val.toString()));
 	            default:
-	                return new PGUnknown(val);
+	                return PGUnknown.valueOf(val);
             }
         }
         catch( Exception ex )
@@ -61,6 +70,7 @@ public class PGInteger implements PGType
             throw new PSQLException(GT.tr("Cannot convert an instance of {0} to type {1}", new Object[]{val.getClass().getName(),"Types.OTHER"}), PSQLState.INVALID_PARAMETER_TYPE, ex);
         }
     }
+    @Override
     public String toString()
     {
         return val.toString();

--- a/org/postgresql/core/types/PGLong.java
+++ b/org/postgresql/core/types/PGLong.java
@@ -20,41 +20,50 @@ import org.postgresql.util.PSQLState;
  */
 public class PGLong implements PGType
 {
+    static final PGLong ZERO = new PGLong(0L);
+
+    static final PGLong ONE = new PGLong(1L);
+
     private Long val;
-    
-    protected PGLong( Long x )
+
+    private PGLong( Long x )
     {
         val = x;
     }
-    
-    public static PGType castToServerType(Long val, int targetType ) throws PSQLException 
+
+    static final PGLong valueOf(final Long value) {
+        final long v = value; // Prevent double auto-unboxing
+        return v == 0L ? PGLong.ZERO : v == 1L ? PGLong.ONE : new PGLong(value);
+    }
+
+    public static PGType castToServerType(Long val, int targetType ) throws PSQLException
     {
         try
         {
             switch ( targetType )
             {
 	            case Types.BIT:
-	                return new PGBoolean(val ==0?Boolean.FALSE:Boolean.TRUE);
+	                return PGBoolean.valueOf(val != 0L);
 	            case Types.REAL:
-	                return new PGFloat(val.floatValue());
+	                return PGFloat.valueOf(val.floatValue());
 	            case Types.FLOAT:
 	            case Types.DOUBLE:
-	                return new PGDouble(val.doubleValue());
+	                return PGDouble.valueOf(val.doubleValue());
 	            case Types.VARCHAR:
-	            case Types.LONGVARCHAR:                
-	                return new PGString(val.toString());
+	            case Types.LONGVARCHAR:
+	                return PGString.valueOf(val.toString());
 	            case Types.BIGINT:
-	                return new PGLong( val );
+	                return PGLong.valueOf(val);
 	            case Types.INTEGER:
-	                return new PGInteger(val.intValue());
+	                return PGInteger.valueOf(val.intValue());
 	            case Types.SMALLINT:
 	            case Types.TINYINT:
-	                return new PGShort(val.shortValue());
+	                return PGShort.valueOf(val.shortValue());
 	            case Types.DECIMAL:
 	            case Types.NUMERIC:
-	                return new PGBigDecimal( new BigDecimal( val.toString())); 
+	                return PGBigDecimal.valueOf( new BigDecimal( val.toString()));
 	            default:
-	                return new PGUnknown(val);
+	                return PGUnknown.valueOf(val);
             }
         }
         catch( Exception ex )
@@ -62,6 +71,7 @@ public class PGLong implements PGType
             throw new PSQLException(GT.tr("Cannot convert an instance of {0} to type {1}", new Object[]{val.getClass().getName(),"Types.OTHER"}), PSQLState.INVALID_PARAMETER_TYPE, ex);
         }
     }
+    @Override
     public String toString()
     {
         return val.toString();

--- a/org/postgresql/core/types/PGNumber.java
+++ b/org/postgresql/core/types/PGNumber.java
@@ -22,10 +22,15 @@ public class PGNumber implements PGType
 {
     private Number val;
     
-    protected PGNumber( Number x )
+    private PGNumber( Number x )
     {
         val = x;
     }
+    
+    static final PGNumber valueOf(final Number value) {
+        return new PGNumber(value);
+    }
+    
     public static PGType castToServerType( Number val, int targetType ) throws PSQLException
     {
         try
@@ -33,28 +38,28 @@ public class PGNumber implements PGType
             switch ( targetType )
             {
 	            case Types.BIT:
-	                return new PGBoolean( val.doubleValue() == 0?Boolean.FALSE:Boolean.TRUE );
+	                return PGBoolean.valueOf(val.doubleValue() != 0d);
 	            
 	            case Types.BIGINT:
-	                return new PGLong(val.longValue());
+	                return PGLong.valueOf(val.longValue());
 	            case Types.INTEGER:
-	                return new PGInteger(val.intValue());
+	                return PGInteger.valueOf(val.intValue());
 	            case Types.TINYINT:
 	            case Types.SMALLINT:
-	                return new PGShort(val.shortValue());
+	                return PGShort.valueOf(val.shortValue());
 	            case Types.VARCHAR:
 	            case Types.LONGVARCHAR:                
-	                return new PGString( val.toString() );
+	                return PGString.valueOf( val.toString() );
 	            case Types.DOUBLE:
 	            case Types.FLOAT:
-	                return( new PGDouble(val.doubleValue()));
+	                return PGDouble.valueOf(val.doubleValue());
 	            case Types.REAL:
-	                return (new PGFloat(val.floatValue()));
+	                return PGFloat.valueOf(val.floatValue());
 	            case Types.DECIMAL:
 	            case Types.NUMERIC:
-	                return new PGNumber( val );
+	                return PGNumber.valueOf( val );
 	            default:
-	                return new PGUnknown(val);                
+	                return PGUnknown.valueOf(val);                
 	            }
         }
         catch( Exception ex )

--- a/org/postgresql/core/types/PGShort.java
+++ b/org/postgresql/core/types/PGShort.java
@@ -21,11 +21,22 @@ import org.postgresql.util.PSQLState;
  */
 public class PGShort implements PGType
 {
-    Short val;
-    protected  PGShort( Short x )
+    static final PGShort ZERO = new PGShort((short) 0);
+
+    static final PGShort ONE = new PGShort((short) 1);
+    
+    private Short val;
+
+    private PGShort( Short x )
     {
         val = x;
     }
+    
+    static final PGShort valueOf(final Short value) {
+        final short v = value; // Prevent double auto-unboxing
+        return v == (short) 0 ? PGShort.ZERO : v == (short) 1 ? PGShort.ONE : new PGShort(value);
+    }
+    
     public static PGType castToServerType( Short val, int targetType ) throws PSQLException
     {
         try
@@ -33,24 +44,24 @@ public class PGShort implements PGType
             switch ( targetType )
             {
 	            case Types.BIT:
-	                return new PGBoolean(val == 0?Boolean.FALSE:Boolean.TRUE );
+	                return PGBoolean.valueOf(val != (short) 0);
 	            
 	            case Types.SMALLINT:
 	            case Types.TINYINT:
-	                return new PGShort(val);
+	                return PGShort.valueOf(val);
 	            case Types.REAL:
-	                return new PGFloat(val.floatValue());
+	                return PGFloat.valueOf(val.floatValue());
 	            case Types.DOUBLE:
 	            case Types.FLOAT:
-	                return new PGDouble(val.doubleValue());
+	                return PGDouble.valueOf(val.doubleValue());
 	            case Types.VARCHAR:
 	            case Types.LONGVARCHAR:                
-	                return new PGString ( val.toString() );
+	                return PGString.valueOf( val.toString() );
 	            case Types.DECIMAL:
 	            case Types.NUMERIC:
-	                return new PGBigDecimal( new BigDecimal( val.toString()));
+	                return PGBigDecimal.valueOf( new BigDecimal( val.toString()));
 	            default:
-	                return new PGUnknown(val);
+	                return PGUnknown.valueOf(val);
 	            }
         }
         catch (Exception ex)

--- a/org/postgresql/core/types/PGString.java
+++ b/org/postgresql/core/types/PGString.java
@@ -19,14 +19,23 @@ import org.postgresql.util.PSQLState;
  * TODO To change the template for this generated type comment go to
  * Window - Preferences - Java - Code Style - Code Templates
  */
-public class PGString implements PGType
+class PGString implements PGType
 {
+    static final PGString FALSE = new PGString("false");
 
-    String val;
-    protected PGString( String x )
+    static final PGString TRUE = new PGString("true");
+
+    private String val;
+
+    private PGString( String x )
     {
         val = x;
     }
+
+    static final PGString valueOf(final String value) {
+        return new PGString(value);
+    }
+
     /* (non-Javadoc)
      * @see org.postgresql.types.PGType#castToServerType(int)
      */
@@ -39,33 +48,33 @@ public class PGString implements PGType
 	            case Types.BIT:
 	            {
 	                if ( val.equalsIgnoreCase("true") || val.equalsIgnoreCase("1") || val.equalsIgnoreCase("t"))
-	                    return new PGBoolean( Boolean.TRUE );
+	                    return PGBoolean.TRUE;
 	                if ( val.equalsIgnoreCase("false") || val.equalsIgnoreCase("0") || val.equalsIgnoreCase("f"))
-	                    return new PGBoolean( Boolean.FALSE);
+	                    return PGBoolean.FALSE;
 	            }
-	            
-	            return new PGBoolean( Boolean.FALSE);
-	            
+
+	            return PGBoolean.FALSE;
+
 	            case Types.VARCHAR:
-	            case Types.LONGVARCHAR:                
-	                return new PGString(val);
+	            case Types.LONGVARCHAR:
+	                return PGString.valueOf(val);
 	            case Types.BIGINT:
-	                return new PGLong(Long.parseLong(val));
+	                return PGLong.valueOf(Long.parseLong(val));
 	            case Types.INTEGER:
-	                return new PGInteger(Integer.parseInt(val));
+	                return PGInteger.valueOf(Integer.parseInt(val));
 	            case Types.TINYINT:
-	                return new PGShort(Short.parseShort(val));
+	                return PGShort.valueOf(Short.parseShort(val));
 	            case Types.FLOAT:
 	            case Types.DOUBLE:
-	                return new PGDouble(Double.parseDouble(val));
+	                return PGDouble.valueOf(Double.parseDouble(val));
 	            case Types.REAL:
-	                return new PGFloat(Float.parseFloat(val));
+	                return PGFloat.valueOf(Float.parseFloat(val));
 	            case Types.NUMERIC:
 	            case Types.DECIMAL:
-	                return new PGBigDecimal( new BigDecimal( val));
+	                return PGBigDecimal.valueOf( new BigDecimal( val));
 	            default:
-	                return new PGUnknown( val );
-	            
+	                return PGUnknown.valueOf( val );
+
 	            }
         }
         catch( Exception ex )
@@ -73,6 +82,7 @@ public class PGString implements PGType
             throw new PSQLException(GT.tr("Cannot convert an instance of {0} to type {1}", new Object[]{val.getClass().getName(),"Types.OTHER"}), PSQLState.INVALID_PARAMETER_TYPE, ex);
         }
     }
+    @Override
     public String toString()
     {
         return val;

--- a/org/postgresql/core/types/PGType.java
+++ b/org/postgresql/core/types/PGType.java
@@ -14,5 +14,6 @@ package org.postgresql.core.types;
  */
 public interface PGType
 {
+    @Override
     public String toString();
 }

--- a/org/postgresql/core/types/PGUnknown.java
+++ b/org/postgresql/core/types/PGUnknown.java
@@ -18,14 +18,20 @@ public class PGUnknown implements PGType
     /* (non-Javadoc)
      * @see org.postgresql.types.PGType#castToServerType(int)
      */
-    Object val;
-    public PGUnknown( Object x)
+    private Object val;
+
+    private PGUnknown( Object x)
     {
         val = x;
     }
+
+    public static final PGUnknown valueOf(final Object value) {
+        return new PGUnknown(value);
+    }
+
     public static PGType castToServerType(Object val, int targetType) 
     {
-        return new PGUnknown( val );
+        return PGUnknown.valueOf( val );
     }
     public String toString()
     {

--- a/org/postgresql/jdbc2/AbstractJdbc2Statement.java
+++ b/org/postgresql/jdbc2/AbstractJdbc2Statement.java
@@ -1684,7 +1684,7 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
         // since all of the above are instances of Number make sure this is after them
         if ( x instanceof Number ) return PGNumber.castToServerType((Number)x, targetType );
         if ( x instanceof Boolean) return PGBoolean.castToServerType((Boolean)x, targetType );
-        return new PGUnknown(x);
+        return PGUnknown.valueOf(x);
         
     }
     // Helper method for setting parameters to PGobject subclasses.


### PR DESCRIPTION
Reduce GC stress by using solely two shared PGBoolean instances.
Test shows that setObject(i, v, type) runs 13% faster for boolean.
Prepare future caching of PG* types using valueOf().

Closes #315