### PR TITLE
Fix to mend debug logging to allow programmatic level setting.

### DIFF
--- a/org/postgresql/PGProperty.java
+++ b/org/postgresql/PGProperty.java
@@ -463,7 +463,7 @@ public enum PGProperty
      */
     public boolean isPresent(Properties properties)
     {
-        return get(properties) != null;
+        return getSetString(properties) != null;
     }
 
     /**
@@ -490,6 +490,19 @@ public enum PGProperty
                 return property;
             }
         }
+        return null;
+    }
+    /**
+     * Return the property if exists but avoiding the default. Allowing the caller
+     * to detect the lack of a property. 
+     * @param properties properties bundle
+     * @return the value of a set property
+     */
+    public String getSetString(Properties properties)
+    {
+        Object o = properties.get(_name);
+        if (o instanceof String)
+            return (String) o;
         return null;
     }
 }

--- a/org/postgresql/jdbc2/AbstractJdbc2Connection.java
+++ b/org/postgresql/jdbc2/AbstractJdbc2Connection.java
@@ -8,7 +8,6 @@
 package org.postgresql.jdbc2;
 
 import java.io.IOException;
-import java.io.PrintWriter;
 import java.sql.*;
 import java.util.*;
 
@@ -122,12 +121,22 @@ public abstract class AbstractJdbc2Connection implements BaseConnection
     {
         this.creatingURL = url;
 
-        // Read loglevel arg and set the loglevel based on this value;
+        // Read loglevel arg and set the loglevel based on this value
+        // otherwise use the programmatic or init logger level;
         // In addition to setting the log level, enable output to
         // standard out if no other printwriter is set
 
         int logLevel = Driver.getLogLevel();
-
+        String connectionLogLevel = PGProperty.LOG_LEVEL.getSetString(info);
+        if (connectionLogLevel != null) {
+            try
+            {
+                logLevel = Integer.parseInt(connectionLogLevel);
+            } catch (NumberFormatException nfe) 
+            {
+                // ignore
+            }
+        }
         synchronized (AbstractJdbc2Connection.class) {
             logger = new Logger(nextConnectionID++);
             logger.setLogLevel(logLevel);

--- a/org/postgresql/test/TestUtil.java
+++ b/org/postgresql/test/TestUtil.java
@@ -58,6 +58,11 @@ public class TestUtil
 			sendBufferSize = "&sendBufferSize="+getSendBufferSize();
 		}
 		
+		String ssl = "";
+        if (getSSL() != null ){
+            ssl = "&ssl="+getSSL();
+        }
+		
         return "jdbc:postgresql://"
                                 + server + ":"
                                 + port + "/"
@@ -66,7 +71,8 @@ public class TestUtil
                                 + protocolVersion
                                 + binaryTransfer
 								+ receiveBufferSize
-								+ sendBufferSize;
+								+ sendBufferSize
+								+ ssl;
     }
 
     /*
@@ -159,6 +165,11 @@ public class TestUtil
 	public static int getReceiveBufferSize()
 	{
 		return Integer.parseInt(System.getProperty("receiveBufferSize","-1"));
+	}
+	
+	public static String getSSL()
+	{
+	    return System.getProperty("ssl");
 	}
 	
     private static boolean initialized = false;

--- a/org/postgresql/test/TestUtil.java
+++ b/org/postgresql/test/TestUtil.java
@@ -58,11 +58,11 @@ public class TestUtil
 			sendBufferSize = "&sendBufferSize="+getSendBufferSize();
 		}
 		
-		String ssl = "";
+        String ssl = "";
         if (getSSL() != null ){
             ssl = "&ssl="+getSSL();
         }
-		
+        
         return "jdbc:postgresql://"
                                 + server + ":"
                                 + port + "/"

--- a/org/postgresql/test/jdbc2/PGPropertyTest.java
+++ b/org/postgresql/test/jdbc2/PGPropertyTest.java
@@ -204,9 +204,11 @@ public class PGPropertyTest extends TestCase
         givenProperties.setProperty("user", TestUtil.getUser());
         givenProperties.setProperty("password", TestUtil.getPassword());
 
+        System.setProperty("ssl", null);
         Properties parsedProperties = Driver.parseURL(TestUtil.getURL(), givenProperties);
-        Assert.assertFalse("SSL property should not be present", PGProperty.SSL.isPresent(parsedProperties));
+        Assert.assertTrue("SSL property should not be present", PGProperty.SSL.isPresent(parsedProperties));
 
+        System.setProperty("ssl", "true");
         givenProperties.setProperty("ssl", "true");
         parsedProperties = Driver.parseURL(TestUtil.getURL(), givenProperties);
         Assert.assertTrue("SSL property should be present", PGProperty.SSL.isPresent(parsedProperties));

--- a/org/postgresql/test/jdbc2/PGPropertyTest.java
+++ b/org/postgresql/test/jdbc2/PGPropertyTest.java
@@ -218,4 +218,26 @@ public class PGPropertyTest extends TestCase
         parsedProperties = Driver.parseURL(TestUtil.getURL() + "&ssl=true" , null);
         Assert.assertTrue("SSL property should be present", PGProperty.SSL.isPresent(parsedProperties));
     }
+    
+    /**
+     * Check whether the isPresent method really works.
+     */
+    public void testPresenceCheck() 
+    {
+        Properties empty = new Properties();
+        Object value = PGProperty.LOG_LEVEL.get(empty);
+        assertNotNull(value);
+        Assert.assertFalse(PGProperty.LOG_LEVEL.isPresent(empty));
+    }
+    
+    public void testNullValue() 
+    {
+        Properties empty = new Properties();
+        assertNull(PGProperty.LOG_LEVEL.getSetString(empty));
+        assertNull(PGProperty.LOG_LEVEL.getSetString(empty));
+        Properties withLogging = new Properties();
+        withLogging.setProperty(PGProperty.LOG_LEVEL.getName(), "2");
+        assertNotNull(PGProperty.LOG_LEVEL.getSetString(withLogging));
+    }
+    
 }

--- a/org/postgresql/test/jdbc2/PGPropertyTest.java
+++ b/org/postgresql/test/jdbc2/PGPropertyTest.java
@@ -204,9 +204,11 @@ public class PGPropertyTest extends TestCase
         givenProperties.setProperty("user", TestUtil.getUser());
         givenProperties.setProperty("password", TestUtil.getPassword());
 
-        System.setProperty("ssl", null);
+        Properties sysProperties = System.getProperties();
+        sysProperties.remove("ssl");
+        System.setProperties(sysProperties);
         Properties parsedProperties = Driver.parseURL(TestUtil.getURL(), givenProperties);
-        Assert.assertTrue("SSL property should not be present", PGProperty.SSL.isPresent(parsedProperties));
+        Assert.assertFalse("SSL property should not be present", PGProperty.SSL.isPresent(parsedProperties));
 
         System.setProperty("ssl", "true");
         givenProperties.setProperty("ssl", "true");
@@ -236,10 +238,31 @@ public class PGPropertyTest extends TestCase
     {
         Properties empty = new Properties();
         assertNull(PGProperty.LOG_LEVEL.getSetString(empty));
-        assertNull(PGProperty.LOG_LEVEL.getSetString(empty));
         Properties withLogging = new Properties();
         withLogging.setProperty(PGProperty.LOG_LEVEL.getName(), "2");
         assertNotNull(PGProperty.LOG_LEVEL.getSetString(withLogging));
     }
+
+    public void setUp()
+    {
+        bootSSLPropertyValue = System.getProperty("ssl");
+    }
+
+    public void tearDown()
+    {
+        if (bootSSLPropertyValue == null) {
+            System.getProperties().remove("ssl");
+        }
+        else
+        {
+            System.setProperty("ssl", bootSSLPropertyValue);
+        }
+    }
     
+    /**
+     * Some tests modify the "ssl" system property. To not disturb 
+     * other test cases in the suite store the value of the property 
+     * and restore it.
+     */
+    private String bootSSLPropertyValue;
 }


### PR DESCRIPTION


This PR fixes changes introduced in 1205 release.
It adds a new method to PGProperty to return a property value without using the default. Allowing NULL to be returned.
Changed the impl of isPresent method. To actually work.
Added two test cases. To check isPresent and getSetString methods both work.

The fixed isPresent method smokes out an issue in an SSL test case. Now the method is fixed this test fails now.
