### PR TITLE
fix: use UTF-8 instead of US-ASCII for initial encoding

### DIFF
--- a/org/postgresql/core/PGStream.java
+++ b/org/postgresql/core/PGStream.java
@@ -60,7 +60,7 @@ public class PGStream
         Socket socket = new Socket();
         socket.connect(new InetSocketAddress(hostSpec.getHost(), hostSpec.getPort()), timeout);
         changeSocket(socket);
-        setEncoding(Encoding.getJVMEncoding("US-ASCII"));
+        setEncoding(Encoding.getJVMEncoding("UTF-8"));
 
         _int2buf = new byte[2];
         _int4buf = new byte[4];


### PR DESCRIPTION
If lc_messages is set to a language which uses UTF-8 then connections which fail garble messages