### PR TITLE
fix: Improve type detection with casing issues.

### DIFF
--- a/org/postgresql/jdbc4/AbstractJdbc4Connection.java
+++ b/org/postgresql/jdbc4/AbstractJdbc4Connection.java
@@ -100,8 +100,7 @@ public abstract class AbstractJdbc4Connection extends org.postgresql.jdbc3g.Abst
     {
         checkClosed();
 
-        // coerce to lower case to handle upper case type names
-        int oid = getTypeInfo().getPGArrayType(typeName.toLowerCase());
+        int oid = getTypeInfo().getPGArrayType(typeName);
 
         if (oid == Oid.UNSPECIFIED)
             throw new PSQLException(GT.tr("Unable to find server array type for provided name {0}.", typeName), PSQLState.INVALID_NAME);

--- a/org/postgresql/test/jdbc3/CompositeTest.java
+++ b/org/postgresql/test/jdbc3/CompositeTest.java
@@ -90,7 +90,7 @@ public class CompositeTest extends TestCase
         pstmt.setObject(1, pgo1);
         String[] ctArr = new String[1];
         ctArr[0] = "(\"{1,2}\",{},\"(1,2.2,)\")";
-        Array pgarr1 = _conn.createArrayOf("Composites.ComplexCompositeTest", ctArr);
+        Array pgarr1 = _conn.createArrayOf("\"Composites\".\"ComplexCompositeTest\"", ctArr);
         pstmt.setArray(2, pgarr1);
         int res = pstmt.executeUpdate();
         assertEquals(1, res);


### PR DESCRIPTION
Instead of lowercasing typename which causes problems for types which require quote due to non lowercase casing, lowercase on failed alias check and during type lookup for types without schema or quote.

Improve the quote casing heuristics by checking for quote char.
Support case type in schemas on path without schema reference.

Current rules for casing

type => "type"
TYPE => "type"
"Type" => "Type"
NS.TYPE => "ns"."type"
"NS"."Type" => "NS"."Type"
NS."TYPE" => "ns"."TYPE"

This change introduces breaking change. Previously casing was not changed.
Now unquoted names will be considered lowercase.

So if you had type: CREATE TYPE "TIMESTAMPTZ"(at timestamp, offset int)
you could reference it with TIMESTAMPTZ. Now quotes are required, otherwise it will default to timestamptz which is Postgres built-in type.

Fixes issue with: f1a5cc4a1dcc1ff52a607b31d2d6da65b6a9d530 which would interpret "Ns"."Type" as "ns"."type"