### PR TITLE
feat: ignore empty sub-queries in composite queries

### DIFF
--- a/org/postgresql/test/jdbc3/Jdbc3TestSuite.java
+++ b/org/postgresql/test/jdbc3/Jdbc3TestSuite.java
@@ -42,7 +42,7 @@ public class Jdbc3TestSuite extends TestSuite
         {
             ex.printStackTrace();
         }
-        
+        suite.addTestSuite(CompositeQueryParseTest.class);
         suite.addTestSuite(Jdbc3SavepointTest.class);
         suite.addTestSuite(TypesTest.class);
         suite.addTestSuite(ResultSetTest.class);


### PR DESCRIPTION
This allows having trailing "; ".
I'm not sure why users want that, however this seems to be the behavior of a previous pgjdbc version.

Note: I am not sure with the expected behavior in case of "empty queries". Alternative solution would be to throw human-understandable error that would tell user not to use empty queries (or semicolons).