### PR TITLE
fix: prepared statement "S_2" does not exist in batch executions

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -1196,6 +1196,7 @@ public class QueryExecutorImpl implements QueryExecutor {
             // under us.
             query.setStatementName(statementName);
             query.setStatementTypes((int[])typeOIDs.clone());
+            registerParsedQuery(query, statementName);
         }
 
         byte[] encodedStatementName = query.getEncodedStatementName();
@@ -1731,7 +1732,6 @@ public class QueryExecutorImpl implements QueryExecutor {
                 if (logger.logDebug())
                     logger.debug(" <=BE ParseComplete [" + parsedStatementName + "]");
 
-                registerParsedQuery(parsedQuery, parsedStatementName);
                 break;
 
             case 't':    // ParameterDescription


### PR DESCRIPTION
Register cleanup for statement unprepare early, so it points to the proper statement name.

This might fix #443.

The test causes query executor to re-prepare statement in case types of binds change.
The bug is caused by late creation of PhantomReference->statementName cache entry (as both ParseComplete messages arrive, the Query has changed its statement name)
