### PR TITLE
perf: avoid useBinary(field) check for each sendBind

### DIFF
--- a/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -1388,20 +1388,20 @@ public class QueryExecutorImpl implements QueryExecutor {
                 encodedSize += (long)4 + params.getV3Length(i);
         }
 
-        // This is not the number of binary fields, but the total number
-        // of fields if any of them are binary or zero if all of them
-        // are text.
-
-        int numBinaryFields = 0;
         Field[] fields = query.getFields();
-        if (!noBinaryTransfer && fields != null) {
+        if (!noBinaryTransfer && query.needUpdateFieldFormats()) {
             for (Field field : fields) {
                 if (useBinary(field)) {
                     field.setFormat(Field.BINARY_FORMAT);
-                    numBinaryFields = fields.length;
+                    query.setHasBinaryFields(true);
                 }
             }
         }
+
+        // This is not the number of binary fields, but the total number
+        // of fields if any of them are binary or zero if all of them
+        // are text.
+        int numBinaryFields = !noBinaryTransfer && query.hasBinaryFields() ? fields.length : 0;
 
         encodedSize = 4
                       + (encodedPortalName == null ? 0 : encodedPortalName.length) + 1

--- a/org/postgresql/core/v3/SimpleQuery.java
+++ b/org/postgresql/core/v3/SimpleQuery.java
@@ -180,6 +180,8 @@ class SimpleQuery implements V3Query {
     void setFields(Field[] fields) {
         this.fields = fields;
         this.cachedMaxResultRowSize = null;
+        this.needUpdateFieldFormats = fields != null;
+        this.hasBinaryFields = false; // just in case
     }
 
     /**
@@ -190,6 +192,29 @@ class SimpleQuery implements V3Query {
      */
     Field[] getFields() {
         return fields;
+    }
+
+    /**
+     * Returns true if current query needs field formats be adjusted as per connection configuration.
+     * Subsequent invocations would return {@code false}.
+     * The idea is to perform adjustments only once, not for each {@link QueryExecutorImpl#sendBind(SimpleQuery, SimpleParameterList, Portal, boolean)}.
+     * @return true if current query needs field formats be adjusted as per connection configuration
+     */
+    boolean needUpdateFieldFormats() {
+        if (needUpdateFieldFormats) {
+            needUpdateFieldFormats = false;
+            return true;
+        }
+        return false;
+    }
+
+
+    public boolean hasBinaryFields() {
+        return hasBinaryFields;
+    }
+
+    public void setHasBinaryFields(boolean hasBinaryFields) {
+        this.hasBinaryFields = hasBinaryFields;
     }
 
     // Have we sent a Describe Portal message for this query yet?
@@ -249,6 +274,8 @@ class SimpleQuery implements V3Query {
      * statement. Always null for non-prepared statements.
      */
     private Field[] fields;
+    private boolean needUpdateFieldFormats;
+    private boolean hasBinaryFields;
     private boolean portalDescribed;
     private boolean statementDescribed;
     private PhantomReference cleanupRef;

--- a/org/postgresql/test/jdbc4/BinaryTest.java
+++ b/org/postgresql/test/jdbc4/BinaryTest.java
@@ -114,6 +114,20 @@ public class BinaryTest extends TestCase {
         ((PGStatement) statement).setPrepareThreshold(5);
     }
 
+    public void testReceiveBinary() throws Exception
+    {
+        PreparedStatement ps = connection.prepareStatement("select ?");
+        for (int i = 0; i < 10; i++)
+        {
+            ps.setInt(1, 42 + i);
+            ResultSet rs = ps.executeQuery();
+            assertEquals("One row should be returned", true, rs.next());
+            assertEquals(42 + i, rs.getInt(1));
+            rs.close();
+        }
+        ps.close();
+    }
+
     private int getFormat(ResultSet results) throws SQLException {
         return ((PGResultSetMetaData) results.getMetaData()).getFormat(1);
     }


### PR DESCRIPTION
When using prepared statement, field format needs to be computed only once.