### PR TITLE
perf: improve performance of resultSet.getObject

### DIFF
--- a/org/postgresql/core/Field.java
+++ b/org/postgresql/core/Field.java
@@ -38,6 +38,11 @@ public class Field
     private String schemaName = "";
     private int nullable = ResultSetMetaData.columnNullableUnknown;
     private boolean autoIncrement = false;
+    private int sqlType;
+    private String pgType = NOT_YET_LOADED;
+
+    // New string to avoid clashes with other strings
+    private static final String NOT_YET_LOADED = new String("pgType is not yet loaded");
 
     /*
      * Construct a field based on the information fed to it.
@@ -199,5 +204,29 @@ public class Field
         return "Field("+ (columnName != null ? columnName : "") + "," +
                 Oid.toString(oid) + "," + length + "," +
                 (format == TEXT_FORMAT ? 'T' : 'B') + ")";
+    }
+
+    public void setSQLType(int sqlType)
+    {
+        this.sqlType = sqlType;
+    }
+
+    public int getSQLType()
+    {
+        return sqlType;
+    }
+
+    public void setPGType(String pgType)
+    {
+        this.pgType = pgType;
+    }
+
+    public String getPGType()
+    {
+        return pgType;
+    }
+
+    public boolean isTypeInitialized() {
+        return pgType != NOT_YET_LOADED;
     }
 }


### PR DESCRIPTION
There are two changes:
1) Fast-path for `long` -> BigDecimal. For small values, database can send binary `long`, so there is no need to convert the received long back to string (see type=BIGINT below)
2) "Cached getSQLType" speeds up getObject (see type=bigdecimal, getter=object below).

Before:
```
Benchmark                 (getter)  (ncols)  (nrows)     (type)  Mode  Cnt      Score    Error  Units
ProcessResultSet.execFetch    BEST        5     1000         INT  avgt    5   599,098 ± 11,030  us/op
ProcessResultSet.execFetch    BEST        5     1000  BIGDECIMAL  avgt    5  2392,760 ± 26,083  us/op

ProcessResultSet.execFetch    BEST        5     1000      BIGINT  avgt    5  3141,686 ± 92,846  us/op
ProcessResultSet.execFetch  OBJECT        5     1000  BIGDECIMAL  avgt    5  3400,252 ± 61,252  us/op
```

After:
```
Benchmark                 (getter)  (ncols)  (nrows)      (type)  Mode  Cnt     Score    Error  Units
ProcessResultSet.execFetch    BEST        5     1000         INT  avgt    5   598,402 ± 10,890  us/op
ProcessResultSet.execFetch    BEST        5     1000  BIGDECIMAL  avgt    5  2370,942 ± 31,716  us/op

ProcessResultSet.execFetch    BEST        5     1000      BIGINT  avgt    5   719,552 ±  9,449  us/op
ProcessResultSet.execFetch  OBJECT        5     1000  BIGDECIMAL  avgt    5  2450,741 ± 52,455  us/op
```