### PR TITLE
Useless condition in parseQuery

### DIFF
--- a/org/postgresql/jdbc2/AbstractJdbc2ResultSet.java
+++ b/org/postgresql/jdbc2/AbstractJdbc2ResultSet.java
@@ -1775,23 +1775,14 @@ public abstract class AbstractJdbc2ResultSet implements BaseResultSet, org.postg
         while ( !tableFound && !tablesChecked && st.hasMoreTokens() )
         {
             name = st.nextToken();
-            if ( !tableFound )
+            if ("from".equalsIgnoreCase(name))
             {
-                if ("from".equalsIgnoreCase(name))
-                {
+                tableName = st.nextToken();
+                if ("only".equalsIgnoreCase(tableName)) {
                     tableName = st.nextToken();
-                    if ("only".equalsIgnoreCase(tableName)) {
-                        tableName = st.nextToken();
-                        onlyTable = "ONLY ";
-                    }
-                    tableFound = true;
+                    onlyTable = "ONLY ";
                 }
-            }
-            else
-            {
-                tablesChecked = true;
-                // if the very next token is , then there are multiple tables
-                singleTable = !name.equalsIgnoreCase(",");
+                tableFound = true;
             }
         }
     }


### PR DESCRIPTION
AbstractJdbc2ResultSet#parseQuery contains the following code

```java
if ( !tableFound )
{
}
else
{
}
```

However since that code is inside a loop with the following condition

```java
while ( !tableFound && !tablesChecked && st.hasMoreTokens() )
```
We know that `tableFound` will always be false and therefore the true
branch of the if else will always be executed.
