### PR TITLE
fix: abort connection on I/O error instead of closing

### DIFF
--- a/org/postgresql/core/ProtocolConnection.java
+++ b/org/postgresql/core/ProtocolConnection.java
@@ -148,4 +148,11 @@ public interface ProtocolConnection {
      * Return the process ID (PID) of the backend server process handling this connection.
      */
     public int getBackendPID();
+    
+    /**
+     * Do not attempt to send anything to the backend, just close the underlying connection 
+     * and mark the protocol closed 
+     * 
+     */
+    public void abort();
 }

--- a/org/postgresql/core/v2/ProtocolConnectionImpl.java
+++ b/org/postgresql/core/v2/ProtocolConnectionImpl.java
@@ -143,6 +143,23 @@ class ProtocolConnectionImpl implements ProtocolConnection {
         closed = true;
     }
 
+    /*
+     * (non-Javadoc)
+     * @see org.postgresql.core.ProtocolConnection#abort()
+     */
+    public void abort() 
+    {
+        try
+        {
+            pgStream.getSocket().close();
+        }
+        catch (IOException e)
+        {
+            // ignore
+        }
+        closed = true;
+    }
+    
     public Encoding getEncoding() {
         return pgStream.getEncoding();
     }

--- a/org/postgresql/core/v2/QueryExecutorImpl.java
+++ b/org/postgresql/core/v2/QueryExecutorImpl.java
@@ -365,7 +365,7 @@ public class QueryExecutorImpl implements QueryExecutor {
         }
         catch (IOException e)
         {
-            protoConnection.close();
+            protoConnection.abort();
             handler.handleError(new PSQLException(GT.tr("An I/O error occurred while sending to the backend."), PSQLState.CONNECTION_FAILURE, e));
         }
 

--- a/org/postgresql/core/v3/ProtocolConnectionImpl.java
+++ b/org/postgresql/core/v3/ProtocolConnectionImpl.java
@@ -147,6 +147,23 @@ class ProtocolConnectionImpl implements ProtocolConnection {
         closed = true;
     }
 
+    /*
+     * (non-Javadoc)
+     * @see org.postgresql.core.ProtocolConnection#abort()
+     */
+    public void abort() 
+    {
+        try
+        {
+            pgStream.getSocket().close();
+        }
+        catch (IOException e)
+        {
+            // ignore
+        }
+        closed = true;
+    }
+    
     public Encoding getEncoding() {
         return pgStream.getEncoding();
     }

--- a/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -277,7 +277,7 @@ public class QueryExecutorImpl implements QueryExecutor {
         }
         catch (IOException e)
         {
-            protoConnection.close();
+            protoConnection.abort();
             handler.handleError(new PSQLException(GT.tr("An I/O error occurred while sending to the backend."), PSQLState.CONNECTION_FAILURE, e));
         }
 
@@ -407,7 +407,7 @@ public class QueryExecutorImpl implements QueryExecutor {
         }
         catch (IOException e)
         {
-            protoConnection.close();
+            protoConnection.abort();
             handler.handleError(new PSQLException(GT.tr("An I/O error occurred while sending to the backend."), PSQLState.CONNECTION_FAILURE, e));
         }
 
@@ -485,7 +485,7 @@ public class QueryExecutorImpl implements QueryExecutor {
         }
         catch (IOException ioe)
         {
-            protoConnection.close();
+            protoConnection.abort();
             throw new PSQLException(GT.tr("An I/O error occurred while sending to the backend."), PSQLState.CONNECTION_FAILURE, ioe);
         }
     }
@@ -2131,7 +2131,7 @@ public class QueryExecutorImpl implements QueryExecutor {
         }
         catch (IOException e)
         {
-            protoConnection.close();
+            protoConnection.abort();
             handler.handleError(new PSQLException(GT.tr("An I/O error occurred while sending to the backend."), PSQLState.CONNECTION_FAILURE, e));
         }
 


### PR DESCRIPTION
Fixes a situation where the backend aborts ungracefully. It appears the backend does not attempt to close the connection which leaves the socket "half" open. We just abort and close the underlying socket