### PR TITLE
fix: try re-execute statement if backend responds with "prepared statement is no longer valid"

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/PGConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGConnection.java
@@ -10,6 +10,7 @@ package org.postgresql;
 
 import org.postgresql.copy.CopyManager;
 import org.postgresql.fastpath.Fastpath;
+import org.postgresql.jdbc.AutoSave;
 import org.postgresql.jdbc.PreferQueryMode;
 import org.postgresql.largeobject.LargeObjectManager;
 import org.postgresql.util.PGobject;
@@ -178,4 +179,20 @@ public interface PGConnection {
    * @return true if the connection is configured to use "simple 'Q' execute" commands only
    */
   PreferQueryMode getPreferQueryMode();
+
+
+  /**
+   * Connection configuration regarding automatic per-query savepoints.
+   *
+   * @see PGProperty#AUTOSAVE
+   * @return connection configuration regarding automatic per-query savepoints
+   */
+  AutoSave getAutosave();
+
+  /**
+   * Configures if connection should use automatic savepoints.
+   * @see PGProperty#AUTOSAVE
+   * @param autoSave connection configuration regarding automatic per-query savepoints
+   */
+  void setAutosave(AutoSave autoSave);
 }

--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -370,6 +370,19 @@ public enum PGProperty {
       "extended", "extendedForPrepared", "extendedCacheEveryting", "simple"),
 
   /**
+   * Specifies what the driver should do if a query fails. In {@code autosave=always} mode, JDBC driver sets a safepoint before each query,
+   * and rolls back to that safepoint in case of failure. In {@code autosave=never} mode (default), no safepoint dance is made ever.
+   * In {@code autosave=conservative} mode, safepoint is set for each query, however the rollback is done only for rare cases
+   * like 'cached statement cannot change return type' or 'statement XXX is not valid' so JDBC driver rollsback and retries
+   */
+  AUTOSAVE("autosave", "never",
+      "Specifies what the driver should do if a query fails. In autosave=always mode, JDBC driver sets a safepoint before each query, "
+          + "and rolls back to that safepoint in case of failure. In autosave=never mode (default), no safepoint dance is made ever. "
+          + "In autosave=conservative mode, safepoint is set for each query, however the rollback is done only for rare cases"
+          + " like 'cached statement cannot change return type' or 'statement XXX is not valid' so JDBC driver rollsback and retries", false,
+      "always", "never", "conservative"),
+
+  /**
    * Configure optimization to enable batch insert re-writing.
    */
   REWRITE_BATCHED_INSERTS ("reWriteBatchedInserts", "false",

--- a/pgjdbc/src/main/java/org/postgresql/core/BaseConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/BaseConnection.java
@@ -244,4 +244,13 @@ public interface BaseConnection extends PGConnection, Connection {
   CachedQuery createQuery(String sql, boolean escapeProcessing, boolean isParameterized,
       String... columnNames)
       throws SQLException;
+
+  /**
+   * By default, the connection resets statement cache in case deallocate all/discard all
+   * message is observed.
+   * This API allows to disable that feature for testing purposes.
+   *
+   * @param flushCacheOnDeallocate true if statement cache should be reset when "deallocate/discard" message observed
+   */
+  void setFlushCacheOnDeallocate(boolean flushCacheOnDeallocate);
 }

--- a/pgjdbc/src/main/java/org/postgresql/core/QueryExecutor.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/QueryExecutor.java
@@ -415,4 +415,13 @@ public interface QueryExecutor extends TypeTransferModeRegistry {
   void setAutoSave(AutoSave autoSave);
 
   boolean willHealOnRetry(SQLException e);
+
+  /**
+   * By default, the connection resets statement cache in case deallocate all/discard all
+   * message is observed.
+   * This API allows to disable that feature for testing purposes.
+   *
+   * @param flushCacheOnDeallocate true if statement cache should be reset when "deallocate/discard" message observed
+   */
+  void setFlushCacheOnDeallocate(boolean flushCacheOnDeallocate);
 }

--- a/pgjdbc/src/main/java/org/postgresql/core/QueryExecutor.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/QueryExecutor.java
@@ -12,6 +12,7 @@ package org.postgresql.core;
 import org.postgresql.PGNotification;
 import org.postgresql.copy.CopyOperation;
 import org.postgresql.core.v3.TypeTransferModeRegistry;
+import org.postgresql.jdbc.AutoSave;
 import org.postgresql.jdbc.BatchResultHandler;
 import org.postgresql.jdbc.PreferQueryMode;
 import org.postgresql.util.HostSpec;
@@ -408,4 +409,10 @@ public interface QueryExecutor extends TypeTransferModeRegistry {
   boolean isColumnSanitiserDisabled();
 
   PreferQueryMode getPreferQueryMode();
+
+  AutoSave getAutoSave();
+
+  void setAutoSave(AutoSave autoSave);
+
+  boolean willHealOnRetry(SQLException e);
 }

--- a/pgjdbc/src/main/java/org/postgresql/core/QueryExecutorBase.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/QueryExecutorBase.java
@@ -33,6 +33,7 @@ public abstract class QueryExecutorBase implements QueryExecutor {
   private final boolean columnSanitiserDisabled;
   private final PreferQueryMode preferQueryMode;
   private AutoSave autoSave;
+  private boolean flushCacheOnDeallocate = true;
 
   // default value for server versions that don't report standard_conforming_strings
   private boolean standardConformingStrings = false;
@@ -365,5 +366,13 @@ public abstract class QueryExecutorBase implements QueryExecutor {
       return false;
     }
     return willHealViaReparse(e);
+  }
+
+  public boolean isFlushCacheOnDeallocate() {
+    return flushCacheOnDeallocate;
+  }
+
+  public void setFlushCacheOnDeallocate(boolean flushCacheOnDeallocate) {
+    this.flushCacheOnDeallocate = flushCacheOnDeallocate;
   }
 }

--- a/pgjdbc/src/main/java/org/postgresql/core/ResultHandler.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/ResultHandler.java
@@ -83,4 +83,16 @@ public interface ResultHandler {
    * statements are executed successfully and which are not.
    */
   void secureProgress();
+
+  /**
+   * Returns the first encountered exception. The rest are chained via {@link SQLException#setNextException(SQLException)}
+   * @return the first encountered exception
+   */
+  SQLException getException();
+
+  /**
+   * Returns the first encountered warning. The rest are chained via {@link SQLException#setNextException(SQLException)}
+   * @return the first encountered warning
+   */
+  SQLWarning getWarning();
 }

--- a/pgjdbc/src/main/java/org/postgresql/core/ResultHandlerBase.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/ResultHandlerBase.java
@@ -1,0 +1,78 @@
+/*-------------------------------------------------------------------------
+*
+* Copyright (c) 2016-2016, PostgreSQL Global Development Group
+*
+*
+*-------------------------------------------------------------------------
+*/
+
+package org.postgresql.core;
+
+import java.sql.SQLException;
+import java.sql.SQLWarning;
+import java.util.List;
+
+/**
+ * Empty implementation of {@link ResultHandler} interface.
+ * {@link SQLException#setNextException(SQLException)} has {@code O(N)} complexity,
+ * so this class tracks the last exception object to speedup {@code setNextException}.
+ */
+public class ResultHandlerBase implements ResultHandler {
+  // Last exception is tracked to avoid O(N) SQLException#setNextException just in case there
+  // will be lots of exceptions (e.g. all batch rows fail with constraint violation or so)
+  private SQLException firstException;
+  private SQLException lastException;
+
+  private SQLWarning firstWarning;
+  private SQLWarning lastWarning;
+
+  @Override
+  public void handleResultRows(Query fromQuery, Field[] fields, List<byte[][]> tuples,
+      ResultCursor cursor) {
+  }
+
+  @Override
+  public void handleCommandStatus(String status, int updateCount, long insertOID) {
+  }
+
+  @Override
+  public void secureProgress() {
+  }
+
+  @Override
+  public void handleWarning(SQLWarning warning) {
+    if (firstWarning == null) {
+      firstWarning = lastWarning = warning;
+      return;
+    }
+    lastWarning.setNextException(warning);
+    lastWarning = warning;
+  }
+
+  @Override
+  public void handleError(SQLException error) {
+    if (firstException == null) {
+      firstException = lastException = error;
+      return;
+    }
+    lastException.setNextException(error);
+    lastException = error;
+  }
+
+  @Override
+  public void handleCompletion() throws SQLException {
+    if (firstException != null) {
+      throw firstException;
+    }
+  }
+
+  @Override
+  public SQLException getException() {
+    return firstException;
+  }
+
+  @Override
+  public SQLWarning getWarning() {
+    return firstWarning;
+  }
+}

--- a/pgjdbc/src/main/java/org/postgresql/core/ResultHandlerDelegate.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/ResultHandlerDelegate.java
@@ -59,4 +59,20 @@ public class ResultHandlerDelegate implements ResultHandler {
       delegate.secureProgress();
     }
   }
+
+  @Override
+  public SQLException getException() {
+    if (delegate != null) {
+      return delegate.getException();
+    }
+    return null;
+  }
+
+  @Override
+  public SQLWarning getWarning() {
+    if (delegate != null) {
+      return delegate.getWarning();
+    }
+    return null;
+  }
 }

--- a/pgjdbc/src/main/java/org/postgresql/core/SetupQueryRunner.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/SetupQueryRunner.java
@@ -23,12 +23,8 @@ import java.util.List;
  */
 public class SetupQueryRunner {
 
-  private static class SimpleResultHandler implements ResultHandler {
-    private SQLException error;
+  private static class SimpleResultHandler extends ResultHandlerBase {
     private List<byte[][]> tuples;
-
-    SimpleResultHandler() {
-    }
 
     List<byte[][]> getResults() {
       return tuples;
@@ -39,30 +35,9 @@ public class SetupQueryRunner {
       this.tuples = tuples;
     }
 
-    public void handleCommandStatus(String status, int updateCount, long insertOID) {
-    }
-
     public void handleWarning(SQLWarning warning) {
       // We ignore warnings. We assume we know what we're
       // doing in the setup queries.
-    }
-
-    public void handleError(SQLException newError) {
-      if (error == null) {
-        error = newError;
-      } else {
-        error.setNextException(newError);
-      }
-    }
-
-    public void handleCompletion() throws SQLException {
-      if (error != null) {
-        throw error;
-      }
-    }
-
-    @Override
-    public void secureProgress() {
     }
   }
 

--- a/pgjdbc/src/main/java/org/postgresql/core/SqlCommand.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/SqlCommand.java
@@ -18,6 +18,7 @@ import static org.postgresql.core.SqlCommandType.INSERT;
  *
  */
 public class SqlCommand {
+  public static final SqlCommand BLANK = SqlCommand.createStatementTypeInfo(SqlCommandType.BLANK);
 
   public boolean isBatchedReWriteCompatible() {
     return valuesBraceOpenPosition >= 0;

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -2030,7 +2030,8 @@ public class QueryExecutorImpl extends QueryExecutorBase {
         case 'C': // Command Status (end of Execute)
           // Handle status.
           String status = receiveCommandStatus();
-          if (status.startsWith("DEALLOCATE ALL") || status.startsWith("DISCARD ALL")) {
+          if (isFlushCacheOnDeallocate()
+              && (status.startsWith("DEALLOCATE ALL") || status.startsWith("DISCARD ALL"))) {
             deallocateEpoch++;
           }
 

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/SimpleQuery.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/SimpleQuery.java
@@ -110,10 +110,11 @@ class SimpleQuery implements Query {
     return nativeQuery.nativeSql;
   }
 
-  void setStatementName(String statementName) {
+  void setStatementName(String statementName, short deallocateEpoch) {
     assert statementName != null : "statement name should not be null";
     this.statementName = statementName;
     this.encodedStatementName = Utils.encodeUTF8(statementName);
+    this.deallocateEpoch = deallocateEpoch;
   }
 
   void setStatementTypes(int[] paramTypes) {
@@ -128,9 +129,12 @@ class SimpleQuery implements Query {
     return statementName;
   }
 
-  boolean isPreparedFor(int[] paramTypes) {
+  boolean isPreparedFor(int[] paramTypes, short deallocateEpoch) {
     if (statementName == null) {
       return false; // Not prepared.
+    }
+    if (this.deallocateEpoch != deallocateEpoch) {
+      return false;
     }
 
     assert preparedTypes == null || paramTypes.length == preparedTypes.length
@@ -311,6 +315,7 @@ class SimpleQuery implements Query {
   private final boolean sanitiserDisabled;
   private PhantomReference<?> cleanupRef;
   private int[] preparedTypes;
+  private short deallocateEpoch;
 
   private Integer cachedMaxResultRowSize;
 

--- a/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
+++ b/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
@@ -9,6 +9,7 @@
 package org.postgresql.ds.common;
 
 import org.postgresql.PGProperty;
+import org.postgresql.jdbc.AutoSave;
 import org.postgresql.jdbc.PreferQueryMode;
 import org.postgresql.util.GT;
 import org.postgresql.util.PSQLException;
@@ -1243,6 +1244,22 @@ public abstract class BaseDataSource implements Referenceable {
    */
   public void setPreferQueryMode(PreferQueryMode preferQueryMode) {
     PGProperty.PREFER_QUERY_MODE.set(properties, preferQueryMode.value());
+  }
+
+  /**
+   * @see PGProperty#AUTOSAVE
+   * @return connection configuration regarding automatic per-query savepoints
+   */
+  public AutoSave getAutosave() {
+    return AutoSave.of(PGProperty.AUTOSAVE.get(properties));
+  }
+
+  /**
+   * @see PGProperty#AUTOSAVE
+   * @param autoSave connection configuration regarding automatic per-query savepoints
+   */
+  public void setAutosave(AutoSave autoSave) {
+    PGProperty.AUTOSAVE.set(properties, autoSave.value());
   }
 
   /**

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/AutoSave.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/AutoSave.java
@@ -1,0 +1,21 @@
+package org.postgresql.jdbc;
+
+public enum AutoSave {
+  NEVER,
+  ALWAYS,
+  CONSERVATIVE;
+
+  private final String value;
+
+  AutoSave() {
+    value = this.name().toLowerCase();
+  }
+
+  public String value() {
+    return value;
+  }
+
+  public static AutoSave of(String value) {
+    return valueOf(value.toUpperCase());
+  }
+}

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/CallableBatchResultHandler.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/CallableBatchResultHandler.java
@@ -1,3 +1,11 @@
+/*-------------------------------------------------------------------------
+*
+* Copyright (c) 2016-2016, PostgreSQL Global Development Group
+*
+*
+*-------------------------------------------------------------------------
+*/
+
 package org.postgresql.jdbc;
 
 import org.postgresql.core.Field;

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
@@ -17,14 +17,12 @@ import org.postgresql.core.BaseStatement;
 import org.postgresql.core.CachedQuery;
 import org.postgresql.core.ConnectionFactory;
 import org.postgresql.core.Encoding;
-import org.postgresql.core.Field;
 import org.postgresql.core.Logger;
 import org.postgresql.core.Oid;
 import org.postgresql.core.Provider;
 import org.postgresql.core.Query;
 import org.postgresql.core.QueryExecutor;
-import org.postgresql.core.ResultCursor;
-import org.postgresql.core.ResultHandler;
+import org.postgresql.core.ResultHandlerBase;
 import org.postgresql.core.ServerVersion;
 import org.postgresql.core.SqlCommand;
 import org.postgresql.core.TransactionState;
@@ -64,7 +62,6 @@ import java.sql.Types;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -1047,36 +1044,13 @@ public class PgConnection implements BaseConnection {
   /**
    * Handler for transaction queries
    */
-  private class TransactionCommandHandler implements ResultHandler {
-    private SQLException error;
-
-    public void handleResultRows(Query fromQuery, Field[] fields, List<byte[][]> tuples,
-        ResultCursor cursor) {
-    }
-
-    public void handleCommandStatus(String status, int updateCount, long insertOID) {
-    }
-
-    public void handleWarning(SQLWarning warning) {
-      PgConnection.this.addWarning(warning);
-    }
-
-    public void handleError(SQLException newError) {
-      if (error == null) {
-        error = newError;
-      } else {
-        error.setNextException(newError);
-      }
-    }
-
+  private class TransactionCommandHandler extends ResultHandlerBase {
     public void handleCompletion() throws SQLException {
-      if (error != null) {
-        throw error;
+      SQLWarning warning = getWarning();
+      if (warning != null) {
+        PgConnection.this.addWarning(warning);
       }
-    }
-
-    @Override
-    public void secureProgress() {
+      super.handleCompletion();
     }
   }
 

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
@@ -165,6 +165,11 @@ public class PgConnection implements BaseConnection {
     queryExecutor.releaseQuery(cachedQuery);
   }
 
+  @Override
+  public void setFlushCacheOnDeallocate(boolean flushCacheOnDeallocate) {
+    queryExecutor.setFlushCacheOnDeallocate(flushCacheOnDeallocate);
+  }
+
   //
   // Ctor.
   //

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
@@ -16,7 +16,7 @@ import org.postgresql.core.Field;
 import org.postgresql.core.Oid;
 import org.postgresql.core.Query;
 import org.postgresql.core.ResultCursor;
-import org.postgresql.core.ResultHandler;
+import org.postgresql.core.ResultHandlerBase;
 import org.postgresql.core.ServerVersion;
 import org.postgresql.core.TypeInfo;
 import org.postgresql.core.Utils;
@@ -1751,8 +1751,7 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
     }
   }
 
-  public class CursorResultHandler implements ResultHandler {
-    private SQLException error;
+  public class CursorResultHandler extends ResultHandlerBase {
 
     public void handleResultRows(Query fromQuery, Field[] fields, List<byte[][]> tuples,
         ResultCursor cursor) {
@@ -1765,30 +1764,14 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
           PSQLState.PROTOCOL_VIOLATION));
     }
 
-    public void handleWarning(SQLWarning warning) {
-      PgResultSet.this.addWarning(warning);
-    }
-
-    public void handleError(SQLException newError) {
-      if (error == null) {
-        error = newError;
-      } else {
-        error.setNextException(newError);
-      }
-    }
-
     public void handleCompletion() throws SQLException {
-      if (error != null) {
-        throw error;
+      SQLWarning warning = getWarning();
+      if (warning != null) {
+        PgResultSet.this.addWarning(warning);
       }
-    }
-
-    @Override
-    public void secureProgress() {
+      super.handleCompletion();
     }
   }
-
-  ;
 
 
   public BaseStatement getPGStatement() {

--- a/pgjdbc/src/main/java/org/postgresql/util/PSQLState.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/PSQLState.java
@@ -83,6 +83,7 @@ public class PSQLState implements java.io.Serializable {
   public final static PSQLState NUMERIC_VALUE_OUT_OF_RANGE = new PSQLState("22003");
   public final static PSQLState BAD_DATETIME_FORMAT = new PSQLState("22007");
   public final static PSQLState DATETIME_OVERFLOW = new PSQLState("22008");
+  public final static PSQLState DIVISION_BY_ZERO = new PSQLState("22012");
   public final static PSQLState MOST_SPECIFIC_TYPE_DOES_NOT_MATCH = new PSQLState("2200G");
   public final static PSQLState INVALID_PARAMETER_VALUE = new PSQLState("22023");
 
@@ -91,6 +92,9 @@ public class PSQLState implements java.io.Serializable {
   public final static PSQLState TRANSACTION_STATE_INVALID = new PSQLState("25000");
   public final static PSQLState ACTIVE_SQL_TRANSACTION = new PSQLState("25001");
   public final static PSQLState NO_ACTIVE_SQL_TRANSACTION = new PSQLState("25P01");
+  public final static PSQLState IN_FAILED_SQL_TRANSACTION = new PSQLState("25P02");
+
+  public final static PSQLState INVALID_SQL_STATEMENT_NAME = new PSQLState("26000");
   public final static PSQLState INVALID_AUTHORIZATION_SPECIFICATION = new PSQLState("28000");
 
   public final static PSQLState STATEMENT_NOT_ALLOWED_IN_FUNCTION_CALL = new PSQLState("2F003");

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/AutoRollbackTestSuite.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/AutoRollbackTestSuite.java
@@ -1,0 +1,258 @@
+package org.postgresql.test.jdbc2;
+
+import org.postgresql.PGProperty;
+import org.postgresql.core.TransactionState;
+import org.postgresql.jdbc.AutoSave;
+import org.postgresql.jdbc.PgConnection;
+import org.postgresql.test.TestUtil;
+import org.postgresql.util.PSQLState;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Properties;
+
+@RunWith(Parameterized.class)
+public class AutoRollbackTestSuite extends BaseTest4 {
+
+  private enum FailMode {
+    /**
+     * Executes "select 1/0" and causes transaction failure (if autocommit=no).
+     * Mitigation: "autosave=always" or "autocommit=true"
+     */
+    SELECT,
+    /**
+     * Executes "alter table rollbacktest", thus it breaks a prepared select over that table
+     * Mitigation: "autosave in (always, conservative)"
+     */
+    ALTER,
+    /**
+     * Executes DEALLOCATE ALL
+     * Mitigation:
+     *  1) QueryExecutor tracks "DEALLOCATE ALL" responses ({@see org.postgresql.core.QueryExecutor#setFlushCacheOnDeallocate(boolean)}
+     *  2) QueryExecutor tracks "prepared statement name is invalid" and unprepares relevant statements ({@link org.postgresql.core.v3.QueryExecutorImpl#processResults(ResultHandler, int)}
+     *  3) "autosave in (always, conservative)"
+     *  4) Non-transactional cases are healed by retry (when no transaction present, just retry is possible)
+     */
+    DEALLOCATE,
+    /**
+     * Executes DISCARD ALL
+     * Mitigation: the same as for {@link #DEALLOCATE}
+     */
+    DISCARD,
+    /**
+     * Executes "insert ... select 1/0" in a batch statement, thus causing the transaction to fail.
+     */
+    INSERT_BATCH,
+  }
+
+  private enum ContinueMode {
+    COMMIT,
+    IS_VALID,
+    SELECT,
+  }
+
+  private final AutoSave autoSave;
+  private final AutoCommit autoCommit;
+  private final FailMode failMode;
+  private final ContinueMode continueMode;
+
+  public AutoRollbackTestSuite(AutoSave autoSave, AutoCommit autoCommit,
+      FailMode failMode, ContinueMode continueMode) {
+    this.autoSave = autoSave;
+    this.autoCommit = autoCommit;
+    this.failMode = failMode;
+    this.continueMode = continueMode;
+  }
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    TestUtil.createTable(con, "rollbacktest", "a int, str text");
+    con.setAutoCommit(autoCommit == AutoCommit.YES);
+  }
+
+  @Override
+  public void tearDown() throws SQLException {
+    try {
+      con.setAutoCommit(true);
+      TestUtil.dropTable(con, "rollbacktest");
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+    super.tearDown();
+  }
+
+  @Override
+  protected void updateProperties(Properties props) {
+    super.updateProperties(props);
+    PGProperty.AUTOSAVE.set(props, autoSave.value());
+    PGProperty.PREPARE_THRESHOLD.set(props, 1);
+  }
+
+
+  @Parameterized.Parameters(name = "{index}: autorollback(autoSave={0}, autoCommit={1}, failMode={2}, continueMode={3})")
+  public static Iterable<Object[]> data() {
+    Collection<Object[]> ids = new ArrayList<Object[]>();
+    for (AutoSave autoSave : AutoSave.values()) {
+      for (AutoCommit autoCommit : AutoCommit.values()) {
+        for (FailMode failMode : FailMode.values()) {
+          // ERROR: DISCARD ALL cannot run inside a transaction block
+          if (failMode == FailMode.DISCARD && autoCommit == AutoCommit.NO) {
+            continue;
+          }
+          for (ContinueMode continueMode : ContinueMode.values()) {
+            if (failMode == FailMode.ALTER && continueMode != ContinueMode.SELECT) {
+              continue;
+            }
+            ids.add(new Object[]{autoSave, autoCommit, failMode, continueMode});
+          }
+        }
+      }
+    }
+    return ids;
+  }
+
+
+  @Test
+  public void run() throws SQLException {
+    if (continueMode == ContinueMode.IS_VALID) {
+      // make "isValid" a server-prepared statement
+      con.isValid(4);
+    } else if (continueMode == ContinueMode.COMMIT) {
+      doCommit();
+    } else if (continueMode == ContinueMode.SELECT) {
+      assertRows("rollbacktest", 0);
+    }
+
+    Statement statement = con.createStatement();
+    statement.executeUpdate("insert into rollbacktest(a, str) values (0, 'test')");
+
+    PreparedStatement ps = con.prepareStatement("select * from rollbacktest");
+    // Server-prepare the statement
+    ps.executeQuery().close();
+
+    switch (failMode) {
+      case SELECT:
+        try {
+          statement.execute("select 1/0");
+          Assert.fail("select 1/0 should fail");
+        } catch (SQLException e) {
+          Assert.assertEquals("division by zero expected",
+              PSQLState.DIVISION_BY_ZERO.getState(), e.getSQLState());
+        }
+        break;
+      case DEALLOCATE:
+        statement.executeUpdate("DEALLOCATE ALL");
+        break;
+      case DISCARD:
+        statement.executeUpdate("DISCARD ALL");
+        break;
+      case ALTER:
+        statement.executeUpdate("alter table rollbacktest add q int");
+        break;
+      case INSERT_BATCH:
+        try {
+          statement.addBatch("insert into rollbacktest(a, str) values (1/0, 'test')");
+          statement.executeBatch();
+          Assert.fail("select 1/0 should fail");
+        } catch (SQLException e) {
+          Assert.assertEquals("division by zero expected",
+              PSQLState.DIVISION_BY_ZERO.getState(), e.getSQLState());
+        }
+        break;
+      default:
+        Assert.fail("Fail mode " + failMode + " is not implemented");
+    }
+
+    PgConnection pgConnection = con.unwrap(PgConnection.class);
+    if (autoSave == AutoSave.ALWAYS) {
+      Assert.assertNotEquals("In AutoSave.ALWAYS, transaction should not fail",
+          TransactionState.FAILED, pgConnection.getTransactionState());
+    }
+    if (autoCommit == AutoCommit.NO) {
+      Assert.assertNotEquals("AutoCommit == NO, thus transaction should be active (open or failed)",
+          TransactionState.IDLE, pgConnection.getTransactionState());
+    }
+    statement.close();
+
+    switch (continueMode) {
+      case COMMIT:
+        doCommit();
+        return;
+      case IS_VALID:
+        Assert.assertTrue("Connection.isValid should return true unless the connection is closed",
+            con.isValid(4));
+        return;
+      default:
+        break;
+    }
+
+    try {
+      // Try execute server-prepared statement again
+      ps.executeQuery().close();
+    } catch (SQLException e) {
+      if (autoSave != AutoSave.ALWAYS && failMode == FailMode.ALTER) {
+        Assert.assertEquals(
+            "AutoSave==" + autoSave + " != ALWAYS, thus ALTER TABLE causes SELECT * to fail with "
+                + "'cached plan must not change result type', "
+                + " error message is " + e.getMessage(),
+            PSQLState.NOT_IMPLEMENTED.getState(), e.getSQLState());
+        return;
+      }
+      if (autoSave == AutoSave.NEVER
+          || autoSave == AutoSave.CONSERVATIVE && (failMode == FailMode.SELECT
+          || failMode == FailMode.INSERT_BATCH)) {
+        Assert.assertEquals(
+            "AutoSave==NEVER, thus statements should fail with 'current transaction is aborted...', "
+                + " error message is " + e.getMessage(),
+            PSQLState.IN_FAILED_SQL_TRANSACTION.getState(), e.getSQLState());
+        return;
+      }
+      throw e;
+    }
+
+    try {
+      assertRows("rollbacktest", 1);
+    } catch (SQLException e) {
+      if (autoSave == AutoSave.NEVER
+          || autoSave == AutoSave.CONSERVATIVE && failMode == FailMode.SELECT) {
+        Assert.assertEquals(
+            "AutoSave==NEVER, thus statements should fail with 'current transaction is aborted...', "
+                + " error message is " + e.getMessage(),
+            PSQLState.IN_FAILED_SQL_TRANSACTION.getState(), e.getSQLState());
+        return;
+      }
+      throw e;
+    }
+  }
+
+  private void assertRows(String tableName, int nrows) throws SQLException {
+    Statement st = con.createStatement();
+    ResultSet rs = st.executeQuery("select count(*) from " + tableName);
+    rs.next();
+    Assert.assertEquals("Table " + tableName, nrows, rs.getInt(1));
+  }
+
+  private void doCommit() throws SQLException {
+    // Such a dance is required since "commit" checks "current transaction state",
+    // so we need some pending changes, so "commit" query would be sent to the database
+    if (con.getAutoCommit()) {
+      con.setAutoCommit(false);
+      Statement st = con.createStatement();
+      st.executeUpdate(
+          "insert into rollbacktest(a, str) values (42, '" + System.currentTimeMillis() + "')");
+      st.close();
+    }
+    con.commit();
+    con.setAutoCommit(autoCommit == AutoCommit.YES);
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PreparedStatementTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PreparedStatementTest.java
@@ -60,6 +60,7 @@ public class PreparedStatementTest extends BaseTest4 {
     TestUtil.createTable(con, "streamtable", "bin bytea, str text");
     TestUtil.createTable(con, "texttable", "ch char(3), te text, vc varchar(3)");
     TestUtil.createTable(con, "intervaltable", "i interval");
+    TestUtil.createTable(con, "inttable", "a int");
   }
 
   @Override
@@ -67,6 +68,7 @@ public class PreparedStatementTest extends BaseTest4 {
     TestUtil.dropTable(con, "streamtable");
     TestUtil.dropTable(con, "texttable");
     TestUtil.dropTable(con, "intervaltable");
+    TestUtil.dropTable(con, "inttable");
     super.tearDown();
   }
 

--- a/ubenchmark/src/main/java/org/postgresql/benchmark/statement/ParseStatement.java
+++ b/ubenchmark/src/main/java/org/postgresql/benchmark/statement/ParseStatement.java
@@ -50,6 +50,9 @@ public class ParseStatement {
 
   private Connection connection;
 
+  @Param({"conservative"})
+  private String autoSave;
+
   private String sql;
 
   private int cntr;
@@ -57,8 +60,16 @@ public class ParseStatement {
   @Setup(Level.Trial)
   public void setUp() throws SQLException {
     Properties props = ConnectionUtil.getProperties();
+    props.put("autosave", autoSave);
 
     connection = DriverManager.getConnection(ConnectionUtil.getURL(), props);
+
+    // Start transaction
+    Statement st = connection.createStatement();
+    connection.setAutoCommit(false);
+    st.execute("BEGIN");
+    st.close();
+
     StringBuilder sb = new StringBuilder();
     sb.append("SELECT ");
     for (int i = 0; i < bindCount; i++) {


### PR DESCRIPTION
Bug report: http://stackoverflow.com/questions/34180932/error-cached-plan-must-not-change-result-type-when-mixing-ddl-with-select-via
When using "deallocate all" or "alter table", cached prepared statements might become invalid, thus we need to reexecute query in those cases

It might require some logging, however I'm not sure what is the best way to log that.

Summary (technical details):
1) By default pgjdbc watches for `DEALLOCATE ALL`, and `DISCARD ALL` statements, and invalidates prepared statement cache if those are detected.
That does not mean "deallocate all" should be used often. It just means deallocate all might be suitable for maintenance-like procedures.
Note: `deallocate all` invalidates only a single connection.
2) If either `prepared statement XXX does not exist` or `cached statement must not change result type` observed, pgjdbc would invalidate prepared statement cache (see `deallocateEpoch++;`). In general those errors should not happen, however if observed it means something had changed behind the scenes.
3) By default pgjdbc would retry `prepared statement XXX does not exist` and `cached statement must not change result type` errors in `autocommit=true` (non-transactional) mode.
4) New connection property: `autosave`
 * `conservative` -- rollback to savepoint only in case of "prepared statement does not exist" and
       "cached plan must not change result type". Then the driver would re-execute the statement ant it would pass through
 * `never` (default) -- never set automatic safepoint. Note: in this mode statements might still fail with "cached plan must not change result type"
       in autoCommit=FALSE mode
 * `always` -- always rollback to "before statement execution" state in case of failure. This mode prevents "current transaction aborted" errors.
       It is similar to psql's ON_ERROR_ROLLBACK.

For `autocommit=true` the savepoint is not used.
In `conservative` mode, savepoint is used only for queries that return something (see `org.postgresql.core.v3.QueryExecutorImpl#sendAutomaticSavepoint`)