### PR TITLE
feat: Support for Simple queries on v3 protocol.

### DIFF
--- a/doc/pgjdbc.xml
+++ b/doc/pgjdbc.xml
@@ -661,6 +661,22 @@ openssl pkcs8 -topk8 -in client.key -out client.pk8 -outform DER -v1 PBE-SHA1-3D
       </varlistentry>
 
       <varlistentry>
+       <term><varname>enableSimpleQueries</varname> = <type>boolean</type></term>
+       <listitem>
+        <para>
+         When using the V3 protocol the driver can send non-prepared statements
+         as either extended queries or simple queries.
+         By default driver will always use extended queries which are sent as
+         PARSE/BIND/EXECUTE commands.
+         To enable use of simple queries set <literal>enableSimpleQueries</literal>
+         to <literal>true</literal>.
+         V2 protocol only supports simple queries, so this parameter doesn't have an
+         effect on it.
+        </para>
+       </listitem>
+      </varlistentry>
+
+      <varlistentry>
        <term><varname>logUnclosedConnections</varname> = <type>boolean</type></term>
        <listitem>
         <para>

--- a/org/postgresql/PGProperty.java
+++ b/org/postgresql/PGProperty.java
@@ -274,6 +274,14 @@ public enum PGProperty
     ALLOW_ENCODING_CHANGES("allowEncodingChanges", "false", "Allow for changes in client_encoding"),
 
     /**
+     * When simple queries are enabled, non-prepared statements on V3 protocol are send as simple queries
+     * instead of as extended queries.
+     * To enable this behavior (on v3) set enableSimpleQueries to true
+     * v2 only supports simple queries, so this parameter doesn't have an effect for it.
+     */
+    ENABLE_SIMPLE_QUERIES("enableSimpleQueries", "false", "Allow simple queries on V3 protocol"),
+
+    /**
      * Specify the schema to be set in the search-path. This schema will be used
      * to resolve unqualified object names used in statements over this connection.
      */

--- a/org/postgresql/core/QueryExecutor.java
+++ b/org/postgresql/core/QueryExecutor.java
@@ -114,7 +114,7 @@ public interface QueryExecutor {
      * Execute a Query, passing results to a provided ResultHandler.
      *
      * @param query the query to execute; must be a query returned from
-     *  calling {@link #createSimpleQuery(String)} or {@link #createParameterizedQuery(String)}
+     *  calling {@link #createSimpleQuery(String, boolean)} or {@link #createParameterizedQuery(String)}
      *  on this QueryExecutor object.
      * @param parameters the parameters for the query. Must be non-<code>null</code>
      *  if the query takes parameters. Must be a parameter object returned by
@@ -139,7 +139,7 @@ public interface QueryExecutor {
      * Execute several Query, passing results to a provided ResultHandler.
      *
      * @param queries the queries to execute; each must be a query returned from
-     *  calling {@link #createSimpleQuery(String)} or {@link #createParameterizedQuery(String)}
+     *  calling {@link #createSimpleQuery(String, boolean)} or {@link #createParameterizedQuery(String)}
      *  on this QueryExecutor object.
      * @param parameterLists the parameter lists for the queries. The parameter lists
      *  correspond 1:1 to the queries passed in the <code>queries</code> array. Each must be
@@ -163,6 +163,20 @@ public interface QueryExecutor {
     throws SQLException;
 
     /**
+     * Execute a SQL, passing results to a provided ResultHandler. It uses simple protocol for communication.
+     *
+     * @param query the query to execute; must be a query returned from
+     *  calling {@link #createSimpleQuery(String, boolean)}
+     *  on this QueryExecutor object.
+     * @param handler a ResultHandler responsible for handling results generated
+     *  by this query
+     * @param flags a combination of QUERY_* flags indicating how to handle the query.
+     *
+     * @throws SQLException if query execution fails
+     */
+    void execute(Query query, ResultHandler handler, int flags) throws SQLException;
+
+    /**
      * Fetch additional rows from a cursor.
      *
      * @param cursor the cursor to fetch from
@@ -180,9 +194,10 @@ public interface QueryExecutor {
      * always return an empty ParameterList.
      *
      * @param sql the SQL for the query to create
+     * @param textProtocol create query for text based protocol
      * @return a new Query object
      */
-    Query createSimpleQuery(String sql);
+    Query createSimpleQuery(String sql, boolean textProtocol);
 
     /**
      * Create a parameterized Query object suitable for execution by

--- a/org/postgresql/core/SetupQueryRunner.java
+++ b/org/postgresql/core/SetupQueryRunner.java
@@ -62,7 +62,7 @@ public class SetupQueryRunner {
 
     public static byte[][] run(ProtocolConnection protoConnection, String queryString, boolean wantResults) throws SQLException {
         QueryExecutor executor = protoConnection.getQueryExecutor();
-        Query query = executor.createSimpleQuery(queryString);
+        Query query = executor.createSimpleQuery(queryString, false);
         SimpleResultHandler handler = new SimpleResultHandler(protoConnection);
 
         int flags = QueryExecutor.QUERY_ONESHOT | QueryExecutor.QUERY_SUPPRESS_BEGIN;

--- a/org/postgresql/core/v2/QueryExecutorImpl.java
+++ b/org/postgresql/core/v2/QueryExecutorImpl.java
@@ -34,7 +34,7 @@ public class QueryExecutorImpl implements QueryExecutor {
     // Query parsing
     //
 
-    public Query createSimpleQuery(String sql) {
+    public Query createSimpleQuery(String sql, boolean textProtocol) {
         return new V2Query(sql, false, protoConnection);
     }
 
@@ -108,7 +108,7 @@ public class QueryExecutorImpl implements QueryExecutor {
             try
             {
                 // Create and issue a dummy query to use the existing prefix infrastructure
-                V2Query query = (V2Query)createSimpleQuery("");
+                V2Query query = (V2Query)createSimpleQuery("", true);
                 SimpleParameterList params = (SimpleParameterList)query.createParameterList();
                 sendQuery(query, params, "BEGIN");
                 processResults(query, handler, 0, 0);
@@ -256,6 +256,12 @@ public class QueryExecutorImpl implements QueryExecutor {
     throws SQLException
     {
         execute((V2Query) query, (SimpleParameterList) parameters, handler, maxRows, flags);
+    }
+
+    public synchronized void execute(Query query, ResultHandler handler, int flags)
+            throws SQLException
+    {
+        execute((V2Query)query, null, handler, 0, flags);
     }
 
     // Nothing special yet, just run the queries one at a time.

--- a/org/postgresql/ds/common/BaseDataSource.java
+++ b/org/postgresql/ds/common/BaseDataSource.java
@@ -964,6 +964,22 @@ public abstract class BaseDataSource implements Referenceable
     }
 
     /**
+     * @see PGProperty#ENABLE_SIMPLE_QUERIES
+     */
+    public boolean getEnableSimpleQueries()
+    {
+        return PGProperty.ENABLE_SIMPLE_QUERIES.getBoolean(properties);
+    }
+
+    /**
+     * @see PGProperty#ENABLE_SIMPLE_QUERIES
+     */
+    public void setEnableSimpleQueries(boolean enable)
+    {
+        PGProperty.ENABLE_SIMPLE_QUERIES.set(properties, enable);
+    }
+
+    /**
      * Generates a DriverManager URL from the other properties supplied.
      */
     public String getUrl()

--- a/org/postgresql/jdbc2/AbstractJdbc2Connection.java
+++ b/org/postgresql/jdbc2/AbstractJdbc2Connection.java
@@ -263,8 +263,8 @@ public abstract class AbstractJdbc2Connection implements BaseConnection
                                             !protoConnection.getIntegerDateTimes());
 
         // Initialize common queries.
-        commitQuery = getQueryExecutor().createSimpleQuery("COMMIT");
-        rollbackQuery = getQueryExecutor().createSimpleQuery("ROLLBACK");
+        commitQuery = getQueryExecutor().createSimpleQuery("COMMIT", false);
+        rollbackQuery = getQueryExecutor().createSimpleQuery("ROLLBACK", false);
 
         int unknownLength = PGProperty.UNKNOWN_LENGTH.getInt(info);
 


### PR DESCRIPTION
Postgres supports both simple and extended queries on v3 protocol.
Prepared statements are always executed with extended protocol.
This commit introduces option to change the behavior of non-prepared statements, so they are not parsed on the client side and are sent to the server as simple queries.
This fixes the problem of large SQL statements hanging, since it sends them with a known size.
By default, large SQL statement are parsed into subqueries and sent to the server as large collection of Parse/Bind/Execute commands.
In some scenarios, this can lead to hanging of SQL statement.

Simple protocol format is:
Q
length
sql command text
\0

To enable this behavior set enableSimpleQueries=true connection parameter.