### PR TITLE
Deadlock after IO exception during copy cancel

### DIFF
--- a/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -731,6 +731,14 @@ public class QueryExecutorImpl implements QueryExecutor {
 
         } catch(IOException ioe) {
             throw new PSQLException(GT.tr("Database connection failed when canceling copy operation"), PSQLState.CONNECTION_FAILURE, ioe);
+        } finally {
+            // Need to ensure the lock isn't held anymore, or else
+            // future operations, rather than failing due to the
+            // broken connection, will simply hang waiting for this
+            // lock.
+            synchronized(this) {
+                if(hasLock(op)) unlock(op);
+            }
         }
 
         if (op instanceof CopyInImpl) {


### PR DESCRIPTION
During a copy, the query executor lock is taken and held until the copy
either completes successfully or is cancelled.  In the latter case, if
an IOException occurs during the cancel the lock can be left unreleased.
Afterward, no operation on the connection (e.g., a rollback in a finally
block) can even fail because it will wait for the lock to be released.

This can be easily reproduced by the following program, which uses COPY
to populate a single-column table.  Using `pg_terminate_backend` on the
COPY process while it is running will lead to the deadlock in the
rollback.

```java
import java.sql.Connection;
import java.sql.DriverManager;
import java.nio.charset.StandardCharsets;
import org.postgresql.PGConnection;
import org.postgresql.copy.CopyIn;

public class Main {
    public static void main(String[] args) throws Exception{
        Connection conn = DriverManager.getConnection("jdbc:postgresql://localhost/dbname", "user", "pwd");
        try {
            conn.setAutoCommit(false);
            // This takes the connection lock
            CopyIn copy = ((PGConnection)conn).getCopyAPI().copyIn("COPY breakpg FROM STDIN WITH (FORMAT csv)");
            try {
                int i = 0;
                while(true) {
                    byte[] row = (i++ + "\n").getBytes(StandardCharsets.UTF_8);
                    copy.writeToCopy(row, 0, row.length);
                }
            } catch(Exception e) {
                // When we get here the connection is broken, but the
                // CopyIn object still holds the connection lock.
                // The cancel would release it, only it tries to do
                // some IO first and so throws another exception.
                try {
                    if(copy.isActive()) copy.cancelCopy();
                } catch(Exception e2) {
                    e.addSuppressed(e2);
                    System.err.println("Caught an exception while cancelling the copy; the connection is now permanently locked");
                    e2.printStackTrace();
                    throw e;
                }
            } finally {
                System.err.println("Rolling back transaction.  This will never complete.");
                conn.rollback();
                System.err.println("Doesn't get here");
            }
        } finally {
            conn.close();
        }
    }
}
```