### PR TITLE
perf: improve setTimestamp, setTime, setDate performance

### DIFF
--- a/org/postgresql/jdbc2/AbstractJdbc2Statement.java
+++ b/org/postgresql/jdbc2/AbstractJdbc2Statement.java
@@ -3262,9 +3262,6 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
             return;
         }
         
-        if (cal != null)
-            cal = (Calendar)cal.clone();
-
         // We must use UNSPECIFIED here, or inserting a Date-with-timezone into a
         // timestamptz field does an unexpected rotation by the server's TimeZone:
         //
@@ -3297,9 +3294,6 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
             return;
         }
 
-        if (cal != null)
-            cal = (Calendar)cal.clone();
-
         int oid = Oid.UNSPECIFIED;
 
         // If a PGTime is used, we can define the OID explicitly.
@@ -3309,7 +3303,7 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
                 oid = Oid.TIME;
             } else {
                 oid = Oid.TIMETZ;
-                cal = (Calendar) pgTime.getCalendar().clone();
+                cal = pgTime.getCalendar();
             }
         }
 
@@ -3324,9 +3318,6 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
             setNull(i, Types.TIMESTAMP);
             return;
         }
-
-        if (cal != null)
-            cal = (Calendar)cal.clone();
 
         int oid = Oid.UNSPECIFIED;
 
@@ -3367,7 +3358,7 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
                 oid = Oid.TIMESTAMP;
             } else {
                 oid = Oid.TIMESTAMPTZ;
-                cal = (Calendar) pgTimestamp.getCalendar().clone();
+                cal = pgTimestamp.getCalendar();
             }
         }
 

--- a/ubenchmark/src/main/java/org/postgresql/benchmark/statement/BindTimestamp.java
+++ b/ubenchmark/src/main/java/org/postgresql/benchmark/statement/BindTimestamp.java
@@ -1,0 +1,73 @@
+/*-------------------------------------------------------------------------
+*
+* Copyright (c) 2003-2015, PostgreSQL Global Development Group
+*
+*
+*-------------------------------------------------------------------------
+*/
+package org.postgresql.benchmark.statement;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.postgresql.benchmark.profilers.FlightRecorderProfiler;
+import org.postgresql.util.ConnectionUtil;
+
+import java.sql.*;
+import java.util.Calendar;
+import java.util.Properties;
+import java.util.TimeZone;
+import java.util.concurrent.TimeUnit;
+
+@Fork(value = 1, jvmArgsPrepend = "-Xmx128m")
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class BindTimestamp {
+    private Connection connection;
+    private PreparedStatement ps;
+    private Timestamp ts = new Timestamp(System.currentTimeMillis());
+    private Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+
+    @Setup(Level.Trial)
+    public void setUp() throws SQLException {
+        Properties props = ConnectionUtil.getProperties();
+
+        connection = DriverManager.getConnection(ConnectionUtil.getURL(), props);
+        ps = connection.prepareStatement("select ?");
+    }
+
+    @TearDown(Level.Trial)
+    public void tearDown() throws SQLException {
+        ps.close();
+        connection.close();
+    }
+
+    @Benchmark
+    public Statement timestampLocal() throws SQLException {
+        ps.setTimestamp(1, ts);
+        return ps;
+    }
+
+    @Benchmark
+    public Statement timestampCal() throws SQLException {
+        ps.setTimestamp(1, ts, cal);
+        return ps;
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+                .include(BindTimestamp.class.getSimpleName())
+                .addProfiler(GCProfiler.class)
+                .addProfiler(FlightRecorderProfiler.class)
+                .detectJvmArgs()
+                .build();
+
+        new Runner(opt).run();
+    }
+}


### PR DESCRIPTION
Avoid Calendar cloning and Integer.toString in setCalendar. This improves setTimestamp from 0.8us to 0.2us

Before
```
Benchmark                                                      Mode  Cnt    Score     Error   Units
BindTimestamp.timestampCal                                     avgt    5  754,114 ±  91,625   ns/op
BindTimestamp.timestampCal:·gc.alloc.rate                      avgt    5  931,234 ± 111,715  MB/sec
BindTimestamp.timestampCal:·gc.alloc.rate.norm                 avgt    5  736,007 ±   0,061    B/op
BindTimestamp.timestampCal:·gc.churn.PS_Eden_Space             avgt    5  934,073 ±  86,972  MB/sec
BindTimestamp.timestampCal:·gc.churn.PS_Eden_Space.norm        avgt    5  738,410 ±  34,828    B/op
BindTimestamp.timestampCal:·gc.churn.PS_Survivor_Space         avgt    5    0,405 ±   0,189  MB/sec
BindTimestamp.timestampCal:·gc.churn.PS_Survivor_Space.norm    avgt    5    0,320 ±   0,170    B/op
BindTimestamp.timestampCal:·gc.count                           avgt    5  113,000            counts
BindTimestamp.timestampCal:·gc.time                            avgt    5   61,000                ms
BindTimestamp.timestampLocal                                   avgt    5  661,347 ±  30,940   ns/op
BindTimestamp.timestampLocal:·gc.alloc.rate                    avgt    5  346,037 ±  16,301  MB/sec
BindTimestamp.timestampLocal:·gc.alloc.rate.norm               avgt    5  240,007 ±   0,056    B/op
BindTimestamp.timestampLocal:·gc.churn.PS_Eden_Space           avgt    5  346,885 ±  39,791  MB/sec
BindTimestamp.timestampLocal:·gc.churn.PS_Eden_Space.norm      avgt    5  240,608 ±  27,597    B/op
BindTimestamp.timestampLocal:·gc.churn.PS_Survivor_Space       avgt    5    0,262 ±   0,183  MB/sec
BindTimestamp.timestampLocal:·gc.churn.PS_Survivor_Space.norm  avgt    5    0,182 ±   0,136    B/op
BindTimestamp.timestampLocal:·gc.count                         avgt    5   74,000            counts
BindTimestamp.timestampLocal:·gc.time                          avgt    5   40,000                ms
```

After:

```
Benchmark                                                      Mode  Cnt    Score    Error   Units
BindTimestamp.timestampCal                                     avgt    5  214,056 ± 15,606   ns/op
BindTimestamp.timestampCal:·gc.alloc.rate                      avgt    5  463,340 ± 33,136  MB/sec
BindTimestamp.timestampCal:·gc.alloc.rate.norm                 avgt    5  104,002 ±  0,018    B/op
BindTimestamp.timestampCal:·gc.churn.PS_Eden_Space             avgt    5  463,675 ± 59,896  MB/sec
BindTimestamp.timestampCal:·gc.churn.PS_Eden_Space.norm        avgt    5  104,087 ± 12,810    B/op
BindTimestamp.timestampCal:·gc.churn.PS_Survivor_Space         avgt    5    0,287 ±  0,428  MB/sec
BindTimestamp.timestampCal:·gc.churn.PS_Survivor_Space.norm    avgt    5    0,064 ±  0,093    B/op
BindTimestamp.timestampCal:·gc.count                           avgt    5   87,000           counts
BindTimestamp.timestampCal:·gc.time                            avgt    5   49,000               ms
BindTimestamp.timestampLocal                                   avgt    5  157,395 ±  8,393   ns/op
BindTimestamp.timestampLocal:·gc.alloc.rate                    avgt    5  630,067 ± 33,089  MB/sec
BindTimestamp.timestampLocal:·gc.alloc.rate.norm               avgt    5  104,002 ±  0,013    B/op
BindTimestamp.timestampLocal:·gc.churn.PS_Eden_Space           avgt    5  633,737 ± 43,571  MB/sec
BindTimestamp.timestampLocal:·gc.churn.PS_Eden_Space.norm      avgt    5  104,635 ± 11,285    B/op
BindTimestamp.timestampLocal:·gc.churn.PS_Survivor_Space       avgt    5    0,336 ±  0,427  MB/sec
BindTimestamp.timestampLocal:·gc.churn.PS_Survivor_Space.norm  avgt    5    0,055 ±  0,070    B/op
BindTimestamp.timestampLocal:·gc.count                         avgt    5   89,000           counts
BindTimestamp.timestampLocal:·gc.time                          avgt    5   49,000               ms
```