### PR TITLE
fix: make Statement.cancel and Statement.setQueryTimeout thread safe

### DIFF
--- a/org/postgresql/jdbc2/AbstractJdbc2Statement.java
+++ b/org/postgresql/jdbc2/AbstractJdbc2Statement.java
@@ -115,7 +115,7 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
     /** Number of rows to get in a batch. */
     protected int fetchSize = 0;
 
-    /** Timeout (in seconds) for a query */
+    /** Timeout (in milli-seconds) for a query */
     protected int timeout = 0;
 
     protected boolean replaceProcessingEnabled = true;
@@ -758,8 +758,7 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
      */
     public int getQueryTimeout() throws SQLException
     {
-        checkClosed();
-        return timeout;
+        return getQueryTimeoutMs() / 1000;
     }
 
     /*
@@ -770,12 +769,37 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
      */
     public void setQueryTimeout(int seconds) throws SQLException
     {
+        setQueryTimeoutMs(seconds * 1000);
+    }
+
+    /*
+     * The queryTimeout limit is the number of seconds the driver
+     * will wait for a Statement to execute.  If the limit is
+     * exceeded, a SQLException is thrown.
+     *
+     * @return the current query timeout limit in seconds; 0 = unlimited
+     * @exception SQLException if a database access error occurs
+     */
+    public int getQueryTimeoutMs() throws SQLException
+    {
+        checkClosed();
+        return timeout;
+    }
+
+    /*
+     * Sets the queryTimeout limit
+     *
+     * @param seconds - the new query timeout limit in seconds
+     * @exception SQLException if a database access error occurs
+     */
+    public void setQueryTimeoutMs(int millis) throws SQLException
+    {
         checkClosed();
 
-        if (seconds < 0)
+        if (millis < 0)
             throw new PSQLException(GT.tr("Query timeout must be a value greater than or equals to 0."),
                                     PSQLState.INVALID_PARAMETER_VALUE);
-        timeout = seconds;
+        timeout = millis;
     }
 
     /**
@@ -3475,7 +3499,7 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
 	    }
 	};
 
-        connection.addTimerTask(cancelTimerTask, timeout * 1000);
+        connection.addTimerTask(cancelTimerTask, timeout);
     }
 
     private synchronized void killTimerTask()

--- a/org/postgresql/test/jdbc2/StatementTest.java
+++ b/org/postgresql/test/jdbc2/StatementTest.java
@@ -8,6 +8,7 @@
 package org.postgresql.test.jdbc2;
 
 import junit.framework.TestCase;
+import org.postgresql.jdbc2.AbstractJdbc2Statement;
 import org.postgresql.test.TestUtil;
 
 import java.sql.*;
@@ -503,6 +504,30 @@ public class StatementTest extends TestCase
     		if (sqle.getSQLState().compareTo("57014") == 0) 
     			timer.cancel();
     	}
+    }
+
+    /**
+     * Test executes two queries one after another.
+     * The first one has timeout of 1ms, and the second one does not.
+     * The timeout of the first query should not impact the second one.
+     * @throws SQLException
+     */
+    public void testShortQueryTimeout() throws SQLException
+    {
+        long deadLine = System.currentTimeMillis() + 10000;
+        Statement stmt = con.createStatement();
+        ((AbstractJdbc2Statement) stmt).setQueryTimeoutMs(1);
+        Statement stmt2 = con.createStatement();
+        while(System.currentTimeMillis() < deadLine) {
+            try
+            {
+                stmt.execute("select 1");
+            } catch (SQLException e)
+            {
+                // ignore "statement cancelled"
+            }
+            stmt2.executeQuery("select 1");
+        }
     }
 
     public void testSetQueryTimeoutWithSleep() throws SQLException, InterruptedException


### PR DESCRIPTION
Statement.cancel was not thread-safe, thus query timeout from one statement might cancel subsequent statement.

The change introduces state tracking of a statement (ide, in-query, cancelling, cancelled), so out-of-order cancels can be detected and ignored.

There are two basic problems with .cancel handing:
1) `cancel`s called at random from user code. Even thought `Statement#cancel` does not require thread-safety, it would be "a bit" unexpected if `statementA.cancel` would cancel subsequent `statementB` that is run in the same connection.
The thing is backend protocol does not allow to cancel a specific execution, thus if user invokes `cancel`, pgjdbc should ensure that cancel would not terminate another statement by mistake.

The approach is to have `statementState` and skip cancels that appear when state is "idle".
Additionally, if .execute notices there was a cancel, it waits till cancel completes.

Note: this dance does not guarantee that cancel is indeed dispatched to the backend, however the case when "cancel request" is not dispatched should be very rare. The remaining race is due to OS signals. In other words, current implementation just waits till the "interrupt" signal is sent to the proper backend, however it does not wait till the signal is processed.

2) `setQueryTimeout` should not affect another statements or subsequent executions of the same statement.

The approach here is to atomically `compareAndSwap` `cancelTimerTask` reference, so the task can detect presence of another task and exit safely.