### PR TITLE
style: checkstyle pass org.postgresql.copy

### DIFF
--- a/org/postgresql/copy/CopyIn.java
+++ b/org/postgresql/copy/CopyIn.java
@@ -16,6 +16,7 @@ public interface CopyIn extends CopyOperation {
 
     /**
      * Writes specified part of given byte array to an open and writable copy operation.
+     *
      * @param buf array of bytes to write
      * @param off offset of first byte to write (normally zero)
      * @param siz number of bytes to write (normally buf.length)
@@ -29,13 +30,16 @@ public interface CopyIn extends CopyOperation {
      * pushed over in due time or when endCopy is called.  Some specific
      * modified server versions (Truviso) want this data sooner.
      * If you are unsure if you need to use this method, don't.
+     *
+     * @throws SQLException if the operation fails
      */
     void flushCopy() throws SQLException;
-    
+
     /**
-     * Finishes copy operation succesfully.
+     * Finishes copy operation successfully.
+     *
      * @return number of updated rows for server 8.2 or newer (see getHandledRowCount())
      * @throws SQLException if the operation fails.
      */
-    public long endCopy() throws SQLException;
+    long endCopy() throws SQLException;
 }

--- a/org/postgresql/copy/CopyOperation.java
+++ b/org/postgresql/copy/CopyOperation.java
@@ -30,14 +30,15 @@ public interface CopyOperation {
      * @return format of requested field: 0 = textual, 1 = binary
      */
     int getFieldFormat(int field);
-    
+
     /**
      * @return is connection reserved for this Copy operation?
      */
     boolean isActive();
-    
+
     /**
      * Cancels this copy operation, discarding any exchanged data.
+     *
      * @throws SQLException if cancelling fails
      */
     void cancelCopy() throws SQLException;
@@ -47,7 +48,8 @@ public interface CopyOperation {
      * of database records handled in that operation.
      * Only implemented in PostgreSQL server version 8.2 and up.
      * Otherwise, returns -1.
+     *
      * @return number of handled rows or -1
      */
-    public long getHandledRowCount();
+    long getHandledRowCount();
 }

--- a/org/postgresql/copy/PGCopyInputStream.java
+++ b/org/postgresql/copy/PGCopyInputStream.java
@@ -7,17 +7,17 @@
 */
 package org.postgresql.copy;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.sql.SQLException;
-
 import org.postgresql.PGConnection;
 import org.postgresql.util.GT;
 import org.postgresql.util.PSQLException;
 import org.postgresql.util.PSQLState;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.sql.SQLException;
+
 /**
- * InputStream for reading from a PostgreSQL COPY TO STDOUT operation
+ * InputStream for reading from a PostgreSQL COPY TO STDOUT operation.
  */
 public class PGCopyInputStream extends InputStream implements CopyOut {
     private CopyOut op;
@@ -25,9 +25,10 @@ public class PGCopyInputStream extends InputStream implements CopyOut {
     private int at, len;
 
     /**
-     * Uses given connection for specified COPY TO STDOUT operation
+     * Uses given connection for specified COPY TO STDOUT operation.
+     *
      * @param connection database connection to use for copying (protocol version 3 required)
-     * @param sql COPY TO STDOUT statement
+     * @param sql        COPY TO STDOUT statement
      * @throws SQLException if initializing the operation fails
      */
     public PGCopyInputStream(PGConnection connection, String sql) throws SQLException {
@@ -35,7 +36,8 @@ public class PGCopyInputStream extends InputStream implements CopyOut {
     }
 
     /**
-     * Use given CopyOut operation for reading
+     * Use given CopyOut operation for reading.
+     *
      * @param op COPY TO STDOUT operation
      */
     public PGCopyInputStream(CopyOut op) {
@@ -43,13 +45,13 @@ public class PGCopyInputStream extends InputStream implements CopyOut {
     }
 
     private boolean gotBuf() throws IOException {
-        if(at >= len) {
+        if (at >= len) {
             try {
                 buf = op.readFromCopy();
-            } catch(SQLException sqle) {
+            } catch (SQLException sqle) {
                 throw new IOException(GT.tr("Copying from database failed: {0}", sqle));
             }
-            if(buf == null) {
+            if (buf == null) {
                 at = -1;
                 return false;
             } else {
@@ -67,27 +69,26 @@ public class PGCopyInputStream extends InputStream implements CopyOut {
         }
     }
 
-    
     public int available() throws IOException {
         checkClosed();
-        return ( buf != null ? len - at : 0 );
+        return (buf != null ? len - at : 0);
     }
-    
+
     public int read() throws IOException {
         checkClosed();
         return gotBuf() ? buf[at++] : -1;
     }
 
     public int read(byte[] buf) throws IOException {
-        return read(buf, 0, buf.length); 
+        return read(buf, 0, buf.length);
     }
-    
+
     public int read(byte[] buf, int off, int siz) throws IOException {
         checkClosed();
         int got = 0;
         boolean didReadSomething = false;
-        while( got < siz && (didReadSomething = gotBuf()) ) {
-            buf[off+got++] = this.buf[at++];
+        while (got < siz && (didReadSomething = gotBuf())) {
+            buf[off + got++] = this.buf[at++];
         }
         return got == 0 && !didReadSomething ? -1 : got;
     }
@@ -95,16 +96,17 @@ public class PGCopyInputStream extends InputStream implements CopyOut {
     public byte[] readFromCopy() throws SQLException {
         byte[] result = buf;
         try {
-            if(gotBuf()) {
-                if(at>0 || len < buf.length) {
-                    byte[] ba = new byte[len-at];
-                    for(int i=at; i<len; i++)
-                        ba[i-at] = buf[i];
+            if (gotBuf()) {
+                if (at > 0 || len < buf.length) {
+                    byte[] ba = new byte[len - at];
+                    for (int i = at; i < len; i++) {
+                        ba[i - at] = buf[i];
+                    }
                     result = ba;
                 }
                 at = len; // either partly or fully returned, buffer is exhausted
             }
-        } catch(IOException ioe) {
+        } catch (IOException ioe) {
             throw new PSQLException(GT.tr("Read from copy failed."), PSQLState.CONNECTION_FAILURE);
         }
         return result;
@@ -112,17 +114,18 @@ public class PGCopyInputStream extends InputStream implements CopyOut {
 
     public void close() throws IOException {
         // Don't complain about a double close.
-        if (op == null)
+        if (op == null) {
             return;
+        }
 
         if (op.isActive()) {
-	        try {
-	            op.cancelCopy();
-	        } catch(SQLException se) {
-	            IOException ioe = new IOException("Failed to close copy reader.");
-	            ioe.initCause(se);
-	            throw ioe;
-	        }
+            try {
+                op.cancelCopy();
+            } catch (SQLException se) {
+                IOException ioe = new IOException("Failed to close copy reader.");
+                ioe.initCause(se);
+                throw ioe;
+            }
         }
         op = null;
     }
@@ -134,7 +137,7 @@ public class PGCopyInputStream extends InputStream implements CopyOut {
     public int getFormat() {
         return op.getFormat();
     }
-    
+
     public int getFieldFormat(int field) {
         return op.getFieldFormat(field);
     }

--- a/org/postgresql/copy/PGCopyOutputStream.java
+++ b/org/postgresql/copy/PGCopyOutputStream.java
@@ -7,15 +7,15 @@
 */
 package org.postgresql.copy;
 
+import org.postgresql.PGConnection;
+import org.postgresql.util.GT;
+
 import java.io.IOException;
 import java.io.OutputStream;
 import java.sql.SQLException;
 
-import org.postgresql.PGConnection;
-import org.postgresql.util.GT;
-
 /**
- * OutputStream for buffered input into a PostgreSQL COPY FROM STDIN operation
+ * OutputStream for buffered input into a PostgreSQL COPY FROM STDIN operation.
  */
 public class PGCopyOutputStream extends OutputStream implements CopyIn {
     private CopyIn op;
@@ -24,9 +24,10 @@ public class PGCopyOutputStream extends OutputStream implements CopyIn {
     private int at = 0;
 
     /**
-     * Uses given connection for specified COPY FROM STDIN operation
+     * Uses given connection for specified COPY FROM STDIN operation.
+     *
      * @param connection database connection to use for copying (protocol version 3 required)
-     * @param sql COPY FROM STDIN statement
+     * @param sql        COPY FROM STDIN statement
      * @throws SQLException if initializing the operation fails
      */
     public PGCopyOutputStream(PGConnection connection, String sql) throws SQLException {
@@ -34,9 +35,10 @@ public class PGCopyOutputStream extends OutputStream implements CopyIn {
     }
 
     /**
-     * Uses given connection for specified COPY FROM STDIN operation
+     * Uses given connection for specified COPY FROM STDIN operation.
+     *
      * @param connection database connection to use for copying (protocol version 3 required)
-     * @param sql COPY FROM STDIN statement
+     * @param sql        COPY FROM STDIN statement
      * @param bufferSize try to send this many bytes at a time
      * @throws SQLException if initializing the operation fails
      */
@@ -45,7 +47,8 @@ public class PGCopyOutputStream extends OutputStream implements CopyIn {
     }
 
     /**
-     * Use given CopyIn operation for writing
+     * Use given CopyIn operation for writing.
+     *
      * @param op COPY FROM STDIN operation
      */
     public PGCopyOutputStream(CopyIn op) {
@@ -53,8 +56,9 @@ public class PGCopyOutputStream extends OutputStream implements CopyIn {
     }
 
     /**
-     * Use given CopyIn operation for writing
-     * @param op COPY FROM STDIN operation
+     * Use given CopyIn operation for writing.
+     *
+     * @param op         COPY FROM STDIN operation
      * @param bufferSize try to send this many bytes at a time
      */
     public PGCopyOutputStream(CopyIn op, int bufferSize) {
@@ -64,9 +68,10 @@ public class PGCopyOutputStream extends OutputStream implements CopyIn {
 
     public void write(int b) throws IOException {
         checkClosed();
-        if(b<0 || b>255)
+        if (b < 0 || b > 255) {
             throw new IOException(GT.tr("Cannot write to copy a byte of value {0}", b));
-        singleByteBuffer[0] = (byte)b;
+        }
+        singleByteBuffer[0] = (byte) b;
         write(singleByteBuffer, 0, 1);
     }
 
@@ -78,7 +83,7 @@ public class PGCopyOutputStream extends OutputStream implements CopyIn {
         checkClosed();
         try {
             writeToCopy(buf, off, siz);
-        } catch(SQLException se) {
+        } catch (SQLException se) {
             IOException ioe = new IOException("Write to copy failed.");
             ioe.initCause(se);
             throw ioe;
@@ -93,12 +98,13 @@ public class PGCopyOutputStream extends OutputStream implements CopyIn {
 
     public void close() throws IOException {
         // Don't complain about a double close.
-        if (op == null)
+        if (op == null) {
             return;
+        }
 
-        try{
+        try {
             endCopy();
-        } catch(SQLException se) {
+        } catch (SQLException se) {
             IOException ioe = new IOException("Ending write to copy failed.");
             ioe.initCause(se);
             throw ioe;
@@ -119,11 +125,11 @@ public class PGCopyOutputStream extends OutputStream implements CopyIn {
     }
 
     public void writeToCopy(byte[] buf, int off, int siz) throws SQLException {
-        if(at > 0 && siz > copyBuffer.length - at) { // would not fit into rest of our buf, so flush buf
+        if (at > 0 && siz > copyBuffer.length - at) { // would not fit into rest of our buf, so flush buf
             op.writeToCopy(copyBuffer, 0, at);
             at = 0;
         }
-        if(siz > copyBuffer.length) { // would still not fit into buf, so just pass it through
+        if (siz > copyBuffer.length) { // would still not fit into buf, so just pass it through
             op.writeToCopy(buf, off, siz);
         } else { // fits into our buf, so save it there
             System.arraycopy(buf, off, copyBuffer, at, siz);
@@ -156,7 +162,7 @@ public class PGCopyOutputStream extends OutputStream implements CopyIn {
     }
 
     public long endCopy() throws SQLException {
-        if(at > 0) {
+        if (at > 0) {
             op.writeToCopy(copyBuffer, 0, at);
         }
         op.endCopy();


### PR DESCRIPTION
First pass at checkstyle and sonarlint runs against org.postgresql.copy.
Focused primarily on refactoring and pedantic style, such as braces,
spacing, imports, JLS compliance, etc.  This does not yield a clean
checkstyle run.  Code fixes will be done under another CR.

Done as part of #441.