### PR TITLE
fix: binary processing of Date/Time/Timestamps

### DIFF
--- a/org/postgresql/jdbc2/AbstractJdbc2Statement.java
+++ b/org/postgresql/jdbc2/AbstractJdbc2Statement.java
@@ -37,8 +37,6 @@ import java.sql.Time;
 import java.sql.Timestamp;
 import java.sql.Types;
 import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.GregorianCalendar;
 import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
@@ -3412,9 +3410,6 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
         if (callResult[i-1] == null)
             return null;
 
-        if (cal != null)
-            cal = (Calendar)cal.clone();
-
         String value = callResult[i-1].toString();
         return connection.getTimestampUtils().toDate(cal, value);
     }
@@ -3427,9 +3422,6 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
         if (callResult[i-1] == null)
             return null;
 
-        if (cal != null)
-            cal = (Calendar)cal.clone();
-
         String value = callResult[i-1].toString();
         return connection.getTimestampUtils().toTime(cal, value);
     }
@@ -3441,9 +3433,6 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
 
         if (callResult[i-1] == null)
             return null;
-
-        if (cal != null)
-            cal = (Calendar)cal.clone();
 
         String value = callResult[i-1].toString();
         return connection.getTimestampUtils().toTimestamp(cal, value);

--- a/org/postgresql/test/TestUtil.java
+++ b/org/postgresql/test/TestUtil.java
@@ -18,6 +18,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Properties;
 
+import org.postgresql.PGProperty;
 import org.postgresql.core.ServerVersion;
 import org.postgresql.core.Version;
 import org.postgresql.jdbc2.AbstractJdbc2Connection;
@@ -61,8 +62,7 @@ public class TestUtil
                                 + server + ":"
                                 + port + "/"
                                 + getDatabase() 
-                                + "?prepareThreshold=" + getPrepareThreshold()
-                                + "&loglevel=" + getLogLevel()
+                                + "?loglevel=" + getLogLevel()
                                 + protocolVersion
                                 + binaryTransfer
 								+ receiveBufferSize
@@ -223,6 +223,9 @@ public class TestUtil
 
         props.setProperty("user", getUser());
         props.setProperty("password", getPassword());
+        if (!props.containsKey(PGProperty.PREPARE_THRESHOLD.getName())) {
+            PGProperty.PREPARE_THRESHOLD.set(props, getPrepareThreshold());
+        }
 
         return DriverManager.getConnection(getURL(), props);
     }

--- a/ubenchmark/src/main/java/org/postgresql/benchmark/statement/ProcessResultSet.java
+++ b/ubenchmark/src/main/java/org/postgresql/benchmark/statement/ProcessResultSet.java
@@ -1,0 +1,123 @@
+package org.postgresql.benchmark.statement;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.postgresql.util.ConnectionUtil;
+
+import java.sql.*;
+import java.util.Properties;
+import java.util.TimeZone;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Tests the performance of preparing, executing and performing a fetch out of a simple "SELECT ?, ?, ... ?" statement.
+ */
+@Fork(value = 1, jvmArgsPrepend = "-Xmx128m")
+@Measurement(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+public class ProcessResultSet {
+    public enum FieldType {
+        INT,
+        BIGINT,
+        STRING,
+        TIMESTAMP,
+        TIMESTAMPTZ,
+    }
+
+    @Param({"1", "50", "100"})
+    private int nrows;
+
+    @Param({"5"})
+    private int ncols;
+
+    @Param
+    private FieldType type;
+
+    @Param({"false"})
+    public boolean unique;
+
+    private Connection connection;
+
+    private String sql;
+
+    private int cntr;
+
+    @Setup(Level.Trial)
+    public void setUp() throws SQLException {
+        if (type == FieldType.TIMESTAMP) {
+            System.out.println("TimeZone.getDefault().getDisplayName() = " + TimeZone.getDefault().getDisplayName());
+        }
+
+        Properties props = ConnectionUtil.getProperties();
+        connection = DriverManager.getConnection(ConnectionUtil.getURL(), props);
+        StringBuilder sb = new StringBuilder();
+        sb.append("SELECT ");
+        for (int i = 0; i < ncols; i++) {
+            if (i > 0) sb.append(", ");
+            if (type == FieldType.INT) {
+                sb.append("t.x");
+            } if (type == FieldType.BIGINT) {
+                sb.append("1234567890123456789");
+            } else if (type == FieldType.STRING) {
+                sb.append("'test string'");
+            } else if (type == FieldType.TIMESTAMP) {
+                sb.append("localtimestamp");
+            } else if (type == FieldType.TIMESTAMPTZ) {
+                sb.append("current_timestamp");
+            }
+            sb.append(" c").append(i);
+        }
+        sb.append(" from generate_series(1, ?) as t(x)");
+        sql = sb.toString();
+    }
+
+    @TearDown(Level.Trial)
+    public void tearDown() throws SQLException {
+        connection.close();
+    }
+
+    @Benchmark
+    public Statement bindExecuteFetch(Blackhole b) throws SQLException {
+        String sql = this.sql;
+        if (unique) sql += " -- " + cntr++;
+        PreparedStatement ps = connection.prepareStatement(sql);
+        ps.setInt(1, nrows);
+        ResultSet rs = ps.executeQuery();
+        while (rs.next()) {
+            for (int i = 1; i <= ncols; i++) {
+                if (type == FieldType.INT) {
+                    b.consume(rs.getInt(i));
+                } else if (type == FieldType.BIGINT) {
+                    b.consume(rs.getBigDecimal(i));
+                } else if (type == FieldType.STRING) {
+                    b.consume(rs.getString(i));
+                } else if (type == FieldType.TIMESTAMP) {
+                    b.consume(rs.getTimestamp(i));
+                } else if (type == FieldType.TIMESTAMPTZ) {
+                    b.consume(rs.getTimestamp(i));
+                }
+            }
+        }
+        rs.close();
+        ps.close();
+        return ps;
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+                .include(ProcessResultSet.class.getSimpleName())
+//                .addProfiler(GCProfiler.class)
+                .detectJvmArgs()
+                .build();
+
+        new Runner(opt).run();
+    }
+}

--- a/ubenchmark/src/main/java/org/postgresql/benchmark/time/TimestampToDate.java
+++ b/ubenchmark/src/main/java/org/postgresql/benchmark/time/TimestampToDate.java
@@ -1,0 +1,103 @@
+/*-------------------------------------------------------------------------
+*
+* Copyright (c) 2003-2015, PostgreSQL Global Development Group
+*
+*
+*-------------------------------------------------------------------------
+*/
+package org.postgresql.benchmark.time;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.sql.Date;
+import java.sql.Timestamp;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.TimeZone;
+import java.util.concurrent.TimeUnit;
+
+@Fork(value = 1, jvmArgsPrepend = "-Xmx128m")
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class TimestampToDate {
+    private static final long ONEDAY = TimeUnit.DAYS.toMillis(1);
+
+    @Param({"GMT+02:00", "Europe/Moscow"})
+    String tz;
+    TimeZone timeZone;
+
+    Timestamp ts = new Timestamp(System.currentTimeMillis());
+    Calendar cachedCalendar = new GregorianCalendar();
+
+    @Setup
+    public void init() {
+        timeZone = TimeZone.getTimeZone(tz);
+    }
+
+    @Benchmark
+    public long simple() {
+        long millis = ts.getTime() + 10;
+        ts.setTime(millis);
+        Calendar cal = cachedCalendar;
+        cal.setTimeZone(timeZone);
+        cal.setTimeInMillis(millis);
+        cal.set(Calendar.HOUR_OF_DAY, 0);
+        cal.set(Calendar.MINUTE, 0);
+        cal.set(Calendar.SECOND, 0);
+        cal.set(Calendar.MILLISECOND, 0);
+        return cal.getTimeInMillis();
+    }
+
+    private static boolean isSimpleTimeZone(String id)
+    {
+        return id.startsWith("GMT") || id.startsWith("UTC");
+    }
+
+    @Benchmark
+    public long advanced() {
+        long millis = ts.getTime() + 10;
+        TimeZone tz = this.timeZone;
+        if (isSimpleTimeZone(tz.getID()))
+        {
+            // Truncate to 00:00 of the day.
+            // Suppose the input date is 7 Jan 15:40 GMT+02:00 (that is 13:40 UTC)
+            // We want it to become 7 Jan 00:00 GMT+02:00
+            // 1) Make sure millis becomes 15:40 in UTC, so add offset
+            int offset = tz.getRawOffset();
+            millis += offset;
+            // 2) Truncate hours, minutes, etc. Day is always 86400 seconds, no matter what leap seconds are
+            millis = millis / ONEDAY * ONEDAY;
+            // 2) Now millis is 7 Jan 00:00 UTC, however we need that in GMT+02:00, so subtract some offset
+            millis -= offset;
+            // Now we have brand-new 7 Jan 00:00 GMT+02:00
+            return millis;
+        }
+        Calendar cal = cachedCalendar;
+        cal.setTimeZone(tz);
+        cal.setTimeInMillis(millis);
+        cal.set(Calendar.HOUR_OF_DAY, 0);
+        cal.set(Calendar.MINUTE, 0);
+        cal.set(Calendar.SECOND, 0);
+        cal.set(Calendar.MILLISECOND, 0);
+        return cal.getTimeInMillis();
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+                .include(TimestampToDate.class.getSimpleName())
+//                .addProfiler(GCProfiler.class)
+//                .addProfiler(FlightRecorderProfiler.class)
+                .detectJvmArgs()
+                .build();
+
+        new Runner(opt).run();
+    }
+
+}

--- a/ubenchmark/src/main/java/org/postgresql/benchmark/time/TimestampToTime.java
+++ b/ubenchmark/src/main/java/org/postgresql/benchmark/time/TimestampToTime.java
@@ -1,0 +1,103 @@
+/*-------------------------------------------------------------------------
+*
+* Copyright (c) 2003-2015, PostgreSQL Global Development Group
+*
+*
+*-------------------------------------------------------------------------
+*/
+package org.postgresql.benchmark.time;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.sql.Timestamp;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.TimeZone;
+import java.util.concurrent.TimeUnit;
+
+@Fork(value = 1, jvmArgsPrepend = "-Xmx128m")
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class TimestampToTime {
+    private static final long ONEDAY = TimeUnit.DAYS.toMillis(1);
+
+    @Param({"GMT+02:00", "Europe/Moscow"})
+    String tz;
+    TimeZone timeZone;
+
+    Timestamp ts = new Timestamp(System.currentTimeMillis());
+    Calendar cachedCalendar = new GregorianCalendar();
+
+    @Setup
+    public void init() {
+        timeZone = TimeZone.getTimeZone(tz);
+    }
+
+    @Benchmark
+    public long simple() {
+        long millis = ts.getTime() + 10;
+        ts.setTime(millis);
+        Calendar cal = cachedCalendar;
+        cal.setTimeZone(timeZone);
+        cal.setTimeInMillis(millis);
+        cal.set(Calendar.ERA,          GregorianCalendar.AD);
+        cal.set(Calendar.YEAR,         1970);
+        cal.set(Calendar.MONTH,        0);
+        cal.set(Calendar.DAY_OF_MONTH, 1);
+        return cal.getTimeInMillis();
+    }
+
+    private static boolean isSimpleTimeZone(String id)
+    {
+        return id.startsWith("GMT") || id.startsWith("UTC");
+    }
+
+    @Benchmark
+    public long advanced() {
+        long millis = ts.getTime() + 10;
+        TimeZone tz = this.timeZone;
+        if (isSimpleTimeZone(tz.getID()))
+        {
+            // Leave just time part of the day.
+            // Suppose the input date is 2015 7 Jan 15:40 GMT+02:00 (that is 13:40 UTC)
+            // We want it to become 1970 1 Jan 15:40 GMT+02:00
+            // 1) Make sure millis becomes 15:40 in UTC, so add offset
+            int offset = tz.getRawOffset();
+            millis += offset;
+            // 2) Truncate year, month, day. Day is always 86400 seconds, no matter what leap seconds are
+            millis = millis % ONEDAY;
+            // 2) Now millis is 1970 1 Jan 15:40 UTC, however we need that in GMT+02:00, so subtract some offset
+            millis -= offset;
+            // Now we have brand-new 1970 1 Jan 15:40 GMT+02:00
+            return millis;
+        }
+        ts.setTime(millis);
+        Calendar cal = cachedCalendar;
+        cal.setTimeZone(tz);
+        cal.setTimeInMillis(millis);
+        cal.set(Calendar.ERA,          GregorianCalendar.AD);
+        cal.set(Calendar.YEAR,         1970);
+        cal.set(Calendar.MONTH,        0);
+        cal.set(Calendar.DAY_OF_MONTH, 1);
+        return cal.getTimeInMillis();
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+                .include(TimestampToTime.class.getSimpleName())
+//                .addProfiler(GCProfiler.class)
+//                .addProfiler(FlightRecorderProfiler.class)
+                .detectJvmArgs()
+                .build();
+
+        new Runner(opt).run();
+    }
+
+}


### PR DESCRIPTION
This is a follow-up on #376.
I force TimezoneTest to test both text and binary encoding and it makes 

It looks like this PR fixes all known problems with Timestamp/Date/Time parsing.
I wish someone could add more tests.

Here are the measurements (jdk 1.8u60, OS X 10.11, Intel(R) Core(TM) i7-4960HQ CPU @ 2.60GHz, time zone == Europe/Moscow, local postgresql 9.4).
The test is to perform and fully fetch a query like `select localtimestamp c0, localtimestamp c1, ... from generate_series(1, ?) as t(x)`: https://github.com/pgjdbc/pgjdbc/pull/387/files#diff-962be0de5c547f8cb43ea8efd768dccaR88

Notes:
1) There is a slight degradation of `getTimestamp` when selecting `localtimestamp` if compared with 1203. I believe the degradation is due to more complex logic in `TimestampUtil.guessTimestamp`.
I believe it is not a showstopper as I see no alternative solution there: https://github.com/pgjdbc/pgjdbc/pull/387/files#diff-d3ce26f4020b4504cf0a8ef2e019b316R699
2) If timezone is provided by backend (or if is requested as `GMT+-XX:...`), the performance is better: 130us vs 350us for 100 rows x 5 columns test. No degradation here if compared with 1203
3) BIGINT is somewhat slow. The case is `getBigDecimal` for `1234567890123456789`
4) 1201 is the slowest in all the cases
5) Caching of `TimeZone.getDefault()` does not buy much, thus I switched to `TimeZone.getDefault()` when needed. So pgjdbc supports "default timezone" changes.
6) pgjdbc is somewhat slower than pgjdbc-ng for receiving BIGINT and sometimes TIMESTAMP. Otherwise, pgjdbc is like twice as fast as pgjdbc-ng.

With current fix:
```
Benchmark                          (ncols)  (nrows)       (type)  Mode  Cnt    Score   Error  Units
ProcessResultSet.bindExecuteFetch        5        1          INT  avgt   10   44,268 ± 1,090  us/op
ProcessResultSet.bindExecuteFetch        5        1       BIGINT  avgt   10   47,229 ± 0,400  us/op
ProcessResultSet.bindExecuteFetch        5        1       STRING  avgt   10   45,106 ± 0,541  us/op
ProcessResultSet.bindExecuteFetch        5        1    TIMESTAMP  avgt   10   50,908 ± 0,930  us/op
ProcessResultSet.bindExecuteFetch        5        1  TIMESTAMPTZ  avgt   10   46,002 ± 0,815  us/op
ProcessResultSet.bindExecuteFetch        5       50          INT  avgt   10   77,516 ± 0,771  us/op
ProcessResultSet.bindExecuteFetch        5       50       BIGINT  avgt   10  210,191 ± 2,177  us/op
ProcessResultSet.bindExecuteFetch        5       50       STRING  avgt   10   87,583 ± 1,627  us/op
ProcessResultSet.bindExecuteFetch        5       50    TIMESTAMP  avgt   10  189,531 ± 1,372  us/op
ProcessResultSet.bindExecuteFetch        5       50  TIMESTAMPTZ  avgt   10   86,771 ± 0,690  us/op
ProcessResultSet.bindExecuteFetch        5      100          INT  avgt   10  114,029 ± 1,062  us/op
ProcessResultSet.bindExecuteFetch        5      100       BIGINT  avgt   10  398,847 ± 4,706  us/op
ProcessResultSet.bindExecuteFetch        5      100       STRING  avgt   10  123,094 ± 0,944  us/op
ProcessResultSet.bindExecuteFetch        5      100    TIMESTAMP  avgt   10  360,408 ± 4,311  us/op
ProcessResultSet.bindExecuteFetch        5      100  TIMESTAMPTZ  avgt   10  131,307 ± 1,544  us/op
```

With caching of `TimeZone.getDefault()` (like in previous pgjdbc versions):
```
Benchmark                          (ncols)  (nrows)       (type)  Mode  Cnt    Score   Error  Units
ProcessResultSet.bindExecuteFetch        5        1    TIMESTAMP  avgt   10   48,748 ± 0,423  us/op
ProcessResultSet.bindExecuteFetch        5        1  TIMESTAMPTZ  avgt   10   46,089 ± 0,491  us/op
ProcessResultSet.bindExecuteFetch        5       50    TIMESTAMP  avgt   10  187,591 ± 1,812  us/op
ProcessResultSet.bindExecuteFetch        5       50  TIMESTAMPTZ  avgt   10   86,319 ± 0,990  us/op
ProcessResultSet.bindExecuteFetch        5      100    TIMESTAMP  avgt   10  353,440 ± 4,387  us/op
ProcessResultSet.bindExecuteFetch        5      100  TIMESTAMPTZ  avgt   10  131,478 ± 1,669  us/op
```



1203 (2014-09-18, a0bafcd8158b1):
```
Benchmark                          (ncols)  (nrows)       (type)  Mode  Cnt    Score   Error  Units
ProcessResultSet.bindExecuteFetch        5        1          INT  avgt   10   43,859 ± 0,304  us/op
ProcessResultSet.bindExecuteFetch        5        1       BIGINT  avgt   10   47,499 ± 0,737  us/op
ProcessResultSet.bindExecuteFetch        5        1       STRING  avgt   10   44,528 ± 0,820  us/op
ProcessResultSet.bindExecuteFetch        5        1    TIMESTAMP  avgt   10   48,178 ± 0,493  us/op
ProcessResultSet.bindExecuteFetch        5        1  TIMESTAMPTZ  avgt   10   45,336 ± 0,544  us/op
ProcessResultSet.bindExecuteFetch        5       50          INT  avgt   10   76,734 ± 0,767  us/op
ProcessResultSet.bindExecuteFetch        5       50       BIGINT  avgt   10  208,770 ± 2,250  us/op
ProcessResultSet.bindExecuteFetch        5       50       STRING  avgt   10   87,040 ± 0,606  us/op
ProcessResultSet.bindExecuteFetch        5       50    TIMESTAMP  avgt   10  149,451 ± 1,147  us/op
ProcessResultSet.bindExecuteFetch        5       50  TIMESTAMPTZ  avgt   10   86,390 ± 0,796  us/op
ProcessResultSet.bindExecuteFetch        5      100          INT  avgt   10  112,417 ± 1,183  us/op
ProcessResultSet.bindExecuteFetch        5      100       BIGINT  avgt   10  390,190 ± 5,070  us/op
ProcessResultSet.bindExecuteFetch        5      100       STRING  avgt   10  123,966 ± 1,410  us/op
ProcessResultSet.bindExecuteFetch        5      100    TIMESTAMP  avgt   10  263,847 ± 3,001  us/op
ProcessResultSet.bindExecuteFetch        5      100  TIMESTAMPTZ  avgt   10  131,515 ± 2,472  us/op
```

1201 (2015-02-28, a4f8c9ecfe0cf8):
```
Benchmark                          (ncols)  (nrows)       (type)  Mode  Cnt    Score   Error  Units
ProcessResultSet.bindExecuteFetch        5        1          INT  avgt   10   81,928 ± 2,433  us/op
ProcessResultSet.bindExecuteFetch        5        1       BIGINT  avgt   10   84,142 ± 1,656  us/op
ProcessResultSet.bindExecuteFetch        5        1       STRING  avgt   10   81,131 ± 0,537  us/op
ProcessResultSet.bindExecuteFetch        5        1    TIMESTAMP  avgt   10  110,941 ± 1,069  us/op
ProcessResultSet.bindExecuteFetch        5        1  TIMESTAMPTZ  avgt   10   94,211 ± 1,269  us/op
ProcessResultSet.bindExecuteFetch        5       50          INT  avgt   10  118,746 ± 1,309  us/op
ProcessResultSet.bindExecuteFetch        5       50       BIGINT  avgt   10  204,295 ± 2,628  us/op
ProcessResultSet.bindExecuteFetch        5       50       STRING  avgt   10  131,523 ± 3,601  us/op
ProcessResultSet.bindExecuteFetch        5       50    TIMESTAMP  avgt   10  446,562 ± 4,103  us/op
ProcessResultSet.bindExecuteFetch        5       50  TIMESTAMPTZ  avgt   10  396,859 ± 6,574  us/op
ProcessResultSet.bindExecuteFetch        5      100          INT  avgt   10  156,238 ± 1,413  us/op
ProcessResultSet.bindExecuteFetch        5      100       BIGINT  avgt   10  289,011 ± 2,651  us/op
ProcessResultSet.bindExecuteFetch        5      100       STRING  avgt   10  157,809 ± 1,809  us/op
ProcessResultSet.bindExecuteFetch        5      100    TIMESTAMP  avgt   10  730,901 ± 7,670  us/op
ProcessResultSet.bindExecuteFetch        5      100  TIMESTAMPTZ  avgt   10  677,107 ± 5,350  us/op
```

pgjdbc-ng 0.6-SNAPSHOT (2015-10-09, https://github.com/impossibl/pgjdbc-ng/commit/1f8cdcb6f8f75b012fb37763ea8caefd29835dd4)
```
Benchmark                          (ncols)  (nrows)       (type)  Mode  Cnt    Score    Error  Units
ProcessResultSet.bindExecuteFetch        5        1          INT  avgt   10  107,731 ±  1,419  us/op
ProcessResultSet.bindExecuteFetch        5        1       BIGINT  avgt   10  108,796 ±  1,502  us/op
ProcessResultSet.bindExecuteFetch        5        1       STRING  avgt   10  107,165 ±  1,532  us/op
ProcessResultSet.bindExecuteFetch        5        1    TIMESTAMP  avgt   10  112,654 ±  1,862  us/op
ProcessResultSet.bindExecuteFetch        5        1  TIMESTAMPTZ  avgt   10  111,331 ±  5,782  us/op
ProcessResultSet.bindExecuteFetch        5       50          INT  avgt   10  145,734 ±  2,173  us/op
ProcessResultSet.bindExecuteFetch        5       50       BIGINT  avgt   10  209,057 ±  2,261  us/op
ProcessResultSet.bindExecuteFetch        5       50       STRING  avgt   10  167,522 ±  2,010  us/op
ProcessResultSet.bindExecuteFetch        5       50    TIMESTAMP  avgt   10  276,840 ±  5,459  us/op
ProcessResultSet.bindExecuteFetch        5       50  TIMESTAMPTZ  avgt   10  219,972 ±  1,909  us/op
ProcessResultSet.bindExecuteFetch        5      100          INT  avgt   10  187,370 ±  4,903  us/op
ProcessResultSet.bindExecuteFetch        5      100       BIGINT  avgt   10  302,751 ±  3,111  us/op
ProcessResultSet.bindExecuteFetch        5      100       STRING  avgt   10  214,831 ±  3,807  us/op
ProcessResultSet.bindExecuteFetch        5      100    TIMESTAMP  avgt   10  477,054 ± 10,552  us/op
ProcessResultSet.bindExecuteFetch        5      100  TIMESTAMPTZ  avgt   10  329,831 ±  2,572  us/op
```

pgjdbc-ng 0.6, "do not close preparedstatement test"
```
Benchmark                          (ncols)  (nrows)       (type)  Mode  Cnt    Score   Error  Units
ProcessResultSet.bindExecuteFetch        5        1          INT  avgt   10   83,651 ± 0,619  us/op
ProcessResultSet.bindExecuteFetch        5        1       BIGINT  avgt   10   85,302 ± 1,135  us/op
ProcessResultSet.bindExecuteFetch        5        1       STRING  avgt   10   84,268 ± 1,074  us/op
ProcessResultSet.bindExecuteFetch        5        1    TIMESTAMP  avgt   10   92,074 ± 1,756  us/op
ProcessResultSet.bindExecuteFetch        5        1  TIMESTAMPTZ  avgt   10   89,613 ± 3,663  us/op
ProcessResultSet.bindExecuteFetch        5       50          INT  avgt   10  122,788 ± 2,616  us/op
ProcessResultSet.bindExecuteFetch        5       50       BIGINT  avgt   10  183,256 ± 1,257  us/op
ProcessResultSet.bindExecuteFetch        5       50       STRING  avgt   10  143,807 ± 2,142  us/op
ProcessResultSet.bindExecuteFetch        5       50    TIMESTAMP  avgt   10  251,899 ± 3,357  us/op
ProcessResultSet.bindExecuteFetch        5       50  TIMESTAMPTZ  avgt   10  196,308 ± 1,799  us/op
ProcessResultSet.bindExecuteFetch        5      100          INT  avgt   10  161,394 ± 1,482  us/op
ProcessResultSet.bindExecuteFetch        5      100       BIGINT  avgt   10  277,571 ± 3,665  us/op
ProcessResultSet.bindExecuteFetch        5      100       STRING  avgt   10  191,090 ± 5,264  us/op
ProcessResultSet.bindExecuteFetch        5      100    TIMESTAMP  avgt   10  444,816 ± 4,581  us/op
ProcessResultSet.bindExecuteFetch        5      100  TIMESTAMPTZ  avgt   10  306,673 ± 2,182  us/op
```

pgjdbc-ng 0.5 (2015-04-30, https://github.com/impossibl/pgjdbc-ng/commit/9cefd79504f98a73021b9cfbf9e346e9c8437568)
```
Benchmark                          (ncols)  (nrows)       (type)  Mode  Cnt    Score   Error  Units
ProcessResultSet.bindExecuteFetch        5        1          INT  avgt   10  106,952 ± 1,894  us/op
ProcessResultSet.bindExecuteFetch        5        1       BIGINT  avgt   10  109,359 ± 3,502  us/op
ProcessResultSet.bindExecuteFetch        5        1       STRING  avgt   10  108,511 ± 2,270  us/op
ProcessResultSet.bindExecuteFetch        5        1    TIMESTAMP  avgt   10  112,952 ± 2,138  us/op
ProcessResultSet.bindExecuteFetch        5        1  TIMESTAMPTZ  avgt   10  109,572 ± 2,632  us/op
ProcessResultSet.bindExecuteFetch        5       50          INT  avgt   10  150,396 ± 6,917  us/op
ProcessResultSet.bindExecuteFetch        5       50       BIGINT  avgt   10  205,146 ± 2,679  us/op
ProcessResultSet.bindExecuteFetch        5       50       STRING  avgt   10  168,976 ± 2,761  us/op
ProcessResultSet.bindExecuteFetch        5       50    TIMESTAMP  avgt   10  277,680 ± 3,604  us/op
ProcessResultSet.bindExecuteFetch        5       50  TIMESTAMPTZ  avgt   10  221,149 ± 2,832  us/op
ProcessResultSet.bindExecuteFetch        5      100          INT  avgt   10  187,435 ± 2,364  us/op
ProcessResultSet.bindExecuteFetch        5      100       BIGINT  avgt   10  298,107 ± 2,482  us/op
ProcessResultSet.bindExecuteFetch        5      100       STRING  avgt   10  217,826 ± 1,990  us/op
ProcessResultSet.bindExecuteFetch        5      100    TIMESTAMP  avgt   10  476,290 ± 7,048  us/op
ProcessResultSet.bindExecuteFetch        5      100  TIMESTAMPTZ  avgt   10  330,508 ± 3,006  us/op
```