### PR TITLE
Replace question marks only in PreparedStatements

### DIFF
--- a/org/postgresql/core/Parser.java
+++ b/org/postgresql/core/Parser.java
@@ -83,6 +83,9 @@ public class Parser {
                 break;
 
             case '?':
+				if (!withParameters)
+					break;
+
                 nativeSql.append(aChars, fragmentStart, i - fragmentStart);
                 if (i + 1 < aChars.length && aChars[i + 1] == '?') /* replace ?? with ? */
                 {

--- a/org/postgresql/core/Parser.java
+++ b/org/postgresql/core/Parser.java
@@ -90,7 +90,11 @@ public class Parser {
                     i++; // make sure the coming ? is not treated as a bind
                 } else
                 {
-                    if (withParameters)
+                    if (!withParameters)
+                    {
+                        nativeSql.append('?');
+                    }
+                    else
                     {
                         if (bindPositions == null)
                             bindPositions = new ArrayList<Integer>();
@@ -98,8 +102,6 @@ public class Parser {
                         int bindIndex = bindPositions.size();
                         nativeSql.append(NativeQuery.bindName(bindIndex));
                     }
-                    else
-                        nativeSql.append('?');
                 }
                 fragmentStart = i + 1;
                 break;

--- a/org/postgresql/core/Parser.java
+++ b/org/postgresql/core/Parser.java
@@ -83,9 +83,6 @@ public class Parser {
                 break;
 
             case '?':
-				if (!withParameters)
-					break;
-
                 nativeSql.append(aChars, fragmentStart, i - fragmentStart);
                 if (i + 1 < aChars.length && aChars[i + 1] == '?') /* replace ?? with ? */
                 {
@@ -93,11 +90,16 @@ public class Parser {
                     i++; // make sure the coming ? is not treated as a bind
                 } else
                 {
-                    if (bindPositions == null)
-                        bindPositions = new ArrayList<Integer>();
-                    bindPositions.add(nativeSql.length());
-                    int bindIndex = bindPositions.size();
-                    nativeSql.append(NativeQuery.bindName(bindIndex));
+                    if (withParameters)
+                    {
+                        if (bindPositions == null)
+                            bindPositions = new ArrayList<Integer>();
+                        bindPositions.add(nativeSql.length());
+                        int bindIndex = bindPositions.size();
+                        nativeSql.append(NativeQuery.bindName(bindIndex));
+                    }
+                    else
+                        nativeSql.append('?');
                 }
                 fragmentStart = i + 1;
                 break;

--- a/org/postgresql/test/jdbc3/CompositeQueryParseTest.java
+++ b/org/postgresql/test/jdbc3/CompositeQueryParseTest.java
@@ -30,7 +30,12 @@ public class CompositeQueryParseTest extends TestCase {
 
     public void testSimpleBind()
     {
-        assertEquals("select $1", reparse("select ?", true, false, true));
+        assertEquals("select $1", reparse("select ?", true, true, true));
+    }
+
+    public void testUnquotedQuestionmark()
+    {
+        assertEquals("select '{\"key\": \"val\"}'::jsonb ? 'key'", reparse("select '{\"key\": \"val\"}'::jsonb ? 'key'", true, false, true));
     }
 
     public void testQuotedQuestionmark()
@@ -40,7 +45,7 @@ public class CompositeQueryParseTest extends TestCase {
 
     public void testDoubleQuestionmark()
     {
-        assertEquals("select '?', $1 ?=> $2", reparse("select '?', ? ??=> ?", true, false, true));
+        assertEquals("select '?', $1 ?=> $2", reparse("select '?', ? ??=> ?", true, true, true));
     }
 
     public void testCompositeBasic()
@@ -50,7 +55,7 @@ public class CompositeQueryParseTest extends TestCase {
 
     public void testCompositeWithBinds()
     {
-        assertEquals("select $1;/*cut*/\n select $1", reparse("select ?; select ?", true, false, true));
+        assertEquals("select $1;/*cut*/\n select $1", reparse("select ?; select ?", true, true, true));
     }
 
     public void testTrailingSemicolon()

--- a/org/postgresql/test/jdbc3/CompositeQueryParseTest.java
+++ b/org/postgresql/test/jdbc3/CompositeQueryParseTest.java
@@ -38,6 +38,11 @@ public class CompositeQueryParseTest extends TestCase {
         assertEquals("select '{\"key\": \"val\"}'::jsonb ? 'key'", reparse("select '{\"key\": \"val\"}'::jsonb ? 'key'", true, false, true));
     }
 
+    public void testRepeatedQuestionmark()
+    {
+        assertEquals("select '{\"key\": \"val\"}'::jsonb ? 'key'", reparse("select '{\"key\": \"val\"}'::jsonb ?? 'key'", true, false, true));
+    }
+
     public void testQuotedQuestionmark()
     {
         assertEquals("select '?'", reparse("select '?'", true, false, true));


### PR DESCRIPTION
In [this thread](http://www.postgresql.org/message-id/n2ha84$5u8$1@ger.gmane.org) Thomas Kellerer uttered his surprise that questions marks are replaced with positional parameters in a <tt>java.sql.Statement</tt>.

I think that is a bug, an I came up with this patch to fix it.

My only concern is that this is a behaviour change that might break existing code...