### PR TITLE
style: checkstyle pass org.postgresql.geometric

### DIFF
--- a/org/postgresql/geometric/PGbox.java
+++ b/org/postgresql/geometric/PGbox.java
@@ -18,10 +18,9 @@ import java.io.Serializable;
 import java.sql.SQLException;
 
 /**
- *     This represents the box datatype within org.postgresql.
+ * This represents the box datatype within org.postgresql.
  */
-public class PGbox extends PGobject implements PGBinaryObject, Serializable, Cloneable
-{
+public class PGbox extends PGobject implements PGBinaryObject, Serializable, Cloneable {
     /**
      * These are the two points.
      */
@@ -33,8 +32,7 @@ public class PGbox extends PGobject implements PGBinaryObject, Serializable, Clo
      * @param x2 second x coordinate
      * @param y2 second y coordinate
      */
-    public PGbox(double x1, double y1, double x2, double y2)
-    {
+    public PGbox(double x1, double y1, double x2, double y2) {
         this();
         this.point[0] = new PGpoint(x1, y1);
         this.point[1] = new PGpoint(x2, y2);
@@ -44,8 +42,7 @@ public class PGbox extends PGobject implements PGBinaryObject, Serializable, Clo
      * @param p1 first point
      * @param p2 second point
      */
-    public PGbox(PGpoint p1, PGpoint p2)
-    {
+    public PGbox(PGpoint p1, PGpoint p2) {
         this();
         this.point[0] = p1;
         this.point[1] = p2;
@@ -53,19 +50,17 @@ public class PGbox extends PGobject implements PGBinaryObject, Serializable, Clo
 
     /**
      * @param s Box definition in PostgreSQL syntax
-     * @exception SQLException if definition is invalid
+     * @throws SQLException if definition is invalid
      */
-    public PGbox(String s) throws SQLException
-    {
+    public PGbox(String s) throws SQLException {
         this();
         setValue(s);
     }
 
     /**
-     * Required constructor
+     * Required constructor.
      */
-    public PGbox()
-    {
+    public PGbox() {
         setType("box");
     }
 
@@ -74,18 +69,18 @@ public class PGbox extends PGobject implements PGBinaryObject, Serializable, Clo
      * but still called by subclasses.
      *
      * @param value a string representation of the value of the object
-     * @exception SQLException thrown if value is invalid for this type
+     * @throws SQLException thrown if value is invalid for this type
      */
-    public void setValue(String value) throws SQLException
-    {
+    public void setValue(String value) throws SQLException {
         PGtokenizer t = new PGtokenizer(value, ',');
-        if (t.getSize() != 2)
-            throw new PSQLException(GT.tr("Conversion to type {0} failed: {1}.", new Object[]{type,value}), PSQLState.DATA_TYPE_MISMATCH);
+        if (t.getSize() != 2) {
+            throw new PSQLException(GT.tr("Conversion to type {0} failed: {1}.", new Object[]{type, value}), PSQLState.DATA_TYPE_MISMATCH);
+        }
 
         point[0] = new PGpoint(t.getToken(0));
         point[1] = new PGpoint(t.getToken(1));
     }
-    
+
     /**
      * @param b Definition of this point in PostgreSQL's binary syntax
      */
@@ -100,38 +95,39 @@ public class PGbox extends PGobject implements PGBinaryObject, Serializable, Clo
      * @param obj Object to compare with
      * @return true if the two boxes are identical
      */
-    public boolean equals(Object obj)
-    {
-        if (obj instanceof PGbox)
-        {
-            PGbox p = (PGbox)obj;
+    public boolean equals(Object obj) {
+        if (obj instanceof PGbox) {
+            PGbox p = (PGbox) obj;
 
             // Same points.
-            if (p.point[0].equals(point[0]) && p.point[1].equals(point[1]))
+            if (p.point[0].equals(point[0]) && p.point[1].equals(point[1])) {
                 return true;
+            }
 
             // Points swapped.
-            if (p.point[0].equals(point[1]) && p.point[1].equals(point[0]))
+            if (p.point[0].equals(point[1]) && p.point[1].equals(point[0])) {
                 return true;
+            }
 
             // Using the opposite two points of the box:
             //  (x1,y1),(x2,y2)  ->   (x1,y2),(x2,y1)
-            if (p.point[0].x == point[0].x && p.point[0].y == point[1].y &&
-                    p.point[1].x == point[1].x && p.point[1].y == point[0].y)
+            if (p.point[0].x == point[0].x && p.point[0].y == point[1].y
+                    && p.point[1].x == point[1].x && p.point[1].y == point[0].y) {
                 return true;
+            }
 
             // Using the opposite two points of the box, and the points are swapped
             //  (x1,y1),(x2,y2)  ->   (x2,y1),(x1,y2)
-            if (p.point[0].x == point[1].x && p.point[0].y == point[0].y &&
-                    p.point[1].x == point[0].x && p.point[1].y == point[1].y)
+            if (p.point[0].x == point[1].x && p.point[0].y == point[0].y
+                    && p.point[1].x == point[0].x && p.point[1].y == point[1].y) {
                 return true;
+            }
         }
 
         return false;
     }
 
-    public int hashCode()
-    {
+    public int hashCode() {
         // This relies on the behaviour of point's hashcode being an exclusive-OR of
         // its X and Y components; we end up with an exclusive-OR of the two X and
         // two Y components, which is equal whenever equals() would return true
@@ -139,15 +135,15 @@ public class PGbox extends PGobject implements PGBinaryObject, Serializable, Clo
         return point[0].hashCode() ^ point[1].hashCode();
     }
 
-    public Object clone() throws CloneNotSupportedException
-    {
+    public Object clone() throws CloneNotSupportedException {
         PGbox newPGbox = (PGbox) super.clone();
-        if( newPGbox.point != null )
-        {
+        if (newPGbox.point != null) {
             newPGbox.point = (PGpoint[]) newPGbox.point.clone();
-            for( int i = 0; i < newPGbox.point.length; ++i )
-                if( newPGbox.point[i] != null )
+            for (int i = 0; i < newPGbox.point.length; ++i) {
+                if (newPGbox.point[i] != null) {
                     newPGbox.point[i] = (PGpoint) newPGbox.point[i].clone();
+                }
+            }
         }
         return newPGbox;
     }
@@ -155,8 +151,7 @@ public class PGbox extends PGobject implements PGBinaryObject, Serializable, Clo
     /**
      * @return the PGbox in the syntax expected by org.postgresql
      */
-    public String getValue()
-    {
+    public String getValue() {
         return point[0].toString() + "," + point[1].toString();
     }
 

--- a/org/postgresql/geometric/PGcircle.java
+++ b/org/postgresql/geometric/PGcircle.java
@@ -17,18 +17,17 @@ import java.io.Serializable;
 import java.sql.SQLException;
 
 /**
- *     This represents org.postgresql's circle datatype, consisting of a point
- *     and a radius
+ * This represents org.postgresql's circle datatype, consisting of a point
+ * and a radius
  */
-public class PGcircle extends PGobject implements Serializable, Cloneable
-{
+public class PGcircle extends PGobject implements Serializable, Cloneable {
     /**
-     * This is the center point
+     * This is the center point.
      */
     public PGpoint center;
 
     /**
-     * This is the radius
+     * This is the radius.
      */
     public double radius;
 
@@ -37,8 +36,7 @@ public class PGcircle extends PGobject implements Serializable, Cloneable
      * @param y coordinate of center
      * @param r radius of circle
      */
-    public PGcircle(double x, double y, double r)
-    {
+    public PGcircle(double x, double y, double r) {
         this(new PGpoint(x, y), r);
     }
 
@@ -46,8 +44,7 @@ public class PGcircle extends PGobject implements Serializable, Cloneable
      * @param c PGpoint describing the circle's center
      * @param r radius of circle
      */
-    public PGcircle(PGpoint c, double r)
-    {
+    public PGcircle(PGpoint c, double r) {
         this();
         this.center = c;
         this.radius = r;
@@ -55,10 +52,9 @@ public class PGcircle extends PGobject implements Serializable, Cloneable
 
     /**
      * @param s definition of the circle in PostgreSQL's syntax.
-     * @exception SQLException on conversion failure
+     * @throws SQLException on conversion failure
      */
-    public PGcircle(String s) throws SQLException
-    {
+    public PGcircle(String s) throws SQLException {
         this();
         setValue(s);
     }
@@ -66,29 +62,25 @@ public class PGcircle extends PGobject implements Serializable, Cloneable
     /**
      * This constructor is used by the driver.
      */
-    public PGcircle()
-    {
+    public PGcircle() {
         setType("circle");
     }
 
     /**
      * @param s definition of the circle in PostgreSQL's syntax.
-     * @exception SQLException on conversion failure
+     * @throws SQLException on conversion failure
      */
-    public void setValue(String s) throws SQLException
-    {
+    public void setValue(String s) throws SQLException {
         PGtokenizer t = new PGtokenizer(PGtokenizer.removeAngle(s), ',');
-        if (t.getSize() != 2)
-            throw new PSQLException(GT.tr("Conversion to type {0} failed: {1}.", new Object[]{type,s}), PSQLState.DATA_TYPE_MISMATCH);
+        if (t.getSize() != 2) {
+            throw new PSQLException(GT.tr("Conversion to type {0} failed: {1}.", new Object[]{type, s}), PSQLState.DATA_TYPE_MISMATCH);
+        }
 
-        try
-        {
+        try {
             center = new PGpoint(t.getToken(0));
             radius = Double.parseDouble(t.getToken(1));
-        }
-        catch (NumberFormatException e)
-        {
-            throw new PSQLException(GT.tr("Conversion to type {0} failed: {1}.", new Object[]{type,s}), PSQLState.DATA_TYPE_MISMATCH, e);
+        } catch (NumberFormatException e) {
+            throw new PSQLException(GT.tr("Conversion to type {0} failed: {1}.", new Object[]{type, s}), PSQLState.DATA_TYPE_MISMATCH, e);
         }
     }
 
@@ -96,35 +88,31 @@ public class PGcircle extends PGobject implements Serializable, Cloneable
      * @param obj Object to compare with
      * @return true if the two circles are identical
      */
-    public boolean equals(Object obj)
-    {
-        if (obj instanceof PGcircle)
-        {
-            PGcircle p = (PGcircle)obj;
+    public boolean equals(Object obj) {
+        if (obj instanceof PGcircle) {
+            PGcircle p = (PGcircle) obj;
             return p.center.equals(center) && p.radius == radius;
         }
         return false;
     }
 
-    public int hashCode()
-    {
+    public int hashCode() {
         long v = Double.doubleToLongBits(radius);
         return (int) (center.hashCode() ^ v ^ (v >>> 32));
     }
 
-    public Object clone() throws CloneNotSupportedException
-    {
+    public Object clone() throws CloneNotSupportedException {
         PGcircle newPGcircle = (PGcircle) super.clone();
-        if( newPGcircle.center != null )
+        if (newPGcircle.center != null) {
             newPGcircle.center = (PGpoint) newPGcircle.center.clone();
+        }
         return newPGcircle;
     }
 
     /**
      * @return the PGcircle in the syntax expected by org.postgresql
      */
-    public String getValue()
-    {
+    public String getValue() {
         return "<" + center + "," + radius + ">";
     }
 }

--- a/org/postgresql/geometric/PGline.java
+++ b/org/postgresql/geometric/PGline.java
@@ -19,23 +19,21 @@ import java.sql.SQLException;
 
 /**
  * This implements a line represented by the linear equation Ax + By + C = 0
- *
  **/
-public class PGline extends PGobject implements Serializable, Cloneable
-{
+public class PGline extends PGobject implements Serializable, Cloneable {
 
     /**
-     * Coefficient of x
+     * Coefficient of x.
      */
     public double a;
 
     /**
-     * Coefficient of y
+     * Coefficient of y.
      */
     public double b;
 
     /**
-     * Constant
+     * Constant.
      */
     public double c;
 
@@ -57,8 +55,7 @@ public class PGline extends PGobject implements Serializable, Cloneable
      * @param x2 coordinate for second point on the line
      * @param y2 coordinate for second point on the line
      */
-    public PGline(double x1, double y1, double x2, double y2)
-    {
+    public PGline(double x1, double y1, double x2, double y2) {
         this();
         if (x1 == x2) {
             a = -1;
@@ -74,8 +71,7 @@ public class PGline extends PGobject implements Serializable, Cloneable
      * @param p1 first point on the line
      * @param p2 second point on the line
      */
-    public PGline(PGpoint p1, PGpoint p2)
-    {
+    public PGline(PGpoint p1, PGpoint p2) {
         this(p1.x, p1.y, p2.x, p2.y);
     }
 
@@ -88,39 +84,38 @@ public class PGline extends PGobject implements Serializable, Cloneable
 
     /**
      * @param s definition of the line in PostgreSQL's syntax.
-     * @exception SQLException on conversion failure
+     * @throws SQLException on conversion failure
      */
-    public PGline(String s) throws SQLException
-    {
+    public PGline(String s) throws SQLException {
         this();
         setValue(s);
     }
 
     /**
-     * required by the driver
+     * Required by the driver.
      */
-    public PGline()
-    {
+    public PGline() {
         setType("line");
     }
 
     /**
      * @param s Definition of the line in PostgreSQL's syntax
-     * @exception SQLException on conversion failure
+     * @throws SQLException on conversion failure
      */
-    public void setValue(String s) throws SQLException
-    {
+    public void setValue(String s) throws SQLException {
         if (s.trim().startsWith("{")) {
             PGtokenizer t = new PGtokenizer(PGtokenizer.removeCurlyBrace(s), ',');
-            if (t.getSize() != 3)
-                throw new PSQLException(GT.tr("Conversion to type {0} failed: {1}.", new Object[]{type,s}), PSQLState.DATA_TYPE_MISMATCH);
+            if (t.getSize() != 3) {
+                throw new PSQLException(GT.tr("Conversion to type {0} failed: {1}.", new Object[]{type, s}), PSQLState.DATA_TYPE_MISMATCH);
+            }
             a = Double.parseDouble(t.getToken(0));
             b = Double.parseDouble(t.getToken(1));
             c = Double.parseDouble(t.getToken(2));
         } else if (s.trim().startsWith("[")) {
             PGtokenizer t = new PGtokenizer(PGtokenizer.removeBox(s), ',');
-            if (t.getSize() != 2)
-                throw new PSQLException(GT.tr("Conversion to type {0} failed: {1}.", new Object[]{type,s}), PSQLState.DATA_TYPE_MISMATCH);
+            if (t.getSize() != 2) {
+                throw new PSQLException(GT.tr("Conversion to type {0} failed: {1}.", new Object[]{type, s}), PSQLState.DATA_TYPE_MISMATCH);
+            }
             PGpoint point1 = new PGpoint(t.getToken(0));
             PGpoint point2 = new PGpoint(t.getToken(1));
             a = point2.x - point1.x;
@@ -134,35 +129,39 @@ public class PGline extends PGobject implements Serializable, Cloneable
      * @return true if the two lines are identical
      */
     public boolean equals(Object obj) {
-        if (this == obj) return true;
-        if (obj == null || getClass() != obj.getClass()) return false;
-        if (!super.equals(obj)) return false;
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        if (!super.equals(obj)) {
+            return false;
+        }
 
-        PGline pGline = (PGline)obj;
+        PGline pGline = (PGline) obj;
 
-        return Double.compare(pGline.a, a) == 0 &&
-                Double.compare(pGline.b, b) == 0 &&
-                Double.compare(pGline.c, c) == 0;
+        return Double.compare(pGline.a, a) == 0
+                && Double.compare(pGline.b, b) == 0
+                && Double.compare(pGline.c, c) == 0;
     }
 
     public int hashCode() {
         int result = super.hashCode();
         long temp;
         temp = Double.doubleToLongBits(a);
-        result = 31 * result + (int)(temp ^ (temp >>> 32));
+        result = 31 * result + (int) (temp ^ (temp >>> 32));
         temp = Double.doubleToLongBits(b);
-        result = 31 * result + (int)(temp ^ (temp >>> 32));
+        result = 31 * result + (int) (temp ^ (temp >>> 32));
         temp = Double.doubleToLongBits(c);
-        result = 31 * result + (int)(temp ^ (temp >>> 32));
+        result = 31 * result + (int) (temp ^ (temp >>> 32));
         return result;
     }
 
     /**
      * @return the PGline in the syntax expected by org.postgresql
      */
-    public String getValue()
-    {
+    public String getValue() {
         return "{" + a + "," + b + "," + c + "}";
     }
-
 }

--- a/org/postgresql/geometric/PGlseg.java
+++ b/org/postgresql/geometric/PGlseg.java
@@ -17,10 +17,9 @@ import java.io.Serializable;
 import java.sql.SQLException;
 
 /**
- *     This implements a lseg (line segment) consisting of two points
+ * This implements a lseg (line segment) consisting of two points.
  */
-public class PGlseg extends PGobject implements Serializable, Cloneable
-{
+public class PGlseg extends PGobject implements Serializable, Cloneable {
     /**
      * These are the two points.
      */
@@ -32,8 +31,7 @@ public class PGlseg extends PGobject implements Serializable, Cloneable
      * @param x2 coordinate for second point
      * @param y2 coordinate for second point
      */
-    public PGlseg(double x1, double y1, double x2, double y2)
-    {
+    public PGlseg(double x1, double y1, double x2, double y2) {
         this(new PGpoint(x1, y1), new PGpoint(x2, y2));
     }
 
@@ -41,8 +39,7 @@ public class PGlseg extends PGobject implements Serializable, Cloneable
      * @param p1 first point
      * @param p2 second point
      */
-    public PGlseg(PGpoint p1, PGpoint p2)
-    {
+    public PGlseg(PGpoint p1, PGpoint p2) {
         this();
         this.point[0] = p1;
         this.point[1] = p2;
@@ -50,31 +47,29 @@ public class PGlseg extends PGobject implements Serializable, Cloneable
 
     /**
      * @param s definition of the line segment in PostgreSQL's syntax.
-     * @exception SQLException on conversion failure
+     * @throws SQLException on conversion failure
      */
-    public PGlseg(String s) throws SQLException
-    {
+    public PGlseg(String s) throws SQLException {
         this();
         setValue(s);
     }
 
     /**
-     * reuired by the driver
+     * Required by the driver.
      */
-    public PGlseg()
-    {
+    public PGlseg() {
         setType("lseg");
     }
 
     /**
      * @param s Definition of the line segment in PostgreSQL's syntax
-     * @exception SQLException on conversion failure
+     * @throws SQLException on conversion failure
      */
-    public void setValue(String s) throws SQLException
-    {
+    public void setValue(String s) throws SQLException {
         PGtokenizer t = new PGtokenizer(PGtokenizer.removeBox(s), ',');
-        if (t.getSize() != 2)
-            throw new PSQLException(GT.tr("Conversion to type {0} failed: {1}.", new Object[]{type,s}), PSQLState.DATA_TYPE_MISMATCH);
+        if (t.getSize() != 2) {
+            throw new PSQLException(GT.tr("Conversion to type {0} failed: {1}.", new Object[]{type, s}), PSQLState.DATA_TYPE_MISMATCH);
+        }
 
         point[0] = new PGpoint(t.getToken(0));
         point[1] = new PGpoint(t.getToken(1));
@@ -84,31 +79,28 @@ public class PGlseg extends PGobject implements Serializable, Cloneable
      * @param obj Object to compare with
      * @return true if the two line segments are identical
      */
-    public boolean equals(Object obj)
-    {
-        if (obj instanceof PGlseg)
-        {
-            PGlseg p = (PGlseg)obj;
-            return (p.point[0].equals(point[0]) && p.point[1].equals(point[1])) ||
-                   (p.point[0].equals(point[1]) && p.point[1].equals(point[0]));
+    public boolean equals(Object obj) {
+        if (obj instanceof PGlseg) {
+            PGlseg p = (PGlseg) obj;
+            return (p.point[0].equals(point[0]) && p.point[1].equals(point[1]))
+                    || (p.point[0].equals(point[1]) && p.point[1].equals(point[0]));
         }
         return false;
     }
 
-    public int hashCode()
-    {
+    public int hashCode() {
         return point[0].hashCode() ^ point[1].hashCode();
     }
 
-    public Object clone() throws CloneNotSupportedException
-    {
+    public Object clone() throws CloneNotSupportedException {
         PGlseg newPGlseg = (PGlseg) super.clone();
-        if( newPGlseg.point != null )
-        {
+        if (newPGlseg.point != null) {
             newPGlseg.point = (PGpoint[]) newPGlseg.point.clone();
-            for( int i = 0; i < newPGlseg.point.length; ++i )
-                if( newPGlseg.point[i] != null )
+            for (int i = 0; i < newPGlseg.point.length; ++i) {
+                if (newPGlseg.point[i] != null) {
                     newPGlseg.point[i] = (PGpoint) newPGlseg.point[i].clone();
+                }
+            }
         }
         return newPGlseg;
     }
@@ -116,8 +108,7 @@ public class PGlseg extends PGobject implements Serializable, Cloneable
     /**
      * @return the PGlseg in the syntax expected by org.postgresql
      */
-    public String getValue()
-    {
+    public String getValue() {
         return "[" + point[0] + "," + point[1] + "]";
     }
 }

--- a/org/postgresql/geometric/PGpath.java
+++ b/org/postgresql/geometric/PGpath.java
@@ -17,96 +17,90 @@ import java.io.Serializable;
 import java.sql.SQLException;
 
 /**
- *     This implements a path (a multiple segmented line, which may be closed)
+ * This implements a path (a multiple segmented line, which may be closed)
  */
-public class PGpath extends PGobject implements Serializable, Cloneable
-{
+public class PGpath extends PGobject implements Serializable, Cloneable {
     /**
-     * True if the path is open, false if closed
+     * True if the path is open, false if closed.
      */
     public boolean open;
 
     /**
-     * The points defining this path
+     * The points defining this path.
      */
     public PGpoint points[];
 
     /**
      * @param points the PGpoints that define the path
-     * @param open True if the path is open, false if closed
+     * @param open   True if the path is open, false if closed
      */
-    public PGpath(PGpoint[] points, boolean open)
-    {
+    public PGpath(PGpoint[] points, boolean open) {
         this();
         this.points = points;
         this.open = open;
     }
 
     /**
-     * Required by the driver
+     * Required by the driver.
      */
-    public PGpath()
-    {
+    public PGpath() {
         setType("path");
     }
 
     /**
      * @param s definition of the path in PostgreSQL's syntax.
-     * @exception SQLException on conversion failure
+     * @throws SQLException on conversion failure
      */
-    public PGpath(String s) throws SQLException
-    {
+    public PGpath(String s) throws SQLException {
         this();
         setValue(s);
     }
 
     /**
      * @param s Definition of the path in PostgreSQL's syntax
-     * @exception SQLException on conversion failure
+     * @throws SQLException on conversion failure
      */
-    public void setValue(String s) throws SQLException
-    {
+    public void setValue(String s) throws SQLException {
         // First test to see if were open
-        if (s.startsWith("[") && s.endsWith("]"))
-        {
+        if (s.startsWith("[") && s.endsWith("]")) {
             open = true;
             s = PGtokenizer.removeBox(s);
-        }
-        else if (s.startsWith("(") && s.endsWith(")"))
-        {
+        } else if (s.startsWith("(") && s.endsWith(")")) {
             open = false;
             s = PGtokenizer.removePara(s);
-        }
-        else
+        } else {
             throw new PSQLException(GT.tr("Cannot tell if path is open or closed: {0}.", s), PSQLState.DATA_TYPE_MISMATCH);
+        }
 
         PGtokenizer t = new PGtokenizer(s, ',');
         int npoints = t.getSize();
         points = new PGpoint[npoints];
-        for (int p = 0;p < npoints;p++)
+        for (int p = 0; p < npoints; p++) {
             points[p] = new PGpoint(t.getToken(p));
+        }
     }
 
     /**
      * @param obj Object to compare with
      * @return true if the two paths are identical
      */
-    public boolean equals(Object obj)
-    {
-        if (obj instanceof PGpath)
-        {
-            PGpath p = (PGpath)obj;
+    public boolean equals(Object obj) {
+        if (obj instanceof PGpath) {
+            PGpath p = (PGpath) obj;
 
-            if (p.points.length != points.length)
+            if (p.points.length != points.length) {
                 return false;
+            }
 
-            if (p.open != open)
+            if (p.open != open) {
                 return false;
+            }
 
-            for (int i = 0;i < points.length;i++)
-                if (!points[i].equals(p.points[i]))
+            for (int i = 0; i < points.length; i++) {
+                if (!points[i].equals(p.points[i])) {
                     return false;
-
+                }
+            }
             return true;
         }
         return false;
@@ -115,36 +109,33 @@ public class PGpath extends PGobject implements Serializable, Cloneable
     public int hashCode() {
         // XXX not very good..
         int hash = 0;
-        for (int i = 0; i < points.length && i < 5; ++i)
-        {
+        for (int i = 0; i < points.length && i < 5; ++i) {
             hash = hash ^ points[i].hashCode();
         }
         return hash;
     }
 
-    public Object clone() throws CloneNotSupportedException
-    {
+    public Object clone() throws CloneNotSupportedException {
         PGpath newPGpath = (PGpath) super.clone();
-        if( newPGpath.points != null )
-        {
+        if (newPGpath.points != null) {
             newPGpath.points = (PGpoint[]) newPGpath.points.clone();
-            for( int i = 0; i < newPGpath.points.length; ++i )
+            for (int i = 0; i < newPGpath.points.length; ++i) {
                 newPGpath.points[i] = (PGpoint) newPGpath.points[i].clone();
-        }        
+            }
+        }
         return newPGpath;
     }
 
     /**
      * This returns the path in the syntax expected by org.postgresql
      */
-    public String getValue()
-    {
+    public String getValue() {
         StringBuilder b = new StringBuilder(open ? "[" : "(");
 
-        for (int p = 0;p < points.length;p++)
-        {
-            if (p > 0)
+        for (int p = 0; p < points.length; p++) {
+            if (p > 0) {
                 b.append(",");
+            }
             b.append(points[p].toString());
         }
         b.append(open ? "]" : ")");
@@ -152,23 +143,19 @@ public class PGpath extends PGobject implements Serializable, Cloneable
         return b.toString();
     }
 
-    public boolean isOpen()
-    {
+    public boolean isOpen() {
         return open;
     }
 
-    public boolean isClosed()
-    {
+    public boolean isClosed() {
         return !open;
     }
 
-    public void closePath()
-    {
+    public void closePath() {
         open = false;
     }
 
-    public void openPath()
-    {
+    public void openPath() {
         open = true;
     }
 }

--- a/org/postgresql/geometric/PGpoint.java
+++ b/org/postgresql/geometric/PGpoint.java
@@ -25,8 +25,7 @@ import java.sql.SQLException;
  * This implements a version of java.awt.Point, except it uses double
  * to represent the coordinates.
  */
-public class PGpoint extends PGobject implements PGBinaryObject, Serializable, Cloneable
-{
+public class PGpoint extends PGobject implements PGBinaryObject, Serializable, Cloneable {
     /**
      * The X coordinate of the point
      */
@@ -41,8 +40,7 @@ public class PGpoint extends PGobject implements PGBinaryObject, Serializable, C
      * @param x coordinate
      * @param y coordinate
      */
-    public PGpoint(double x, double y)
-    {
+    public PGpoint(double x, double y) {
         this();
         this.x = x;
         this.y = y;
@@ -53,9 +51,9 @@ public class PGpoint extends PGobject implements PGBinaryObject, Serializable, C
      * point is embedded within their definition.
      *
      * @param value Definition of this point in PostgreSQL's syntax
+     * @throws SQLException
      */
-    public PGpoint(String value) throws SQLException
-    {
+    public PGpoint(String value) throws SQLException {
         this();
         setValue(value);
     }
@@ -63,29 +61,24 @@ public class PGpoint extends PGobject implements PGBinaryObject, Serializable, C
     /**
      * Required by the driver
      */
-    public PGpoint()
-    {
+    public PGpoint() {
         setType("point");
     }
 
     /**
      * @param s Definition of this point in PostgreSQL's syntax
-     * @exception SQLException on conversion failure
+     * @throws SQLException on conversion failure
      */
-    public void setValue(String s) throws SQLException
-    {
+    public void setValue(String s) throws SQLException {
         PGtokenizer t = new PGtokenizer(PGtokenizer.removePara(s), ',');
-        try
-        {
+        try {
             x = Double.parseDouble(t.getToken(0));
             y = Double.parseDouble(t.getToken(1));
-        }
-        catch (NumberFormatException e)
-        {
-            throw new PSQLException(GT.tr("Conversion to type {0} failed: {1}.", new Object[]{type,s}), PSQLState.DATA_TYPE_MISMATCH, e);
+        } catch (NumberFormatException e) {
+            throw new PSQLException(GT.tr("Conversion to type {0} failed: {1}.", new Object[]{type, s}), PSQLState.DATA_TYPE_MISMATCH, e);
         }
     }
-    
+
     /**
      * @param b Definition of this point in PostgreSQL's binary syntax
      */
@@ -98,18 +91,15 @@ public class PGpoint extends PGobject implements PGBinaryObject, Serializable, C
      * @param obj Object to compare with
      * @return true if the two points are identical
      */
-    public boolean equals(Object obj)
-    {
-        if (obj instanceof PGpoint)
-        {
-            PGpoint p = (PGpoint)obj;
+    public boolean equals(Object obj) {
+        if (obj instanceof PGpoint) {
+            PGpoint p = (PGpoint) obj;
             return x == p.x && y == p.y;
         }
         return false;
     }
 
-    public int hashCode()
-    {
+    public int hashCode() {
         long v1 = Double.doubleToLongBits(x);
         long v2 = Double.doubleToLongBits(y);
         return (int) (v1 ^ v2 ^ (v1 >>> 32) ^ (v2 >>> 32));
@@ -118,8 +108,7 @@ public class PGpoint extends PGobject implements PGBinaryObject, Serializable, C
     /**
      * @return the PGpoint in the syntax expected by org.postgresql
      */
-    public String getValue()
-    {
+    public String getValue() {
         return "(" + x + "," + y + ")";
     }
 
@@ -138,42 +127,42 @@ public class PGpoint extends PGobject implements PGBinaryObject, Serializable, C
 
     /**
      * Translate the point by the supplied amount.
+     *
      * @param x integer amount to add on the x axis
      * @param y integer amount to add on the y axis
      */
-    public void translate(int x, int y)
-    {
-        translate((double)x, (double)y);
+    public void translate(int x, int y) {
+        translate((double) x, (double) y);
     }
 
     /**
      * Translate the point by the supplied amount.
+     *
      * @param x double amount to add on the x axis
      * @param y double amount to add on the y axis
      */
-    public void translate(double x, double y)
-    {
+    public void translate(double x, double y) {
         this.x += x;
         this.y += y;
     }
 
     /**
      * Moves the point to the supplied coordinates.
+     *
      * @param x integer coordinate
      * @param y integer coordinate
      */
-    public void move(int x, int y)
-    {
+    public void move(int x, int y) {
         setLocation(x, y);
     }
 
     /**
      * Moves the point to the supplied coordinates.
+     *
      * @param x double coordinate
      * @param y double coordinate
      */
-    public void move(double x, double y)
-    {
+    public void move(double x, double y) {
         this.x = x;
         this.y = y;
     }
@@ -181,23 +170,23 @@ public class PGpoint extends PGobject implements PGBinaryObject, Serializable, C
     /**
      * Moves the point to the supplied coordinates.
      * refer to java.awt.Point for description of this
+     *
      * @param x integer coordinate
      * @param y integer coordinate
      * @see java.awt.Point
      */
-    public void setLocation(int x, int y)
-    {
-        move((double)x, (double)y);
+    public void setLocation(int x, int y) {
+        move((double) x, (double) y);
     }
 
     /**
      * Moves the point to the supplied java.awt.Point
      * refer to java.awt.Point for description of this
+     *
      * @param p Point to move to
      * @see java.awt.Point
      */
-    public void setLocation(Point p)
-    {
+    public void setLocation(Point p) {
         setLocation(p.x, p.y);
     }
 }

--- a/org/postgresql/geometric/PGpolygon.java
+++ b/org/postgresql/geometric/PGpolygon.java
@@ -9,77 +9,75 @@ package org.postgresql.geometric;
 
 import org.postgresql.util.PGobject;
 import org.postgresql.util.PGtokenizer;
+
 import java.io.Serializable;
 import java.sql.SQLException;
 
 /**
- *     This implements the polygon datatype within PostgreSQL.
+ * This implements the polygon datatype within PostgreSQL.
  */
-public class PGpolygon extends PGobject implements Serializable, Cloneable
-{
+public class PGpolygon extends PGobject implements Serializable, Cloneable {
     /**
-     * The points defining the polygon
+     * The points defining the polygon.
      */
     public PGpoint points[];
 
     /**
-     * Creates a polygon using an array of PGpoints
+     * Creates a polygon using an array of PGpoints.
      *
      * @param points the points defining the polygon
      */
-    public PGpolygon(PGpoint[] points)
-    {
+    public PGpolygon(PGpoint[] points) {
         this();
         this.points = points;
     }
 
     /**
      * @param s definition of the polygon in PostgreSQL's syntax.
-     * @exception SQLException on conversion failure
+     * @throws SQLException on conversion failure
      */
-    public PGpolygon(String s) throws SQLException
-    {
+    public PGpolygon(String s) throws SQLException {
         this();
         setValue(s);
     }
 
     /**
-     * Required by the driver
+     * Required by the driver.
      */
-    public PGpolygon()
-    {
+    public PGpolygon() {
         setType("polygon");
     }
 
     /**
      * @param s Definition of the polygon in PostgreSQL's syntax
-     * @exception SQLException on conversion failure
+     * @throws SQLException on conversion failure
      */
-    public void setValue(String s) throws SQLException
-    {
+    public void setValue(String s) throws SQLException {
         PGtokenizer t = new PGtokenizer(PGtokenizer.removePara(s), ',');
         int npoints = t.getSize();
         points = new PGpoint[npoints];
-        for (int p = 0;p < npoints;p++)
+        for (int p = 0; p < npoints; p++) {
             points[p] = new PGpoint(t.getToken(p));
+        }
     }
 
     /**
      * @param obj Object to compare with
      * @return true if the two polygons are identical
      */
-    public boolean equals(Object obj)
-    {
-        if (obj instanceof PGpolygon)
-        {
-            PGpolygon p = (PGpolygon)obj;
+    public boolean equals(Object obj) {
+        if (obj instanceof PGpolygon) {
+            PGpolygon p = (PGpolygon) obj;
 
-            if (p.points.length != points.length)
+            if (p.points.length != points.length) {
                 return false;
+            }
 
-            for (int i = 0;i < points.length;i++)
-                if (!points[i].equals(p.points[i]))
+            for (int i = 0; i < points.length; i++) {
+                if (!points[i].equals(p.points[i])) {
                     return false;
+                }
+            }
 
             return true;
         }
@@ -89,22 +87,21 @@ public class PGpolygon extends PGobject implements Serializable, Cloneable
     public int hashCode() {
         // XXX not very good..
         int hash = 0;
-        for (int i = 0; i < points.length && i < 5; ++i)
-        {
+        for (int i = 0; i < points.length && i < 5; ++i) {
             hash = hash ^ points[i].hashCode();
         }
         return hash;
     }
 
-    public Object clone() throws CloneNotSupportedException
-    {
-        PGpolygon newPGpolygon = (PGpolygon) super.clone();        
-        if( newPGpolygon.points != null )
-        {
+    public Object clone() throws CloneNotSupportedException {
+        PGpolygon newPGpolygon = (PGpolygon) super.clone();
+        if (newPGpolygon.points != null) {
             newPGpolygon.points = (PGpoint[]) newPGpolygon.points.clone();
-            for( int i = 0; i < newPGpolygon.points.length; ++i )
-                if( newPGpolygon.points[i] != null )
+            for (int i = 0; i < newPGpolygon.points.length; ++i) {
+                if (newPGpolygon.points[i] != null) {
                     newPGpolygon.points[i] = (PGpoint) newPGpolygon.points[i].clone();
+                }
+            }
         }
         return newPGpolygon;
     }
@@ -112,14 +109,13 @@ public class PGpolygon extends PGobject implements Serializable, Cloneable
     /**
      * @return the PGpolygon in the syntax expected by org.postgresql
      */
-    public String getValue()
-    {
+    public String getValue() {
         StringBuilder b = new StringBuilder();
         b.append("(");
-        for (int p = 0;p < points.length;p++)
-        {
-            if (p > 0)
+        for (int p = 0; p < points.length; p++) {
+            if (p > 0) {
                 b.append(",");
+            }
             b.append(points[p].toString());
         }
         b.append(")");


### PR DESCRIPTION
First pass at checkstyle and sonarlint runs against org.postgresql.geometric.
Focused primarily on refactoring and pedantic style, such as braces, spacing,
imports, JLS compliance, etc.  This does not yield a clean checkstyle run.
Code fixes will be done under another CR.

Done as part of #441.