### PR TITLE
fix: restore clobbered translations (cs, de, fr, it)

### DIFF
--- a/org/postgresql/translation/cs.po
+++ b/org/postgresql/translation/cs.po
@@ -30,7 +30,7 @@ msgstr ""
 #: bin/org/postgresql/Driver.java.in:287 bin/org/postgresql/Driver.java.in:351
 #: org/postgresql/Driver.java.in:287 org/postgresql/Driver.java.in:351
 msgid ""
-"Something unusual has occured to cause the driver to fail. Please report "
+"Something unusual has occurred to cause the driver to fail. Please report "
 "this exception."
 msgstr ""
 "Nìco neobvyklého pøinutilo ovladaè selhat. Prosím nahlaste tuto vyjímku."
@@ -188,7 +188,7 @@ msgstr "Server nepodporuje SSL."
 
 #: org/postgresql/core/v2/ConnectionFactoryImpl.java:223
 #: org/postgresql/core/v3/ConnectionFactoryImpl.java:281
-msgid "An error occured while setting up the SSL connection."
+msgid "An error occurred while setting up the SSL connection."
 msgstr "Nastala chyba pøi nastavení SSL spojení."
 
 #: org/postgresql/core/v2/ConnectionFactoryImpl.java:272
@@ -284,7 +284,7 @@ msgstr "Neoèekávaný stav pøíkazu: {0}."
 #: org/postgresql/core/v3/QueryExecutorImpl.java:551
 #: org/postgresql/core/v3/QueryExecutorImpl.java:631
 #: org/postgresql/core/v3/QueryExecutorImpl.java:2094
-msgid "An I/O error occured while sending to the backend."
+msgid "An I/O error occurred while sending to the backend."
 msgstr "Vystupnì/výstupní chyba pøi odesílání k backend."
 
 #: org/postgresql/core/v2/QueryExecutorImpl.java:170

--- a/org/postgresql/translation/cs.po
+++ b/org/postgresql/translation/cs.po
@@ -18,7 +18,7 @@ msgstr ""
 
 #: bin/org/postgresql/Driver.java.in:235 org/postgresql/Driver.java.in:235
 msgid "Error loading default settings from driverconfig.properties"
-msgstr "Chyba naï¿½ï¿½tï¿½nï¿½ standardnï¿½ho nastavenï¿½ z driverconfig.properties"
+msgstr "Chyba naèítání standardního nastavení z driverconfig.properties"
 
 #: bin/org/postgresql/Driver.java.in:282 org/postgresql/Driver.java.in:282
 msgid ""
@@ -30,25 +30,25 @@ msgstr ""
 #: bin/org/postgresql/Driver.java.in:287 bin/org/postgresql/Driver.java.in:351
 #: org/postgresql/Driver.java.in:287 org/postgresql/Driver.java.in:351
 msgid ""
-"Something unusual has occurred to cause the driver to fail. Please report "
+"Something unusual has occured to cause the driver to fail. Please report "
 "this exception."
 msgstr ""
-"Nï¿½co neobvyklï¿½ho pï¿½inutilo ovladaï¿½ selhat. Prosï¿½m nahlaste tuto vyjï¿½mku."
+"Nìco neobvyklého pøinutilo ovladaè selhat. Prosím nahlaste tuto vyjímku."
 
 #: bin/org/postgresql/Driver.java.in:359 org/postgresql/Driver.java.in:359
 #, fuzzy
 msgid "Connection attempt timed out."
-msgstr "Pokus o pï¿½ipojenï¿½ selhal."
+msgstr "Pokus o pøipojení selhal."
 
 #: bin/org/postgresql/Driver.java.in:367 org/postgresql/Driver.java.in:367
 #, fuzzy
 msgid "Interrupted while attempting to connect."
-msgstr "Nastala chyba pï¿½i nastavenï¿½ SSL spojenï¿½."
+msgstr "Nastala chyba pøi nastavení SSL spojení."
 
 #: bin/org/postgresql/Driver.java.in:710 org/postgresql/Driver.java.in:710
 #, java-format
 msgid "Method {0} is not yet implemented."
-msgstr "Metoda {0} nenï¿½ implementovï¿½na."
+msgstr "Metoda {0} není implementována."
 
 #: org/postgresql/copy/CopyManager.java:56
 #, java-format
@@ -69,7 +69,7 @@ msgstr ""
 #: org/postgresql/copy/PGCopyOutputStream.java:90
 #, fuzzy
 msgid "This copy stream is closed."
-msgstr "Tento ResultSet je uzavï¿½enï¿½."
+msgstr "Tento ResultSet je uzavøený."
 
 #: org/postgresql/copy/PGCopyInputStream.java:108
 msgid "Read from copy failed."
@@ -83,7 +83,7 @@ msgstr ""
 #: org/postgresql/core/ConnectionFactory.java:70
 #, java-format
 msgid "A connection could not be made using the requested protocol {0}."
-msgstr "Spojenï¿½ nelze vytvoï¿½it s pouï¿½itï¿½m ï¿½ï¿½danï¿½ho protokolu {0}."
+msgstr "Spojení nelze vytvoøit s pou¾itím ¾ádaného protokolu {0}."
 
 #: org/postgresql/core/Oid.java:113
 #, java-format
@@ -102,7 +102,7 @@ msgstr ""
 
 #: org/postgresql/core/SetupQueryRunner.java:86
 msgid "An unexpected result was returned by a query."
-msgstr "Obdrï¿½en neoï¿½ekï¿½vanï¿½ vï¿½sledek dotazu."
+msgstr "Obdr¾en neoèekávaný výsledek dotazu."
 
 #: org/postgresql/core/UTF8Encoding.java:28
 #, java-format
@@ -151,13 +151,13 @@ msgstr ""
 #: org/postgresql/core/types/PGString.java:73
 #, fuzzy, java-format
 msgid "Cannot convert an instance of {0} to type {1}"
-msgstr "Nemohu pï¿½etypovat instanci {0} na typ {1}"
+msgstr "Nemohu pøetypovat instanci {0} na typ {1}"
 
 #: org/postgresql/core/v2/ConnectionFactoryImpl.java:66
 #: org/postgresql/core/v3/ConnectionFactoryImpl.java:74
 #, fuzzy, java-format
 msgid "Invalid sslmode value: {0}"
-msgstr "Vadnï¿½ dï¿½lka proudu {0}."
+msgstr "Vadná délka proudu {0}."
 
 #: org/postgresql/core/v2/ConnectionFactoryImpl.java:134
 #: org/postgresql/core/v3/ConnectionFactoryImpl.java:168
@@ -165,19 +165,19 @@ msgid ""
 "Connection refused. Check that the hostname and port are correct and that "
 "the postmaster is accepting TCP/IP connections."
 msgstr ""
-"Spojenï¿½ odmï¿½tnuto. Zkontrolujte zda je jmï¿½no hosta a port sprï¿½vnï¿½ a zda "
-"postmaster pï¿½ijï¿½mï¿½ TCP/IP spojenï¿½."
+"Spojení odmítnuto. Zkontrolujte zda je jméno hosta a port správné a zda "
+"postmaster pøijímá TCP/IP spojení."
 
 #: org/postgresql/core/v2/ConnectionFactoryImpl.java:153
 #: org/postgresql/core/v3/ConnectionFactoryImpl.java:186
 msgid "The connection attempt failed."
-msgstr "Pokus o pï¿½ipojenï¿½ selhal."
+msgstr "Pokus o pøipojení selhal."
 
 #: org/postgresql/core/v2/ConnectionFactoryImpl.java:175
 #: org/postgresql/core/v3/ConnectionFactoryImpl.java:207
 #, fuzzy
 msgid "The connection url is invalid."
-msgstr "Pokus o pï¿½ipojenï¿½ selhal."
+msgstr "Pokus o pøipojení selhal."
 
 #: org/postgresql/core/v2/ConnectionFactoryImpl.java:198
 #: org/postgresql/core/v2/ConnectionFactoryImpl.java:210
@@ -188,13 +188,13 @@ msgstr "Server nepodporuje SSL."
 
 #: org/postgresql/core/v2/ConnectionFactoryImpl.java:223
 #: org/postgresql/core/v3/ConnectionFactoryImpl.java:281
-msgid "An error occurred while setting up the SSL connection."
-msgstr "Nastala chyba pï¿½i nastavenï¿½ SSL spojenï¿½."
+msgid "An error occured while setting up the SSL connection."
+msgstr "Nastala chyba pøi nastavení SSL spojení."
 
 #: org/postgresql/core/v2/ConnectionFactoryImpl.java:272
 #, java-format
 msgid "Connection rejected: {0}."
-msgstr "Spojenï¿½ odmï¿½tnuto: {0}."
+msgstr "Spojení odmítnuto: {0}."
 
 #: org/postgresql/core/v2/ConnectionFactoryImpl.java:290
 #: org/postgresql/core/v2/ConnectionFactoryImpl.java:312
@@ -205,7 +205,7 @@ msgstr "Spojenï¿½ odmï¿½tnuto: {0}."
 msgid ""
 "The server requested password-based authentication, but no password was "
 "provided."
-msgstr "Server vyï¿½aduje ovï¿½ï¿½enï¿½ heslem, ale ï¿½ï¿½dnï¿½ nebylo poslï¿½no."
+msgstr "Server vy¾aduje ovìøení heslem, ale ¾ádné nebylo posláno."
 
 #: org/postgresql/core/v2/ConnectionFactoryImpl.java:356
 #: org/postgresql/core/v3/ConnectionFactoryImpl.java:465
@@ -215,9 +215,9 @@ msgid ""
 "the pg_hba.conf file to include the client''s IP address or subnet, and that "
 "it is using an authentication scheme supported by the driver."
 msgstr ""
-"Ovï¿½ï¿½enï¿½ typu {0} nenï¿½ podporovï¿½no. Zkontrolujte zda konfiguraï¿½nï¿½ soubor "
-"pg_hba.conf obsahuje klientskou IP adresu ï¿½i podsï¿½ a zda je pouï¿½itï¿½ "
-"ovï¿½ï¿½enovacï¿½ schï¿½ma podporovï¿½no ovladaï¿½em."
+"Ovìøení typu {0} není podporováno. Zkontrolujte zda konfiguraèní soubor "
+"pg_hba.conf obsahuje klientskou IP adresu èi podsí» a zda je pou¾ité "
+"ovìøenovací schéma podporováno ovladaèem."
 
 #: org/postgresql/core/v2/ConnectionFactoryImpl.java:362
 #: org/postgresql/core/v2/ConnectionFactoryImpl.java:400
@@ -229,7 +229,7 @@ msgstr ""
 #: org/postgresql/core/v3/ConnectionFactoryImpl.java:587
 #: org/postgresql/gss/MakeGSS.java:158
 msgid "Protocol error.  Session setup failed."
-msgstr "Chyba protokolu. Nastavenï¿½ relace selhalo."
+msgstr "Chyba protokolu. Nastavení relace selhalo."
 
 #: org/postgresql/core/v2/ConnectionFactoryImpl.java:390
 #, java-format
@@ -250,14 +250,14 @@ msgstr "Selhal start backendu: {0}."
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSetMetaData.java:419
 #, java-format
 msgid "The column index is out of range: {0}, number of columns: {1}."
-msgstr "Index sloupece je mimo rozsah: {0}, poï¿½et sloupcï¿½: {1}."
+msgstr "Index sloupece je mimo rozsah: {0}, poèet sloupcù: {1}."
 
 #: org/postgresql/core/v2/FastpathParameterList.java:142
 #: org/postgresql/core/v2/SimpleParameterList.java:155
 #: org/postgresql/core/v3/SimpleParameterList.java:183
 #, java-format
 msgid "No value specified for parameter {0}."
-msgstr "Nespecifikovï¿½na hodnota parametru {0}."
+msgstr "Nespecifikována hodnota parametru {0}."
 
 #: org/postgresql/core/v2/QueryExecutorImpl.java:72
 #: org/postgresql/core/v2/QueryExecutorImpl.java:337
@@ -265,14 +265,14 @@ msgstr "Nespecifikovï¿½na hodnota parametru {0}."
 #: org/postgresql/core/v3/QueryExecutorImpl.java:507
 #, java-format
 msgid "Expected command status BEGIN, got {0}."
-msgstr "Oï¿½ekï¿½vï¿½n pï¿½ï¿½kaz BEGIN, obdrï¿½en {0}."
+msgstr "Oèekáván pøíkaz BEGIN, obdr¾en {0}."
 
 #: org/postgresql/core/v2/QueryExecutorImpl.java:78
 #: org/postgresql/core/v3/QueryExecutorImpl.java:513
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:1828
 #, java-format
 msgid "Unexpected command status: {0}."
-msgstr "Neoï¿½ekï¿½vanï¿½ stav pï¿½ï¿½kazu: {0}."
+msgstr "Neoèekávaný stav pøíkazu: {0}."
 
 #: org/postgresql/core/v2/QueryExecutorImpl.java:118
 #: org/postgresql/core/v2/QueryExecutorImpl.java:129
@@ -284,8 +284,8 @@ msgstr "Neoï¿½ekï¿½vanï¿½ stav pï¿½ï¿½kazu: {0}."
 #: org/postgresql/core/v3/QueryExecutorImpl.java:551
 #: org/postgresql/core/v3/QueryExecutorImpl.java:631
 #: org/postgresql/core/v3/QueryExecutorImpl.java:2094
-msgid "An I/O error occurred while sending to the backend."
-msgstr "Vystupnï¿½/vï¿½stupnï¿½ chyba pï¿½i odesï¿½lï¿½nï¿½ k backend."
+msgid "An I/O error occured while sending to the backend."
+msgstr "Vystupnì/výstupní chyba pøi odesílání k backend."
 
 #: org/postgresql/core/v2/QueryExecutorImpl.java:170
 #: org/postgresql/core/v2/QueryExecutorImpl.java:225
@@ -294,7 +294,7 @@ msgstr "Vystupnï¿½/vï¿½stupnï¿½ chyba pï¿½i odesï¿½lï¿½nï¿½ k backend."
 #: org/postgresql/core/v3/QueryExecutorImpl.java:685
 #, java-format
 msgid "Unknown Response Type {0}."
-msgstr "Neznï¿½mï¿½ typ odpovï¿½di {0}."
+msgstr "Neznámý typ odpovìdi {0}."
 
 #: org/postgresql/core/v2/QueryExecutorImpl.java:430
 #: org/postgresql/core/v2/QueryExecutorImpl.java:475
@@ -327,7 +327,7 @@ msgstr ""
 #: org/postgresql/core/v3/QueryExecutorImpl.java:93
 #, fuzzy
 msgid "Interrupted while waiting to obtain lock on database connection"
-msgstr "Nastala chyba pï¿½i nastavenï¿½ SSL spojenï¿½."
+msgstr "Nastala chyba pøi nastavení SSL spojení."
 
 #: org/postgresql/core/v3/QueryExecutorImpl.java:275
 msgid "Unable to bind parameter values for statement."
@@ -402,7 +402,7 @@ msgstr ""
 #: org/postgresql/core/v3/QueryExecutorImpl.java:1005
 #, fuzzy, java-format
 msgid "Unexpected copydata from server for {0}"
-msgstr "Neoï¿½ekï¿½vanï¿½ stav pï¿½ï¿½kazu: {0}."
+msgstr "Neoèekávaný stav pøíkazu: {0}."
 
 #: org/postgresql/core/v3/QueryExecutorImpl.java:1056
 #, java-format
@@ -439,11 +439,11 @@ msgstr ""
 
 #: org/postgresql/core/v3/QueryExecutorImpl.java:2015
 msgid "The driver currently does not support COPY operations."
-msgstr "Ovladaï¿½ nynï¿½ nepodporuje pï¿½ï¿½kaz COPY."
+msgstr "Ovladaè nyní nepodporuje pøíkaz COPY."
 
 #: org/postgresql/ds/jdbc23/AbstractJdbc23PooledConnection.java:112
 msgid "This PooledConnection has already been closed."
-msgstr "Tento PooledConnection byl uzavï¿½en."
+msgstr "Tento PooledConnection byl uzavøen."
 
 #: org/postgresql/ds/jdbc23/AbstractJdbc23PooledConnection.java:295
 msgid ""
@@ -453,11 +453,11 @@ msgstr ""
 
 #: org/postgresql/ds/jdbc23/AbstractJdbc23PooledConnection.java:295
 msgid "Connection has been closed."
-msgstr "Spojeni bylo uzavï¿½eno."
+msgstr "Spojeni bylo uzavøeno."
 
 #: org/postgresql/ds/jdbc23/AbstractJdbc23PooledConnection.java:442
 msgid "Statement has been closed."
-msgstr "Statement byl uzavï¿½en."
+msgstr "Statement byl uzavøen."
 
 #: org/postgresql/ds/jdbc23/AbstractJdbc23PoolingDataSource.java:291
 msgid "Failed to setup DataSource."
@@ -465,7 +465,7 @@ msgstr ""
 
 #: org/postgresql/ds/jdbc23/AbstractJdbc23PoolingDataSource.java:414
 msgid "DataSource has been closed."
-msgstr "DataSource byl uzavï¿½en."
+msgstr "DataSource byl uzavøen."
 
 #: org/postgresql/fastpath/Fastpath.java:81
 #: org/postgresql/fastpath/Fastpath.java:128
@@ -508,7 +508,7 @@ msgstr "Index pole mimo rozsah: {0}"
 #: org/postgresql/jdbc2/AbstractJdbc2Array.java:807
 #, java-format
 msgid "The array index is out of range: {0}, number of elements: {1}."
-msgstr "Index pole mimo rozsah: {0}, poï¿½et prvkï¿½: {1}."
+msgstr "Index pole mimo rozsah: {0}, poèet prvkù: {1}."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Array.java:196
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:1982
@@ -520,10 +520,10 @@ msgid ""
 "was created in.  The most common example of this is storing 8bit data in a "
 "SQL_ASCII database."
 msgstr ""
-"Nalezena vada ve znakovï¿½ch datech. Toto mï¿½e bï¿½t zpï¿½sobeno uloï¿½enï¿½mi daty "
-"obsahujï¿½cï¿½mi znaky, kterï¿½ jsou zï¿½vadnï¿½ pro znakovou sadu nastavenou pï¿½i "
-"zaklï¿½dï¿½nï¿½ databï¿½ze. Nejznï¿½mejï¿½ï¿½ pï¿½ï¿½klad je uklï¿½dï¿½nï¿½ 8bitovï¿½ch dat vSQL_ASCII "
-"databï¿½zi."
+"Nalezena vada ve znakových datech. Toto mù¾e být zpùsobeno ulo¾enými daty "
+"obsahujícími znaky, které jsou závadné pro znakovou sadu nastavenou pøi "
+"zakládání databáze. Nejznámej¹í pøíklad je ukládání 8bitových dat vSQL_ASCII "
+"databázi."
 
 #: org/postgresql/jdbc2/AbstractJdbc2BlobClob.java:73
 msgid ""
@@ -542,7 +542,7 @@ msgstr ""
 
 #: org/postgresql/jdbc2/AbstractJdbc2BlobClob.java:231
 msgid "LOB positioning offsets start at 1."
-msgstr "Zaï¿½ï¿½tek pozicovï¿½nï¿½ LOB zaï¿½ï¿½na na 1."
+msgstr "Zaèátek pozicování LOB zaèína na 1."
 
 #: org/postgresql/jdbc2/AbstractJdbc2BlobClob.java:246
 msgid "free() was called on this LOB previously"
@@ -551,7 +551,7 @@ msgstr ""
 #: org/postgresql/jdbc2/AbstractJdbc2Connection.java:229
 #, fuzzy, java-format
 msgid "Unsupported value for stringtype parameter: {0}"
-msgstr "Nepodporovanï¿½ hodnota typu: {0}"
+msgstr "Nepodporovaná hodnota typu: {0}"
 
 #: org/postgresql/jdbc2/AbstractJdbc2Connection.java:249
 msgid "unknownLength parameter value must be an integer"
@@ -568,14 +568,14 @@ msgstr ""
 #: org/postgresql/jdbc2/TypeInfoCache.java:384
 #: org/postgresql/jdbc2/TypeInfoCache.java:388
 msgid "No results were returned by the query."
-msgstr "Neobdrï¿½en ï¿½ï¿½dnï¿½ vï¿½sledek dotazu."
+msgstr "Neobdr¾en ¾ádný výsledek dotazu."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Connection.java:371
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:336
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:368
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:2695
 msgid "A result was returned when none was expected."
-msgstr "Obdrï¿½en vï¿½sledek, ikdyï¿½ ï¿½ï¿½dnï¿½ nebyl oï¿½ekï¿½vï¿½n."
+msgstr "Obdr¾en výsledek, ikdy¾ ¾ádný nebyl oèekáván."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Connection.java:523
 msgid "Custom type maps are not supported."
@@ -584,12 +584,12 @@ msgstr ""
 #: org/postgresql/jdbc2/AbstractJdbc2Connection.java:571
 #, java-format
 msgid "Failed to create object for: {0}."
-msgstr "Selhalo vytvoï¿½enï¿½ objektu: {0}."
+msgstr "Selhalo vytvoøení objektu: {0}."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Connection.java:633
 #, java-format
 msgid "Unable to load the class {0} responsible for the datatype {1}"
-msgstr "Nemohu naï¿½ï¿½st tï¿½ï¿½du {0} odpovï¿½dnou za typ {1}"
+msgstr "Nemohu naèíst tøídu {0} odpovìdnou za typ {1}"
 
 #: org/postgresql/jdbc2/AbstractJdbc2Connection.java:729
 msgid ""
@@ -603,7 +603,7 @@ msgstr ""
 #: org/postgresql/jdbc2/AbstractJdbc2Connection.java:826
 #, fuzzy
 msgid "This connection has been closed."
-msgstr "Spojeni bylo uzavï¿½eno."
+msgstr "Spojeni bylo uzavøeno."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Connection.java:846
 msgid "Cannot rollback when autoCommit is enabled."
@@ -622,22 +622,22 @@ msgstr ""
 #: org/postgresql/jdbc2/AbstractJdbc2Connection.java:1005
 #, fuzzy
 msgid "Finalizing a Connection that was never closed:"
-msgstr "Spojeni bylo uzavï¿½eno."
+msgstr "Spojeni bylo uzavøeno."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Connection.java:1107
 msgid "Unable to translate data into the desired encoding."
-msgstr "Nemohu pï¿½eloï¿½it data do poï¿½adovanï¿½ho kï¿½dovï¿½nï¿½."
+msgstr "Nemohu pøelo¾it data do po¾adovaného kódování."
 
 #: org/postgresql/jdbc2/AbstractJdbc2DatabaseMetaData.java:63
 #, fuzzy
 msgid ""
 "Unable to determine a value for MaxIndexKeys due to missing system catalog "
 "data."
-msgstr "Nemohu najï¿½t oid a oidvector typu v systï¿½movï¿½m katalogu."
+msgstr "Nemohu najít oid a oidvector typu v systémovém katalogu."
 
 #: org/postgresql/jdbc2/AbstractJdbc2DatabaseMetaData.java:86
 msgid "Unable to find name datatype in the system catalogs."
-msgstr "Nemohu najï¿½t nï¿½zev typu v systï¿½movï¿½m katalogu."
+msgstr "Nemohu najít název typu v systémovém katalogu."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:235
 msgid ""
@@ -647,7 +647,7 @@ msgstr ""
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:416
 msgid "Unexpected error while decoding character data from a large object."
-msgstr "Neoï¿½ekï¿½vanï¿½ chyba bï¿½ham dekï¿½dovï¿½nï¿½ znaku z velkï¿½ho objektu."
+msgstr "Neoèekávaná chyba bìham dekódování znaku z velkého objektu."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:462
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:491
@@ -656,27 +656,27 @@ msgstr "Neoï¿½ekï¿½vanï¿½ chyba bï¿½ham dekï¿½dovï¿½nï¿½ znaku z velkï¿½ho objek
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:3174
 #, fuzzy, java-format
 msgid "Cannot convert the column of type {0} to requested type {1}."
-msgstr "Nemohu pï¿½etypovat instanci {0} na typ {1}"
+msgstr "Nemohu pøetypovat instanci {0} na typ {1}"
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:744
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:768
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:1892
 msgid "Can''t use relative move methods while on the insert row."
-msgstr "Nemï¿½ete pouï¿½ï¿½vat relativnï¿½ pï¿½esuny pï¿½i vklï¿½dï¿½nï¿½ ï¿½ï¿½dku."
+msgstr "Nemù¾ete pou¾ívat relativní pøesuny pøi vkládání øádku."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:788
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:2949
 #, java-format
 msgid "Invalid fetch direction constant: {0}."
-msgstr "ï¿½patnï¿½ smï¿½r ï¿½tenï¿½: {0}."
+msgstr "©patný smìr ètení: {0}."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:802
 msgid "Cannot call cancelRowUpdates() when on the insert row."
-msgstr "Nemï¿½ete volat cancelRowUpdates() pï¿½i vklï¿½dï¿½nï¿½ ï¿½ï¿½dku."
+msgstr "Nemù¾ete volat cancelRowUpdates() pøi vkládání øádku."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:822
 msgid "Cannot call deleteRow() when on the insert row."
-msgstr "Nemï¿½ete volat deleteRow() pï¿½i vklï¿½dï¿½nï¿½ ï¿½ï¿½dku."
+msgstr "Nemù¾ete volat deleteRow() pøi vkládání øádku."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:828
 msgid ""
@@ -689,19 +689,19 @@ msgid ""
 "Currently positioned after the end of the ResultSet.  You cannot call "
 "deleteRow() here."
 msgstr ""
-"Prï¿½vï¿½ jste za pozicï¿½ konce ResultSetu. Zde nemï¿½ete volat deleteRow().s"
+"Právì jste za pozicí konce ResultSetu. Zde nemù¾ete volat deleteRow().s"
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:838
 msgid "There are no rows in this ResultSet."
-msgstr "ï¿½ï¿½dnï¿½ ï¿½ï¿½dek v ResultSet."
+msgstr "®ádný øádek v ResultSet."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:885
 msgid "Not on the insert row."
-msgstr "Ne na vklï¿½danï¿½m ï¿½ï¿½dku."
+msgstr "Ne na vkládaném øádku."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:889
 msgid "You must specify at least one column value to insert a row."
-msgstr "Musï¿½te vyplnit alespoï¿½ jeden sloupec pro vloï¿½enï¿½ ï¿½ï¿½dku."
+msgstr "Musíte vyplnit alespoò jeden sloupec pro vlo¾ení øádku."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:1074
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:1805
@@ -709,27 +709,27 @@ msgstr "Musï¿½te vyplnit alespoï¿½ jeden sloupec pro vloï¿½enï¿½ ï¿½ï¿½dku."
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:2524
 #, java-format
 msgid "The JVM claims not to support the encoding: {0}"
-msgstr "JVM tvrdï¿½, ï¿½e nepodporuje kodovï¿½nï¿½: {0}"
+msgstr "JVM tvrdí, ¾e nepodporuje kodování: {0}"
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:1078
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:1121
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:1527
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:1656
 msgid "Provided InputStream failed."
-msgstr "Selhal poskytnutï¿½ InputStream."
+msgstr "Selhal poskytnutý InputStream."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:1191
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:3130
 msgid "Provided Reader failed."
-msgstr "Selhal poskytnutï¿½ Reader."
+msgstr "Selhal poskytnutý Reader."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:1259
 msgid "Can''t refresh the insert row."
-msgstr "Nemohu obnovit vklï¿½danï¿½ ï¿½ï¿½dek."
+msgstr "Nemohu obnovit vkládaný øádek."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:1327
 msgid "Cannot call updateRow() when on the insert row."
-msgstr "Nemohu volat updateRow() na vlkï¿½danï¿½m ï¿½ï¿½dku."
+msgstr "Nemohu volat updateRow() na vlkádaném øádku."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:1333
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:3190
@@ -740,17 +740,17 @@ msgstr ""
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:1582
 msgid "ResultSets with concurrency CONCUR_READ_ONLY cannot be updated."
-msgstr "ResultSets se soubï¿½nostï¿½ CONCUR_READ_ONLY nemï¿½e bï¿½t aktualizovï¿½no"
+msgstr "ResultSets se soubì¾ností CONCUR_READ_ONLY nemù¾e být aktualizováno"
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:1650
 #, java-format
 msgid "No primary key found for table {0}."
-msgstr "Nenalezen primï¿½rnï¿½ klï¿½ï¿½ pro tabulku {0}."
+msgstr "Nenalezen primární klíè pro tabulku {0}."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:1876
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:2958
 msgid "Fetch size must be a value greater to or equal to 0."
-msgstr "Nabranï¿½ velikost musï¿½ bï¿½t nezï¿½pornï¿½."
+msgstr "Nabraná velikost musí být nezáporná."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:2044
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:2051
@@ -768,12 +768,12 @@ msgstr "Nabranï¿½ velikost musï¿½ bï¿½t nezï¿½pornï¿½."
 #: org/postgresql/jdbc2/TimestampUtils.java:258
 #, java-format
 msgid "Bad value for type {0} : {1}"
-msgstr "ï¿½patnï¿½ hodnota pro typ {0} : {1}"
+msgstr "©patná hodnota pro typ {0} : {1}"
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:2727
 #, java-format
 msgid "The column name {0} was not found in this ResultSet."
-msgstr "Sloupec pojmenovanï¿½ {0} nebyl nalezen v ResultSet."
+msgstr "Sloupec pojmenovaný {0} nebyl nalezen v ResultSet."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:2827
 msgid ""
@@ -781,13 +781,13 @@ msgid ""
 "select only one table, and must select all primary keys from that table. See "
 "the JDBC 2.1 API Specification, section 5.6 for more details."
 msgstr ""
-"ResultSet nenï¿½ aktualizavatelnï¿½. Dotaz musï¿½ vybï¿½rat pouze z jednï¿½ tabulky a "
-"musï¿½ obsahovat vï¿½echny primï¿½rnï¿½ klï¿½ï¿½e tabulky. Koukni do JDBC 2.1 API "
-"Specifikace, sekce 5.6 pro vï¿½ce podrobnostï¿½."
+"ResultSet není aktualizavatelný. Dotaz musí vybírat pouze z jedné tabulky a "
+"musí obsahovat v¹echny primární klíèe tabulky. Koukni do JDBC 2.1 API "
+"Specifikace, sekce 5.6 pro více podrobností."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:2839
 msgid "This ResultSet is closed."
-msgstr "Tento ResultSet je uzavï¿½enï¿½."
+msgstr "Tento ResultSet je uzavøený."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:2860
 msgid "ResultSet not positioned properly, perhaps you need to call next."
@@ -804,17 +804,17 @@ msgstr ""
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:287
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:306
 msgid "Multiple ResultSets were returned by the query."
-msgstr "Vï¿½cenï¿½sobnï¿½ ResultSet byl vrï¿½cen dotazem."
+msgstr "Vícenásobný ResultSet byl vrácen dotazem."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:425
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:429
 msgid "A CallableStatement was executed with nothing returned."
-msgstr "CallableStatement byl spuï¿½tï¿½n, leï¿½ nic nebylo vrï¿½ceno."
+msgstr "CallableStatement byl spu¹tìn, leè nic nebylo vráceno."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:437
 #, fuzzy
 msgid "A CallableStatement was executed with an invalid number of parameters"
-msgstr "CallableStatement byl spuï¿½tï¿½n, leï¿½ nic nebylo vrï¿½ceno."
+msgstr "CallableStatement byl spu¹tìn, leè nic nebylo vráceno."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:468
 #, java-format
@@ -825,37 +825,37 @@ msgstr ""
 
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:670
 msgid "Maximum number of rows must be a value grater than or equal to 0."
-msgstr "Maximï¿½lnï¿½ poï¿½et ï¿½ï¿½dek musï¿½ bï¿½t nezï¿½pornï¿½ ï¿½ï¿½slo."
+msgstr "Maximální poèet øádek musí být nezáporné èíslo."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:713
 msgid "Query timeout must be a value greater than or equals to 0."
-msgstr "ï¿½asovï¿½ limit dotazu musï¿½ bï¿½t nezï¿½pornï¿½ ï¿½ï¿½slo."
+msgstr "Èasový limit dotazu musí být nezáporné èíslo."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:804
 msgid "The maximum field size must be a value greater than or equal to 0."
-msgstr "Maximï¿½lnï¿½ velikost pole musï¿½ bï¿½t nezï¿½pornï¿½ ï¿½ï¿½slo."
+msgstr "Maximální velikost pole musí být nezáporné èíslo."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:1219
 msgid "Unknown Types value."
-msgstr "Neznï¿½mï¿½ hodnota typu."
+msgstr "Neznámá hodnota typu."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:1492
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:1617
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:3101
 #, java-format
 msgid "Invalid stream length {0}."
-msgstr "Vadnï¿½ dï¿½lka proudu {0}."
+msgstr "Vadná délka proudu {0}."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:1523
 #, java-format
 msgid "The JVM claims not to support the {0} encoding."
-msgstr "JVM tvrdï¿½, ï¿½e nepodporuje kodovï¿½nï¿½ {0}."
+msgstr "JVM tvrdí, ¾e nepodporuje kodování {0}."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:1698
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:3023
 #, java-format
 msgid "Unknown type {0}."
-msgstr "Neznï¿½mï¿½ typ {0}."
+msgstr "Neznámý typ {0}."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:1713
 msgid "No hstore extension installed."
@@ -866,12 +866,12 @@ msgstr ""
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:1850
 #, java-format
 msgid "Cannot cast an instance of {0} to type {1}"
-msgstr "Nemohu pï¿½etypovat instanci {0} na typ {1}"
+msgstr "Nemohu pøetypovat instanci {0} na typ {1}"
 
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:1862
 #, java-format
 msgid "Unsupported Types value: {0}"
-msgstr "Nepodporovanï¿½ hodnota typu: {0}"
+msgstr "Nepodporovaná hodnota typu: {0}"
 
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:1920
 #, java-format
@@ -893,7 +893,7 @@ msgstr ""
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:2514
 #, java-format
 msgid "Malformed function or procedure escape syntax at offset {0}."
-msgstr "Poï¿½kozenï¿½ funkce nebo opuï¿½tï¿½nï¿½ procedury na pozici {0}."
+msgstr "Po¹kozená funkce nebo opu¹tìní procedury na pozici {0}."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:2564
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:2578
@@ -920,12 +920,12 @@ msgstr ""
 
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:2637
 msgid "This statement has been closed."
-msgstr "Pï¿½ï¿½kaz byl uzavï¿½en."
+msgstr "Pøíkaz byl uzavøen."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:2717
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:2787
 msgid "Too many update results were returned."
-msgstr "Bylo vrï¿½ceno pï¿½ï¿½liï¿½ mnoho vï¿½sledkï¿½ aktualizacï¿½."
+msgstr "Bylo vráceno pøíli¹ mnoho výsledkù aktualizací."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:2746
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:2816
@@ -938,7 +938,7 @@ msgstr ""
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:3160
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:3200
 msgid "Unexpected error writing large object to database."
-msgstr "Neoï¿½ekï¿½vanï¿½ chyba pï¿½i zapisovï¿½nï¿½ velkï¿½ho objektu do databï¿½ze."
+msgstr "Neoèekávaná chyba pøi zapisování velkého objektu do databáze."
 
 #: org/postgresql/jdbc2/EscapedFunctions.java:145
 #: org/postgresql/jdbc2/EscapedFunctions.java:157
@@ -973,18 +973,18 @@ msgstr "Funkce {0} bere jeden argument."
 #: org/postgresql/jdbc2/EscapedFunctions.java:582
 #, java-format
 msgid "{0} function takes two and only two arguments."
-msgstr "Funkce {0} bere prï¿½vï¿½ dva argumenty."
+msgstr "Funkce {0} bere právì dva argumenty."
 
 #: org/postgresql/jdbc2/EscapedFunctions.java:230
 #, java-format
 msgid "{0} function takes four and only four argument."
-msgstr "Funkce {0} bere pï¿½esnï¿½ ï¿½tyï¿½i argumenty."
+msgstr "Funkce {0} bere pøesnì ètyøi argumenty."
 
 #: org/postgresql/jdbc2/EscapedFunctions.java:282
 #: org/postgresql/jdbc2/EscapedFunctions.java:342
 #, java-format
 msgid "{0} function takes two or three arguments."
-msgstr "Funkce {0} bere dva nebo tï¿½i argumenty."
+msgstr "Funkce {0} bere dva nebo tøi argumenty."
 
 #: org/postgresql/jdbc2/EscapedFunctions.java:362
 #: org/postgresql/jdbc2/EscapedFunctions.java:371
@@ -992,13 +992,13 @@ msgstr "Funkce {0} bere dva nebo tï¿½i argumenty."
 #: org/postgresql/jdbc2/EscapedFunctions.java:591
 #, java-format
 msgid "{0} function doesn''t take any argument."
-msgstr "Funkce {0} nebere ï¿½ï¿½dnï¿½ argument."
+msgstr "Funkce {0} nebere ¾ádný argument."
 
 #: org/postgresql/jdbc2/EscapedFunctions.java:489
 #: org/postgresql/jdbc2/EscapedFunctions.java:531
 #, fuzzy, java-format
 msgid "{0} function takes three and only three arguments."
-msgstr "Funkce {0} bere prï¿½vï¿½ dva argumenty."
+msgstr "Funkce {0} bere právì dva argumenty."
 
 #: org/postgresql/jdbc2/EscapedFunctions.java:501
 #: org/postgresql/jdbc2/EscapedFunctions.java:521
@@ -1008,24 +1008,24 @@ msgstr "Funkce {0} bere prï¿½vï¿½ dva argumenty."
 #: org/postgresql/jdbc2/EscapedFunctions.java:566
 #, fuzzy, java-format
 msgid "Interval {0} not yet implemented"
-msgstr "Metoda {0} nenï¿½ implementovï¿½na."
+msgstr "Metoda {0} není implementována."
 
 #: org/postgresql/jdbc2/TimestampUtils.java:360
 msgid ""
 "Infinite value found for timestamp/date. This cannot be represented as time."
-msgstr "Nekoneï¿½nï¿½ hodnota pro timestamp/date. Toto nemï¿½e reprezentovat ï¿½as."
+msgstr "Nekoneèná hodnota pro timestamp/date. Toto nemù¾e reprezentovat èas."
 
 #: org/postgresql/jdbc2/TimestampUtils.java:648
 #: org/postgresql/jdbc2/TimestampUtils.java:680
 #: org/postgresql/jdbc2/TimestampUtils.java:727
 #, fuzzy, java-format
 msgid "Unsupported binary encoding of {0}."
-msgstr "Nepodporovanï¿½ hodnota typu: {0}"
+msgstr "Nepodporovaná hodnota typu: {0}"
 
 #: org/postgresql/jdbc2/TypeInfoCache.java:161
 #, java-format
 msgid "The class {0} does not implement org.postgresql.util.PGobject."
-msgstr "Tï¿½ï¿½da {0} nepodporuje org.postgresql.util.PGobject."
+msgstr "Tøída {0} nepodporuje org.postgresql.util.PGobject."
 
 #: org/postgresql/jdbc3/AbstractJdbc3Connection.java:60
 #, java-format
@@ -1037,47 +1037,47 @@ msgstr ""
 #: org/postgresql/jdbc3/AbstractJdbc3Connection.java:165
 #: org/postgresql/jdbc3/AbstractJdbc3Connection.java:187
 msgid "Server versions prior to 8.0 do not support savepoints."
-msgstr "Verze serveru niï¿½ï¿½ï¿½ neï¿½ 8.0 nepodporujï¿½ savepoints."
+msgstr "Verze serveru ni¾¹í ne¾ 8.0 nepodporují savepoints."
 
 #: org/postgresql/jdbc3/AbstractJdbc3Connection.java:100
 #: org/postgresql/jdbc3/AbstractJdbc3Connection.java:132
 msgid "Cannot establish a savepoint in auto-commit mode."
-msgstr "Nemohu vytvoï¿½it savepoint v auto-commit modu."
+msgstr "Nemohu vytvoøit savepoint v auto-commit modu."
 
 #: org/postgresql/jdbc3/AbstractJdbc3Connection.java:419
 msgid "Returning autogenerated keys is not supported."
-msgstr "Vrï¿½cenï¿½ automaticky generovanï¿½ch klï¿½ï¿½ï¿½ nenï¿½ podporovï¿½no."
+msgstr "Vrácení automaticky generovaných klíèù není podporováno."
 
 #: org/postgresql/jdbc3/AbstractJdbc3ParameterMetaData.java:81
 #, java-format
 msgid "The parameter index is out of range: {0}, number of parameters: {1}."
-msgstr "Index parametru mimo rozsah: {0}, poï¿½et parametrï¿½ {1}."
+msgstr "Index parametru mimo rozsah: {0}, poèet parametrù {1}."
 
 #: org/postgresql/jdbc3/AbstractJdbc3Statement.java:151
 #, fuzzy
 msgid ""
 "Returning autogenerated keys is only supported for 8.2 and later servers."
-msgstr "Vrï¿½cenï¿½ automaticky generovanï¿½ch klï¿½ï¿½ï¿½ nenï¿½ podporovï¿½no."
+msgstr "Vrácení automaticky generovaných klíèù není podporováno."
 
 #: org/postgresql/jdbc3/AbstractJdbc3Statement.java:199
 #: org/postgresql/jdbc3/AbstractJdbc3Statement.java:317
 #, fuzzy
 msgid "Returning autogenerated keys by column index is not supported."
-msgstr "Vrï¿½cenï¿½ automaticky generovanï¿½ch klï¿½ï¿½ï¿½ nenï¿½ podporovï¿½no."
+msgstr "Vrácení automaticky generovaných klíèù není podporováno."
 
 #: org/postgresql/jdbc3/PSQLSavepoint.java:38
 #: org/postgresql/jdbc3/PSQLSavepoint.java:50
 #: org/postgresql/jdbc3/PSQLSavepoint.java:66
 msgid "Cannot reference a savepoint after it has been released."
-msgstr "Nemohu zï¿½skat odkaz na savepoint, kdyï¿½ byl uvolnï¿½n."
+msgstr "Nemohu získat odkaz na savepoint, kdy¾ byl uvolnìn."
 
 #: org/postgresql/jdbc3/PSQLSavepoint.java:42
 msgid "Cannot retrieve the id of a named savepoint."
-msgstr "Nemohu zï¿½skat id nepojmenovanï¿½ho savepointu."
+msgstr "Nemohu získat id nepojmenovaného savepointu."
 
 #: org/postgresql/jdbc3/PSQLSavepoint.java:54
 msgid "Cannot retrieve the name of an unnamed savepoint."
-msgstr "Nemohu zï¿½skat nï¿½zev nepojmenovanï¿½ho savepointu."
+msgstr "Nemohu získat název nepojmenovaného savepointu."
 
 #: org/postgresql/jdbc3g/AbstractJdbc3gResultSet.java:37
 msgid "Invalid UUID data."
@@ -1091,7 +1091,7 @@ msgstr ""
 #: org/postgresql/jdbc4/AbstractJdbc4Connection.java:120
 #, fuzzy, java-format
 msgid "Invalid timeout ({0}<0)."
-msgstr "Vadnï¿½ dï¿½lka proudu {0}."
+msgstr "Vadná délka proudu {0}."
 
 #: org/postgresql/jdbc4/AbstractJdbc4Connection.java:133
 msgid "Validating connection."
@@ -1100,13 +1100,13 @@ msgstr ""
 #: org/postgresql/jdbc4/AbstractJdbc4Connection.java:156
 #, fuzzy, java-format
 msgid "Failed to set ClientInfo property: {0}"
-msgstr "Selhalo vytvoï¿½enï¿½ objektu: {0}."
+msgstr "Selhalo vytvoøení objektu: {0}."
 
 #: org/postgresql/jdbc4/AbstractJdbc4Connection.java:165
 #: org/postgresql/jdbc4/AbstractJdbc4Connection.java:187
 #, fuzzy
 msgid "ClientInfo property not supported."
-msgstr "Vrï¿½cenï¿½ automaticky generovanï¿½ch klï¿½ï¿½ï¿½ nenï¿½ podporovï¿½no."
+msgstr "Vrácení automaticky generovaných klíèù není podporováno."
 
 #: org/postgresql/jdbc4/AbstractJdbc4Statement.java:127
 msgid "Object is too large to send over the protocol."
@@ -1124,7 +1124,7 @@ msgstr ""
 #: org/postgresql/jdbc4/Jdbc4SQLXML.java:195
 #, fuzzy
 msgid "Unable to create SAXResult for SQLXML."
-msgstr "Selhalo vytvoï¿½enï¿½ objektu: {0}."
+msgstr "Selhalo vytvoøení objektu: {0}."
 
 #: org/postgresql/jdbc4/Jdbc4SQLXML.java:209
 msgid "Unable to create StAXResult for SQLXML"
@@ -1138,7 +1138,7 @@ msgstr ""
 #: org/postgresql/jdbc4/Jdbc4SQLXML.java:226
 #, fuzzy
 msgid "This SQLXML object has already been freed."
-msgstr "Tento PooledConnection byl uzavï¿½en."
+msgstr "Tento PooledConnection byl uzavøen."
 
 #: org/postgresql/jdbc4/Jdbc4SQLXML.java:233
 msgid ""
@@ -1168,13 +1168,13 @@ msgstr "Selhala inicializace LargeObject API"
 #: org/postgresql/largeobject/LargeObjectManager.java:198
 #: org/postgresql/largeobject/LargeObjectManager.java:239
 msgid "Large Objects may not be used in auto-commit mode."
-msgstr "Velkï¿½ objecky nemohou bï¿½t pouï¿½ity v auto-commit modu."
+msgstr "Velké objecky nemohou být pou¾ity v auto-commit modu."
 
 #: org/postgresql/ssl/jdbc3/AbstractJdbc3MakeSSL.java:58
 #: org/postgresql/ssl/jdbc4/AbstractJdbc4MakeSSL.java:110
 #, java-format
 msgid "The SSLSocketFactory class provided {0} could not be instantiated."
-msgstr "Tï¿½ï¿½da SSLSocketFactory poskytla {0} coï¿½ nemï¿½e bï¿½t instancionizovï¿½no."
+msgstr "Tøída SSLSocketFactory poskytla {0} co¾ nemù¾e být instancionizováno."
 
 #: org/postgresql/ssl/jdbc4/AbstractJdbc4MakeSSL.java:125
 #, java-format
@@ -1184,7 +1184,7 @@ msgstr ""
 #: org/postgresql/ssl/jdbc4/AbstractJdbc4MakeSSL.java:138
 #, fuzzy, java-format
 msgid "The HostnameVerifier class provided {0} could not be instantiated."
-msgstr "Tï¿½ï¿½da SSLSocketFactory poskytla {0} coï¿½ nemï¿½e bï¿½t instancionizovï¿½no."
+msgstr "Tøída SSLSocketFactory poskytla {0} co¾ nemù¾e být instancionizováno."
 
 #: org/postgresql/ssl/jdbc4/AbstractJdbc4MakeSSL.java:142
 #, java-format
@@ -1244,7 +1244,7 @@ msgstr ""
 #: org/postgresql/ssl/jdbc4/LibPQFactory.java:99
 #, fuzzy, java-format
 msgid "The password callback class provided {0} could not be instantiated."
-msgstr "Tï¿½ï¿½da SSLSocketFactory poskytla {0} coï¿½ nemï¿½e bï¿½t instancionizovï¿½no."
+msgstr "Tøída SSLSocketFactory poskytla {0} co¾ nemù¾e být instancionizováno."
 
 #: org/postgresql/ssl/jdbc4/LibPQFactory.java:133
 #, java-format
@@ -1268,11 +1268,11 @@ msgstr ""
 #: org/postgresql/util/PGInterval.java:164
 #, fuzzy
 msgid "Conversion of interval failed"
-msgstr "Pï¿½evod penï¿½z selhal."
+msgstr "Pøevod penìz selhal."
 
 #: org/postgresql/util/PGmoney.java:73
 msgid "Conversion of money failed."
-msgstr "Pï¿½evod penï¿½z selhal."
+msgstr "Pøevod penìz selhal."
 
 #: org/postgresql/util/ServerErrorMessage.java:155
 #, java-format
@@ -1307,7 +1307,7 @@ msgstr "Pozice: {0}"
 #: org/postgresql/util/ServerErrorMessage.java:180
 #, java-format
 msgid "Location: File: {0}, Routine: {1}, Line: {2}"
-msgstr "Poloha: Soubor: {0}, Rutina: {1}, ï¿½ï¿½dek: {2}"
+msgstr "Poloha: Soubor: {0}, Rutina: {1}, Øádek: {2}"
 
 #: org/postgresql/util/ServerErrorMessage.java:183
 #, java-format
@@ -1367,7 +1367,7 @@ msgstr ""
 #: org/postgresql/xa/PGXAConnection.java:292
 #, fuzzy
 msgid "Server versions prior to 8.1 do not support two-phase commit."
-msgstr "Verze serveru niï¿½ï¿½ï¿½ neï¿½ 8.0 nepodporujï¿½ savepoints."
+msgstr "Verze serveru ni¾¹í ne¾ 8.0 nepodporují savepoints."
 
 #: org/postgresql/xa/PGXAConnection.java:313
 msgid "Error preparing transaction"
@@ -1413,25 +1413,25 @@ msgid "Heuristic commit/rollback not supported"
 msgstr ""
 
 #~ msgid "The driver does not support SSL."
-#~ msgstr "Ovladaï¿½ nepodporuje SSL."
+#~ msgstr "Ovladaè nepodporuje SSL."
 
 #~ msgid "Multi-dimensional arrays are currently not supported."
-#~ msgstr "Vï¿½ce-rozmï¿½rnï¿½ pole nejsou nynï¿½ podporovï¿½ny."
+#~ msgstr "Více-rozmìrné pole nejsou nyní podporovány."
 
 #~ msgid "rand function only takes zero or one argument(the seed)."
-#~ msgstr "Funkce rand bere ï¿½ï¿½dnï¿½ nebo jen jeden argument(seed)."
+#~ msgstr "Funkce rand bere ¾ádný nebo jen jeden argument(seed)."
 
 #~ msgid "Exception: {0}"
-#~ msgstr "Vyjï¿½mka: {0}"
+#~ msgstr "Vyjímka: {0}"
 
 #~ msgid "Stack Trace:"
-#~ msgstr "Vï¿½pis zï¿½sobnï¿½ku:"
+#~ msgstr "Výpis zásobníku:"
 
 #~ msgid "End of Stack Trace"
-#~ msgstr "Konec vï¿½pisu zï¿½sobnï¿½ku"
+#~ msgstr "Konec výpisu zásobníku"
 
 #~ msgid "Exception generating stacktrace for: {0} encountered: {1}"
-#~ msgstr "Vyjï¿½mka tvoï¿½ï¿½cï¿½ vï¿½pis zï¿½sobnï¿½ku pro: {0} encountered: {1}"
+#~ msgstr "Vyjímka tvoøící výpis zásobníku pro: {0} encountered: {1}"
 
 #~ msgid ""
 #~ "PostgreSQL only supports a single OUT function return value at index 1."

--- a/org/postgresql/translation/de.po
+++ b/org/postgresql/translation/de.po
@@ -31,22 +31,22 @@ msgid ""
 "server host and port that you wish to connect to."
 msgstr ""
 "Ihre Sicherheitsrichtlinie hat den Versuch des Verbindungsaufbaus "
-"verhindert. Sie mï¿½ssen wahrscheinlich der Verbindung zum Datenbankrechner "
-"java.net.SocketPermission gewï¿½hren, um den Rechner auf dem gewï¿½hlten Port zu "
+"verhindert. Sie müssen wahrscheinlich der Verbindung zum Datenbankrechner "
+"java.net.SocketPermission gewähren, um den Rechner auf dem gewählten Port zu "
 "erreichen."
 
 #: bin/org/postgresql/Driver.java.in:287 bin/org/postgresql/Driver.java.in:351
 #: org/postgresql/Driver.java.in:287 org/postgresql/Driver.java.in:351
 msgid ""
-"Something unusual has occurred to cause the driver to fail. Please report "
+"Something unusual has occured to cause the driver to fail. Please report "
 "this exception."
 msgstr ""
-"Etwas Ungewï¿½hnliches ist passiert, das den Treiber fehlschlagen lieï¿½. Bitte "
+"Etwas Ungewöhnliches ist passiert, das den Treiber fehlschlagen ließ. Bitte "
 "teilen Sie diesen Fehler mit."
 
 #: bin/org/postgresql/Driver.java.in:359 org/postgresql/Driver.java.in:359
 msgid "Connection attempt timed out."
-msgstr "Keine Verbindung innerhalb des Zeitintervalls mï¿½glich."
+msgstr "Keine Verbindung innerhalb des Zeitintervalls möglich."
 
 #: bin/org/postgresql/Driver.java.in:367 org/postgresql/Driver.java.in:367
 msgid "Interrupted while attempting to connect."
@@ -70,7 +70,7 @@ msgstr ""
 #: org/postgresql/copy/PGCopyInputStream.java:51
 #, fuzzy, java-format
 msgid "Copying from database failed: {0}"
-msgstr "Konnte ï¿½{0}ï¿½ nicht in Typ ï¿½boxï¿½ umwandeln"
+msgstr "Konnte »{0}« nicht in Typ »box« umwandeln"
 
 #: org/postgresql/copy/PGCopyInputStream.java:67
 #: org/postgresql/copy/PGCopyOutputStream.java:90
@@ -120,40 +120,40 @@ msgstr "Eine Abfrage lieferte ein unerwartetes Resultat."
 msgid ""
 "Illegal UTF-8 sequence: byte {0} of {1} byte sequence is not 10xxxxxx: {2}"
 msgstr ""
-"Ungï¿½ltige UTF-8-Sequenz: Byte {0} der {1} Bytesequenz ist nicht 10xxxxxx: {2}"
+"Ungültige UTF-8-Sequenz: Byte {0} der {1} Bytesequenz ist nicht 10xxxxxx: {2}"
 
 #: org/postgresql/core/UTF8Encoding.java:61
 #, java-format
 msgid "Illegal UTF-8 sequence: {0} bytes used to encode a {1} byte value: {2}"
 msgstr ""
-"Ungï¿½ltige UTF-8-Sequenz: {0} Bytes wurden verwendet um einen {1} Bytewert zu "
+"Ungültige UTF-8-Sequenz: {0} Bytes wurden verwendet um einen {1} Bytewert zu "
 "kodieren: {2}"
 
 #: org/postgresql/core/UTF8Encoding.java:98
 #: org/postgresql/core/UTF8Encoding.java:125
 #, java-format
 msgid "Illegal UTF-8 sequence: initial byte is {0}: {1}"
-msgstr "Ungï¿½ltige UTF-8-Sequenz: das erste Byte ist {0}: {1}"
+msgstr "Ungültige UTF-8-Sequenz: das erste Byte ist {0}: {1}"
 
 #: org/postgresql/core/UTF8Encoding.java:130
 #, java-format
 msgid "Illegal UTF-8 sequence: final value is out of range: {0}"
 msgstr ""
-"Ungï¿½ltige UTF-8-Sequenz: Der letzte Wert ist auï¿½erhalb des zulï¿½ssigen "
+"Ungültige UTF-8-Sequenz: Der letzte Wert ist außerhalb des zulässigen "
 "Bereichs: {0}"
 
 #: org/postgresql/core/UTF8Encoding.java:145
 #, java-format
 msgid "Illegal UTF-8 sequence: final value is a surrogate value: {0}"
-msgstr "Ungï¿½ltige UTF-8-Sequenz: der letzte Wert ist ein Ersatzwert: {0}"
+msgstr "Ungültige UTF-8-Sequenz: der letzte Wert ist ein Ersatzwert: {0}"
 
 #: org/postgresql/core/Utils.java:95 org/postgresql/core/Utils.java:112
 msgid "Zero bytes may not occur in string parameters."
-msgstr "Stringparameter dï¿½rfen keine Nullbytes enthalten."
+msgstr "Stringparameter dürfen keine Nullbytes enthalten."
 
 #: org/postgresql/core/Utils.java:145
 msgid "Zero bytes may not occur in identifiers."
-msgstr "Nullbytes dï¿½rfen in Bezeichnern nicht vorkommen."
+msgstr "Nullbytes dürfen in Bezeichnern nicht vorkommen."
 
 #: org/postgresql/core/types/PGBigDecimal.java:63
 #: org/postgresql/core/types/PGBoolean.java:62
@@ -167,13 +167,13 @@ msgstr "Nullbytes dï¿½rfen in Bezeichnern nicht vorkommen."
 #: org/postgresql/core/types/PGString.java:73
 #, java-format
 msgid "Cannot convert an instance of {0} to type {1}"
-msgstr "Die Typwandlung fï¿½r eine Instanz von {0} nach {1} ist nicht mï¿½glich."
+msgstr "Die Typwandlung für eine Instanz von {0} nach {1} ist nicht möglich."
 
 #: org/postgresql/core/v2/ConnectionFactoryImpl.java:66
 #: org/postgresql/core/v3/ConnectionFactoryImpl.java:74
 #, fuzzy, java-format
 msgid "Invalid sslmode value: {0}"
-msgstr "Ungï¿½ltige Lï¿½nge des Datenstroms: {0}."
+msgstr "Ungültige Länge des Datenstroms: {0}."
 
 #: org/postgresql/core/v2/ConnectionFactoryImpl.java:134
 #: org/postgresql/core/v3/ConnectionFactoryImpl.java:168
@@ -181,7 +181,7 @@ msgid ""
 "Connection refused. Check that the hostname and port are correct and that "
 "the postmaster is accepting TCP/IP connections."
 msgstr ""
-"Verbindung verweigert. ï¿½berprï¿½fen Sie die Korrektheit von Hostnamen und der "
+"Verbindung verweigert. Überprüfen Sie die Korrektheit von Hostnamen und der "
 "Portnummer und dass der Datenbankserver TCP/IP-Verbindungen annimmt."
 
 #: org/postgresql/core/v2/ConnectionFactoryImpl.java:153
@@ -200,11 +200,11 @@ msgstr "Der Verbindungsversuch schlug fehl."
 #: org/postgresql/core/v3/ConnectionFactoryImpl.java:256
 #: org/postgresql/core/v3/ConnectionFactoryImpl.java:268
 msgid "The server does not support SSL."
-msgstr "Der Server unterstï¿½tzt SSL nicht."
+msgstr "Der Server unterstützt SSL nicht."
 
 #: org/postgresql/core/v2/ConnectionFactoryImpl.java:223
 #: org/postgresql/core/v3/ConnectionFactoryImpl.java:281
-msgid "An error occurred while setting up the SSL connection."
+msgid "An error occured while setting up the SSL connection."
 msgstr "Beim Aufbau der SSL-Verbindung trat ein Fehler auf."
 
 #: org/postgresql/core/v2/ConnectionFactoryImpl.java:272
@@ -233,10 +233,10 @@ msgid ""
 "the pg_hba.conf file to include the client''s IP address or subnet, and that "
 "it is using an authentication scheme supported by the driver."
 msgstr ""
-"Der Authentifizierungstyp {0} wird nicht unterstï¿½tzt. Stellen Sie sicher, "
+"Der Authentifizierungstyp {0} wird nicht unterstützt. Stellen Sie sicher, "
 "dass die Datei ''pg_hba.conf'' die IP-Adresse oder das Subnetz des Clients "
-"enthï¿½lt und dass der Client ein Authentifizierungsschema nutzt, das vom "
-"Treiber unterstï¿½tzt wird."
+"enthält und dass der Client ein Authentifizierungsschema nutzt, das vom "
+"Treiber unterstützt wird."
 
 #: org/postgresql/core/v2/ConnectionFactoryImpl.java:362
 #: org/postgresql/core/v2/ConnectionFactoryImpl.java:400
@@ -270,7 +270,7 @@ msgstr "Das Backend konnte nicht gestartet werden: {0}."
 #, java-format
 msgid "The column index is out of range: {0}, number of columns: {1}."
 msgstr ""
-"Der Spaltenindex {0} ist auï¿½erhalb des gï¿½ltigen Bereichs. Anzahl Spalten: "
+"Der Spaltenindex {0} ist außerhalb des gültigen Bereichs. Anzahl Spalten: "
 "{1}."
 
 #: org/postgresql/core/v2/FastpathParameterList.java:142
@@ -278,7 +278,7 @@ msgstr ""
 #: org/postgresql/core/v3/SimpleParameterList.java:183
 #, java-format
 msgid "No value specified for parameter {0}."
-msgstr "Fï¿½r den Parameter {0} wurde kein Wert angegeben."
+msgstr "Für den Parameter {0} wurde kein Wert angegeben."
 
 #: org/postgresql/core/v2/QueryExecutorImpl.java:72
 #: org/postgresql/core/v2/QueryExecutorImpl.java:337
@@ -305,7 +305,7 @@ msgstr "Unerwarteter Befehlsstatus: {0}."
 #: org/postgresql/core/v3/QueryExecutorImpl.java:551
 #: org/postgresql/core/v3/QueryExecutorImpl.java:631
 #: org/postgresql/core/v3/QueryExecutorImpl.java:2094
-msgid "An I/O error occurred while sending to the backend."
+msgid "An I/O error occured while sending to the backend."
 msgstr "Eingabe/Ausgabe-Fehler {0} beim Senden an das Backend."
 
 #: org/postgresql/core/v2/QueryExecutorImpl.java:170
@@ -321,14 +321,14 @@ msgstr "Die Antwort weist einen unbekannten Typ auf: {0}."
 #: org/postgresql/core/v2/QueryExecutorImpl.java:475
 #: org/postgresql/core/v3/QueryExecutorImpl.java:1857
 msgid "Ran out of memory retrieving query results."
-msgstr "Nicht genï¿½gend Speicher beim Abholen der Abfrageergebnisse."
+msgstr "Nicht genügend Speicher beim Abholen der Abfrageergebnisse."
 
 #: org/postgresql/core/v2/QueryExecutorImpl.java:597
 #: org/postgresql/core/v3/QueryExecutorImpl.java:2199
 #, java-format
 msgid "Unable to interpret the update count in command completion tag: {0}."
 msgstr ""
-"Der Updatecount aus der Kommandovervollstï¿½ndigungsmarkierung(?) {0} konnte "
+"Der Updatecount aus der Kommandovervollständigungsmarkierung(?) {0} konnte "
 "nicht interpretiert werden."
 
 #: org/postgresql/core/v2/QueryExecutorImpl.java:610
@@ -438,8 +438,8 @@ msgid ""
 "Bind message length {0} too long.  This can be caused by very large or "
 "incorrect length specifications on InputStream parameters."
 msgstr ""
-"Die Nachrichtenlï¿½nge {0} ist zu groï¿½. Das kann von sehr groï¿½en oder "
-"inkorrekten Lï¿½ngenangaben eines InputStream-Parameters herrï¿½hren."
+"Die Nachrichtenlänge {0} ist zu groß. Das kann von sehr großen oder "
+"inkorrekten Längenangaben eines InputStream-Parameters herrühren."
 
 #: org/postgresql/core/v3/QueryExecutorImpl.java:1925
 #, fuzzy, java-format
@@ -447,8 +447,8 @@ msgid ""
 "The server''s client_encoding parameter was changed to {0}. The JDBC driver "
 "requires client_encoding to be UTF8 for correct operation."
 msgstr ""
-"Der Parameter ''client_encoding'' wurde auf dem Server auf {0} verï¿½ndert. "
-"Der JDBC-Treiber setzt fï¿½r korrektes Funktionieren die Einstellung UNICODE "
+"Der Parameter ''client_encoding'' wurde auf dem Server auf {0} verändert. "
+"Der JDBC-Treiber setzt für korrektes Funktionieren die Einstellung UNICODE "
 "voraus."
 
 #: org/postgresql/core/v3/QueryExecutorImpl.java:1932
@@ -457,8 +457,8 @@ msgid ""
 "The server''s DateStyle parameter was changed to {0}. The JDBC driver "
 "requires DateStyle to begin with ISO for correct operation."
 msgstr ""
-"Der Parameter ''Date Style'' wurde auf dem Server auf {0} verï¿½ndert. Der "
-"JDBC-Treiber setzt fï¿½r korrekte Funktion voraus, dass ''Date Style'' mit "
+"Der Parameter ''Date Style'' wurde auf dem Server auf {0} verändert. Der "
+"JDBC-Treiber setzt für korrekte Funktion voraus, dass ''Date Style'' mit "
 "''ISO'' beginnt."
 
 #: org/postgresql/core/v3/QueryExecutorImpl.java:1945
@@ -472,7 +472,7 @@ msgstr ""
 
 #: org/postgresql/core/v3/QueryExecutorImpl.java:2015
 msgid "The driver currently does not support COPY operations."
-msgstr "Der Treiber unterstï¿½tzt derzeit keine COPY-Operationen."
+msgstr "Der Treiber unterstützt derzeit keine COPY-Operationen."
 
 #: org/postgresql/ds/jdbc23/AbstractJdbc23PooledConnection.java:112
 msgid "This PooledConnection has already been closed."
@@ -484,7 +484,7 @@ msgid ""
 "for the same PooledConnection or the PooledConnection has been closed."
 msgstr ""
 "Die Verbindung wurde automatisch geschlossen, da entweder eine neue "
-"Verbindung fï¿½r die gleiche PooledConnection geï¿½ffnet wurde, oder die "
+"Verbindung für die gleiche PooledConnection geöffnet wurde, oder die "
 "PooledConnection geschlossen worden ist.."
 
 #: org/postgresql/ds/jdbc23/AbstractJdbc23PooledConnection.java:295
@@ -508,7 +508,7 @@ msgstr "Die Datenquelle wurde geschlossen."
 #, java-format
 msgid "Fastpath call {0} - No result was returned and we expected an integer."
 msgstr ""
-"Der Fastpath-Aufruf {0} gab kein Ergebnis zurï¿½ck, jedoch wurde ein Integer "
+"Der Fastpath-Aufruf {0} gab kein Ergebnis zurück, jedoch wurde ein Integer "
 "erwartet."
 
 #: org/postgresql/fastpath/Fastpath.java:237
@@ -542,14 +542,14 @@ msgstr ""
 #: org/postgresql/jdbc2/AbstractJdbc2Array.java:790
 #, java-format
 msgid "The array index is out of range: {0}"
-msgstr "Der Arrayindex ist auï¿½erhalb des gï¿½ltigen Bereichs: {0}."
+msgstr "Der Arrayindex ist außerhalb des gültigen Bereichs: {0}."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Array.java:168
 #: org/postgresql/jdbc2/AbstractJdbc2Array.java:807
 #, java-format
 msgid "The array index is out of range: {0}, number of elements: {1}."
 msgstr ""
-"Der Arrayindex {0} ist auï¿½erhalb des gï¿½ltigen Bereichs. Vorhandene Elemente: "
+"Der Arrayindex {0} ist außerhalb des gültigen Bereichs. Vorhandene Elemente: "
 "{1}."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Array.java:196
@@ -562,16 +562,16 @@ msgid ""
 "was created in.  The most common example of this is storing 8bit data in a "
 "SQL_ASCII database."
 msgstr ""
-"Ungï¿½ltige Zeichendaten.  Das ist hï¿½chstwahrscheinlich von in der Datenbank "
+"Ungültige Zeichendaten.  Das ist höchstwahrscheinlich von in der Datenbank "
 "gespeicherten Zeichen hervorgerufen, die in einer anderen Kodierung "
-"vorliegen, als die, in der die Datenbank erstellt wurde.  Das hï¿½ufigste "
-"Beispiel dafï¿½r ist es, 8Bit-Daten in SQL_ASCII-Datenbanken abzulegen."
+"vorliegen, als die, in der die Datenbank erstellt wurde.  Das häufigste "
+"Beispiel dafür ist es, 8Bit-Daten in SQL_ASCII-Datenbanken abzulegen."
 
 #: org/postgresql/jdbc2/AbstractJdbc2BlobClob.java:73
 msgid ""
 "Truncation of large objects is only implemented in 8.3 and later servers."
 msgstr ""
-"Das Abschneiden groï¿½er Objekte ist nur in Versionen nach 8.3 implementiert."
+"Das Abschneiden großer Objekte ist nur in Versionen nach 8.3 implementiert."
 
 #: org/postgresql/jdbc2/AbstractJdbc2BlobClob.java:77
 msgid "Cannot truncate LOB to a negative length."
@@ -581,20 +581,20 @@ msgstr ""
 #: org/postgresql/jdbc2/AbstractJdbc2BlobClob.java:235
 #, java-format
 msgid "PostgreSQL LOBs can only index to: {0}"
-msgstr "LOBs in PostgreSQL kï¿½nnen nur auf {0} verweisen."
+msgstr "LOBs in PostgreSQL können nur auf {0} verweisen."
 
 #: org/postgresql/jdbc2/AbstractJdbc2BlobClob.java:231
 msgid "LOB positioning offsets start at 1."
-msgstr "Positionsoffsets fï¿½r LOBs beginnen bei 1."
+msgstr "Positionsoffsets für LOBs beginnen bei 1."
 
 #: org/postgresql/jdbc2/AbstractJdbc2BlobClob.java:246
 msgid "free() was called on this LOB previously"
-msgstr "free() wurde bereits fï¿½r dieses LOB aufgerufen."
+msgstr "free() wurde bereits für dieses LOB aufgerufen."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Connection.java:229
 #, java-format
 msgid "Unsupported value for stringtype parameter: {0}"
-msgstr "Nichtunterstï¿½tzter Wert fï¿½r den Stringparameter: {0}"
+msgstr "Nichtunterstützter Wert für den Stringparameter: {0}"
 
 #: org/postgresql/jdbc2/AbstractJdbc2Connection.java:249
 msgid "unknownLength parameter value must be an integer"
@@ -623,26 +623,26 @@ msgstr "Die Anweisung lieferte ein Ergebnis obwohl keines erwartet wurde."
 #: org/postgresql/jdbc2/AbstractJdbc2Connection.java:523
 #, fuzzy
 msgid "Custom type maps are not supported."
-msgstr "Selbstdefinierte Typabbildungen werden nicht unterstï¿½tzt."
+msgstr "Selbstdefinierte Typabbildungen werden nicht unterstützt."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Connection.java:571
 #, java-format
 msgid "Failed to create object for: {0}."
-msgstr "Erstellung des Objektes schlug fehl fï¿½r: {0}."
+msgstr "Erstellung des Objektes schlug fehl für: {0}."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Connection.java:633
 #, java-format
 msgid "Unable to load the class {0} responsible for the datatype {1}"
 msgstr ""
-"Die fï¿½r den Datentyp {1} verantwortliche Klasse {0} konnte nicht geladen "
+"Die für den Datentyp {1} verantwortliche Klasse {0} konnte nicht geladen "
 "werden."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Connection.java:729
 msgid ""
 "Cannot change transaction read-only property in the middle of a transaction."
 msgstr ""
-"Die Nur-Lesen-Eigenschaft einer Transaktion kann nicht wï¿½hrend der "
-"Transaktion verï¿½ndert werden."
+"Die Nur-Lesen-Eigenschaft einer Transaktion kann nicht während der "
+"Transaktion verändert werden."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Connection.java:817
 msgid "Cannot commit when autoCommit is enabled."
@@ -661,13 +661,13 @@ msgstr ""
 msgid ""
 "Cannot change transaction isolation level in the middle of a transaction."
 msgstr ""
-"Die Transaktions-Trennungsstufe kann nicht wï¿½hrend einer Transaktion "
-"verï¿½ndert werden."
+"Die Transaktions-Trennungsstufe kann nicht während einer Transaktion "
+"verändert werden."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Connection.java:938
 #, java-format
 msgid "Transaction isolation level {0} not supported."
-msgstr "Die Transaktions-Trennungsstufe {0} ist nicht unterstï¿½tzt."
+msgstr "Die Transaktions-Trennungsstufe {0} ist nicht unterstützt."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Connection.java:1005
 msgid "Finalizing a Connection that was never closed:"
@@ -675,14 +675,14 @@ msgstr "Eine Connection wurde finalisiert, die nie geschlossen wurde:"
 
 #: org/postgresql/jdbc2/AbstractJdbc2Connection.java:1107
 msgid "Unable to translate data into the desired encoding."
-msgstr "Die Daten konnten nicht in die gewï¿½nschte Kodierung gewandelt werden."
+msgstr "Die Daten konnten nicht in die gewünschte Kodierung gewandelt werden."
 
 #: org/postgresql/jdbc2/AbstractJdbc2DatabaseMetaData.java:63
 msgid ""
 "Unable to determine a value for MaxIndexKeys due to missing system catalog "
 "data."
 msgstr ""
-"Es konnte kein Wert fï¿½r MaxIndexKeys gefunden werden, da die "
+"Es konnte kein Wert für MaxIndexKeys gefunden werden, da die "
 "Systemkatalogdaten fehlen."
 
 #: org/postgresql/jdbc2/AbstractJdbc2DatabaseMetaData.java:86
@@ -711,29 +711,29 @@ msgstr ""
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:3174
 #, fuzzy, java-format
 msgid "Cannot convert the column of type {0} to requested type {1}."
-msgstr "Die Typwandlung fï¿½r eine Instanz von {0} nach {1} ist nicht mï¿½glich."
+msgstr "Die Typwandlung für eine Instanz von {0} nach {1} ist nicht möglich."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:744
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:768
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:1892
 msgid "Can''t use relative move methods while on the insert row."
 msgstr ""
-"Relative Bewegungen kï¿½nnen in der Einfï¿½gezeile nicht durchgefï¿½hrt werden."
+"Relative Bewegungen können in der Einfügezeile nicht durchgeführt werden."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:788
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:2949
 #, java-format
 msgid "Invalid fetch direction constant: {0}."
-msgstr "Unzulï¿½ssige Richtungskonstante bei fetch: {0}."
+msgstr "Unzulässige Richtungskonstante bei fetch: {0}."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:802
 msgid "Cannot call cancelRowUpdates() when on the insert row."
 msgstr ""
-"''cancelRowUpdates()'' kann in der Einfï¿½gezeile nicht aufgerufen werden."
+"''cancelRowUpdates()'' kann in der Einfügezeile nicht aufgerufen werden."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:822
 msgid "Cannot call deleteRow() when on the insert row."
-msgstr "''deleteRow()'' kann in der Einfï¿½gezeile nicht aufgerufen werden."
+msgstr "''deleteRow()'' kann in der Einfügezeile nicht aufgerufen werden."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:828
 msgid ""
@@ -757,12 +757,12 @@ msgstr "Es gibt keine Zeilen in diesem ResultSet."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:885
 msgid "Not on the insert row."
-msgstr "Nicht in der Einfï¿½gezeile."
+msgstr "Nicht in der Einfügezeile."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:889
 msgid "You must specify at least one column value to insert a row."
 msgstr ""
-"Sie mï¿½ssen mindestens einen Spaltenwert angeben, um eine Zeile einzufï¿½gen."
+"Sie müssen mindestens einen Spaltenwert angeben, um eine Zeile einzufügen."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:1074
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:1805
@@ -770,7 +770,7 @@ msgstr ""
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:2524
 #, java-format
 msgid "The JVM claims not to support the encoding: {0}"
-msgstr "Die JVM behauptet, die Zeichenkodierung {0} nicht zu unterstï¿½tzen."
+msgstr "Die JVM behauptet, die Zeichenkodierung {0} nicht zu unterstützen."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:1078
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:1121
@@ -786,11 +786,11 @@ msgstr "Der bereitgestellte Reader scheiterte."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:1259
 msgid "Can''t refresh the insert row."
-msgstr "Die Einfï¿½gezeile kann nicht aufgefrischt werden."
+msgstr "Die Einfügezeile kann nicht aufgefrischt werden."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:1327
 msgid "Cannot call updateRow() when on the insert row."
-msgstr "''updateRow()'' kann in der Einfï¿½gezeile nicht aufgerufen werden."
+msgstr "''updateRow()'' kann in der Einfügezeile nicht aufgerufen werden."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:1333
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:3190
@@ -804,18 +804,18 @@ msgstr ""
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:1582
 msgid "ResultSets with concurrency CONCUR_READ_ONLY cannot be updated."
 msgstr ""
-"ResultSets, deren Zugriffsart CONCUR_READ_ONLY ist, kï¿½nnen nicht "
+"ResultSets, deren Zugriffsart CONCUR_READ_ONLY ist, können nicht "
 "aktualisiert werden."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:1650
 #, java-format
 msgid "No primary key found for table {0}."
-msgstr "Fï¿½r die Tabelle {0} konnte kein Primï¿½rschlï¿½ssel gefunden werden."
+msgstr "Für die Tabelle {0} konnte kein Primärschlüssel gefunden werden."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:1876
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:2958
 msgid "Fetch size must be a value greater to or equal to 0."
-msgstr "Die Fetch-Grï¿½ï¿½e muss ein Wert grï¿½ï¿½er oder gleich Null sein."
+msgstr "Die Fetch-Größe muss ein Wert größer oder gleich Null sein."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:2044
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:2051
@@ -833,7 +833,7 @@ msgstr "Die Fetch-Grï¿½ï¿½e muss ein Wert grï¿½ï¿½er oder gleich Null sein."
 #: org/postgresql/jdbc2/TimestampUtils.java:258
 #, java-format
 msgid "Bad value for type {0} : {1}"
-msgstr "Unzulï¿½ssiger Wert fï¿½r den Typ {0} : {1}."
+msgstr "Unzulässiger Wert für den Typ {0} : {1}."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:2727
 #, java-format
@@ -847,8 +847,8 @@ msgid ""
 "the JDBC 2.1 API Specification, section 5.6 for more details."
 msgstr ""
 "Das ResultSet kann nicht aktualisiert werden.  Die Abfrage, die es erzeugte, "
-"darf nur eine Tabelle und muss darin alle Primï¿½rschlï¿½ssel auswï¿½hlen. Siehe "
-"JDBC 2.1 API-Spezifikation, Abschnitt 5.6 fï¿½r mehr Details."
+"darf nur eine Tabelle und muss darin alle Primärschlüssel auswählen. Siehe "
+"JDBC 2.1 API-Spezifikation, Abschnitt 5.6 für mehr Details."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:2839
 msgid "This ResultSet is closed."
@@ -868,7 +868,7 @@ msgstr ""
 msgid ""
 "Can''t use query methods that take a query string on a PreparedStatement."
 msgstr ""
-"Abfragemethoden, die einen Abfragestring annehmen, kï¿½nnen nicht auf ein "
+"Abfragemethoden, die einen Abfragestring annehmen, können nicht auf ein "
 "PreparedStatement angewandt werden."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:287
@@ -879,12 +879,12 @@ msgstr "Die Abfrage ergab mehrere ResultSets."
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:425
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:429
 msgid "A CallableStatement was executed with nothing returned."
-msgstr "Ein CallableStatement wurde ausgefï¿½hrt ohne etwas zurï¿½ckzugeben."
+msgstr "Ein CallableStatement wurde ausgeführt ohne etwas zurückzugeben."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:437
 msgid "A CallableStatement was executed with an invalid number of parameters"
 msgstr ""
-"Ein CallableStatement wurde mit einer falschen Anzahl Parameter ausgefï¿½hrt."
+"Ein CallableStatement wurde mit einer falschen Anzahl Parameter ausgeführt."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:468
 #, java-format
@@ -892,20 +892,20 @@ msgid ""
 "A CallableStatement function was executed and the out parameter {0} was of "
 "type {1} however type {2} was registered."
 msgstr ""
-"Eine CallableStatement-Funktion wurde ausgefï¿½hrt und der Rï¿½ckgabewert {0} "
-"war vom Typ {1}. Jedoch wurde der Typ {2} dafï¿½r registriert."
+"Eine CallableStatement-Funktion wurde ausgeführt und der Rückgabewert {0} "
+"war vom Typ {1}. Jedoch wurde der Typ {2} dafür registriert."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:670
 msgid "Maximum number of rows must be a value grater than or equal to 0."
-msgstr "Die maximale Zeilenzahl muss ein Wert grï¿½ï¿½er oder gleich Null sein."
+msgstr "Die maximale Zeilenzahl muss ein Wert größer oder gleich Null sein."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:713
 msgid "Query timeout must be a value greater than or equals to 0."
-msgstr "Das Abfragetimeout muss ein Wert grï¿½ï¿½er oder gleich Null sein."
+msgstr "Das Abfragetimeout muss ein Wert größer oder gleich Null sein."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:804
 msgid "The maximum field size must be a value greater than or equal to 0."
-msgstr "Die maximale Feldgrï¿½ï¿½e muss ein Wert grï¿½ï¿½er oder gleich Null sein."
+msgstr "Die maximale Feldgröße muss ein Wert größer oder gleich Null sein."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:1219
 msgid "Unknown Types value."
@@ -916,12 +916,12 @@ msgstr "Unbekannter Typ."
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:3101
 #, java-format
 msgid "Invalid stream length {0}."
-msgstr "Ungï¿½ltige Lï¿½nge des Datenstroms: {0}."
+msgstr "Ungültige Länge des Datenstroms: {0}."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:1523
 #, java-format
 msgid "The JVM claims not to support the {0} encoding."
-msgstr "Die JVM behauptet, die Zeichenkodierung {0} nicht zu unterstï¿½tzen."
+msgstr "Die JVM behauptet, die Zeichenkodierung {0} nicht zu unterstützen."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:1698
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:3023
@@ -938,7 +938,7 @@ msgstr ""
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:1850
 #, java-format
 msgid "Cannot cast an instance of {0} to type {1}"
-msgstr "Die Typwandlung fï¿½r eine Instanz von {0} nach {1} ist nicht mï¿½glich."
+msgstr "Die Typwandlung für eine Instanz von {0} nach {1} ist nicht möglich."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:1862
 #, java-format
@@ -951,7 +951,7 @@ msgid ""
 "Can''t infer the SQL type to use for an instance of {0}. Use setObject() "
 "with an explicit Types value to specify the type to use."
 msgstr ""
-"Der in SQL fï¿½r eine Instanz von {0} zu verwendende Datentyp kann nicht "
+"Der in SQL für eine Instanz von {0} zu verwendende Datentyp kann nicht "
 "abgeleitet werden. Benutzen Sie ''setObject()'' mit einem expliziten Typ, um "
 "ihn festzulegen."
 
@@ -972,7 +972,7 @@ msgstr ""
 #, java-format
 msgid "Malformed function or procedure escape syntax at offset {0}."
 msgstr ""
-"Unzulï¿½ssige Syntax fï¿½r ein Funktions- oder Prozedur-Escape an Offset {0}."
+"Unzulässige Syntax für ein Funktions- oder Prozedur-Escape an Offset {0}."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:2564
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:2578
@@ -1001,8 +1001,8 @@ msgstr "Es wurden keine Funktionsausgaben registriert."
 msgid ""
 "Results cannot be retrieved from a CallableStatement before it is executed."
 msgstr ""
-"Ergebnisse kï¿½nnen nicht von einem CallableStatement abgerufen werden, bevor "
-"es ausgefï¿½hrt wurde."
+"Ergebnisse können nicht von einem CallableStatement abgerufen werden, bevor "
+"es ausgeführt wurde."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:2637
 msgid "This statement has been closed."
@@ -1011,7 +1011,7 @@ msgstr "Die Anweisung wurde geschlossen."
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:2717
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:2787
 msgid "Too many update results were returned."
-msgstr "Zu viele Updateergebnisse wurden zurï¿½ckgegeben."
+msgstr "Zu viele Updateergebnisse wurden zurückgegeben."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:2746
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:2816
@@ -1104,8 +1104,8 @@ msgstr "Intervall {0} ist noch nicht implementiert."
 msgid ""
 "Infinite value found for timestamp/date. This cannot be represented as time."
 msgstr ""
-"Fï¿½r den Zeitstempel oder das Datum wurde der Wert ''unendlich'' gefunden. "
-"Dies kann nicht als Zeit reprï¿½sentiert werden."
+"Für den Zeitstempel oder das Datum wurde der Wert ''unendlich'' gefunden. "
+"Dies kann nicht als Zeit repräsentiert werden."
 
 #: org/postgresql/jdbc2/TimestampUtils.java:648
 #: org/postgresql/jdbc2/TimestampUtils.java:680
@@ -1122,14 +1122,14 @@ msgstr "Die Klasse {0} implementiert nicht ''org.postgresql.util.PGobject''."
 #: org/postgresql/jdbc3/AbstractJdbc3Connection.java:60
 #, java-format
 msgid "Unknown ResultSet holdability setting: {0}."
-msgstr "Unbekannte Einstellung fï¿½r die Haltbarkeit des ResultSets: {0}."
+msgstr "Unbekannte Einstellung für die Haltbarkeit des ResultSets: {0}."
 
 #: org/postgresql/jdbc3/AbstractJdbc3Connection.java:98
 #: org/postgresql/jdbc3/AbstractJdbc3Connection.java:130
 #: org/postgresql/jdbc3/AbstractJdbc3Connection.java:165
 #: org/postgresql/jdbc3/AbstractJdbc3Connection.java:187
 msgid "Server versions prior to 8.0 do not support savepoints."
-msgstr "Der Server unterstï¿½tzt keine Rettungspunkte vor Version 8.0."
+msgstr "Der Server unterstützt keine Rettungspunkte vor Version 8.0."
 
 #: org/postgresql/jdbc3/AbstractJdbc3Connection.java:100
 #: org/postgresql/jdbc3/AbstractJdbc3Connection.java:132
@@ -1138,26 +1138,26 @@ msgstr "Ein Rettungspunkt kann im Modus ''auto-commit'' nicht erstellt werden."
 
 #: org/postgresql/jdbc3/AbstractJdbc3Connection.java:419
 msgid "Returning autogenerated keys is not supported."
-msgstr "Die Rï¿½ckgabe automatisch generierter Schlï¿½ssel wird nicht unterstï¿½tzt,"
+msgstr "Die Rückgabe automatisch generierter Schlüssel wird nicht unterstützt,"
 
 #: org/postgresql/jdbc3/AbstractJdbc3ParameterMetaData.java:81
 #, java-format
 msgid "The parameter index is out of range: {0}, number of parameters: {1}."
 msgstr ""
-"Der Parameterindex {0} ist auï¿½erhalb des gï¿½ltigen Bereichs. Es gibt {1} "
+"Der Parameterindex {0} ist außerhalb des gültigen Bereichs. Es gibt {1} "
 "Parameter."
 
 #: org/postgresql/jdbc3/AbstractJdbc3Statement.java:151
 #, fuzzy
 msgid ""
 "Returning autogenerated keys is only supported for 8.2 and later servers."
-msgstr "Die Rï¿½ckgabe automatisch generierter Schlï¿½ssel wird nicht unterstï¿½tzt,"
+msgstr "Die Rückgabe automatisch generierter Schlüssel wird nicht unterstützt,"
 
 #: org/postgresql/jdbc3/AbstractJdbc3Statement.java:199
 #: org/postgresql/jdbc3/AbstractJdbc3Statement.java:317
 #, fuzzy
 msgid "Returning autogenerated keys by column index is not supported."
-msgstr "Die Rï¿½ckgabe automatisch generierter Schlï¿½ssel wird nicht unterstï¿½tzt,"
+msgstr "Die Rückgabe automatisch generierter Schlüssel wird nicht unterstützt,"
 
 #: org/postgresql/jdbc3/PSQLSavepoint.java:38
 #: org/postgresql/jdbc3/PSQLSavepoint.java:50
@@ -1177,18 +1177,18 @@ msgstr "Der Name eines namenlosen Rettungpunktes kann nicht ermittelt werden."
 #: org/postgresql/jdbc3g/AbstractJdbc3gResultSet.java:37
 #, fuzzy
 msgid "Invalid UUID data."
-msgstr "Ungï¿½ltiges Flag."
+msgstr "Ungültiges Flag."
 
 #: org/postgresql/jdbc4/AbstractJdbc4Connection.java:83
 #, fuzzy, java-format
 msgid "Unable to find server array type for provided name {0}."
 msgstr ""
-"Fï¿½r den angegebenen Namen {0} konnte kein Serverarraytyp gefunden werden."
+"Für den angegebenen Namen {0} konnte kein Serverarraytyp gefunden werden."
 
 #: org/postgresql/jdbc4/AbstractJdbc4Connection.java:120
 #, fuzzy, java-format
 msgid "Invalid timeout ({0}<0)."
-msgstr "Ungï¿½ltige Lï¿½nge des Datenstroms: {0}."
+msgstr "Ungültige Länge des Datenstroms: {0}."
 
 #: org/postgresql/jdbc4/AbstractJdbc4Connection.java:133
 msgid "Validating connection."
@@ -1197,12 +1197,12 @@ msgstr ""
 #: org/postgresql/jdbc4/AbstractJdbc4Connection.java:156
 #, fuzzy, java-format
 msgid "Failed to set ClientInfo property: {0}"
-msgstr "Erstellung des Objektes schlug fehl fï¿½r: {0}."
+msgstr "Erstellung des Objektes schlug fehl für: {0}."
 
 #: org/postgresql/jdbc4/AbstractJdbc4Connection.java:165
 #: org/postgresql/jdbc4/AbstractJdbc4Connection.java:187
 msgid "ClientInfo property not supported."
-msgstr "Die ClientInfo-Eigenschaft ist nicht unterstï¿½tzt."
+msgstr "Die ClientInfo-Eigenschaft ist nicht unterstützt."
 
 #: org/postgresql/jdbc4/AbstractJdbc4Statement.java:127
 msgid "Object is too large to send over the protocol."
@@ -1220,7 +1220,7 @@ msgstr ""
 #: org/postgresql/jdbc4/Jdbc4SQLXML.java:195
 #, fuzzy
 msgid "Unable to create SAXResult for SQLXML."
-msgstr "Erstellung des Objektes schlug fehl fï¿½r: {0}."
+msgstr "Erstellung des Objektes schlug fehl für: {0}."
 
 #: org/postgresql/jdbc4/Jdbc4SQLXML.java:209
 msgid "Unable to create StAXResult for SQLXML"
@@ -1229,7 +1229,7 @@ msgstr ""
 #: org/postgresql/jdbc4/Jdbc4SQLXML.java:213
 #, fuzzy, java-format
 msgid "Unknown XML Result class: {0}"
-msgstr "Unbekannte Einstellung fï¿½r die Haltbarkeit des ResultSets: {0}."
+msgstr "Unbekannte Einstellung für die Haltbarkeit des ResultSets: {0}."
 
 #: org/postgresql/jdbc4/Jdbc4SQLXML.java:226
 #, fuzzy
@@ -1265,7 +1265,7 @@ msgstr "Die LargeObject-API konnte nicht initialisiert werden."
 #: org/postgresql/largeobject/LargeObjectManager.java:239
 msgid "Large Objects may not be used in auto-commit mode."
 msgstr ""
-"LargeObjects (LOB) dï¿½rfen im Modus ''auto-commit'' nicht verwendet werden."
+"LargeObjects (LOB) dürfen im Modus ''auto-commit'' nicht verwendet werden."
 
 #: org/postgresql/ssl/jdbc3/AbstractJdbc3MakeSSL.java:58
 #: org/postgresql/ssl/jdbc4/AbstractJdbc4MakeSSL.java:110
@@ -1374,7 +1374,7 @@ msgstr "Die Umwandlung eines Intervalls schlug fehl."
 
 #: org/postgresql/util/PGmoney.java:73
 msgid "Conversion of money failed."
-msgstr "Die Umwandlung eines Wï¿½hrungsbetrags schlug fehl."
+msgstr "Die Umwandlung eines Währungsbetrags schlug fehl."
 
 #: org/postgresql/util/ServerErrorMessage.java:155
 #, java-format
@@ -1425,7 +1425,7 @@ msgstr ""
 #: org/postgresql/xa/PGXAConnection.java:186
 #: org/postgresql/xa/PGXAConnection.java:245
 msgid "Invalid flags"
-msgstr "Ungï¿½ltige Flags"
+msgstr "Ungültige Flags"
 
 #: org/postgresql/xa/PGXAConnection.java:189
 #: org/postgresql/xa/PGXAConnection.java:248
@@ -1435,7 +1435,7 @@ msgstr "Die xid darf nicht null sein."
 
 #: org/postgresql/xa/PGXAConnection.java:192
 msgid "Connection is busy with another transaction"
-msgstr "Die Verbindung ist derzeit mit einer anderen Transaktion beschï¿½ftigt."
+msgstr "Die Verbindung ist derzeit mit einer anderen Transaktion beschäftigt."
 
 #: org/postgresql/xa/PGXAConnection.java:198
 #: org/postgresql/xa/PGXAConnection.java:255
@@ -1455,14 +1455,14 @@ msgstr "Fehler beim Abschalten von Autocommit."
 #: org/postgresql/xa/PGXAConnection.java:251
 msgid "tried to call end without corresponding start call"
 msgstr ""
-"Es wurde versucht, ohne dazugehï¿½rigen ''start''-Aufruf ''end'' aufzurufen."
+"Es wurde versucht, ohne dazugehörigen ''start''-Aufruf ''end'' aufzurufen."
 
 #: org/postgresql/xa/PGXAConnection.java:282
 msgid ""
 "Not implemented: Prepare must be issued using the same connection that "
 "started the transaction"
 msgstr ""
-"Nicht implementiert: ''Prepare'' muss ï¿½ber die selbe Verbindung abgesetzt "
+"Nicht implementiert: ''Prepare'' muss über die selbe Verbindung abgesetzt "
 "werden, die die Transaktion startete."
 
 #: org/postgresql/xa/PGXAConnection.java:286
@@ -1471,7 +1471,7 @@ msgstr "''Prepare'' wurde vor ''end'' aufgerufen."
 
 #: org/postgresql/xa/PGXAConnection.java:292
 msgid "Server versions prior to 8.1 do not support two-phase commit."
-msgstr "Der Server unterstï¿½tzt keine zweiphasige Bestï¿½tigung vor Version 8.1."
+msgstr "Der Server unterstützt keine zweiphasige Bestätigung vor Version 8.1."
 
 #: org/postgresql/xa/PGXAConnection.java:313
 msgid "Error preparing transaction"
@@ -1479,7 +1479,7 @@ msgstr "Beim Vorbereiten der Transaktion trat ein Fehler auf."
 
 #: org/postgresql/xa/PGXAConnection.java:328
 msgid "Invalid flag"
-msgstr "Ungï¿½ltiges Flag."
+msgstr "Ungültiges Flag."
 
 #: org/postgresql/xa/PGXAConnection.java:368
 msgid "Error during recover"
@@ -1494,7 +1494,7 @@ msgid ""
 "Not implemented: one-phase commit must be issued using the same connection "
 "that was used to start it"
 msgstr ""
-"Nicht implementiert: Die einphasige Bestï¿½tigung muss ï¿½ber die selbe "
+"Nicht implementiert: Die einphasige Bestätigung muss über die selbe "
 "Verbindung abgewickelt werden, die verwendet wurde, um sie zu beginnen."
 
 #: org/postgresql/xa/PGXAConnection.java:455
@@ -1503,13 +1503,13 @@ msgstr "''Commit'' wurde vor ''end'' aufgerufen."
 
 #: org/postgresql/xa/PGXAConnection.java:466
 msgid "Error during one-phase commit"
-msgstr "Bei der einphasigen Bestï¿½tigung trat ein Fehler auf."
+msgstr "Bei der einphasigen Bestätigung trat ein Fehler auf."
 
 #: org/postgresql/xa/PGXAConnection.java:487
 msgid ""
 "Not implemented: 2nd phase commit must be issued using an idle connection"
 msgstr ""
-"Nicht implementiert: Die zweite Bestï¿½tigungsphase muss ï¿½ber eine im Leerlauf "
+"Nicht implementiert: Die zweite Bestätigungsphase muss über eine im Leerlauf "
 "befindliche Verbindung abgewickelt werden."
 
 #: org/postgresql/xa/PGXAConnection.java:507
@@ -1519,10 +1519,10 @@ msgstr "Fehler beim Rollback einer vorbereiteten Transaktion."
 
 #: org/postgresql/xa/PGXAConnection.java:522
 msgid "Heuristic commit/rollback not supported"
-msgstr "Heuristisches Commit/Rollback wird nicht unterstï¿½tzt."
+msgstr "Heuristisches Commit/Rollback wird nicht unterstützt."
 
 #~ msgid "The driver does not support SSL."
-#~ msgstr "Der Treiber unterstï¿½tzt SSL nicht."
+#~ msgstr "Der Treiber unterstützt SSL nicht."
 
 #~ msgid "Exception: {0}"
 #~ msgstr "Exception: {0}."
@@ -1535,10 +1535,10 @@ msgstr "Heuristisches Commit/Rollback wird nicht unterstï¿½tzt."
 
 #~ msgid "Exception generating stacktrace for: {0} encountered: {1}"
 #~ msgstr ""
-#~ "Beim Erstellen eines Stack-Traces fï¿½r {0} trat eine Exception auf: {1}"
+#~ "Beim Erstellen eines Stack-Traces für {0} trat eine Exception auf: {1}"
 
 #~ msgid "Multi-dimensional arrays are currently not supported."
-#~ msgstr "Mehrdimensionale Arrays werden derzeit nicht unterstï¿½tzt."
+#~ msgstr "Mehrdimensionale Arrays werden derzeit nicht unterstützt."
 
 #~ msgid "rand function only takes zero or one argument(the seed)."
 #~ msgstr ""
@@ -1552,14 +1552,14 @@ msgstr "Heuristisches Commit/Rollback wird nicht unterstï¿½tzt."
 #~ "setNull(i,Types.OTHER) is not supported; use setObject(i,nullobject,Types."
 #~ "OTHER) instead."
 #~ msgstr ""
-#~ "''setNull(i, Types.OTHER)'' wird nicht unterstï¿½tzt; benutzen Sie "
+#~ "''setNull(i, Types.OTHER)'' wird nicht unterstützt; benutzen Sie "
 #~ "stattdessen ''setObject(i, nullobject, Types.OTHER)''."
 
 #~ msgid ""
 #~ "setObject(i,null) is not supported. Instead, use setNull(i,type) or "
 #~ "setObject(i,null,type)"
 #~ msgstr ""
-#~ "''setObejct(i, null)'' ist nicht unterstï¿½tzt. Benutzen Sie ''setNull(i, "
+#~ "''setObejct(i, null)'' ist nicht unterstützt. Benutzen Sie ''setNull(i, "
 #~ "type)'' oder ''setObject(i, null, type)'' stattdessen."
 
 #~ msgid ""
@@ -1573,20 +1573,20 @@ msgstr "Heuristisches Commit/Rollback wird nicht unterstï¿½tzt."
 #~ msgid ""
 #~ "PostgreSQL only supports a single OUT function return value at index 1."
 #~ msgstr ""
-#~ "PostgreSQL unterstï¿½tzt auf dem Index 1 nur einen einzigen Rï¿½ckgabewert "
-#~ "fï¿½r die OUT-Funktion."
+#~ "PostgreSQL unterstützt auf dem Index 1 nur einen einzigen Rückgabewert "
+#~ "für die OUT-Funktion."
 
 #, fuzzy
 #~ msgid "Conversion of circle failed: {0}."
-#~ msgstr "Konnte ï¿½{0}ï¿½ nicht in Typ ï¿½circleï¿½ umwandeln"
+#~ msgstr "Konnte »{0}« nicht in Typ »circle« umwandeln"
 
 #, fuzzy
 #~ msgid "Conversion of line failed: {0}."
-#~ msgstr "Konnte ï¿½{0}ï¿½ nicht in Typ ï¿½lineï¿½ umwandeln"
+#~ msgstr "Konnte »{0}« nicht in Typ »line« umwandeln"
 
 #, fuzzy
 #~ msgid "Conversion of point failed: {0}."
-#~ msgstr "Konnte ï¿½{0}ï¿½ nicht in Typ ï¿½pointï¿½ umwandeln"
+#~ msgstr "Konnte »{0}« nicht in Typ »point« umwandeln"
 
 #, fuzzy
 #~ msgid "No results where returned by the query."
@@ -1594,32 +1594,32 @@ msgstr "Heuristisches Commit/Rollback wird nicht unterstï¿½tzt."
 
 #, fuzzy
 #~ msgid "Bad byte: {0}"
-#~ msgstr "Ungï¿½ltiges Format fï¿½r Byte: {0}"
+#~ msgstr "Ungültiges Format für Byte: {0}"
 
 #, fuzzy
 #~ msgid "Bad short: {0}"
-#~ msgstr "Ungï¿½ltiges Format fï¿½r Short: {0}"
+#~ msgstr "Ungültiges Format für Short: {0}"
 
 #, fuzzy
 #~ msgid "Bad int: {0}"
-#~ msgstr "Ungï¿½ltiges Format fï¿½r Long: {0}"
+#~ msgstr "Ungültiges Format für Long: {0}"
 
 #, fuzzy
 #~ msgid "Bad long: {0}"
-#~ msgstr "Ungï¿½ltiges Format fï¿½r Long: {0}"
+#~ msgstr "Ungültiges Format für Long: {0}"
 
 #, fuzzy
 #~ msgid "Bad BigDecimal: {0}"
-#~ msgstr "Ungï¿½ltiges Format fï¿½r BigDecimal: {0}"
+#~ msgstr "Ungültiges Format für BigDecimal: {0}"
 
 #, fuzzy
 #~ msgid "Bad float: {0}"
-#~ msgstr "Ungï¿½ltiges Format fï¿½r Float: {0}"
+#~ msgstr "Ungültiges Format für Float: {0}"
 
 #, fuzzy
 #~ msgid "Bad double: {0}"
-#~ msgstr "Ungï¿½ltiges Format fï¿½r Double: {0}"
+#~ msgstr "Ungültiges Format für Double: {0}"
 
 #, fuzzy
 #~ msgid "Bad date: {0}"
-#~ msgstr "Ungï¿½ltiges Format fï¿½r Byte: {0}"
+#~ msgstr "Ungültiges Format für Byte: {0}"

--- a/org/postgresql/translation/de.po
+++ b/org/postgresql/translation/de.po
@@ -38,7 +38,7 @@ msgstr ""
 #: bin/org/postgresql/Driver.java.in:287 bin/org/postgresql/Driver.java.in:351
 #: org/postgresql/Driver.java.in:287 org/postgresql/Driver.java.in:351
 msgid ""
-"Something unusual has occured to cause the driver to fail. Please report "
+"Something unusual has occurred to cause the driver to fail. Please report "
 "this exception."
 msgstr ""
 "Etwas Ungewöhnliches ist passiert, das den Treiber fehlschlagen ließ. Bitte "
@@ -204,7 +204,7 @@ msgstr "Der Server unterstützt SSL nicht."
 
 #: org/postgresql/core/v2/ConnectionFactoryImpl.java:223
 #: org/postgresql/core/v3/ConnectionFactoryImpl.java:281
-msgid "An error occured while setting up the SSL connection."
+msgid "An error occurred while setting up the SSL connection."
 msgstr "Beim Aufbau der SSL-Verbindung trat ein Fehler auf."
 
 #: org/postgresql/core/v2/ConnectionFactoryImpl.java:272
@@ -305,7 +305,7 @@ msgstr "Unerwarteter Befehlsstatus: {0}."
 #: org/postgresql/core/v3/QueryExecutorImpl.java:551
 #: org/postgresql/core/v3/QueryExecutorImpl.java:631
 #: org/postgresql/core/v3/QueryExecutorImpl.java:2094
-msgid "An I/O error occured while sending to the backend."
+msgid "An I/O error occurred while sending to the backend."
 msgstr "Eingabe/Ausgabe-Fehler {0} beim Senden an das Backend."
 
 #: org/postgresql/core/v2/QueryExecutorImpl.java:170

--- a/org/postgresql/translation/fr.po
+++ b/org/postgresql/translation/fr.po
@@ -22,7 +22,7 @@ msgstr ""
 #: bin/org/postgresql/Driver.java.in:235 org/postgresql/Driver.java.in:235
 msgid "Error loading default settings from driverconfig.properties"
 msgstr ""
-"Erreur de chargement des valeurs par dï¿½faut depuis driverconfig.properties"
+"Erreur de chargement des valeurs par défaut depuis driverconfig.properties"
 
 #: bin/org/postgresql/Driver.java.in:282 org/postgresql/Driver.java.in:282
 msgid ""
@@ -34,24 +34,24 @@ msgstr ""
 #: bin/org/postgresql/Driver.java.in:287 bin/org/postgresql/Driver.java.in:351
 #: org/postgresql/Driver.java.in:287 org/postgresql/Driver.java.in:351
 msgid ""
-"Something unusual has occurred to cause the driver to fail. Please report "
+"Something unusual has occured to cause the driver to fail. Please report "
 "this exception."
 msgstr ""
-"Quelque chose d''inhabituel a provoquï¿½ l''ï¿½chec du pilote. Veuillez faire un "
+"Quelque chose d''inhabituel a provoqué l''échec du pilote. Veuillez faire un "
 "rapport sur cette erreur."
 
 #: bin/org/postgresql/Driver.java.in:359 org/postgresql/Driver.java.in:359
 msgid "Connection attempt timed out."
-msgstr "La tentative de connexion a ï¿½chouï¿½ dans le dï¿½lai imparti."
+msgstr "La tentative de connexion a échoué dans le délai imparti."
 
 #: bin/org/postgresql/Driver.java.in:367 org/postgresql/Driver.java.in:367
 msgid "Interrupted while attempting to connect."
-msgstr "Interrompu pendant l''ï¿½tablissement de la connexion."
+msgstr "Interrompu pendant l''établissement de la connexion."
 
 #: bin/org/postgresql/Driver.java.in:710 org/postgresql/Driver.java.in:710
 #, java-format
 msgid "Method {0} is not yet implemented."
-msgstr "La fonction {0} n''est pas encore implï¿½mentï¿½e."
+msgstr "La fonction {0} n''est pas encore implémentée."
 
 #: org/postgresql/copy/CopyManager.java:56
 #, java-format
@@ -72,7 +72,7 @@ msgstr ""
 #: org/postgresql/copy/PGCopyOutputStream.java:90
 #, fuzzy
 msgid "This copy stream is closed."
-msgstr "Ce ResultSet est fermï¿½."
+msgstr "Ce ResultSet est fermé."
 
 #: org/postgresql/copy/PGCopyInputStream.java:108
 msgid "Read from copy failed."
@@ -87,7 +87,7 @@ msgstr ""
 #, java-format
 msgid "A connection could not be made using the requested protocol {0}."
 msgstr ""
-"Aucune connexion n''a pu ï¿½tre ï¿½tablie en utilisant le protocole demandï¿½ {0}. "
+"Aucune connexion n''a pu être établie en utilisant le protocole demandé {0}. "
 
 #: org/postgresql/core/Oid.java:113
 #, java-format
@@ -98,60 +98,60 @@ msgstr ""
 #, java-format
 msgid "Premature end of input stream, expected {0} bytes, but only read {1}."
 msgstr ""
-"Fin prï¿½maturï¿½e du flux en entrï¿½e, {0} octets attendus, mais seulement {1} "
+"Fin prématurée du flux en entrée, {0} octets attendus, mais seulement {1} "
 "lus."
 
 #: org/postgresql/core/PGStream.java:530
 #, java-format
 msgid "Expected an EOF from server, got: {0}"
-msgstr "Attendait une fin de fichier du serveur, reï¿½u: {0}"
+msgstr "Attendait une fin de fichier du serveur, reçu: {0}"
 
 #: org/postgresql/core/SetupQueryRunner.java:86
 msgid "An unexpected result was returned by a query."
-msgstr "Un rï¿½sultat inattendu a ï¿½tï¿½ retournï¿½ par une requï¿½te."
+msgstr "Un résultat inattendu a été retourné par une requête."
 
 #: org/postgresql/core/UTF8Encoding.java:28
 #, java-format
 msgid ""
 "Illegal UTF-8 sequence: byte {0} of {1} byte sequence is not 10xxxxxx: {2}"
 msgstr ""
-"Sï¿½quence UTF-8 illï¿½gale: l''octet {0} de la sï¿½quence d''octet {1} n''est pas "
+"Séquence UTF-8 illégale: l''octet {0} de la séquence d''octet {1} n''est pas "
 "10xxxxxx: {2}"
 
 #: org/postgresql/core/UTF8Encoding.java:61
 #, java-format
 msgid "Illegal UTF-8 sequence: {0} bytes used to encode a {1} byte value: {2}"
 msgstr ""
-"Sï¿½quence UTF-8 illï¿½gale: {0} octets utilisï¿½ pour encoder une valeur ï¿½ {1} "
+"Séquence UTF-8 illégale: {0} octets utilisé pour encoder une valeur à {1} "
 "octets: {2}"
 
 #: org/postgresql/core/UTF8Encoding.java:98
 #: org/postgresql/core/UTF8Encoding.java:125
 #, java-format
 msgid "Illegal UTF-8 sequence: initial byte is {0}: {1}"
-msgstr "Sï¿½quence UTF-8 illï¿½gale: le premier octet est {0}: {1}"
+msgstr "Séquence UTF-8 illégale: le premier octet est {0}: {1}"
 
 #: org/postgresql/core/UTF8Encoding.java:130
 #, java-format
 msgid "Illegal UTF-8 sequence: final value is out of range: {0}"
 msgstr ""
-"Sï¿½quence UTF-8 illï¿½gale: la valeur finale est en dehors des limites: {0}"
+"Séquence UTF-8 illégale: la valeur finale est en dehors des limites: {0}"
 
 #: org/postgresql/core/UTF8Encoding.java:145
 #, java-format
 msgid "Illegal UTF-8 sequence: final value is a surrogate value: {0}"
 msgstr ""
-"Sï¿½quence UTF-8 illï¿½gale: la valeur finale est une valeur de remplacement: {0}"
+"Séquence UTF-8 illégale: la valeur finale est une valeur de remplacement: {0}"
 
 #: org/postgresql/core/Utils.java:95 org/postgresql/core/Utils.java:112
 msgid "Zero bytes may not occur in string parameters."
 msgstr ""
-"Zï¿½ro octets ne devrait pas se produire dans les paramï¿½tres de type chaï¿½ne de "
-"caractï¿½res."
+"Zéro octets ne devrait pas se produire dans les paramètres de type chaîne de "
+"caractères."
 
 #: org/postgresql/core/Utils.java:145
 msgid "Zero bytes may not occur in identifiers."
-msgstr "Des octects ï¿½ 0 ne devraient pas apparaï¿½tre dans les identifiants."
+msgstr "Des octects à 0 ne devraient pas apparaître dans les identifiants."
 
 #: org/postgresql/core/types/PGBigDecimal.java:63
 #: org/postgresql/core/types/PGBoolean.java:62
@@ -179,19 +179,19 @@ msgid ""
 "Connection refused. Check that the hostname and port are correct and that "
 "the postmaster is accepting TCP/IP connections."
 msgstr ""
-"Connexion refusï¿½e. Vï¿½rifiez que le nom de machine et le port sont corrects "
+"Connexion refusée. Vérifiez que le nom de machine et le port sont corrects "
 "et que postmaster accepte les connexions TCP/IP."
 
 #: org/postgresql/core/v2/ConnectionFactoryImpl.java:153
 #: org/postgresql/core/v3/ConnectionFactoryImpl.java:186
 msgid "The connection attempt failed."
-msgstr "La tentative de connexion a ï¿½chouï¿½."
+msgstr "La tentative de connexion a échoué."
 
 #: org/postgresql/core/v2/ConnectionFactoryImpl.java:175
 #: org/postgresql/core/v3/ConnectionFactoryImpl.java:207
 #, fuzzy
 msgid "The connection url is invalid."
-msgstr "La tentative de connexion a ï¿½chouï¿½."
+msgstr "La tentative de connexion a échoué."
 
 #: org/postgresql/core/v2/ConnectionFactoryImpl.java:198
 #: org/postgresql/core/v2/ConnectionFactoryImpl.java:210
@@ -202,14 +202,14 @@ msgstr "Le serveur ne supporte pas SSL."
 
 #: org/postgresql/core/v2/ConnectionFactoryImpl.java:223
 #: org/postgresql/core/v3/ConnectionFactoryImpl.java:281
-msgid "An error occurred while setting up the SSL connection."
+msgid "An error occured while setting up the SSL connection."
 msgstr ""
-"Une erreur s''est produite pendant l''ï¿½tablissement de la connexion SSL."
+"Une erreur s''est produite pendant l''établissement de la connexion SSL."
 
 #: org/postgresql/core/v2/ConnectionFactoryImpl.java:272
 #, java-format
 msgid "Connection rejected: {0}."
-msgstr "Connexion rejetï¿½eï¿½: {0}."
+msgstr "Connexion rejetée : {0}."
 
 #: org/postgresql/core/v2/ConnectionFactoryImpl.java:290
 #: org/postgresql/core/v2/ConnectionFactoryImpl.java:312
@@ -221,8 +221,8 @@ msgid ""
 "The server requested password-based authentication, but no password was "
 "provided."
 msgstr ""
-"Le serveur a demandï¿½ une authentification par mots de passe, mais aucun mot "
-"de passe n''a ï¿½tï¿½ fourni."
+"Le serveur a demandé une authentification par mots de passe, mais aucun mot "
+"de passe n''a été fourni."
 
 #: org/postgresql/core/v2/ConnectionFactoryImpl.java:356
 #: org/postgresql/core/v3/ConnectionFactoryImpl.java:465
@@ -232,9 +232,9 @@ msgid ""
 "the pg_hba.conf file to include the client''s IP address or subnet, and that "
 "it is using an authentication scheme supported by the driver."
 msgstr ""
-"Le type d''authentification {0} n''est pas supportï¿½. Vï¿½rifiez que vous avez "
-"configurï¿½ le fichier pg_hba.conf pour inclure l''adresse IP du client ou le "
-"sous-rï¿½seau et qu''il utilise un schï¿½ma d''authentification supportï¿½ par le "
+"Le type d''authentification {0} n''est pas supporté. Vérifiez que vous avez "
+"configuré le fichier pg_hba.conf pour inclure l''adresse IP du client ou le "
+"sous-réseau et qu''il utilise un schéma d''authentification supporté par le "
 "pilote."
 
 #: org/postgresql/core/v2/ConnectionFactoryImpl.java:362
@@ -247,12 +247,12 @@ msgstr ""
 #: org/postgresql/core/v3/ConnectionFactoryImpl.java:587
 #: org/postgresql/gss/MakeGSS.java:158
 msgid "Protocol error.  Session setup failed."
-msgstr "Erreur de protocole. Ouverture de la session en ï¿½chec."
+msgstr "Erreur de protocole. Ouverture de la session en échec."
 
 #: org/postgresql/core/v2/ConnectionFactoryImpl.java:390
 #, java-format
 msgid "Backend start-up failed: {0}."
-msgstr "Dï¿½marrage du serveur en ï¿½checï¿½: {0}."
+msgstr "Démarrage du serveur en échec : {0}."
 
 #: org/postgresql/core/v2/FastpathParameterList.java:55
 #: org/postgresql/core/v2/FastpathParameterList.java:77
@@ -269,14 +269,14 @@ msgstr "Dï¿½marrage du serveur en ï¿½checï¿½: {0}."
 #, java-format
 msgid "The column index is out of range: {0}, number of columns: {1}."
 msgstr ""
-"L''indice de la colonne est hors limiteï¿½: {0}, nombre de colonnesï¿½: {1}."
+"L''indice de la colonne est hors limite : {0}, nombre de colonnes : {1}."
 
 #: org/postgresql/core/v2/FastpathParameterList.java:142
 #: org/postgresql/core/v2/SimpleParameterList.java:155
 #: org/postgresql/core/v3/SimpleParameterList.java:183
 #, java-format
 msgid "No value specified for parameter {0}."
-msgstr "Pas de valeur spï¿½cifiï¿½e pour le paramï¿½tre {0}."
+msgstr "Pas de valeur spécifiée pour le paramètre {0}."
 
 #: org/postgresql/core/v2/QueryExecutorImpl.java:72
 #: org/postgresql/core/v2/QueryExecutorImpl.java:337
@@ -291,7 +291,7 @@ msgstr "Attendait le statut de commande BEGIN, obtenu {0}."
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:1828
 #, java-format
 msgid "Unexpected command status: {0}."
-msgstr "Statut de commande inattenduï¿½: {0}."
+msgstr "Statut de commande inattendu : {0}."
 
 #: org/postgresql/core/v2/QueryExecutorImpl.java:118
 #: org/postgresql/core/v2/QueryExecutorImpl.java:129
@@ -303,8 +303,8 @@ msgstr "Statut de commande inattenduï¿½: {0}."
 #: org/postgresql/core/v3/QueryExecutorImpl.java:551
 #: org/postgresql/core/v3/QueryExecutorImpl.java:631
 #: org/postgresql/core/v3/QueryExecutorImpl.java:2094
-msgid "An I/O error occurred while sending to the backend."
-msgstr "Une erreur d''entrï¿½e/sortie a eu lieu lors d''envoi vers le serveur."
+msgid "An I/O error occured while sending to the backend."
+msgstr "Une erreur d''entrée/sortie a eu lieu lors d''envoi vers le serveur."
 
 #: org/postgresql/core/v2/QueryExecutorImpl.java:170
 #: org/postgresql/core/v2/QueryExecutorImpl.java:225
@@ -313,21 +313,21 @@ msgstr "Une erreur d''entrï¿½e/sortie a eu lieu lors d''envoi vers le serveur."
 #: org/postgresql/core/v3/QueryExecutorImpl.java:685
 #, java-format
 msgid "Unknown Response Type {0}."
-msgstr "Type de rï¿½ponse inconnu {0}."
+msgstr "Type de réponse inconnu {0}."
 
 #: org/postgresql/core/v2/QueryExecutorImpl.java:430
 #: org/postgresql/core/v2/QueryExecutorImpl.java:475
 #: org/postgresql/core/v3/QueryExecutorImpl.java:1857
 msgid "Ran out of memory retrieving query results."
-msgstr "Ai manquï¿½ de mï¿½moire en rï¿½cupï¿½rant les rï¿½sultats de la requï¿½te."
+msgstr "Ai manqué de mémoire en récupérant les résultats de la requête."
 
 #: org/postgresql/core/v2/QueryExecutorImpl.java:597
 #: org/postgresql/core/v3/QueryExecutorImpl.java:2199
 #, java-format
 msgid "Unable to interpret the update count in command completion tag: {0}."
 msgstr ""
-"Incapable d''interprï¿½ter le nombre de mise ï¿½ jour dans la balise de "
-"complï¿½tion de commandeï¿½: {0}."
+"Incapable d''interpréter le nombre de mise à jour dans la balise de "
+"complétion de commande : {0}."
 
 #: org/postgresql/core/v2/QueryExecutorImpl.java:610
 msgid "Copy not implemented for protocol version 2"
@@ -348,11 +348,11 @@ msgstr ""
 #: org/postgresql/core/v3/QueryExecutorImpl.java:93
 #, fuzzy
 msgid "Interrupted while waiting to obtain lock on database connection"
-msgstr "Interrompu pendant l''ï¿½tablissement de la connexion."
+msgstr "Interrompu pendant l''établissement de la connexion."
 
 #: org/postgresql/core/v3/QueryExecutorImpl.java:275
 msgid "Unable to bind parameter values for statement."
-msgstr "Incapable de lier les valeurs des paramï¿½tres pour la commande."
+msgstr "Incapable de lier les valeurs des paramètres pour la commande."
 
 #: org/postgresql/core/v3/QueryExecutorImpl.java:726
 msgid "Database connection failed when starting copy"
@@ -423,7 +423,7 @@ msgstr ""
 #: org/postgresql/core/v3/QueryExecutorImpl.java:1005
 #, fuzzy, java-format
 msgid "Unexpected copydata from server for {0}"
-msgstr "Attendait une fin de fichier du serveur, reï¿½u: {0}"
+msgstr "Attendait une fin de fichier du serveur, reçu: {0}"
 
 #: org/postgresql/core/v3/QueryExecutorImpl.java:1056
 #, java-format
@@ -436,9 +436,9 @@ msgid ""
 "Bind message length {0} too long.  This can be caused by very large or "
 "incorrect length specifications on InputStream parameters."
 msgstr ""
-"La longueur du message de liaison {0} est trop grande. Cela peut ï¿½tre causï¿½ "
-"par des spï¿½cification de longueur trï¿½s grandes ou incorrectes pour les "
-"paramï¿½tres de type InputStream."
+"La longueur du message de liaison {0} est trop grande. Cela peut être causé "
+"par des spécification de longueur très grandes ou incorrectes pour les "
+"paramètres de type InputStream."
 
 #: org/postgresql/core/v3/QueryExecutorImpl.java:1925
 #, fuzzy, java-format
@@ -446,8 +446,8 @@ msgid ""
 "The server''s client_encoding parameter was changed to {0}. The JDBC driver "
 "requires client_encoding to be UTF8 for correct operation."
 msgstr ""
-"Le paramï¿½tre client_encoding du serveur a ï¿½tï¿½ changï¿½ pour {0}. Le pilote "
-"JDBC nï¿½cessite l''affectation de la valeur UNICODE ï¿½ client_encoding pour un "
+"Le paramètre client_encoding du serveur a été changé pour {0}. Le pilote "
+"JDBC nécessite l''affectation de la valeur UNICODE à client_encoding pour un "
 "fonctionnement correct."
 
 #: org/postgresql/core/v3/QueryExecutorImpl.java:1932
@@ -456,8 +456,8 @@ msgid ""
 "The server''s DateStyle parameter was changed to {0}. The JDBC driver "
 "requires DateStyle to begin with ISO for correct operation."
 msgstr ""
-"Le paramï¿½tre DateStyle du serveur a ï¿½tï¿½ changï¿½ pour {0}. Le pilote JDBC "
-"nï¿½cessite que DateStyle commence par ISO pour un fonctionnement correct."
+"Le paramètre DateStyle du serveur a été changé pour {0}. Le pilote JDBC "
+"nécessite que DateStyle commence par ISO pour un fonctionnement correct."
 
 #: org/postgresql/core/v3/QueryExecutorImpl.java:1945
 #, java-format
@@ -465,32 +465,32 @@ msgid ""
 "The server''s standard_conforming_strings parameter was reported as {0}. The "
 "JDBC driver expected on or off."
 msgstr ""
-"Le paramï¿½tre serveur standard_conforming_strings a pour valeur {0}. Le "
+"Le paramètre serveur standard_conforming_strings a pour valeur {0}. Le "
 "driver JDBC attend on ou off."
 
 #: org/postgresql/core/v3/QueryExecutorImpl.java:2015
 msgid "The driver currently does not support COPY operations."
-msgstr "Le pilote ne supporte pas actuellement les opï¿½rations COPY."
+msgstr "Le pilote ne supporte pas actuellement les opérations COPY."
 
 #: org/postgresql/ds/jdbc23/AbstractJdbc23PooledConnection.java:112
 msgid "This PooledConnection has already been closed."
-msgstr "Cette PooledConnection a dï¿½jï¿½ ï¿½tï¿½ fermï¿½e."
+msgstr "Cette PooledConnection a déjà été fermée."
 
 #: org/postgresql/ds/jdbc23/AbstractJdbc23PooledConnection.java:295
 msgid ""
 "Connection has been closed automatically because a new connection was opened "
 "for the same PooledConnection or the PooledConnection has been closed."
 msgstr ""
-"La connexion a ï¿½tï¿½ fermï¿½e automatiquement car une nouvelle connexion a ï¿½tï¿½ "
-"ouverte pour la mï¿½me PooledConnection ou la PooledConnection a ï¿½tï¿½ fermï¿½e."
+"La connexion a été fermée automatiquement car une nouvelle connexion a été "
+"ouverte pour la même PooledConnection ou la PooledConnection a été fermée."
 
 #: org/postgresql/ds/jdbc23/AbstractJdbc23PooledConnection.java:295
 msgid "Connection has been closed."
-msgstr "La connexion a ï¿½tï¿½ fermï¿½e."
+msgstr "La connexion a été fermée."
 
 #: org/postgresql/ds/jdbc23/AbstractJdbc23PooledConnection.java:442
 msgid "Statement has been closed."
-msgstr "Statement a ï¿½tï¿½ fermï¿½."
+msgstr "Statement a été fermé."
 
 #: org/postgresql/ds/jdbc23/AbstractJdbc23PoolingDataSource.java:291
 msgid "Failed to setup DataSource."
@@ -498,14 +498,14 @@ msgstr ""
 
 #: org/postgresql/ds/jdbc23/AbstractJdbc23PoolingDataSource.java:414
 msgid "DataSource has been closed."
-msgstr "DataSource a ï¿½tï¿½ fermï¿½e."
+msgstr "DataSource a été fermée."
 
 #: org/postgresql/fastpath/Fastpath.java:81
 #: org/postgresql/fastpath/Fastpath.java:128
 #, java-format
 msgid "Fastpath call {0} - No result was returned and we expected an integer."
 msgstr ""
-"Appel Fastpath {0} - Aucun rï¿½sultat n''a ï¿½tï¿½ retournï¿½ et nous attendions un "
+"Appel Fastpath {0} - Aucun résultat n''a été retourné et nous attendions un "
 "entier."
 
 #: org/postgresql/fastpath/Fastpath.java:237
@@ -521,12 +521,12 @@ msgstr "La fonction fastpath {0} est inconnue."
 #: org/postgresql/geometric/PGpoint.java:85
 #, java-format
 msgid "Conversion to type {0} failed: {1}."
-msgstr "La conversion vers le type {0} a ï¿½chouï¿½: {1}."
+msgstr "La conversion vers le type {0} a échoué : {1}."
 
 #: org/postgresql/geometric/PGpath.java:81
 #, java-format
 msgid "Cannot tell if path is open or closed: {0}."
-msgstr "Impossible de dire si path est fermï¿½ ou ouvertï¿½: {0}."
+msgstr "Impossible de dire si path est fermé ou ouvert : {0}."
 
 #: org/postgresql/gss/MakeGSS.java:47 org/postgresql/gss/MakeGSS.java:55
 #: org/postgresql/gss/MakeGSS.java:168
@@ -537,13 +537,13 @@ msgstr ""
 #: org/postgresql/jdbc2/AbstractJdbc2Array.java:790
 #, java-format
 msgid "The array index is out of range: {0}"
-msgstr "L''indice du tableau est hors limitesï¿½: {0}"
+msgstr "L''indice du tableau est hors limites : {0}"
 
 #: org/postgresql/jdbc2/AbstractJdbc2Array.java:168
 #: org/postgresql/jdbc2/AbstractJdbc2Array.java:807
 #, java-format
 msgid "The array index is out of range: {0}, number of elements: {1}."
-msgstr "L''indice du tableau est hors limitesï¿½: {0}, nombre d''ï¿½lï¿½mentsï¿½: {1}."
+msgstr "L''indice du tableau est hors limites : {0}, nombre d''éléments : {1}."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Array.java:196
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:1982
@@ -555,17 +555,17 @@ msgid ""
 "was created in.  The most common example of this is storing 8bit data in a "
 "SQL_ASCII database."
 msgstr ""
-"Des donnï¿½es de caractï¿½res invalides ont ï¿½tï¿½ trouvï¿½es. C''est probablement "
-"causï¿½ par le stockage de caractï¿½res invalides pour le jeu de caractï¿½res de "
-"crï¿½ation de la base. L''exemple le plus courant est le stockage de donnï¿½es "
+"Des données de caractères invalides ont été trouvées. C''est probablement "
+"causé par le stockage de caractères invalides pour le jeu de caractères de "
+"création de la base. L''exemple le plus courant est le stockage de données "
 "8bit dans une base SQL_ASCII."
 
 #: org/postgresql/jdbc2/AbstractJdbc2BlobClob.java:73
 msgid ""
 "Truncation of large objects is only implemented in 8.3 and later servers."
 msgstr ""
-"Le troncage des large objects n''est implï¿½mentï¿½ que dans les serveurs 8.3 et "
-"supï¿½rieurs."
+"Le troncage des large objects n''est implémenté que dans les serveurs 8.3 et "
+"supérieurs."
 
 #: org/postgresql/jdbc2/AbstractJdbc2BlobClob.java:77
 msgid "Cannot truncate LOB to a negative length."
@@ -575,21 +575,21 @@ msgstr ""
 #: org/postgresql/jdbc2/AbstractJdbc2BlobClob.java:235
 #, java-format
 msgid "PostgreSQL LOBs can only index to: {0}"
-msgstr "Les LOB PostgreSQL peuvent seulement s''indicer ï¿½: {0}"
+msgstr "Les LOB PostgreSQL peuvent seulement s''indicer à: {0}"
 
 #: org/postgresql/jdbc2/AbstractJdbc2BlobClob.java:231
 msgid "LOB positioning offsets start at 1."
-msgstr "Les dï¿½calages de position des LOB commencent ï¿½ 1."
+msgstr "Les décalages de position des LOB commencent à 1."
 
 #: org/postgresql/jdbc2/AbstractJdbc2BlobClob.java:246
 msgid "free() was called on this LOB previously"
-msgstr "free() a ï¿½tï¿½ appelï¿½e auparavant sur ce LOB"
+msgstr "free() a été appelée auparavant sur ce LOB"
 
 #: org/postgresql/jdbc2/AbstractJdbc2Connection.java:229
 #, java-format
 msgid "Unsupported value for stringtype parameter: {0}"
 msgstr ""
-"Valeur non supportï¿½e pour les paramï¿½tre de type chaï¿½ne de caractï¿½resï¿½: {0}"
+"Valeur non supportée pour les paramètre de type chaîne de caractères : {0}"
 
 #: org/postgresql/jdbc2/AbstractJdbc2Connection.java:249
 msgid "unknownLength parameter value must be an integer"
@@ -606,14 +606,14 @@ msgstr ""
 #: org/postgresql/jdbc2/TypeInfoCache.java:384
 #: org/postgresql/jdbc2/TypeInfoCache.java:388
 msgid "No results were returned by the query."
-msgstr "Aucun rï¿½sultat retournï¿½ par la requï¿½te."
+msgstr "Aucun résultat retourné par la requête."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Connection.java:371
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:336
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:368
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:2695
 msgid "A result was returned when none was expected."
-msgstr "Un rï¿½sultat a ï¿½tï¿½ retournï¿½ alors qu''aucun n''ï¿½tait attendu."
+msgstr "Un résultat a été retourné alors qu''aucun n''était attendu."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Connection.java:523
 msgid "Custom type maps are not supported."
@@ -622,18 +622,18 @@ msgstr ""
 #: org/postgresql/jdbc2/AbstractJdbc2Connection.java:571
 #, java-format
 msgid "Failed to create object for: {0}."
-msgstr "ï¿½chec ï¿½ la crï¿½ation de l''objet pourï¿½: {0}."
+msgstr "Échec à la création de l''objet pour : {0}."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Connection.java:633
 #, java-format
 msgid "Unable to load the class {0} responsible for the datatype {1}"
-msgstr "Incapable de charger la classe {0} responsable du type de donnï¿½es {1}"
+msgstr "Incapable de charger la classe {0} responsable du type de données {1}"
 
 #: org/postgresql/jdbc2/AbstractJdbc2Connection.java:729
 msgid ""
 "Cannot change transaction read-only property in the middle of a transaction."
 msgstr ""
-"Impossible de changer la propriï¿½tï¿½ read-only d''une transaction au milieu "
+"Impossible de changer la propriété read-only d''une transaction au milieu "
 "d''une transaction."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Connection.java:817
@@ -643,7 +643,7 @@ msgstr ""
 #: org/postgresql/jdbc2/AbstractJdbc2Connection.java:826
 #, fuzzy
 msgid "This connection has been closed."
-msgstr "La connexion a ï¿½tï¿½ fermï¿½e."
+msgstr "La connexion a été fermée."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Connection.java:846
 msgid "Cannot rollback when autoCommit is enabled."
@@ -659,41 +659,41 @@ msgstr ""
 #: org/postgresql/jdbc2/AbstractJdbc2Connection.java:938
 #, java-format
 msgid "Transaction isolation level {0} not supported."
-msgstr "Le niveau d''isolation de transaction {0} n''est pas supportï¿½."
+msgstr "Le niveau d''isolation de transaction {0} n''est pas supporté."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Connection.java:1005
 msgid "Finalizing a Connection that was never closed:"
-msgstr "Destruction d''une connection qui n''a jamais ï¿½tï¿½ fermï¿½e:"
+msgstr "Destruction d''une connection qui n''a jamais été fermée:"
 
 #: org/postgresql/jdbc2/AbstractJdbc2Connection.java:1107
 msgid "Unable to translate data into the desired encoding."
-msgstr "Impossible de traduire les donnï¿½es dans l''encodage dï¿½sirï¿½."
+msgstr "Impossible de traduire les données dans l''encodage désiré."
 
 #: org/postgresql/jdbc2/AbstractJdbc2DatabaseMetaData.java:63
 msgid ""
 "Unable to determine a value for MaxIndexKeys due to missing system catalog "
 "data."
 msgstr ""
-"Incapable de dï¿½terminer la valeur de MaxIndexKeys en raison de donnï¿½es "
-"manquante dans lecatalogue systï¿½me."
+"Incapable de déterminer la valeur de MaxIndexKeys en raison de données "
+"manquante dans lecatalogue système."
 
 #: org/postgresql/jdbc2/AbstractJdbc2DatabaseMetaData.java:86
 msgid "Unable to find name datatype in the system catalogs."
 msgstr ""
-"Incapable de trouver le type de donnï¿½e name dans les catalogues systï¿½mes."
+"Incapable de trouver le type de donnée name dans les catalogues systèmes."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:235
 msgid ""
 "Operation requires a scrollable ResultSet, but this ResultSet is "
 "FORWARD_ONLY."
 msgstr ""
-"L''opï¿½ration nï¿½cessite un scrollable ResultSet, mais ce ResultSet est "
+"L''opération nécessite un scrollable ResultSet, mais ce ResultSet est "
 "FORWARD_ONLY."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:416
 msgid "Unexpected error while decoding character data from a large object."
 msgstr ""
-"Erreur inattendue pendant le dï¿½codage des donnï¿½es caractï¿½res pour un large "
+"Erreur inattendue pendant le décodage des données caractères pour un large "
 "object."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:462
@@ -710,14 +710,14 @@ msgstr "Impossible de convertir une instance de type {0} vers le type {1}"
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:1892
 msgid "Can''t use relative move methods while on the insert row."
 msgstr ""
-"Impossible d''utiliser les fonctions de dï¿½placement relatif pendant "
+"Impossible d''utiliser les fonctions de déplacement relatif pendant "
 "l''insertion d''une ligne."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:788
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:2949
 #, java-format
 msgid "Invalid fetch direction constant: {0}."
-msgstr "Constante de direction pour la rï¿½cupï¿½ration invalideï¿½: {0}."
+msgstr "Constante de direction pour la récupération invalide : {0}."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:802
 msgid "Cannot call cancelRowUpdates() when on the insert row."
@@ -733,7 +733,7 @@ msgid ""
 "Currently positioned before the start of the ResultSet.  You cannot call "
 "deleteRow() here."
 msgstr ""
-"Actuellement positionnï¿½ avant le dï¿½but du ResultSet. Vous ne pouvez pas "
+"Actuellement positionné avant le début du ResultSet. Vous ne pouvez pas "
 "appeler deleteRow() ici."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:833
@@ -741,7 +741,7 @@ msgid ""
 "Currently positioned after the end of the ResultSet.  You cannot call "
 "deleteRow() here."
 msgstr ""
-"Actuellement positionnï¿½ aprï¿½s la fin du ResultSet. Vous ne pouvez pas "
+"Actuellement positionné après la fin du ResultSet. Vous ne pouvez pas "
 "appeler deleteRow() ici."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:838
@@ -755,7 +755,7 @@ msgstr "Pas sur la ligne en insertion."
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:889
 msgid "You must specify at least one column value to insert a row."
 msgstr ""
-"Vous devez spï¿½cifier au moins une valeur de colonne pour insï¿½rer une ligne."
+"Vous devez spécifier au moins une valeur de colonne pour insérer une ligne."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:1074
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:1805
@@ -763,28 +763,28 @@ msgstr ""
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:2524
 #, java-format
 msgid "The JVM claims not to support the encoding: {0}"
-msgstr "La JVM prï¿½tend ne pas supporter l''encodage: {0}"
+msgstr "La JVM prétend ne pas supporter l''encodage: {0}"
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:1078
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:1121
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:1527
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:1656
 msgid "Provided InputStream failed."
-msgstr "L''InputStream fourni a ï¿½chouï¿½."
+msgstr "L''InputStream fourni a échoué."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:1191
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:3130
 msgid "Provided Reader failed."
-msgstr "Le Reader fourni a ï¿½chouï¿½."
+msgstr "Le Reader fourni a échoué."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:1259
 msgid "Can''t refresh the insert row."
-msgstr "Impossible de rafraï¿½chir la ligne insï¿½rï¿½e."
+msgstr "Impossible de rafraîchir la ligne insérée."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:1327
 msgid "Cannot call updateRow() when on the insert row."
 msgstr ""
-"Impossible d''appeler updateRow() tant que l''on est sur la ligne insï¿½rï¿½e."
+"Impossible d''appeler updateRow() tant que l''on est sur la ligne insérée."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:1333
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:3190
@@ -792,24 +792,24 @@ msgid ""
 "Cannot update the ResultSet because it is either before the start or after "
 "the end of the results."
 msgstr ""
-"Impossible de mettre ï¿½ jour le ResultSet car c''est soit avant le dï¿½but ou "
-"aprï¿½s la fin des rï¿½sultats."
+"Impossible de mettre à jour le ResultSet car c''est soit avant le début ou "
+"après la fin des résultats."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:1582
 msgid "ResultSets with concurrency CONCUR_READ_ONLY cannot be updated."
 msgstr ""
-"Les ResultSets avec la concurrence CONCUR_READ_ONLY ne peuvent ï¿½tre mis ï¿½ "
+"Les ResultSets avec la concurrence CONCUR_READ_ONLY ne peuvent être mis à "
 "jour."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:1650
 #, java-format
 msgid "No primary key found for table {0}."
-msgstr "Pas de clï¿½ primaire trouvï¿½e pour la table {0}."
+msgstr "Pas de clé primaire trouvée pour la table {0}."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:1876
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:2958
 msgid "Fetch size must be a value greater to or equal to 0."
-msgstr "Fetch size doit ï¿½tre une valeur supï¿½rieur ou ï¿½gal ï¿½ 0."
+msgstr "Fetch size doit être une valeur supérieur ou égal à 0."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:2044
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:2051
@@ -827,12 +827,12 @@ msgstr "Fetch size doit ï¿½tre une valeur supï¿½rieur ou ï¿½gal ï¿½ 0."
 #: org/postgresql/jdbc2/TimestampUtils.java:258
 #, java-format
 msgid "Bad value for type {0} : {1}"
-msgstr "Mauvaise valeur pour le type {0}ï¿½: {1}"
+msgstr "Mauvaise valeur pour le type {0} : {1}"
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:2727
 #, java-format
 msgid "The column name {0} was not found in this ResultSet."
-msgstr "Le nom de colonne {0} n''a pas ï¿½tï¿½ trouvï¿½ dans ce ResultSet."
+msgstr "Le nom de colonne {0} n''a pas été trouvé dans ce ResultSet."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:2827
 msgid ""
@@ -840,19 +840,19 @@ msgid ""
 "select only one table, and must select all primary keys from that table. See "
 "the JDBC 2.1 API Specification, section 5.6 for more details."
 msgstr ""
-"Le ResultSet n''est pas modifiable. La requï¿½te qui a gï¿½nï¿½rï¿½ ce rï¿½sultat doit "
-"sï¿½lectionner seulement une table, et doit sï¿½lectionner toutes les clï¿½s "
-"primaires de cette table. Voir la spï¿½cification de l''API JDBC 2.1, section "
-"5.6 pour plus de dï¿½tails."
+"Le ResultSet n''est pas modifiable. La requête qui a généré ce résultat doit "
+"sélectionner seulement une table, et doit sélectionner toutes les clés "
+"primaires de cette table. Voir la spécification de l''API JDBC 2.1, section "
+"5.6 pour plus de détails."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:2839
 msgid "This ResultSet is closed."
-msgstr "Ce ResultSet est fermï¿½."
+msgstr "Ce ResultSet est fermé."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:2860
 msgid "ResultSet not positioned properly, perhaps you need to call next."
 msgstr ""
-"Le ResultSet n''est pas positionnï¿½ correctement, vous devez peut-ï¿½tre "
+"Le ResultSet n''est pas positionné correctement, vous devez peut-être "
 "appeler next()."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:259
@@ -862,24 +862,24 @@ msgstr ""
 msgid ""
 "Can''t use query methods that take a query string on a PreparedStatement."
 msgstr ""
-"Impossible d''utiliser les fonctions de requï¿½te qui utilisent une chaï¿½ne de "
-"caractï¿½res sur un PreparedStatement."
+"Impossible d''utiliser les fonctions de requête qui utilisent une chaîne de "
+"caractères sur un PreparedStatement."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:287
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:306
 msgid "Multiple ResultSets were returned by the query."
-msgstr "Plusieurs ResultSets ont ï¿½tï¿½ retournï¿½s par la requï¿½te."
+msgstr "Plusieurs ResultSets ont été retournés par la requête."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:425
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:429
 msgid "A CallableStatement was executed with nothing returned."
-msgstr "Un CallableStatement a ï¿½tï¿½ exï¿½cutï¿½ mais n''a rien retournï¿½."
+msgstr "Un CallableStatement a été exécuté mais n''a rien retourné."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:437
 #, fuzzy
 msgid "A CallableStatement was executed with an invalid number of parameters"
 msgstr ""
-"Un CallableStatement a ï¿½tï¿½ exï¿½cutï¿½ avec un nombre de paramï¿½tres incorrect"
+"Un CallableStatement a été exécuté avec un nombre de paramètres incorrect"
 
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:468
 #, java-format
@@ -887,22 +887,22 @@ msgid ""
 "A CallableStatement function was executed and the out parameter {0} was of "
 "type {1} however type {2} was registered."
 msgstr ""
-"Une fonction CallableStatement a ï¿½tï¿½ exï¿½cutï¿½e et le paramï¿½tre en sortie {0} "
-"ï¿½tait du type {1} alors que le type {2} ï¿½tait prï¿½vu."
+"Une fonction CallableStatement a été exécutée et le paramètre en sortie {0} "
+"était du type {1} alors que le type {2} était prévu."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:670
 msgid "Maximum number of rows must be a value grater than or equal to 0."
 msgstr ""
-"Le nombre maximum de lignes doit ï¿½tre une valeur supï¿½rieure ou ï¿½gale ï¿½ 0."
+"Le nombre maximum de lignes doit être une valeur supérieure ou égale à 0."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:713
 msgid "Query timeout must be a value greater than or equals to 0."
-msgstr "Query timeout doit ï¿½tre une valeur supï¿½rieure ou ï¿½gale ï¿½ 0."
+msgstr "Query timeout doit être une valeur supérieure ou égale à 0."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:804
 msgid "The maximum field size must be a value greater than or equal to 0."
 msgstr ""
-"La taille maximum des champs doit ï¿½tre une valeur supï¿½rieure ou ï¿½gale ï¿½ 0."
+"La taille maximum des champs doit être une valeur supérieure ou égale à 0."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:1219
 msgid "Unknown Types value."
@@ -918,13 +918,13 @@ msgstr "Longueur de flux invalide {0}."
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:1523
 #, java-format
 msgid "The JVM claims not to support the {0} encoding."
-msgstr "La JVM prï¿½tend ne pas supporter l''encodage {0}."
+msgstr "La JVM prétend ne pas supporter l''encodage {0}."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:1698
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:3023
 #, java-format
 msgid "Unknown type {0}."
-msgstr "Type inconnuï¿½: {0}."
+msgstr "Type inconnu : {0}."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:1713
 msgid "No hstore extension installed."
@@ -940,7 +940,7 @@ msgstr "Impossible de convertir une instance de {0} vers le type {1}"
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:1862
 #, java-format
 msgid "Unsupported Types value: {0}"
-msgstr "Valeur de type non supportï¿½eï¿½: {0}"
+msgstr "Valeur de type non supportée : {0}"
 
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:1920
 #, java-format
@@ -948,27 +948,27 @@ msgid ""
 "Can''t infer the SQL type to use for an instance of {0}. Use setObject() "
 "with an explicit Types value to specify the type to use."
 msgstr ""
-"Impossible de dï¿½duire le type SQL ï¿½ utiliser pour une instance de {0}. "
-"Utilisez setObject() avec une valeur de type explicite pour spï¿½cifier le "
-"type ï¿½ utiliser."
+"Impossible de déduire le type SQL à utiliser pour une instance de {0}. "
+"Utilisez setObject() avec une valeur de type explicite pour spécifier le "
+"type à utiliser."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:1968
 msgid ""
 "This statement does not declare an OUT parameter.  Use '{' ?= call ... '}' "
 "to declare one."
 msgstr ""
-"Cette requï¿½te ne dï¿½clare pas de paramï¿½tre OUT. Utilisez '{' ?= call ... '}' "
-"pour en dï¿½clarer un."
+"Cette requête ne déclare pas de paramètre OUT. Utilisez '{' ?= call ... '}' "
+"pour en déclarer un."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:2018
 msgid "wasNull cannot be call before fetching a result."
-msgstr "wasNull ne peut pas ï¿½tre appelï¿½ avant la rï¿½cupï¿½ration d''un rï¿½sultat."
+msgstr "wasNull ne peut pas être appelé avant la récupération d''un résultat."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:2514
 #, java-format
 msgid "Malformed function or procedure escape syntax at offset {0}."
 msgstr ""
-"Syntaxe de fonction ou d''ï¿½chappement de procï¿½dure malformï¿½e ï¿½ l''indice {0}."
+"Syntaxe de fonction ou d''échappement de procédure malformée à l''indice {0}."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:2564
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:2578
@@ -977,36 +977,36 @@ msgid ""
 "Parameter of type {0} was registered, but call to get{1} (sqltype={2}) was "
 "made."
 msgstr ""
-"Un paramï¿½tre de type {0} a ï¿½tï¿½ enregistrï¿½, mais un appel ï¿½ get{1} (sqltype="
-"{2}) a ï¿½tï¿½ fait."
+"Un paramètre de type {0} a été enregistré, mais un appel à get{1} (sqltype="
+"{2}) a été fait."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:2597
 msgid ""
 "A CallableStatement was declared, but no call to registerOutParameter(1, "
 "<some type>) was made."
 msgstr ""
-"Un CallableStatement a ï¿½tï¿½ dï¿½clarï¿½, mais aucun appel ï¿½ registerOutParameter"
-"(1, <un type>) n''a ï¿½tï¿½ fait."
+"Un CallableStatement a été déclaré, mais aucun appel à registerOutParameter"
+"(1, <un type>) n''a été fait."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:2601
 msgid "No function outputs were registered."
-msgstr "Aucune fonction outputs n''a ï¿½tï¿½ enregistrï¿½e."
+msgstr "Aucune fonction outputs n''a été enregistrée."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:2604
 msgid ""
 "Results cannot be retrieved from a CallableStatement before it is executed."
 msgstr ""
-"Les rï¿½sultats ne peuvent ï¿½tre rï¿½cupï¿½rï¿½s ï¿½ partir d''un CallableStatement "
-"avant qu''il ne soit exï¿½cutï¿½."
+"Les résultats ne peuvent être récupérés à partir d''un CallableStatement "
+"avant qu''il ne soit exécuté."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:2637
 msgid "This statement has been closed."
-msgstr "Ce statement a ï¿½tï¿½ fermï¿½."
+msgstr "Ce statement a été fermé."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:2717
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:2787
 msgid "Too many update results were returned."
-msgstr "Trop de rï¿½sultats de mise ï¿½ jour ont ï¿½tï¿½ retournï¿½s."
+msgstr "Trop de résultats de mise à jour ont été retournés."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:2746
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:2816
@@ -1014,14 +1014,14 @@ msgstr "Trop de rï¿½sultats de mise ï¿½ jour ont ï¿½tï¿½ retournï¿½s."
 msgid ""
 "Batch entry {0} {1} was aborted.  Call getNextException to see the cause."
 msgstr ""
-"L''ï¿½lï¿½ment du batch {0} {1} a ï¿½tï¿½ annulï¿½. Appeler getNextException pour en "
-"connaï¿½tre la cause."
+"L''élément du batch {0} {1} a été annulé. Appeler getNextException pour en "
+"connaître la cause."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:3071
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:3160
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:3200
 msgid "Unexpected error writing large object to database."
-msgstr "Erreur inattendue pendant l''ï¿½criture de large object dans la base."
+msgstr "Erreur inattendue pendant l''écriture de large object dans la base."
 
 #: org/postgresql/jdbc2/EscapedFunctions.java:145
 #: org/postgresql/jdbc2/EscapedFunctions.java:157
@@ -1091,31 +1091,31 @@ msgstr "La fonction {0} n''accepte que trois et seulement trois arguments."
 #: org/postgresql/jdbc2/EscapedFunctions.java:566
 #, java-format
 msgid "Interval {0} not yet implemented"
-msgstr "L''interval {0} n''est pas encore implï¿½mentï¿½"
+msgstr "L''interval {0} n''est pas encore implémenté"
 
 #: org/postgresql/jdbc2/TimestampUtils.java:360
 msgid ""
 "Infinite value found for timestamp/date. This cannot be represented as time."
 msgstr ""
-"Valeur infinie trouvï¿½e pour une date/timestamp. Cette valeur ne peut ï¿½tre "
-"reprï¿½sentï¿½ comme une valeur temporelle."
+"Valeur infinie trouvée pour une date/timestamp. Cette valeur ne peut être "
+"représenté comme une valeur temporelle."
 
 #: org/postgresql/jdbc2/TimestampUtils.java:648
 #: org/postgresql/jdbc2/TimestampUtils.java:680
 #: org/postgresql/jdbc2/TimestampUtils.java:727
 #, fuzzy, java-format
 msgid "Unsupported binary encoding of {0}."
-msgstr "Valeur de type non supportï¿½eï¿½: {0}"
+msgstr "Valeur de type non supportée : {0}"
 
 #: org/postgresql/jdbc2/TypeInfoCache.java:161
 #, java-format
 msgid "The class {0} does not implement org.postgresql.util.PGobject."
-msgstr "La classe {0} n''implï¿½mente pas org.postgresql.util.PGobject."
+msgstr "La classe {0} n''implémente pas org.postgresql.util.PGobject."
 
 #: org/postgresql/jdbc3/AbstractJdbc3Connection.java:60
 #, java-format
 msgid "Unknown ResultSet holdability setting: {0}."
-msgstr "Paramï¿½tre holdability du ResultSet inconnuï¿½: {0}."
+msgstr "Paramètre holdability du ResultSet inconnu : {0}."
 
 #: org/postgresql/jdbc3/AbstractJdbc3Connection.java:98
 #: org/postgresql/jdbc3/AbstractJdbc3Connection.java:130
@@ -1123,44 +1123,44 @@ msgstr "Paramï¿½tre holdability du ResultSet inconnuï¿½: {0}."
 #: org/postgresql/jdbc3/AbstractJdbc3Connection.java:187
 msgid "Server versions prior to 8.0 do not support savepoints."
 msgstr ""
-"Les serveurs de version antï¿½rieure ï¿½ 8.0 ne supportent pas les savepoints."
+"Les serveurs de version antérieure à 8.0 ne supportent pas les savepoints."
 
 #: org/postgresql/jdbc3/AbstractJdbc3Connection.java:100
 #: org/postgresql/jdbc3/AbstractJdbc3Connection.java:132
 msgid "Cannot establish a savepoint in auto-commit mode."
-msgstr "Impossible d''ï¿½tablir un savepoint en mode auto-commit."
+msgstr "Impossible d''établir un savepoint en mode auto-commit."
 
 #: org/postgresql/jdbc3/AbstractJdbc3Connection.java:419
 msgid "Returning autogenerated keys is not supported."
-msgstr "Le renvoi des clï¿½s automatiquement gï¿½nï¿½rï¿½es n''est pas supportï¿½."
+msgstr "Le renvoi des clés automatiquement générées n''est pas supporté."
 
 #: org/postgresql/jdbc3/AbstractJdbc3ParameterMetaData.java:81
 #, java-format
 msgid "The parameter index is out of range: {0}, number of parameters: {1}."
 msgstr ""
-"L''indice du paramï¿½tre est hors limitesï¿½: {0}, nombre de paramï¿½tresï¿½: {1}."
+"L''indice du paramètre est hors limites : {0}, nombre de paramètres : {1}."
 
 #: org/postgresql/jdbc3/AbstractJdbc3Statement.java:151
 #, fuzzy
 msgid ""
 "Returning autogenerated keys is only supported for 8.2 and later servers."
-msgstr "Le renvoi des clï¿½s automatiquement gï¿½nï¿½rï¿½es n''est pas supportï¿½."
+msgstr "Le renvoi des clés automatiquement générées n''est pas supporté."
 
 #: org/postgresql/jdbc3/AbstractJdbc3Statement.java:199
 #: org/postgresql/jdbc3/AbstractJdbc3Statement.java:317
 #, fuzzy
 msgid "Returning autogenerated keys by column index is not supported."
-msgstr "Le renvoi des clï¿½s automatiquement gï¿½nï¿½rï¿½es n''est pas supportï¿½."
+msgstr "Le renvoi des clés automatiquement générées n''est pas supporté."
 
 #: org/postgresql/jdbc3/PSQLSavepoint.java:38
 #: org/postgresql/jdbc3/PSQLSavepoint.java:50
 #: org/postgresql/jdbc3/PSQLSavepoint.java:66
 msgid "Cannot reference a savepoint after it has been released."
-msgstr "Impossible de rï¿½fï¿½rencer un savepoint aprï¿½s qu''il ait ï¿½tï¿½ libï¿½rï¿½."
+msgstr "Impossible de référencer un savepoint après qu''il ait été libéré."
 
 #: org/postgresql/jdbc3/PSQLSavepoint.java:42
 msgid "Cannot retrieve the id of a named savepoint."
-msgstr "Impossible de retrouver l''identifiant d''un savepoint nommï¿½."
+msgstr "Impossible de retrouver l''identifiant d''un savepoint nommé."
 
 #: org/postgresql/jdbc3/PSQLSavepoint.java:54
 msgid "Cannot retrieve the name of an unnamed savepoint."
@@ -1188,13 +1188,13 @@ msgstr ""
 #: org/postgresql/jdbc4/AbstractJdbc4Connection.java:156
 #, fuzzy, java-format
 msgid "Failed to set ClientInfo property: {0}"
-msgstr "ï¿½chec ï¿½ la crï¿½ation de l''objet pourï¿½: {0}."
+msgstr "Échec à la création de l''objet pour : {0}."
 
 #: org/postgresql/jdbc4/AbstractJdbc4Connection.java:165
 #: org/postgresql/jdbc4/AbstractJdbc4Connection.java:187
 #, fuzzy
 msgid "ClientInfo property not supported."
-msgstr "Le renvoi des clï¿½s automatiquement gï¿½nï¿½rï¿½es n''est pas supportï¿½."
+msgstr "Le renvoi des clés automatiquement générées n''est pas supporté."
 
 #: org/postgresql/jdbc4/AbstractJdbc4Statement.java:127
 msgid "Object is too large to send over the protocol."
@@ -1212,7 +1212,7 @@ msgstr ""
 #: org/postgresql/jdbc4/Jdbc4SQLXML.java:195
 #, fuzzy
 msgid "Unable to create SAXResult for SQLXML."
-msgstr "ï¿½chec ï¿½ la crï¿½ation de l''objet pourï¿½: {0}."
+msgstr "Échec à la création de l''objet pour : {0}."
 
 #: org/postgresql/jdbc4/Jdbc4SQLXML.java:209
 msgid "Unable to create StAXResult for SQLXML"
@@ -1221,12 +1221,12 @@ msgstr ""
 #: org/postgresql/jdbc4/Jdbc4SQLXML.java:213
 #, fuzzy, java-format
 msgid "Unknown XML Result class: {0}"
-msgstr "Paramï¿½tre holdability du ResultSet inconnuï¿½: {0}."
+msgstr "Paramètre holdability du ResultSet inconnu : {0}."
 
 #: org/postgresql/jdbc4/Jdbc4SQLXML.java:226
 #, fuzzy
 msgid "This SQLXML object has already been freed."
-msgstr "Cette PooledConnection a dï¿½jï¿½ ï¿½tï¿½ fermï¿½e."
+msgstr "Cette PooledConnection a déjà été fermée."
 
 #: org/postgresql/jdbc4/Jdbc4SQLXML.java:233
 msgid ""
@@ -1251,18 +1251,18 @@ msgstr ""
 
 #: org/postgresql/largeobject/LargeObjectManager.java:138
 msgid "Failed to initialize LargeObject API"
-msgstr "ï¿½chec ï¿½ l''initialisation de l''API LargeObject"
+msgstr "Échec à l''initialisation de l''API LargeObject"
 
 #: org/postgresql/largeobject/LargeObjectManager.java:198
 #: org/postgresql/largeobject/LargeObjectManager.java:239
 msgid "Large Objects may not be used in auto-commit mode."
-msgstr "Les Large Objects ne devraient pas ï¿½tre utilisï¿½s en mode auto-commit."
+msgstr "Les Large Objects ne devraient pas être utilisés en mode auto-commit."
 
 #: org/postgresql/ssl/jdbc3/AbstractJdbc3MakeSSL.java:58
 #: org/postgresql/ssl/jdbc4/AbstractJdbc4MakeSSL.java:110
 #, java-format
 msgid "The SSLSocketFactory class provided {0} could not be instantiated."
-msgstr "La classe SSLSocketFactory fournie {0} n''a pas pu ï¿½tre instanciï¿½e."
+msgstr "La classe SSLSocketFactory fournie {0} n''a pas pu être instanciée."
 
 #: org/postgresql/ssl/jdbc4/AbstractJdbc4MakeSSL.java:125
 #, java-format
@@ -1272,7 +1272,7 @@ msgstr ""
 #: org/postgresql/ssl/jdbc4/AbstractJdbc4MakeSSL.java:138
 #, fuzzy, java-format
 msgid "The HostnameVerifier class provided {0} could not be instantiated."
-msgstr "La classe SSLSocketFactory fournie {0} n''a pas pu ï¿½tre instanciï¿½e."
+msgstr "La classe SSLSocketFactory fournie {0} n''a pas pu être instanciée."
 
 #: org/postgresql/ssl/jdbc4/AbstractJdbc4MakeSSL.java:142
 #, java-format
@@ -1332,7 +1332,7 @@ msgstr ""
 #: org/postgresql/ssl/jdbc4/LibPQFactory.java:99
 #, fuzzy, java-format
 msgid "The password callback class provided {0} could not be instantiated."
-msgstr "La classe SSLSocketFactory fournie {0} n''a pas pu ï¿½tre instanciï¿½e."
+msgstr "La classe SSLSocketFactory fournie {0} n''a pas pu être instanciée."
 
 #: org/postgresql/ssl/jdbc4/LibPQFactory.java:133
 #, java-format
@@ -1355,51 +1355,51 @@ msgstr ""
 
 #: org/postgresql/util/PGInterval.java:164
 msgid "Conversion of interval failed"
-msgstr "La conversion de l''intervalle a ï¿½chouï¿½"
+msgstr "La conversion de l''intervalle a échoué"
 
 #: org/postgresql/util/PGmoney.java:73
 msgid "Conversion of money failed."
-msgstr "La conversion de money a ï¿½chouï¿½."
+msgstr "La conversion de money a échoué."
 
 #: org/postgresql/util/ServerErrorMessage.java:155
 #, java-format
 msgid "Detail: {0}"
-msgstr "Dï¿½tailï¿½: {0}"
+msgstr "Détail : {0}"
 
 #: org/postgresql/util/ServerErrorMessage.java:159
 #, java-format
 msgid "Hint: {0}"
-msgstr "Indiceï¿½: {0}"
+msgstr "Indice : {0}"
 
 #: org/postgresql/util/ServerErrorMessage.java:162
 #, java-format
 msgid "Position: {0}"
-msgstr "Positionï¿½: {0}"
+msgstr "Position : {0}"
 
 #: org/postgresql/util/ServerErrorMessage.java:165
 #, java-format
 msgid "Where: {0}"
-msgstr "Oï¿½: {0}"
+msgstr "Où : {0}"
 
 #: org/postgresql/util/ServerErrorMessage.java:171
 #, java-format
 msgid "Internal Query: {0}"
-msgstr "Requï¿½te interne: {0}"
+msgstr "Requête interne: {0}"
 
 #: org/postgresql/util/ServerErrorMessage.java:174
 #, java-format
 msgid "Internal Position: {0}"
-msgstr "Position interneï¿½: {0}"
+msgstr "Position interne : {0}"
 
 #: org/postgresql/util/ServerErrorMessage.java:180
 #, java-format
 msgid "Location: File: {0}, Routine: {1}, Line: {2}"
-msgstr "Localisationï¿½: Fichierï¿½: {0}, Routineï¿½: {1}, Ligneï¿½: {2}"
+msgstr "Localisation : Fichier : {0}, Routine : {1}, Ligne : {2}"
 
 #: org/postgresql/util/ServerErrorMessage.java:183
 #, java-format
 msgid "Server SQLState: {0}"
-msgstr "SQLState serveurï¿½: {0}"
+msgstr "SQLState serveur : {0}"
 
 #: org/postgresql/xa/PGXAConnection.java:148
 msgid ""
@@ -1416,26 +1416,26 @@ msgstr "Drapeaux invalides"
 #: org/postgresql/xa/PGXAConnection.java:248
 #: org/postgresql/xa/PGXAConnection.java:425
 msgid "xid must not be null"
-msgstr "xid ne doit pas ï¿½tre nul"
+msgstr "xid ne doit pas être nul"
 
 #: org/postgresql/xa/PGXAConnection.java:192
 msgid "Connection is busy with another transaction"
-msgstr "La connection est occupï¿½e avec une autre transaction"
+msgstr "La connection est occupée avec une autre transaction"
 
 #: org/postgresql/xa/PGXAConnection.java:198
 #: org/postgresql/xa/PGXAConnection.java:255
 msgid "suspend/resume not implemented"
-msgstr "suspend/resume pas implï¿½mentï¿½"
+msgstr "suspend/resume pas implémenté"
 
 #: org/postgresql/xa/PGXAConnection.java:204
 #: org/postgresql/xa/PGXAConnection.java:207
 #: org/postgresql/xa/PGXAConnection.java:209
 msgid "Transaction interleaving not implemented"
-msgstr "L''entrelacement des transactions n''est pas implï¿½mentï¿½"
+msgstr "L''entrelacement des transactions n''est pas implémenté"
 
 #: org/postgresql/xa/PGXAConnection.java:218
 msgid "Error disabling autocommit"
-msgstr "Erreur en dï¿½sactivant autocommit"
+msgstr "Erreur en désactivant autocommit"
 
 #: org/postgresql/xa/PGXAConnection.java:251
 msgid "tried to call end without corresponding start call"
@@ -1446,22 +1446,22 @@ msgid ""
 "Not implemented: Prepare must be issued using the same connection that "
 "started the transaction"
 msgstr ""
-"Pas implï¿½mentï¿½: Prepare doit ï¿½tre envoyï¿½ sur la mï¿½me connection qui a "
-"dï¿½marrï¿½ la transaction"
+"Pas implémenté: Prepare doit être envoyé sur la même connection qui a "
+"démarré la transaction"
 
 #: org/postgresql/xa/PGXAConnection.java:286
 msgid "Prepare called before end"
-msgstr "Prï¿½paration appelï¿½e avant la fin"
+msgstr "Préparation appelée avant la fin"
 
 #: org/postgresql/xa/PGXAConnection.java:292
 msgid "Server versions prior to 8.1 do not support two-phase commit."
 msgstr ""
-"Les serveurs de versions antï¿½rieures ï¿½ 8.1 ne supportent pas le commit ï¿½ "
+"Les serveurs de versions antérieures à 8.1 ne supportent pas le commit à "
 "deux phases."
 
 #: org/postgresql/xa/PGXAConnection.java:313
 msgid "Error preparing transaction"
-msgstr "Erreur en prï¿½parant la transaction"
+msgstr "Erreur en préparant la transaction"
 
 #: org/postgresql/xa/PGXAConnection.java:328
 msgid "Invalid flag"
@@ -1473,56 +1473,56 @@ msgstr "Erreur durant la restauration"
 
 #: org/postgresql/xa/PGXAConnection.java:416
 msgid "Error rolling back prepared transaction"
-msgstr "Erreur en annulant une transaction prï¿½parï¿½e"
+msgstr "Erreur en annulant une transaction préparée"
 
 #: org/postgresql/xa/PGXAConnection.java:451
 msgid ""
 "Not implemented: one-phase commit must be issued using the same connection "
 "that was used to start it"
 msgstr ""
-"Pas implï¿½mentï¿½: le commit ï¿½ une phase doit avoir lieu en utilisant la mï¿½me "
-"connection que celle oï¿½ il a commencï¿½"
+"Pas implémenté: le commit à une phase doit avoir lieu en utilisant la même "
+"connection que celle où il a commencé"
 
 #: org/postgresql/xa/PGXAConnection.java:455
 msgid "commit called before end"
-msgstr "Commit appelï¿½ avant la fin"
+msgstr "Commit appelé avant la fin"
 
 #: org/postgresql/xa/PGXAConnection.java:466
 msgid "Error during one-phase commit"
-msgstr "Erreur pendant le commit ï¿½ une phase"
+msgstr "Erreur pendant le commit à une phase"
 
 #: org/postgresql/xa/PGXAConnection.java:487
 msgid ""
 "Not implemented: 2nd phase commit must be issued using an idle connection"
 msgstr ""
-"Pas implï¿½mentï¿½: le commit ï¿½ deux phase doit ï¿½tre envoyï¿½ sur une connection "
-"inutilisï¿½e"
+"Pas implémenté: le commit à deux phase doit être envoyé sur une connection "
+"inutilisée"
 
 #: org/postgresql/xa/PGXAConnection.java:507
 #, fuzzy
 msgid "Error committing prepared transaction"
-msgstr "Erreur en annulant une transaction prï¿½parï¿½e"
+msgstr "Erreur en annulant une transaction préparée"
 
 #: org/postgresql/xa/PGXAConnection.java:522
 msgid "Heuristic commit/rollback not supported"
-msgstr "Heuristic commit/rollback non supportï¿½"
+msgstr "Heuristic commit/rollback non supporté"
 
 #~ msgid "The driver does not support SSL."
 #~ msgstr "Ce pilote ne supporte pas SSL."
 
 #~ msgid "Multi-dimensional arrays are currently not supported."
 #~ msgstr ""
-#~ "Les tableaux ï¿½ plusieurs dimensions ne sont pas supportï¿½s pour le moment."
+#~ "Les tableaux à plusieurs dimensions ne sont pas supportés pour le moment."
 
 #~ msgid "Exception: {0}"
-#~ msgstr "Exceptionï¿½: {0}"
+#~ msgstr "Exception : {0}"
 
 #~ msgid "Stack Trace:"
-#~ msgstr "Pile d''appelï¿½:"
+#~ msgstr "Pile d''appel :"
 
 #~ msgid "End of Stack Trace"
 #~ msgstr "Fin de la pile d''appel"
 
 #~ msgid "Exception generating stacktrace for: {0} encountered: {1}"
 #~ msgstr ""
-#~ "Exception en gï¿½nï¿½rant la pile d''appel pourï¿½: {0} erreur rencontrï¿½eï¿½: {1}"
+#~ "Exception en générant la pile d''appel pour : {0} erreur rencontrée : {1}"

--- a/org/postgresql/translation/fr.po
+++ b/org/postgresql/translation/fr.po
@@ -34,7 +34,7 @@ msgstr ""
 #: bin/org/postgresql/Driver.java.in:287 bin/org/postgresql/Driver.java.in:351
 #: org/postgresql/Driver.java.in:287 org/postgresql/Driver.java.in:351
 msgid ""
-"Something unusual has occured to cause the driver to fail. Please report "
+"Something unusual has occurred to cause the driver to fail. Please report "
 "this exception."
 msgstr ""
 "Quelque chose d''inhabituel a provoqué l''échec du pilote. Veuillez faire un "
@@ -202,7 +202,7 @@ msgstr "Le serveur ne supporte pas SSL."
 
 #: org/postgresql/core/v2/ConnectionFactoryImpl.java:223
 #: org/postgresql/core/v3/ConnectionFactoryImpl.java:281
-msgid "An error occured while setting up the SSL connection."
+msgid "An error occurred while setting up the SSL connection."
 msgstr ""
 "Une erreur s''est produite pendant l''établissement de la connexion SSL."
 
@@ -303,7 +303,7 @@ msgstr "Statut de commande inattendu : {0}."
 #: org/postgresql/core/v3/QueryExecutorImpl.java:551
 #: org/postgresql/core/v3/QueryExecutorImpl.java:631
 #: org/postgresql/core/v3/QueryExecutorImpl.java:2094
-msgid "An I/O error occured while sending to the backend."
+msgid "An I/O error occurred while sending to the backend."
 msgstr "Une erreur d''entrée/sortie a eu lieu lors d''envoi vers le serveur."
 
 #: org/postgresql/core/v2/QueryExecutorImpl.java:170

--- a/org/postgresql/translation/it.po
+++ b/org/postgresql/translation/it.po
@@ -34,7 +34,7 @@ msgstr ""
 #: bin/org/postgresql/Driver.java.in:287 bin/org/postgresql/Driver.java.in:351
 #: org/postgresql/Driver.java.in:287 org/postgresql/Driver.java.in:351
 msgid ""
-"Something unusual has occured to cause the driver to fail. Please report "
+"Something unusual has occurred to cause the driver to fail. Please report "
 "this exception."
 msgstr ""
 "Qualcosa di insolito si è verificato causando il fallimento del driver. Per "
@@ -205,7 +205,7 @@ msgstr "Il server non supporta SSL."
 
 #: org/postgresql/core/v2/ConnectionFactoryImpl.java:223
 #: org/postgresql/core/v3/ConnectionFactoryImpl.java:281
-msgid "An error occured while setting up the SSL connection."
+msgid "An error occurred while setting up the SSL connection."
 msgstr "Si è verificato un errore impostando la connessione SSL."
 
 #: org/postgresql/core/v2/ConnectionFactoryImpl.java:272
@@ -304,7 +304,7 @@ msgstr "Stato del comando non previsto: {0}."
 #: org/postgresql/core/v3/QueryExecutorImpl.java:551
 #: org/postgresql/core/v3/QueryExecutorImpl.java:631
 #: org/postgresql/core/v3/QueryExecutorImpl.java:2094
-msgid "An I/O error occured while sending to the backend."
+msgid "An I/O error occurred while sending to the backend."
 msgstr "Si è verificato un errore di I/O nella spedizione di dati al server."
 
 #: org/postgresql/core/v2/QueryExecutorImpl.java:170

--- a/org/postgresql/translation/it.po
+++ b/org/postgresql/translation/it.po
@@ -21,8 +21,8 @@ msgstr ""
 #: bin/org/postgresql/Driver.java.in:235 org/postgresql/Driver.java.in:235
 msgid "Error loading default settings from driverconfig.properties"
 msgstr ""
-"Si ï¿½ verificato un errore caricando le impostazioni predefinite da "
-"ï¿½driverconfig.propertiesï¿½."
+"Si è verificato un errore caricando le impostazioni predefinite da "
+"«driverconfig.properties»."
 
 #: bin/org/postgresql/Driver.java.in:282 org/postgresql/Driver.java.in:282
 msgid ""
@@ -34,24 +34,24 @@ msgstr ""
 #: bin/org/postgresql/Driver.java.in:287 bin/org/postgresql/Driver.java.in:351
 #: org/postgresql/Driver.java.in:287 org/postgresql/Driver.java.in:351
 msgid ""
-"Something unusual has occurred to cause the driver to fail. Please report "
+"Something unusual has occured to cause the driver to fail. Please report "
 "this exception."
 msgstr ""
-"Qualcosa di insolito si ï¿½ verificato causando il fallimento del driver. Per "
+"Qualcosa di insolito si è verificato causando il fallimento del driver. Per "
 "favore riferire all''autore del driver questa eccezione."
 
 #: bin/org/postgresql/Driver.java.in:359 org/postgresql/Driver.java.in:359
 msgid "Connection attempt timed out."
-msgstr "Il tentativo di connessione ï¿½ scaduto."
+msgstr "Il tentativo di connessione è scaduto."
 
 #: bin/org/postgresql/Driver.java.in:367 org/postgresql/Driver.java.in:367
 msgid "Interrupted while attempting to connect."
-msgstr "Si ï¿½ verificata una interruzione durante il tentativo di connessione."
+msgstr "Si è verificata una interruzione durante il tentativo di connessione."
 
 #: bin/org/postgresql/Driver.java.in:710 org/postgresql/Driver.java.in:710
 #, java-format
 msgid "Method {0} is not yet implemented."
-msgstr "Il metodo ï¿½{0}ï¿½ non ï¿½ stato ancora implementato."
+msgstr "Il metodo «{0}» non è stato ancora implementato."
 
 #: org/postgresql/copy/CopyManager.java:56
 #, java-format
@@ -72,7 +72,7 @@ msgstr "Fallita la conversione di un ``box'': {0}."
 #: org/postgresql/copy/PGCopyOutputStream.java:90
 #, fuzzy
 msgid "This copy stream is closed."
-msgstr "Questo ï¿½ResultSetï¿½ ï¿½ chiuso."
+msgstr "Questo «ResultSet» è chiuso."
 
 #: org/postgresql/copy/PGCopyInputStream.java:108
 msgid "Read from copy failed."
@@ -87,7 +87,7 @@ msgstr ""
 #, java-format
 msgid "A connection could not be made using the requested protocol {0}."
 msgstr ""
-"Non ï¿½ stato possibile attivare la connessione utilizzando il protocollo "
+"Non è stato possibile attivare la connessione utilizzando il protocollo "
 "richiesto {0}."
 
 #: org/postgresql/core/Oid.java:113
@@ -99,24 +99,24 @@ msgstr ""
 #, java-format
 msgid "Premature end of input stream, expected {0} bytes, but only read {1}."
 msgstr ""
-"Il flusso di input ï¿½ stato interrotto, sono arrivati {1} byte al posto dei "
+"Il flusso di input è stato interrotto, sono arrivati {1} byte al posto dei "
 "{0} attesi."
 
 #: org/postgresql/core/PGStream.java:530
 #, java-format
 msgid "Expected an EOF from server, got: {0}"
-msgstr "Ricevuto dal server ï¿½{0}ï¿½ mentre era atteso un EOF"
+msgstr "Ricevuto dal server «{0}» mentre era atteso un EOF"
 
 #: org/postgresql/core/SetupQueryRunner.java:86
 msgid "An unexpected result was returned by a query."
-msgstr "Un risultato inaspettato ï¿½ stato ricevuto dalla query."
+msgstr "Un risultato inaspettato è stato ricevuto dalla query."
 
 #: org/postgresql/core/UTF8Encoding.java:28
 #, java-format
 msgid ""
 "Illegal UTF-8 sequence: byte {0} of {1} byte sequence is not 10xxxxxx: {2}"
 msgstr ""
-"Sequenza UTF-8 illegale: il byte {0} di una sequenza di {1} byte non ï¿½ "
+"Sequenza UTF-8 illegale: il byte {0} di una sequenza di {1} byte non è "
 "10xxxxxx: {2}"
 
 #: org/postgresql/core/UTF8Encoding.java:61
@@ -130,19 +130,19 @@ msgstr ""
 #: org/postgresql/core/UTF8Encoding.java:125
 #, java-format
 msgid "Illegal UTF-8 sequence: initial byte is {0}: {1}"
-msgstr "Sequenza UTF-8 illegale: il byte iniziale ï¿½ {0}: {1}"
+msgstr "Sequenza UTF-8 illegale: il byte iniziale è {0}: {1}"
 
 #: org/postgresql/core/UTF8Encoding.java:130
 #, java-format
 msgid "Illegal UTF-8 sequence: final value is out of range: {0}"
 msgstr ""
-"Sequenza UTF-8 illegale: il valore finale ï¿½ fuori dall''intervallo permesso: "
+"Sequenza UTF-8 illegale: il valore finale è fuori dall''intervallo permesso: "
 "{0}"
 
 #: org/postgresql/core/UTF8Encoding.java:145
 #, java-format
 msgid "Illegal UTF-8 sequence: final value is a surrogate value: {0}"
-msgstr "Sequenza UTF-8 illegale: il valore ï¿½ finale ï¿½ un surrogato: {0}"
+msgstr "Sequenza UTF-8 illegale: il valore è finale è un surrogato: {0}"
 
 #: org/postgresql/core/Utils.java:95 org/postgresql/core/Utils.java:112
 msgid "Zero bytes may not occur in string parameters."
@@ -167,13 +167,13 @@ msgstr ""
 #: org/postgresql/core/types/PGString.java:73
 #, java-format
 msgid "Cannot convert an instance of {0} to type {1}"
-msgstr "Non ï¿½ possibile convertire una istanza di ï¿½{0}ï¿½ nel tipo ï¿½{1}ï¿½"
+msgstr "Non è possibile convertire una istanza di «{0}» nel tipo «{1}»"
 
 #: org/postgresql/core/v2/ConnectionFactoryImpl.java:66
 #: org/postgresql/core/v3/ConnectionFactoryImpl.java:74
 #, fuzzy, java-format
 msgid "Invalid sslmode value: {0}"
-msgstr "La dimensione specificata, {0}, per lo ï¿½streamï¿½ non ï¿½ valida."
+msgstr "La dimensione specificata, {0}, per lo «stream» non è valida."
 
 #: org/postgresql/core/v2/ConnectionFactoryImpl.java:134
 #: org/postgresql/core/v3/ConnectionFactoryImpl.java:168
@@ -188,13 +188,13 @@ msgstr ""
 #: org/postgresql/core/v2/ConnectionFactoryImpl.java:153
 #: org/postgresql/core/v3/ConnectionFactoryImpl.java:186
 msgid "The connection attempt failed."
-msgstr "Il tentativo di connessione ï¿½ fallito."
+msgstr "Il tentativo di connessione è fallito."
 
 #: org/postgresql/core/v2/ConnectionFactoryImpl.java:175
 #: org/postgresql/core/v3/ConnectionFactoryImpl.java:207
 #, fuzzy
 msgid "The connection url is invalid."
-msgstr "Il tentativo di connessione ï¿½ fallito."
+msgstr "Il tentativo di connessione è fallito."
 
 #: org/postgresql/core/v2/ConnectionFactoryImpl.java:198
 #: org/postgresql/core/v2/ConnectionFactoryImpl.java:210
@@ -205,8 +205,8 @@ msgstr "Il server non supporta SSL."
 
 #: org/postgresql/core/v2/ConnectionFactoryImpl.java:223
 #: org/postgresql/core/v3/ConnectionFactoryImpl.java:281
-msgid "An error occurred while setting up the SSL connection."
-msgstr "Si ï¿½ verificato un errore impostando la connessione SSL."
+msgid "An error occured while setting up the SSL connection."
+msgstr "Si è verificato un errore impostando la connessione SSL."
 
 #: org/postgresql/core/v2/ConnectionFactoryImpl.java:272
 #, java-format
@@ -224,7 +224,7 @@ msgid ""
 "provided."
 msgstr ""
 "Il server ha richiesto l''autenticazione con password, ma tale password non "
-"ï¿½ stata fornita."
+"è stata fornita."
 
 #: org/postgresql/core/v2/ConnectionFactoryImpl.java:356
 #: org/postgresql/core/v3/ConnectionFactoryImpl.java:465
@@ -234,7 +234,7 @@ msgid ""
 "the pg_hba.conf file to include the client''s IP address or subnet, and that "
 "it is using an authentication scheme supported by the driver."
 msgstr ""
-"L''autenticazione di tipo {0} non ï¿½ supportata. Verificare che nel file di "
+"L''autenticazione di tipo {0} non è supportata. Verificare che nel file di "
 "configurazione pg_hba.conf sia presente l''indirizzo IP o la sottorete del "
 "client, e che lo schema di autenticazione utilizzato sia supportato dal "
 "driver."
@@ -270,7 +270,7 @@ msgstr "Attivazione del backend fallita: {0}."
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSetMetaData.java:419
 #, java-format
 msgid "The column index is out of range: {0}, number of columns: {1}."
-msgstr "Indice di colonna, {0}, ï¿½ maggiore del numero di colonne {1}."
+msgstr "Indice di colonna, {0}, è maggiore del numero di colonne {1}."
 
 #: org/postgresql/core/v2/FastpathParameterList.java:142
 #: org/postgresql/core/v2/SimpleParameterList.java:155
@@ -285,7 +285,7 @@ msgstr "Nessun valore specificato come parametro {0}."
 #: org/postgresql/core/v3/QueryExecutorImpl.java:507
 #, java-format
 msgid "Expected command status BEGIN, got {0}."
-msgstr "Lo stato del comando avrebbe dovuto essere BEGIN, mentre invece ï¿½ {0}."
+msgstr "Lo stato del comando avrebbe dovuto essere BEGIN, mentre invece è {0}."
 
 #: org/postgresql/core/v2/QueryExecutorImpl.java:78
 #: org/postgresql/core/v3/QueryExecutorImpl.java:513
@@ -304,8 +304,8 @@ msgstr "Stato del comando non previsto: {0}."
 #: org/postgresql/core/v3/QueryExecutorImpl.java:551
 #: org/postgresql/core/v3/QueryExecutorImpl.java:631
 #: org/postgresql/core/v3/QueryExecutorImpl.java:2094
-msgid "An I/O error occurred while sending to the backend."
-msgstr "Si ï¿½ verificato un errore di I/O nella spedizione di dati al server."
+msgid "An I/O error occured while sending to the backend."
+msgstr "Si è verificato un errore di I/O nella spedizione di dati al server."
 
 #: org/postgresql/core/v2/QueryExecutorImpl.java:170
 #: org/postgresql/core/v2/QueryExecutorImpl.java:225
@@ -327,7 +327,7 @@ msgstr "Fine memoria scaricando i risultati della query."
 #, java-format
 msgid "Unable to interpret the update count in command completion tag: {0}."
 msgstr ""
-"Impossibile interpretare il numero degli aggiornamenti nel ï¿½tagï¿½ di "
+"Impossibile interpretare il numero degli aggiornamenti nel «tag» di "
 "completamento del comando: {0}."
 
 #: org/postgresql/core/v2/QueryExecutorImpl.java:610
@@ -349,12 +349,12 @@ msgstr ""
 #: org/postgresql/core/v3/QueryExecutorImpl.java:93
 #, fuzzy
 msgid "Interrupted while waiting to obtain lock on database connection"
-msgstr "Si ï¿½ verificata una interruzione durante il tentativo di connessione."
+msgstr "Si è verificata una interruzione durante il tentativo di connessione."
 
 #: org/postgresql/core/v3/QueryExecutorImpl.java:275
 msgid "Unable to bind parameter values for statement."
 msgstr ""
-"Impossibile fare il ï¿½bindï¿½ dei valori passati come parametri per lo "
+"Impossibile fare il «bind» dei valori passati come parametri per lo "
 "statement."
 
 #: org/postgresql/core/v3/QueryExecutorImpl.java:726
@@ -426,7 +426,7 @@ msgstr ""
 #: org/postgresql/core/v3/QueryExecutorImpl.java:1005
 #, fuzzy, java-format
 msgid "Unexpected copydata from server for {0}"
-msgstr "Ricevuto dal server ï¿½{0}ï¿½ mentre era atteso un EOF"
+msgstr "Ricevuto dal server «{0}» mentre era atteso un EOF"
 
 #: org/postgresql/core/v3/QueryExecutorImpl.java:1056
 #, java-format
@@ -439,8 +439,8 @@ msgid ""
 "Bind message length {0} too long.  This can be caused by very large or "
 "incorrect length specifications on InputStream parameters."
 msgstr ""
-"Il messaggio di ï¿½bindï¿½ ï¿½ troppo lungo ({0}). Questo puï¿½ essere causato da "
-"una dimensione eccessiva o non corretta dei parametri dell''ï¿½InputStreamï¿½."
+"Il messaggio di «bind» è troppo lungo ({0}). Questo può essere causato da "
+"una dimensione eccessiva o non corretta dei parametri dell''«InputStream»."
 
 #: org/postgresql/core/v3/QueryExecutorImpl.java:1925
 #, fuzzy, java-format
@@ -448,8 +448,8 @@ msgid ""
 "The server''s client_encoding parameter was changed to {0}. The JDBC driver "
 "requires client_encoding to be UTF8 for correct operation."
 msgstr ""
-"Il parametro ï¿½client_encodingï¿½ del server ï¿½ stato cambiato in {0}. Il driver "
-"JDBC richiede che ï¿½client_encodingï¿½ sia UNICODE per un corretto "
+"Il parametro «client_encoding» del server è stato cambiato in {0}. Il driver "
+"JDBC richiede che «client_encoding» sia UNICODE per un corretto "
 "funzionamento."
 
 #: org/postgresql/core/v3/QueryExecutorImpl.java:1932
@@ -458,8 +458,8 @@ msgid ""
 "The server''s DateStyle parameter was changed to {0}. The JDBC driver "
 "requires DateStyle to begin with ISO for correct operation."
 msgstr ""
-"Il parametro del server ï¿½DateStyleï¿½ ï¿½ stato cambiato in {0}. Il driver JDBC "
-"richiede che ï¿½DateStyleï¿½ cominci con ï¿½ISOï¿½ per un corretto funzionamento."
+"Il parametro del server «DateStyle» è stato cambiato in {0}. Il driver JDBC "
+"richiede che «DateStyle» cominci con «ISO» per un corretto funzionamento."
 
 #: org/postgresql/core/v3/QueryExecutorImpl.java:1945
 #, fuzzy, java-format
@@ -467,34 +467,34 @@ msgid ""
 "The server''s standard_conforming_strings parameter was reported as {0}. The "
 "JDBC driver expected on or off."
 msgstr ""
-"Il parametro ï¿½client_encodingï¿½ del server ï¿½ stato cambiato in {0}. Il driver "
-"JDBC richiede che ï¿½client_encodingï¿½ sia UNICODE per un corretto "
+"Il parametro «client_encoding» del server è stato cambiato in {0}. Il driver "
+"JDBC richiede che «client_encoding» sia UNICODE per un corretto "
 "funzionamento."
 
 #: org/postgresql/core/v3/QueryExecutorImpl.java:2015
 msgid "The driver currently does not support COPY operations."
-msgstr "Il driver non supporta al momento l''operazione ï¿½COPYï¿½."
+msgstr "Il driver non supporta al momento l''operazione «COPY»."
 
 #: org/postgresql/ds/jdbc23/AbstractJdbc23PooledConnection.java:112
 msgid "This PooledConnection has already been closed."
-msgstr "Questo ï¿½PooledConnectionï¿½ ï¿½ stato chiuso."
+msgstr "Questo «PooledConnection» è stato chiuso."
 
 #: org/postgresql/ds/jdbc23/AbstractJdbc23PooledConnection.java:295
 msgid ""
 "Connection has been closed automatically because a new connection was opened "
 "for the same PooledConnection or the PooledConnection has been closed."
 msgstr ""
-"La ï¿½Connectionï¿½ ï¿½ stata chiusa automaticamente perchï¿½ una nuova l''ha "
-"sostituita nello stesso ï¿½PooledConnectionï¿½, oppure il ï¿½PooledConnectionï¿½ ï¿½ "
+"La «Connection» è stata chiusa automaticamente perché una nuova l''ha "
+"sostituita nello stesso «PooledConnection», oppure il «PooledConnection» è "
 "stato chiuso."
 
 #: org/postgresql/ds/jdbc23/AbstractJdbc23PooledConnection.java:295
 msgid "Connection has been closed."
-msgstr "Questo ï¿½Connectionï¿½ ï¿½ stato chiuso."
+msgstr "Questo «Connection» è stato chiuso."
 
 #: org/postgresql/ds/jdbc23/AbstractJdbc23PooledConnection.java:442
 msgid "Statement has been closed."
-msgstr "Questo ï¿½Statementï¿½ ï¿½ stato chiuso."
+msgstr "Questo «Statement» è stato chiuso."
 
 #: org/postgresql/ds/jdbc23/AbstractJdbc23PoolingDataSource.java:291
 msgid "Failed to setup DataSource."
@@ -502,20 +502,20 @@ msgstr ""
 
 #: org/postgresql/ds/jdbc23/AbstractJdbc23PoolingDataSource.java:414
 msgid "DataSource has been closed."
-msgstr "Questo ï¿½DataSourceï¿½ ï¿½ stato chiuso."
+msgstr "Questo «DataSource» è stato chiuso."
 
 #: org/postgresql/fastpath/Fastpath.java:81
 #: org/postgresql/fastpath/Fastpath.java:128
 #, java-format
 msgid "Fastpath call {0} - No result was returned and we expected an integer."
 msgstr ""
-"Chiamata Fastpath ï¿½{0}ï¿½: Nessun risultato restituito mentre ci si aspettava "
+"Chiamata Fastpath «{0}»: Nessun risultato restituito mentre ci si aspettava "
 "un intero."
 
 #: org/postgresql/fastpath/Fastpath.java:237
 #, java-format
 msgid "The fastpath function {0} is unknown."
-msgstr "La funzione fastpath ï¿½{0}ï¿½ ï¿½ sconosciuta."
+msgstr "La funzione fastpath «{0}» è sconosciuta."
 
 #: org/postgresql/geometric/PGbox.java:83
 #: org/postgresql/geometric/PGcircle.java:82
@@ -530,7 +530,7 @@ msgstr "Conversione al tipo {0} fallita: {1}."
 #: org/postgresql/geometric/PGpath.java:81
 #, java-format
 msgid "Cannot tell if path is open or closed: {0}."
-msgstr "Impossibile stabilire se il percorso ï¿½ aperto o chiuso: {0}."
+msgstr "Impossibile stabilire se il percorso è aperto o chiuso: {0}."
 
 #: org/postgresql/gss/MakeGSS.java:47 org/postgresql/gss/MakeGSS.java:55
 #: org/postgresql/gss/MakeGSS.java:168
@@ -548,7 +548,7 @@ msgstr "Indice di colonna fuori dall''intervallo ammissibile: {0}"
 #, java-format
 msgid "The array index is out of range: {0}, number of elements: {1}."
 msgstr ""
-"L''indice dell''array ï¿½ fuori intervallo: {0}, numero di elementi: {1}."
+"L''indice dell''array è fuori intervallo: {0}, numero di elementi: {1}."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Array.java:196
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:1982
@@ -562,7 +562,7 @@ msgid ""
 msgstr ""
 "Sono stati trovati caratteri non validi tra i dati. Molto probabilmente sono "
 "stati memorizzati dei caratteri che non sono validi per la codifica dei "
-"caratteri impostata alla creazione del database. Il caso piï¿½ diffuso ï¿½ "
+"caratteri impostata alla creazione del database. Il caso più diffuso è "
 "quello nel quale si memorizzano caratteri a 8bit in un database con codifica "
 "SQL_ASCII."
 
@@ -579,7 +579,7 @@ msgstr ""
 #: org/postgresql/jdbc2/AbstractJdbc2BlobClob.java:235
 #, java-format
 msgid "PostgreSQL LOBs can only index to: {0}"
-msgstr "Il massimo valore per l''indice dei LOB di PostgreSQL ï¿½ {0}. "
+msgstr "Il massimo valore per l''indice dei LOB di PostgreSQL è {0}. "
 
 #: org/postgresql/jdbc2/AbstractJdbc2BlobClob.java:231
 msgid "LOB positioning offsets start at 1."
@@ -592,7 +592,7 @@ msgstr ""
 #: org/postgresql/jdbc2/AbstractJdbc2Connection.java:229
 #, java-format
 msgid "Unsupported value for stringtype parameter: {0}"
-msgstr "Il valore per il parametro di tipo string ï¿½{0}ï¿½ non ï¿½ supportato."
+msgstr "Il valore per il parametro di tipo string «{0}» non è supportato."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Connection.java:249
 msgid "unknownLength parameter value must be an integer"
@@ -609,14 +609,14 @@ msgstr ""
 #: org/postgresql/jdbc2/TypeInfoCache.java:384
 #: org/postgresql/jdbc2/TypeInfoCache.java:388
 msgid "No results were returned by the query."
-msgstr "Nessun risultato ï¿½ stato restituito dalla query."
+msgstr "Nessun risultato è stato restituito dalla query."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Connection.java:371
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:336
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:368
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:2695
 msgid "A result was returned when none was expected."
-msgstr "ï¿½ stato restituito un valore nonostante non ne fosse atteso nessuno."
+msgstr "È stato restituito un valore nonostante non ne fosse atteso nessuno."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Connection.java:523
 msgid "Custom type maps are not supported."
@@ -630,13 +630,13 @@ msgstr "Fallita la creazione dell''oggetto per: {0}."
 #: org/postgresql/jdbc2/AbstractJdbc2Connection.java:633
 #, java-format
 msgid "Unable to load the class {0} responsible for the datatype {1}"
-msgstr "Non ï¿½ possibile caricare la class ï¿½{0}ï¿½ per gestire il tipo ï¿½{1}ï¿½."
+msgstr "Non è possibile caricare la class «{0}» per gestire il tipo «{1}»."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Connection.java:729
 msgid ""
 "Cannot change transaction read-only property in the middle of a transaction."
 msgstr ""
-"Non ï¿½ possibile modificare la proprietï¿½ ï¿½read-onlyï¿½ delle transazioni nel "
+"Non è possibile modificare la proprietà «read-only» delle transazioni nel "
 "mezzo di una transazione."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Connection.java:817
@@ -646,7 +646,7 @@ msgstr ""
 #: org/postgresql/jdbc2/AbstractJdbc2Connection.java:826
 #, fuzzy
 msgid "This connection has been closed."
-msgstr "Questo ï¿½Connectionï¿½ ï¿½ stato chiuso."
+msgstr "Questo «Connection» è stato chiuso."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Connection.java:846
 msgid "Cannot rollback when autoCommit is enabled."
@@ -656,17 +656,17 @@ msgstr ""
 msgid ""
 "Cannot change transaction isolation level in the middle of a transaction."
 msgstr ""
-"Non ï¿½ possibile cambiare il livello di isolamento delle transazioni nel "
+"Non è possibile cambiare il livello di isolamento delle transazioni nel "
 "mezzo di una transazione."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Connection.java:938
 #, java-format
 msgid "Transaction isolation level {0} not supported."
-msgstr "Il livello di isolamento delle transazioni ï¿½{0}ï¿½ non ï¿½ supportato."
+msgstr "Il livello di isolamento delle transazioni «{0}» non è supportato."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Connection.java:1005
 msgid "Finalizing a Connection that was never closed:"
-msgstr "Finalizzazione di una ï¿½Connectionï¿½ che non ï¿½ stata chiusa."
+msgstr "Finalizzazione di una «Connection» che non è stata chiusa."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Connection.java:1107
 msgid "Unable to translate data into the desired encoding."
@@ -677,25 +677,25 @@ msgid ""
 "Unable to determine a value for MaxIndexKeys due to missing system catalog "
 "data."
 msgstr ""
-"Non ï¿½ possibile trovare il valore di ï¿½MaxIndexKeysï¿½ nel catalogo si sistema."
+"Non è possibile trovare il valore di «MaxIndexKeys» nel catalogo si sistema."
 
 #: org/postgresql/jdbc2/AbstractJdbc2DatabaseMetaData.java:86
 msgid "Unable to find name datatype in the system catalogs."
-msgstr "Non ï¿½ possibile trovare il datatype ï¿½nameï¿½ nel catalogo di sistema."
+msgstr "Non è possibile trovare il datatype «name» nel catalogo di sistema."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:235
 msgid ""
 "Operation requires a scrollable ResultSet, but this ResultSet is "
 "FORWARD_ONLY."
 msgstr ""
-"L''operazione richiete un ï¿½ResultSetï¿½ scorribile mentre questo ï¿½ "
-"ï¿½FORWARD_ONLYï¿½."
+"L''operazione richiete un «ResultSet» scorribile mentre questo è "
+"«FORWARD_ONLY»."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:416
 msgid "Unexpected error while decoding character data from a large object."
 msgstr ""
 "Errore non previsto durante la decodifica di caratteri a partire da un "
-"ï¿½large objectï¿½."
+"«large object»."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:462
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:491
@@ -704,14 +704,14 @@ msgstr ""
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:3174
 #, fuzzy, java-format
 msgid "Cannot convert the column of type {0} to requested type {1}."
-msgstr "Non ï¿½ possibile convertire una istanza di ï¿½{0}ï¿½ nel tipo ï¿½{1}ï¿½"
+msgstr "Non è possibile convertire una istanza di «{0}» nel tipo «{1}»"
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:744
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:768
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:1892
 msgid "Can''t use relative move methods while on the insert row."
 msgstr ""
-"Non ï¿½ possibile utilizzare gli spostamenti relativi durante l''inserimento "
+"Non è possibile utilizzare gli spostamenti relativi durante l''inserimento "
 "di una riga."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:788
@@ -723,37 +723,37 @@ msgstr "Costante per la direzione dell''estrazione non valida: {0}."
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:802
 msgid "Cannot call cancelRowUpdates() when on the insert row."
 msgstr ""
-"Non ï¿½ possibile invocare ï¿½cancelRowUpdates()ï¿½ durante l''inserimento di una "
+"Non è possibile invocare «cancelRowUpdates()» durante l''inserimento di una "
 "riga."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:822
 msgid "Cannot call deleteRow() when on the insert row."
 msgstr ""
-"Non ï¿½ possibile invocare ï¿½deleteRow()ï¿½ durante l''inserimento di una riga."
+"Non è possibile invocare «deleteRow()» durante l''inserimento di una riga."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:828
 msgid ""
 "Currently positioned before the start of the ResultSet.  You cannot call "
 "deleteRow() here."
 msgstr ""
-"La posizione attuale ï¿½ precedente all''inizio del ResultSet. Non ï¿½ possibile "
-"invocare ï¿½deleteRow()ï¿½ qui."
+"La posizione attuale è precedente all''inizio del ResultSet. Non è possibile "
+"invocare «deleteRow()» qui."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:833
 msgid ""
 "Currently positioned after the end of the ResultSet.  You cannot call "
 "deleteRow() here."
 msgstr ""
-"La posizione attuale ï¿½ successiva alla fine del ResultSet. Non ï¿½ possibile "
-"invocare ï¿½deleteRow()ï¿½ qui."
+"La posizione attuale è successiva alla fine del ResultSet. Non è possibile "
+"invocare «deleteRow()» qui."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:838
 msgid "There are no rows in this ResultSet."
-msgstr "Non ci sono righe in questo ï¿½ResultSetï¿½."
+msgstr "Non ci sono righe in questo «ResultSet»."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:885
 msgid "Not on the insert row."
-msgstr "Non si ï¿½ in una nuova riga."
+msgstr "Non si è in una nuova riga."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:889
 msgid "You must specify at least one column value to insert a row."
@@ -773,21 +773,21 @@ msgstr "La JVM sostiene di non supportare la codifica: {0}."
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:1527
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:1656
 msgid "Provided InputStream failed."
-msgstr "L''ï¿½InputStreamï¿½ fornito ï¿½ fallito."
+msgstr "L''«InputStream» fornito è fallito."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:1191
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:3130
 msgid "Provided Reader failed."
-msgstr "Il ï¿½Readerï¿½ fornito ï¿½ fallito."
+msgstr "Il «Reader» fornito è fallito."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:1259
 msgid "Can''t refresh the insert row."
-msgstr "Non ï¿½ possibile aggiornare la riga in inserimento."
+msgstr "Non è possibile aggiornare la riga in inserimento."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:1327
 msgid "Cannot call updateRow() when on the insert row."
 msgstr ""
-"Non ï¿½ possibile invocare ï¿½updateRow()ï¿½ durante l''inserimento di una riga."
+"Non è possibile invocare «updateRow()» durante l''inserimento di una riga."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:1333
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:3190
@@ -795,23 +795,23 @@ msgid ""
 "Cannot update the ResultSet because it is either before the start or after "
 "the end of the results."
 msgstr ""
-"Non ï¿½ possibile aggiornare il ï¿½ResultSetï¿½ perchï¿½ la posizione attuale ï¿½ "
+"Non è possibile aggiornare il «ResultSet» perché la posizione attuale è "
 "precedente all''inizio o successiva alla file dei risultati."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:1582
 msgid "ResultSets with concurrency CONCUR_READ_ONLY cannot be updated."
 msgstr ""
-"I ï¿½ResultSetï¿½ in modalitï¿½ CONCUR_READ_ONLY non possono essere aggiornati."
+"I «ResultSet» in modalità CONCUR_READ_ONLY non possono essere aggiornati."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:1650
 #, java-format
 msgid "No primary key found for table {0}."
-msgstr "Non ï¿½ stata trovata la chiave primaria della tabella ï¿½{0}ï¿½."
+msgstr "Non è stata trovata la chiave primaria della tabella «{0}»."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:1876
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:2958
 msgid "Fetch size must be a value greater to or equal to 0."
-msgstr "La dimensione dell''area di ï¿½fetchï¿½ deve essere maggiore o eguale a 0."
+msgstr "La dimensione dell''area di «fetch» deve essere maggiore o eguale a 0."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:2044
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:2051
@@ -829,12 +829,12 @@ msgstr "La dimensione dell''area di ï¿½fetchï¿½ deve essere maggiore o eguale a 
 #: org/postgresql/jdbc2/TimestampUtils.java:258
 #, java-format
 msgid "Bad value for type {0} : {1}"
-msgstr "Il valore ï¿½{1}ï¿½ non ï¿½ adeguato al tipo ï¿½{0}ï¿½."
+msgstr "Il valore «{1}» non è adeguato al tipo «{0}»."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:2727
 #, java-format
 msgid "The column name {0} was not found in this ResultSet."
-msgstr "Colonna denominata ï¿½{0}ï¿½ non ï¿½ presente in questo ï¿½ResultSetï¿½."
+msgstr "Colonna denominata «{0}» non è presente in questo «ResultSet»."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:2827
 msgid ""
@@ -842,20 +842,20 @@ msgid ""
 "select only one table, and must select all primary keys from that table. See "
 "the JDBC 2.1 API Specification, section 5.6 for more details."
 msgstr ""
-"Il ï¿½ResultSetï¿½ non ï¿½ aggiornabile. La query che lo genera deve selezionare "
+"Il «ResultSet» non è aggiornabile. La query che lo genera deve selezionare "
 "una sola tabella e deve selezionarne tutti i campi che ne compongono la "
 "chiave primaria. Si vedano le specifiche dell''API JDBC 2.1, sezione 5.6, "
 "per ulteriori dettagli."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:2839
 msgid "This ResultSet is closed."
-msgstr "Questo ï¿½ResultSetï¿½ ï¿½ chiuso."
+msgstr "Questo «ResultSet» è chiuso."
 
 #: org/postgresql/jdbc2/AbstractJdbc2ResultSet.java:2860
 msgid "ResultSet not positioned properly, perhaps you need to call next."
 msgstr ""
-"Il ï¿½ResultSetï¿½ non ï¿½ correttamente posizionato; forse ï¿½ necessario invocare "
-"ï¿½next()ï¿½."
+"Il «ResultSet» non è correttamente posizionato; forse è necessario invocare "
+"«next()»."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:259
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:323
@@ -865,24 +865,24 @@ msgid ""
 "Can''t use query methods that take a query string on a PreparedStatement."
 msgstr ""
 "Non si possono utilizzare i metodi \"query\" che hanno come argomento una "
-"stringa nel caso di ï¿½PreparedStatementï¿½."
+"stringa nel caso di «PreparedStatement»."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:287
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:306
 msgid "Multiple ResultSets were returned by the query."
-msgstr "La query ha restituito ï¿½ResultSetï¿½ multipli."
+msgstr "La query ha restituito «ResultSet» multipli."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:425
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:429
 msgid "A CallableStatement was executed with nothing returned."
 msgstr ""
-"Un ï¿½CallableStatementï¿½ ï¿½ stato eseguito senza produrre alcun risultato. "
+"Un «CallableStatement» è stato eseguito senza produrre alcun risultato. "
 
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:437
 #, fuzzy
 msgid "A CallableStatement was executed with an invalid number of parameters"
 msgstr ""
-"Un ï¿½CallableStatementï¿½ ï¿½ stato eseguito con un numero errato di parametri."
+"Un «CallableStatement» è stato eseguito con un numero errato di parametri."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:468
 #, java-format
@@ -890,8 +890,8 @@ msgid ""
 "A CallableStatement function was executed and the out parameter {0} was of "
 "type {1} however type {2} was registered."
 msgstr ""
-"ï¿½ stato eseguito un ï¿½CallableStatementï¿½ ma il parametro in uscita ï¿½{0}ï¿½ era "
-"di tipo ï¿½{1}ï¿½ al posto di ï¿½{2}ï¿½, che era stato dichiarato."
+"È stato eseguito un «CallableStatement» ma il parametro in uscita «{0}» era "
+"di tipo «{1}» al posto di «{2}», che era stato dichiarato."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:670
 msgid "Maximum number of rows must be a value grater than or equal to 0."
@@ -914,7 +914,7 @@ msgstr "Valore di tipo sconosciuto."
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:3101
 #, java-format
 msgid "Invalid stream length {0}."
-msgstr "La dimensione specificata, {0}, per lo ï¿½streamï¿½ non ï¿½ valida."
+msgstr "La dimensione specificata, {0}, per lo «stream» non è valida."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:1523
 #, java-format
@@ -936,12 +936,12 @@ msgstr ""
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:1850
 #, java-format
 msgid "Cannot cast an instance of {0} to type {1}"
-msgstr "Non ï¿½ possibile fare il cast di una istanza di ï¿½{0}ï¿½ al tipo ï¿½{1}ï¿½."
+msgstr "Non è possibile fare il cast di una istanza di «{0}» al tipo «{1}»."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:1862
 #, java-format
 msgid "Unsupported Types value: {0}"
-msgstr "Valore di tipo ï¿½{0}ï¿½ non supportato."
+msgstr "Valore di tipo «{0}» non supportato."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:1920
 #, java-format
@@ -949,8 +949,8 @@ msgid ""
 "Can''t infer the SQL type to use for an instance of {0}. Use setObject() "
 "with an explicit Types value to specify the type to use."
 msgstr ""
-"Non ï¿½ possibile identificare il tipo SQL da usare per l''istanza di tipo "
-"ï¿½{0}ï¿½. Usare ï¿½setObject()ï¿½ specificando esplicitamente il tipo da usare per "
+"Non è possibile identificare il tipo SQL da usare per l''istanza di tipo "
+"«{0}». Usare «setObject()» specificando esplicitamente il tipo da usare per "
 "questo valore."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:1968
@@ -958,8 +958,8 @@ msgid ""
 "This statement does not declare an OUT parameter.  Use '{' ?= call ... '}' "
 "to declare one."
 msgstr ""
-"Questo statement non dichiara il parametro in uscita. Usare ï¿½{ ?= "
-"call ... }ï¿½ per farlo."
+"Questo statement non dichiara il parametro in uscita. Usare «{ ?= "
+"call ... }» per farlo."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:2018
 msgid "wasNull cannot be call before fetching a result."
@@ -979,16 +979,16 @@ msgid ""
 "Parameter of type {0} was registered, but call to get{1} (sqltype={2}) was "
 "made."
 msgstr ""
-"ï¿½ stato definito il parametro di tipo ï¿½{0}ï¿½, ma poi ï¿½ stato invocato il "
-"metodo ï¿½get{1}()ï¿½ (sqltype={2})."
+"È stato definito il parametro di tipo «{0}», ma poi è stato invocato il "
+"metodo «get{1}()» (sqltype={2})."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:2597
 msgid ""
 "A CallableStatement was declared, but no call to registerOutParameter(1, "
 "<some type>) was made."
 msgstr ""
-"ï¿½ stato definito un ï¿½CallableStatementï¿½ ma non ï¿½ stato invocato il metodo "
-"ï¿½registerOutParameter(1, <tipo>)ï¿½."
+"È stato definito un «CallableStatement» ma non è stato invocato il metodo "
+"«registerOutParameter(1, <tipo>)»."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:2601
 msgid "No function outputs were registered."
@@ -1001,7 +1001,7 @@ msgstr ""
 
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:2637
 msgid "This statement has been closed."
-msgstr "Questo statement ï¿½ stato chiuso."
+msgstr "Questo statement è stato chiuso."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:2717
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:2787
@@ -1014,14 +1014,14 @@ msgstr "Sono stati restituiti troppi aggiornamenti."
 msgid ""
 "Batch entry {0} {1} was aborted.  Call getNextException to see the cause."
 msgstr ""
-"L''operazione ï¿½batchï¿½ {0} {1} ï¿½ stata interrotta. Chiamare "
-"ï¿½getNextExceptionï¿½ per scoprirne il motivo."
+"L''operazione «batch» {0} {1} è stata interrotta. Chiamare "
+"«getNextException» per scoprirne il motivo."
 
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:3071
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:3160
 #: org/postgresql/jdbc2/AbstractJdbc2Statement.java:3200
 msgid "Unexpected error writing large object to database."
-msgstr "Errore inatteso inviando un ï¿½large objectï¿½ al database."
+msgstr "Errore inatteso inviando un «large object» al database."
 
 #: org/postgresql/jdbc2/EscapedFunctions.java:145
 #: org/postgresql/jdbc2/EscapedFunctions.java:157
@@ -1047,7 +1047,7 @@ msgstr "Errore inatteso inviando un ï¿½large objectï¿½ al database."
 #: org/postgresql/jdbc2/EscapedFunctions.java:480
 #, java-format
 msgid "{0} function takes one and only one argument."
-msgstr "Il metodo ï¿½{0}ï¿½ accetta un ed un solo argomento."
+msgstr "Il metodo «{0}» accetta un ed un solo argomento."
 
 #: org/postgresql/jdbc2/EscapedFunctions.java:181
 #: org/postgresql/jdbc2/EscapedFunctions.java:193
@@ -1056,18 +1056,18 @@ msgstr "Il metodo ï¿½{0}ï¿½ accetta un ed un solo argomento."
 #: org/postgresql/jdbc2/EscapedFunctions.java:582
 #, java-format
 msgid "{0} function takes two and only two arguments."
-msgstr "Il metodo ï¿½{0}ï¿½ accetta due e solo due argomenti."
+msgstr "Il metodo «{0}» accetta due e solo due argomenti."
 
 #: org/postgresql/jdbc2/EscapedFunctions.java:230
 #, java-format
 msgid "{0} function takes four and only four argument."
-msgstr "Il metodo ï¿½{0}ï¿½ accetta quattro e solo quattro argomenti."
+msgstr "Il metodo «{0}» accetta quattro e solo quattro argomenti."
 
 #: org/postgresql/jdbc2/EscapedFunctions.java:282
 #: org/postgresql/jdbc2/EscapedFunctions.java:342
 #, java-format
 msgid "{0} function takes two or three arguments."
-msgstr "Il metodo ï¿½{0}ï¿½ accetta due o tre argomenti."
+msgstr "Il metodo «{0}» accetta due o tre argomenti."
 
 #: org/postgresql/jdbc2/EscapedFunctions.java:362
 #: org/postgresql/jdbc2/EscapedFunctions.java:371
@@ -1075,13 +1075,13 @@ msgstr "Il metodo ï¿½{0}ï¿½ accetta due o tre argomenti."
 #: org/postgresql/jdbc2/EscapedFunctions.java:591
 #, java-format
 msgid "{0} function doesn''t take any argument."
-msgstr "Il metodo ï¿½{0}ï¿½ non accetta argomenti."
+msgstr "Il metodo «{0}» non accetta argomenti."
 
 #: org/postgresql/jdbc2/EscapedFunctions.java:489
 #: org/postgresql/jdbc2/EscapedFunctions.java:531
 #, java-format
 msgid "{0} function takes three and only three arguments."
-msgstr "Il metodo ï¿½{0}ï¿½ accetta tre e solo tre argomenti."
+msgstr "Il metodo «{0}» accetta tre e solo tre argomenti."
 
 #: org/postgresql/jdbc2/EscapedFunctions.java:501
 #: org/postgresql/jdbc2/EscapedFunctions.java:521
@@ -1091,31 +1091,31 @@ msgstr "Il metodo ï¿½{0}ï¿½ accetta tre e solo tre argomenti."
 #: org/postgresql/jdbc2/EscapedFunctions.java:566
 #, java-format
 msgid "Interval {0} not yet implemented"
-msgstr "L''intervallo ï¿½{0}ï¿½ non ï¿½ stato ancora implementato."
+msgstr "L''intervallo «{0}» non è stato ancora implementato."
 
 #: org/postgresql/jdbc2/TimestampUtils.java:360
 msgid ""
 "Infinite value found for timestamp/date. This cannot be represented as time."
 msgstr ""
-"Il valore specificato per il tipo ï¿½timestampï¿½ o ï¿½dateï¿½, infinito, non puï¿½ "
-"essere rappresentato come ï¿½timeï¿½."
+"Il valore specificato per il tipo «timestamp» o «date», infinito, non può "
+"essere rappresentato come «time»."
 
 #: org/postgresql/jdbc2/TimestampUtils.java:648
 #: org/postgresql/jdbc2/TimestampUtils.java:680
 #: org/postgresql/jdbc2/TimestampUtils.java:727
 #, fuzzy, java-format
 msgid "Unsupported binary encoding of {0}."
-msgstr "Valore di tipo ï¿½{0}ï¿½ non supportato."
+msgstr "Valore di tipo «{0}» non supportato."
 
 #: org/postgresql/jdbc2/TypeInfoCache.java:161
 #, java-format
 msgid "The class {0} does not implement org.postgresql.util.PGobject."
-msgstr "La class ï¿½{0}ï¿½ non implementa ï¿½org.postgresql.util.PGobjectï¿½."
+msgstr "La class «{0}» non implementa «org.postgresql.util.PGobject»."
 
 #: org/postgresql/jdbc3/AbstractJdbc3Connection.java:60
 #, java-format
 msgid "Unknown ResultSet holdability setting: {0}."
-msgstr "Il parametro ï¿½holdabilityï¿½ per il ï¿½ResultSetï¿½ ï¿½ sconosciuto: {0}."
+msgstr "Il parametro «holdability» per il «ResultSet» è sconosciuto: {0}."
 
 #: org/postgresql/jdbc3/AbstractJdbc3Connection.java:98
 #: org/postgresql/jdbc3/AbstractJdbc3Connection.java:130
@@ -1130,44 +1130,44 @@ msgstr ""
 #: org/postgresql/jdbc3/AbstractJdbc3Connection.java:132
 msgid "Cannot establish a savepoint in auto-commit mode."
 msgstr ""
-"Non ï¿½ possibile impostare i punti di ripristino in modalitï¿½ ï¿½auto-commitï¿½."
+"Non è possibile impostare i punti di ripristino in modalità «auto-commit»."
 
 #: org/postgresql/jdbc3/AbstractJdbc3Connection.java:419
 msgid "Returning autogenerated keys is not supported."
-msgstr "La restituzione di chiavi autogenerate non ï¿½ supportata."
+msgstr "La restituzione di chiavi autogenerate non è supportata."
 
 #: org/postgresql/jdbc3/AbstractJdbc3ParameterMetaData.java:81
 #, java-format
 msgid "The parameter index is out of range: {0}, number of parameters: {1}."
-msgstr "Il parametro indice ï¿½ fuori intervallo: {0}, numero di elementi: {1}."
+msgstr "Il parametro indice è fuori intervallo: {0}, numero di elementi: {1}."
 
 #: org/postgresql/jdbc3/AbstractJdbc3Statement.java:151
 #, fuzzy
 msgid ""
 "Returning autogenerated keys is only supported for 8.2 and later servers."
-msgstr "La restituzione di chiavi autogenerate non ï¿½ supportata."
+msgstr "La restituzione di chiavi autogenerate non è supportata."
 
 #: org/postgresql/jdbc3/AbstractJdbc3Statement.java:199
 #: org/postgresql/jdbc3/AbstractJdbc3Statement.java:317
 #, fuzzy
 msgid "Returning autogenerated keys by column index is not supported."
-msgstr "La restituzione di chiavi autogenerate non ï¿½ supportata."
+msgstr "La restituzione di chiavi autogenerate non è supportata."
 
 #: org/postgresql/jdbc3/PSQLSavepoint.java:38
 #: org/postgresql/jdbc3/PSQLSavepoint.java:50
 #: org/postgresql/jdbc3/PSQLSavepoint.java:66
 msgid "Cannot reference a savepoint after it has been released."
 msgstr ""
-"Non ï¿½ possibile utilizzare un punto di ripristino successivamente al suo "
+"Non è possibile utilizzare un punto di ripristino successivamente al suo "
 "rilascio."
 
 #: org/postgresql/jdbc3/PSQLSavepoint.java:42
 msgid "Cannot retrieve the id of a named savepoint."
-msgstr "Non ï¿½ possibile trovare l''id del punto di ripristino indicato."
+msgstr "Non è possibile trovare l''id del punto di ripristino indicato."
 
 #: org/postgresql/jdbc3/PSQLSavepoint.java:54
 msgid "Cannot retrieve the name of an unnamed savepoint."
-msgstr "Non ï¿½ possibile trovare il nome di un punto di ripristino anonimo."
+msgstr "Non è possibile trovare il nome di un punto di ripristino anonimo."
 
 #: org/postgresql/jdbc3g/AbstractJdbc3gResultSet.java:37
 #, fuzzy
@@ -1182,7 +1182,7 @@ msgstr ""
 #: org/postgresql/jdbc4/AbstractJdbc4Connection.java:120
 #, fuzzy, java-format
 msgid "Invalid timeout ({0}<0)."
-msgstr "La dimensione specificata, {0}, per lo ï¿½streamï¿½ non ï¿½ valida."
+msgstr "La dimensione specificata, {0}, per lo «stream» non è valida."
 
 #: org/postgresql/jdbc4/AbstractJdbc4Connection.java:133
 msgid "Validating connection."
@@ -1197,7 +1197,7 @@ msgstr "Fallita la creazione dell''oggetto per: {0}."
 #: org/postgresql/jdbc4/AbstractJdbc4Connection.java:187
 #, fuzzy
 msgid "ClientInfo property not supported."
-msgstr "La restituzione di chiavi autogenerate non ï¿½ supportata."
+msgstr "La restituzione di chiavi autogenerate non è supportata."
 
 #: org/postgresql/jdbc4/AbstractJdbc4Statement.java:127
 msgid "Object is too large to send over the protocol."
@@ -1224,12 +1224,12 @@ msgstr ""
 #: org/postgresql/jdbc4/Jdbc4SQLXML.java:213
 #, fuzzy, java-format
 msgid "Unknown XML Result class: {0}"
-msgstr "Il parametro ï¿½holdabilityï¿½ per il ï¿½ResultSetï¿½ ï¿½ sconosciuto: {0}."
+msgstr "Il parametro «holdability» per il «ResultSet» è sconosciuto: {0}."
 
 #: org/postgresql/jdbc4/Jdbc4SQLXML.java:226
 #, fuzzy
 msgid "This SQLXML object has already been freed."
-msgstr "Questo ï¿½PooledConnectionï¿½ ï¿½ stato chiuso."
+msgstr "Questo «PooledConnection» è stato chiuso."
 
 #: org/postgresql/jdbc4/Jdbc4SQLXML.java:233
 msgid ""
@@ -1259,14 +1259,14 @@ msgstr "Inizializzazione di LargeObject API fallita."
 #: org/postgresql/largeobject/LargeObjectManager.java:198
 #: org/postgresql/largeobject/LargeObjectManager.java:239
 msgid "Large Objects may not be used in auto-commit mode."
-msgstr "Non ï¿½ possibile impostare i ï¿½Large Objectï¿½ in modalitï¿½ ï¿½auto-commitï¿½."
+msgstr "Non è possibile impostare i «Large Object» in modalità «auto-commit»."
 
 #: org/postgresql/ssl/jdbc3/AbstractJdbc3MakeSSL.java:58
 #: org/postgresql/ssl/jdbc4/AbstractJdbc4MakeSSL.java:110
 #, java-format
 msgid "The SSLSocketFactory class provided {0} could not be instantiated."
 msgstr ""
-"La classe ï¿½SSLSocketFactoryï¿½ specificata, ï¿½{0}ï¿½, non puï¿½ essere istanziata."
+"La classe «SSLSocketFactory» specificata, «{0}», non può essere istanziata."
 
 #: org/postgresql/ssl/jdbc4/AbstractJdbc4MakeSSL.java:125
 #, java-format
@@ -1277,7 +1277,7 @@ msgstr ""
 #, fuzzy, java-format
 msgid "The HostnameVerifier class provided {0} could not be instantiated."
 msgstr ""
-"La classe ï¿½SSLSocketFactoryï¿½ specificata, ï¿½{0}ï¿½, non puï¿½ essere istanziata."
+"La classe «SSLSocketFactory» specificata, «{0}», non può essere istanziata."
 
 #: org/postgresql/ssl/jdbc4/AbstractJdbc4MakeSSL.java:142
 #, java-format
@@ -1338,7 +1338,7 @@ msgstr ""
 #, fuzzy, java-format
 msgid "The password callback class provided {0} could not be instantiated."
 msgstr ""
-"La classe ï¿½SSLSocketFactoryï¿½ specificata, ï¿½{0}ï¿½, non puï¿½ essere istanziata."
+"La classe «SSLSocketFactory» specificata, «{0}», non può essere istanziata."
 
 #: org/postgresql/ssl/jdbc4/LibPQFactory.java:133
 #, java-format
@@ -1361,11 +1361,11 @@ msgstr ""
 
 #: org/postgresql/util/PGInterval.java:164
 msgid "Conversion of interval failed"
-msgstr "Fallita la conversione di un ï¿½intervalï¿½."
+msgstr "Fallita la conversione di un «interval»."
 
 #: org/postgresql/util/PGmoney.java:73
 msgid "Conversion of money failed."
-msgstr "Fallita la conversione di un ï¿½moneyï¿½."
+msgstr "Fallita la conversione di un «money»."
 
 #: org/postgresql/util/ServerErrorMessage.java:155
 #, java-format
@@ -1422,22 +1422,22 @@ msgstr "Flag non validi"
 #: org/postgresql/xa/PGXAConnection.java:248
 #: org/postgresql/xa/PGXAConnection.java:425
 msgid "xid must not be null"
-msgstr "xid non puï¿½ essere NULL"
+msgstr "xid non può essere NULL"
 
 #: org/postgresql/xa/PGXAConnection.java:192
 msgid "Connection is busy with another transaction"
-msgstr "La connessione ï¿½ utilizzata da un''altra transazione"
+msgstr "La connessione è utilizzata da un''altra transazione"
 
 #: org/postgresql/xa/PGXAConnection.java:198
 #: org/postgresql/xa/PGXAConnection.java:255
 msgid "suspend/resume not implemented"
-msgstr "ï¿½suspendï¿½/ï¿½resumeï¿½ non implementato"
+msgstr "«suspend»/«resume» non implementato"
 
 #: org/postgresql/xa/PGXAConnection.java:204
 #: org/postgresql/xa/PGXAConnection.java:207
 #: org/postgresql/xa/PGXAConnection.java:209
 msgid "Transaction interleaving not implemented"
-msgstr "L''\"interleaving\" delle transazioni ï¿½{0}ï¿½ non ï¿½ supportato."
+msgstr "L''\"interleaving\" delle transazioni «{0}» non è supportato."
 
 #: org/postgresql/xa/PGXAConnection.java:218
 #, fuzzy
@@ -1446,19 +1446,19 @@ msgstr "Errore durante il commit \"one-phase\""
 
 #: org/postgresql/xa/PGXAConnection.java:251
 msgid "tried to call end without corresponding start call"
-msgstr "ï¿½ stata chiamata ï¿½endï¿½ senza la corrispondente chiamata a ï¿½startï¿½"
+msgstr "È stata chiamata «end» senza la corrispondente chiamata a «start»"
 
 #: org/postgresql/xa/PGXAConnection.java:282
 msgid ""
 "Not implemented: Prepare must be issued using the same connection that "
 "started the transaction"
 msgstr ""
-"Non implementato: ï¿½Prepareï¿½ deve essere eseguito nella stessa connessione "
+"Non implementato: «Prepare» deve essere eseguito nella stessa connessione "
 "che ha iniziato la transazione."
 
 #: org/postgresql/xa/PGXAConnection.java:286
 msgid "Prepare called before end"
-msgstr "ï¿½Prepareï¿½ invocato prima della fine"
+msgstr "«Prepare» invocato prima della fine"
 
 #: org/postgresql/xa/PGXAConnection.java:292
 msgid "Server versions prior to 8.1 do not support two-phase commit."
@@ -1480,7 +1480,7 @@ msgstr "Errore durante il ripristino"
 
 #: org/postgresql/xa/PGXAConnection.java:416
 msgid "Error rolling back prepared transaction"
-msgstr "Errore durante il ï¿½rollbackï¿½ di una transazione preparata"
+msgstr "Errore durante il «rollback» di una transazione preparata"
 
 #: org/postgresql/xa/PGXAConnection.java:451
 msgid ""
@@ -1492,7 +1492,7 @@ msgstr ""
 
 #: org/postgresql/xa/PGXAConnection.java:455
 msgid "commit called before end"
-msgstr "ï¿½Commitï¿½ ï¿½ stato chiamato prima della fine"
+msgstr "«Commit» è stato chiamato prima della fine"
 
 #: org/postgresql/xa/PGXAConnection.java:466
 msgid "Error during one-phase commit"
@@ -1502,17 +1502,17 @@ msgstr "Errore durante il commit \"one-phase\""
 msgid ""
 "Not implemented: 2nd phase commit must be issued using an idle connection"
 msgstr ""
-"Non implementato: la seconda fase del ï¿½commitï¿½ deve essere effettuata con "
+"Non implementato: la seconda fase del «commit» deve essere effettuata con "
 "una connessione non in uso"
 
 #: org/postgresql/xa/PGXAConnection.java:507
 #, fuzzy
 msgid "Error committing prepared transaction"
-msgstr "Errore durante il ï¿½rollbackï¿½ di una transazione preparata"
+msgstr "Errore durante il «rollback» di una transazione preparata"
 
 #: org/postgresql/xa/PGXAConnection.java:522
 msgid "Heuristic commit/rollback not supported"
-msgstr "ï¿½Commitï¿½ e ï¿½rollbackï¿½ euristici non sono supportati"
+msgstr "«Commit» e «rollback» euristici non sono supportati"
 
 #~ msgid "The driver does not support SSL."
 #~ msgstr "Il driver non supporta SSL."
@@ -1521,7 +1521,7 @@ msgstr "ï¿½Commitï¿½ e ï¿½rollbackï¿½ euristici non sono supportati"
 #~ msgstr "Gli array multidimensionali non sono attualmente gestiti."
 
 #~ msgid "rand function only takes zero or one argument(the seed)."
-#~ msgstr "Il metodo ï¿½randï¿½ vuole al massimo un argomento (il seme)."
+#~ msgstr "Il metodo «rand» vuole al massimo un argomento (il seme)."
 
 #~ msgid "Exception: {0}"
 #~ msgstr "Eccezione: {0}."
@@ -1534,18 +1534,18 @@ msgstr "ï¿½Commitï¿½ e ï¿½rollbackï¿½ euristici non sono supportati"
 
 #~ msgid "Exception generating stacktrace for: {0} encountered: {1}"
 #~ msgstr ""
-#~ "Eccezione durante la generazione dello stack trace per: ï¿½{0}ï¿½ trovata: {1}"
+#~ "Eccezione durante la generazione dello stack trace per: «{0}» trovata: {1}"
 
 #~ msgid "suspend/resume and join not implemented"
-#~ msgstr "ï¿½Suspendï¿½, ï¿½resumeï¿½ e ï¿½joinï¿½ non sono implementati"
+#~ msgstr "«Suspend», «resume» e «join» non sono implementati"
 
 #~ msgid ""
 #~ "Cannot call setXXX(1, ..) on a CallableStatement.  This is an output that "
 #~ "must be configured with registerOutParameter instead."
 #~ msgstr ""
-#~ "Non ï¿½ possibile invocare ï¿½setXXX(1,...)ï¿½ per un ï¿½CallableStatementï¿½. Si "
+#~ "Non è possibile invocare «setXXX(1,...)» per un «CallableStatement». Si "
 #~ "tratta di un valore restituito che va configurato usando il metodo "
-#~ "ï¿½registerOutParameter()ï¿½."
+#~ "«registerOutParameter()»."
 
 #~ msgid ""
 #~ "PostgreSQL only supports a single OUT function return value at index 1."
@@ -1563,34 +1563,34 @@ msgstr "ï¿½Commitï¿½ e ï¿½rollbackï¿½ euristici non sono supportati"
 #~ msgstr "Fallita la conversione di un ``point'': {0}."
 
 #~ msgid "No results where returned by the query."
-#~ msgstr "Nessun risultato ï¿½ stato restituito dalla query."
+#~ msgstr "Nessun risultato è stato restituito dalla query."
 
 #~ msgid "Bad byte: {0}"
-#~ msgstr "ï¿½Byteï¿½ non corretto: {0}"
+#~ msgstr "«Byte» non corretto: {0}"
 
 #~ msgid "Bad short: {0}"
-#~ msgstr "ï¿½Shortï¿½ non corretto: {0}"
+#~ msgstr "«Short» non corretto: {0}"
 
 #~ msgid "The JVM claims not to support the UTF-8 encoding."
 #~ msgstr "La JVM sostiene di non supportare la codifica UTF-8."
 
 #~ msgid "Bad int: {0}"
-#~ msgstr "ï¿½Intï¿½ non corretto: {0}"
+#~ msgstr "«Int» non corretto: {0}"
 
 #~ msgid "Bad long: {0}"
-#~ msgstr "ï¿½Longï¿½ non corretto: {0}"
+#~ msgstr "«Long» non corretto: {0}"
 
 #~ msgid "Bad BigDecimal: {0}"
-#~ msgstr "ï¿½BigDecimalï¿½ non corretto: {0}"
+#~ msgstr "«BigDecimal» non corretto: {0}"
 
 #~ msgid "Bad float: {0}"
-#~ msgstr "ï¿½Floatï¿½ non corretto: {0}"
+#~ msgstr "«Float» non corretto: {0}"
 
 #~ msgid "Bad double: {0}"
-#~ msgstr "ï¿½Doubleï¿½ non corretto: {0}"
+#~ msgstr "«Double» non corretto: {0}"
 
 #~ msgid "Bad date: {0}"
-#~ msgstr "ï¿½Dateï¿½ non corretto: {0}"
+#~ msgstr "«Date» non corretto: {0}"
 
 #~ msgid "The given date {0} does not match the format required: {1}."
 #~ msgstr "La data fornita {0} non corrisponde al formato richiesto: {1}."
@@ -1603,9 +1603,9 @@ msgstr "ï¿½Commitï¿½ e ï¿½rollbackï¿½ euristici non sono supportati"
 #~ "La marca temporale fornita {0} non corrisponde al formato richiesto: {1}."
 
 #~ msgid "Could not extract nanoseconds from {0}."
-#~ msgstr "Non ï¿½ possibile estrarre i nanosecondi da {0}."
+#~ msgstr "Non è possibile estrarre i nanosecondi da {0}."
 
 #~ msgid "ResultSet holdability of HOLD_CURSORS_OVER_COMMIT is not supported."
 #~ msgstr ""
-#~ "Il mantenimento del ResultSet tramite HOLD_CURSOR_OVER_COMMIT non ï¿½ "
+#~ "Il mantenimento del ResultSet tramite HOLD_CURSOR_OVER_COMMIT non è "
 #~ "supportato."


### PR DESCRIPTION
This should close #408.

I notice there is an open #348 to make `update-translations.sh` be automatically run (contrary to the maintainer instructions on the [translations page][trn]). I wonder if the project has escaped embarrassment in international quarters exactly because that _didn't_ happen in 2013 when these files got clobbered....

[trn]: https://jdbc.postgresql.org/development/translations.html