### PR TITLE
style: checkstyle pass org.postgresql.ds

### DIFF
--- a/org/postgresql/ds/common/BaseDataSource.java
+++ b/org/postgresql/ds/common/BaseDataSource.java
@@ -7,20 +7,25 @@
 */
 package org.postgresql.ds.common;
 
-import javax.naming.*;
-
 import org.postgresql.PGProperty;
 import org.postgresql.util.GT;
 import org.postgresql.util.PSQLException;
 import org.postgresql.util.PSQLState;
 
-import java.sql.*;
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
+import javax.naming.NamingException;
+import javax.naming.RefAddr;
+import javax.naming.Reference;
+import javax.naming.Referenceable;
+import javax.naming.StringRefAddr;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.PrintWriter;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
 import java.util.Properties;
 
 /**
@@ -28,18 +33,14 @@ import java.util.Properties;
  *
  * @author Aaron Mulder (ammulder@chariotsolutions.com)
  */
-public abstract class BaseDataSource implements Referenceable
-{
+public abstract class BaseDataSource implements Referenceable {
     // Load the normal driver, since we'll use it to actually connect to the
     // database.  That way we don't have to maintain the connecting code in
     // multiple places.
     static {
-        try
-        {
+        try {
             Class.forName("org.postgresql.Driver");
-        }
-        catch (ClassNotFoundException e)
-        {
+        } catch (ClassNotFoundException e) {
             System.err.println("PostgreSQL DataSource unable to load PostgreSQL JDBC Driver");
         }
     }
@@ -63,11 +64,9 @@ public abstract class BaseDataSource implements Referenceable
      * connect as is identified by the DataSource properties user and password.
      *
      * @return A valid database connection.
-     * @throws SQLException
-     *     Occurs when the database connection cannot be established.
+     * @throws SQLException Occurs when the database connection cannot be established.
      */
-    public Connection getConnection() throws SQLException
-    {
+    public Connection getConnection() throws SQLException {
         return getConnection(user, password);
     }
 
@@ -78,24 +77,17 @@ public abstract class BaseDataSource implements Referenceable
      * the DataSource properties by the same name.
      *
      * @return A valid database connection.
-     * @throws SQLException
-     *     Occurs when the database connection cannot be established.
+     * @throws SQLException Occurs when the database connection cannot be established.
      */
-    public Connection getConnection(String user, String password) throws SQLException
-    {
-        try
-        {
+    public Connection getConnection(String user, String password) throws SQLException {
+        try {
             Connection con = DriverManager.getConnection(getUrl(), user, password);
-            if (logger != null)
-            {
+            if (logger != null) {
                 logger.println("Created a non-pooled connection for " + user + " at " + getUrl());
             }
             return con;
-        }
-        catch (SQLException e)
-        {
-            if (logger != null)
-            {
+        } catch (SQLException e) {
+            if (logger != null) {
                 logger.println("Failed to create a non-pooled connection for " + user + " at " + getUrl() + ": " + e);
             }
             throw e;
@@ -105,24 +97,21 @@ public abstract class BaseDataSource implements Referenceable
     /**
      * Gets the log writer used to log connections opened.
      */
-    public PrintWriter getLogWriter()
-    {
+    public PrintWriter getLogWriter() {
         return logger;
     }
 
     /**
      * The DataSource will note every connection opened to the provided log writer.
      */
-    public void setLogWriter(PrintWriter printWriter)
-    {
+    public void setLogWriter(PrintWriter printWriter) {
         logger = printWriter;
     }
 
     /**
      * Gets the name of the host the PostgreSQL database is running on.
      */
-    public String getServerName()
-    {
+    public String getServerName() {
         return serverName;
     }
 
@@ -131,14 +120,10 @@ public abstract class BaseDataSource implements Referenceable
      * is changed, it will only affect future calls to getConnection.  The default
      * value is <tt>localhost</tt>.
      */
-    public void setServerName(String serverName)
-    {
-        if (serverName == null || serverName.equals(""))
-        {
+    public void setServerName(String serverName) {
+        if (serverName == null || serverName.equals("")) {
             this.serverName = "localhost";
-        }
-        else
-        {
+        } else {
             this.serverName = serverName;
         }
     }
@@ -147,8 +132,7 @@ public abstract class BaseDataSource implements Referenceable
      * Gets the name of the PostgreSQL database, running on the server identified
      * by the serverName property.
      */
-    public String getDatabaseName()
-    {
+    public String getDatabaseName() {
         return databaseName;
     }
 
@@ -157,8 +141,7 @@ public abstract class BaseDataSource implements Referenceable
      * by the serverName property. If this is changed, it will only affect
      * future calls to getConnection.
      */
-    public void setDatabaseName(String databaseName)
-    {
+    public void setDatabaseName(String databaseName) {
         this.databaseName = databaseName;
     }
 
@@ -172,8 +155,7 @@ public abstract class BaseDataSource implements Referenceable
      * Gets the user to connect as by default. If this is not specified, you must
      * use the getConnection method which takes a user and password as parameters.
      */
-    public String getUser()
-    {
+    public String getUser() {
         return user;
     }
 
@@ -182,8 +164,7 @@ public abstract class BaseDataSource implements Referenceable
      * use the getConnection method which takes a user and password as parameters.
      * If this is changed, it will only affect future calls to getConnection.
      */
-    public void setUser(String user)
-    {
+    public void setUser(String user) {
         this.user = user;
     }
 
@@ -192,8 +173,7 @@ public abstract class BaseDataSource implements Referenceable
      * password is needed to log in, you must use the getConnection method which takes
      * a user and password as parameters.
      */
-    public String getPassword()
-    {
+    public String getPassword() {
         return password;
     }
 
@@ -203,8 +183,7 @@ public abstract class BaseDataSource implements Referenceable
      * a user and password as parameters.  If this is changed, it will only affect
      * future calls to getConnection.
      */
-    public void setPassword(String password)
-    {
+    public void setPassword(String password) {
         this.password = password;
     }
 
@@ -214,8 +193,7 @@ public abstract class BaseDataSource implements Referenceable
      *
      * @return The port, or 0 if the default port will be used.
      */
-    public int getPortNumber()
-    {
+    public int getPortNumber() {
         return portNumber;
     }
 
@@ -224,245 +202,208 @@ public abstract class BaseDataSource implements Referenceable
      * connections.  Be sure the -i flag is passed to postmaster when PostgreSQL
      * is started. If this is not set, or set to 0, the default port will be used.
      */
-    public void setPortNumber(int portNumber)
-    {
+    public void setPortNumber(int portNumber) {
         this.portNumber = portNumber;
     }
 
     /**
-     * @see PGProperty#COMPATIBLE 
+     * @see PGProperty#COMPATIBLE
      */
-    public String getCompatible()
-    {
+    public String getCompatible() {
         return PGProperty.COMPATIBLE.get(properties);
     }
 
     /**
-     * @see PGProperty#COMPATIBLE 
+     * @see PGProperty#COMPATIBLE
      */
-    public void setCompatible(String compatible)
-    {
+    public void setCompatible(String compatible) {
         PGProperty.COMPATIBLE.set(properties, compatible);
     }
 
     /**
-     * @see PGProperty#LOGIN_TIMEOUT 
+     * @see PGProperty#LOGIN_TIMEOUT
      */
-    public int getLoginTimeout()
-    {
+    public int getLoginTimeout() {
         return PGProperty.LOGIN_TIMEOUT.getIntNoCheck(properties);
     }
 
     /**
-     * @see PGProperty#LOGIN_TIMEOUT 
+     * @see PGProperty#LOGIN_TIMEOUT
      */
-    public void setLoginTimeout(int loginTimeout)
-    {
+    public void setLoginTimeout(int loginTimeout) {
         PGProperty.LOGIN_TIMEOUT.set(properties, loginTimeout);
     }
 
     /**
-     * @see PGProperty#CONNECT_TIMEOUT 
+     * @see PGProperty#CONNECT_TIMEOUT
      */
-    public int getConnectTimeout()
-    {
+    public int getConnectTimeout() {
         return PGProperty.CONNECT_TIMEOUT.getIntNoCheck(properties);
     }
 
     /**
-     * @see PGProperty#CONNECT_TIMEOUT 
+     * @see PGProperty#CONNECT_TIMEOUT
      */
-    public void setConnectTimeout(int connectTimeout)
-    {
+    public void setConnectTimeout(int connectTimeout) {
         PGProperty.CONNECT_TIMEOUT.set(properties, connectTimeout);
     }
 
     /**
-     * @see PGProperty#LOG_LEVEL 
+     * @see PGProperty#LOG_LEVEL
      */
-    public int getLogLevel()
-    {
+    public int getLogLevel() {
         return PGProperty.LOG_LEVEL.getIntNoCheck(properties);
     }
 
     /**
-     * @see PGProperty#LOG_LEVEL 
+     * @see PGProperty#LOG_LEVEL
      */
-    public void setLogLevel(int logLevel)
-    {
+    public void setLogLevel(int logLevel) {
         PGProperty.LOG_LEVEL.set(properties, logLevel);
     }
 
     /**
-     * @see PGProperty#PROTOCOL_VERSION 
+     * @see PGProperty#PROTOCOL_VERSION
      */
-    public int getProtocolVersion()
-    {
-        if (!PGProperty.PROTOCOL_VERSION.isPresent(properties))
-        {
+    public int getProtocolVersion() {
+        if (!PGProperty.PROTOCOL_VERSION.isPresent(properties)) {
             return 0;
-        }
-        else
-        {
+        } else {
             return PGProperty.PROTOCOL_VERSION.getIntNoCheck(properties);
         }
     }
 
     /**
-     * @see PGProperty#PROTOCOL_VERSION 
+     * @see PGProperty#PROTOCOL_VERSION
      */
-    public void setProtocolVersion(int protocolVersion)
-    {
-        if (protocolVersion == 0)
-        {
+    public void setProtocolVersion(int protocolVersion) {
+        if (protocolVersion == 0) {
             PGProperty.PROTOCOL_VERSION.set(properties, null);
-        }
-        else
-        {
+        } else {
             PGProperty.PROTOCOL_VERSION.set(properties, protocolVersion);
         }
     }
 
     /**
-     * @see PGProperty#RECEIVE_BUFFER_SIZE 
+     * @see PGProperty#RECEIVE_BUFFER_SIZE
      */
-    public int getReceiveBufferSize()
-    {
+    public int getReceiveBufferSize() {
         return PGProperty.RECEIVE_BUFFER_SIZE.getIntNoCheck(properties);
     }
 
     /**
-     * @see PGProperty#RECEIVE_BUFFER_SIZE 
+     * @see PGProperty#RECEIVE_BUFFER_SIZE
      */
-    public void setReceiveBufferSize(int nbytes)
-    {
+    public void setReceiveBufferSize(int nbytes) {
         PGProperty.RECEIVE_BUFFER_SIZE.set(properties, nbytes);
     }
 
     /**
-     * @see PGProperty#SEND_BUFFER_SIZE 
+     * @see PGProperty#SEND_BUFFER_SIZE
      */
-    public int getSendBufferSize()
-    {
+    public int getSendBufferSize() {
         return PGProperty.SEND_BUFFER_SIZE.getIntNoCheck(properties);
     }
 
     /**
-     * @see PGProperty#SEND_BUFFER_SIZE 
+     * @see PGProperty#SEND_BUFFER_SIZE
      */
-    public void setSendBufferSize(int nbytes)
-    {
+    public void setSendBufferSize(int nbytes) {
         PGProperty.SEND_BUFFER_SIZE.set(properties, nbytes);
     }
 
     /**
-     * @see PGProperty#PREPARE_THRESHOLD 
+     * @see PGProperty#PREPARE_THRESHOLD
      */
-    public void setPrepareThreshold(int count)
-    {
+    public void setPrepareThreshold(int count) {
         PGProperty.PREPARE_THRESHOLD.set(properties, count);
     }
 
     /**
      * @see PGProperty#PREPARE_THRESHOLD
      */
-    public int getPrepareThreshold()
-    {
+    public int getPrepareThreshold() {
         return PGProperty.PREPARE_THRESHOLD.getIntNoCheck(properties);
     }
 
     /**
      * @see PGProperty#PREPARED_STATEMENT_CACHE_QUERIES
      */
-    public int getPreparedStatementCacheQueries()
-    {
+    public int getPreparedStatementCacheQueries() {
         return PGProperty.PREPARED_STATEMENT_CACHE_QUERIES.getIntNoCheck(properties);
     }
 
     /**
      * @see PGProperty#PREPARED_STATEMENT_CACHE_QUERIES
      */
-    public void setPreparedStatementCacheQueries(int cacheSize)
-    {
+    public void setPreparedStatementCacheQueries(int cacheSize) {
         PGProperty.PREPARED_STATEMENT_CACHE_QUERIES.set(properties, cacheSize);
     }
 
     /**
      * @see PGProperty#PREPARED_STATEMENT_CACHE_SIZE_MIB
      */
-    public int getPreparedStatementCacheSizeMiB()
-    {
+    public int getPreparedStatementCacheSizeMiB() {
         return PGProperty.PREPARED_STATEMENT_CACHE_SIZE_MIB.getIntNoCheck(properties);
     }
 
     /**
      * @see PGProperty#PREPARED_STATEMENT_CACHE_SIZE_MIB
      */
-    public void setPreparedStatementCacheSizeMiB(int cacheSize)
-    {
+    public void setPreparedStatementCacheSizeMiB(int cacheSize) {
         PGProperty.PREPARED_STATEMENT_CACHE_SIZE_MIB.set(properties, cacheSize);
     }
 
     /**
      * @see PGProperty#DEFAULT_ROW_FETCH_SIZE
      */
-    public void setDefaultRowFetchSize(int fetchSize)
-    {
+    public void setDefaultRowFetchSize(int fetchSize) {
         PGProperty.DEFAULT_ROW_FETCH_SIZE.set(properties, fetchSize);
     }
 
     /**
      * @see PGProperty#DEFAULT_ROW_FETCH_SIZE
      */
-    public int getDefaultRowFetchSize()
-    {
+    public int getDefaultRowFetchSize() {
         return PGProperty.DEFAULT_ROW_FETCH_SIZE.getIntNoCheck(properties);
     }
 
     /**
-     * @see PGProperty#UNKNOWN_LENGTH 
+     * @see PGProperty#UNKNOWN_LENGTH
      */
-    public void setUnknownLength(int unknownLength)
-    {
+    public void setUnknownLength(int unknownLength) {
         PGProperty.UNKNOWN_LENGTH.set(properties, unknownLength);
     }
 
     /**
-     * @see PGProperty#UNKNOWN_LENGTH 
+     * @see PGProperty#UNKNOWN_LENGTH
      */
-    public int getUnknownLength()
-    {
+    public int getUnknownLength() {
         return PGProperty.UNKNOWN_LENGTH.getIntNoCheck(properties);
     }
 
     /**
-     * @see PGProperty#SOCKET_TIMEOUT 
+     * @see PGProperty#SOCKET_TIMEOUT
      */
-    public void setSocketTimeout(int seconds)
-    {
+    public void setSocketTimeout(int seconds) {
         PGProperty.SOCKET_TIMEOUT.set(properties, seconds);
     }
 
     /**
-     * @see PGProperty#SOCKET_TIMEOUT 
+     * @see PGProperty#SOCKET_TIMEOUT
      */
-    public int getSocketTimeout() 
-    {
+    public int getSocketTimeout() {
         return PGProperty.SOCKET_TIMEOUT.getIntNoCheck(properties);
     }
 
 
     /**
-     * @see PGProperty#SSL 
+     * @see PGProperty#SSL
      */
-    public void setSsl(boolean enabled)
-    {
-        if (enabled)
-        {
+    public void setSsl(boolean enabled) {
+        if (enabled) {
             PGProperty.SSL.set(properties, true);
-        }
-        else
-        {
+        } else {
             PGProperty.SSL.set(properties, null);
         }
     }
@@ -470,504 +411,441 @@ public abstract class BaseDataSource implements Referenceable
     /**
      * @see PGProperty#SSL
      */
-    public boolean getSsl()
-    {
+    public boolean getSsl() {
         return PGProperty.SSL.isPresent(properties);
     }
 
     /**
      * @see PGProperty#SSL_FACTORY
      */
-    public void setSslfactory(String classname)
-    {
+    public void setSslfactory(String classname) {
         PGProperty.SSL_FACTORY.set(properties, classname);
     }
 
     /**
      * @see PGProperty#SSL_FACTORY
      */
-    public String getSslfactory()
-    {
+    public String getSslfactory() {
         return PGProperty.SSL_FACTORY.get(properties);
     }
 
     /**
      * @see PGProperty#SSL_MODE
      */
-    public String getSslMode()
-    {
+    public String getSslMode() {
         return PGProperty.SSL_MODE.get(properties);
     }
 
     /**
      * @see PGProperty#SSL_MODE
      */
-    public void setSslMode(String mode)
-    {
+    public void setSslMode(String mode) {
         PGProperty.SSL_MODE.set(properties, mode);
     }
 
     /**
      * @see PGProperty#SSL_FACTORY_ARG
      */
-    public String getSslFactoryArg()
-    {
+    public String getSslFactoryArg() {
         return PGProperty.SSL_FACTORY_ARG.get(properties);
     }
 
     /**
      * @see PGProperty#SSL_FACTORY_ARG
      */
-    public void setSslFactoryArg(String arg)
-    {
+    public void setSslFactoryArg(String arg) {
         PGProperty.SSL_FACTORY_ARG.set(properties, arg);
     }
 
     /**
      * @see PGProperty#SSL_HOSTNAME_VERIFIER
      */
-    public String getSslHostnameVerifier()
-    {
+    public String getSslHostnameVerifier() {
         return PGProperty.SSL_HOSTNAME_VERIFIER.get(properties);
     }
 
     /**
      * @see PGProperty#SSL_HOSTNAME_VERIFIER
      */
-    public void setSslHostnameVerifier(String className)
-    {
+    public void setSslHostnameVerifier(String className) {
         PGProperty.SSL_HOSTNAME_VERIFIER.set(properties, className);
     }
 
     /**
      * @see PGProperty#SSL_CERT
      */
-    public String getSslCert()
-    {
+    public String getSslCert() {
         return PGProperty.SSL_CERT.get(properties);
     }
 
     /**
      * @see PGProperty#SSL_CERT
      */
-    public void setSslCert(String file)
-    {
+    public void setSslCert(String file) {
         PGProperty.SSL_CERT.set(properties, file);
     }
 
     /**
      * @see PGProperty#SSL_KEY
      */
-    public String getSslKey()
-    {
+    public String getSslKey() {
         return PGProperty.SSL_KEY.get(properties);
     }
 
     /**
      * @see PGProperty#SSL_KEY
      */
-    public void setSslKey(String file)
-    {
+    public void setSslKey(String file) {
         PGProperty.SSL_KEY.set(properties, file);
     }
 
     /**
      * @see PGProperty#SSL_ROOT_CERT
      */
-    public String getSslRootCert()
-    {
+    public String getSslRootCert() {
         return PGProperty.SSL_ROOT_CERT.get(properties);
     }
 
     /**
      * @see PGProperty#SSL_ROOT_CERT
      */
-    public void setSslRootCert(String file)
-    {
+    public void setSslRootCert(String file) {
         PGProperty.SSL_ROOT_CERT.set(properties, file);
     }
 
     /**
      * @see PGProperty#SSL_PASSWORD
      */
-    public String getSslPassword()
-    {
+    public String getSslPassword() {
         return PGProperty.SSL_PASSWORD.get(properties);
     }
 
     /**
      * @see PGProperty#SSL_PASSWORD
      */
-    public void setSslPassword(String password)
-    {
+    public void setSslPassword(String password) {
         PGProperty.SSL_PASSWORD.set(properties, password);
     }
 
     /**
      * @see PGProperty#SSL_PASSWORD_CALLBACK
      */
-    public String getSslPasswordCallback()
-    {
+    public String getSslPasswordCallback() {
         return PGProperty.SSL_PASSWORD_CALLBACK.get(properties);
     }
 
     /**
      * @see PGProperty#SSL_PASSWORD_CALLBACK
      */
-    public void setSslPasswordCallback(String className)
-    {
+    public void setSslPasswordCallback(String className) {
         PGProperty.SSL_PASSWORD_CALLBACK.set(properties, className);
     }
 
     /**
      * @see PGProperty#APPLICATION_NAME
      */
-    public void setApplicationName(String applicationName)
-    {
+    public void setApplicationName(String applicationName) {
         PGProperty.APPLICATION_NAME.set(properties, applicationName);
     }
 
     /**
      * @see PGProperty#APPLICATION_NAME
      */
-    public String getApplicationName()
-    {
+    public String getApplicationName() {
         return PGProperty.APPLICATION_NAME.get(properties);
     }
 
     /**
      * @see PGProperty#TARGET_SERVER_TYPE
      */
-    public void setTargetServerType(String targetServerType)
-    {
+    public void setTargetServerType(String targetServerType) {
         PGProperty.TARGET_SERVER_TYPE.set(properties, targetServerType);
     }
 
     /**
      * @see PGProperty#TARGET_SERVER_TYPE
      */
-    public String getTargetServerType()
-    {
+    public String getTargetServerType() {
         return PGProperty.TARGET_SERVER_TYPE.get(properties);
     }
 
     /**
      * @see PGProperty#LOAD_BALANCE_HOSTS
      */
-    public void setLoadBalanceHosts(boolean loadBalanceHosts)
-    {
+    public void setLoadBalanceHosts(boolean loadBalanceHosts) {
         PGProperty.LOAD_BALANCE_HOSTS.set(properties, loadBalanceHosts);
     }
 
     /**
      * @see PGProperty#LOAD_BALANCE_HOSTS
      */
-    public boolean getLoadBalanceHosts()
-    {
+    public boolean getLoadBalanceHosts() {
         return PGProperty.LOAD_BALANCE_HOSTS.isPresent(properties);
     }
 
     /**
      * @see PGProperty#HOST_RECHECK_SECONDS
      */
-    public void setHostRecheckSeconds(int hostRecheckSeconds)
-    {
+    public void setHostRecheckSeconds(int hostRecheckSeconds) {
         PGProperty.HOST_RECHECK_SECONDS.set(properties, hostRecheckSeconds);
     }
 
     /**
      * @see PGProperty#HOST_RECHECK_SECONDS
      */
-    public int getHostRecheckSeconds()
-    {
+    public int getHostRecheckSeconds() {
         return PGProperty.HOST_RECHECK_SECONDS.getIntNoCheck(properties);
     }
 
     /**
      * @see PGProperty#TCP_KEEP_ALIVE
      */
-    public void setTcpKeepAlive(boolean enabled)
-    {
+    public void setTcpKeepAlive(boolean enabled) {
         PGProperty.TCP_KEEP_ALIVE.set(properties, enabled);
     }
 
     /**
      * @see PGProperty#TCP_KEEP_ALIVE
      */
-    public boolean getTcpKeepAlive()
-    {
+    public boolean getTcpKeepAlive() {
         return PGProperty.TCP_KEEP_ALIVE.getBoolean(properties);
     }
 
     /**
      * @see PGProperty#BINARY_TRANSFER
      */
-    public void setBinaryTransfer(boolean enabled)
-    {
+    public void setBinaryTransfer(boolean enabled) {
         PGProperty.BINARY_TRANSFER.set(properties, enabled);
     }
 
     /**
      * @see PGProperty#BINARY_TRANSFER
      */
-    public boolean getBinaryTransfer()
-    {
+    public boolean getBinaryTransfer() {
         return PGProperty.BINARY_TRANSFER.getBoolean(properties);
     }
 
     /**
      * @see PGProperty#BINARY_TRANSFER_ENABLE
      */
-    public void setBinaryTransferEnable(String oidList)
-    {
+    public void setBinaryTransferEnable(String oidList) {
         PGProperty.BINARY_TRANSFER_ENABLE.set(properties, oidList);
     }
 
     /**
      * @see PGProperty#BINARY_TRANSFER_ENABLE
      */
-    public String getBinaryTransferEnable()
-    {
+    public String getBinaryTransferEnable() {
         return PGProperty.BINARY_TRANSFER_ENABLE.get(properties);
     }
 
     /**
      * @see PGProperty#BINARY_TRANSFER_DISABLE
      */
-    public void setBinaryTransferDisable(String oidList)
-    {
+    public void setBinaryTransferDisable(String oidList) {
         PGProperty.BINARY_TRANSFER_DISABLE.set(properties, oidList);
     }
 
     /**
      * @see PGProperty#BINARY_TRANSFER_DISABLE
      */
-    public String getBinaryTransferDisable()
-    {
+    public String getBinaryTransferDisable() {
         return PGProperty.BINARY_TRANSFER_DISABLE.get(properties);
     }
 
     /**
      * @see PGProperty#STRING_TYPE
      */
-    public String getStringType()
-    {
+    public String getStringType() {
         return PGProperty.STRING_TYPE.get(properties);
     }
 
     /**
      * @see PGProperty#STRING_TYPE
      */
-    public void setStringType(String stringType)
-    {
+    public void setStringType(String stringType) {
         PGProperty.STRING_TYPE.set(properties, stringType);
     }
 
     /**
      * @see PGProperty#DISABLE_COLUMN_SANITISER
      */
-    public boolean isColumnSanitiserDisabled()
-    {
+    public boolean isColumnSanitiserDisabled() {
         return PGProperty.DISABLE_COLUMN_SANITISER.getBoolean(properties);
     }
 
     /**
      * @see PGProperty#DISABLE_COLUMN_SANITISER
      */
-    public boolean getDisableColumnSanitiser()
-    {
+    public boolean getDisableColumnSanitiser() {
         return PGProperty.DISABLE_COLUMN_SANITISER.getBoolean(properties);
     }
 
     /**
      * @see PGProperty#DISABLE_COLUMN_SANITISER
      */
-    public void setDisableColumnSanitiser(boolean disableColumnSanitiser)
-    {
+    public void setDisableColumnSanitiser(boolean disableColumnSanitiser) {
         PGProperty.DISABLE_COLUMN_SANITISER.set(properties, disableColumnSanitiser);
     }
 
     /**
      * @see PGProperty#CURRENT_SCHEMA
      */
-    public String getCurrentSchema()
-    {
+    public String getCurrentSchema() {
         return PGProperty.CURRENT_SCHEMA.get(properties);
     }
 
     /**
      * @see PGProperty#CURRENT_SCHEMA
      */
-    public void setCurrentSchema(String currentSchema)
-    {
+    public void setCurrentSchema(String currentSchema) {
         PGProperty.CURRENT_SCHEMA.set(properties, currentSchema);
     }
 
     /**
      * @see PGProperty#READ_ONLY
      */
-    public boolean getReadOnly()
-    {
+    public boolean getReadOnly() {
         return PGProperty.READ_ONLY.getBoolean(properties);
     }
 
     /**
      * @see PGProperty#READ_ONLY
      */
-    public void setReadOnly(boolean readOnly)
-    {
+    public void setReadOnly(boolean readOnly) {
         PGProperty.READ_ONLY.set(properties, readOnly);
     }
 
     /**
      * @see PGProperty#LOG_UNCLOSED_CONNECTIONS
      */
-    public boolean getLogUnclosedConnections()
-    {
+    public boolean getLogUnclosedConnections() {
         return PGProperty.LOG_UNCLOSED_CONNECTIONS.getBoolean(properties);
     }
 
     /**
      * @see PGProperty#LOG_UNCLOSED_CONNECTIONS
      */
-    public void setLogUnclosedConnections(boolean enabled)
-    {
+    public void setLogUnclosedConnections(boolean enabled) {
         PGProperty.LOG_UNCLOSED_CONNECTIONS.set(properties, enabled);
     }
 
     /**
      * @see PGProperty#ASSUME_MIN_SERVER_VERSION
      */
-    public String getAssumeMinServerVersion()
-    {
+    public String getAssumeMinServerVersion() {
         return PGProperty.ASSUME_MIN_SERVER_VERSION.get(properties);
     }
 
     /**
      * @see PGProperty#ASSUME_MIN_SERVER_VERSION
      */
-    public void setAssumeMinServerVersion(String minVersion)
-    {
+    public void setAssumeMinServerVersion(String minVersion) {
         PGProperty.ASSUME_MIN_SERVER_VERSION.set(properties, minVersion);
     }
 
     /**
      * @see PGProperty#JAAS_APPLICATION_NAME
      */
-    public String getJaasApplicationName()
-    {
+    public String getJaasApplicationName() {
         return PGProperty.JAAS_APPLICATION_NAME.get(properties);
     }
 
     /**
      * @see PGProperty#JAAS_APPLICATION_NAME
      */
-    public void setJaasApplicationName(String name)
-    {
+    public void setJaasApplicationName(String name) {
         PGProperty.JAAS_APPLICATION_NAME.set(properties, name);
     }
 
     /**
      * @see PGProperty#KERBEROS_SERVER_NAME
      */
-    public String getKerberosServerName()
-    {
+    public String getKerberosServerName() {
         return PGProperty.KERBEROS_SERVER_NAME.get(properties);
     }
 
     /**
      * @see PGProperty#KERBEROS_SERVER_NAME
      */
-    public void setKerberosServerName(String serverName)
-    {
+    public void setKerberosServerName(String serverName) {
         PGProperty.KERBEROS_SERVER_NAME.set(properties, serverName);
     }
 
     /**
      * @see PGProperty#USE_SPNEGO
      */
-    public boolean getUseSpNego()
-    {
+    public boolean getUseSpNego() {
         return PGProperty.USE_SPNEGO.getBoolean(properties);
     }
 
     /**
      * @see PGProperty#USE_SPNEGO
      */
-    public void setUseSpNego(boolean use)
-    {
+    public void setUseSpNego(boolean use) {
         PGProperty.USE_SPNEGO.set(properties, use);
     }
 
     /**
      * @see PGProperty#GSS_LIB
      */
-    public String getGssLib()
-    {
+    public String getGssLib() {
         return PGProperty.GSS_LIB.get(properties);
     }
 
     /**
      * @see PGProperty#GSS_LIB
      */
-    public void setGssLib(String lib)
-    {
+    public void setGssLib(String lib) {
         PGProperty.GSS_LIB.set(properties, lib);
     }
 
     /**
      * @see PGProperty#SSPI_SERVICE_CLASS
      */
-    public String getSspiServiceClass()
-    {
+    public String getSspiServiceClass() {
         return PGProperty.SSPI_SERVICE_CLASS.get(properties);
     }
 
     /**
      * @see PGProperty#SSPI_SERVICE_CLASS
      */
-    public void setSspiServiceClass(String serviceClass)
-    {
+    public void setSspiServiceClass(String serviceClass) {
         PGProperty.SSPI_SERVICE_CLASS.set(properties, serviceClass);
     }
 
     /**
      * @see PGProperty#CHARSET
      */
-    public String getCharset()
-    {
+    public String getCharset() {
         return PGProperty.CHARSET.get(properties);
     }
 
     /**
      * @see PGProperty#CHARSET
      */
-    public void setCharset(String charset)
-    {
+    public void setCharset(String charset) {
         PGProperty.CHARSET.set(properties, charset);
     }
 
     /**
      * @see PGProperty#ALLOW_ENCODING_CHANGES
      */
-    public boolean getAllowEncodingChanges()
-    {
+    public boolean getAllowEncodingChanges() {
         return PGProperty.ALLOW_ENCODING_CHANGES.getBoolean(properties);
     }
 
     /**
      * @see PGProperty#ALLOW_ENCODING_CHANGES
      */
-    public void setAllowEncodingChanges(boolean allow)
-    {
+    public void setAllowEncodingChanges(boolean allow) {
         PGProperty.ALLOW_ENCODING_CHANGES.set(properties, allow);
     }
 
     /**
      * Generates a DriverManager URL from the other properties supplied.
      */
-    public String getUrl()
-    {
+    public String getUrl() {
         StringBuilder url = new StringBuilder(100);
         url.append("jdbc:postgresql://");
         url.append(serverName);
@@ -977,12 +855,9 @@ public abstract class BaseDataSource implements Referenceable
         url.append("/").append(databaseName);
 
         StringBuilder query = new StringBuilder(100);
-        for (PGProperty property: PGProperty.values())
-        {
-            if (property.isPresent(properties))
-            {
-                if (query.length() != 0)
-                {
+        for (PGProperty property : PGProperty.values()) {
+            if (property.isPresent(properties)) {
+                if (query.length() != 0) {
                     query.append("&");
                 }
                 query.append(property.getName());
@@ -991,8 +866,7 @@ public abstract class BaseDataSource implements Referenceable
             }
         }
 
-        if (query.length() > 0)
-        {
+        if (query.length() > 0) {
             url.append("?");
             url.append(query);
         }
@@ -1006,65 +880,50 @@ public abstract class BaseDataSource implements Referenceable
     public void setUrl(String url) {
 
         Properties p = org.postgresql.Driver.parseURL(url, null);
-        
-        for (PGProperty property: PGProperty.values())
-        {
+
+        for (PGProperty property : PGProperty.values()) {
             setProperty(property, property.get(p));
         }
     }
 
     public String getProperty(String name)
-      throws SQLException
-    {
+            throws SQLException {
         PGProperty pgProperty = PGProperty.forName(name);
-        if (pgProperty != null)
-        {
+        if (pgProperty != null) {
             return getProperty(pgProperty);
-        }
-        else
-        {
+        } else {
             throw new PSQLException(GT.tr("Unsupported property name: {0}", name),
-                                    PSQLState.INVALID_PARAMETER_VALUE);
+                    PSQLState.INVALID_PARAMETER_VALUE);
         }
     }
 
     public void setProperty(String name, String value)
-      throws SQLException
-    {
+            throws SQLException {
         PGProperty pgProperty = PGProperty.forName(name);
-        if (pgProperty != null)
-        {
+        if (pgProperty != null) {
             setProperty(pgProperty, value);
-        }
-        else
-        {
+        } else {
             throw new PSQLException(GT.tr("Unsupported property name: {0}", name),
-                                    PSQLState.INVALID_PARAMETER_VALUE);
+                    PSQLState.INVALID_PARAMETER_VALUE);
         }
     }
 
-    public String getProperty(PGProperty property)
-    {
+    public String getProperty(PGProperty property) {
         return property.get(properties);
     }
 
-    public void setProperty(PGProperty property, String value)
-    {
+    public void setProperty(PGProperty property, String value) {
         if (value == null) {
             return;
         }
-        switch(property)
-        {
+        switch (property) {
             case PG_HOST:
                 serverName = value;
                 break;
             case PG_PORT:
-                try
-                {
+                try {
                     portNumber = Integer.parseInt(value);
-                }
-                catch (NumberFormatException e)
-                {
+                } catch (NumberFormatException e) {
                     portNumber = 0;
                 }
                 break;
@@ -1087,33 +946,27 @@ public abstract class BaseDataSource implements Referenceable
      */
     protected Reference createReference() {
         return new Reference(
-                   getClass().getName(),
-                   PGObjectFactory.class.getName(),
-                   null);
+                getClass().getName(),
+                PGObjectFactory.class.getName(),
+                null);
     }
 
-    public Reference getReference() throws NamingException
-    {
+    public Reference getReference() throws NamingException {
         Reference ref = createReference();
         ref.add(new StringRefAddr("serverName", serverName));
-        if (portNumber != 0)
-        {
+        if (portNumber != 0) {
             ref.add(new StringRefAddr("portNumber", Integer.toString(portNumber)));
         }
         ref.add(new StringRefAddr("databaseName", databaseName));
-        if (user != null)
-        {
+        if (user != null) {
             ref.add(new StringRefAddr("user", user));
         }
-        if (password != null)
-        {
+        if (password != null) {
             ref.add(new StringRefAddr("password", password));
         }
 
-        for (PGProperty property: PGProperty.values())
-        {
-            if (property.isPresent(properties))
-            {
+        for (PGProperty property : PGProperty.values()) {
+            if (property.isPresent(properties)) {
                 ref.add(new StringRefAddr(property.getName(), property.get(properties)));
             }
         }
@@ -1121,36 +974,30 @@ public abstract class BaseDataSource implements Referenceable
         return ref;
     }
 
-    public void setFromReference(Reference ref)
-    {
+    public void setFromReference(Reference ref) {
         databaseName = getReferenceProperty(ref, "databaseName");
         String port = getReferenceProperty(ref, "portNumber");
-        if (port != null)
-        {
+        if (port != null) {
             portNumber = Integer.parseInt(port);
         }
         serverName = getReferenceProperty(ref, "serverName");
         user = getReferenceProperty(ref, "user");
         password = getReferenceProperty(ref, "password");
 
-        for (PGProperty property: PGProperty.values())
-        {
+        for (PGProperty property : PGProperty.values()) {
             property.set(properties, getReferenceProperty(ref, property.getName()));
         }
     }
 
-    private String getReferenceProperty(Reference ref, String propertyName)
-    {
+    private String getReferenceProperty(Reference ref, String propertyName) {
         RefAddr addr = ref.get(propertyName);
-        if (addr == null)
-        {
+        if (addr == null) {
             return null;
         }
-        return (String)addr.getContent();
+        return (String) addr.getContent();
     }
 
-    protected void writeBaseObject(ObjectOutputStream out) throws IOException
-    {
+    protected void writeBaseObject(ObjectOutputStream out) throws IOException {
         out.writeObject(serverName);
         out.writeObject(databaseName);
         out.writeObject(user);
@@ -1160,15 +1007,14 @@ public abstract class BaseDataSource implements Referenceable
         out.writeObject(properties);
     }
 
-    protected void readBaseObject(ObjectInputStream in) throws IOException, ClassNotFoundException
-    {
-        serverName = (String)in.readObject();
-        databaseName = (String)in.readObject();
-        user = (String)in.readObject();
-        password = (String)in.readObject();
+    protected void readBaseObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+        serverName = (String) in.readObject();
+        databaseName = (String) in.readObject();
+        user = (String) in.readObject();
+        password = (String) in.readObject();
         portNumber = in.readInt();
 
-        properties = (Properties)in.readObject();
+        properties = (Properties) in.readObject();
     }
 
     public void initializeFrom(BaseDataSource source) throws IOException, ClassNotFoundException {
@@ -1181,8 +1027,7 @@ public abstract class BaseDataSource implements Referenceable
         readBaseObject(ois);
     }
 
-    public void setLoglevel(int logLevel)
-    {
+    public void setLoglevel(int logLevel) {
         PGProperty.LOG_LEVEL.set(properties, logLevel);
     }
 

--- a/org/postgresql/ds/common/PGObjectFactory.java
+++ b/org/postgresql/ds/common/PGObjectFactory.java
@@ -7,11 +7,14 @@
 */
 package org.postgresql.ds.common;
 
-import javax.naming.*;
+import org.postgresql.ds.*;
+
+import javax.naming.Context;
+import javax.naming.Name;
+import javax.naming.RefAddr;
+import javax.naming.Reference;
 import javax.naming.spi.ObjectFactory;
 import java.util.Hashtable;
-
-import org.postgresql.ds.*;
 
 /**
  * Returns a DataSource-ish thing based on a JNDI reference.  In the case of a
@@ -23,48 +26,37 @@ import org.postgresql.ds.*;
  *
  * @author Aaron Mulder (ammulder@chariotsolutions.com)
  */
-public class PGObjectFactory implements ObjectFactory
-{
+public class PGObjectFactory implements ObjectFactory {
     /**
      * Dereferences a PostgreSQL DataSource.  Other types of references are
      * ignored.
      */
     public Object getObjectInstance(Object obj, Name name, Context nameCtx,
-                                    Hashtable environment) throws Exception
-    {
-        Reference ref = (Reference)obj;
+                                    Hashtable environment) throws Exception {
+        Reference ref = (Reference) obj;
         String className = ref.getClassName();
         if (className.equals("org.postgresql.ds.PGSimpleDataSource")
                 || className.equals("org.postgresql.jdbc2.optional.SimpleDataSource")
-                || className.equals("org.postgresql.jdbc3.Jdbc3SimpleDataSource"))
-        {
+                || className.equals("org.postgresql.jdbc3.Jdbc3SimpleDataSource")) {
             return loadSimpleDataSource(ref);
-        }
-        else if (className.equals("org.postgresql.ds.PGConnectionPoolDataSource")
-                 || className.equals("org.postgresql.jdbc2.optional.ConnectionPool")
-                 || className.equals("org.postgresql.jdbc3.Jdbc3ConnectionPool"))
-        {
+        } else if (className.equals("org.postgresql.ds.PGConnectionPoolDataSource")
+                || className.equals("org.postgresql.jdbc2.optional.ConnectionPool")
+                || className.equals("org.postgresql.jdbc3.Jdbc3ConnectionPool")) {
             return loadConnectionPool(ref);
-        }
-        else if (className.equals("org.postgresql.ds.PGPoolingDataSource")
-                 || className.equals("org.postgresql.jdbc2.optional.PoolingDataSource")
-                 || className.equals("org.postgresql.jdbc3.Jdbc3PoolingDataSource"))
-        {
+        } else if (className.equals("org.postgresql.ds.PGPoolingDataSource")
+                || className.equals("org.postgresql.jdbc2.optional.PoolingDataSource")
+                || className.equals("org.postgresql.jdbc3.Jdbc3PoolingDataSource")) {
             return loadPoolingDataSource(ref);
-        }
-        else
-        {
+        } else {
             return null;
         }
     }
 
-    private Object loadPoolingDataSource(Reference ref)
-    {
+    private Object loadPoolingDataSource(Reference ref) {
         // If DataSource exists, return it
         String name = getProperty(ref, "dataSourceName");
         PGPoolingDataSource pds = PGPoolingDataSource.getDataSource(name);
-        if (pds != null)
-        {
+        if (pds != null) {
             return pds;
         }
         // Otherwise, create a new one
@@ -72,45 +64,38 @@ public class PGObjectFactory implements ObjectFactory
         pds.setDataSourceName(name);
         loadBaseDataSource(pds, ref);
         String min = getProperty(ref, "initialConnections");
-        if (min != null)
-        {
+        if (min != null) {
             pds.setInitialConnections(Integer.parseInt(min));
         }
         String max = getProperty(ref, "maxConnections");
-        if (max != null)
-        {
+        if (max != null) {
             pds.setMaxConnections(Integer.parseInt(max));
         }
         return pds;
     }
 
-    private Object loadSimpleDataSource(Reference ref)
-    {
+    private Object loadSimpleDataSource(Reference ref) {
         PGSimpleDataSource ds = new PGSimpleDataSource();
         return loadBaseDataSource(ds, ref);
     }
 
-    private Object loadConnectionPool(Reference ref)
-    {
+    private Object loadConnectionPool(Reference ref) {
         PGConnectionPoolDataSource cp = new PGConnectionPoolDataSource();
         return loadBaseDataSource(cp, ref);
     }
 
-    protected Object loadBaseDataSource(BaseDataSource ds, Reference ref)
-    {
+    protected Object loadBaseDataSource(BaseDataSource ds, Reference ref) {
         ds.setFromReference(ref);
 
         return ds;
     }
 
-    protected String getProperty(Reference ref, String s)
-    {
+    protected String getProperty(Reference ref, String s) {
         RefAddr addr = ref.get(s);
-        if (addr == null)
-        {
+        if (addr == null) {
             return null;
         }
-        return (String)addr.getContent();
+        return (String) addr.getContent();
     }
 
 }

--- a/org/postgresql/ds/jdbc23/AbstractJdbc23ConnectionPoolDataSource.java
+++ b/org/postgresql/ds/jdbc23/AbstractJdbc23ConnectionPoolDataSource.java
@@ -7,15 +7,15 @@
 */
 package org.postgresql.ds.jdbc23;
 
-import javax.sql.PooledConnection;
-import java.sql.SQLException;
-import java.io.Serializable;
-import java.io.ObjectOutputStream;
-import java.io.ObjectInputStream;
-import java.io.IOException;
-
-import org.postgresql.ds.common.*;
 import org.postgresql.ds.PGPooledConnection;
+import org.postgresql.ds.common.BaseDataSource;
+
+import javax.sql.PooledConnection;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.sql.SQLException;
 
 /**
  * PostgreSQL implementation of ConnectionPoolDataSource.  The app server or
@@ -34,15 +34,13 @@ import org.postgresql.ds.PGPooledConnection;
  *
  * @author Aaron Mulder (ammulder@chariotsolutions.com)
  */
-public class AbstractJdbc23ConnectionPoolDataSource extends BaseDataSource implements Serializable
-{
+public class AbstractJdbc23ConnectionPoolDataSource extends BaseDataSource implements Serializable {
     private boolean defaultAutoCommit = true;
 
     /**
      * Gets a description of this DataSource.
      */
-    public String getDescription()
-    {
+    public String getDescription() {
         return "ConnectionPoolDataSource from " + org.postgresql.Driver.getVersion();
     }
 
@@ -50,11 +48,9 @@ public class AbstractJdbc23ConnectionPoolDataSource extends BaseDataSource imple
      * Gets a connection which may be pooled by the app server or middleware
      * implementation of DataSource.
      *
-     * @throws java.sql.SQLException
-     *     Occurs when the physical database connection cannot be established.
+     * @throws java.sql.SQLException Occurs when the physical database connection cannot be established.
      */
-    public PooledConnection getPooledConnection() throws SQLException
-    {
+    public PooledConnection getPooledConnection() throws SQLException {
         return new PGPooledConnection(getConnection(), defaultAutoCommit);
     }
 
@@ -62,11 +58,11 @@ public class AbstractJdbc23ConnectionPoolDataSource extends BaseDataSource imple
      * Gets a connection which may be pooled by the app server or middleware
      * implementation of DataSource.
      *
-     * @throws java.sql.SQLException
-     *     Occurs when the physical database connection cannot be established.
+     * @param user
+     * @param password
+     * @throws java.sql.SQLException Occurs when the physical database connection cannot be established.
      */
-    public PooledConnection getPooledConnection(String user, String password) throws SQLException
-    {
+    public PooledConnection getPooledConnection(String user, String password) throws SQLException {
         return new PGPooledConnection(getConnection(user, password), defaultAutoCommit);
     }
 
@@ -75,8 +71,7 @@ public class AbstractJdbc23ConnectionPoolDataSource extends BaseDataSource imple
      * turned on by default.  The default value is <tt>false</tt>, so that
      * autoCommit will be turned off by default.
      */
-    public boolean isDefaultAutoCommit()
-    {
+    public boolean isDefaultAutoCommit() {
         return defaultAutoCommit;
     }
 
@@ -84,22 +79,20 @@ public class AbstractJdbc23ConnectionPoolDataSource extends BaseDataSource imple
      * Sets whether connections supplied by this pool will have autoCommit
      * turned on by default.  The default value is <tt>false</tt>, so that
      * autoCommit will be turned off by default.
+     *
+     * @param defaultAutoCommit
      */
-    public void setDefaultAutoCommit(boolean defaultAutoCommit)
-    {
+    public void setDefaultAutoCommit(boolean defaultAutoCommit) {
         this.defaultAutoCommit = defaultAutoCommit;
     }
 
-    private void writeObject(ObjectOutputStream out) throws IOException
-    {
+    private void writeObject(ObjectOutputStream out) throws IOException {
         writeBaseObject(out);
         out.writeBoolean(defaultAutoCommit);
     }
 
-    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException
-    {
+    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
         readBaseObject(in);
         defaultAutoCommit = in.readBoolean();
     }
-
 }

--- a/org/postgresql/ds/jdbc23/AbstractJdbc23PooledConnection.java
+++ b/org/postgresql/ds/jdbc23/AbstractJdbc23PooledConnection.java
@@ -7,26 +7,35 @@
 */
 package org.postgresql.ds.jdbc23;
 
-import javax.sql.*;
-import java.sql.*;
-import java.util.*;
-import java.lang.reflect.*;
 import org.postgresql.PGConnection;
 import org.postgresql.util.GT;
 import org.postgresql.util.PSQLException;
 import org.postgresql.util.PSQLState;
 
+import javax.sql.ConnectionEvent;
+import javax.sql.ConnectionEventListener;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.sql.CallableStatement;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.LinkedList;
+import java.util.List;
+
 /**
  * PostgreSQL implementation of the PooledConnection interface.  This shouldn't
  * be used directly, as the pooling client should just interact with the
  * ConnectionPool instead.
- * @see org.postgresql.ds.PGConnectionPoolDataSource
  *
  * @author Aaron Mulder (ammulder@chariotsolutions.com)
  * @author Csaba Nagy (ncsaba@yahoo.com)
+ * @see org.postgresql.ds.PGConnectionPoolDataSource
  */
-public abstract class AbstractJdbc23PooledConnection
-{
+public abstract class AbstractJdbc23PooledConnection {
     private final List<ConnectionEventListener> listeners = new LinkedList<ConnectionEventListener>();
     private Connection con;
     private ConnectionHandler last;
@@ -36,9 +45,12 @@ public abstract class AbstractJdbc23PooledConnection
     /**
      * Creates a new PooledConnection representing the specified physical
      * connection.
+     *
+     * @param con
+     * @param autoCommit
+     * @param isXA
      */
-    public AbstractJdbc23PooledConnection(Connection con, boolean autoCommit, boolean isXA)
-    {
+    public AbstractJdbc23PooledConnection(Connection con, boolean autoCommit, boolean isXA) {
         this.con = con;
         this.autoCommit = autoCommit;
         this.isXA = isXA;
@@ -47,18 +59,20 @@ public abstract class AbstractJdbc23PooledConnection
     /**
      * Adds a listener for close or fatal error events on the connection
      * handed out to a client.
+     *
+     * @param connectionEventListener
      */
-    public void addConnectionEventListener(ConnectionEventListener connectionEventListener)
-    {
+    public void addConnectionEventListener(ConnectionEventListener connectionEventListener) {
         listeners.add(connectionEventListener);
     }
 
     /**
      * Removes a listener for close or fatal error events on the connection
      * handed out to a client.
+     *
+     * @param connectionEventListener
      */
-    public void removeConnectionEventListener(ConnectionEventListener connectionEventListener)
-    {
+    public void removeConnectionEventListener(ConnectionEventListener connectionEventListener) {
         listeners.remove(connectionEventListener);
     }
 
@@ -66,32 +80,24 @@ public abstract class AbstractJdbc23PooledConnection
      * Closes the physical database connection represented by this
      * PooledConnection.  If any client has a connection based on
      * this PooledConnection, it is forcibly closed as well.
+     *
+     * @throws SQLException
      */
-    public void close() throws SQLException
-    {
-        if (last != null)
-        {
+    public void close() throws SQLException {
+        if (last != null) {
             last.close();
-            if (!con.isClosed())
-            {
-                if (!con.getAutoCommit())
-                {
-                    try
-                    {
+            if (!con.isClosed()) {
+                if (!con.getAutoCommit()) {
+                    try {
                         con.rollback();
-                    }
-                    catch (SQLException ignored)
-                    {
+                    } catch (SQLException ignored) {
                     }
                 }
             }
         }
-        try
-        {
+        try {
             con.close();
-        }
-        finally
-        {
+        } finally {
             con = null;
         }
     }
@@ -100,40 +106,34 @@ public abstract class AbstractJdbc23PooledConnection
      * Gets a handle for a client to use.  This is a wrapper around the
      * physical connection, so the client can call close and it will just
      * return the connection to the pool without really closing the
-     * pgysical connection.
-     *
+     * physical connection.
+     * <p>
      * <p>According to the JDBC 2.0 Optional Package spec (6.2.3), only one
      * client may have an active handle to the connection at a time, so if
      * there is a previous handle active when this is called, the previous
      * one is forcibly closed and its work rolled back.</p>
+     *
+     * @throws SQLException
      */
-    public Connection getConnection() throws SQLException
-    {
-        if (con == null)
-        {
+    public Connection getConnection() throws SQLException {
+        if (con == null) {
             // Before throwing the exception, let's notify the registered listeners about the error
             PSQLException sqlException = new PSQLException(GT.tr("This PooledConnection has already been closed."),
-                                                           PSQLState.CONNECTION_DOES_NOT_EXIST);
+                    PSQLState.CONNECTION_DOES_NOT_EXIST);
             fireConnectionFatalError(sqlException);
             throw sqlException;
         }
-        // If any error occures while opening a new connection, the listeners
+        // If any error occurs while opening a new connection, the listeners
         // have to be notified. This gives a chance to connection pools to
         // eliminate bad pooled connections.
-        try
-        {
+        try {
             // Only one connection can be open at a time from this PooledConnection.  See JDBC 2.0 Optional Package spec section 6.2.3
-            if (last != null)
-            {
+            if (last != null) {
                 last.close();
-                if (!con.getAutoCommit())
-                {
-                    try
-                    {
+                if (!con.getAutoCommit()) {
+                    try {
                         con.rollback();
-                    }
-                    catch (SQLException ignored)
-                    {
+                    } catch (SQLException ignored) {
                     }
                 }
                 con.clearWarnings();
@@ -143,18 +143,17 @@ public abstract class AbstractJdbc23PooledConnection
              * because it depends on whether an XA-transaction is open
              * or not
              */
-            if (!isXA)
+            if (!isXA) {
                 con.setAutoCommit(autoCommit);
-        }
-        catch (SQLException sqlException)
-        {
+            }
+        } catch (SQLException sqlException) {
             fireConnectionFatalError(sqlException);
-            throw (SQLException)sqlException.fillInStackTrace();
+            throw (SQLException) sqlException.fillInStackTrace();
         }
         ConnectionHandler handler = new ConnectionHandler(con);
         last = handler;
 
-        Connection proxyCon = (Connection)Proxy.newProxyInstance(getClass().getClassLoader(), new Class[]{Connection.class, PGConnection.class}, handler);
+        Connection proxyCon = (Connection) Proxy.newProxyInstance(getClass().getClassLoader(), new Class[]{Connection.class, PGConnection.class}, handler);
         last.setProxy(proxyCon);
         return proxyCon;
     }
@@ -162,8 +161,7 @@ public abstract class AbstractJdbc23PooledConnection
     /**
      * Used to fire a connection closed event to all listeners.
      */
-    void fireConnectionClosed()
-    {
+    void fireConnectionClosed() {
         ConnectionEvent evt = null;
         // Copy the listener list so the listener can remove itself during this method call
         ConnectionEventListener[] local = listeners.toArray(new ConnectionEventListener[listeners.size()]);
@@ -178,8 +176,7 @@ public abstract class AbstractJdbc23PooledConnection
     /**
      * Used to fire a connection error event to all listeners.
      */
-    void fireConnectionFatalError(SQLException e)
-    {
+    void fireConnectionFatalError(SQLException e) {
         ConnectionEvent evt = null;
         // Copy the listener list so the listener can remove itself during this method call
         ConnectionEventListener[] local = listeners.toArray(new ConnectionEventListener[listeners.size()]);
@@ -195,30 +192,34 @@ public abstract class AbstractJdbc23PooledConnection
 
     // Classes we consider fatal.
     private static String[] fatalClasses = {
-        "08",  // connection error
-        "53",  // insufficient resources
+            "08",  // connection error
+            "53",  // insufficient resources
 
-        // nb: not just "57" as that includes query cancel which is nonfatal
-        "57P01",  // admin shutdown
-        "57P02",  // crash shutdown
-        "57P03",  // cannot connect now
+            // nb: not just "57" as that includes query cancel which is nonfatal
+            "57P01",  // admin shutdown
+            "57P02",  // crash shutdown
+            "57P03",  // cannot connect now
 
-        "58",  // system error (backend)
-        "60",  // system error (driver)
-        "99",  // unexpected error
-        "F0",  // configuration file error (backend)
-        "XX",  // internal error (backend)
+            "58",  // system error (backend)
+            "60",  // system error (driver)
+            "99",  // unexpected error
+            "F0",  // configuration file error (backend)
+            "XX",  // internal error (backend)
     };
 
     private static boolean isFatalState(String state) {
-        if (state == null)      // no info, assume fatal
+        if (state == null) { // no info, assume fatal
             return true;
-        if (state.length() < 2) // no class info, assume fatal
+        }
+        if (state.length() < 2) { // no class info, assume fatal
             return true;
+        }
 
-        for (String fatalClass : fatalClasses)
-            if (state.startsWith(fatalClass))
+        for (String fatalClass : fatalClasses) {
+            if (state.startsWith(fatalClass)) {
                 return true; // fatal
+            }
+        }
 
         return false;
     }
@@ -228,11 +229,11 @@ public abstract class AbstractJdbc23PooledConnection
      * think the exception is fatal.
      *
      * @param e the SQLException to consider
-     */    
-    private void fireConnectionError(SQLException e) 
-    {
-        if (!isFatalState(e.getSQLState()))
+     */
+    private void fireConnectionError(SQLException e) {
+        if (!isFatalState(e.getSQLState())) {
             return;
+        }
 
         fireConnectionFatalError(e);
     }
@@ -244,69 +245,53 @@ public abstract class AbstractJdbc23PooledConnection
      * requires JDK 1.3 or higher, though JDK 1.2 could be supported with a
      * 3rd-party proxy package.
      */
-    private class ConnectionHandler implements InvocationHandler
-    {
+    private class ConnectionHandler implements InvocationHandler {
         private Connection con;
         private Connection proxy; // the Connection the client is currently using, which is a proxy
         private boolean automatic = false;
 
-        public ConnectionHandler(Connection con)
-        {
+        public ConnectionHandler(Connection con) {
             this.con = con;
         }
 
         public Object invoke(Object proxy, Method method, Object[] args)
-        throws Throwable
-        {
+                throws Throwable {
             final String methodName = method.getName();
             // From Object
-            if (method.getDeclaringClass().getName().equals("java.lang.Object"))
-            {
-                if (methodName.equals("toString"))
-                {
+            if (method.getDeclaringClass().getName().equals("java.lang.Object")) {
+                if (methodName.equals("toString")) {
                     return "Pooled connection wrapping physical connection " + con;
                 }
-                if (methodName.equals("equals"))
-                {
+                if (methodName.equals("equals")) {
                     return proxy == args[0];
                 }
-                if (methodName.equals("hashCode"))
-                {
+                if (methodName.equals("hashCode")) {
                     return System.identityHashCode(proxy);
                 }
-                try
-                {
+                try {
                     return method.invoke(con, args);
-                }
-                catch (InvocationTargetException e)
-                {
+                } catch (InvocationTargetException e) {
                     throw e.getTargetException();
                 }
             }
 
             // All the rest is from the Connection or PGConnection interface
-            if (methodName.equals("isClosed"))
-            {
+            if (methodName.equals("isClosed")) {
                 return con == null || con.isClosed();
             }
-            if (methodName.equals("close"))
-            {
+            if (methodName.equals("close")) {
                 // we are already closed and a double close
                 // is not an error.
-                if (con == null)
+                if (con == null) {
                     return null;
+                }
 
                 SQLException ex = null;
-                if (!con.isClosed())
-                {
-                    if (!isXA && !con.getAutoCommit())
-                    {
-                        try
-                        {
+                if (!con.isClosed()) {
+                    if (!isXA && !con.getAutoCommit()) {
+                        try {
                             con.rollback();
-                        }
-                        catch (SQLException e)
-                        {
+                        } catch (SQLException e) {
                             ex = e;
                         }
                     }
@@ -316,14 +301,12 @@ public abstract class AbstractJdbc23PooledConnection
                 this.proxy = null;
                 last = null;
                 fireConnectionClosed();
-                if (ex != null)
-                {
+                if (ex != null) {
                     throw ex;
                 }
                 return null;
             }
-            if (con == null || con.isClosed())
-            {
+            if (con == null || con.isClosed()) {
                 throw new PSQLException(automatic ? GT.tr("Connection has been closed automatically because a new connection was opened for the same PooledConnection or the PooledConnection has been closed.") : GT.tr("Connection has been closed."),
                         PSQLState.CONNECTION_DOES_NOT_EXIST);
             }
@@ -331,29 +314,23 @@ public abstract class AbstractJdbc23PooledConnection
             // From here on in, we invoke via reflection, catch exceptions,
             // and check if they're fatal before rethrowing.
             try {
-                if (methodName.equals("createStatement"))
-                {
-                    Statement st = (Statement)method.invoke(con, args);
+                if (methodName.equals("createStatement")) {
+                    Statement st = (Statement) method.invoke(con, args);
                     return Proxy.newProxyInstance(getClass().getClassLoader(), new Class[]{Statement.class, org.postgresql.PGStatement.class}, new StatementHandler(this, st));
-                }
-                else if (methodName.equals("prepareCall"))
-                {
-                    Statement st = (Statement)method.invoke(con, args);
+                } else if (methodName.equals("prepareCall")) {
+                    Statement st = (Statement) method.invoke(con, args);
                     return Proxy.newProxyInstance(getClass().getClassLoader(), new Class[]{CallableStatement.class, org.postgresql.PGStatement.class}, new StatementHandler(this, st));
-                }
-                else if (methodName.equals("prepareStatement"))
-                {
-                    Statement st = (Statement)method.invoke(con, args);
+                } else if (methodName.equals("prepareStatement")) {
+                    Statement st = (Statement) method.invoke(con, args);
                     return Proxy.newProxyInstance(getClass().getClassLoader(), new Class[]{PreparedStatement.class, org.postgresql.PGStatement.class}, new StatementHandler(this, st));
-                }
-                else
-                {
+                } else {
                     return method.invoke(con, args);
                 }
             } catch (final InvocationTargetException ite) {
                 final Throwable te = ite.getTargetException();
-                if (te instanceof SQLException)
+                if (te instanceof SQLException) {
                     fireConnectionError((SQLException) te); // Tell listeners about exception if it's fatal
+                }
                 throw te;
             }
         }
@@ -366,10 +343,8 @@ public abstract class AbstractJdbc23PooledConnection
             this.proxy = proxy;
         }
 
-        public void close()
-        {
-            if (con != null)
-            {
+        public void close() {
+            if (con != null) {
                 automatic = true;
             }
             con = null;
@@ -388,7 +363,7 @@ public abstract class AbstractJdbc23PooledConnection
      * use a dynamic proxy to handle all calls through the Statement
      * interfaces. This is the part that requires JDK 1.3 or higher, though
      * JDK 1.2 could be supported with a 3rd-party proxy package.
-     *
+     * <p>
      * The StatementHandler is required in order to return the proper
      * Connection proxy for the getConnection method.
      */
@@ -400,61 +375,54 @@ public abstract class AbstractJdbc23PooledConnection
             this.con = con;
             this.st = st;
         }
+
         public Object invoke(Object proxy, Method method, Object[] args)
-        throws Throwable
-        {
+                throws Throwable {
             final String methodName = method.getName();
             // From Object
-            if (method.getDeclaringClass().getName().equals("java.lang.Object"))
-            {
-                if (methodName.equals("toString"))
-                {
+            if (method.getDeclaringClass().getName().equals("java.lang.Object")) {
+                if (methodName.equals("toString")) {
                     return "Pooled statement wrapping physical statement " + st;
                 }
-                if (methodName.equals("hashCode"))
-                {
+                if (methodName.equals("hashCode")) {
                     return System.identityHashCode(proxy);
                 }
-                if (methodName.equals("equals"))
-                {
+                if (methodName.equals("equals")) {
                     return proxy == args[0];
                 }
                 return method.invoke(st, args);
             }
 
             // All the rest is from the Statement interface
-            if (methodName.equals("isClosed"))
-            {
+            if (methodName.equals("isClosed")) {
                 return st == null || st.isClosed();
             }
-            if (methodName.equals("close"))
-            {
-                if (st == null || st.isClosed())
+            if (methodName.equals("close")) {
+                if (st == null || st.isClosed()) {
                     return null;
+                }
                 con = null;
                 final Statement oldSt = st;
                 st = null;
                 oldSt.close();
                 return null;
             }
-            if (st == null || st.isClosed())
-            {
+            if (st == null || st.isClosed()) {
                 throw new PSQLException(GT.tr("Statement has been closed."),
                         PSQLState.OBJECT_NOT_IN_STATE);
             }
-            if (methodName.equals("getConnection"))
-            {
+            if (methodName.equals("getConnection")) {
                 return con.getProxy(); // the proxied connection, not a physical connection
             }
 
             // Delegate the call to the proxied Statement.
-            try
-            {
+            try {
                 return method.invoke(st, args);
             } catch (final InvocationTargetException ite) {
                 final Throwable te = ite.getTargetException();
-                if (te instanceof SQLException)
+                if (te instanceof SQLException) {
                     fireConnectionError((SQLException) te); // Tell listeners about exception if it's fatal
+                }
                 throw te;
             }
         }

--- a/org/postgresql/ds/jdbc23/AbstractJdbc23SimpleDataSource.java
+++ b/org/postgresql/ds/jdbc23/AbstractJdbc23SimpleDataSource.java
@@ -7,12 +7,12 @@
 */
 package org.postgresql.ds.jdbc23;
 
-import java.io.Serializable;
-import java.io.ObjectOutputStream;
-import java.io.ObjectInputStream;
-import java.io.IOException;
+import org.postgresql.ds.common.BaseDataSource;
 
-import org.postgresql.ds.common.*;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
 
 /**
  * Simple DataSource which does not perform connection pooling.  In order to use
@@ -22,23 +22,19 @@ import org.postgresql.ds.common.*;
  *
  * @author Aaron Mulder (ammulder@chariotsolutions.com)
  */
-public abstract class AbstractJdbc23SimpleDataSource extends BaseDataSource implements Serializable
-{
+public abstract class AbstractJdbc23SimpleDataSource extends BaseDataSource implements Serializable {
     /**
      * Gets a description of this DataSource.
      */
-    public String getDescription()
-    {
+    public String getDescription() {
         return "Non-Pooling DataSource from " + org.postgresql.Driver.getVersion();
     }
 
-    private void writeObject(ObjectOutputStream out) throws IOException
-    {
+    private void writeObject(ObjectOutputStream out) throws IOException {
         writeBaseObject(out);
     }
 
-    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException
-    {
+    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
         readBaseObject(in);
     }
 }

--- a/org/postgresql/ds/jdbc4/AbstractJdbc4ConnectionPoolDataSource.java
+++ b/org/postgresql/ds/jdbc4/AbstractJdbc4ConnectionPoolDataSource.java
@@ -1,15 +1,13 @@
 package org.postgresql.ds.jdbc4;
 
-import java.sql.SQLFeatureNotSupportedException;
-
 import org.postgresql.ds.jdbc23.AbstractJdbc23ConnectionPoolDataSource;
 
-public class AbstractJdbc4ConnectionPoolDataSource
-	extends AbstractJdbc23ConnectionPoolDataSource
-{
+import java.sql.SQLFeatureNotSupportedException;
 
-    public java.util.logging.Logger getParentLogger() throws java.sql.SQLFeatureNotSupportedException
-    {
+public class AbstractJdbc4ConnectionPoolDataSource
+        extends AbstractJdbc23ConnectionPoolDataSource {
+
+    public java.util.logging.Logger getParentLogger() throws SQLFeatureNotSupportedException {
         throw org.postgresql.Driver.notImplemented(this.getClass(), "getParentLogger()");
     }
 

--- a/org/postgresql/ds/jdbc4/AbstractJdbc4PooledConnection.java
+++ b/org/postgresql/ds/jdbc4/AbstractJdbc4PooledConnection.java
@@ -7,30 +7,25 @@
 */
 package org.postgresql.ds.jdbc4;
 
-import java.sql.Connection;
-import java.sql.SQLFeatureNotSupportedException;
-import javax.sql.StatementEventListener;
-
 import org.postgresql.ds.jdbc23.AbstractJdbc23PooledConnection;
 
-public abstract class AbstractJdbc4PooledConnection extends AbstractJdbc23PooledConnection
-{
+import javax.sql.StatementEventListener;
+import java.sql.Connection;
+import java.sql.SQLFeatureNotSupportedException;
 
-    public AbstractJdbc4PooledConnection(Connection con, boolean autoCommit, boolean isXA)
-    {
+public abstract class AbstractJdbc4PooledConnection extends AbstractJdbc23PooledConnection {
+
+    public AbstractJdbc4PooledConnection(Connection con, boolean autoCommit, boolean isXA) {
         super(con, autoCommit, isXA);
     }
 
-    public void removeStatementEventListener(StatementEventListener listener)
-    {
+    public void removeStatementEventListener(StatementEventListener listener) {
     }
 
-    public void addStatementEventListener(StatementEventListener listener)
-    {
+    public void addStatementEventListener(StatementEventListener listener) {
     }
 
-    public java.util.logging.Logger getParentLogger() throws SQLFeatureNotSupportedException
-    {
+    public java.util.logging.Logger getParentLogger() throws SQLFeatureNotSupportedException {
         throw org.postgresql.Driver.notImplemented(this.getClass(), "getParentLogger()");
     }
 

--- a/org/postgresql/ds/jdbc4/AbstractJdbc4PoolingDataSource.java
+++ b/org/postgresql/ds/jdbc4/AbstractJdbc4PoolingDataSource.java
@@ -7,30 +7,25 @@
 */
 package org.postgresql.ds.jdbc4;
 
+import org.postgresql.ds.jdbc23.AbstractJdbc23PoolingDataSource;
+
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 
-import org.postgresql.ds.jdbc23.AbstractJdbc23PoolingDataSource;
+public abstract class AbstractJdbc4PoolingDataSource extends AbstractJdbc23PoolingDataSource {
 
-public abstract class AbstractJdbc4PoolingDataSource extends AbstractJdbc23PoolingDataSource 
-{
-
-    public boolean isWrapperFor(Class<?> iface) throws SQLException
-    {
+    public boolean isWrapperFor(Class<?> iface) throws SQLException {
         return iface.isAssignableFrom(getClass());
     }
 
-    public <T> T unwrap(Class<T> iface) throws SQLException
-    {
-        if (iface.isAssignableFrom(getClass()))
-        {
+    public <T> T unwrap(Class<T> iface) throws SQLException {
+        if (iface.isAssignableFrom(getClass())) {
             return iface.cast(this);
         }
         throw new SQLException("Cannot unwrap to " + iface.getName());
     }
 
-    public java.util.logging.Logger getParentLogger() throws SQLFeatureNotSupportedException
-    {
+    public java.util.logging.Logger getParentLogger() throws SQLFeatureNotSupportedException {
         throw org.postgresql.Driver.notImplemented(this.getClass(), "getParentLogger()");
     }
 

--- a/org/postgresql/ds/jdbc4/AbstractJdbc4SimpleDataSource.java
+++ b/org/postgresql/ds/jdbc4/AbstractJdbc4SimpleDataSource.java
@@ -7,30 +7,24 @@
 */
 package org.postgresql.ds.jdbc4;
 
+import org.postgresql.ds.jdbc23.AbstractJdbc23SimpleDataSource;
+
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 
-import org.postgresql.ds.jdbc23.AbstractJdbc23SimpleDataSource;
-
-public abstract class AbstractJdbc4SimpleDataSource extends AbstractJdbc23SimpleDataSource
-{
-    public boolean isWrapperFor(Class<?> iface) throws SQLException
-    {
+public abstract class AbstractJdbc4SimpleDataSource extends AbstractJdbc23SimpleDataSource {
+    public boolean isWrapperFor(Class<?> iface) throws SQLException {
         return iface.isAssignableFrom(getClass());
     }
 
-    public <T> T unwrap(Class<T> iface) throws SQLException
-    {
-        if (iface.isAssignableFrom(getClass()))
-        {
+    public <T> T unwrap(Class<T> iface) throws SQLException {
+        if (iface.isAssignableFrom(getClass())) {
             return iface.cast(this);
         }
         throw new SQLException("Cannot unwrap to " + iface.getName());
     }
 
-    public java.util.logging.Logger getParentLogger() throws SQLFeatureNotSupportedException
-    {
+    public java.util.logging.Logger getParentLogger() throws SQLFeatureNotSupportedException {
         throw org.postgresql.Driver.notImplemented(this.getClass(), "getParentLogger()");
     }
-
 }


### PR DESCRIPTION
First pass at checkstyle and sonarlint runs against org.postgresql.ds.
Focused primarily on refactoring and pedantic style, such as braces,
spacing, imports, JLS compliance, etc.  This does not yield a clean
checkstyle run.  Code fixes will be done under another CR.

Done as part of #441.