### PR TITLE
feat: Improved composite/array type support and type naming changes.

### DIFF
--- a/org/postgresql/jdbc2/AbstractJdbc2Array.java
+++ b/org/postgresql/jdbc2/AbstractJdbc2Array.java
@@ -762,6 +762,25 @@ public abstract class AbstractJdbc2Array
             }
         }
 
+        else if (dims == 1)
+        {
+            Object[] oa = new Object[count];
+            String typeName = getBaseTypeName();
+            for (; count > 0; count--)
+            {
+                Object v = input.get(index++);
+                if (v instanceof String) {
+                    oa[length++] = connection.getObject(typeName, (String) v, null);
+                } else if (v instanceof byte[]) {
+                    oa[length++] = connection.getObject(typeName, null, (byte[])v);
+                } else if (v == null) {
+                    oa[length++] = null;
+                } else {
+                    throw org.postgresql.Driver.notImplemented(this.getClass(), "getArrayImpl(long,int,Map)");
+                }
+            }
+            ret = oa;
+        }
         // other datatypes not currently supported
         else
         {

--- a/org/postgresql/jdbc2/AbstractJdbc2Statement.java
+++ b/org/postgresql/jdbc2/AbstractJdbc2Statement.java
@@ -3061,9 +3061,8 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
         // from ResultSet.getArray(). Eventually we need a proper implementation
         // here that works for any Array implementation.
 
-        // Use a typename that is "_" plus the base type; this matches how the
-        // backend looks for array types.
-        String typename = "_" + x.getBaseTypeName();
+        // Add special suffix for array identification
+        String typename = x.getBaseTypeName() + "[]";
         int oid = connection.getTypeInfo().getPGType(typename);
         if (oid == Oid.UNSPECIFIED)
             throw new PSQLException(GT.tr("Unknown type {0}.", typename), PSQLState.INVALID_PARAMETER_TYPE);

--- a/org/postgresql/test/TestUtil.java
+++ b/org/postgresql/test/TestUtil.java
@@ -372,6 +372,33 @@ public class TestUtil
         }
     }
 
+    /**
+     * Helper creates an composite type
+     * @param con Connection
+     * @param name String
+     * @param values String
+     * @throws SQLException
+     */
+
+    public static void createCompositeType( Connection con,
+                                            String name,
+                                            String values) throws SQLException
+    {
+        Statement st = con.createStatement();
+        try
+        {
+            dropType(con, name);
+
+
+            // Now create the table
+            st.executeUpdate("create type " + name + " as (" + values + ")");
+        }
+        finally
+        {
+            st.close();
+        }
+    }
+
     /*
      * drop a sequence because older versions don't have dependency
      * information for serials

--- a/org/postgresql/test/jdbc3/CompositeTest.java
+++ b/org/postgresql/test/jdbc3/CompositeTest.java
@@ -1,0 +1,129 @@
+/*-------------------------------------------------------------------------
+*
+* Copyright (c) 2007-2014, PostgreSQL Global Development Group
+*
+*
+*-------------------------------------------------------------------------
+*/
+package org.postgresql.test.jdbc3;
+
+import junit.framework.TestCase;
+import org.postgresql.test.TestUtil;
+import org.postgresql.util.PGobject;
+
+import java.sql.*;
+
+public class CompositeTest extends TestCase
+{
+
+    private Connection _conn;
+
+    public CompositeTest(String name) {
+        super(name);
+    }
+
+    protected void setUp() throws Exception {
+        _conn = TestUtil.openDB();
+        TestUtil.createSchema(_conn, "\"Composites\"");
+        TestUtil.createCompositeType(_conn, "simplecompositetest", "i int, d decimal, u uuid");
+        TestUtil.createCompositeType(_conn, "nestedcompositetest", "t text, s simplecompositetest");
+        TestUtil.createCompositeType(_conn, "\"Composites\".\"ComplexCompositeTest\"", "l bigint[], n nestedcompositetest[], s simplecompositetest");
+        TestUtil.createTable(_conn, "compositetabletest", "s simplecompositetest, cc \"Composites\".\"ComplexCompositeTest\"[]");
+    }
+
+    protected void tearDown() throws SQLException {
+        TestUtil.dropTable(_conn, "compositetabletest");
+        TestUtil.dropType(_conn, "\"Composites\".\"ComplexCompositeTest\"");
+        TestUtil.dropType(_conn, "nestedcompositetest");
+        TestUtil.dropType(_conn, "simplecompositetest");
+        TestUtil.dropSchema(_conn, "\"Composites\"");
+        TestUtil.closeDB(_conn);
+    }
+
+    public void testSimpleSelect() throws SQLException {
+        PreparedStatement pstmt = _conn.prepareStatement("SELECT '(1,2.2,)'::simplecompositetest");
+        ResultSet rs = pstmt.executeQuery();
+        assertTrue(rs.next());
+        PGobject pgo = (PGobject)rs.getObject(1);
+        assertEquals("simplecompositetest", pgo.getType());
+        assertEquals("(1,2.2,)", pgo.getValue());
+    }
+
+    public void testComplexSelect() throws SQLException {
+        PreparedStatement pstmt = _conn.prepareStatement("SELECT '(\"{1,2}\",{},\"(1,2.2,)\")'::\"Composites\".\"ComplexCompositeTest\"");
+        ResultSet rs = pstmt.executeQuery();
+        assertTrue(rs.next());
+        PGobject pgo = (PGobject)rs.getObject(1);
+        assertEquals("\"Composites\".\"ComplexCompositeTest\"", pgo.getType());
+        assertEquals("(\"{1,2}\",{},\"(1,2.2,)\")", pgo.getValue());
+    }
+
+    public void testSimpleArgumentSelect() throws SQLException {
+        PreparedStatement pstmt = _conn.prepareStatement("SELECT ?");
+        PGobject pgo = new PGobject();
+        pgo.setType("simplecompositetest");
+        pgo.setValue("(1,2.2,)");
+        pstmt.setObject(1, pgo);
+        ResultSet rs = pstmt.executeQuery();
+        assertTrue(rs.next());
+        PGobject pgo2 = (PGobject)rs.getObject(1);
+        assertEquals(pgo, pgo2);
+    }
+
+    public void testComplexArgumentSelect() throws SQLException {
+        PreparedStatement pstmt = _conn.prepareStatement("SELECT ?");
+        PGobject pgo = new PGobject();
+        pgo.setType("\"Composites\".\"ComplexCompositeTest\"");
+        pgo.setValue("(\"{1,2}\",{},\"(1,2.2,)\")");
+        pstmt.setObject(1, pgo);
+        ResultSet rs = pstmt.executeQuery();
+        assertTrue(rs.next());
+        PGobject pgo2 = (PGobject)rs.getObject(1);
+        assertEquals(pgo, pgo2);
+    }
+
+    public void testCompositeFromTable() throws SQLException {
+        PreparedStatement pstmt = _conn.prepareStatement("INSERT INTO compositetabletest VALUES(?, ?)");
+        PGobject pgo1 = new PGobject();
+        pgo1.setType("public.simplecompositetest");
+        pgo1.setValue("(1,2.2,)");
+        pstmt.setObject(1, pgo1);
+        String[] ctArr = new String[1];
+        ctArr[0] = "(\"{1,2}\",{},\"(1,2.2,)\")";
+        Array pgarr1 = _conn.createArrayOf("Composites.ComplexCompositeTest", ctArr);
+        pstmt.setArray(2, pgarr1);
+        int res = pstmt.executeUpdate();
+        assertEquals(1, res);
+        pstmt = _conn.prepareStatement("SELECT * FROM compositetabletest");
+        ResultSet rs = pstmt.executeQuery();
+        assertTrue(rs.next());
+        PGobject pgo2 = (PGobject)rs.getObject(1);
+        Array pgarr2 = (Array)rs.getObject(2);
+        assertEquals("public.simplecompositetest", pgo2.getType());
+        assertEquals("\"Composites\".\"ComplexCompositeTest\"", pgarr2.getBaseTypeName());
+        Object[] pgobjarr2 = (Object[])pgarr2.getArray();
+        assertEquals(1, pgobjarr2.length);
+        PGobject arr2Elem = (PGobject) pgobjarr2[0];
+        assertEquals("\"Composites\".\"ComplexCompositeTest\"", arr2Elem.getType());
+        assertEquals("(\"{1,2}\",{},\"(1,2.2,)\")", arr2Elem.getValue());
+        rs.close();
+        pstmt = _conn.prepareStatement("SELECT c FROM compositetabletest c");
+        rs = pstmt.executeQuery();
+        assertTrue(rs.next());
+        PGobject pgo3 = (PGobject)rs.getObject(1);
+        assertEquals("compositetabletest", pgo3.getType());
+        assertEquals("(\"(1,2.2,)\",\"{\"\"(\\\\\"\"{1,2}\\\\\"\",{},\\\\\"\"(1,2.2,)\\\\\"\")\"\"}\")", pgo3.getValue());
+    }
+
+    public void testNullArrayElement() throws SQLException {
+        PreparedStatement pstmt = _conn.prepareStatement("SELECT array[NULL, NULL]::compositetabletest[]");
+        ResultSet rs = pstmt.executeQuery();
+        assertTrue(rs.next());
+        Array arr = rs.getArray(1);
+        assertEquals("compositetabletest", arr.getBaseTypeName());
+        Object[] items = (Object[])arr.getArray();
+        assertEquals(2, items.length);
+        assertNull(items[0]);
+        assertNull(items[1]);
+    }
+}


### PR DESCRIPTION
Composite types can live if their own schema. This requires type name lookup to cope with it.
Names are case sensitive.
Added simple logic which will split schema/name when . is used.
Postgres allows for names which start with '_' ; therefore it is incorrect to assume array type will start with '_' , although that can be assumed for all builtin types.
Improve type detection and use '[]' suffix as array alias.
Make most of the code backward compatible so it uses old logic with '_' instead of '[]' on lookups and naming.
Relations which live in search_path will be registered using both simple and full name.
Simple arrays will be populated using connection.getObject if everything else fails (only 1-dim array are handled as such)

TODO: handle scenario when '"' is used inside schema or type name.