### PR TITLE
fix: use current_schema() for Connection#getSchema

### DIFF
--- a/org/postgresql/jdbc2/AbstractJdbc2Connection.java
+++ b/org/postgresql/jdbc2/AbstractJdbc2Connection.java
@@ -1323,31 +1323,6 @@ public abstract class AbstractJdbc2Connection implements BaseConnection
         this.disableColumnSanitiser = disableColumnSanitiser;
     }
 
-    public void setSchema(String schema) throws SQLException
-    {
-        checkClosed();
-        Statement stmt = createStatement();
-        try
-        {
-            if (schema != null)
-            {
-                StringBuilder sb = new StringBuilder();
-                sb.append("SET SESSION search_path TO '");
-                Utils.escapeLiteral(sb, schema, protoConnection.getStandardConformingStrings());
-                sb.append("'");
-                stmt.executeUpdate(sb.toString());
-            }
-            else
-            {
-                stmt.executeUpdate("SET SESSION search_path TO DEFAULT");
-            }
-        }
-        finally
-        {
-            stmt.close();
-        }
-    }
-
     protected void abort()
     {
        protoConnection.abort();


### PR DESCRIPTION
Previously the driver used "show search_path", however it might result into non-evaluated '$user' value

fixes #354