### PR TITLE
chore: add .gitattributes to ensure automatic end-of-line storage of text files is used

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+* text=auto
+*.java text
+*.md text
+*.sql text
+*.sh text eol=lf
+*.xml text
+*.yaml text
+*.yml text


### PR DESCRIPTION
This makes sure text files are sored in LF form in the git repository, so Windows contributors do not end up with "EOL changed" PRs