### PR TITLE
Fix null check in getTablePrivileges

### DIFF
--- a/org/postgresql/jdbc2/AbstractJdbc2DatabaseMetaData.java
+++ b/org/postgresql/jdbc2/AbstractJdbc2DatabaseMetaData.java
@@ -2866,7 +2866,7 @@ public abstract class AbstractJdbc2DatabaseMetaData
                     for (Object grant : grants) {
                         String[] grantTuple = (String[]) grant;
                         // report the owner as grantor if it's missing
-                        String grantor = grantTuple[0].equals(null) ? owner : grantTuple[0];
+                        String grantor = grantTuple[0] == null ? owner : grantTuple[0];
                         // owner always has grant privileges
                         String grantable = owner.equals(grantee) ? "YES" : grantTuple[1];
                         byte[][] tuple = new byte[7][];


### PR DESCRIPTION
AbstractJdbc2DatabaseMetaData.getTablePrivileges contains the following
code:

```java
// report the owner as grantor if it's missing
String grantor = grantTuple[0].equals(null) ? owner : grantTuple[0];
```

This will cause a `NullPointerException` if the grantor is missing
instead of using the owner because you can't call `#equals` (or any
method) on `null`.

The code should read

```java
// report the owner as grantor if it's missing
String grantor = grantTuple[0] == null ? owner : grantTuple[0];
```
