### PR TITLE
style: checkstyle pass org.postgresql.core

### DIFF
--- a/org/postgresql/PGConnection.java
+++ b/org/postgresql/PGConnection.java
@@ -7,43 +7,44 @@
 */
 package org.postgresql;
 
-import java.sql.*;
 import org.postgresql.copy.CopyManager;
 import org.postgresql.fastpath.Fastpath;
 import org.postgresql.largeobject.LargeObjectManager;
+
+import java.sql.SQLException;
+import java.sql.Statement;
 
 /**
  *  This interface defines the public PostgreSQL extensions to
  *  java.sql.Connection. All Connections returned by the PostgreSQL driver
  *  implement PGConnection.
  */
-public interface PGConnection
-{
+public interface PGConnection {
     /**
      * This method returns any notifications that have been received
      * since the last call to this method.
      * Returns null if there have been no notifications.
      * @since 7.3
      */
-    public PGNotification[] getNotifications() throws SQLException;
+    PGNotification[] getNotifications() throws SQLException;
 
     /**
      * This returns the COPY API for the current connection.
      * @since 8.4
      */
-    public CopyManager getCopyAPI() throws SQLException;
+    CopyManager getCopyAPI() throws SQLException;
 
     /**
      * This returns the LargeObject API for the current connection.
      * @since 7.3
      */
-    public LargeObjectManager getLargeObjectAPI() throws SQLException;
+    LargeObjectManager getLargeObjectAPI() throws SQLException;
 
     /**
      * This returns the Fastpath API for the current connection.
      * @since 7.3
      */
-    public Fastpath getFastpathAPI() throws SQLException;
+    Fastpath getFastpathAPI() throws SQLException;
 
     /**
      * This allows client code to add a handler for one of org.postgresql's
@@ -57,7 +58,7 @@ public interface PGConnection
      * @throws RuntimeException if the type cannot be registered (class not
      *   found, etc).
      */
-    public void addDataType(String type, String name);
+    void addDataType(String type, String name);
 
     /**
      * This allows client code to add a handler for one of org.postgresql's
@@ -88,7 +89,7 @@ public interface PGConnection
      *
      * @see org.postgresql.util.PGobject
      */
-    public void addDataType(String type, Class klass)
+    void addDataType(String type, Class klass)
     throws SQLException;
 
     /**
@@ -99,7 +100,7 @@ public interface PGConnection
      * @since build 302
      * @param threshold the new threshold
      */
-    public void setPrepareThreshold(int threshold);
+    void setPrepareThreshold(int threshold);
 
     /**
      * Get the default server-side prepare reuse threshold for statements created
@@ -108,7 +109,7 @@ public interface PGConnection
      * @since build 302
      * @return the current threshold
      */
-    public int getPrepareThreshold();
+    int getPrepareThreshold();
 
     /**
      * Set the default fetch size for statements created from this connection
@@ -119,7 +120,7 @@ public interface PGConnection
      * @see Statement#setFetchSize(int)
      *
      */
-    public void setDefaultFetchSize(int fetchSize) throws SQLException;
+    void setDefaultFetchSize(int fetchSize) throws SQLException;
 
 
     /**
@@ -129,14 +130,14 @@ public interface PGConnection
      * @see PGProperty#DEFAULT_ROW_FETCH_SIZE
      * @see Statement#getFetchSize()
      */
-    public int getDefaultFetchSize();
+    int getDefaultFetchSize();
 
     /**
      * Return the process ID (PID) of the backend server process handling this connection.
      * 
      * @return PID of backend server process. 
      */
-    public int getBackendPID();
+    int getBackendPID();
 
     /**
      * Return the given string suitably quoted to be used as an identifier in an SQL statement string.
@@ -145,7 +146,7 @@ public interface PGConnection
      *
      * @return the escaped identifier
      */
-    public String escapeIdentifier(String identifier) throws SQLException;
+    String escapeIdentifier(String identifier) throws SQLException;
 
     /**
      * Return the given string suitably quoted to be used as a string literal in an SQL statement string.
@@ -154,5 +155,5 @@ public interface PGConnection
      *
      * @return the quoted literal
      */
-    public String escapeLiteral(String literal) throws SQLException;
+    String escapeLiteral(String literal) throws SQLException;
 }

--- a/org/postgresql/core/BaseConnection.java
+++ b/org/postgresql/core/BaseConnection.java
@@ -7,23 +7,25 @@
 */
 package org.postgresql.core;
 
-import java.util.TimerTask;
-import java.sql.*;
 import org.postgresql.PGConnection;
 import org.postgresql.jdbc2.TimestampUtils;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.TimerTask;
 
 /**
  * Driver-internal connection interface. Application code should not use
  * this interface.
  */
-public interface BaseConnection extends PGConnection, Connection
-{
+public interface BaseConnection extends PGConnection, Connection {
     /**
      * Cancel the current query executing on this connection.
      *
      * @throws SQLException if something goes wrong.
      */
-    public void cancelQuery() throws SQLException;
+    void cancelQuery() throws SQLException;
 
     /**
      * Execute a SQL query that returns a single resultset.
@@ -33,9 +35,9 @@ public interface BaseConnection extends PGConnection, Connection
      * @return the (non-null) returned resultset
      * @throws SQLException if something goes wrong.
      */
-    public ResultSet execSQLQuery(String s) throws SQLException;
+    ResultSet execSQLQuery(String s) throws SQLException;
 
-    public ResultSet execSQLQuery(String s, int resultSetType, int resultSetConcurrency) throws SQLException;
+    ResultSet execSQLQuery(String s, int resultSetType, int resultSetConcurrency) throws SQLException;
 
     /**
      * Execute a SQL query that does not return results.
@@ -44,73 +46,72 @@ public interface BaseConnection extends PGConnection, Connection
      * @param s the query to execute
      * @throws SQLException if something goes wrong.
      */
-    public void execSQLUpdate(String s) throws SQLException;
+    void execSQLUpdate(String s) throws SQLException;
 
     /**
      * Get the QueryExecutor implementation for this connection.
      *
      * @return the (non-null) executor
      */
-    public QueryExecutor getQueryExecutor();
+    QueryExecutor getQueryExecutor();
 
     /**
      * Construct and return an appropriate object for the given
      * type and value. This only considers the types registered via
-     * {@link org.postgresql.PGConnection#addDataType(String,Class)} and
-     * {@link org.postgresql.PGConnection#addDataType(String,String)}.
-     *<p>
+     * {@link org.postgresql.PGConnection#addDataType(String, Class)} and
+     * {@link org.postgresql.PGConnection#addDataType(String, String)}.
+     * <p>
      * If no class is registered as handling the given type, then a generic
      * {@link org.postgresql.util.PGobject} instance is returned.
      *
-     * @param type the backend typename
-     * @param value the type-specific string representation of the value
+     * @param type      the backend typename
+     * @param value     the type-specific string representation of the value
      * @param byteValue the type-specific binary representation of the value
      * @return an appropriate object; never null.
      * @throws SQLException if something goes wrong
      */
-    public Object getObject(String type, String value, byte[] byteValue) throws SQLException;
+    Object getObject(String type, String value, byte[] byteValue) throws SQLException;
 
-    public Encoding getEncoding() throws SQLException;
+    Encoding getEncoding() throws SQLException;
 
-    public TypeInfo getTypeInfo();
+    TypeInfo getTypeInfo();
 
     /**
      * Check if we should use driver behaviour introduced in a particular
      * driver version. This defaults to behaving as the actual driver's version
      * but can be overridden by the "compatible" URL parameter.
-     *
+     * <p>
      * If possible you should use the integer version of this method instead.
      * It was introduced with the 9.4 driver release.
-     *
-     * @deprecated Avoid using this in new code that can require PgJDBC
-     * 9.4.
      *
      * @param ver the driver version to check
      * @return true if the driver's behavioural version is at least "ver".
      * @throws SQLException if something goes wrong
+     * @deprecated Avoid using this in new code that can require PgJDBC
+     * 9.4.
      */
     @Deprecated
-    public boolean haveMinimumCompatibleVersion(String ver);
+    boolean haveMinimumCompatibleVersion(String ver);
 
     /**
      * Check if we should use driver behaviour introduced in a particular
      * driver version.
-     *
+     * <p>
      * This defaults to behaving as the actual driver's version but can be
      * overridden by the "compatible" URL parameter.
-     *
+     * <p>
      * The version is of the form xxyyzz, e.g. 90401 for PgJDBC 9.4.1.
      *
      * @param ver the driver version to check, eg 90401 for 9.4.1
      * @return true if the driver's behavioural version is at least "ver".
      * @throws SQLException if something goes wrong
      */
-    public boolean haveMinimumCompatibleVersion(int ver);
+    boolean haveMinimumCompatibleVersion(int ver);
 
     /**
      * Check if we should use driver behaviour introduced in a particular
      * driver version.
-     *
+     * <p>
      * This defaults to behaving as the actual driver's version but can be
      * overridden by the "compatible" URL parameter.
      *
@@ -118,23 +119,22 @@ public interface BaseConnection extends PGConnection, Connection
      * @return true if the driver's behavioural version is at least "ver".
      * @throws SQLException if something goes wrong
      */
-    public boolean haveMinimumCompatibleVersion(Version ver);
+    boolean haveMinimumCompatibleVersion(Version ver);
 
     /**
      * Check if we have at least a particular server version.
-     *
-     * @deprecated Use haveMinimumServerVersion(int) instead
      *
      * @param ver the server version to check
      * @return true if the server version is at least "ver".
      * @throws SQLException if something goes wrong
+     * @deprecated Use haveMinimumServerVersion(int) instead
      */
     @Deprecated
-    public boolean haveMinimumServerVersion(String ver);
+    boolean haveMinimumServerVersion(String ver);
 
     /**
      * Check if we have at least a particular server version.
-     *
+     * <p>
      * The input version is of the form xxyyzz, matching a PostgreSQL
      * version like xx.yy.zz. So 9.0.12 is 90012 .
      *
@@ -142,11 +142,11 @@ public interface BaseConnection extends PGConnection, Connection
      * @return true if the server version is at least "ver".
      * @throws SQLException if something goes wrong
      */
-    public boolean haveMinimumServerVersion(int ver);
+    boolean haveMinimumServerVersion(int ver);
 
     /**
      * Check if we have at least a particular server version.
-     *
+     * <p>
      * The input version is of the form xxyyzz, matching a PostgreSQL
      * version like xx.yy.zz. So 9.0.12 is 90012 .
      *
@@ -154,7 +154,7 @@ public interface BaseConnection extends PGConnection, Connection
      * @return true if the server version is at least "ver".
      * @throws SQLException if something goes wrong
      */
-    public boolean haveMinimumServerVersion(Version ver);
+    boolean haveMinimumServerVersion(Version ver);
 
     /**
      * Encode a string using the database's client_encoding
@@ -166,48 +166,47 @@ public interface BaseConnection extends PGConnection, Connection
      * @return an encoded representation of the string
      * @throws SQLException if something goes wrong.
      */
-    public byte[] encodeString(String str) throws SQLException;
+    byte[] encodeString(String str) throws SQLException;
 
     /**
      * Escapes a string for use as string-literal within an SQL command. The
      * method chooses the applicable escaping rules based on the value of
      * {@link #getStandardConformingStrings()}.
-     * 
+     *
      * @param str a string value
      * @return the escaped representation of the string
      * @throws SQLException if the string contains a <tt>\0</tt> character
      */
-    public String escapeString(String str) throws SQLException;
+    String escapeString(String str) throws SQLException;
 
     /**
      * Returns whether the server treats string-literals according to the SQL
      * standard or if it uses traditional PostgreSQL escaping rules. Versions
      * up to 8.1 always treated backslashes as escape characters in
      * string-literals. Since 8.2, this depends on the value of the
-     * <tt>standard_conforming_strings<tt> server variable.
-     * 
+     * <tt>standard_conforming_strings</tt> server variable.
+     *
      * @return true if the server treats string literals according to the SQL
-     *   standard
-     * 
+     * standard
      * @see ProtocolConnection#getStandardConformingStrings()
      */
-    public boolean getStandardConformingStrings();
+    boolean getStandardConformingStrings();
 
     // Ew. Quick hack to give access to the connection-specific utils implementation.
-    public TimestampUtils getTimestampUtils();
+    TimestampUtils getTimestampUtils();
 
     // Get the per-connection logger.
-    public Logger getLogger();
+    Logger getLogger();
 
     // Get the bind-string-as-varchar config flag
-    public boolean getStringVarcharFlag();
+    boolean getStringVarcharFlag();
 
     /**
      * Get the current transaction state of this connection.
-     * 
+     *
      * @return a ProtocolConnection.TRANSACTION_* constant.
      */
-    public int getTransactionState();
+    int getTransactionState();
 
     /**
      * Returns true if value for the given oid should be sent using binary
@@ -216,21 +215,21 @@ public interface BaseConnection extends PGConnection, Connection
      * @param oid The oid to check.
      * @return True for binary transfer, false for text transfer.
      */
-    public boolean binaryTransferSend(int oid);
-    
-    /**
-     *  Return whether to disable column name sanitization. 
-     */
-    public boolean isColumnSanitiserDisabled();
+    boolean binaryTransferSend(int oid);
 
     /**
-     *  Schedule a TimerTask for later execution.
-     *  The task will be scheduled with the shared Timer for this connection.
+     * Return whether to disable column name sanitization.
      */
-    public void addTimerTask(TimerTask timerTask, long milliSeconds);
+    boolean isColumnSanitiserDisabled();
 
     /**
-     *  Invoke purge() on the underlying shared Timer so that internal resources will be released.
+     * Schedule a TimerTask for later execution.
+     * The task will be scheduled with the shared Timer for this connection.
      */
-    public void purgeTimerTasks();
+    void addTimerTask(TimerTask timerTask, long milliSeconds);
+
+    /**
+     * Invoke purge() on the underlying shared Timer so that internal resources will be released.
+     */
+    void purgeTimerTasks();
 }

--- a/org/postgresql/core/BaseResultSet.java
+++ b/org/postgresql/core/BaseResultSet.java
@@ -7,14 +7,14 @@
 */
 package org.postgresql.core;
 
-import java.sql.*;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 
 /**
  * Driver-internal resultset interface. Application code should not use
  * this interface.
  */
-public interface BaseResultSet extends ResultSet
-{
+public interface BaseResultSet extends ResultSet {
     /**
      * Return a sanitized numeric string for a column. This handles
      * "money" representations, stripping $ and () as appropriate.
@@ -23,6 +23,6 @@ public interface BaseResultSet extends ResultSet
      * @return the sanitized string
      * @throws SQLException if something goes wrong
      */
-    public String getFixedString(int col) throws SQLException;
+    String getFixedString(int col) throws SQLException;
 
 }

--- a/org/postgresql/core/BaseStatement.java
+++ b/org/postgresql/core/BaseStatement.java
@@ -8,15 +8,17 @@
 package org.postgresql.core;
 
 import org.postgresql.PGStatement;
-import java.sql.*;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.List;
 
 /**
  * Driver-internal statement interface. Application code should not use
  * this interface.
  */
-public interface BaseStatement extends PGStatement, Statement
-{
+public interface BaseStatement extends PGStatement, Statement {
     /**
      * Create a synthetic resultset from data provided by the driver.
      *
@@ -25,7 +27,7 @@ public interface BaseStatement extends PGStatement, Statement
      * @return the new ResultSet
      * @throws SQLException if something goes wrong
      */
-    public ResultSet createDriverResultSet(Field[] fields, List tuples) throws SQLException;
+    ResultSet createDriverResultSet(Field[] fields, List tuples) throws SQLException;
 
     /**
      * Create a resultset from data retrieved from the server.
@@ -37,7 +39,7 @@ public interface BaseStatement extends PGStatement, Statement
      * @return the new ResultSet
      * @throws SQLException if something goes wrong
      */
-    public ResultSet createResultSet(Query originalQuery, Field[] fields, List tuples, ResultCursor cursor) throws SQLException;
+    ResultSet createResultSet(Query originalQuery, Field[] fields, List tuples, ResultCursor cursor) throws SQLException;
 
     /**
      * Execute a query, passing additional query flags.
@@ -47,7 +49,7 @@ public interface BaseStatement extends PGStatement, Statement
      *  are bitwise-ORed into the default flags.
      * @throws SQLException if something goes wrong.
      */
-    public boolean executeWithFlags(String p_sql, int flags) throws SQLException;
+    boolean executeWithFlags(String p_sql, int flags) throws SQLException;
 
     /**
      * Execute a prepared query, passing additional query flags.
@@ -56,5 +58,5 @@ public interface BaseStatement extends PGStatement, Statement
      *  are bitwise-ORed into the default flags.
      * @throws SQLException if something goes wrong.
      */
-    public boolean executeWithFlags(int flags) throws SQLException;
+    boolean executeWithFlags(int flags) throws SQLException;
 }

--- a/org/postgresql/core/CachedQuery.java
+++ b/org/postgresql/core/CachedQuery.java
@@ -26,8 +26,7 @@ public class CachedQuery implements CanEstimateSize {
 
     private int executeCount;
 
-    public CachedQuery(Object key, Query query, boolean isFunction, boolean outParmBeforeFunc)
-    {
+    public CachedQuery(Object key, Query query, boolean isFunction, boolean outParmBeforeFunc) {
         this.key = key;
         this.query = query;
         this.isFunction = isFunction;
@@ -35,18 +34,22 @@ public class CachedQuery implements CanEstimateSize {
     }
 
     public void increaseExecuteCount() {
-        if (executeCount < Integer.MAX_VALUE)
+        if (executeCount < Integer.MAX_VALUE) {
             executeCount++;
+        }
     }
 
     public void increaseExecuteCount(int inc) {
         int newValue = executeCount + inc;
-        if (newValue > 0) // if overflows, just ignore the update
+        if (newValue > 0) {
+            // if overflows, just ignore the update
             executeCount = newValue;
+        }
     }
 
     /**
-     * Number of times this statement has been used
+     * Number of times this statement has been used.
+     *
      * @return number of times this statement has been used
      */
     public int getExecuteCount() {
@@ -54,8 +57,7 @@ public class CachedQuery implements CanEstimateSize {
     }
 
     @Override
-    public long getSize()
-    {
+    public long getSize() {
         int queryLength = String.valueOf(key).length() * 2 /* 2 bytes per char */;
         return queryLength * 2 /* original query and native sql */ + 100 /* entry in hash map, CachedQuery wrapper, etc */;
     }

--- a/org/postgresql/core/ConnectionFactory.java
+++ b/org/postgresql/core/ConnectionFactory.java
@@ -8,15 +8,15 @@
 */
 package org.postgresql.core;
 
-import java.util.Properties;
-import java.io.IOException;
-import java.sql.SQLException;
-
 import org.postgresql.PGProperty;
+import org.postgresql.util.GT;
 import org.postgresql.util.HostSpec;
 import org.postgresql.util.PSQLException;
-import org.postgresql.util.GT;
 import org.postgresql.util.PSQLState;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.Properties;
 
 /**
  * Handles protocol-specific connection setup.
@@ -31,8 +31,8 @@ public abstract class ConnectionFactory {
      * connection is returned.
      */
     private static final Object[][] versions = {
-                { "3", new org.postgresql.core.v3.ConnectionFactoryImpl() },
-                { "2", new org.postgresql.core.v2.ConnectionFactoryImpl() },
+                {"3", new org.postgresql.core.v3.ConnectionFactoryImpl() },
+                {"2", new org.postgresql.core.v2.ConnectionFactoryImpl() },
             };
 
     /**
@@ -58,13 +58,15 @@ public abstract class ConnectionFactory {
 
         for (Object[] version : versions) {
             String versionProtoName = (String) version[0];
-            if (protoName != null && !protoName.equals(versionProtoName))
+            if (protoName != null && !protoName.equals(versionProtoName)) {
                 continue;
+            }
 
             ConnectionFactory factory = (ConnectionFactory) version[1];
             ProtocolConnection connection = factory.openConnectionImpl(hostSpecs, user, database, info, logger);
-            if (connection != null)
+            if (connection != null) {
                 return connection;
+            }
         }
 
         throw new PSQLException(GT.tr("A connection could not be made using the requested protocol {0}.", protoName),
@@ -94,14 +96,10 @@ public abstract class ConnectionFactory {
      * @param newStream The stream to close.
      */
     protected void closeStream(PGStream newStream) {
-        if (newStream != null)
-        {
-            try
-            {
+        if (newStream != null) {
+            try {
                 newStream.close();
-            }
-            catch (IOException e)
-            {
+            } catch (IOException e) {
             }
         }
     }

--- a/org/postgresql/core/Encoding.java
+++ b/org/postgresql/core/Encoding.java
@@ -19,8 +19,7 @@ import java.util.HashMap;
 /**
  * Representation of a particular character encoding.
  */
-public class Encoding
-{
+public class Encoding {
     private static final Encoding DEFAULT_ENCODING = new Encoding(null);
 
     /*
@@ -75,16 +74,15 @@ public class Encoding
     private final String encoding;
     private final boolean fastASCIINumbers;
 
-    protected Encoding(String encoding)
-    {
+    protected Encoding(String encoding) {
         this.encoding = encoding;
         fastASCIINumbers = testAsciiNumbers();
     }
-    
+
     /**
      * Returns true if this encoding has characters
      * '-' and '0'..'9' in exactly same posision as ascii.
-     *  
+     *
      * @return true if the bytes can be scanned directly for ascii numbers.
      */
     public boolean hasAsciiNumbers() {
@@ -93,41 +91,39 @@ public class Encoding
 
     /**
      * Construct an Encoding for a given JVM encoding.
-     * 
+     *
      * @param jvmEncoding the name of the JVM encoding
      * @return an Encoding instance for the specified encoding,
      *   or an Encoding instance for the default JVM encoding if the
      *   specified encoding is unavailable.
      */
     public static Encoding getJVMEncoding(String jvmEncoding) {
-        if (isAvailable(jvmEncoding))
-        {
-            if (jvmEncoding.equals("UTF-8") || jvmEncoding.equals("UTF8"))
+        if (isAvailable(jvmEncoding)) {
+            if (jvmEncoding.equals("UTF-8") || jvmEncoding.equals("UTF8")) {
                 return new UTF8Encoding(jvmEncoding);
-            else
+            } else {
                 return new Encoding(jvmEncoding);
-        }
-        else
+            }
+        } else {
             return defaultEncoding();
+        }
     }
 
     /**
      * Construct an Encoding for a given database encoding.
-     * 
+     *
      * @param databaseEncoding the name of the database encoding
      * @return an Encoding instance for the specified encoding,
      *   or an Encoding instance for the default JVM encoding if the
      *   specified encoding is unavailable.
      */
-    public static Encoding getDatabaseEncoding(String databaseEncoding)
-    {
+    public static Encoding getDatabaseEncoding(String databaseEncoding) {
         // If the backend encoding is known and there is a suitable
         // encoding in the JVM we use that. Otherwise we fall back
         // to the default encoding of the JVM.
 
         String[] candidates = (String[]) encodings.get(databaseEncoding);
-        if (candidates != null)
-        {
+        if (candidates != null) {
             for (String candidate : candidates) {
                 if (isAvailable(candidate)) {
                     return new Encoding(candidate);
@@ -137,8 +133,9 @@ public class Encoding
 
         // Try the encoding name directly -- maybe the charset has been
         // provided by the user.
-        if (isAvailable(databaseEncoding))
+        if (isAvailable(databaseEncoding)) {
             return new Encoding(databaseEncoding);
+        }
 
         // Fall back to default JVM encoding.
         return defaultEncoding();
@@ -149,8 +146,7 @@ public class Encoding
      *
      * @return the JVM encoding name used by this instance.
      */
-    public String name()
-    {
+    public String name() {
         return encoding;
     }
 
@@ -161,30 +157,31 @@ public class Encoding
      * @return a bytearray containing the encoded string
      * @throws IOException if something goes wrong
      */
-    public byte[] encode(String s) throws IOException
-    {
-        if (s == null)
+    public byte[] encode(String s) throws IOException {
+        if (s == null) {
             return null;
+        }
 
-        if (encoding == null)
+        if (encoding == null) {
             return s.getBytes();
+        }
 
         return s.getBytes(encoding);
     }
 
     /**
      * Decode an array of bytes into a string.
-     * 
+     *
      * @param encodedString a bytearray containing the encoded string  the string to encod
      * @param offset the offset in <code>encodedString</code> of the first byte of the encoded representation
      * @param length the length, in bytes, of the encoded representation
      * @return the decoded string
      * @throws IOException if something goes wrong
      */
-    public String decode(byte[] encodedString, int offset, int length) throws IOException
-    {
-        if (encoding == null)
+    public String decode(byte[] encodedString, int offset, int length) throws IOException {
+        if (encoding == null) {
             return new String(encodedString, offset, length);
+        }
 
         return new String(encodedString, offset, length, encoding);
     }
@@ -196,8 +193,7 @@ public class Encoding
      * @return the decoded string
      * @throws IOException if something goes wrong
      */
-    public String decode(byte[] encodedString) throws IOException
-    {
+    public String decode(byte[] encodedString) throws IOException {
         return decode(encodedString, 0, encodedString.length);
     }
 
@@ -208,10 +204,10 @@ public class Encoding
      * @return a non-null Reader implementation.
      * @throws IOException if something goes wrong
      */
-    public Reader getDecodingReader(InputStream in) throws IOException
-    {
-        if (encoding == null)
+    public Reader getDecodingReader(InputStream in) throws IOException {
+        if (encoding == null) {
             return new InputStreamReader(in);
+        }
 
         return new InputStreamReader(in, encoding);
     }
@@ -223,10 +219,10 @@ public class Encoding
      * @return a non-null Writer implementation.
      * @throws IOException if something goes wrong
      */
-    public Writer getEncodingWriter(OutputStream out) throws IOException
-    {
-        if (encoding == null)
+    public Writer getEncodingWriter(OutputStream out) throws IOException {
+        if (encoding == null) {
             return new OutputStreamWriter(out);
+        }
 
         return new OutputStreamWriter(out, encoding);
     }
@@ -235,8 +231,7 @@ public class Encoding
      * Get an Encoding using the default encoding for the JVM.
      * @return an Encoding instance
      */
-    public static Encoding defaultEncoding()
-    {
+    public static Encoding defaultEncoding() {
         return DEFAULT_ENCODING;
     }
 
@@ -246,28 +241,25 @@ public class Encoding
      * @param encodingName the JVM encoding name to test
      * @return true iff the encoding is supported
      */
-    private static boolean isAvailable(String encodingName)
-    {
-        try
-        {
+    private static boolean isAvailable(String encodingName) {
+        try {
             "DUMMY".getBytes(encodingName);
             return true;
-        }
-        catch (java.io.UnsupportedEncodingException e)
-        {
+        } catch (java.io.UnsupportedEncodingException e) {
             return false;
         }
     }
 
+    @Override
     public String toString() {
         return (encoding == null ? "<default JVM encoding>" : encoding);
     }
-    
+
     /**
      * Checks weather this encoding is compatible with ASCII for the number
      * characters '-' and '0'..'9'. Where compatible means that they are encoded
-     * with exactly same values. 
-     * 
+     * with exactly same values.
+     *
      * @return If faster ASCII number parsing can be used with this encoding.
      */
     private boolean testAsciiNumbers() {
@@ -275,15 +267,15 @@ public class Encoding
         // any which do _not_ have ascii numbers in same location
         // at least all the encoding listed in the encodings hashmap have
         // working ascii numbers
-	try {
-	    String test = "-0123456789";
-	    byte[] bytes = encode(test);
-	    String res = new String(bytes, "US-ASCII");
-	    return test.equals(res);
-	} catch (java.io.UnsupportedEncodingException e) {
-	    return false;
-	} catch (IOException e) {
-	    return false;
-	}
+        try {
+            String test = "-0123456789";
+            byte[] bytes = encode(test);
+            String res = new String(bytes, "US-ASCII");
+            return test.equals(res);
+        } catch (java.io.UnsupportedEncodingException e) {
+            return false;
+        } catch (IOException e) {
+            return false;
+        }
     }
 }

--- a/org/postgresql/core/Field.java
+++ b/org/postgresql/core/Field.java
@@ -11,8 +11,7 @@ import java.sql.ResultSetMetaData;
 
 /*
  */
-public class Field
-{
+public class Field {
     //The V3 protocol defines two constants for the format of data
     public static final int TEXT_FORMAT = 0;
     public static final int BINARY_FORMAT = 1;
@@ -51,8 +50,7 @@ public class Field
      * @param oid the OID of the field
      * @param len the length of the field
      */
-    public Field(String name, int oid, int length, int mod)
-    {
+    public Field(String name, int oid, int length, int mod) {
         this(name, name, oid, length, mod, 0, 0);
     }
 
@@ -63,8 +61,7 @@ public class Field
      * @param oid the OID of the field
      * @param len the length of the field
      */
-    public Field(String name, int oid)
-    {
+    public Field(String name, int oid) {
         this(name, oid, 0, -1);
     }
 
@@ -78,8 +75,7 @@ public class Field
      * @param tableOid the OID of the columns' table
      * @param positionInTable the position of column in the table (first column is 1, second column is 2, etc...)
      */
-    public Field(String columnLabel, String columnName, int oid, int length, int mod, int tableOid, int positionInTable)
-    {
+    public Field(String columnLabel, String columnName, int oid, int length, int mod, int tableOid, int positionInTable) {
         this.columnLabel = columnLabel;
         this.columnName = columnName;
         this.oid = oid;
@@ -92,137 +88,115 @@ public class Field
     /*
      * @return the oid of this Field's data type
      */
-    public int getOID()
-    {
+    public int getOID() {
         return oid;
     }
 
     /*
      * @return the mod of this Field's data type
      */
-    public int getMod()
-    {
+    public int getMod() {
         return mod;
     }
 
     /*
      * @return the column label of this Field's data type
      */
-    public String getColumnLabel()
-    {
+    public String getColumnLabel() {
         return columnLabel;
     }
 
     /*
      * @return the length of this Field's data type
      */
-    public int getLength()
-    {
+    public int getLength() {
         return length;
     }
 
     /*
      * @return the format of this Field's data (text=0, binary=1)
      */
-    public int getFormat()
-    {
+    public int getFormat() {
         return format;
     }
 
     /*
      * @param format the format of this Field's data (text=0, binary=1)
      */
-    public void setFormat(int format)
-    {
+    public void setFormat(int format) {
         this.format = format;
     }
 
     /*
      * @return the columns' table oid, zero if no oid available
      */
-    public int getTableOid()
-    {
+    public int getTableOid() {
         return tableOid;
     }
 
-    public int getPositionInTable()
-    {
+    public int getPositionInTable() {
         return positionInTable;
     }
 
-    public void setNullable(int nullable)
-    {
+    public void setNullable(int nullable) {
         this.nullable = nullable;
     }
 
-    public int getNullable()
-    {
+    public int getNullable() {
         return nullable;
     }
 
-    public void setAutoIncrement(boolean autoIncrement)
-    {
+    public void setAutoIncrement(boolean autoIncrement) {
         this.autoIncrement = autoIncrement;
     }
 
-    public boolean getAutoIncrement()
-    {
+    public boolean getAutoIncrement() {
         return autoIncrement;
     }
 
-    public void setColumnName(String columnName)
-    {
+    public void setColumnName(String columnName) {
         this.columnName = columnName;
     }
 
-    public String getColumnName()
-    {
+    public String getColumnName() {
         return columnName;
     }
 
-    public void setTableName(String tableName)
-    {
+    public void setTableName(String tableName) {
         this.tableName = tableName;
     }
 
-    public String getTableName()
-    {
+    public String getTableName() {
         return tableName;
     }
 
-    public void setSchemaName(String schemaName)
-    {
+    public void setSchemaName(String schemaName) {
         this.schemaName = schemaName;
     }
 
-    public String getSchemaName()
-    {
+    public String getSchemaName() {
         return schemaName;
     }
 
     public String toString() {
-        return "Field("+ (columnName != null ? columnName : "") + "," +
-                Oid.toString(oid) + "," + length + "," +
-                (format == TEXT_FORMAT ? 'T' : 'B') + ")";
+        return "Field(" + (columnName != null ? columnName : "") + ","
+                + Oid.toString(oid) + "," + length + ","
+                + (format == TEXT_FORMAT ? 'T' : 'B') + ")";
     }
 
-    public void setSQLType(int sqlType)
-    {
+    public void setSQLType(int sqlType) {
         this.sqlType = sqlType;
     }
 
-    public int getSQLType()
-    {
+    public int getSQLType() {
         return sqlType;
     }
 
-    public void setPGType(String pgType)
-    {
+    public void setPGType(String pgType) {
         this.pgType = pgType;
     }
 
-    public String getPGType()
-    {
+    public String getPGType() {
         return pgType;
     }
 

--- a/org/postgresql/core/JdbcCallParseInfo.java
+++ b/org/postgresql/core/JdbcCallParseInfo.java
@@ -17,15 +17,14 @@ public class JdbcCallParseInfo {
     private final boolean isFunction;
     private final boolean outParmBeforeFunc;
 
-    public JdbcCallParseInfo(String sql, boolean isFunction, boolean outParmBeforeFunc)
-    {
+    public JdbcCallParseInfo(String sql, boolean isFunction, boolean outParmBeforeFunc) {
         this.sql = sql;
         this.isFunction = isFunction;
         this.outParmBeforeFunc = outParmBeforeFunc;
     }
 
     /**
-     * SQL in a native for certain backend version
+     * SQL in a native for certain backend version.
      * @return SQL in a native for certain backend version
      */
     public String getSql() {
@@ -33,21 +32,18 @@ public class JdbcCallParseInfo {
     }
 
     /**
-     * Returns if given SQL is a function
+     * Returns if given SQL is a function.
      * @return {@code true} if given SQL is a function
      */
-    public boolean isFunction()
-    {
+    public boolean isFunction() {
         return isFunction;
     }
 
     /**
-     * Returns if given SQL is a function with one out parameter
+     * Returns if given SQL is a function with one out parameter.
      * @return {@code true} if given SQL is a function with one out parameter
-     * @return
      */
-    public boolean isOutParmBeforeFunc()
-    {
+    public boolean isOutParmBeforeFunc() {
         return outParmBeforeFunc;
     }
 }

--- a/org/postgresql/core/Logger.java
+++ b/org/postgresql/core/Logger.java
@@ -59,8 +59,9 @@ public final class Logger {
     }
 
     public void debug(String str, Throwable t) {
-        if (logDebug())
+        if (logDebug()) {
             log(str, t);
+        }
     }
 
     public void info(String str) {
@@ -68,27 +69,30 @@ public final class Logger {
     }
 
     public void info(String str, Throwable t) {
-        if (logInfo())
+        if (logInfo()) {
             log(str, t);
+        }
     }
 
     public void log(String str, Throwable t) {
         PrintWriter writer = DriverManager.getLogWriter();
-        if (writer == null)
+        if (writer == null) {
             return;
+        }
 
         synchronized (this) {
             buffer.setLength(0);
             dateFormat.format(new Date(), buffer, dummyPosition);
             buffer.append(connectionIDString);
             buffer.append(str);
-            
+
             // synchronize to ensure that the exception (if any) does
             // not get split up from the corresponding log message
             synchronized (writer) {
-                writer.println(buffer.toString());        
-                if (t != null)
+                writer.println(buffer.toString());
+                if (t != null) {
                     t.printStackTrace(writer);
+                }
             }
             writer.flush();
         }

--- a/org/postgresql/core/NativeQuery.java
+++ b/org/postgresql/core/NativeQuery.java
@@ -13,27 +13,23 @@ package org.postgresql.core;
  * The main difference from JDBC is ? are replaced with $1, $2, etc.
  */
 public class NativeQuery {
-    private final static String[] BIND_NAMES = new String[128];
-    private final static int[] NO_BINDS = new int[0];
+    private static final String[] BIND_NAMES = new String[128];
+    private static final int[] NO_BINDS = new int[0];
 
     public final String nativeSql;
     public final int[] bindPositions;
 
-    static
-    {
-        for (int i = 1; i < BIND_NAMES.length; i++)
-        {
+    static {
+        for (int i = 1; i < BIND_NAMES.length; i++) {
             BIND_NAMES[i] = "$" + i;
         }
     }
 
-    public NativeQuery(String nativeSql)
-    {
+    public NativeQuery(String nativeSql) {
         this(nativeSql, NO_BINDS);
     }
 
-    public NativeQuery(String nativeSql, int[] bindPositions)
-    {
+    public NativeQuery(String nativeSql, int[] bindPositions) {
         this.nativeSql = nativeSql;
         this.bindPositions = bindPositions == null || bindPositions.length == 0 ? NO_BINDS : bindPositions;
     }
@@ -47,15 +43,14 @@ public class NativeQuery {
      *  leave the parameter placeholders unsubstituted.
      * @return a human-readable representation of this query
      */
-    public String toString(ParameterList parameters)
-    {
-        if (bindPositions.length == 0)
+    public String toString(ParameterList parameters) {
+        if (bindPositions.length == 0) {
             return nativeSql;
+        }
 
         int queryLength = nativeSql.length();
         String[] params = new String[bindPositions.length];
-        for (int i = 1; i <= bindPositions.length; ++i)
-        {
+        for (int i = 1; i <= bindPositions.length; ++i) {
             String param = parameters == null ? "?" : parameters.toString(i);
             params[i - 1] = param;
             queryLength += param.length() - bindName(i).length();
@@ -63,8 +58,7 @@ public class NativeQuery {
 
         StringBuilder sbuf = new StringBuilder(queryLength);
         sbuf.append(nativeSql, 0, bindPositions[0]);
-        for (int i = 1; i <= bindPositions.length; ++i)
-        {
+        for (int i = 1; i <= bindPositions.length; ++i) {
             sbuf.append(params[i - 1]);
             int nextBind = i < bindPositions.length ? bindPositions[i] : nativeSql.length();
             sbuf.append(nativeSql, bindPositions[i - 1] + bindName(i).length(), nextBind);

--- a/org/postgresql/core/Notification.java
+++ b/org/postgresql/core/Notification.java
@@ -9,15 +9,12 @@ package org.postgresql.core;
 
 import org.postgresql.PGNotification;
 
-public class Notification implements PGNotification
-{
-    public Notification(String p_name, int p_pid)
-    {
+public class Notification implements PGNotification {
+    public Notification(String p_name, int p_pid) {
         this(p_name, p_pid, "");
     }
 
-    public Notification(String p_name, int p_pid, String p_parameter)
-    {
+    public Notification(String p_name, int p_pid, String p_parameter) {
         m_name = p_name;
         m_pid = p_pid;
         m_parameter = p_parameter;
@@ -26,21 +23,18 @@ public class Notification implements PGNotification
     /*
      * Returns name of this notification
      */
-    public String getName()
-    {
+    public String getName() {
         return m_name;
     }
 
     /*
      * Returns the process id of the backend process making this notification
      */
-    public int getPID()
-    {
+    public int getPID() {
         return m_pid;
     }
 
-    public String getParameter()
-    {
+    public String getParameter() {
         return m_parameter;
     }
 

--- a/org/postgresql/core/Oid.java
+++ b/org/postgresql/core/Oid.java
@@ -7,11 +7,11 @@
 */
 package org.postgresql.core;
 
-import java.lang.reflect.Field;
-
 import org.postgresql.util.GT;
 import org.postgresql.util.PSQLException;
 import org.postgresql.util.PSQLState;
+
+import java.lang.reflect.Field;
 
 /**
  * Provides constants for well-known backend OIDs for the types we commonly
@@ -97,7 +97,7 @@ public class Oid {
 
     public static int valueOf(String oid) throws PSQLException {
         try {
-            return (int)Long.parseLong(oid);
+            return (int) Long.parseLong(oid);
         } catch (NumberFormatException ex) {
         }
         try {

--- a/org/postgresql/core/ParameterList.java
+++ b/org/postgresql/core/ParameterList.java
@@ -8,8 +8,8 @@
 */
 package org.postgresql.core;
 
-import java.sql.SQLException;
 import java.io.InputStream;
+import java.sql.SQLException;
 
 /**
  * Abstraction of a list of parameters to be substituted into a Query.
@@ -26,9 +26,8 @@ import java.io.InputStream;
  * @author Oliver Jowett (oliver@opencloud.com)
  */
 public interface ParameterList {
-    
-    
-    void registerOutParameter( int index, int sqlType ) throws SQLException;
+
+    void registerOutParameter(int index, int sqlType) throws SQLException;
     /**
      * Get the number of parameters in this list. This value never changes
      * for a particular instance, and might be zero.
@@ -36,17 +35,17 @@ public interface ParameterList {
      * @return the number of parameters in this list.
      */
     int getParameterCount();
-    
+
     /**
-     * Get the number of IN parameters in this list. 
-     * 
+     * Get the number of IN parameters in this list.
+     *
      * @return the number of IN parameters in this list
      */
     int getInParameterCount();
 
     /**
-     * Get the number of OUT parameters in this list. 
-     * 
+     * Get the number of OUT parameters in this list.
+     *
      * @return the number of OUT parameters in this list
      */
     int getOutParameterCount();
@@ -55,7 +54,7 @@ public interface ParameterList {
      * Return the oids of the parameters in this list.  May be null for
      * a ParameterList that does not support typing of parameters.
      */
-    public int[] getTypeOIDs();
+    int[] getTypeOIDs();
 
     /**
      * Binds an integer value to a parameter. The type of the parameter is

--- a/org/postgresql/core/ProtocolConnection.java
+++ b/org/postgresql/core/ProtocolConnection.java
@@ -11,7 +11,8 @@ package org.postgresql.core;
 import org.postgresql.PGNotification;
 import org.postgresql.util.HostSpec;
 
-import java.sql.*;
+import java.sql.SQLException;
+import java.sql.SQLWarning;
 import java.util.Set;
 
 /**
@@ -24,20 +25,20 @@ public interface ProtocolConnection {
      * Constant returned by {@link #getTransactionState} indicating that no
      * transaction is currently open.
      */
-    static final int TRANSACTION_IDLE = 0;
+    int TRANSACTION_IDLE = 0;
 
     /**
      * Constant returned by {@link #getTransactionState} indicating that a
      * transaction is currently open.
      */
-    static final int TRANSACTION_OPEN = 1;
+    int TRANSACTION_OPEN = 1;
 
     /**
      * Constant returned by {@link #getTransactionState} indicating that a
      * transaction is currently open, but it has seen errors and will
      * refuse subsequent queries until a ROLLBACK.
      */
-    static final int TRANSACTION_FAILED = 2;
+    int TRANSACTION_FAILED = 2;
 
     /**
      * @return the host and port this connection is connected to.
@@ -74,7 +75,7 @@ public interface ProtocolConnection {
     /**
      * Get a machine-readable server version.
      *
-     * This returns the value of the server_version_num GUC. If no such GUC exists, 
+     * This returns the value of the server_version_num GUC. If no such GUC exists,
      * it falls back on attempting to parse the text server version for the major version.
      * If there's no minor version (e.g. a devel or beta release) then the
      * minor version is set to zero. If the version could not be parsed, zero is returned.
@@ -87,14 +88,14 @@ public interface ProtocolConnection {
      * @return the current encoding in use by this connection
      */
     Encoding getEncoding();
-    
+
     /**
      * Returns whether the server treats string-literals according to the SQL
      * standard or if it uses traditional PostgreSQL escaping rules. Versions
      * up to 8.1 always treated backslashes as escape characters in
      * string-literals. Since 8.2, this depends on the value of the
-     * <tt>standard_conforming_strings<tt> server variable.
-     * 
+     * <tt>standard_conforming_strings</tt> server variable.
+     *
      * @return true if the server treats string literals according to the SQL
      *   standard
      */
@@ -102,7 +103,7 @@ public interface ProtocolConnection {
 
     /**
      * Get the current transaction state of this connection.
-     * 
+     *
      * @return a ProtocolConnection.TRANSACTION_* constant.
      */
     int getTransactionState();
@@ -113,6 +114,7 @@ public interface ProtocolConnection {
      *
      * @return an array of notifications; if there are no notifications, an empty
      *   array is returned.
+     * @throws SQLException
      */
     PGNotification[] getNotifications() throws SQLException;
 
@@ -146,35 +148,35 @@ public interface ProtocolConnection {
      * @return true iff the connection is closed.
      */
     boolean isClosed();
-    
+
     /**
-     * 
+     *
      * @return the version of the implementation
      */
-    public int getProtocolVersion();
+    int getProtocolVersion();
 
     /**
      * Sets the oids that should be received using binary encoding.
      *
      * @param useBinaryForOids The oids to request with binary encoding.
      */
-    public void setBinaryReceiveOids(Set<Integer> useBinaryForOids);
+    void setBinaryReceiveOids(Set<Integer> useBinaryForOids);
 
     /**
      * Returns true if server uses integer instead of double for binary
      * date and time encodings.
-     * 
+     *
      * @return the server integer_datetime setting.
      */
-    public boolean getIntegerDateTimes();
+    boolean getIntegerDateTimes();
 
     /**
      * Return the process ID (PID) of the backend server process handling this connection.
      */
-    public int getBackendPID();
+    int getBackendPID();
 
     /**
      * Abort at network level without sending the Terminate message to the backend.
      */
-    public void abort();
+    void abort();
 }

--- a/org/postgresql/core/QueryExecutor.java
+++ b/org/postgresql/core/QueryExecutor.java
@@ -8,16 +8,16 @@
 */
 package org.postgresql.core;
 
-import java.sql.SQLException;
-
 import org.postgresql.copy.CopyOperation;
+
+import java.sql.SQLException;
 
 /**
  * Abstracts the protocol-specific details of executing a query.
  *<p>
  * Every connection has a single QueryExecutor implementation associated with it.
  * This object provides:
- * 
+ *
  * <ul>
  *   <li> factory methods for Query objects ({@link #createSimpleQuery}
  *        and {@link #createParameterizedQuery})
@@ -50,51 +50,51 @@ public interface QueryExecutor {
      * Flag for query execution that indicates the given Query object is unlikely
      * to be reused.
      */
-    static int QUERY_ONESHOT = 1;
+    int QUERY_ONESHOT = 1;
 
     /**
      * Flag for query execution that indicates that resultset metadata isn't needed
      * and can be safely omitted.
      */
-    static int QUERY_NO_METADATA = 2;
+    int QUERY_NO_METADATA = 2;
 
     /**
      * Flag for query execution that indicates that a resultset isn't expected and
      * the query executor can safely discard any rows (although the resultset should
      * still appear to be from a resultset-returning query).
      */
-    static int QUERY_NO_RESULTS = 4;
+    int QUERY_NO_RESULTS = 4;
 
     /**
      * Flag for query execution that indicates a forward-fetch-capable cursor should
      * be used if possible.
      */
-    static int QUERY_FORWARD_CURSOR = 8;
+    int QUERY_FORWARD_CURSOR = 8;
 
     /**
      * Flag for query execution that indicates the automatic BEGIN on the first statement
      * when outside a transaction should not be done.
      */
-    static int QUERY_SUPPRESS_BEGIN = 16;
+    int QUERY_SUPPRESS_BEGIN = 16;
 
     /**
      * Flag for query execution when we don't really want to execute, we just
      * want to get the parameter metadata for the statement.
      */
-    static int QUERY_DESCRIBE_ONLY = 32;
+    int QUERY_DESCRIBE_ONLY = 32;
 
     /**
      * Flag for query execution used by generated keys where we want to receive
      * both the ResultSet and associated update count from the command status.
      */
-    static int QUERY_BOTH_ROWS_AND_STATUS = 64;
-    
+    int QUERY_BOTH_ROWS_AND_STATUS = 64;
+
     /**
      * Force this query to be described at each execution. This is done in
      * pipelined batches where we might need to detect mismatched result
      * types.
      */
-    static int QUERY_FORCE_DESCRIBE_PORTAL = 512;
+    int QUERY_FORCE_DESCRIBE_PORTAL = 512;
 
     /**
      * Flag to disable batch execution when we expect results (generated keys)
@@ -103,12 +103,12 @@ public interface QueryExecutor {
      * @deprecated in PgJDBC 9.4 as we now auto-size batches.
      */
     @Deprecated
-    static int QUERY_DISALLOW_BATCHING = 128;
+    int QUERY_DISALLOW_BATCHING = 128;
 
     /**
      * Flag for query execution to avoid using binary transfer.
      */
-    static int QUERY_NO_BINARY_TRANSFER = 256;
+    int QUERY_NO_BINARY_TRANSFER = 256;
 
     /**
      * Execute a Query, passing results to a provided ResultHandler.
@@ -175,7 +175,7 @@ public interface QueryExecutor {
     /**
      * Create an unparameterized Query object suitable for execution by
      * this QueryExecutor. The provided query string is not parsed for
-     * parameter placeholders ('?' characters), and the 
+     * parameter placeholders ('?' characters), and the
      * {@link Query#createParameterList} of the returned object will
      * always return an empty ParameterList.
      *
@@ -187,7 +187,7 @@ public interface QueryExecutor {
     /**
      * Create a parameterized Query object suitable for execution by
      * this QueryExecutor. The provided query string is parsed for
-     * parameter placeholders ('?' characters), and the 
+     * parameter placeholders ('?' characters), and the
      * {@link Query#createParameterList} of the returned object will
      * create an appropriately-sized ParameterList.
      *
@@ -203,6 +203,7 @@ public interface QueryExecutor {
      * The notification retrieval in ProtocolConnection cannot do this
      * as it is prone to deadlock, so the higher level caller must be
      * responsible which requires exposing this method.
+     * @throws SQLException
      */
     void processNotifies() throws SQLException;
 

--- a/org/postgresql/core/ResultHandler.java
+++ b/org/postgresql/core/ResultHandler.java
@@ -8,19 +8,20 @@
 */
 package org.postgresql.core;
 
-import java.sql.*;
+import java.sql.SQLException;
+import java.sql.SQLWarning;
 import java.util.List;
 
 /**
  * Callback interface for passing query results from the protocol-specific
  * layer to the protocol-independent JDBC implementation code.
- *<p>
+ * <p>
  * In general, a single query execution will consist of a number of calls
  * to handleResultRows, handleCommandStatus, handleWarning, and handleError,
  * followed by a single call to handleCompletion when query execution is
- * complete. If the caller wants to throw SQLException, this can be done 
+ * complete. If the caller wants to throw SQLException, this can be done
  * in handleCompletion.
- *<p>
+ * <p>
  * Each executed query ends with a call to handleResultRows,
  * handleCommandStatus, or handleError. If an error occurs, subsequent queries
  * won't generate callbacks.
@@ -32,25 +33,25 @@ public interface ResultHandler {
      * Called when result rows are received from a query.
      *
      * @param fromQuery the underlying query that generated these results;
-     *   this may not be very specific (e.g. it may be a query that includes
-     *   multiple statements).
-     * @param fields column metadata for the resultset; might be
-     *   <code>null</code> if Query.QUERY_NO_METADATA was specified.
-     * @param tuples the actual data
-     * @param cursor a cursor to use to fetch additional data;
-     *   <code>null</code> if no further results are present.
+     *                  this may not be very specific (e.g. it may be a query that includes
+     *                  multiple statements).
+     * @param fields    column metadata for the resultset; might be
+     *                  <code>null</code> if Query.QUERY_NO_METADATA was specified.
+     * @param tuples    the actual data
+     * @param cursor    a cursor to use to fetch additional data;
+     *                  <code>null</code> if no further results are present.
      */
     void handleResultRows(Query fromQuery, Field[] fields, List tuples, ResultCursor cursor);
 
     /**
      * Called when a query that did not return a resultset completes.
      *
-     * @param status the command status string (e.g. "SELECT") returned by
-     *   the backend
+     * @param status      the command status string (e.g. "SELECT") returned by
+     *                    the backend
      * @param updateCount the number of rows affected by an INSERT, UPDATE,
-     *   DELETE, FETCH, or MOVE command; -1 if not available.
-     * @param insertOID for a single-row INSERT query, the OID of the newly
-     *   inserted row; 0 if not available.
+     *                    DELETE, FETCH, or MOVE command; -1 if not available.
+     * @param insertOID   for a single-row INSERT query, the OID of the newly
+     *                    inserted row; 0 if not available.
      */
     void handleCommandStatus(String status, int updateCount, long insertOID);
 
@@ -63,7 +64,7 @@ public interface ResultHandler {
 
     /**
      * Called when an error occurs. Subsequent queries are abandoned;
-     * in general the only calls between a handleError call and 
+     * in general the only calls between a handleError call and
      * a subsequent handleCompletion call are handleError or handleWarning.
      *
      * @param error the error that occurred
@@ -76,7 +77,7 @@ public interface ResultHandler {
      * method will propagate that exception to the original caller.
      *
      * @throws SQLException if the handler wishes the original method to
-     *   throw an exception.
+     *                      throw an exception.
      */
     void handleCompletion() throws SQLException;
 }

--- a/org/postgresql/core/ServerVersion.java
+++ b/org/postgresql/core/ServerVersion.java
@@ -27,12 +27,11 @@ public enum ServerVersion implements Version {
     v9_3("9.3.0"),
     v9_4("9.4.0"),
     v9_5("9.5.0"),
-
     ;
 
     private final int version;
 
-    private ServerVersion(String version) {
+    ServerVersion(String version) {
         this.version = parseServerVersionStr(version);
     }
 
@@ -49,7 +48,7 @@ public enum ServerVersion implements Version {
     /**
      * Attempt to parse the server version string into an XXYYZZ form version
      * number into a {@link Version}.
-     *
+     * <p>
      * If the specified version cannot be parsed, the
      * {@link Version#getVersionNum()} will return 0.
      *
@@ -86,61 +85,64 @@ public enum ServerVersion implements Version {
 
     /**
      * Attempt to parse the server version string into an XXYYZZ form version number.
-     *
+     * <p>
      * Returns 0 if the version could not be parsed.
-     *
+     * <p>
      * Returns minor version 0 if the minor version could not be determined, e.g. devel
      * or beta releases.
-     *
+     * <p>
      * If a single major part like 90400 is passed, it's assumed to be a pre-parsed
      * version and returned verbatim. (Anything equal to or greater than 10000
      * is presumed to be this form).
-     *
+     * <p>
      * The yy or zz version parts may be larger than 99. A
      * NumberFormatException is thrown if a version part is out of range.
      */
-    /* package */ static int parseServerVersionStr(String serverVersion)
-        throws NumberFormatException
-    {
+    /* package */
+    static int parseServerVersionStr(String serverVersion)
+            throws NumberFormatException {
         int vers;
         NumberFormat numformat = NumberFormat.getIntegerInstance();
         numformat.setGroupingUsed(false);
         ParsePosition parsepos = new ParsePosition(0);
         Long parsed;
 
-        if (serverVersion == null)
+        if (serverVersion == null) {
             return 0;
+        }
 
         /* Get first major version part */
         parsed = (Long) numformat.parseObject(serverVersion, parsepos);
         if (parsed == null) {
             return 0;
         }
-        if (parsed.intValue() >= 10000)
-        {
+        if (parsed.intValue() >= 10000) {
             /*
              * PostgreSQL version 1000? I don't think so. We're seeing a version like
              * 90401; return it verbatim, but only if there's nothing else in the version.
              * If there is, treat it as a parse error.
              */
-            if (parsepos.getIndex() == serverVersion.length())
+            if (parsepos.getIndex() == serverVersion.length()) {
                 return parsed.intValue();
-            else
+            } else {
                 throw new NumberFormatException("First major-version part equal to or greater than 10000 in invalid version string: " + serverVersion);
+            }
         }
 
         vers = parsed.intValue() * 10000;
 
         /* Did we run out of string? */
-        if (parsepos.getIndex() == serverVersion.length())
+        if (parsepos.getIndex() == serverVersion.length()) {
             return 0;
+        }
 
         /* Skip the . */
-        if (serverVersion.charAt(parsepos.getIndex()) == '.')
+        if (serverVersion.charAt(parsepos.getIndex()) == '.') {
             parsepos.setIndex(parsepos.getIndex() + 1);
-        else
+        } else {
             /* Unexpected version format */
             return 0;
+        }
 
         /*
          * Get second major version part. If this isn't purely an integer,
@@ -155,26 +157,30 @@ public enum ServerVersion implements Version {
              */
             return 0;
         }
-        if (parsed.intValue() > 99)
+        if (parsed.intValue() > 99) {
             throw new NumberFormatException("Unsupported second part of major version > 99 in invalid version string: " + serverVersion);
+        }
         vers = vers + parsed.intValue() * 100;
 
         /* Did we run out of string? Return just the major. */
-        if (parsepos.getIndex() == serverVersion.length())
+        if (parsepos.getIndex() == serverVersion.length()) {
             return vers;
+        }
 
         /* Skip the . */
-        if (serverVersion.charAt(parsepos.getIndex()) == '.')
+        if (serverVersion.charAt(parsepos.getIndex()) == '.') {
             parsepos.setIndex(parsepos.getIndex() + 1);
-        else
+        } else {
             /* Doesn't look like an x.y.z version, return what we have */
             return vers;
+        }
 
         /* Try to parse any remainder as a minor version */
         parsed = (Long) numformat.parseObject(serverVersion, parsepos);
         if (parsed != null) {
-            if (parsed.intValue() > 99)
+            if (parsed.intValue() > 99) {
                 throw new NumberFormatException("Unsupported minor version value > 99 in invalid version string: " + serverVersion);
+            }
             vers = vers + parsed.intValue();
         }
 

--- a/org/postgresql/core/SetupQueryRunner.java
+++ b/org/postgresql/core/SetupQueryRunner.java
@@ -8,13 +8,13 @@
 */
 package org.postgresql.core;
 
-import java.util.List;
-import java.sql.SQLWarning;
-import java.sql.SQLException;
-
 import org.postgresql.util.GT;
-import org.postgresql.util.PSQLState;
 import org.postgresql.util.PSQLException;
+import org.postgresql.util.PSQLState;
+
+import java.sql.SQLException;
+import java.sql.SQLWarning;
+import java.util.List;
 
 /**
  * Poor man's Statement & ResultSet, used for initial queries while we're
@@ -48,15 +48,17 @@ public class SetupQueryRunner {
         }
 
         public void handleError(SQLException newError) {
-            if (error == null)
+            if (error == null) {
                 error = newError;
-            else
+            } else {
                 error.setNextException(newError);
+            }
         }
 
         public void handleCompletion() throws SQLException {
-            if (error != null)
+            if (error != null) {
                 throw error;
+            }
         }
     }
 
@@ -66,24 +68,24 @@ public class SetupQueryRunner {
         SimpleResultHandler handler = new SimpleResultHandler(protoConnection);
 
         int flags = QueryExecutor.QUERY_ONESHOT | QueryExecutor.QUERY_SUPPRESS_BEGIN;
-        if (!wantResults)
+        if (!wantResults) {
             flags |= QueryExecutor.QUERY_NO_RESULTS | QueryExecutor.QUERY_NO_METADATA;
-
-        try
-        {
-            executor.execute(query, null, handler, 0, 0, flags);
         }
-        finally
-        {
+
+        try {
+            executor.execute(query, null, handler, 0, 0, flags);
+        } finally {
             query.close();
         }
 
-        if (!wantResults)
+        if (!wantResults) {
             return null;
+        }
 
         List tuples = handler.getResults();
-        if (tuples == null || tuples.size() != 1)
+        if (tuples == null || tuples.size() != 1) {
             throw new PSQLException(GT.tr("An unexpected result was returned by a query."), PSQLState.CONNECTION_UNABLE_TO_CONNECT);
+        }
 
         return (byte[][]) tuples.get(0);
     }

--- a/org/postgresql/core/TypeInfo.java
+++ b/org/postgresql/core/TypeInfo.java
@@ -10,29 +10,30 @@ package org.postgresql.core;
 import java.sql.SQLException;
 import java.util.Iterator;
 
-public interface TypeInfo
-{
-    public void addCoreType(String pgTypeName, Integer oid, Integer sqlType, String javaClass, Integer arrayOid);
+public interface TypeInfo {
+    void addCoreType(String pgTypeName, Integer oid, Integer sqlType, String javaClass, Integer arrayOid);
 
-    public void addDataType(String type, Class klass) throws SQLException;
+    void addDataType(String type, Class klass) throws SQLException;
 
     /**
      * Look up the SQL typecode for a given type oid.
      *
      * @param oid the type's OID
      * @return the SQL type code (a constant from {@link java.sql.Types})
-     *         for the type
+     * for the type
+     * @throws SQLException
      */
-    public int getSQLType(int oid) throws SQLException;
+    int getSQLType(int oid) throws SQLException;
 
     /**
      * Look up the SQL typecode for a given postgresql type name.
      *
      * @param pgTypeName the server type name to look up
      * @return the SQL type code (a constant from {@link java.sql.Types})
-     *         for the type
+     * for the type
+     * @throws SQLException
      */
-    public int getSQLType(String pgTypeName) throws SQLException;
+    int getSQLType(String pgTypeName) throws SQLException;
 
     /**
      * Look up the oid for a given postgresql type name.  This is
@@ -40,8 +41,9 @@ public interface TypeInfo
      *
      * @param pgTypeName the server type name to look up
      * @return the type's OID, or 0 if unknown
+     * @throws SQLException
      */
-    public int getPGType(String pgTypeName) throws SQLException;
+    int getPGType(String pgTypeName) throws SQLException;
 
     /**
      * Look up the postgresql type name for a given oid.  This is the
@@ -49,53 +51,57 @@ public interface TypeInfo
      *
      * @param oid the type's OID
      * @return the server type name for that OID or null if unknown
+     * @throws SQLException
      */
-    public String getPGType(int oid) throws SQLException;
+    String getPGType(int oid) throws SQLException;
 
     /**
      * Look up the oid of an array's base type given the array's type oid.
      *
      * @param oid the array type's OID
      * @return the base type's OID, or 0 if unknown
+     * @throws SQLException
      */
-    public int getPGArrayElement(int oid) throws SQLException;
+    int getPGArrayElement(int oid) throws SQLException;
 
     /**
      * Determine the oid of the given base postgresql type's array type
      *
      * @param elementTypeName the base type's
      * @return the array type's OID, or 0 if unknown
+     * @throws SQLException
      */
-    public int getPGArrayType(String elementTypeName) throws SQLException;
+    int getPGArrayType(String elementTypeName) throws SQLException;
 
     /**
      * Determine the delimiter for the elements of the given array type oid.
      *
      * @param oid the array type's OID
      * @return the base type's array type delimiter
+     * @throws SQLException
      */
-    public char getArrayDelimiter(int oid) throws SQLException;
+    char getArrayDelimiter(int oid) throws SQLException;
 
-    public Iterator getPGTypeNamesWithSQLTypes();
+    Iterator getPGTypeNamesWithSQLTypes();
 
-    public Class getPGobject(String type);
+    Class getPGobject(String type);
 
-    public String getJavaClass(int oid) throws SQLException;
+    String getJavaClass(int oid) throws SQLException;
 
-    public String getTypeForAlias(String alias);
+    String getTypeForAlias(String alias);
 
-    public int getPrecision(int oid, int typmod);
+    int getPrecision(int oid, int typmod);
 
-    public int getScale(int oid, int typmod);
+    int getScale(int oid, int typmod);
 
-    public boolean isCaseSensitive(int oid);
+    boolean isCaseSensitive(int oid);
 
-    public boolean isSigned(int oid);
+    boolean isSigned(int oid);
 
-    public int getDisplaySize(int oid, int typmod);
+    int getDisplaySize(int oid, int typmod);
 
-    public int getMaximumPrecision(int oid);
+    int getMaximumPrecision(int oid);
 
-    public boolean requiresQuoting(int oid) throws SQLException;
+    boolean requiresQuoting(int oid) throws SQLException;
 
 }

--- a/org/postgresql/core/Utils.java
+++ b/org/postgresql/core/Utils.java
@@ -9,17 +9,13 @@
 
 package org.postgresql.core;
 
-import java.sql.SQLException;
-import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.nio.CharBuffer;
-import java.nio.charset.Charset;
-import java.text.NumberFormat;
-import java.text.ParsePosition;
-
 import org.postgresql.util.GT;
 import org.postgresql.util.PSQLException;
 import org.postgresql.util.PSQLState;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.sql.SQLException;
 
 /**
  * Collection of utilities used by the protocol-level code.
@@ -46,7 +42,7 @@ public class Utils {
      * synchronization overhead from looking up the Charset by
      * name as String.getBytes(String) requires.
      */
-    private final static Charset utf8Charset = Charset.forName("UTF-8");
+    private static final Charset utf8Charset = Charset.forName("UTF-8");
 
     /**
      * Encode a string as UTF-8.
@@ -68,19 +64,17 @@ public class Utils {
      * returned. The argument <tt>standardConformingStrings</tt> defines whether the
      * backend expects standard-conforming string literals or allows backslash
      * escape sequences.
-     * 
-     * @param sbuf the string buffer to append to; or <tt>null</tt>
-     * @param value the string value
+     *
+     * @param sbuf                      the string buffer to append to; or <tt>null</tt>
+     * @param value                     the string value
      * @param standardConformingStrings
      * @return the sbuf argument; or a new string buffer for sbuf == null
      * @throws SQLException if the string contains a <tt>\0</tt> character
      * @deprecated use {@link #escapeLiteral(StringBuilder, String, boolean)} instead
      */
     public static StringBuffer appendEscapedLiteral(StringBuffer sbuf, String value, boolean standardConformingStrings)
-        throws SQLException
-    {
-        if (sbuf == null)
-        {
+            throws SQLException {
+        if (sbuf == null) {
             sbuf = new StringBuffer(value.length() * 11 / 10); // Add 10% for escaping.
         }
         doAppendEscapedLiteral(sbuf, value, standardConformingStrings);
@@ -93,18 +87,16 @@ public class Utils {
      * returned. The argument <tt>standardConformingStrings</tt> defines whether the
      * backend expects standard-conforming string literals or allows backslash
      * escape sequences.
-     * 
-     * @param sbuf the string builder to append to; or <tt>null</tt>
-     * @param value the string value
+     *
+     * @param sbuf                      the string builder to append to; or <tt>null</tt>
+     * @param value                     the string value
      * @param standardConformingStrings
      * @return the sbuf argument; or a new string builder for sbuf == null
      * @throws SQLException if the string contains a <tt>\0</tt> character
      */
     public static StringBuilder escapeLiteral(StringBuilder sbuf, String value, boolean standardConformingStrings)
-        throws SQLException
-    {
-        if (sbuf == null)
-        {
+            throws SQLException {
+        if (sbuf == null) {
             sbuf = new StringBuilder(value.length() * 11 / 10); // Add 10% for escaping.
         }
         doAppendEscapedLiteral(sbuf, value, standardConformingStrings);
@@ -112,50 +104,46 @@ public class Utils {
     }
 
     /**
-     * Common part for {@link #appendEscapedLiteral(StringBuffer, String, boolean)} and {@link #escapeLiteral(StringBuilder, String, boolean)}
-     * @param sbuf Either StringBuffer or StringBuilder as we do not expect any IOException to be thrown
+     * Common part for {@link #appendEscapedLiteral(StringBuffer, String, boolean)} and {@link #escapeLiteral(StringBuilder, String, boolean)}.
+     *
+     * @param sbuf                      Either StringBuffer or StringBuilder as we do not expect any IOException to be thrown
      * @param value
      * @param standardConformingStrings
      * @throws SQLException
      */
     private static void doAppendEscapedLiteral(Appendable sbuf, String value, boolean standardConformingStrings)
-        throws SQLException
-    {
-        try
-        {
-            if (standardConformingStrings)
-            {
+            throws SQLException {
+        try {
+            if (standardConformingStrings) {
                 // With standard_conforming_strings on, escape only single-quotes.
-                for (int i = 0; i < value.length(); ++i)
-                {
+                for (int i = 0; i < value.length(); ++i) {
                     char ch = value.charAt(i);
-                    if (ch == '\0')
+                    if (ch == '\0') {
                         throw new PSQLException(GT.tr("Zero bytes may not occur in string parameters."), PSQLState.INVALID_PARAMETER_VALUE);
-                    if (ch == '\'')
+                    }
+                    if (ch == '\'') {
                         sbuf.append('\'');
+                    }
                     sbuf.append(ch);
                 }
-            }
-            else
-            {
+            } else {
                 // With standard_conforming_string off, escape backslashes and
                 // single-quotes, but still escape single-quotes by doubling, to
                 // avoid a security hazard if the reported value of
                 // standard_conforming_strings is incorrect, or an error if
                 // backslash_quote is off.
-                for (int i = 0; i < value.length(); ++i)
-                {
+                for (int i = 0; i < value.length(); ++i) {
                     char ch = value.charAt(i);
-                    if (ch == '\0')
+                    if (ch == '\0') {
                         throw new PSQLException(GT.tr("Zero bytes may not occur in string parameters."), PSQLState.INVALID_PARAMETER_VALUE);
-                    if (ch == '\\' || ch == '\'')
+                    }
+                    if (ch == '\\' || ch == '\'') {
                         sbuf.append(ch);
+                    }
                     sbuf.append(ch);
                 }
             }
-        }
-        catch (IOException e)
-        {
+        } catch (IOException e) {
             throw new PSQLException(GT.tr("No IOException expected from StringBuffer or StringBuilder"), PSQLState.UNEXPECTED_ERROR, e);
         }
     }
@@ -166,18 +154,16 @@ public class Utils {
      * StringBuffer will be returned.  This method is different from
      * appendEscapedLiteral in that it includes the quoting required for the
      * identifier while appendEscapedLiteral does not.
-     * 
-     * @param sbuf the string buffer to append to; or <tt>null</tt>
+     *
+     * @param sbuf  the string buffer to append to; or <tt>null</tt>
      * @param value the string value
      * @return the sbuf argument; or a new string buffer for sbuf == null
      * @throws SQLException if the string contains a <tt>\0</tt> character
      * @deprecated use {@link #escapeIdentifier(StringBuilder, String)} instead
      */
     public static StringBuffer appendEscapedIdentifier(StringBuffer sbuf, String value)
-        throws SQLException
-    {
-        if (sbuf == null)
-        {
+            throws SQLException {
+        if (sbuf == null) {
             sbuf = new StringBuffer(2 + value.length() * 11 / 10); // Add 10% for escaping.
         }
         doAppendEscapedIdentifier(sbuf, value);
@@ -190,17 +176,15 @@ public class Utils {
      * StringBuilder will be returned.  This method is different from
      * appendEscapedLiteral in that it includes the quoting required for the
      * identifier while {@link #escapeLiteral(StringBuilder, String, boolean)} does not.
-     * 
-     * @param sbuf the string builder to append to; or <tt>null</tt>
+     *
+     * @param sbuf  the string builder to append to; or <tt>null</tt>
      * @param value the string value
      * @return the sbuf argument; or a new string builder for sbuf == null
      * @throws SQLException if the string contains a <tt>\0</tt> character
      */
     public static StringBuilder escapeIdentifier(StringBuilder sbuf, String value)
-        throws SQLException
-    {
-        if (sbuf == null)
-        {
+            throws SQLException {
+        if (sbuf == null) {
             sbuf = new StringBuilder(2 + value.length() * 11 / 10); // Add 10% for escaping.
         }
         doAppendEscapedIdentifier(sbuf, value);
@@ -209,55 +193,54 @@ public class Utils {
 
     /**
      * Common part for appendEscapedIdentifier
-     * @param sbuf Either StringBuffer or StringBuilder as we do not expect any IOException to be thrown.
+     *
+     * @param sbuf  Either StringBuffer or StringBuilder as we do not expect any IOException to be thrown.
      * @param value
      * @throws SQLException
      */
     private static void doAppendEscapedIdentifier(Appendable sbuf, String value)
-        throws SQLException
-    {
-        try
-        {
+            throws SQLException {
+        try {
             sbuf.append('"');
-    
-            for (int i = 0; i < value.length(); ++i)
-            {
+
+            for (int i = 0; i < value.length(); ++i) {
                 char ch = value.charAt(i);
-                if (ch == '\0')
+                if (ch == '\0') {
                     throw new PSQLException(GT.tr("Zero bytes may not occur in identifiers."), PSQLState.INVALID_PARAMETER_VALUE);
-                if (ch == '"')
+                }
+                if (ch == '"') {
                     sbuf.append(ch);
+                }
                 sbuf.append(ch);
             }
-    
+
             sbuf.append('"');
-        }
-        catch (IOException e)
-        {
+        } catch (IOException e) {
             throw new PSQLException(GT.tr("No IOException expected from StringBuffer or StringBuilder"), PSQLState.UNEXPECTED_ERROR, e);
         }
     }
 
     /**
      * Attempt to parse the server version string into an XXYYZZ form version number.
-     *
+     * <p>
      * Returns 0 if the version could not be parsed.
-     *
+     * <p>
      * Returns minor version 0 if the minor version could not be determined, e.g. devel
      * or beta releases.
-     *
+     * <p>
      * If a single major part like 90400 is passed, it's assumed to be a pre-parsed
-	 * version and returned verbatim. (Anything equal to or greater than 10000
-	 * is presumed to be this form).
+     * version and returned verbatim. (Anything equal to or greater than 10000
+     * is presumed to be this form).
+     * <p>
+     * The yy or zz version parts may be larger than 99. A
+     * NumberFormatException is thrown if a version part is out of range.
      *
-	 * The yy or zz version parts may be larger than 99. A
-	 * NumberFormatException is thrown if a version part is out of range.
-	 * @deprecated use specific {@link Version} instance
+     * @throws NumberFormatException
+     * @deprecated use specific {@link Version} instance
      */
     @Deprecated
     public static int parseServerVersionStr(String serverVersion)
-		throws NumberFormatException
- 	{
+            throws NumberFormatException {
         return ServerVersion.parseServerVersionStr(serverVersion);
     }
 }

--- a/org/postgresql/core/VisibleBufferedInputStream.java
+++ b/org/postgresql/core/VisibleBufferedInputStream.java
@@ -13,8 +13,8 @@ import java.io.InputStream;
 
 /**
  * A faster version of BufferedInputStream. Does no synchronisation and
- * allows direct access to the used byte[] buffer. 
- * 
+ * allows direct access to the used byte[] buffer.
+ *
  * @author Mikko Tiihonen
  */
 public class VisibleBufferedInputStream extends InputStream {
@@ -26,7 +26,7 @@ public class VisibleBufferedInputStream extends InputStream {
      * reads are directly done to the provided byte array.
      */
     private static final int MINIMUM_READ = 1024;
-    
+
     /**
      * In how large spans is the C string zero-byte scanned.
      */
@@ -54,19 +54,20 @@ public class VisibleBufferedInputStream extends InputStream {
 
     /**
      * Creates a new buffer around the given stream.
-     * 
-     * @param in The stream to buffer.
-     * @param bufferSize The initial size of the buffer. 
+     *
+     * @param in         The stream to buffer.
+     * @param bufferSize The initial size of the buffer.
      */
     public VisibleBufferedInputStream(InputStream in, int bufferSize) {
         wrapped = in;
-        buffer = new byte[bufferSize < MINIMUM_READ ?
-                          MINIMUM_READ : bufferSize];
+        buffer = new byte[bufferSize < MINIMUM_READ
+                ? MINIMUM_READ : bufferSize];
     }
 
     /**
      * {@inheritDoc}
      */
+    @Override
     public int read() throws IOException {
         if (ensureBytes(1)) {
             return buffer[index++] & 0xFF;
@@ -89,10 +90,10 @@ public class VisibleBufferedInputStream extends InputStream {
      * reads from the underlaying stream.
      * Before calling this method the {@link #ensureBytes} method must
      * have been called.
-     * 
+     *
      * @return The next byte from the buffer.
      * @throws ArrayIndexOutOfBoundsException If ensureBytes was not called
-     * to make sure the buffer contains the byte.  
+     *                                        to make sure the buffer contains the byte.
      */
     public byte readRaw() {
         return buffer[index++];
@@ -101,7 +102,7 @@ public class VisibleBufferedInputStream extends InputStream {
     /**
      * Ensures that the buffer contains at least n bytes.
      * This method invalidates the buffer and index fields.
-     * 
+     *
      * @param n The amount of bytes to ensure exists in buffer
      * @return true if required bytes are available and false if EOF
      * @throws IOException If reading of the wrapped stream failed.
@@ -119,7 +120,7 @@ public class VisibleBufferedInputStream extends InputStream {
 
     /**
      * Reads more bytes into the buffer.
-     * 
+     *
      * @param wanted How much should be at least read.
      * @return True if at least some bytes were read.
      * @throws IOException If reading of the wrapped stream failed.
@@ -167,7 +168,7 @@ public class VisibleBufferedInputStream extends InputStream {
     /**
      * Moves bytes from the buffer to the begining of the destination buffer.
      * Also sets the index and endIndex variables.
-     * 
+     *
      * @param dest The destination buffer.
      */
     private void moveBufferTo(byte[] dest) {
@@ -211,7 +212,7 @@ public class VisibleBufferedInputStream extends InputStream {
         // good place to reset index because the buffer is fully drained
         index = 0;
         endIndex = 0;
-        
+
         // then directly from wrapped stream
         do {
             int r = wrapped.read(to, off, len);
@@ -260,8 +261,8 @@ public class VisibleBufferedInputStream extends InputStream {
      * Returns direct handle to the used buffer. Use the {@link #ensureBytes}
      * to prefill required bytes the buffer and {@link #getIndex} to fetch
      * the current position of the buffer.
-     *  
-     * @return The underlaying buffer. 
+     *
+     * @return The underlying buffer.
      */
     public byte[] getBuffer() {
         return buffer;
@@ -269,7 +270,7 @@ public class VisibleBufferedInputStream extends InputStream {
 
     /**
      * Returns the current read position in the buffer.
-     * 
+     *
      * @return the current read position in the buffer.
      */
     public int getIndex() {
@@ -279,14 +280,14 @@ public class VisibleBufferedInputStream extends InputStream {
     /**
      * Scans the length of the next null terminated string (C-style string) from
      * the stream.
-     * 
+     *
      * @return The length of the next null terminated string.
-     * @throws IOException If reading of stream fails.
-     * @throws EOFxception If the stream did not contain any null terminators.
+     * @throws IOException  If reading of stream fails.
+     * @throws EOFException If the stream did not contain any null terminators.
      */
     public int scanCStringLength() throws IOException {
         int pos = index;
-        for (;;) {
+        for (; ; ) {
             while (pos < endIndex) {
                 if (buffer[pos++] == '\0') {
                     return pos - index;

--- a/org/postgresql/core/v2/ConnectionFactoryImpl.java
+++ b/org/postgresql/core/v2/ConnectionFactoryImpl.java
@@ -8,27 +8,33 @@
 */
 package org.postgresql.core.v2;
 
-import java.util.Iterator;
-import java.util.Properties;
-import java.util.StringTokenizer;
-import java.sql.SQLException;
-import java.sql.SQLWarning;
-import java.io.IOException;
-import java.net.ConnectException;
-
 import org.postgresql.PGProperty;
-import org.postgresql.core.*;
+import org.postgresql.core.ConnectionFactory;
+import org.postgresql.core.Encoding;
+import org.postgresql.core.Logger;
+import org.postgresql.core.PGStream;
+import org.postgresql.core.ProtocolConnection;
+import org.postgresql.core.SetupQueryRunner;
+import org.postgresql.core.Utils;
 import org.postgresql.hostchooser.GlobalHostStatusTracker;
 import org.postgresql.hostchooser.HostChooser;
 import org.postgresql.hostchooser.HostChooserFactory;
 import org.postgresql.hostchooser.HostRequirement;
 import org.postgresql.hostchooser.HostStatus;
+import org.postgresql.util.GT;
+import org.postgresql.util.HostSpec;
+import org.postgresql.util.MD5Digest;
 import org.postgresql.util.PSQLException;
 import org.postgresql.util.PSQLState;
 import org.postgresql.util.UnixCrypt;
-import org.postgresql.util.MD5Digest;
-import org.postgresql.util.GT;
-import org.postgresql.util.HostSpec;
+
+import java.io.IOException;
+import java.net.ConnectException;
+import java.sql.SQLException;
+import java.sql.SQLWarning;
+import java.util.Iterator;
+import java.util.Properties;
+import java.util.StringTokenizer;
 
 /**
  * ConnectionFactory implementation for version 2 (pre-7.4) connections.
@@ -50,27 +56,25 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
         boolean requireSSL;
         boolean trySSL;
         String sslmode = PGProperty.SSL_MODE.get(info);
-        if (sslmode==null)
-        { //Fall back to the ssl property
-          requireSSL = trySSL  = PGProperty.SSL.isPresent(info);
+        if (sslmode == null) { //Fall back to the ssl property
+            requireSSL = trySSL = PGProperty.SSL.isPresent(info);
         } else {
-          if ("disable".equals(sslmode))
-          {
-            requireSSL = trySSL = false;
-          }
-          //allow and prefer are not handled yet
-          /*else if ("allow".equals(sslmode) || "prefer".equals(sslmode))
-          {  
+            if ("disable".equals(sslmode)) {
+                requireSSL = trySSL = false;
+            }
+            //allow and prefer are not handled yet
+            /*
+            else if ("allow".equals(sslmode) || "prefer".equals(sslmode))  {
             //XXX Allow and prefer are treated the same way
             requireSSL = false;
             trySSL = true;
-          }*/
-          else if ("require".equals(sslmode) || "verify-ca".equals(sslmode) || "verify-full".equals(sslmode))
-          {
-            requireSSL = trySSL = true;
-          } else {
-            throw new PSQLException (GT.tr("Invalid sslmode value: {0}", sslmode), PSQLState.CONNECTION_UNABLE_TO_CONNECT);
-          }
+            }
+            */
+            else if ("require".equals(sslmode) || "verify-ca".equals(sslmode) || "verify-full".equals(sslmode)) {
+                requireSSL = trySSL = true;
+            } else {
+                throw new PSQLException(GT.tr("Invalid sslmode value: {0}", sslmode), PSQLState.CONNECTION_UNABLE_TO_CONNECT);
+            }
         }
 
         //  - the TCP keep alive setting
@@ -81,109 +85,105 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
         try {
             targetServerType = HostRequirement.valueOf(info.getProperty("targetServerType", HostRequirement.any.name()));
         } catch (IllegalArgumentException ex) {
-            throw new PSQLException (GT.tr("Invalid targetServerType value: {0}", info.getProperty("targetServerType")), PSQLState.CONNECTION_UNABLE_TO_CONNECT);
+            throw new PSQLException(GT.tr("Invalid targetServerType value: {0}", info.getProperty("targetServerType")), PSQLState.CONNECTION_UNABLE_TO_CONNECT);
         }
 
         HostChooser hostChooser = HostChooserFactory.createHostChooser(hostSpecs, targetServerType, info);
-        for (Iterator<HostSpec> hostIter = hostChooser.iterator(); hostIter.hasNext(); ) {
+        for (Iterator<HostSpec> hostIter = hostChooser.iterator(); hostIter.hasNext();) {
             HostSpec hostSpec = hostIter.next();
 
-            if (logger.logDebug())
+            if (logger.logDebug()) {
                 logger.debug("Trying to establish a protocol version 2 connection to " + hostSpec);
+            }
 
             //
             // Establish a connection.
             //
-        int connectTimeout = PGProperty.CONNECT_TIMEOUT.getInt(info) * 1000;
+            int connectTimeout = PGProperty.CONNECT_TIMEOUT.getInt(info) * 1000;
 
-        PGStream newStream = null;
-        try
-        {
-            newStream = new PGStream(hostSpec, connectTimeout);
+            PGStream newStream = null;
+            try {
+                newStream = new PGStream(hostSpec, connectTimeout);
 
-            // Construct and send an ssl startup packet if requested.
-            if (trySSL)
-                newStream = enableSSL(newStream, requireSSL, info, logger, connectTimeout);
-            
-            
-            // Set the socket timeout if the "socketTimeout" property has been set.
-            int socketTimeout = PGProperty.SOCKET_TIMEOUT.getInt(info);
-            if (socketTimeout > 0) {
-                newStream.getSocket().setSoTimeout(socketTimeout*1000);
-            }
+                // Construct and send an ssl startup packet if requested.
+                if (trySSL) {
+                    newStream = enableSSL(newStream, requireSSL, info, logger, connectTimeout);
+                }
 
-            // Enable TCP keep-alive probe if required.
-            newStream.getSocket().setKeepAlive(requireTCPKeepAlive);
 
-            // Construct and send a startup packet.
-            sendStartupPacket(newStream, user, database, logger);
+                // Set the socket timeout if the "socketTimeout" property has been set.
+                int socketTimeout = PGProperty.SOCKET_TIMEOUT.getInt(info);
+                if (socketTimeout > 0) {
+                    newStream.getSocket().setSoTimeout(socketTimeout * 1000);
+                }
 
-            // Do authentication (until AuthenticationOk).
-            doAuthentication(newStream, user, PGProperty.PASSWORD.get(info), logger);
+                // Enable TCP keep-alive probe if required.
+                newStream.getSocket().setKeepAlive(requireTCPKeepAlive);
 
-            // Do final startup.
-            ProtocolConnectionImpl protoConnection = new ProtocolConnectionImpl(newStream, user, database, logger, connectTimeout);
-            readStartupMessages(newStream, protoConnection, logger);
+                // Construct and send a startup packet.
+                sendStartupPacket(newStream, user, database, logger);
 
-            // Check Master or Slave
-            HostStatus hostStatus = HostStatus.ConnectOK;
-            if (targetServerType != HostRequirement.any) {
-                hostStatus = isMaster(protoConnection, logger) ? HostStatus.Master : HostStatus.Slave;
-            }
-            GlobalHostStatusTracker.reportHostStatus(hostSpec, hostStatus);
-            if (!targetServerType.allowConnectingTo(hostStatus)) {
-                protoConnection.close();
+                // Do authentication (until AuthenticationOk).
+                doAuthentication(newStream, user, PGProperty.PASSWORD.get(info), logger);
+
+                // Do final startup.
+                ProtocolConnectionImpl protoConnection = new ProtocolConnectionImpl(newStream, user, database, logger, connectTimeout);
+                readStartupMessages(newStream, protoConnection, logger);
+
+                // Check Master or Slave
+                HostStatus hostStatus = HostStatus.ConnectOK;
+                if (targetServerType != HostRequirement.any) {
+                    hostStatus = isMaster(protoConnection, logger) ? HostStatus.Master : HostStatus.Slave;
+                }
+                GlobalHostStatusTracker.reportHostStatus(hostSpec, hostStatus);
+                if (!targetServerType.allowConnectingTo(hostStatus)) {
+                    protoConnection.close();
+                    if (hostIter.hasNext()) {
+                        // still more addresses to try
+                        continue;
+                    }
+                    throw new PSQLException(GT.tr("Could not find a server with specified targetServerType: {0}", targetServerType), PSQLState.CONNECTION_UNABLE_TO_CONNECT);
+                }
+
+                // Run some initial queries
+                runInitialQueries(protoConnection, info, logger);
+
+                // And we're done.
+                return protoConnection;
+            } catch (ConnectException cex) {
+                // Added by Peter Mount <peter@retep.org.uk>
+                // ConnectException is thrown when the connection cannot be made.
+                // we trap this an return a more meaningful message for the end user
+                GlobalHostStatusTracker.reportHostStatus(hostSpec, HostStatus.ConnectFail);
                 if (hostIter.hasNext()) {
                     // still more addresses to try
                     continue;
                 }
-                throw new PSQLException (GT.tr("Could not find a server with specified targetServerType: {0}", targetServerType) , PSQLState.CONNECTION_UNABLE_TO_CONNECT);
+                throw new PSQLException(GT.tr("Connection refused. Check that the hostname and port are correct and that the postmaster is accepting TCP/IP connections."), PSQLState.CONNECTION_UNABLE_TO_CONNECT, cex);
+            } catch (IOException ioe) {
+                closeStream(newStream);
+                GlobalHostStatusTracker.reportHostStatus(hostSpec, HostStatus.ConnectFail);
+                if (hostIter.hasNext()) {
+                    // still more addresses to try
+                    continue;
+                }
+                throw new PSQLException(GT.tr("The connection attempt failed."), PSQLState.CONNECTION_UNABLE_TO_CONNECT, ioe);
+            } catch (SQLException se) {
+                closeStream(newStream);
+                if (hostIter.hasNext()) {
+                    // still more addresses to try
+                    continue;
+                }
+                throw se;
             }
-
-            // Run some initial queries
-            runInitialQueries(protoConnection, info, logger);
-
-            // And we're done.
-            return protoConnection;
         }
-        catch (ConnectException cex)
-        {
-            // Added by Peter Mount <peter@retep.org.uk>
-            // ConnectException is thrown when the connection cannot be made.
-            // we trap this an return a more meaningful message for the end user
-            GlobalHostStatusTracker.reportHostStatus(hostSpec, HostStatus.ConnectFail);
-            if (hostIter.hasNext()) {
-                // still more addresses to try
-                continue;
-            }
-            throw new PSQLException (GT.tr("Connection refused. Check that the hostname and port are correct and that the postmaster is accepting TCP/IP connections."), PSQLState.CONNECTION_UNABLE_TO_CONNECT, cex);
-        }
-        catch (IOException ioe)
-        {
-            closeStream(newStream);
-            GlobalHostStatusTracker.reportHostStatus(hostSpec, HostStatus.ConnectFail);
-            if (hostIter.hasNext()) {
-                // still more addresses to try
-                continue;
-            }
-            throw new PSQLException (GT.tr("The connection attempt failed."), PSQLState.CONNECTION_UNABLE_TO_CONNECT, ioe);
-        }
-        catch (SQLException se)
-        {
-            closeStream(newStream);
-            if (hostIter.hasNext()) {
-                // still more addresses to try
-                continue;
-            }
-            throw se;
-        }
-        }
-        throw new PSQLException (GT.tr("The connection url is invalid."), PSQLState.CONNECTION_UNABLE_TO_CONNECT);
+        throw new PSQLException(GT.tr("The connection url is invalid."), PSQLState.CONNECTION_UNABLE_TO_CONNECT);
     }
 
     private PGStream enableSSL(PGStream pgStream, boolean requireSSL, Properties info, Logger logger, int connectTimeout) throws IOException, SQLException {
-        if (logger.logDebug())
+        if (logger.logDebug()) {
             logger.debug(" FE=> SSLRequest");
+        }
 
         // Send SSL request packet
         pgStream.SendInteger4(8);
@@ -193,40 +193,44 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
 
         // Now get the response from the backend, one of N, E, S.
         int beresp = pgStream.ReceiveChar();
-        switch (beresp)
-        {
-        case 'E':
-            if (logger.logDebug())
-                logger.debug(" <=BE SSLError");
+        switch (beresp) {
+            case 'E':
+                if (logger.logDebug()) {
+                    logger.debug(" <=BE SSLError");
+                }
 
-            // Server doesn't even know about the SSL handshake protocol
-            if (requireSSL)
-                throw new PSQLException(GT.tr("The server does not support SSL."), PSQLState.CONNECTION_REJECTED);
+                // Server doesn't even know about the SSL handshake protocol
+                if (requireSSL) {
+                    throw new PSQLException(GT.tr("The server does not support SSL."), PSQLState.CONNECTION_REJECTED);
+                }
 
-            // We have to reconnect to continue.
-            pgStream.close();
-            return new PGStream(pgStream.getHostSpec(), connectTimeout);
+                // We have to reconnect to continue.
+                pgStream.close();
+                return new PGStream(pgStream.getHostSpec(), connectTimeout);
 
-        case 'N':
-            if (logger.logDebug())
-                logger.debug(" <=BE SSLRefused");
+            case 'N':
+                if (logger.logDebug()) {
+                    logger.debug(" <=BE SSLRefused");
+                }
 
-            // Server does not support ssl
-            if (requireSSL)
-                throw new PSQLException(GT.tr("The server does not support SSL."), PSQLState.CONNECTION_REJECTED);
+                // Server does not support ssl
+                if (requireSSL) {
+                    throw new PSQLException(GT.tr("The server does not support SSL."), PSQLState.CONNECTION_REJECTED);
+                }
 
-            return pgStream;
+                return pgStream;
 
-        case 'S':
-            if (logger.logDebug())
-                logger.debug(" <=BE SSLOk");
+            case 'S':
+                if (logger.logDebug()) {
+                    logger.debug(" <=BE SSLOk");
+                }
 
-            // Server supports ssl
-            org.postgresql.ssl.MakeSSL.convert(pgStream, info, logger);
-            return pgStream;
+                // Server supports ssl
+                org.postgresql.ssl.MakeSSL.convert(pgStream, info, logger);
+                return pgStream;
 
-        default:
-            throw new PSQLException(GT.tr("An error occurred while setting up the SSL connection."), PSQLState.PROTOCOL_VIOLATION);
+            default:
+                throw new PSQLException(GT.tr("An error occurred while setting up the SSL connection."), PSQLState.PROTOCOL_VIOLATION);
         }
     }
 
@@ -240,8 +244,9 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
         // 64: unused
         // 64: tty
 
-        if (logger.logDebug())
+        if (logger.logDebug()) {
             logger.debug(" FE=> StartupPacket(user=" + user + ",database=" + database + ")");
+        }
 
         pgStream.SendInteger4(4 + 4 + 64 + 32 + 64 + 64 + 64);
         pgStream.SendInteger2(2); // protocol major
@@ -259,151 +264,159 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
         // Now get the response from the backend, either an error message
         // or an authentication request
 
-        while (true)
-        {
+        while (true) {
             int beresp = pgStream.ReceiveChar();
 
-            switch (beresp)
-            {
-            case 'E':
-                // An error occured, so pass the error message to the
-                // user.
-                //
-                // The most common one to be thrown here is:
-                // "User authentication failed"
-                //
-                String errorMsg = pgStream.ReceiveString();
-                if (logger.logDebug())
-                    logger.debug(" <=BE ErrorMessage(" + errorMsg + ")");
-                throw new PSQLException(GT.tr("Connection rejected: {0}.", errorMsg), PSQLState.CONNECTION_REJECTED);
+            switch (beresp) {
+                case 'E':
+                    // An error occured, so pass the error message to the
+                    // user.
+                    //
+                    // The most common one to be thrown here is:
+                    // "User authentication failed"
+                    //
+                    String errorMsg = pgStream.ReceiveString();
+                    if (logger.logDebug()) {
+                        logger.debug(" <=BE ErrorMessage(" + errorMsg + ")");
+                    }
+                    throw new PSQLException(GT.tr("Connection rejected: {0}.", errorMsg), PSQLState.CONNECTION_REJECTED);
 
-            case 'R':
-                // Authentication request.
-                // Get the type of request
-                int areq = pgStream.ReceiveInteger4();
+                case 'R':
+                    // Authentication request.
+                    // Get the type of request
+                    int areq = pgStream.ReceiveInteger4();
 
-                // Process the request.
-                switch (areq)
-                {
-                case AUTH_REQ_CRYPT:
-                    {
-                        byte salt[] = pgStream.Receive(2);
+                    // Process the request.
+                    switch (areq) {
+                        case AUTH_REQ_CRYPT: {
+                            byte salt[] = pgStream.Receive(2);
 
-                        if (logger.logDebug())
-                            logger.debug(" <=BE AuthenticationReqCrypt(salt='" + new String(salt, "US-ASCII") + "')");
+                            if (logger.logDebug()) {
+                                logger.debug(" <=BE AuthenticationReqCrypt(salt='" + new String(salt, "US-ASCII") + "')");
+                            }
 
-                        if (password == null)
-                            throw new PSQLException(GT.tr("The server requested password-based authentication, but no password was provided."), PSQLState.CONNECTION_REJECTED);
+                            if (password == null) {
+                                throw new PSQLException(GT.tr("The server requested password-based authentication, but no password was provided."), PSQLState.CONNECTION_REJECTED);
+                            }
 
-                        byte[] encodedResult = UnixCrypt.crypt(salt, password.getBytes("UTF-8"));
+                            byte[] encodedResult = UnixCrypt.crypt(salt, password.getBytes("UTF-8"));
 
-                        if (logger.logDebug())
-                            logger.debug(" FE=> Password(crypt='" + new String(encodedResult, "US-ASCII") + "')");
+                            if (logger.logDebug()) {
+                                logger.debug(" FE=> Password(crypt='" + new String(encodedResult, "US-ASCII") + "')");
+                            }
 
-                        pgStream.SendInteger4(4 + encodedResult.length + 1);
-                        pgStream.Send(encodedResult);
-                        pgStream.SendChar(0);
-                        pgStream.flush();
+                            pgStream.SendInteger4(4 + encodedResult.length + 1);
+                            pgStream.Send(encodedResult);
+                            pgStream.SendChar(0);
+                            pgStream.flush();
 
-                        break;
+                            break;
+                        }
+
+                        case AUTH_REQ_MD5: {
+                            byte[] md5Salt = pgStream.Receive(4);
+                            if (logger.logDebug()) {
+                                logger.debug(" <=BE AuthenticationReqMD5(salt=" + Utils.toHexString(md5Salt) + ")");
+                            }
+
+                            if (password == null) {
+                                throw new PSQLException(GT.tr("The server requested password-based authentication, but no password was provided."), PSQLState.CONNECTION_REJECTED);
+                            }
+
+                            byte[] digest = MD5Digest.encode(user.getBytes("UTF-8"), password.getBytes("UTF-8"), md5Salt);
+                            if (logger.logDebug()) {
+                                logger.debug(" FE=> Password(md5digest=" + new String(digest, "US-ASCII") + ")");
+                            }
+
+                            pgStream.SendInteger4(4 + digest.length + 1);
+                            pgStream.Send(digest);
+                            pgStream.SendChar(0);
+                            pgStream.flush();
+
+                            break;
+                        }
+
+                        case AUTH_REQ_PASSWORD: {
+                            if (logger.logDebug()) {
+                                logger.debug(" <=BE AuthenticationReqPassword");
+                            }
+
+                            if (password == null) {
+                                throw new PSQLException(GT.tr("The server requested password-based authentication, but no password was provided."), PSQLState.CONNECTION_REJECTED);
+                            }
+
+                            if (logger.logDebug()) {
+                                logger.debug(" FE=> Password(password=<not shown>)");
+                            }
+
+                            byte[] encodedPassword = password.getBytes("UTF-8");
+                            pgStream.SendInteger4(4 + encodedPassword.length + 1);
+                            pgStream.Send(encodedPassword);
+                            pgStream.SendChar(0);
+                            pgStream.flush();
+
+                            break;
+                        }
+
+                        case AUTH_REQ_OK:
+                            if (logger.logDebug()) {
+                                logger.debug(" <=BE AuthenticationOk");
+                            }
+
+                            return; // We're done.
+
+                        default:
+                            if (logger.logDebug()) {
+                                logger.debug(" <=BE AuthenticationReq (unsupported type " + ((int) areq) + ")");
+                            }
+
+                            throw new PSQLException(GT.tr("The authentication type {0} is not supported. Check that you have configured the pg_hba.conf file to include the client''s IP address or subnet, and that it is using an authentication scheme supported by the driver.", areq), PSQLState.CONNECTION_REJECTED);
                     }
 
-                case AUTH_REQ_MD5:
-                    {
-                        byte[] md5Salt = pgStream.Receive(4);
-                        if (logger.logDebug())
-                            logger.debug(" <=BE AuthenticationReqMD5(salt=" + Utils.toHexString(md5Salt) + ")");
-
-                        if (password == null)
-                            throw new PSQLException(GT.tr("The server requested password-based authentication, but no password was provided."), PSQLState.CONNECTION_REJECTED);
-
-                        byte[] digest = MD5Digest.encode(user.getBytes("UTF-8"), password.getBytes("UTF-8"), md5Salt);
-                        if (logger.logDebug())
-                            logger.debug(" FE=> Password(md5digest=" + new String(digest, "US-ASCII") + ")");
-
-                        pgStream.SendInteger4(4 + digest.length + 1);
-                        pgStream.Send(digest);
-                        pgStream.SendChar(0);
-                        pgStream.flush();
-
-                        break;
-                    }
-
-                case AUTH_REQ_PASSWORD:
-                    {
-                        if (logger.logDebug())
-                            logger.debug(" <=BE AuthenticationReqPassword");
-
-                        if (password == null)
-                            throw new PSQLException(GT.tr("The server requested password-based authentication, but no password was provided."), PSQLState.CONNECTION_REJECTED);
-
-                        if (logger.logDebug())
-                            logger.debug(" FE=> Password(password=<not shown>)");
-
-                        byte[] encodedPassword = password.getBytes("UTF-8");
-                        pgStream.SendInteger4(4 + encodedPassword.length + 1);
-                        pgStream.Send(encodedPassword);
-                        pgStream.SendChar(0);
-                        pgStream.flush();
-
-                        break;
-                    }
-
-                case AUTH_REQ_OK:
-                    if (logger.logDebug())
-                        logger.debug(" <=BE AuthenticationOk");
-
-                    return ; // We're done.
+                    break;
 
                 default:
-                    if (logger.logDebug())
-                        logger.debug(" <=BE AuthenticationReq (unsupported type " + ((int)areq) + ")");
-
-                    throw new PSQLException(GT.tr("The authentication type {0} is not supported. Check that you have configured the pg_hba.conf file to include the client''s IP address or subnet, and that it is using an authentication scheme supported by the driver.", areq), PSQLState.CONNECTION_REJECTED);
-                }
-
-                break;
-
-            default:
-                throw new PSQLException(GT.tr("Protocol error.  Session setup failed."), PSQLState.PROTOCOL_VIOLATION);
+                    throw new PSQLException(GT.tr("Protocol error.  Session setup failed."), PSQLState.PROTOCOL_VIOLATION);
             }
         }
     }
 
     private void readStartupMessages(PGStream pgStream, ProtocolConnectionImpl protoConnection, Logger logger) throws IOException, SQLException {
-        while (true)
-        {
+        while (true) {
             int beresp = pgStream.ReceiveChar();
-            switch (beresp)
-            {
-            case 'Z':  // ReadyForQuery
-                if (logger.logDebug())
-                    logger.debug(" <=BE ReadyForQuery");
-                return ;
+            switch (beresp) {
+                case 'Z':  // ReadyForQuery
+                    if (logger.logDebug()) {
+                        logger.debug(" <=BE ReadyForQuery");
+                    }
+                    return;
 
-            case 'K':  // BackendKeyData
-                int pid = pgStream.ReceiveInteger4();
-                int ckey = pgStream.ReceiveInteger4();
-                if (logger.logDebug())
-                    logger.debug(" <=BE BackendKeyData(pid=" + pid + ",ckey=" + ckey + ")");
-                protoConnection.setBackendKeyData(pid, ckey);
-                break;
+                case 'K':  // BackendKeyData
+                    int pid = pgStream.ReceiveInteger4();
+                    int ckey = pgStream.ReceiveInteger4();
+                    if (logger.logDebug()) {
+                        logger.debug(" <=BE BackendKeyData(pid=" + pid + ",ckey=" + ckey + ")");
+                    }
+                    protoConnection.setBackendKeyData(pid, ckey);
+                    break;
 
-            case 'E':  // ErrorResponse
-                String errorMsg = pgStream.ReceiveString();
-                if (logger.logDebug())
-                    logger.debug(" <=BE ErrorResponse(" + errorMsg + ")");
-                throw new PSQLException(GT.tr("Backend start-up failed: {0}.", errorMsg), PSQLState.CONNECTION_UNABLE_TO_CONNECT);
+                case 'E':  // ErrorResponse
+                    String errorMsg = pgStream.ReceiveString();
+                    if (logger.logDebug()) {
+                        logger.debug(" <=BE ErrorResponse(" + errorMsg + ")");
+                    }
+                    throw new PSQLException(GT.tr("Backend start-up failed: {0}.", errorMsg), PSQLState.CONNECTION_UNABLE_TO_CONNECT);
 
-            case 'N':  // NoticeResponse
-                String warnMsg = pgStream.ReceiveString();
-                if (logger.logDebug())
-                    logger.debug(" <=BE NoticeResponse(" + warnMsg + ")");
-                protoConnection.addWarning(new SQLWarning(warnMsg));
-                break;
+                case 'N':  // NoticeResponse
+                    String warnMsg = pgStream.ReceiveString();
+                    if (logger.logDebug()) {
+                        logger.debug(" <=BE NoticeResponse(" + warnMsg + ")");
+                    }
+                    protoConnection.addWarning(new SQLWarning(warnMsg));
+                    break;
 
-            default:
-                throw new PSQLException(GT.tr("Protocol error.  Session setup failed."), PSQLState.PROTOCOL_VIOLATION);
+                default:
+                    throw new PSQLException(GT.tr("Protocol error.  Session setup failed."), PSQLState.PROTOCOL_VIOLATION);
             }
         }
     }
@@ -418,15 +431,15 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
 
         protoConnection.setServerVersion(dbVersion);
 
-        if (dbVersion.compareTo("7.3") >= 0)
-        {
+        if (dbVersion.compareTo("7.3") >= 0) {
             // set encoding to be unicode; set datestyle; ensure autocommit is on
             // (no-op on 7.4, but might be needed under 7.3)
             // The begin/commit is to avoid leaving a transaction open if we're talking to a
             // 7.3 server that defaults to autocommit = off.
 
-            if (logger.logDebug())
+            if (logger.logDebug()) {
                 logger.debug("Switching to UTF8 client_encoding");
+            }
 
             String sql = "begin; set autocommit = on; set client_encoding = 'UTF8'; ";
             if (dbVersion.compareTo("9.0") >= 0) {
@@ -438,53 +451,42 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
 
             SetupQueryRunner.run(protoConnection, sql, false);
             protoConnection.setEncoding(Encoding.getDatabaseEncoding("UTF8"));
-        }
-        else
-        {
+        } else {
             String charSet = PGProperty.CHARSET.get(info);
             String dbEncoding = (results[1] == null ? null : protoConnection.getEncoding().decode(results[1]));
-            if (logger.logDebug())
-            {
+            if (logger.logDebug()) {
                 logger.debug("Specified charset:  " + charSet);
                 logger.debug("Database encoding: " + dbEncoding);
             }
 
-            if (charSet != null)
-            {
+            if (charSet != null) {
                 // Explicitly specified encoding.
                 protoConnection.setEncoding(Encoding.getJVMEncoding(charSet));
-            }
-            else if (dbEncoding != null)
-            {
+            } else if (dbEncoding != null) {
                 // Use database-supplied encoding.
                 protoConnection.setEncoding(Encoding.getDatabaseEncoding(dbEncoding));
-            }
-            else
-            {
+            } else {
                 // Fall back to defaults.
                 // XXX is this ever reached?
                 protoConnection.setEncoding(Encoding.defaultEncoding());
             }
         }
 
-        if (logger.logDebug())
+        if (logger.logDebug()) {
             logger.debug("Connection encoding (using JVM's nomenclature): " + protoConnection.getEncoding());
-        
-        if (dbVersion.compareTo("8.1") >= 0)
-        {
+        }
+
+        if (dbVersion.compareTo("8.1") >= 0) {
             // Server versions since 8.1 report standard_conforming_strings
             results = SetupQueryRunner.run(protoConnection, "select current_setting('standard_conforming_strings')", true);
             String value = protoConnection.getEncoding().decode(results[0]);
             protoConnection.setStandardConformingStrings(value.equalsIgnoreCase("on"));
-        }
-        else
-        {
+        } else {
             protoConnection.setStandardConformingStrings(false);
         }
 
         String appName = PGProperty.APPLICATION_NAME.get(info);
-        if (appName != null && dbVersion.compareTo("9.0") >= 0)
-        {
+        if (appName != null && dbVersion.compareTo("9.0") >= 0) {
             StringBuilder sb = new StringBuilder("SET application_name = '");
             Utils.escapeLiteral(sb, appName, protoConnection.getStandardConformingStrings());
             sb.append("'");
@@ -492,8 +494,7 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
         }
 
         String currentSchema = PGProperty.CURRENT_SCHEMA.get(info);
-        if (currentSchema != null)
-        {
+        if (currentSchema != null) {
             StringBuilder sb = new StringBuilder("SET search_path = '");
             Utils.escapeLiteral(sb, appName, protoConnection.getStandardConformingStrings());
             sb.append("'");

--- a/org/postgresql/core/v2/SimpleParameterList.java
+++ b/org/postgresql/core/v2/SimpleParameterList.java
@@ -8,17 +8,19 @@
 */
 package org.postgresql.core.v2;
 
-import org.postgresql.core.*;
-
-import java.io.InputStream;
-import java.io.Writer;
-import java.io.IOException;
-import java.sql.SQLException;
-import java.util.Arrays;
+import org.postgresql.core.Oid;
+import org.postgresql.core.ParameterList;
+import org.postgresql.core.Utils;
+import org.postgresql.util.GT;
 import org.postgresql.util.PSQLException;
 import org.postgresql.util.PSQLState;
 import org.postgresql.util.StreamWrapper;
-import org.postgresql.util.GT;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Writer;
+import java.sql.SQLException;
+import java.util.Arrays;
 
 /**
  * Parameter list for query parameters in the V2 protocol.
@@ -30,20 +32,25 @@ class SimpleParameterList implements ParameterList {
         this.paramValues = new Object[paramCount];
         this.useEStringSyntax = useEStringSyntax;
     }
-    public void registerOutParameter(int index, int sqlType ){};
-    public void registerOutParameter(int index, int sqlType, int precision ){};
-    
+
+    public void registerOutParameter(int index, int sqlType) {
+    }
+
+    public void registerOutParameter(int index, int sqlType, int precision) {
+    }
+
     public int getInParameterCount() {
         return paramValues.length;
     }
-    public int getParameterCount()
-    {
+
+    public int getParameterCount() {
         return paramValues.length;
     }
-    public int getOutParameterCount()
-    {
+
+    public int getOutParameterCount() {
         return 1;
     }
+
     public int[] getTypeOIDs() {
         return null;
     }
@@ -53,8 +60,9 @@ class SimpleParameterList implements ParameterList {
     }
 
     public void setLiteralParameter(int index, String value, int oid) throws SQLException {
-        if (index < 1 || index > paramValues.length)
-            throw new PSQLException(GT.tr("The column index is out of range: {0}, number of columns: {1}.", new Object[]{index, paramValues.length}), PSQLState.INVALID_PARAMETER_VALUE );
+        if (index < 1 || index > paramValues.length) {
+            throw new PSQLException(GT.tr("The column index is out of range: {0}, number of columns: {1}.", new Object[]{index, paramValues.length}), PSQLState.INVALID_PARAMETER_VALUE);
+        }
 
         paramValues[index - 1] = value;
     }
@@ -62,8 +70,9 @@ class SimpleParameterList implements ParameterList {
     public void setStringParameter(int index, String value, int oid) throws SQLException {
         StringBuilder sbuf = new StringBuilder(2 + value.length() * 11 / 10); // Add 10% for escaping.
 
-        if (useEStringSyntax)
+        if (useEStringSyntax) {
             sbuf.append(' ').append('E');
+        }
         sbuf.append('\'');
         Utils.escapeLiteral(sbuf, value, false);
         sbuf.append('\'');
@@ -72,48 +81,56 @@ class SimpleParameterList implements ParameterList {
     }
 
     public void setBytea(int index, byte[] data, int offset, int length) throws SQLException {
-        if (index < 1 || index > paramValues.length)
-            throw new PSQLException(GT.tr("The column index is out of range: {0}, number of columns: {1}.", new Object[]{index, paramValues.length}), PSQLState.INVALID_PARAMETER_VALUE );
+        if (index < 1 || index > paramValues.length) {
+            throw new PSQLException(GT.tr("The column index is out of range: {0}, number of columns: {1}.", new Object[]{index, paramValues.length}), PSQLState.INVALID_PARAMETER_VALUE);
+        }
 
         paramValues[index - 1] = new StreamWrapper(data, offset, length);
     }
 
     public void setBytea(int index, final InputStream stream, final int length) throws SQLException {
-        if (index < 1 || index > paramValues.length)
-            throw new PSQLException(GT.tr("The column index is out of range: {0}, number of columns: {1}.", new Object[]{index, paramValues.length}), PSQLState.INVALID_PARAMETER_VALUE );
+        if (index < 1 || index > paramValues.length) {
+            throw new PSQLException(GT.tr("The column index is out of range: {0}, number of columns: {1}.", new Object[]{index, paramValues.length}), PSQLState.INVALID_PARAMETER_VALUE);
+        }
 
         paramValues[index - 1] = new StreamWrapper(stream, length);
     }
 
-    public void setBytea(int index, InputStream stream) throws SQLException
-    {
-        if (index < 1 || index > paramValues.length)
-            throw new PSQLException(GT.tr("The column index is out of range: {0}, number of columns: {1}.", new Object[]{index, paramValues.length}), PSQLState.INVALID_PARAMETER_VALUE );
+    public void setBytea(int index, InputStream stream) throws SQLException {
+        if (index < 1 || index > paramValues.length) {
+            throw new PSQLException(GT.tr("The column index is out of range: {0}, number of columns: {1}.", new Object[]{index, paramValues.length}), PSQLState.INVALID_PARAMETER_VALUE);
+        }
 
         paramValues[index - 1] = new StreamWrapper(stream);
     }
 
     public void setNull(int index, int oid) throws SQLException {
-        if (index < 1 || index > paramValues.length)
-            throw new PSQLException(GT.tr("The column index is out of range: {0}, number of columns: {1}.", new Object[]{index, paramValues.length}), PSQLState.INVALID_PARAMETER_VALUE );
+        if (index < 1 || index > paramValues.length) {
+            throw new PSQLException(GT.tr("The column index is out of range: {0}, number of columns: {1}.", new Object[]{index, paramValues.length}), PSQLState.INVALID_PARAMETER_VALUE);
+        }
 
         paramValues[index - 1] = NULL_OBJECT;
     }
 
     public String toString(int index) {
-        if (index < 1 || index > paramValues.length)
+        if (index < 1 || index > paramValues.length) {
             throw new IllegalArgumentException("Parameter index " + index + " out of range");
+        }
 
-        if (paramValues[index - 1] == null)
+        if (paramValues[index - 1] == null) {
             return "?";
-        else if (paramValues[index -1] == NULL_OBJECT)
+        } else if (paramValues[index - 1] == NULL_OBJECT) {
             return "NULL";
-        else
-            return paramValues[index -1].toString();
+        } else {
+            return paramValues[index - 1].toString();
+        }
     }
 
     /**
      * Send a streamable bytea encoded as a text representation with an arbitary encoding.
+     * @param param
+     * @param encodingWriter
+     * @throws IOException
      */
     private void streamBytea(StreamWrapper param, Writer encodingWriter) throws IOException {
         // NB: we escape everything in this path, as I don't like assuming
@@ -121,22 +138,20 @@ class SimpleParameterList implements ParameterList {
         // unscathed..
 
         InputStream stream = param.getStream();
-        char[] buffer = new char[] { '\\', '\\', 0, 0, 0 };
+        char[] buffer = new char[]{'\\', '\\', 0, 0, 0};
 
-        if (useEStringSyntax)
-        {
+        if (useEStringSyntax) {
             encodingWriter.write(' ');
             encodingWriter.write('E');
         }
 
         encodingWriter.write('\'');
-        for (int remaining = param.getLength(); remaining > 0; --remaining)
-        {
+        for (int remaining = param.getLength(); remaining > 0; --remaining) {
             int nextByte = stream.read();
 
-            buffer[2] = (char)( '0' + ((nextByte >> 6) & 3));
-            buffer[3] = (char)( '0' + ((nextByte >> 3) & 7));
-            buffer[4] = (char)( '0' + (nextByte & 7));
+            buffer[2] = (char) ('0' + ((nextByte >> 6) & 3));
+            buffer[3] = (char) ('0' + ((nextByte >> 3) & 7));
+            buffer[4] = (char) ('0' + (nextByte & 7));
 
             encodingWriter.write(buffer, 0, 5);
         }
@@ -144,23 +159,19 @@ class SimpleParameterList implements ParameterList {
         encodingWriter.write('\'');
     }
 
-
     void writeV2Value(int index, Writer encodingWriter) throws IOException {
-        if (paramValues[index - 1] instanceof StreamWrapper)
-        {
-            streamBytea((StreamWrapper)paramValues[index - 1], encodingWriter);
-        }
-        else
-        {
-            encodingWriter.write((String)paramValues[index - 1]);
+        if (paramValues[index - 1] instanceof StreamWrapper) {
+            streamBytea((StreamWrapper) paramValues[index - 1], encodingWriter);
+        } else {
+            encodingWriter.write((String) paramValues[index - 1]);
         }
     }
 
     void checkAllParametersSet() throws SQLException {
-        for (int i = 0; i < paramValues.length; i++)
-        {
-            if (paramValues[i] == null)
+        for (int i = 0; i < paramValues.length; i++) {
+            if (paramValues[i] == null) {
                 throw new PSQLException(GT.tr("No value specified for parameter {0}.", i + 1), PSQLState.INVALID_PARAMETER_VALUE);
+            }
         }
     }
 
@@ -179,13 +190,13 @@ class SimpleParameterList implements ParameterList {
     }
 
     private final Object[] paramValues;
-    
+
     private final boolean useEStringSyntax;
 
     /* Object representing NULL; conveniently, String streams exactly as we want it to. *
      * nb: we explicitly say "new String" to avoid interning giving us an object that
      * might be the same (by identity) as a String elsewhere.
      */
-    private final static String NULL_OBJECT = new String("NULL");
+    private static final String NULL_OBJECT = new String("NULL");
 }
 

--- a/org/postgresql/core/v2/V2Query.java
+++ b/org/postgresql/core/v2/V2Query.java
@@ -8,9 +8,13 @@
 */
 package org.postgresql.core.v2;
 
-import java.util.ArrayList;
+import org.postgresql.core.NativeQuery;
+import org.postgresql.core.ParameterList;
+import org.postgresql.core.Parser;
+import org.postgresql.core.ProtocolConnection;
+import org.postgresql.core.Query;
+
 import java.util.List;
-import org.postgresql.core.*;
 
 /**
  * Query implementation for all queries via the V2 protocol.
@@ -28,8 +32,9 @@ class V2Query implements Query {
     }
 
     public ParameterList createParameterList() {
-        if (nativeQuery.bindPositions.length == 0)
+        if (nativeQuery.bindPositions.length == 0) {
             return NO_PARAMETERS;
+        }
 
         return new SimpleParameterList(nativeQuery.bindPositions.length, useEStringSyntax);
     }
@@ -49,15 +54,14 @@ class V2Query implements Query {
         return false;
     }
 
-    public boolean isEmpty()
-    {
+    public boolean isEmpty() {
         return nativeQuery.nativeSql.isEmpty();
     }
 
     private static final ParameterList NO_PARAMETERS = new SimpleParameterList(0, false);
 
     private final NativeQuery nativeQuery;
-    
+
     private final boolean useEStringSyntax; // whether escaped string syntax should be used
 }
 

--- a/org/postgresql/core/v3/CompositeQuery.java
+++ b/org/postgresql/core/v3/CompositeQuery.java
@@ -8,7 +8,7 @@
 */
 package org.postgresql.core.v3;
 
-import org.postgresql.core.*;
+import org.postgresql.core.ParameterList;
 
 /**
  * V3 Query implementation for queries that involve multiple statements.
@@ -26,15 +26,15 @@ class CompositeQuery implements V3Query {
 
     public ParameterList createParameterList() {
         SimpleParameterList[] subparams = new SimpleParameterList[subqueries.length];
-        for (int i = 0; i < subqueries.length; ++i)
-            subparams[i] = (SimpleParameterList)subqueries[i].createParameterList();
+        for (int i = 0; i < subqueries.length; ++i) {
+            subparams[i] = (SimpleParameterList) subqueries[i].createParameterList();
+        }
         return new CompositeParameterList(subparams, offsets);
     }
 
     public String toString(ParameterList parameters) {
         StringBuilder sbuf = new StringBuilder(subqueries[0].toString());
-        for (int i = 1; i < subqueries.length; ++i)
-        {
+        for (int i = 1; i < subqueries.length; ++i) {
             sbuf.append(';');
             sbuf.append(subqueries[i]);
         }
@@ -56,19 +56,20 @@ class CompositeQuery implements V3Query {
     }
 
     public boolean isStatementDescribed() {
-        for (SimpleQuery subquery : subqueries)
+        for (SimpleQuery subquery : subqueries) {
             if (!subquery.isStatementDescribed()) {
-                return false;
-            }
+                            return false;
+                        }
+        }
         return true;
     }
 
-    public boolean isEmpty()
-    {
-        for (SimpleQuery subquery : subqueries)
+    public boolean isEmpty() {
+        for (SimpleQuery subquery : subqueries) {
             if (!subquery.isEmpty()) {
-                return false;
-            }
+                            return false;
+                        }
+        }
         return true;
     }
 

--- a/org/postgresql/core/v3/DescribeRequest.java
+++ b/org/postgresql/core/v3/DescribeRequest.java
@@ -9,6 +9,7 @@ package org.postgresql.core.v3;
 
 /**
  * Information for "pending describe queue".
+ *
  * @see QueryExecutorImpl#pendingDescribeStatementQueue
  */
 class DescribeRequest {
@@ -16,8 +17,7 @@ class DescribeRequest {
     public final SimpleParameterList parameterList;
     public final boolean describeOnly;
 
-    public DescribeRequest(SimpleQuery query, SimpleParameterList parameterList, boolean describeOnly)
-    {
+    public DescribeRequest(SimpleQuery query, SimpleParameterList parameterList, boolean describeOnly) {
         this.query = query;
         this.parameterList = parameterList;
         this.describeOnly = describeOnly;

--- a/org/postgresql/core/v3/ExecuteRequest.java
+++ b/org/postgresql/core/v3/ExecuteRequest.java
@@ -9,14 +9,14 @@ package org.postgresql.core.v3;
 
 /**
  * Information for "pending execute queue"
+ *
  * @see QueryExecutorImpl#pendingExecuteQueue
  */
 class ExecuteRequest {
     public final SimpleQuery query;
     public final Portal portal;
 
-    public ExecuteRequest(SimpleQuery query, Portal portal)
-    {
+    public ExecuteRequest(SimpleQuery query, Portal portal) {
         this.query = query;
         this.portal = portal;
     }

--- a/org/postgresql/core/v3/Portal.java
+++ b/org/postgresql/core/v3/Portal.java
@@ -8,8 +8,10 @@
 */
 package org.postgresql.core.v3;
 
+import org.postgresql.core.ResultCursor;
+import org.postgresql.core.Utils;
+
 import java.lang.ref.PhantomReference;
-import org.postgresql.core.*;
 
 /**
  * V3 ResultCursor implementation in terms of backend Portals.
@@ -26,8 +28,7 @@ class Portal implements ResultCursor {
     }
 
     public void close() {
-        if (cleanupRef != null)
-        {
+        if (cleanupRef != null) {
             cleanupRef.clear();
             cleanupRef.enqueue();
             cleanupRef = null;

--- a/org/postgresql/core/v3/ProtocolConnectionImpl.java
+++ b/org/postgresql/core/v3/ProtocolConnectionImpl.java
@@ -9,16 +9,21 @@
 package org.postgresql.core.v3;
 
 import org.postgresql.PGNotification;
-import org.postgresql.core.*;
+import org.postgresql.core.Encoding;
+import org.postgresql.core.Logger;
+import org.postgresql.core.PGStream;
+import org.postgresql.core.ProtocolConnection;
+import org.postgresql.core.QueryExecutor;
+import org.postgresql.core.Utils;
 import org.postgresql.util.HostSpec;
 
+import java.io.IOException;
 import java.sql.SQLException;
 import java.sql.SQLWarning;
-import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Set;
 import java.util.HashSet;
 import java.util.Properties;
+import java.util.Set;
 
 
 /**
@@ -55,29 +60,27 @@ class ProtocolConnectionImpl implements ProtocolConnection {
     }
 
     public int getServerVersionNum() {
-        if (serverVersionNum != 0)
+        if (serverVersionNum != 0) {
             return serverVersionNum;
+        }
         return Utils.parseServerVersionStr(serverVersion);
     }
 
-    public synchronized boolean getStandardConformingStrings()
-    {
+    public synchronized boolean getStandardConformingStrings() {
         return standardConformingStrings;
     }
 
-    public synchronized int getTransactionState()
-    {
+    public synchronized int getTransactionState() {
         return transactionState;
     }
 
     public synchronized PGNotification[] getNotifications() throws SQLException {
-        PGNotification[] array = (PGNotification[])notifications.toArray(new PGNotification[notifications.size()]);
+        PGNotification[] array = (PGNotification[]) notifications.toArray(new PGNotification[notifications.size()]);
         notifications.clear();
         return array;
     }
 
-    public synchronized SQLWarning getWarnings()
-    {
+    public synchronized SQLWarning getWarnings() {
         SQLWarning chain = warnings;
         warnings = null;
         return chain;
@@ -91,10 +94,10 @@ class ProtocolConnectionImpl implements ProtocolConnection {
         PGStream cancelStream = null;
 
         // Now we need to construct and send a cancel packet
-        try
-        {
-            if (logger.logDebug())
+        try {
+            if (logger.logDebug()) {
                 logger.debug(" FE=> CancelRequest(pid=" + cancelPid + ",ckey=" + cancelKey + ")");
+            }
 
             cancelStream = new PGStream(pgStream.getHostSpec(), connectTimeout);
             cancelStream.SendInteger4(16);
@@ -106,23 +109,16 @@ class ProtocolConnectionImpl implements ProtocolConnection {
             cancelStream.ReceiveEOF();
             cancelStream.close();
             cancelStream = null;
-        }
-        catch (IOException e)
-        {
+        } catch (IOException e) {
             // Safe to ignore.
-            if (logger.logDebug())
+            if (logger.logDebug()) {
                 logger.debug("Ignoring exception on cancel request:", e);
-        }
-        finally
-        {
-            if (cancelStream != null)
-            {
-                try
-                {
+            }
+        } finally {
+            if (cancelStream != null) {
+                try {
                     cancelStream.close();
-                }
-                catch (IOException e)
-                {
+                } catch (IOException e) {
                     // Ignored.
                 }
             }
@@ -130,24 +126,24 @@ class ProtocolConnectionImpl implements ProtocolConnection {
     }
 
     public void close() {
-        if (closed)
-            return ;
+        if (closed) {
+            return;
+        }
 
-        try
-        {
-            if (logger.logDebug())
+        try {
+            if (logger.logDebug()) {
                 logger.debug(" FE=> Terminate");
+            }
 
             pgStream.SendChar('X');
             pgStream.SendInteger4(4);
             pgStream.flush();
             pgStream.close();
-        }
-        catch (IOException ioe)
-        {
+        } catch (IOException ioe) {
             // Forget it.
-            if (logger.logDebug())
+            if (logger.logDebug()) {
                 logger.debug("Discarding IOException on close:", ioe);
+            }
         }
 
         closed = true;
@@ -171,7 +167,7 @@ class ProtocolConnectionImpl implements ProtocolConnection {
 
     void setServerVersionNum(int serverVersionNum) {
         this.serverVersionNum = serverVersionNum;
-    }  
+    }
 
     void setBackendKeyData(int cancelPid, int cancelKey) {
         this.cancelPid = cancelPid;
@@ -182,37 +178,31 @@ class ProtocolConnectionImpl implements ProtocolConnection {
     // Package-private accessors called by the query executor
     //
 
-    synchronized void addWarning(SQLWarning newWarning)
-    {
-        if (warnings == null)
+    synchronized void addWarning(SQLWarning newWarning) {
+        if (warnings == null) {
             warnings = newWarning;
-        else
+        } else
             warnings.setNextWarning(newWarning);
     }
 
-    synchronized void addNotification(PGNotification notification)
-    {
+    synchronized void addNotification(PGNotification notification) {
         notifications.add(notification);
     }
 
-    synchronized void setTransactionState(int state)
-    {
+    synchronized void setTransactionState(int state) {
         transactionState = state;
     }
 
-    synchronized void setStandardConformingStrings(boolean value)
-    {
+    synchronized void setStandardConformingStrings(boolean value) {
         standardConformingStrings = value;
     }
 
-    public int getProtocolVersion()
-    {
+    public int getProtocolVersion() {
         return 3;
     }
-    
-    public int getBackendPID()
-    {
-    	return cancelPid;
+
+    public int getBackendPID() {
+        return cancelPid;
     }
 
     public boolean useBinaryForReceive(int oid) {
@@ -233,27 +223,24 @@ class ProtocolConnectionImpl implements ProtocolConnection {
     }
 
     public void abort() {
-        try
-        {
+        try {
             pgStream.getSocket().close();
-        }
-        catch (IOException e)
-        {
+        } catch (IOException e) {
             // ignore
         }
         closed = true;
     }
 
-   /**
+    /**
      * True if server uses integers for date and time fields. False if
      * server uses double.
      */
     private boolean integerDateTimes;
 
     /**
-    * Bit set that has a bit set for each oid which should be received
-    * using binary format.
-    */
+     * Bit set that has a bit set for each oid which should be received
+     * using binary format.
+     */
     private final Set<Integer> useBinaryForOids = new HashSet<Integer>();
     private String serverVersion;
     private int serverVersionNum = 0;

--- a/org/postgresql/core/v3/V3ParameterList.java
+++ b/org/postgresql/core/v3/V3ParameterList.java
@@ -8,12 +8,13 @@
 */
 package org.postgresql.core.v3;
 
-import java.sql.SQLException;
 import org.postgresql.core.ParameterList;
+
+import java.sql.SQLException;
 
 /**
  * Common interface for all V3 parameter list implementations.
- * 
+ *
  * @author Oliver Jowett (oliver@opencloud.com)
  */
 interface V3ParameterList extends ParameterList {
@@ -39,11 +40,8 @@ interface V3ParameterList extends ParameterList {
      * construction in the common case).
      *
      * @return an array of single-statement parameter lists, or
-     *   <code>null</code> if this object is already a single-statement
-     *   parameter list.
+     * <code>null</code> if this object is already a single-statement
+     * parameter list.
      */
     SimpleParameterList[] getSubparams();
-    
-   
-    
 }

--- a/org/postgresql/core/v3/V3Query.java
+++ b/org/postgresql/core/v3/V3Query.java
@@ -23,7 +23,7 @@ interface V3Query extends Query {
      * construction in the common case).
      *
      * @return an array of single-statement queries, or <code>null</code>
-     *   if this object is already a single-statement query.
+     * if this object is already a single-statement query.
      */
     SimpleQuery[] getSubqueries();
 }


### PR DESCRIPTION
First pass at checkstyle and sonarlint runs against org.postgresql.core.
Focused primarily on refactoring and pedantic style, such as braces,
spacing, imports, JLS compliance, etc.  This does not yield a clean
checkstyle run.  Code fixes will be done under another CR.

Done as part of #441.