### PR TITLE
Fix to mend debug logging to allow programmatic level setting.

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -8,11 +8,11 @@ fullversion=9.4
 def_pgport=5432
 enable_debug=yes
 
-osgi.version=9.4.0.build-1205
+osgi.version=9.4.0.build-1206
 
 maven.group.id=org.postgresql
 maven.artifact.id=postgresql
-maven.artifact.version=9.4-1205
+maven.artifact.version=9.4-1206
 maven.artifact.description=PostgreSQL JDBC Driver
 
 # Maven snapshots and staging repository id and url

--- a/org/postgresql/PGProperty.java
+++ b/org/postgresql/PGProperty.java
@@ -463,7 +463,7 @@ public enum PGProperty
      */
     public boolean isPresent(Properties properties)
     {
-        return get(properties) != null;
+        return getSetString(properties) != null;
     }
 
     /**
@@ -490,6 +490,19 @@ public enum PGProperty
                 return property;
             }
         }
+        return null;
+    }
+    /**
+     * Return the property if exists but avoiding the default. Allowing the caller
+     * to detect the lack of a property. 
+     * @param properties properties bundle
+     * @return the value of a set property
+     */
+    public String getSetString(Properties properties)
+    {
+        Object o = properties.get(_name);
+        if (o instanceof String)
+            return (String) o;
         return null;
     }
 }

--- a/org/postgresql/core/Parser.java
+++ b/org/postgresql/core/Parser.java
@@ -83,6 +83,9 @@ public class Parser {
                 break;
 
             case '?':
+				if (!withParameters)
+					break;
+
                 nativeSql.append(aChars, fragmentStart, i - fragmentStart);
                 if (i + 1 < aChars.length && aChars[i + 1] == '?') /* replace ?? with ? */
                 {

--- a/org/postgresql/core/Parser.java
+++ b/org/postgresql/core/Parser.java
@@ -90,7 +90,11 @@ public class Parser {
                     i++; // make sure the coming ? is not treated as a bind
                 } else
                 {
-                    if (withParameters)
+                    if (!withParameters)
+                    {
+                        nativeSql.append('?');
+                    }
+                    else
                     {
                         if (bindPositions == null)
                             bindPositions = new ArrayList<Integer>();
@@ -98,8 +102,6 @@ public class Parser {
                         int bindIndex = bindPositions.size();
                         nativeSql.append(NativeQuery.bindName(bindIndex));
                     }
-                    else
-                        nativeSql.append('?');
                 }
                 fragmentStart = i + 1;
                 break;

--- a/org/postgresql/core/Parser.java
+++ b/org/postgresql/core/Parser.java
@@ -83,9 +83,6 @@ public class Parser {
                 break;
 
             case '?':
-				if (!withParameters)
-					break;
-
                 nativeSql.append(aChars, fragmentStart, i - fragmentStart);
                 if (i + 1 < aChars.length && aChars[i + 1] == '?') /* replace ?? with ? */
                 {
@@ -93,11 +90,16 @@ public class Parser {
                     i++; // make sure the coming ? is not treated as a bind
                 } else
                 {
-                    if (bindPositions == null)
-                        bindPositions = new ArrayList<Integer>();
-                    bindPositions.add(nativeSql.length());
-                    int bindIndex = bindPositions.size();
-                    nativeSql.append(NativeQuery.bindName(bindIndex));
+                    if (withParameters)
+                    {
+                        if (bindPositions == null)
+                            bindPositions = new ArrayList<Integer>();
+                        bindPositions.add(nativeSql.length());
+                        int bindIndex = bindPositions.size();
+                        nativeSql.append(NativeQuery.bindName(bindIndex));
+                    }
+                    else
+                        nativeSql.append('?');
                 }
                 fragmentStart = i + 1;
                 break;

--- a/org/postgresql/jdbc2/AbstractJdbc2Connection.java
+++ b/org/postgresql/jdbc2/AbstractJdbc2Connection.java
@@ -8,7 +8,6 @@
 package org.postgresql.jdbc2;
 
 import java.io.IOException;
-import java.io.PrintWriter;
 import java.sql.*;
 import java.util.*;
 
@@ -122,12 +121,22 @@ public abstract class AbstractJdbc2Connection implements BaseConnection
     {
         this.creatingURL = url;
 
-        // Read loglevel arg and set the loglevel based on this value;
+        // Read loglevel arg and set the loglevel based on this value
+        // otherwise use the programmatic or init logger level;
         // In addition to setting the log level, enable output to
         // standard out if no other printwriter is set
 
         int logLevel = Driver.getLogLevel();
-
+        String connectionLogLevel = PGProperty.LOG_LEVEL.getSetString(info);
+        if (connectionLogLevel != null) {
+            try
+            {
+                logLevel = Integer.parseInt(connectionLogLevel);
+            } catch (NumberFormatException nfe) 
+            {
+                // ignore
+            }
+        }
         synchronized (AbstractJdbc2Connection.class) {
             logger = new Logger(nextConnectionID++);
             logger.setLogLevel(logLevel);

--- a/org/postgresql/test/jdbc2/PGPropertyTest.java
+++ b/org/postgresql/test/jdbc2/PGPropertyTest.java
@@ -218,4 +218,26 @@ public class PGPropertyTest extends TestCase
         parsedProperties = Driver.parseURL(TestUtil.getURL() + "&ssl=true" , null);
         Assert.assertTrue("SSL property should be present", PGProperty.SSL.isPresent(parsedProperties));
     }
+    
+    /**
+     * Check whether the isPresent method really works.
+     */
+    public void testPresenceCheck() 
+    {
+        Properties empty = new Properties();
+        Object value = PGProperty.LOG_LEVEL.get(empty);
+        assertNotNull(value);
+        Assert.assertFalse(PGProperty.LOG_LEVEL.isPresent(empty));
+    }
+    
+    public void testNullValue() 
+    {
+        Properties empty = new Properties();
+        assertNull(PGProperty.LOG_LEVEL.getSetString(empty));
+        assertNull(PGProperty.LOG_LEVEL.getSetString(empty));
+        Properties withLogging = new Properties();
+        withLogging.setProperty(PGProperty.LOG_LEVEL.getName(), "2");
+        assertNotNull(PGProperty.LOG_LEVEL.getSetString(withLogging));
+    }
+    
 }

--- a/org/postgresql/test/jdbc3/CompositeQueryParseTest.java
+++ b/org/postgresql/test/jdbc3/CompositeQueryParseTest.java
@@ -30,7 +30,12 @@ public class CompositeQueryParseTest extends TestCase {
 
     public void testSimpleBind()
     {
-        assertEquals("select $1", reparse("select ?", true, false, true));
+        assertEquals("select $1", reparse("select ?", true, true, true));
+    }
+
+    public void testUnquotedQuestionmark()
+    {
+        assertEquals("select '{\"key\": \"val\"}'::jsonb ? 'key'", reparse("select '{\"key\": \"val\"}'::jsonb ? 'key'", true, false, true));
     }
 
     public void testQuotedQuestionmark()
@@ -40,7 +45,7 @@ public class CompositeQueryParseTest extends TestCase {
 
     public void testDoubleQuestionmark()
     {
-        assertEquals("select '?', $1 ?=> $2", reparse("select '?', ? ??=> ?", true, false, true));
+        assertEquals("select '?', $1 ?=> $2", reparse("select '?', ? ??=> ?", true, true, true));
     }
 
     public void testCompositeBasic()
@@ -50,7 +55,7 @@ public class CompositeQueryParseTest extends TestCase {
 
     public void testCompositeWithBinds()
     {
-        assertEquals("select $1;/*cut*/\n select $1", reparse("select ?; select ?", true, false, true));
+        assertEquals("select $1;/*cut*/\n select $1", reparse("select ?; select ?", true, true, true));
     }
 
     public void testTrailingSemicolon()

--- a/org/postgresql/test/jdbc3/CompositeQueryParseTest.java
+++ b/org/postgresql/test/jdbc3/CompositeQueryParseTest.java
@@ -38,6 +38,11 @@ public class CompositeQueryParseTest extends TestCase {
         assertEquals("select '{\"key\": \"val\"}'::jsonb ? 'key'", reparse("select '{\"key\": \"val\"}'::jsonb ? 'key'", true, false, true));
     }
 
+    public void testRepeatedQuestionmark()
+    {
+        assertEquals("select '{\"key\": \"val\"}'::jsonb ? 'key'", reparse("select '{\"key\": \"val\"}'::jsonb ?? 'key'", true, false, true));
+    }
+
     public void testQuotedQuestionmark()
     {
         assertEquals("select '?'", reparse("select '?'", true, false, true));

--- a/org/postgresql/util/PSQLDriverVersion.java
+++ b/org/postgresql/util/PSQLDriverVersion.java
@@ -19,7 +19,7 @@ import org.postgresql.Driver;
  */
 public class PSQLDriverVersion {
 
-    public final static int buildNumber = 1205;
+    public final static int buildNumber = 1206;
 
     public static void main(String args[]) {
         java.net.URL url = Driver.class.getResource("/org/postgresql/Driver.class");


### PR DESCRIPTION
This PR fixes changes introduced in 1205 release.
 It adds a new method to PGProperty to return a property value without using the default. Allowing NULL to be returned.
 Changed the impl of isPresent method. To actually work.
 Added two test cases. To check isPresent and getSetString methods both work.

 The fixed isPresent method smokes out an issue in an SSL test case. Now the method is fixed this test fails now.