### PR TITLE
pref: improve executeBatch by avoiding statement-by-statement execution

### DIFF
--- a/org/postgresql/core/QueryExecutor.java
+++ b/org/postgresql/core/QueryExecutor.java
@@ -94,7 +94,7 @@ public interface QueryExecutor {
      * pipelined batches where we might need to detect mismatched result
      * types.
      */
-    static int QUERY_FORCE_DESCRIBE_PORTAL = 128;
+    static int QUERY_FORCE_DESCRIBE_PORTAL = 512;
 
     /**
      * Flag to disable batch execution when we expect results (generated keys)

--- a/ubenchmark/src/main/java/org/postgresql/benchmark/statement/InsertBatch.java
+++ b/ubenchmark/src/main/java/org/postgresql/benchmark/statement/InsertBatch.java
@@ -1,0 +1,98 @@
+/*-------------------------------------------------------------------------
+*
+* Copyright (c) 2003-2015, PostgreSQL Global Development Group
+*
+*
+*-------------------------------------------------------------------------
+*/
+package org.postgresql.benchmark.statement;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.postgresql.benchmark.profilers.FlightRecorderProfiler;
+import org.postgresql.util.ConnectionUtil;
+
+import java.sql.*;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+@Fork(value = 1, jvmArgsPrepend = "-Xmx128m")
+@Measurement(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+public class InsertBatch {
+    private Connection connection;
+    private PreparedStatement ps;
+    String[] strings;
+
+    @Param({"100"})
+    int nrows;
+
+    @Setup(Level.Trial)
+    public void setUp() throws SQLException {
+        Properties props = ConnectionUtil.getProperties();
+
+        connection = DriverManager.getConnection(ConnectionUtil.getURL(), props);
+        Statement s = connection.createStatement();;
+        try {
+            s.execute("drop table batch_perf_test");
+        } catch(SQLException e) {
+            /* ignore */
+        }
+        s.execute("create table batch_perf_test(a int4, b varchar(100), c int4)");
+        s.close();
+        ps = connection.prepareStatement("insert into batch_perf_test(a, b, c) values(?, ?, ?)");
+        strings = new String[nrows];
+        for (int i = 0; i < nrows; i++) {
+            strings[i] = "s" + i;
+        }
+    }
+
+    @TearDown(Level.Trial)
+    public void tearDown() throws SQLException {
+        ps.close();
+        Statement s = connection.createStatement();
+        s.execute("drop table batch_perf_test");
+        s.close();
+        connection.close();
+    }
+
+    @Benchmark
+    public int[] insertBatch() throws SQLException {
+        for (int i = 0; i < nrows; i++) {
+            ps.setInt(1, i);
+            ps.setString(2, strings[i]);
+            ps.setInt(3, i);
+            ps.addBatch();
+        }
+        return ps.executeBatch();
+    }
+
+    @Benchmark
+    public void insertExecute(Blackhole b) throws SQLException {
+        for (int i = 0; i < nrows; i++) {
+            ps.setInt(1, i);
+            ps.setString(2, strings[i]);
+            ps.setInt(3, i);
+            b.consume(ps.execute());
+        }
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+                .include(InsertBatch.class.getSimpleName())
+                .addProfiler(GCProfiler.class)
+//                .addProfiler(FlightRecorderProfiler.class)
+                .detectJvmArgs()
+                .build();
+
+        new Runner(opt).run();
+    }
+}


### PR DESCRIPTION
QUERY_FORCE_DESCRIBE_PORTAL shared the same value as QUERY_DISALLOW_BATCHING (128), so batching was effectively disabled.

For instance, simple insert batch for 100 rows improves from 15ms to 1ms (when testing against local postgresql). The same 100 rows take 15ms for non-batched insert.

Before
```
Benchmark                                                   (nrows)  Mode  Cnt      Score        Error   Units
InsertBatch.insertBatch                                         100  avgt   10     15,052 ±      2,501   ms/op
InsertBatch.insertBatch:·gc.alloc.rate                          100  avgt   10      3,408 ±      0,501  MB/sec
InsertBatch.insertBatch:·gc.alloc.rate.norm                     100  avgt   10  53319,755 ±    333,930    B/op
InsertBatch.insertBatch:·gc.churn.PS_Eden_Space                 100  avgt   10      6,351 ±     30,365  MB/sec
InsertBatch.insertBatch:·gc.churn.PS_Eden_Space.norm            100  avgt   10  91929,951 ± 439509,058    B/op
InsertBatch.insertBatch:·gc.count                               100  avgt   10      1,000               counts
InsertBatch.insertBatch:·gc.time                                100  avgt   10      2,000                   ms
InsertBatch.insertExecute                                       100  avgt   10     14,656 ±      2,628   ms/op
InsertBatch.insertExecute:·gc.alloc.rate                        100  avgt   10      2,940 ±      0,425  MB/sec
InsertBatch.insertExecute:·gc.alloc.rate.norm                   100  avgt   10  44744,617 ±     72,532    B/op
InsertBatch.insertExecute:·gc.churn.PS_Eden_Space               100  avgt   10      6,331 ±     30,268  MB/sec
InsertBatch.insertExecute:·gc.churn.PS_Eden_Space.norm          100  avgt   10  90687,654 ± 433569,747    B/op
InsertBatch.insertExecute:·gc.churn.PS_Survivor_Space           100  avgt   10      0,071 ±      0,338  MB/sec
InsertBatch.insertExecute:·gc.churn.PS_Survivor_Space.norm      100  avgt   10   1012,205 ±   4839,266    B/op
InsertBatch.insertExecute:·gc.count                             100  avgt   10      1,000               counts
InsertBatch.insertExecute:·gc.time                              100  avgt   10      2,000                   ms
```

After:

```
Benchmark                                                 (nrows)  Mode  Cnt      Score        Error   Units
InsertBatch.insertBatch                                       100  avgt   10      1,006 ±      0,062   ms/op
InsertBatch.insertBatch:·gc.alloc.rate                        100  avgt   10     50,430 ±      2,981  MB/sec
InsertBatch.insertBatch:·gc.alloc.rate.norm                   100  avgt   10  53217,819 ±      5,771    B/op
InsertBatch.insertBatch:·gc.churn.PS_Eden_Space               100  avgt   10     55,125 ±     36,402  MB/sec
InsertBatch.insertBatch:·gc.churn.PS_Eden_Space.norm          100  avgt   10  58251,483 ±  38141,313    B/op
InsertBatch.insertBatch:·gc.churn.PS_Survivor_Space           100  avgt   10      0,028 ±      0,081  MB/sec
InsertBatch.insertBatch:·gc.churn.PS_Survivor_Space.norm      100  avgt   10     28,787 ±     82,714    B/op
InsertBatch.insertBatch:·gc.count                             100  avgt   10     10,000               counts
InsertBatch.insertBatch:·gc.time                              100  avgt   10      5,000                   ms
InsertBatch.insertExecute                                     100  avgt   10     14,403 ±      1,150   ms/op
InsertBatch.insertExecute:·gc.alloc.rate                      100  avgt   10      2,810 ±      0,212  MB/sec
InsertBatch.insertExecute:·gc.alloc.rate.norm                 100  avgt   10  42344,836 ±     73,813    B/op
InsertBatch.insertExecute:·gc.churn.PS_Eden_Space             100  avgt   10      4,961 ±     23,719  MB/sec
InsertBatch.insertExecute:·gc.churn.PS_Eden_Space.norm        100  avgt   10  72817,778 ± 348135,430    B/op
InsertBatch.insertExecute:·gc.count                           100  avgt   10      1,000               counts
InsertBatch.insertExecute:·gc.time                            100  avgt   10      1,000                   ms
```