### PR TITLE
chore: teach release_notes.sh to identify PR ids out of merge commits

### DIFF
--- a/release_notes_filter.pl
+++ b/release_notes_filter.pl
@@ -1,4 +1,5 @@
 #!/bin/perl
+use strict;
 
 while(<>) {
   if ($_ !~ /@@@/) {
@@ -10,8 +11,14 @@ while(<>) {
   my $sha = @c[1];
   my $shortSha = @c[2];
   my $body = `git log --format='%B' -n 1 $sha`;
+  my $mergeSha = `git log  --reverse --ancestry-path --merges --format=%H $sha..HEAD | head -1`;
+  my $mergeSubject = `git log --format=%B -n 1 $mergeSha`;
+
   my $pr = '';
   if ($body =~ /(?:fix|fixes|close|closes) *#?(\d+)/) {
+    $pr = ' PR #'.$1;
+  }
+  if ($pr == '' && $mergeSubject =~ /Merge pull request #(\d+)/) {
     $pr = ' PR #'.$1;
   }
   print $subject.$pr." (".$shortSha.")\n";


### PR DESCRIPTION
Not all commit messages have PR ids, so the script needs to try finding merge commit

fixes #358