### PR TITLE
perf: skip instantiation of testReturn and functionReturnType for non-callable statements

### DIFF
--- a/org/postgresql/jdbc2/AbstractJdbc2Statement.java
+++ b/org/postgresql/jdbc2/AbstractJdbc2Statement.java
@@ -168,9 +168,11 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
         this.preparedQuery = connection.getQueryExecutor().createParameterizedQuery(parsed_sql);
         this.preparedParameters = preparedQuery.createParameterList();
 
-        int inParamCount =  preparedParameters.getInParameterCount() + 1;
-        this.testReturn = new int[inParamCount];
-        this.functionReturnType = new int[inParamCount];
+        if (isFunction) {
+            int inParamCount =  preparedParameters.getInParameterCount() + 1;
+            this.testReturn = new int[inParamCount];
+            this.functionReturnType = new int[inParamCount];
+        }
 
         forceBinaryTransfers |= connection.getForceBinary();
 


### PR DESCRIPTION
`testReturn` and `functionReturnType` are used in `CallableStatements` only, so avoid overhead for prepared statements.