### PR TITLE
fix of timestamps type information losing for non null timestamp values

### DIFF
--- a/doc/pgjdbc.xml
+++ b/doc/pgjdbc.xml
@@ -1045,6 +1045,16 @@ openssl pkcs8 -topk8 -in client.key -out client.pk8 -outform DER -v1 PBE-SHA1-3D
       </varlistentry>
 
       <varlistentry>
+       <term><varname>strictTimestamp</varname> = <type>int</type></term>
+       <listitem>
+        <para>
+          Specifies whether setTimestamp(int, java.sql.Timestamp) method produces TIMESTAMP SQL value strictly according to JDBC specification.
+          It is off by default because of compatibility with huge amount of third party code, wich relies on non standard timestamp with timezone type while working via JDBC.
+        </para>
+       </listitem>
+      </varlistentry>
+
+      <varlistentry>
        <term><varname>loadBalanceHosts</varname> = <type>boolean</type></term>
        <listitem>
         <para>

--- a/org/postgresql/PGProperty.java
+++ b/org/postgresql/PGProperty.java
@@ -283,7 +283,9 @@ public enum PGProperty
 
     LOAD_BALANCE_HOSTS("loadBalanceHosts", "false", "If disabled hosts are connected in the given order. If enabled hosts are chosen randomly from the set of suitable candidates"),
 
-    HOST_RECHECK_SECONDS("hostRecheckSeconds", "10", "Specifies period (seconds) after host statuses are checked again in case they have changed");
+    HOST_RECHECK_SECONDS("hostRecheckSeconds", "10", "Specifies period (seconds) after host statuses are checked again in case they have changed"),
+    
+    STRICT_TIMESTAMP("strictTimestamp", "false", "Specifies whether setTimestamp(int, java.sql.Timestamp) method produces TIMESTAMP SQL value strictly according to JDBC specification");
 
     private String _name;
     private String _defaultValue;

--- a/org/postgresql/ds/common/BaseDataSource.java
+++ b/org/postgresql/ds/common/BaseDataSource.java
@@ -684,6 +684,22 @@ public abstract class BaseDataSource implements Referenceable
     }
 
     /**
+     * @see PGProperty#STRICT_TIMESTAMP
+     */
+    public void setStrictTimestamp(boolean aValue)
+    {
+        PGProperty.STRICT_TIMESTAMP.set(properties, aValue);
+    }
+
+    /**
+     * @see PGProperty#STRICT_TIMESTAMP
+     */
+    public boolean getStrictTimestamp()
+    {
+        return PGProperty.STRICT_TIMESTAMP.getBoolean(properties);
+    }
+
+    /**
      * @see PGProperty#TCP_KEEP_ALIVE
      */
     public void setTcpKeepAlive(boolean enabled)

--- a/org/postgresql/jdbc2/AbstractJdbc2Connection.java
+++ b/org/postgresql/jdbc2/AbstractJdbc2Connection.java
@@ -48,6 +48,9 @@ public abstract class AbstractJdbc2Connection implements BaseConnection
     private final ProtocolConnection protoConnection;
     /* Compatible version as xxyyzz form */
     private final int compatibleInt;
+    
+    /** Weither timestamp are strict JDBC timestamps (timestamp without time zone)*/
+    protected boolean strictTimestamp;
 
     /* Query that runs COMMIT */
     private final Query commitQuery;
@@ -261,6 +264,8 @@ public abstract class AbstractJdbc2Connection implements BaseConnection
         // Initialize timestamp stuff
         timestampUtils = new TimestampUtils(haveMinimumServerVersion(ServerVersion.v7_4), haveMinimumServerVersion(ServerVersion.v8_2),
                                             !protoConnection.getIntegerDateTimes());
+        
+        strictTimestamp = PGProperty.STRICT_TIMESTAMP.getBoolean(info);
 
         // Initialize common queries.
         commitQuery = getQueryExecutor().createSimpleQuery("COMMIT");
@@ -316,6 +321,10 @@ public abstract class AbstractJdbc2Connection implements BaseConnection
 
     private final TimestampUtils timestampUtils;
     public TimestampUtils getTimestampUtils() { return timestampUtils; }
+    
+    public boolean isStrictTimestamp() {
+        return strictTimestamp;
+    }
 
     /*
      * The current type mappings

--- a/org/postgresql/jdbc2/AbstractJdbc2Statement.java
+++ b/org/postgresql/jdbc2/AbstractJdbc2Statement.java
@@ -1,12 +1,11 @@
 /*-------------------------------------------------------------------------
-*
-* Copyright (c) 2004-2014, PostgreSQL Global Development Group
-*
-*
-*-------------------------------------------------------------------------
-*/
+ *
+ * Copyright (c) 2004-2014, PostgreSQL Global Development Group
+ *
+ *
+ *-------------------------------------------------------------------------
+ */
 package org.postgresql.jdbc2;
-
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -70,13 +69,14 @@ import org.postgresql.util.PSQLException;
 import org.postgresql.util.PSQLState;
 
 /**
- * This class defines methods of the jdbc2 specification.
- * The real Statement class (for jdbc2) is org.postgresql.jdbc2.Jdbc2Statement
+ * This class defines methods of the jdbc2 specification. The real Statement
+ * class (for jdbc2) is org.postgresql.jdbc2.Jdbc2Statement
  */
-public abstract class AbstractJdbc2Statement implements BaseStatement
-{
+public abstract class AbstractJdbc2Statement implements BaseStatement {
+
     /**
-     * Default state for use or not binary transfers. Can use only for testing purposes
+     * Default state for use or not binary transfers. Can use only for testing
+     * purposes
      */
     private static final boolean DEFAULT_FORCE_BINARY_TRANSFERS = Boolean.getBoolean("org.postgresql.forceBinary");
     // only for testing purposes. even single shot statements will use binary transfers
@@ -89,23 +89,28 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
     protected int fetchdirection = ResultSet.FETCH_FORWARD;  // fetch direction hint (currently ignored)
 
     /**
-     * Protects current statement from cancelTask starting, waiting for a bit, and waking up exactly on subsequent query execution.
-     * The idea is to atomically compare and swap the reference to the task, so the task can detect that statement executes different
-     * query than the one the cancelTask was created.
-     * Note: the field must be set/get/compareAndSet via {@link #CANCEL_TIMER_UPDATER} as per {@link AtomicReferenceFieldUpdater} javadoc.
+     * Protects current statement from cancelTask starting, waiting for a bit,
+     * and waking up exactly on subsequent query execution. The idea is to
+     * atomically compare and swap the reference to the task, so the task can
+     * detect that statement executes different query than the one the
+     * cancelTask was created. Note: the field must be set/get/compareAndSet via
+     * {@link #CANCEL_TIMER_UPDATER} as per {@link AtomicReferenceFieldUpdater}
+     * javadoc.
      */
     private volatile TimerTask cancelTimerTask = null;
-    private static final AtomicReferenceFieldUpdater<AbstractJdbc2Statement, TimerTask> CANCEL_TIMER_UPDATER =
-            AtomicReferenceFieldUpdater.newUpdater(AbstractJdbc2Statement.class, TimerTask.class, "cancelTimerTask");
+    private static final AtomicReferenceFieldUpdater<AbstractJdbc2Statement, TimerTask> CANCEL_TIMER_UPDATER
+            = AtomicReferenceFieldUpdater.newUpdater(AbstractJdbc2Statement.class, TimerTask.class, "cancelTimerTask");
 
     /**
-     * Protects statement from out-of-order cancels. It protects from both {@link #setQueryTimeout(int)} and {@link #cancel()} induced ones.
+     * Protects statement from out-of-order cancels. It protects from both
+     * {@link #setQueryTimeout(int)} and {@link #cancel()} induced ones.
      *
-     * .execute() and friends change statementState to STATE_IN_QUERY during execute.
-     * .cancel() ignores cancel request if state is IDLE.
-     * In case .execute() observes non-IN_QUERY state as it completes the query, it waits till
-     * STATE_CANCELLED.
-     * Note: the field must be set/get/compareAndSet via {@link #STATE_UPDATER} as per {@link AtomicIntegerFieldUpdater} javadoc.
+     * .execute() and friends change statementState to STATE_IN_QUERY during
+     * execute. .cancel() ignores cancel request if state is IDLE. In case
+     * .execute() observes non-IN_QUERY state as it completes the query, it
+     * waits till STATE_CANCELLED. Note: the field must be set/get/compareAndSet
+     * via {@link #STATE_UPDATER} as per {@link AtomicIntegerFieldUpdater}
+     * javadoc.
      */
     private volatile int statementState = STATE_IDLE;
     private final static int STATE_IDLE = 0;
@@ -113,65 +118,79 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
     private final static int STATE_CANCELLING = 2;
     private final static int STATE_CANCELLED = 3;
 
-    private static final AtomicIntegerFieldUpdater<AbstractJdbc2Statement> STATE_UPDATER =
-            AtomicIntegerFieldUpdater.newUpdater(AbstractJdbc2Statement.class, "statementState");
+    private static final AtomicIntegerFieldUpdater<AbstractJdbc2Statement> STATE_UPDATER
+            = AtomicIntegerFieldUpdater.newUpdater(AbstractJdbc2Statement.class, "statementState");
 
     /**
      * Does the caller of execute/executeUpdate want generated keys for this
-     * execution?  This is set by Statement methods that have generated keys
+     * execution? This is set by Statement methods that have generated keys
      * arguments and cleared after execution is complete.
      */
     protected boolean wantsGeneratedKeysOnce = false;
 
     /**
      * Was this PreparedStatement created to return generated keys for every
-     * execution?  This is set at creation time and never cleared by
-     * execution.
+     * execution? This is set at creation time and never cleared by execution.
      */
     public boolean wantsGeneratedKeysAlways = false;
 
     // The connection who created us
     protected final BaseConnection connection;
 
-    /** The warnings chain. */
+    /**
+     * The warnings chain.
+     */
     protected SQLWarning warnings = null;
-    /** The last warning of the warning chain. */
+    /**
+     * The last warning of the warning chain.
+     */
     protected SQLWarning lastWarning = null;
 
-    /** Maximum number of rows to return, 0 = unlimited */
+    /**
+     * Maximum number of rows to return, 0 = unlimited
+     */
     protected int maxrows = 0;
 
-    /** Number of rows to get in a batch. */
+    /**
+     * Number of rows to get in a batch.
+     */
     protected int fetchSize = 0;
 
-    /** Timeout (in milliseconds) for a query */
+    /**
+     * Timeout (in milliseconds) for a query
+     */
     protected int timeout = 0;
 
     protected boolean replaceProcessingEnabled = true;
 
-    /** The current results. */
+    /**
+     * The current results.
+     */
     protected ResultWrapper result = null;
 
-    /** The first unclosed result. */
+    /**
+     * The first unclosed result.
+     */
     protected ResultWrapper firstUnclosedResult = null;
 
-    /** Results returned by a statement that wants generated keys. */
+    /**
+     * Results returned by a statement that wants generated keys.
+     */
     protected ResultWrapper generatedKeys = null;
-    
-    /** used to differentiate between new function call
-     * logic and old function call logic
-     * will be set to true if the server is < 8.1 or 
-     * if we are using v2 protocol
-     * There is an exception to this where we are using v3, and the
+
+    /**
+     * used to differentiate between new function call logic and old function
+     * call logic will be set to true if the server is < 8.1 or if we are using
+     * v2 protocol There is an exception to this where we are using v3, and the
      * call does not have an out parameter before the call
      */
     protected boolean adjustIndex = false;
-    
+
     /*
      * Used to set adjustIndex above
      */
-    protected boolean outParmBeforeFunc=false;
-    
+    protected boolean outParmBeforeFunc = false;
+
     // Static variables for parsing SQL when replaceProcessing is true.
     private static final short IN_SQLCODE = 0;
     private static final short IN_STRING = 1;
@@ -181,7 +200,7 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
     private static final short ESC_FUNCTION = 4;
     private static final short ESC_OUTERJOIN = 5;
     private static final short ESC_ESCAPECHAR = 7;
-    
+
     protected final CachedQuery preparedQuery;        // Query fragments for prepared statement.
     protected final ParameterList preparedParameters; // Parameter values for prepared statement.
     protected Query lastSimpleQuery;
@@ -193,21 +212,19 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
     // functionReturnType contains the user supplied value to check
     // testReturn contains a modified version to make it easier to
     // check the getXXX methods..
-    private int []functionReturnType;
-    private int []testReturn;
+    private int[] functionReturnType;
+    private int[] testReturn;
     // returnTypeSet is true when a proper call to registerOutParameter has been made
     private boolean returnTypeSet;
-    protected Object []callResult;
+    protected Object[] callResult;
     protected int maxfieldSize = 0;
 
     public ResultSet createDriverResultSet(Field[] fields, List tuples)
-    throws SQLException
-    {
+            throws SQLException {
         return createResultSet(null, fields, tuples, null);
     }
 
-    public AbstractJdbc2Statement (AbstractJdbc2Connection c, int rsType, int rsConcurrency) throws SQLException
-    {
+    public AbstractJdbc2Statement(AbstractJdbc2Connection c, int rsType, int rsConcurrency) throws SQLException {
         this.connection = c;
         this.preparedQuery = null;
         this.preparedParameters = null;
@@ -219,14 +236,12 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
         setPrepareThreshold(c.getPrepareThreshold());
     }
 
-    public AbstractJdbc2Statement(AbstractJdbc2Connection connection, String sql, boolean isCallable, int rsType, int rsConcurrency) throws SQLException
-    {
+    public AbstractJdbc2Statement(AbstractJdbc2Connection connection, String sql, boolean isCallable, int rsType, int rsConcurrency) throws SQLException {
         this.connection = connection;
         this.lastSimpleQuery = null;
 
         CachedQuery cachedQuery = connection.borrowQuery(sql, isCallable);
-        if (isCallable)
-        {
+        if (isCallable) {
             this.isFunction = cachedQuery.isFunction;
             this.outParmBeforeFunc = cachedQuery.outParmBeforeFunc;
         }
@@ -235,7 +250,7 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
         this.preparedParameters = preparedQuery.query.createParameterList();
 
         if (isFunction) {
-            int inParamCount =  preparedParameters.getInParameterCount() + 1;
+            int inParamCount = preparedParameters.getInParameterCount() + 1;
             this.testReturn = new int[inParamCount];
             this.functionReturnType = new int[inParamCount];
         }
@@ -249,8 +264,7 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
     }
 
     public abstract ResultSet createResultSet(Query originalQuery, Field[] fields, List tuples, ResultCursor cursor)
-    throws SQLException;
-
+            throws SQLException;
 
     public BaseConnection getPGConnection() {
         return connection;
@@ -275,8 +289,8 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
     //
     // ResultHandler implementations for updates, queries, and either-or.
     //
-
     public class StatementResultHandler implements ResultHandler {
+
         private SQLException error;
         private ResultWrapper results;
 
@@ -285,20 +299,18 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
         }
 
         private void append(ResultWrapper newResult) {
-            if (results == null)
+            if (results == null) {
                 results = newResult;
-            else
+            } else {
                 results.append(newResult);
+            }
         }
 
         public void handleResultRows(Query fromQuery, Field[] fields, List tuples, ResultCursor cursor) {
-            try
-            {
+            try {
                 ResultSet rs = AbstractJdbc2Statement.this.createResultSet(fromQuery, fields, tuples, cursor);
                 append(new ResultWrapper(rs));
-            }
-            catch (SQLException e)
-            {
+            } catch (SQLException e) {
                 handleError(e);
             }
         }
@@ -312,15 +324,17 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
         }
 
         public void handleError(SQLException newError) {
-            if (error == null)
+            if (error == null) {
                 error = newError;
-            else
+            } else {
                 error.setNextException(newError);
+            }
         }
 
         public void handleCompletion() throws SQLException {
-            if (error != null)
+            if (error != null) {
                 throw error;
+            }
         }
     }
 
@@ -331,41 +345,43 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
      * @return a ResulSet that contains the data produced by the query
      * @exception SQLException if a database access error occurs
      */
-    public java.sql.ResultSet executeQuery(String p_sql) throws SQLException
-    {
-        if (preparedQuery != null)
+    public java.sql.ResultSet executeQuery(String p_sql) throws SQLException {
+        if (preparedQuery != null) {
             throw new PSQLException(GT.tr("Can''t use query methods that take a query string on a PreparedStatement."),
-                                    PSQLState.WRONG_OBJECT_TYPE);
-
-        if (forceBinaryTransfers) {
-        	clearWarnings();
-                // Close any existing resultsets associated with this statement.
-                while (firstUnclosedResult != null)
-                {
-                   if (firstUnclosedResult.getResultSet() != null)
-                      firstUnclosedResult.getResultSet().close();
-                   firstUnclosedResult = firstUnclosedResult.getNext();
-                }
-
-        	PreparedStatement ps = connection.prepareStatement(p_sql, resultsettype, concurrency, getResultSetHoldability());
-        	ps.setMaxFieldSize(getMaxFieldSize());
-        	ps.setFetchSize(getFetchSize());
-        	ps.setFetchDirection(getFetchDirection());
-        	AbstractJdbc2ResultSet rs = (AbstractJdbc2ResultSet) ps.executeQuery();
-        	rs.registerRealStatement(this);
-
-                result = firstUnclosedResult = new ResultWrapper(rs);
-        	return rs;
+                    PSQLState.WRONG_OBJECT_TYPE);
         }
 
-        if (!executeWithFlags(p_sql, 0))
+        if (forceBinaryTransfers) {
+            clearWarnings();
+            // Close any existing resultsets associated with this statement.
+            while (firstUnclosedResult != null) {
+                if (firstUnclosedResult.getResultSet() != null) {
+                    firstUnclosedResult.getResultSet().close();
+                }
+                firstUnclosedResult = firstUnclosedResult.getNext();
+            }
+
+            PreparedStatement ps = connection.prepareStatement(p_sql, resultsettype, concurrency, getResultSetHoldability());
+            ps.setMaxFieldSize(getMaxFieldSize());
+            ps.setFetchSize(getFetchSize());
+            ps.setFetchDirection(getFetchDirection());
+            AbstractJdbc2ResultSet rs = (AbstractJdbc2ResultSet) ps.executeQuery();
+            rs.registerRealStatement(this);
+
+            result = firstUnclosedResult = new ResultWrapper(rs);
+            return rs;
+        }
+
+        if (!executeWithFlags(p_sql, 0)) {
             throw new PSQLException(GT.tr("No results were returned by the query."), PSQLState.NO_DATA);
+        }
 
-        if (result.getNext() != null)
+        if (result.getNext() != null) {
             throw new PSQLException(GT.tr("Multiple ResultSets were returned by the query."),
-                                    PSQLState.TOO_MANY_RESULTS);
+                    PSQLState.TOO_MANY_RESULTS);
+        }
 
-        return (ResultSet)result.getResultSet();
+        return (ResultSet) result.getResultSet();
     }
 
     /*
@@ -375,13 +391,14 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
      *   * query - never null
      * @exception SQLException if a database access error occurs
      */
-    public java.sql.ResultSet executeQuery() throws SQLException
-    {
-        if (!executeWithFlags(0))
+    public java.sql.ResultSet executeQuery() throws SQLException {
+        if (!executeWithFlags(0)) {
             throw new PSQLException(GT.tr("No results were returned by the query."), PSQLState.NO_DATA);
+        }
 
-        if (result.getNext() != null)
+        if (result.getNext() != null) {
             throw new PSQLException(GT.tr("Multiple ResultSets were returned by the query."), PSQLState.TOO_MANY_RESULTS);
+        }
 
         return (ResultSet) result.getResultSet();
     }
@@ -395,14 +412,13 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
      * @return either a row count, or 0 for SQL commands
      * @exception SQLException if a database access error occurs
      */
-    public int executeUpdate(String p_sql) throws SQLException
-    {
-        if (preparedQuery != null)
+    public int executeUpdate(String p_sql) throws SQLException {
+        if (preparedQuery != null) {
             throw new PSQLException(GT.tr("Can''t use query methods that take a query string on a PreparedStatement."),
-                                    PSQLState.WRONG_OBJECT_TYPE);
-        if( isFunction )
-        {
-            executeWithFlags(p_sql, 0);                
+                    PSQLState.WRONG_OBJECT_TYPE);
+        }
+        if (isFunction) {
+            executeWithFlags(p_sql, 0);
             return 0;
         }
 
@@ -412,7 +428,7 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
         while (iter != null) {
             if (iter.getResultSet() != null) {
                 throw new PSQLException(GT.tr("A result was returned when none was expected."),
-                    				  PSQLState.TOO_MANY_RESULTS);
+                        PSQLState.TOO_MANY_RESULTS);
 
             }
             iter = iter.getNext();
@@ -430,10 +446,8 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
      *   * 0 for SQL statements that return nothing.
      * @exception SQLException if a database access error occurs
      */
-    public int executeUpdate() throws SQLException
-    {
-        if( isFunction )
-        {
+    public int executeUpdate() throws SQLException {
+        if (isFunction) {
             executeWithFlags(0);
             return 0;
         }
@@ -444,7 +458,7 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
         while (iter != null) {
             if (iter.getResultSet() != null) {
                 throw new PSQLException(GT.tr("A result was returned when none was expected."),
-                    				  PSQLState.TOO_MANY_RESULTS);
+                        PSQLState.TOO_MANY_RESULTS);
 
             }
             iter = iter.getNext();
@@ -464,17 +478,16 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
      * an update count or there are no more results
      * @exception SQLException if a database access error occurs
      */
-    public boolean execute(String p_sql) throws SQLException
-    {
-        if (preparedQuery != null)
+    public boolean execute(String p_sql) throws SQLException {
+        if (preparedQuery != null) {
             throw new PSQLException(GT.tr("Can''t use query methods that take a query string on a PreparedStatement."),
-                                    PSQLState.WRONG_OBJECT_TYPE);
+                    PSQLState.WRONG_OBJECT_TYPE);
+        }
 
         return executeWithFlags(p_sql, 0);
     }
 
-    public boolean executeWithFlags(String p_sql, int flags) throws SQLException
-    {
+    public boolean executeWithFlags(String p_sql, int flags) throws SQLException {
         checkClosed();
         p_sql = replaceProcessing(p_sql, replaceProcessingEnabled, connection.getStandardConformingStrings());
         Query simpleQuery = connection.getQueryExecutor().createSimpleQuery(p_sql);
@@ -483,73 +496,70 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
         return (result != null && result.getResultSet() != null);
     }
 
-    public boolean execute() throws SQLException
-    {
+    public boolean execute() throws SQLException {
         return executeWithFlags(0);
     }
 
-    public boolean executeWithFlags(int flags) throws SQLException
-    {
+    public boolean executeWithFlags(int flags) throws SQLException {
         checkClosed();
-   
+
         execute(preparedQuery.query, preparedParameters, flags);
 
         // If we are executing and there are out parameters 
         // callable statement function set the return data
-        
-        if (isFunction && returnTypeSet )
-        {
-            if (result == null || result.getResultSet() == null)
+        if (isFunction && returnTypeSet) {
+            if (result == null || result.getResultSet() == null) {
                 throw new PSQLException(GT.tr("A CallableStatement was executed with nothing returned."), PSQLState.NO_DATA);
+            }
 
             ResultSet rs = result.getResultSet();
-            if (!rs.next())
+            if (!rs.next()) {
                 throw new PSQLException(GT.tr("A CallableStatement was executed with nothing returned."), PSQLState.NO_DATA);
+            }
 
             // figure out how many columns
             int cols = rs.getMetaData().getColumnCount();
-            
-            int outParameterCount = preparedParameters.getOutParameterCount() ;
-            
-            if ( cols != outParameterCount )
-                throw new PSQLException(GT.tr("A CallableStatement was executed with an invalid number of parameters"),PSQLState.SYNTAX_ERROR);
-           
+
+            int outParameterCount = preparedParameters.getOutParameterCount();
+
+            if (cols != outParameterCount) {
+                throw new PSQLException(GT.tr("A CallableStatement was executed with an invalid number of parameters"), PSQLState.SYNTAX_ERROR);
+            }
+
             // reset last result fetched (for wasNull)
             lastIndex = 0;
 
             // allocate enough space for all possible parameters without regard to in/out            
-            callResult = new Object[preparedParameters.getParameterCount()+1];
-            
+            callResult = new Object[preparedParameters.getParameterCount() + 1];
+
             // move them into the result set
-            for ( int i=0,j=0; i < cols; i++,j++)
-            {
+            for (int i = 0, j = 0; i < cols; i++, j++) {
                 // find the next out parameter, the assumption is that the functionReturnType 
                 // array will be initialized with 0 and only out parameters will have values
                 // other than 0. 0 is the value for java.sql.Types.NULL, which should not 
                 // conflict
-                while( j< functionReturnType.length && functionReturnType[j]==0) j++;
-                
-                callResult[j] = rs.getObject(i+1);
-                int columnType = rs.getMetaData().getColumnType(i+1);
+                while (j < functionReturnType.length && functionReturnType[j] == 0) {
+                    j++;
+                }
 
-                if (columnType != functionReturnType[j])
-                {
+                callResult[j] = rs.getObject(i + 1);
+                int columnType = rs.getMetaData().getColumnType(i + 1);
+
+                if (columnType != functionReturnType[j]) {
                     // this is here for the sole purpose of passing the cts
-                    if ( columnType == Types.DOUBLE && functionReturnType[j] == Types.REAL )
-                    {
+                    if (columnType == Types.DOUBLE && functionReturnType[j] == Types.REAL) {
                         // return it as a float
-                        if ( callResult[j] != null)
+                        if (callResult[j] != null) {
                             callResult[j] = ((Double) callResult[j]).floatValue();
-                    }
-                    else
-                    {    
-	                    throw new PSQLException (GT.tr("A CallableStatement function was executed and the out parameter {0} was of type {1} however type {2} was registered.",
-	                            new Object[]{i + 1,
-	                                "java.sql.Types=" + columnType, "java.sql.Types=" + functionReturnType[j] }),
-	                      PSQLState.DATA_TYPE_MISMATCH);
+                        }
+                    } else {
+                        throw new PSQLException(GT.tr("A CallableStatement function was executed and the out parameter {0} was of type {1} however type {2} was registered.",
+                                new Object[]{i + 1,
+                                    "java.sql.Types=" + columnType, "java.sql.Types=" + functionReturnType[j]}),
+                                PSQLState.DATA_TYPE_MISMATCH);
                     }
                 }
-                    
+
             }
             rs.close();
             result = null;
@@ -564,11 +574,9 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
         clearWarnings();
 
         // Close any existing resultsets associated with this statement.
-        while (firstUnclosedResult != null)
-        {
+        while (firstUnclosedResult != null) {
             ResultSet rs = firstUnclosedResult.getResultSet();
-            if (rs != null)
-            {
+            if (rs != null) {
                 rs.close();
             }
             firstUnclosedResult = firstUnclosedResult.getNext();
@@ -592,76 +600,75 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
         closeForNextExecution();
 
         // Enable cursor-based resultset if possible.
-        if (fetchSize > 0 && !wantsScrollableResultSet() && !connection.getAutoCommit() && !wantsHoldableResultSet())
+        if (fetchSize > 0 && !wantsScrollableResultSet() && !connection.getAutoCommit() && !wantsHoldableResultSet()) {
             flags |= QueryExecutor.QUERY_FORWARD_CURSOR;
+        }
 
-        if (wantsGeneratedKeysOnce || wantsGeneratedKeysAlways)
-        {
+        if (wantsGeneratedKeysOnce || wantsGeneratedKeysAlways) {
             flags |= QueryExecutor.QUERY_BOTH_ROWS_AND_STATUS;
 
             // If the no results flag is set (from executeUpdate)
             // clear it so we get the generated keys results.
             //
-            if ((flags & QueryExecutor.QUERY_NO_RESULTS) != 0)
+            if ((flags & QueryExecutor.QUERY_NO_RESULTS) != 0) {
                 flags &= ~(QueryExecutor.QUERY_NO_RESULTS);
+            }
         }
 
         // Only use named statements after we hit the threshold. Note that only
         // named statements can be transferred in binary format.
-        if (preparedQuery != null && preparedQuery.query == queryToExecute)
-        {
+        if (preparedQuery != null && preparedQuery.query == queryToExecute) {
             preparedQuery.increaseExecuteCount();
-            if ((m_prepareThreshold == 0 || preparedQuery.getExecuteCount() < m_prepareThreshold) && !forceBinaryTransfers)
+            if ((m_prepareThreshold == 0 || preparedQuery.getExecuteCount() < m_prepareThreshold) && !forceBinaryTransfers) {
                 flags |= QueryExecutor.QUERY_ONESHOT;
+            }
         }
 
-        if (connection.getAutoCommit())
+        if (connection.getAutoCommit()) {
             flags |= QueryExecutor.QUERY_SUPPRESS_BEGIN;
+        }
 
         // updateable result sets do not yet support binary updates
-        if (concurrency != ResultSet.CONCUR_READ_ONLY)
+        if (concurrency != ResultSet.CONCUR_READ_ONLY) {
             flags |= QueryExecutor.QUERY_NO_BINARY_TRANSFER;
+        }
 
-        if (queryToExecute.isEmpty())
-        {
+        if (queryToExecute.isEmpty()) {
             flags |= QueryExecutor.QUERY_SUPPRESS_BEGIN;
         }
 
         if (!queryToExecute.isStatementDescribed() && forceBinaryTransfers) {
-                int flags2 = flags | QueryExecutor.QUERY_DESCRIBE_ONLY;
-                StatementResultHandler handler2 = new StatementResultHandler();
-                connection.getQueryExecutor().execute(queryToExecute, queryParameters, handler2, 0, 0, flags2);
-                ResultWrapper result2 = handler2.getResults();
-                if (result2 != null) {
-                    result2.getResultSet().close();
-                }
+            int flags2 = flags | QueryExecutor.QUERY_DESCRIBE_ONLY;
+            StatementResultHandler handler2 = new StatementResultHandler();
+            connection.getQueryExecutor().execute(queryToExecute, queryParameters, handler2, 0, 0, flags2);
+            ResultWrapper result2 = handler2.getResults();
+            if (result2 != null) {
+                result2.getResultSet().close();
+            }
         }
 
         StatementResultHandler handler = new StatementResultHandler();
         result = null;
-        try
-        {
+        try {
             startTimer();
             connection.getQueryExecutor().execute(queryToExecute,
-                                                  queryParameters,
-                                                  handler,
-                                                  maxrows,
-                                                  fetchSize,
-                                                  flags);
-        }
-        finally
-        {
+                    queryParameters,
+                    handler,
+                    maxrows,
+                    fetchSize,
+                    flags);
+        } finally {
             killTimerTask();
         }
         result = firstUnclosedResult = handler.getResults();
 
-        if (wantsGeneratedKeysOnce || wantsGeneratedKeysAlways)
-        {
+        if (wantsGeneratedKeysOnce || wantsGeneratedKeysAlways) {
             generatedKeys = result;
             result = result.getNext();
 
-            if (wantsGeneratedKeysOnce)
+            if (wantsGeneratedKeysOnce) {
                 wantsGeneratedKeysOnce = false;
+            }
         }
 
     }
@@ -682,8 +689,7 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
      * @param name the new cursor name
      * @exception SQLException if a database access error occurs
      */
-    public void setCursorName(String name) throws SQLException
-    {
+    public void setCursorName(String name) throws SQLException {
         checkClosed();
         // No-op.
     }
@@ -700,11 +706,12 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
      * @return the current result as an update count.
      * @exception SQLException if a database access error occurs
      */
-    public int getUpdateCount() throws SQLException
-    {
+
+    public int getUpdateCount() throws SQLException {
         checkClosed();
-        if (result == null || result.getResultSet() != null)
+        if (result == null || result.getResultSet() != null) {
             return -1;
+        }
 
         return result.getUpdateCount();
     }
@@ -716,18 +723,18 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
      * @return true if the next ResultSet is valid
      * @exception SQLException if a database access error occurs
      */
-    public boolean getMoreResults() throws SQLException
-    {
-        if (result == null)
+    public boolean getMoreResults() throws SQLException {
+        if (result == null) {
             return false;
+        }
 
         result = result.getNext();
 
         // Close preceding resultsets.
-        while (firstUnclosedResult != result)
-        {
-            if (firstUnclosedResult.getResultSet() != null)
+        while (firstUnclosedResult != result) {
+            if (firstUnclosedResult.getResultSet() != null) {
                 firstUnclosedResult.getResultSet().close();
+            }
             firstUnclosedResult = firstUnclosedResult.getNext();
         }
 
@@ -742,8 +749,7 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
      * @return the current maximum row limit; zero means unlimited
      * @exception SQLException if a database access error occurs
      */
-    public int getMaxRows() throws SQLException
-    {
+    public int getMaxRows() throws SQLException {
         checkClosed();
         return maxrows;
     }
@@ -755,12 +761,12 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
      * @exception SQLException if a database access error occurs
      * @see getMaxRows
      */
-    public void setMaxRows(int max) throws SQLException
-    {
+    public void setMaxRows(int max) throws SQLException {
         checkClosed();
-        if (max < 0)
+        if (max < 0) {
             throw new PSQLException(GT.tr("Maximum number of rows must be a value grater than or equal to 0."),
-                                    PSQLState.INVALID_PARAMETER_VALUE);
+                    PSQLState.INVALID_PARAMETER_VALUE);
+        }
         maxrows = max;
     }
 
@@ -771,8 +777,7 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
      * @param enable true to enable; false to disable
      * @exception SQLException if a database access error occurs
      */
-    public void setEscapeProcessing(boolean enable) throws SQLException
-    {
+    public void setEscapeProcessing(boolean enable) throws SQLException {
         checkClosed();
         replaceProcessingEnabled = enable;
     }
@@ -785,8 +790,7 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
      * @return the current query timeout limit in seconds; 0 = unlimited
      * @exception SQLException if a database access error occurs
      */
-    public int getQueryTimeout() throws SQLException
-    {
+    public int getQueryTimeout() throws SQLException {
         return getQueryTimeoutMs() / 1000;
     }
 
@@ -796,8 +800,7 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
      * @param seconds - the new query timeout limit in seconds
      * @exception SQLException if a database access error occurs
      */
-    public void setQueryTimeout(int seconds) throws SQLException
-    {
+    public void setQueryTimeout(int seconds) throws SQLException {
         setQueryTimeoutMs(seconds * 1000);
     }
 
@@ -809,8 +812,7 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
      * @return the current query timeout limit in milliseconds; 0 = unlimited
      * @exception SQLException if a database access error occurs
      */
-    public int getQueryTimeoutMs() throws SQLException
-    {
+    public int getQueryTimeoutMs() throws SQLException {
         checkClosed();
         return timeout;
     }
@@ -821,26 +823,25 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
      * @param seconds - the new query timeout limit in milliseconds
      * @exception SQLException if a database access error occurs
      */
-    public void setQueryTimeoutMs(int millis) throws SQLException
-    {
+    public void setQueryTimeoutMs(int millis) throws SQLException {
         checkClosed();
 
-        if (millis < 0)
+        if (millis < 0) {
             throw new PSQLException(GT.tr("Query timeout must be a value greater than or equals to 0."),
-                                    PSQLState.INVALID_PARAMETER_VALUE);
+                    PSQLState.INVALID_PARAMETER_VALUE);
+        }
         timeout = millis;
     }
 
     /**
-     * This adds a warning to the warning chain.  We track the
-     * tail of the warning chain as well to avoid O(N) behavior
-     * for adding a new warning to an existing chain.  Some
-     * server functions which RAISE NOTICE (or equivalent) produce
-     * a ton of warnings.
+     * This adds a warning to the warning chain. We track the tail of the
+     * warning chain as well to avoid O(N) behavior for adding a new warning to
+     * an existing chain. Some server functions which RAISE NOTICE (or
+     * equivalent) produce a ton of warnings.
+     *
      * @param warn warning to add
      */
-    public void addWarning(SQLWarning warn)
-    {
+    public void addWarning(SQLWarning warn) {
         if (warnings == null) {
             warnings = warn;
             lastWarning = warn;
@@ -866,8 +867,7 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
      * @return the first SQLWarning on null
      * @exception SQLException if a database access error occurs
      */
-    public SQLWarning getWarnings() throws SQLException
-    {
+    public SQLWarning getWarnings() throws SQLException {
         checkClosed();
         return warnings;
     }
@@ -882,8 +882,7 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
      * @return the current max column size limit; zero means unlimited
      * @exception SQLException if a database access error occurs
      */
-    public int getMaxFieldSize() throws SQLException
-    {
+    public int getMaxFieldSize() throws SQLException {
         return maxfieldSize;
     }
 
@@ -893,12 +892,12 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
      * @param max the new max column size limit; zero means unlimited
      * @exception SQLException if a database access error occurs
      */
-    public void setMaxFieldSize(int max) throws SQLException
-    {
+    public void setMaxFieldSize(int max) throws SQLException {
         checkClosed();
-        if (max < 0)
+        if (max < 0) {
             throw new PSQLException(GT.tr("The maximum field size must be a value greater than or equal to 0."),
-                                    PSQLState.INVALID_PARAMETER_VALUE);
+                    PSQLState.INVALID_PARAMETER_VALUE);
+        }
         maxfieldSize = max;
     }
 
@@ -908,8 +907,7 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
      *
      * @exception SQLException if a database access error occurs
      */
-    public void clearWarnings() throws SQLException
-    {
+    public void clearWarnings() throws SQLException {
         warnings = null;
         lastWarning = null;
     }
@@ -921,12 +919,12 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
      * @return the current result set; null if there are no more
      * @exception SQLException if a database access error occurs (why?)
      */
-    public java.sql.ResultSet getResultSet() throws SQLException
-    {
+    public java.sql.ResultSet getResultSet() throws SQLException {
         checkClosed();
 
-        if (result == null)
+        if (result == null) {
             return null;
+        }
 
         return (ResultSet) result.getResultSet();
     }
@@ -943,14 +941,14 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
      *
      * @exception SQLException if a database access error occurs (why?)
      */
-    public void close() throws SQLException
-    {
+    public void close() throws SQLException {
         // closing an already closed Statement is a no-op.
-        if (isClosed)
-            return ;
+        if (isClosed) {
+            return;
+        }
 
         cleanupTimer();
-        
+
         closeForNextExecution();
 
         if (preparedQuery != null) {
@@ -969,7 +967,8 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
 
     /**
      * Statement finalizer is not required as "statement" at the database side
-     * is managed by a {@link java.lang.ref.PhantomReference} in {@link QueryExecutorImpl#processDeadParsedQueries()}.
+     * is managed by a {@link java.lang.ref.PhantomReference} in
+     * {@link QueryExecutorImpl#processDeadParsedQueries()}.
      */
 
     /*
@@ -983,16 +982,14 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
      * So, something like "select * from x where d={d '2001-10-09'}" would
      * return "select * from x where d= '2001-10-09'".
      */
-    static String replaceProcessing(String p_sql, boolean replaceProcessingEnabled, boolean standardConformingStrings) throws SQLException
-    {
-        if (replaceProcessingEnabled)
-        {
+    static String replaceProcessing(String p_sql, boolean replaceProcessingEnabled, boolean standardConformingStrings) throws SQLException {
+        if (replaceProcessingEnabled) {
             // Since escape codes can only appear in SQL CODE, we keep track
             // of if we enter a string or not.
             int len = p_sql.length();
             StringBuilder newsql = new StringBuilder(len);
-            int i=0;
-            while (i<len){
+            int i = 0;
+            while (i < len) {
                 i = parseSql(p_sql, i, newsql, false, standardConformingStrings);
                 // We need to loop here in case we encounter invalid
                 // SQL, consider: SELECT a FROM t WHERE (1 > 0)) ORDER BY a
@@ -1005,199 +1002,198 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
                 }
             }
             return newsql.toString();
-        }
-        else
-        {
+        } else {
             return p_sql;
         }
     }
-    
+
     /**
-     * parse the given sql from index i, appending it to the gven buffer
-     * until we hit an unmatched right parentheses or end of string.  When
-     * the stopOnComma flag is set we also stop processing when a comma is
-     * found in sql text that isn't inside nested parenthesis.
+     * parse the given sql from index i, appending it to the gven buffer until
+     * we hit an unmatched right parentheses or end of string. When the
+     * stopOnComma flag is set we also stop processing when a comma is found in
+     * sql text that isn't inside nested parenthesis.
      *
      * @param p_sql the original query text
      * @param i starting position for replacing
      * @param newsql where to write the replaced output
-     * @param stopOnComma should we stop after hitting the first comma in sql text?
+     * @param stopOnComma should we stop after hitting the first comma in sql
+     * text?
      * @param stdStrings whether standard_conforming_strings is on
      * @return the position we stopped processing at
      */
-    protected static int parseSql(String p_sql,int i,StringBuilder newsql, boolean stopOnComma,
-                                  boolean stdStrings)throws SQLException{
+    protected static int parseSql(String p_sql, int i, StringBuilder newsql, boolean stopOnComma,
+            boolean stdStrings) throws SQLException {
         short state = IN_SQLCODE;
         int len = p_sql.length();
-        int nestedParenthesis=0;
-        boolean endOfNested=false;
+        int nestedParenthesis = 0;
+        boolean endOfNested = false;
 
         // because of the ++i loop
         i--;
-        while (!endOfNested && ++i < len)
-        {
+        while (!endOfNested && ++i < len) {
             char c = p_sql.charAt(i);
-            switch (state)
-            {
-            case IN_SQLCODE:
-                if (c == '\'')      // start of a string?
-                    state = IN_STRING;
-                else if (c == '"')      // start of a identifer?
-                    state = IN_IDENTIFIER;
-                else if (c=='(') { // begin nested sql
-                    nestedParenthesis++;
-                } else if (c==')') { // end of nested sql
-                    nestedParenthesis--;
-                    if (nestedParenthesis<0){
-                        endOfNested=true;
-                        break;
-                    }
-                } else if (stopOnComma && c==',' && nestedParenthesis==0) {
-                    endOfNested=true;
-                    break;
-                } else if (c == '{') {     // start of an escape code?
-                    if (i + 1 < len)
+            switch (state) {
+                case IN_SQLCODE:
+                    if (c == '\'') // start of a string?
                     {
-                        char next = p_sql.charAt(i + 1);
-                        char nextnext = (i + 2 < len) ? p_sql.charAt(i + 2) : '\0';
-                        if (next == 'd' || next == 'D')
-                        {
-                            state = ESC_TIMEDATE;
-                            i++;
-                            newsql.append("DATE ");
+                        state = IN_STRING;
+                    } else if (c == '"') // start of a identifer?
+                    {
+                        state = IN_IDENTIFIER;
+                    } else if (c == '(') { // begin nested sql
+                        nestedParenthesis++;
+                    } else if (c == ')') { // end of nested sql
+                        nestedParenthesis--;
+                        if (nestedParenthesis < 0) {
+                            endOfNested = true;
                             break;
                         }
-                        else if (next == 't' || next == 'T')
-                        {
-                            state = ESC_TIMEDATE;
-                            if (nextnext == 's' || nextnext == 'S'){
-                                // timestamp constant
-                                i+=2;
-                                newsql.append("TIMESTAMP ");
-                            }else{
-                                // time constant
+                    } else if (stopOnComma && c == ',' && nestedParenthesis == 0) {
+                        endOfNested = true;
+                        break;
+                    } else if (c == '{') {     // start of an escape code?
+                        if (i + 1 < len) {
+                            char next = p_sql.charAt(i + 1);
+                            char nextnext = (i + 2 < len) ? p_sql.charAt(i + 2) : '\0';
+                            if (next == 'd' || next == 'D') {
+                                state = ESC_TIMEDATE;
                                 i++;
-                                newsql.append("TIME ");
+                                newsql.append("DATE ");
+                                break;
+                            } else if (next == 't' || next == 'T') {
+                                state = ESC_TIMEDATE;
+                                if (nextnext == 's' || nextnext == 'S') {
+                                    // timestamp constant
+                                    i += 2;
+                                    newsql.append("TIMESTAMP ");
+                                } else {
+                                    // time constant
+                                    i++;
+                                    newsql.append("TIME ");
+                                }
+                                break;
+                            } else if (next == 'f' || next == 'F') {
+                                state = ESC_FUNCTION;
+                                i += (nextnext == 'n' || nextnext == 'N') ? 2 : 1;
+                                break;
+                            } else if (next == 'o' || next == 'O') {
+                                state = ESC_OUTERJOIN;
+                                i += (nextnext == 'j' || nextnext == 'J') ? 2 : 1;
+                                break;
+                            } else if (next == 'e' || next == 'E') { // we assume that escape is the only escape sequence beginning with e
+                                state = ESC_ESCAPECHAR;
+                                break;
                             }
-                            break;
-                        }
-                        else if ( next == 'f' || next == 'F' )
-                        {
-                            state = ESC_FUNCTION;
-                            i += (nextnext == 'n' || nextnext == 'N') ? 2 : 1;
-                            break;
-                        }
-                        else if ( next == 'o' || next == 'O' )
-                        {
-                            state = ESC_OUTERJOIN;
-                            i += (nextnext == 'j' || nextnext == 'J') ? 2 : 1;
-                            break;
-                        }
-                        else if ( next == 'e' || next == 'E' )
-                        { // we assume that escape is the only escape sequence beginning with e
-                            state = ESC_ESCAPECHAR;
-                            break;
                         }
                     }
-                }
-                newsql.append(c);
-                break;
-
-            case IN_STRING:
-                if (c == '\'')       // end of string?
-                    state = IN_SQLCODE;
-                else if (c == '\\' && !stdStrings)      // a backslash?
-                    state = BACKSLASH;
-
-                newsql.append(c);
-                break;
-                
-            case IN_IDENTIFIER:
-                if (c == '"')       // end of identifier
-                    state = IN_SQLCODE;
-                newsql.append(c);
-                break;
-
-            case BACKSLASH:
-                state = IN_STRING;
-
-                newsql.append(c);
-                break;
-
-            case ESC_FUNCTION:
-                // extract function name
-                String functionName;
-                int posArgs = p_sql.indexOf('(',i);
-                if (posArgs!=-1){
-                    functionName=p_sql.substring(i,posArgs).trim();
-                    // extract arguments
-                    i= posArgs+1;// we start the scan after the first (
-                    StringBuilder args=new StringBuilder();
-                    i = parseSql(p_sql,i,args,false,stdStrings);
-                    // translate the function and parse arguments
-                    newsql.append(escapeFunction(functionName,args.toString(),stdStrings));
-                }
-                // go to the end of the function copying anything found
-                i++;
-                while (i<len && p_sql.charAt(i)!='}')
-                    newsql.append(p_sql.charAt(i++));
-                state = IN_SQLCODE; // end of escaped function (or query)
-                break;
-            case ESC_TIMEDATE:       
-            case ESC_OUTERJOIN:
-            case ESC_ESCAPECHAR:
-                if (c == '}')
-                    state = IN_SQLCODE;    // end of escape code.
-                else
                     newsql.append(c);
-                break;
+                    break;
+
+                case IN_STRING:
+                    if (c == '\'') // end of string?
+                    {
+                        state = IN_SQLCODE;
+                    } else if (c == '\\' && !stdStrings) // a backslash?
+                    {
+                        state = BACKSLASH;
+                    }
+
+                    newsql.append(c);
+                    break;
+
+                case IN_IDENTIFIER:
+                    if (c == '"') // end of identifier
+                    {
+                        state = IN_SQLCODE;
+                    }
+                    newsql.append(c);
+                    break;
+
+                case BACKSLASH:
+                    state = IN_STRING;
+
+                    newsql.append(c);
+                    break;
+
+                case ESC_FUNCTION:
+                    // extract function name
+                    String functionName;
+                    int posArgs = p_sql.indexOf('(', i);
+                    if (posArgs != -1) {
+                        functionName = p_sql.substring(i, posArgs).trim();
+                        // extract arguments
+                        i = posArgs + 1;// we start the scan after the first (
+                        StringBuilder args = new StringBuilder();
+                        i = parseSql(p_sql, i, args, false, stdStrings);
+                        // translate the function and parse arguments
+                        newsql.append(escapeFunction(functionName, args.toString(), stdStrings));
+                    }
+                    // go to the end of the function copying anything found
+                    i++;
+                    while (i < len && p_sql.charAt(i) != '}') {
+                        newsql.append(p_sql.charAt(i++));
+                    }
+                    state = IN_SQLCODE; // end of escaped function (or query)
+                    break;
+                case ESC_TIMEDATE:
+                case ESC_OUTERJOIN:
+                case ESC_ESCAPECHAR:
+                    if (c == '}') {
+                        state = IN_SQLCODE;    // end of escape code.
+                    } else {
+                        newsql.append(c);
+                    }
+                    break;
             } // end switch
         }
         return i;
     }
-    
+
     /**
      * generate sql for escaped functions
+     *
      * @param functionName the escaped function name
      * @param args the arguments for this functin
      * @param stdStrings whether standard_conforming_strings is on
      * @return the right postgreSql sql
      */
-    protected static String escapeFunction(String functionName, String args, boolean stdStrings) throws SQLException{
+    protected static String escapeFunction(String functionName, String args, boolean stdStrings) throws SQLException {
         // parse function arguments
         int len = args.length();
-        int i=0;
+        int i = 0;
         ArrayList parsedArgs = new ArrayList();
-        while (i<len){
+        while (i < len) {
             StringBuilder arg = new StringBuilder();
-            int lastPos=i;
-            i=parseSql(args,i,arg,true,stdStrings);
-            if (lastPos!=i){
+            int lastPos = i;
+            i = parseSql(args, i, arg, true, stdStrings);
+            if (lastPos != i) {
                 parsedArgs.add(arg);
             }
             i++;
         }
         // we can now tranlate escape functions
-        try{
+        try {
             Method escapeMethod = EscapedFunctions.getFunction(functionName);
-            return (String) escapeMethod.invoke(null,new Object[] {parsedArgs});
-        }catch(InvocationTargetException e){
-            if (e.getTargetException() instanceof SQLException)
+            return (String) escapeMethod.invoke(null, new Object[]{parsedArgs});
+        } catch (InvocationTargetException e) {
+            if (e.getTargetException() instanceof SQLException) {
                 throw (SQLException) e.getTargetException();
-            else
+            } else {
                 throw new PSQLException(e.getTargetException().getMessage(),
-                                        PSQLState.SYSTEM_ERROR);
-        }catch (Exception e){
+                        PSQLState.SYSTEM_ERROR);
+            }
+        } catch (Exception e) {
             // by default the function name is kept unchanged
             StringBuilder buf = new StringBuilder();
             buf.append(functionName).append('(');
-            for (int iArg = 0;iArg<parsedArgs.size();iArg++){
+            for (int iArg = 0; iArg < parsedArgs.size(); iArg++) {
                 buf.append(parsedArgs.get(iArg));
-                if (iArg!=(parsedArgs.size()-1))
+                if (iArg != (parsedArgs.size() - 1)) {
                     buf.append(',');
+                }
             }
             buf.append(')');
-            return buf.toString();    
+            return buf.toString();
         }
     }
 
@@ -1210,27 +1206,27 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
 
     /*
      * Returns the Last inserted/updated oid.  Deprecated in 7.2 because
-      * range of OID values is greater than a java signed int.
+     * range of OID values is greater than a java signed int.
      * @deprecated Replaced by getLastOID in 7.2
      */
-    public int getInsertedOID() throws SQLException
-    {
+    public int getInsertedOID() throws SQLException {
         checkClosed();
-        if (result == null)
+        if (result == null) {
             return 0;
+        }
         return (int) result.getInsertOID();
     }
 
     /*
      * Returns the Last inserted/updated oid.
      * @return OID of last insert
-      * @since 7.2
+     * @since 7.2
      */
-    public long getLastOID() throws SQLException
-    {
+    public long getLastOID() throws SQLException {
         checkClosed();
-        if (result == null)
+        if (result == null) {
             return 0;
+        }
         return result.getInsertOID();
     }
 
@@ -1243,81 +1239,77 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
      * @param sqlType the SQL type code defined in java.sql.Types
      * @exception SQLException if a database access error occurs
      */
-    public void setNull(int parameterIndex, int sqlType) throws SQLException
-    {
+    public void setNull(int parameterIndex, int sqlType) throws SQLException {
         checkClosed();
 
         int oid;
-        switch (sqlType)
-        {
-        case Types.INTEGER:
-            oid = Oid.INT4;
-            break;
-        case Types.TINYINT:
-        case Types.SMALLINT:
-            oid = Oid.INT2;
-            break;
-        case Types.BIGINT:
-            oid = Oid.INT8;
-            break;
-        case Types.REAL:
-            oid = Oid.FLOAT4;
-            break;
-        case Types.DOUBLE:
-        case Types.FLOAT:				
-            oid = Oid.FLOAT8;
-            break;
-        case Types.DECIMAL:
-        case Types.NUMERIC:
-            oid = Oid.NUMERIC;
-            break;
-        case Types.CHAR:
-            oid = Oid.BPCHAR;
-            break;
-        case Types.VARCHAR:
-        case Types.LONGVARCHAR:
-            oid = connection.getStringVarcharFlag() ? Oid.VARCHAR : Oid.UNSPECIFIED;
-            break;
-        case Types.DATE:
-            oid = Oid.DATE;
-            break;
-        case Types.TIME:
-        case Types.TIMESTAMP:
-            oid = Oid.UNSPECIFIED;
-            break;
-        case Types.BIT:
-            oid = Oid.BOOL;
-            break;
-        case Types.BINARY:
-        case Types.VARBINARY:
-        case Types.LONGVARBINARY:
-            if (connection.haveMinimumCompatibleVersion(ServerVersion.v7_2))
-            {
-                oid = Oid.BYTEA;
-            }
-            else
-            {
+        switch (sqlType) {
+            case Types.INTEGER:
+                oid = Oid.INT4;
+                break;
+            case Types.TINYINT:
+            case Types.SMALLINT:
+                oid = Oid.INT2;
+                break;
+            case Types.BIGINT:
+                oid = Oid.INT8;
+                break;
+            case Types.REAL:
+                oid = Oid.FLOAT4;
+                break;
+            case Types.DOUBLE:
+            case Types.FLOAT:
+                oid = Oid.FLOAT8;
+                break;
+            case Types.DECIMAL:
+            case Types.NUMERIC:
+                oid = Oid.NUMERIC;
+                break;
+            case Types.CHAR:
+                oid = Oid.BPCHAR;
+                break;
+            case Types.VARCHAR:
+            case Types.LONGVARCHAR:
+                oid = connection.getStringVarcharFlag() ? Oid.VARCHAR : Oid.UNSPECIFIED;
+                break;
+            case Types.DATE:
+                oid = Oid.DATE;
+                break;
+            case Types.TIME:
+            case Types.TIMESTAMP:
+                oid = Oid.TIMESTAMP;
+                break;
+            case Types.BIT:
+                oid = Oid.BOOL;
+                break;
+            case Types.BINARY:
+            case Types.VARBINARY:
+            case Types.LONGVARBINARY:
+                if (connection.haveMinimumCompatibleVersion(ServerVersion.v7_2)) {
+                    oid = Oid.BYTEA;
+                } else {
+                    oid = Oid.OID;
+                }
+                break;
+            case Types.BLOB:
+            case Types.CLOB:
                 oid = Oid.OID;
-            }
-            break;
-        case Types.BLOB:
-        case Types.CLOB:
-            oid = Oid.OID;
-            break;
-        case Types.ARRAY:
-        case Types.DISTINCT:
-        case Types.STRUCT:
-        case Types.NULL:
-        case Types.OTHER:
-            oid = Oid.UNSPECIFIED;
-            break;
-        default:
-            // Bad Types value.
-            throw new PSQLException(GT.tr("Unknown Types value."), PSQLState.INVALID_PARAMETER_TYPE);
+                break;
+            case Types.ARRAY:
+            case Types.DISTINCT:
+            case Types.STRUCT:
+            case Types.NULL:
+            case Types.OTHER:
+                oid = Oid.UNSPECIFIED;
+                break;
+            default:
+                // Bad Types value.
+                throw new PSQLException(GT.tr("Unknown Types value."), PSQLState.INVALID_PARAMETER_TYPE);
         }
-        if ( adjustIndex )
+        if (adjustIndex) {
             parameterIndex--;
-        preparedParameters.setNull( parameterIndex, oid);
+        }
+        preparedParameters.setNull(parameterIndex, oid);
     }
 
     /*
@@ -1328,8 +1320,7 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
      * @param x the parameter value
      * @exception SQLException if a database access error occurs
      */
-    public void setBoolean(int parameterIndex, boolean x) throws SQLException
-    {
+    public void setBoolean(int parameterIndex, boolean x) throws SQLException {
         checkClosed();
         bindString(parameterIndex, x ? "1" : "0", Oid.BOOL);
     }
@@ -1342,8 +1333,7 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
      * @param x the parameter value
      * @exception SQLException if a database access error occurs
      */
-    public void setByte(int parameterIndex, byte x) throws SQLException
-    {
+    public void setByte(int parameterIndex, byte x) throws SQLException {
         setShort(parameterIndex, x);
     }
 
@@ -1355,8 +1345,7 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
      * @param x the parameter value
      * @exception SQLException if a database access error occurs
      */
-    public void setShort(int parameterIndex, short x) throws SQLException
-    {
+    public void setShort(int parameterIndex, short x) throws SQLException {
         checkClosed();
         if (connection.binaryTransferSend(Oid.INT2)) {
             byte[] val = new byte[2];
@@ -1375,9 +1364,8 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
      * @param x the parameter value
      * @exception SQLException if a database access error occurs
      */
-    public void setInt(int parameterIndex, int x) throws SQLException
-    {
-        checkClosed();         
+    public void setInt(int parameterIndex, int x) throws SQLException {
+        checkClosed();
         if (connection.binaryTransferSend(Oid.INT4)) {
             byte[] val = new byte[4];
             ByteConverter.int4(val, 0, x);
@@ -1395,8 +1383,7 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
      * @param x the parameter value
      * @exception SQLException if a database access error occurs
      */
-    public void setLong(int parameterIndex, long x) throws SQLException
-    {
+    public void setLong(int parameterIndex, long x) throws SQLException {
         checkClosed();
         if (connection.binaryTransferSend(Oid.INT8)) {
             byte[] val = new byte[8];
@@ -1415,8 +1402,7 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
      * @param x the parameter value
      * @exception SQLException if a database access error occurs
      */
-    public void setFloat(int parameterIndex, float x) throws SQLException
-    {
+    public void setFloat(int parameterIndex, float x) throws SQLException {
         checkClosed();
         if (connection.binaryTransferSend(Oid.FLOAT4)) {
             byte[] val = new byte[4];
@@ -1435,8 +1421,7 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
      * @param x the parameter value
      * @exception SQLException if a database access error occurs
      */
-    public void setDouble(int parameterIndex, double x) throws SQLException
-    {
+    public void setDouble(int parameterIndex, double x) throws SQLException {
         checkClosed();
         if (connection.binaryTransferSend(Oid.FLOAT8)) {
             byte[] val = new byte[8];
@@ -1456,13 +1441,13 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
      * @param x the parameter value
      * @exception SQLException if a database access error occurs
      */
-    public void setBigDecimal(int parameterIndex, BigDecimal x) throws SQLException
-    {
+    public void setBigDecimal(int parameterIndex, BigDecimal x) throws SQLException {
         checkClosed();
-        if (x == null)
+        if (x == null) {
             setNull(parameterIndex, Types.DECIMAL);
-        else
+        } else {
             bindLiteral(parameterIndex, x.toString(), Oid.NUMERIC);
+        }
     }
 
     /*
@@ -1475,8 +1460,7 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
      * @param x the parameter value
      * @exception SQLException if a database access error occurs
      */
-    public void setString(int parameterIndex, String x) throws SQLException
-    {
+    public void setString(int parameterIndex, String x) throws SQLException {
         checkClosed();
         setString(parameterIndex, x, getStringType());
     }
@@ -1485,18 +1469,17 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
         return (connection.getStringVarcharFlag() ? Oid.VARCHAR : Oid.UNSPECIFIED);
     }
 
-    protected void setString(int parameterIndex, String x, int oid) throws SQLException
-    {
+    protected void setString(int parameterIndex, String x, int oid) throws SQLException {
         // if the passed string is null, then set this column to null
         checkClosed();
-        if (x == null)
-        {
-            if ( adjustIndex )
+        if (x == null) {
+            if (adjustIndex) {
                 parameterIndex--;
-            preparedParameters.setNull( parameterIndex, oid);
-        }
-        else
+            }
+            preparedParameters.setNull(parameterIndex, oid);
+        } else {
             bindString(parameterIndex, x, oid);
+        }
     }
 
     /*
@@ -1513,25 +1496,20 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
      * @param x the parameter value
      * @exception SQLException if a database access error occurs
      */
-    public void setBytes(int parameterIndex, byte[] x) throws SQLException
-    {
+    public void setBytes(int parameterIndex, byte[] x) throws SQLException {
         checkClosed();
 
-        if (null == x)
-        {
+        if (null == x) {
             setNull(parameterIndex, Types.VARBINARY);
-            return ;
+            return;
         }
 
-        if (connection.haveMinimumCompatibleVersion(ServerVersion.v7_2))
-        {
+        if (connection.haveMinimumCompatibleVersion(ServerVersion.v7_2)) {
             //Version 7.2 supports the bytea datatype for byte arrays
             byte[] copy = new byte[x.length];
             System.arraycopy(x, 0, copy, 0, x.length);
-            preparedParameters.setBytea( parameterIndex, copy, 0, x.length);
-        }
-        else
-        {
+            preparedParameters.setBytea(parameterIndex, copy, 0, x.length);
+        } else {
             //Version 7.1 and earlier support done as LargeObjects
             LargeObjectManager lom = connection.getLargeObjectAPI();
             long oid = lom.createLO();
@@ -1550,8 +1528,7 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
      * @param x the parameter value
      * @exception SQLException if a database access error occurs
      */
-    public void setDate(int parameterIndex, java.sql.Date x) throws SQLException
-    {
+    public void setDate(int parameterIndex, java.sql.Date x) throws SQLException {
         setDate(parameterIndex, x, null);
     }
 
@@ -1563,8 +1540,7 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
      * @param x the parameter value
      * @exception SQLException if a database access error occurs
      */
-    public void setTime(int parameterIndex, Time x) throws SQLException
-    {
+    public void setTime(int parameterIndex, Time x) throws SQLException {
         setTime(parameterIndex, x, null);
     }
 
@@ -1576,23 +1552,20 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
      * @param x the parameter value
      * @exception SQLException if a database access error occurs
      */
-    public void setTimestamp(int parameterIndex, Timestamp x) throws SQLException
-    {
+    public void setTimestamp(int parameterIndex, Timestamp x) throws SQLException {
         setTimestamp(parameterIndex, x, null);
     }
 
-    private void setCharacterStreamPost71(int parameterIndex, InputStream x, int length, String encoding) throws SQLException
-    {
+    private void setCharacterStreamPost71(int parameterIndex, InputStream x, int length, String encoding) throws SQLException {
 
-        if (x == null)
-        {
+        if (x == null) {
             setNull(parameterIndex, Types.VARCHAR);
-            return ;
+            return;
         }
-        if (length < 0)
+        if (length < 0) {
             throw new PSQLException(GT.tr("Invalid stream length {0}.", length),
-                                    PSQLState.INVALID_PARAMETER_VALUE);
-
+                    PSQLState.INVALID_PARAMETER_VALUE);
+        }
 
         //Version 7.2 supports AsciiStream for all PG text types (char, varchar, text)
         //As the spec/javadoc for this method indicate this is to be used for
@@ -1600,31 +1573,27 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
         //long varchar datatype, but with toast all text datatypes are capable of
         //handling very large values.  Thus the implementation ends up calling
         //setString() since there is no current way to stream the value to the server
-        try
-        {
+        try {
             InputStreamReader l_inStream = new InputStreamReader(x, encoding);
             char[] l_chars = new char[length];
             int l_charsRead = 0;
-            while (true)
-            {
+            while (true) {
                 int n = l_inStream.read(l_chars, l_charsRead, length - l_charsRead);
-                if (n == -1)
+                if (n == -1) {
                     break;
+                }
 
                 l_charsRead += n;
 
-                if (l_charsRead == length)
+                if (l_charsRead == length) {
                     break;
+                }
             }
 
             setString(parameterIndex, new String(l_chars, 0, l_charsRead), Oid.VARCHAR);
-        }
-        catch (UnsupportedEncodingException l_uee)
-        {
+        } catch (UnsupportedEncodingException l_uee) {
             throw new PSQLException(GT.tr("The JVM claims not to support the {0} encoding.", encoding), PSQLState.UNEXPECTED_ERROR, l_uee);
-        }
-        catch (IOException l_ioe)
-        {
+        } catch (IOException l_ioe) {
             throw new PSQLException(GT.tr("Provided InputStream failed."), PSQLState.UNEXPECTED_ERROR, l_ioe);
         }
     }
@@ -1645,15 +1614,11 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
      * @param length the number of bytes in the stream
      * @exception SQLException if a database access error occurs
      */
-    public void setAsciiStream(int parameterIndex, InputStream x, int length) throws SQLException
-    {
+    public void setAsciiStream(int parameterIndex, InputStream x, int length) throws SQLException {
         checkClosed();
-        if (connection.haveMinimumCompatibleVersion(ServerVersion.v7_2))
-        {
+        if (connection.haveMinimumCompatibleVersion(ServerVersion.v7_2)) {
             setCharacterStreamPost71(parameterIndex, x, length, "ASCII");
-        }
-        else
-        {
+        } else {
             //Version 7.1 supported only LargeObjects by treating everything
             //as binary data
             setBinaryStream(parameterIndex, x, length);
@@ -1675,15 +1640,11 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
      * @param x the parameter value
      * @exception SQLException if a database access error occurs
      */
-    public void setUnicodeStream(int parameterIndex, InputStream x, int length) throws SQLException
-    {
+    public void setUnicodeStream(int parameterIndex, InputStream x, int length) throws SQLException {
         checkClosed();
-        if (connection.haveMinimumCompatibleVersion(ServerVersion.v7_2))
-        {
+        if (connection.haveMinimumCompatibleVersion(ServerVersion.v7_2)) {
             setCharacterStreamPost71(parameterIndex, x, length, "UTF-8");
-        }
-        else
-        {
+        } else {
             //Version 7.1 supported only LargeObjects by treating everything
             //as binary data
             setBinaryStream(parameterIndex, x, length);
@@ -1704,22 +1665,20 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
      * @param x the parameter value
      * @exception SQLException if a database access error occurs
      */
-    public void setBinaryStream(int parameterIndex, InputStream x, int length) throws SQLException
-    {
+    public void setBinaryStream(int parameterIndex, InputStream x, int length) throws SQLException {
         checkClosed();
 
-        if (x == null)
-        {
+        if (x == null) {
             setNull(parameterIndex, Types.VARBINARY);
-            return ;
+            return;
         }
 
-        if (length < 0)
+        if (length < 0) {
             throw new PSQLException(GT.tr("Invalid stream length {0}.", length),
-                                    PSQLState.INVALID_PARAMETER_VALUE);
+                    PSQLState.INVALID_PARAMETER_VALUE);
+        }
 
-        if (connection.haveMinimumCompatibleVersion(ServerVersion.v7_2))
-        {
+        if (connection.haveMinimumCompatibleVersion(ServerVersion.v7_2)) {
             //Version 7.2 supports BinaryStream for for the PG bytea type
             //As the spec/javadoc for this method indicate this is to be used for
             //large binary values (i.e. LONGVARBINARY) PG doesn't have a separate
@@ -1727,9 +1686,7 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
             //handling very large values.
 
             preparedParameters.setBytea(parameterIndex, x, length);
-        }
-        else
-        {
+        } else {
             //Version 7.1 only supported streams for LargeObjects
             //but the jdbc spec indicates that streams should be
             //available for LONGVARBINARY instead
@@ -1737,23 +1694,19 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
             long oid = lom.createLO();
             LargeObject lob = lom.open(oid);
             OutputStream los = lob.getOutputStream();
-            try
-            {
+            try {
                 // could be buffered, but then the OutputStream returned by LargeObject
                 // is buffered internally anyhow, so there would be no performance
                 // boost gained, if anything it would be worse!
                 int c = x.read();
                 int p = 0;
-                while (c > -1 && p < length)
-                {
+                while (c > -1 && p < length) {
                     los.write(c);
                     c = x.read();
                     p++;
                 }
                 los.close();
-            }
-            catch (IOException se)
-            {
+            } catch (IOException se) {
                 throw new PSQLException(GT.tr("Provided InputStream failed."), PSQLState.UNEXPECTED_ERROR, se);
             }
             // lob is closed by the stream so don't call lob.close()
@@ -1771,8 +1724,7 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
      *
      * @exception SQLException if a database access error occurs
      */
-    public void clearParameters() throws SQLException
-    {
+    public void clearParameters() throws SQLException {
         preparedParameters.clear();
     }
 
@@ -1780,8 +1732,9 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
     private void setPGobject(int parameterIndex, PGobject x) throws SQLException {
         String typename = x.getType();
         int oid = connection.getTypeInfo().getPGType(typename);
-        if (oid == Oid.UNSPECIFIED)
+        if (oid == Oid.UNSPECIFIED) {
             throw new PSQLException(GT.tr("Unknown type {0}.", typename), PSQLState.INVALID_PARAMETER_TYPE);
+        }
 
         if ((x instanceof PGBinaryObject) && connection.binaryTransferSend(oid)) {
             PGBinaryObject binObj = (PGBinaryObject) x;
@@ -1792,11 +1745,12 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
             setString(parameterIndex, x.getValue(), oid);
         }
     }
-    
+
     private void setMap(int parameterIndex, Map x) throws SQLException {
         int oid = connection.getTypeInfo().getPGType("hstore");
-        if (oid == Oid.UNSPECIFIED)
+        if (oid == Oid.UNSPECIFIED) {
             throw new PSQLException(GT.tr("No hstore extension installed."), PSQLState.INVALID_PARAMETER_TYPE);
+        }
         if (connection.binaryTransferSend(oid)) {
             byte[] data = HStoreConverter.toBytes(x, connection.getEncoding());
             bindBytes(parameterIndex, data, oid);
@@ -1824,18 +1778,15 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
      *   * all other types this value will be ignored.
      * @exception SQLException if a database access error occurs
      */
-    public void setObject(int parameterIndex, Object in, int targetSqlType, int scale) throws SQLException
-    {
+    public void setObject(int parameterIndex, Object in, int targetSqlType, int scale) throws SQLException {
         checkClosed();
 
-        if (in == null)
-        {
+        if (in == null) {
             setNull(parameterIndex, targetSqlType);
-            return ;
+            return;
         }
 
-            switch (targetSqlType)
-        {
+        switch (targetSqlType) {
             case Types.INTEGER:
                 setInt(parameterIndex, castToInt(in));
                 break;
@@ -1865,13 +1816,12 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
                 setString(parameterIndex, castToString(in), getStringType());
                 break;
             case Types.DATE:
-                if (in instanceof java.sql.Date)
-                    setDate(parameterIndex, (java.sql.Date)in);
-                else
-                {
+                if (in instanceof java.sql.Date) {
+                    setDate(parameterIndex, (java.sql.Date) in);
+                } else {
                     java.sql.Date tmpd;
                     if (in instanceof java.util.Date) {
-                        tmpd = new java.sql.Date(((java.util.Date)in).getTime());
+                        tmpd = new java.sql.Date(((java.util.Date) in).getTime());
                     } else {
                         tmpd = connection.getTimestampUtils().toDate(null, in.toString());
                     }
@@ -1879,13 +1829,12 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
                 }
                 break;
             case Types.TIME:
-                if (in instanceof java.sql.Time)
-                    setTime(parameterIndex, (java.sql.Time)in);
-                else
-                {
+                if (in instanceof java.sql.Time) {
+                    setTime(parameterIndex, (java.sql.Time) in);
+                } else {
                     java.sql.Time tmpt;
                     if (in instanceof java.util.Date) {
-                        tmpt = new java.sql.Time(((java.util.Date)in).getTime());
+                        tmpt = new java.sql.Time(((java.util.Date) in).getTime());
                     } else {
                         tmpt = connection.getTimestampUtils().toTime(null, in.toString());
                     }
@@ -1893,13 +1842,12 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
                 }
                 break;
             case Types.TIMESTAMP:
-                if (in instanceof java.sql.Timestamp)
-                    setTimestamp(parameterIndex , (java.sql.Timestamp)in);
-                else
-                {
+                if (in instanceof java.sql.Timestamp) {
+                    setTimestamp(parameterIndex, (java.sql.Timestamp) in);
+                } else {
                     java.sql.Timestamp tmpts;
                     if (in instanceof java.util.Date) {
-                        tmpts = new java.sql.Timestamp(((java.util.Date)in).getTime());
+                        tmpts = new java.sql.Timestamp(((java.util.Date) in).getTime());
                     } else {
                         tmpts = connection.getTimestampUtils().toTimestamp(null, in.toString());
                     }
@@ -1915,40 +1863,38 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
                 setObject(parameterIndex, in);
                 break;
             case Types.BLOB:
-                if (in instanceof Blob)
-                {
-                    setBlob(parameterIndex, (Blob)in);
-                }
-                else if (in instanceof InputStream)
-                {
+                if (in instanceof Blob) {
+                    setBlob(parameterIndex, (Blob) in);
+                } else if (in instanceof InputStream) {
                     long oid = createBlob(parameterIndex, (InputStream) in, -1);
                     setLong(parameterIndex, oid);
-                }
-                else
-                {
-                    throw new PSQLException(GT.tr("Cannot cast an instance of {0} to type {1}", new Object[]{in.getClass().getName(),"Types.BLOB"}), PSQLState.INVALID_PARAMETER_TYPE);
+                } else {
+                    throw new PSQLException(GT.tr("Cannot cast an instance of {0} to type {1}", new Object[]{in.getClass().getName(), "Types.BLOB"}), PSQLState.INVALID_PARAMETER_TYPE);
                 }
                 break;
             case Types.CLOB:
-                if (in instanceof Clob)
-                    setClob(parameterIndex, (Clob)in);
-                else
-                    throw new PSQLException(GT.tr("Cannot cast an instance of {0} to type {1}", new Object[]{in.getClass().getName(),"Types.CLOB"}), PSQLState.INVALID_PARAMETER_TYPE);
+                if (in instanceof Clob) {
+                    setClob(parameterIndex, (Clob) in);
+                } else {
+                    throw new PSQLException(GT.tr("Cannot cast an instance of {0} to type {1}", new Object[]{in.getClass().getName(), "Types.CLOB"}), PSQLState.INVALID_PARAMETER_TYPE);
+                }
                 break;
             case Types.ARRAY:
-                if (in instanceof Array)
-                    setArray(parameterIndex, (Array)in);
-                else
-                    throw new PSQLException(GT.tr("Cannot cast an instance of {0} to type {1}", new Object[]{in.getClass().getName(),"Types.ARRAY"}), PSQLState.INVALID_PARAMETER_TYPE);
+                if (in instanceof Array) {
+                    setArray(parameterIndex, (Array) in);
+                } else {
+                    throw new PSQLException(GT.tr("Cannot cast an instance of {0} to type {1}", new Object[]{in.getClass().getName(), "Types.ARRAY"}), PSQLState.INVALID_PARAMETER_TYPE);
+                }
                 break;
             case Types.DISTINCT:
                 bindString(parameterIndex, in.toString(), Oid.UNSPECIFIED);
                 break;
             case Types.OTHER:
-                if (in instanceof PGobject)
-                    setPGobject(parameterIndex, (PGobject)in);
-                else
+                if (in instanceof PGobject) {
+                    setPGobject(parameterIndex, (PGobject) in);
+                } else {
                     bindString(parameterIndex, in.toString(), Oid.UNSPECIFIED);
+                }
                 break;
             default:
                 throw new PSQLException(GT.tr("Unsupported Types value: {0}", targetSqlType), PSQLState.INVALID_PARAMETER_TYPE);
@@ -1961,18 +1907,24 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
 
     private static int castToInt(final Object in) throws SQLException {
         try {
-            if (in instanceof String)
+            if (in instanceof String) {
                 return Integer.parseInt((String) in);
-            if (in instanceof Number)
+            }
+            if (in instanceof Number) {
                 return ((Number) in).intValue();
-            if (in instanceof java.util.Date)
+            }
+            if (in instanceof java.util.Date) {
                 return (int) ((java.util.Date) in).getTime();
-            if (in instanceof Boolean)
+            }
+            if (in instanceof Boolean) {
                 return (Boolean) in ? 1 : 0;
-            if (in instanceof Clob)
+            }
+            if (in instanceof Clob) {
                 return Integer.parseInt(asString((Clob) in));
-            if (in instanceof Character)
+            }
+            if (in instanceof Character) {
                 return Integer.parseInt(in.toString());
+            }
         } catch (final Exception e) {
             throw cannotCastException(in.getClass().getName(), "int", e);
         }
@@ -1981,18 +1933,24 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
 
     private static short castToShort(final Object in) throws SQLException {
         try {
-            if (in instanceof String)
+            if (in instanceof String) {
                 return Short.parseShort((String) in);
-            if (in instanceof Number)
+            }
+            if (in instanceof Number) {
                 return ((Number) in).shortValue();
-            if (in instanceof java.util.Date)
+            }
+            if (in instanceof java.util.Date) {
                 return (short) ((java.util.Date) in).getTime();
-            if (in instanceof Boolean)
+            }
+            if (in instanceof Boolean) {
                 return (Boolean) in ? (short) 1 : (short) 0;
-            if (in instanceof Clob)
+            }
+            if (in instanceof Clob) {
                 return Short.parseShort(asString((Clob) in));
-            if (in instanceof Character)
+            }
+            if (in instanceof Character) {
                 return Short.parseShort(in.toString());
+            }
         } catch (final Exception e) {
             throw cannotCastException(in.getClass().getName(), "short", e);
         }
@@ -2001,18 +1959,24 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
 
     private static long castToLong(final Object in) throws SQLException {
         try {
-            if (in instanceof String)
+            if (in instanceof String) {
                 return Long.parseLong((String) in);
-            if (in instanceof Number)
+            }
+            if (in instanceof Number) {
                 return ((Number) in).longValue();
-            if (in instanceof java.util.Date)
+            }
+            if (in instanceof java.util.Date) {
                 return ((java.util.Date) in).getTime();
-            if (in instanceof Boolean)
+            }
+            if (in instanceof Boolean) {
                 return (Boolean) in ? 1L : 0L;
-            if (in instanceof Clob)
+            }
+            if (in instanceof Clob) {
                 return Long.parseLong(asString((Clob) in));
-            if (in instanceof Character)
+            }
+            if (in instanceof Character) {
                 return Long.parseLong(in.toString());
+            }
         } catch (final Exception e) {
             throw cannotCastException(in.getClass().getName(), "long", e);
         }
@@ -2021,18 +1985,24 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
 
     private static float castToFloat(final Object in) throws SQLException {
         try {
-            if (in instanceof String)
+            if (in instanceof String) {
                 return Float.parseFloat((String) in);
-            if (in instanceof Number)
+            }
+            if (in instanceof Number) {
                 return ((Number) in).floatValue();
-            if (in instanceof java.util.Date)
+            }
+            if (in instanceof java.util.Date) {
                 return ((java.util.Date) in).getTime();
-            if (in instanceof Boolean)
+            }
+            if (in instanceof Boolean) {
                 return (Boolean) in ? 1f : 0f;
-            if (in instanceof Clob)
+            }
+            if (in instanceof Clob) {
                 return Float.parseFloat(asString((Clob) in));
-            if (in instanceof Character)
+            }
+            if (in instanceof Character) {
                 return Float.parseFloat(in.toString());
+            }
         } catch (final Exception e) {
             throw cannotCastException(in.getClass().getName(), "float", e);
         }
@@ -2041,18 +2011,24 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
 
     private static double castToDouble(final Object in) throws SQLException {
         try {
-            if (in instanceof String)
+            if (in instanceof String) {
                 return Double.parseDouble((String) in);
-            if (in instanceof Number)
+            }
+            if (in instanceof Number) {
                 return ((Number) in).doubleValue();
-            if (in instanceof java.util.Date)
+            }
+            if (in instanceof java.util.Date) {
                 return ((java.util.Date) in).getTime();
-            if (in instanceof Boolean)
+            }
+            if (in instanceof Boolean) {
                 return (Boolean) in ? 1d : 0d;
-            if (in instanceof Clob)
+            }
+            if (in instanceof Clob) {
                 return Double.parseDouble(asString((Clob) in));
-            if (in instanceof Character)
+            }
+            if (in instanceof Character) {
                 return Double.parseDouble(in.toString());
+            }
         } catch (final Exception e) {
             throw cannotCastException(in.getClass().getName(), "double", e);
         }
@@ -2061,28 +2037,29 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
 
     private static BigDecimal castToBigDecimal(final Object in, final int scale) throws SQLException {
         try {
-            BigDecimal rc=null;
-            if (in instanceof String)
-                rc=new BigDecimal((String) in);
-            else if (in instanceof BigDecimal)
-                rc=((BigDecimal) in);
-            else if (in instanceof BigInteger)
-                rc=new BigDecimal((BigInteger) in);
-            else if (in instanceof Long || in instanceof Integer || in instanceof Short || in instanceof Byte)
-                rc=BigDecimal.valueOf(((Number) in).longValue());
-            else if (in instanceof Double || in instanceof Float)
-                rc=BigDecimal.valueOf(((Number) in).doubleValue());
-            else if (in instanceof java.util.Date)
-                rc=BigDecimal.valueOf(((java.util.Date) in).getTime());
-            else if (in instanceof Boolean)
-                rc=(Boolean) in ? BigDecimal.ONE : BigDecimal.ZERO;
-            else if (in instanceof Clob)
-                rc=new BigDecimal(asString((Clob) in));
-            else if (in instanceof Character)
-                rc=new BigDecimal(new char[] {(Character) in});
-            if (rc!=null) {
-                if (scale>=0) {
-                    rc=rc.setScale(scale,RoundingMode.HALF_UP);
+            BigDecimal rc = null;
+            if (in instanceof String) {
+                rc = new BigDecimal((String) in);
+            } else if (in instanceof BigDecimal) {
+                rc = ((BigDecimal) in);
+            } else if (in instanceof BigInteger) {
+                rc = new BigDecimal((BigInteger) in);
+            } else if (in instanceof Long || in instanceof Integer || in instanceof Short || in instanceof Byte) {
+                rc = BigDecimal.valueOf(((Number) in).longValue());
+            } else if (in instanceof Double || in instanceof Float) {
+                rc = BigDecimal.valueOf(((Number) in).doubleValue());
+            } else if (in instanceof java.util.Date) {
+                rc = BigDecimal.valueOf(((java.util.Date) in).getTime());
+            } else if (in instanceof Boolean) {
+                rc = (Boolean) in ? BigDecimal.ONE : BigDecimal.ZERO;
+            } else if (in instanceof Clob) {
+                rc = new BigDecimal(asString((Clob) in));
+            } else if (in instanceof Character) {
+                rc = new BigDecimal(new char[]{(Character) in});
+            }
+            if (rc != null) {
+                if (scale >= 0) {
+                    rc = rc.setScale(scale, RoundingMode.HALF_UP);
                 }
                 return rc;
             }
@@ -2094,22 +2071,28 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
 
     private static boolean castToBoolean(final Object in) throws SQLException {
         try {
-            if (in instanceof String)
+            if (in instanceof String) {
                 return ((String) in).equalsIgnoreCase("true") || ((String) in).equals("1") || ((String) in).equalsIgnoreCase("t");
-            if (in instanceof BigDecimal)
+            }
+            if (in instanceof BigDecimal) {
                 return ((BigDecimal) in).signum() != 0;
-            if (in instanceof Number)
+            }
+            if (in instanceof Number) {
                 return ((Number) in).longValue() != 0L;
-            if (in instanceof java.util.Date)
+            }
+            if (in instanceof java.util.Date) {
                 return ((java.util.Date) in).getTime() != 0L;
-            if (in instanceof Boolean)
+            }
+            if (in instanceof Boolean) {
                 return (Boolean) in;
+            }
             if (in instanceof Clob) {
                 final String asString = asString((Clob) in);
                 return asString.equalsIgnoreCase("true") || asString.equals("1") || asString.equalsIgnoreCase("t");
             }
-            if (in instanceof Character)
+            if (in instanceof Character) {
                 return (Character) in == '1' || (Character) in == 't' || (Character) in == 'T';
+            }
         } catch (final Exception e) {
             throw cannotCastException(in.getClass().getName(), "boolean", e);
         }
@@ -2118,12 +2101,15 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
 
     private static String castToString(final Object in) throws SQLException {
         try {
-            if (in instanceof String)
+            if (in instanceof String) {
                 return (String) in;
-            if (in instanceof Number || in instanceof Boolean || in instanceof Character || in instanceof java.util.Date)
+            }
+            if (in instanceof Number || in instanceof Boolean || in instanceof Character || in instanceof java.util.Date) {
                 return in.toString();
-            if (in instanceof Clob)
+            }
+            if (in instanceof Clob) {
                 return asString((Clob) in);
+            }
         } catch (final Exception e) {
             throw cannotCastException(in.getClass().getName(), "String", e);
         }
@@ -2135,62 +2121,59 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
     }
 
     private static PSQLException cannotCastException(final String fromType, final String toType, final Exception cause) {
-        return new PSQLException(GT.tr("Cannot convert an instance of {0} to type {1}", new Object[] { fromType, toType }), PSQLState.INVALID_PARAMETER_TYPE, cause);
+        return new PSQLException(GT.tr("Cannot convert an instance of {0} to type {1}", new Object[]{fromType, toType}), PSQLState.INVALID_PARAMETER_TYPE, cause);
     }
 
-    public void setObject(int parameterIndex, Object x, int targetSqlType) throws SQLException
-    {
+    public void setObject(int parameterIndex, Object x, int targetSqlType) throws SQLException {
         setObject(parameterIndex, x, targetSqlType, -1);
     }
 
     /*
      * This stores an Object into a parameter.
      */
-    public void setObject(int parameterIndex, Object x) throws SQLException
-    {
+    public void setObject(int parameterIndex, Object x) throws SQLException {
         checkClosed();
-        if (x == null)
+        if (x == null) {
             setNull(parameterIndex, Types.OTHER);
-        else if (x instanceof String)
-            setString(parameterIndex, (String)x);
-        else if (x instanceof BigDecimal)
-            setBigDecimal(parameterIndex, (BigDecimal)x);
-        else if (x instanceof Short)
+        } else if (x instanceof String) {
+            setString(parameterIndex, (String) x);
+        } else if (x instanceof BigDecimal) {
+            setBigDecimal(parameterIndex, (BigDecimal) x);
+        } else if (x instanceof Short) {
             setShort(parameterIndex, (Short) x);
-        else if (x instanceof Integer)
+        } else if (x instanceof Integer) {
             setInt(parameterIndex, (Integer) x);
-        else if (x instanceof Long)
+        } else if (x instanceof Long) {
             setLong(parameterIndex, (Long) x);
-        else if (x instanceof Float)
+        } else if (x instanceof Float) {
             setFloat(parameterIndex, (Float) x);
-        else if (x instanceof Double)
+        } else if (x instanceof Double) {
             setDouble(parameterIndex, (Double) x);
-        else if (x instanceof byte[])
-            setBytes(parameterIndex, (byte[])x);
-        else if (x instanceof java.sql.Date)
-            setDate(parameterIndex, (java.sql.Date)x);
-        else if (x instanceof Time)
-            setTime(parameterIndex, (Time)x);
-        else if (x instanceof Timestamp)
-            setTimestamp(parameterIndex, (Timestamp)x);
-        else if (x instanceof Boolean)
+        } else if (x instanceof byte[]) {
+            setBytes(parameterIndex, (byte[]) x);
+        } else if (x instanceof java.sql.Date) {
+            setDate(parameterIndex, (java.sql.Date) x);
+        } else if (x instanceof Time) {
+            setTime(parameterIndex, (Time) x);
+        } else if (x instanceof Timestamp) {
+            setTimestamp(parameterIndex, (Timestamp) x);
+        } else if (x instanceof Boolean) {
             setBoolean(parameterIndex, (Boolean) x);
-        else if (x instanceof Byte)
+        } else if (x instanceof Byte) {
             setByte(parameterIndex, (Byte) x);
-        else if (x instanceof Blob)
-            setBlob(parameterIndex, (Blob)x);
-        else if (x instanceof Clob)
-            setClob(parameterIndex, (Clob)x);
-        else if (x instanceof Array)
-            setArray(parameterIndex, (Array)x);
-        else if (x instanceof PGobject)
-            setPGobject(parameterIndex, (PGobject)x);
-        else if (x instanceof Character)
-            setString(parameterIndex, ((Character)x).toString());
-        else if (x instanceof Map)
-            setMap(parameterIndex, (Map)x);
-        else
-        {
+        } else if (x instanceof Blob) {
+            setBlob(parameterIndex, (Blob) x);
+        } else if (x instanceof Clob) {
+            setClob(parameterIndex, (Clob) x);
+        } else if (x instanceof Array) {
+            setArray(parameterIndex, (Array) x);
+        } else if (x instanceof PGobject) {
+            setPGobject(parameterIndex, (PGobject) x);
+        } else if (x instanceof Character) {
+            setString(parameterIndex, ((Character) x).toString());
+        } else if (x instanceof Map) {
+            setMap(parameterIndex, (Map) x);
+        } else {
             // Can't infer a type.
             throw new PSQLException(GT.tr("Can''t infer the SQL type to use for an instance of {0}. Use setObject() with an explicit Types value to specify the type to use.", x.getClass().getName()), PSQLState.INVALID_PARAMETER_TYPE);
         }
@@ -2213,49 +2196,50 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
      * registerOutParameter that accepts a scale value
      * @exception SQLException if a database-access error occurs.
      */
-    public void registerOutParameter(int parameterIndex, int sqlType, boolean setPreparedParameters) throws SQLException
-    {
+    public void registerOutParameter(int parameterIndex, int sqlType, boolean setPreparedParameters) throws SQLException {
         checkClosed();
-        switch( sqlType )
-        {
-	        case Types.TINYINT:
-			    // we don't have a TINYINT type use SMALLINT
-			    	sqlType = Types.SMALLINT;
-			    	break;
-			case Types.LONGVARCHAR:
-			    sqlType = Types.VARCHAR;
-				break;
-			case Types.DECIMAL:
-			    sqlType = Types.NUMERIC;
-				break;
-			case Types.FLOAT:
-			    // float is the same as double
-			    sqlType = Types.DOUBLE;
-				break;
-			case Types.VARBINARY:
-			case Types.LONGVARBINARY:
-			    sqlType = Types.BINARY;
-				break;
-			default:
-			    break;
+        switch (sqlType) {
+            case Types.TINYINT:
+                // we don't have a TINYINT type use SMALLINT
+                sqlType = Types.SMALLINT;
+                break;
+            case Types.LONGVARCHAR:
+                sqlType = Types.VARCHAR;
+                break;
+            case Types.DECIMAL:
+                sqlType = Types.NUMERIC;
+                break;
+            case Types.FLOAT:
+                // float is the same as double
+                sqlType = Types.DOUBLE;
+                break;
+            case Types.VARBINARY:
+            case Types.LONGVARBINARY:
+                sqlType = Types.BINARY;
+                break;
+            default:
+                break;
         }
-        if (!isFunction)
-            throw new PSQLException (GT.tr("This statement does not declare an OUT parameter.  Use '{' ?= call ... '}' to declare one."), PSQLState.STATEMENT_NOT_ALLOWED_IN_FUNCTION_CALL);
+        if (!isFunction) {
+            throw new PSQLException(GT.tr("This statement does not declare an OUT parameter.  Use '{' ?= call ... '}' to declare one."), PSQLState.STATEMENT_NOT_ALLOWED_IN_FUNCTION_CALL);
+        }
         checkIndex(parameterIndex, false);
-        
-        if( setPreparedParameters )
-            preparedParameters.registerOutParameter( parameterIndex, sqlType );
+
+        if (setPreparedParameters) {
+            preparedParameters.registerOutParameter(parameterIndex, sqlType);
+        }
         // functionReturnType contains the user supplied value to check
         // testReturn contains a modified version to make it easier to
         // check the getXXX methods..
-        functionReturnType[parameterIndex-1] = sqlType;
-        testReturn[parameterIndex-1] = sqlType;
-        
-        if (functionReturnType[parameterIndex-1] == Types.CHAR ||
-                functionReturnType[parameterIndex-1] == Types.LONGVARCHAR)
-            testReturn[parameterIndex-1] = Types.VARCHAR;
-        else if (functionReturnType[parameterIndex-1] == Types.FLOAT)
-            testReturn[parameterIndex-1] = Types.REAL; // changes to streamline later error checking
+        functionReturnType[parameterIndex - 1] = sqlType;
+        testReturn[parameterIndex - 1] = sqlType;
+
+        if (functionReturnType[parameterIndex - 1] == Types.CHAR
+                || functionReturnType[parameterIndex - 1] == Types.LONGVARCHAR) {
+            testReturn[parameterIndex - 1] = Types.VARCHAR;
+        } else if (functionReturnType[parameterIndex - 1] == Types.FLOAT) {
+            testReturn[parameterIndex - 1] = Types.REAL; // changes to streamline later error checking
+        }
         returnTypeSet = true;
     }
 
@@ -2273,9 +2257,8 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
      * @exception SQLException if a database-access error occurs.
      */
     public void registerOutParameter(int parameterIndex, int sqlType,
-                                     int scale, boolean setPreparedParameters) throws SQLException
-    {
-        registerOutParameter (parameterIndex, sqlType, setPreparedParameters); // ignore for now..
+            int scale, boolean setPreparedParameters) throws SQLException {
+        registerOutParameter(parameterIndex, sqlType, setPreparedParameters); // ignore for now..
     }
 
     /*
@@ -2287,13 +2270,13 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
      * @return true if the last parameter read was SQL NULL
      * @exception SQLException if a database-access error occurs.
      */
-    public boolean wasNull() throws SQLException
-    {
-        if (lastIndex == 0)
+    public boolean wasNull() throws SQLException {
+        if (lastIndex == 0) {
             throw new PSQLException(GT.tr("wasNull cannot be call before fetching a result."), PSQLState.OBJECT_NOT_IN_STATE);
+        }
 
         // check to see if the last access threw an exception
-        return (callResult[lastIndex-1] == null);
+        return (callResult[lastIndex - 1] == null);
     }
 
     /*
@@ -2304,11 +2287,10 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
      * @return the parameter value; if the value is SQL NULL, the result is null
      * @exception SQLException if a database-access error occurs.
      */
-    public String getString(int parameterIndex) throws SQLException
-    {
+    public String getString(int parameterIndex) throws SQLException {
         checkClosed();
-        checkIndex (parameterIndex, Types.VARCHAR, "String");
-        return (String)callResult[parameterIndex-1];
+        checkIndex(parameterIndex, Types.VARCHAR, "String");
+        return (String) callResult[parameterIndex - 1];
     }
 
 
@@ -2319,13 +2301,13 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
      * @return the parameter value; if the value is SQL NULL, the result is false
      * @exception SQLException if a database-access error occurs.
      */
-    public boolean getBoolean(int parameterIndex) throws SQLException
-    {
+    public boolean getBoolean(int parameterIndex) throws SQLException {
         checkClosed();
-        checkIndex (parameterIndex, Types.BIT, "Boolean");
-        if (callResult[parameterIndex-1] == null)
+        checkIndex(parameterIndex, Types.BIT, "Boolean");
+        if (callResult[parameterIndex - 1] == null) {
             return false;
-        
+        }
+
         return (Boolean) callResult[parameterIndex - 1];
     }
 
@@ -2336,17 +2318,17 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
      * @return the parameter value; if the value is SQL NULL, the result is 0
      * @exception SQLException if a database-access error occurs.
      */
-    public byte getByte(int parameterIndex) throws SQLException
-    {
+    public byte getByte(int parameterIndex) throws SQLException {
         checkClosed();
         // fake tiny int with smallint
-        checkIndex (parameterIndex, Types.SMALLINT, "Byte");
-        
-        if (callResult[parameterIndex-1] == null)
+        checkIndex(parameterIndex, Types.SMALLINT, "Byte");
+
+        if (callResult[parameterIndex - 1] == null) {
             return 0;
-        
-        return ((Integer)callResult[parameterIndex-1]).byteValue();
-  
+        }
+
+        return ((Integer) callResult[parameterIndex - 1]).byteValue();
+
     }
 
     /*
@@ -2356,13 +2338,13 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
      * @return the parameter value; if the value is SQL NULL, the result is 0
      * @exception SQLException if a database-access error occurs.
      */
-    public short getShort(int parameterIndex) throws SQLException
-    {
+    public short getShort(int parameterIndex) throws SQLException {
         checkClosed();
-        checkIndex (parameterIndex, Types.SMALLINT, "Short");
-        if (callResult[parameterIndex-1] == null)
+        checkIndex(parameterIndex, Types.SMALLINT, "Short");
+        if (callResult[parameterIndex - 1] == null) {
             return 0;
-        return ((Integer)callResult[parameterIndex-1]).shortValue ();
+        }
+        return ((Integer) callResult[parameterIndex - 1]).shortValue();
     }
 
 
@@ -2373,13 +2355,13 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
      * @return the parameter value; if the value is SQL NULL, the result is 0
      * @exception SQLException if a database-access error occurs.
      */
-    public int getInt(int parameterIndex) throws SQLException
-    {
+    public int getInt(int parameterIndex) throws SQLException {
         checkClosed();
-        checkIndex (parameterIndex, Types.INTEGER, "Int");
-        if (callResult[parameterIndex-1] == null)
+        checkIndex(parameterIndex, Types.INTEGER, "Int");
+        if (callResult[parameterIndex - 1] == null) {
             return 0;
-        
+        }
+
         return (Integer) callResult[parameterIndex - 1];
     }
 
@@ -2390,13 +2372,13 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
      * @return the parameter value; if the value is SQL NULL, the result is 0
      * @exception SQLException if a database-access error occurs.
      */
-    public long getLong(int parameterIndex) throws SQLException
-    {
+    public long getLong(int parameterIndex) throws SQLException {
         checkClosed();
-        checkIndex (parameterIndex, Types.BIGINT, "Long");
-        if (callResult[parameterIndex-1] == null)
+        checkIndex(parameterIndex, Types.BIGINT, "Long");
+        if (callResult[parameterIndex - 1] == null) {
             return 0;
-        
+        }
+
         return (Long) callResult[parameterIndex - 1];
     }
 
@@ -2407,12 +2389,12 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
      * @return the parameter value; if the value is SQL NULL, the result is 0
      * @exception SQLException if a database-access error occurs.
      */
-    public float getFloat(int parameterIndex) throws SQLException
-    {
+    public float getFloat(int parameterIndex) throws SQLException {
         checkClosed();
-        checkIndex (parameterIndex, Types.REAL, "Float");
-        if (callResult[parameterIndex-1] == null)
+        checkIndex(parameterIndex, Types.REAL, "Float");
+        if (callResult[parameterIndex - 1] == null) {
             return 0;
+        }
 
         return (Float) callResult[parameterIndex - 1];
     }
@@ -2424,13 +2406,13 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
      * @return the parameter value; if the value is SQL NULL, the result is 0
      * @exception SQLException if a database-access error occurs.
      */
-    public double getDouble(int parameterIndex) throws SQLException
-    {
+    public double getDouble(int parameterIndex) throws SQLException {
         checkClosed();
-        checkIndex (parameterIndex, Types.DOUBLE, "Double");
-        if (callResult[parameterIndex-1] == null)
+        checkIndex(parameterIndex, Types.DOUBLE, "Double");
+        if (callResult[parameterIndex - 1] == null) {
             return 0;
-        
+        }
+
         return (Double) callResult[parameterIndex - 1];
     }
 
@@ -2446,11 +2428,10 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
      * @deprecated in Java2.0
      */
     public BigDecimal getBigDecimal(int parameterIndex, int scale)
-    throws SQLException
-    {
+            throws SQLException {
         checkClosed();
-        checkIndex (parameterIndex, Types.NUMERIC, "BigDecimal");
-        return ((BigDecimal)callResult[parameterIndex-1]);
+        checkIndex(parameterIndex, Types.NUMERIC, "BigDecimal");
+        return ((BigDecimal) callResult[parameterIndex - 1]);
     }
 
     /*
@@ -2461,11 +2442,10 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
      * @return the parameter value; if the value is SQL NULL, the result is null
      * @exception SQLException if a database-access error occurs.
      */
-    public byte[] getBytes(int parameterIndex) throws SQLException
-    {
+    public byte[] getBytes(int parameterIndex) throws SQLException {
         checkClosed();
-        checkIndex (parameterIndex, Types.VARBINARY, Types.BINARY, "Bytes");
-        return ((byte [])callResult[parameterIndex-1]);
+        checkIndex(parameterIndex, Types.VARBINARY, Types.BINARY, "Bytes");
+        return ((byte[]) callResult[parameterIndex - 1]);
     }
 
 
@@ -2476,11 +2456,10 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
      * @return the parameter value; if the value is SQL NULL, the result is null
      * @exception SQLException if a database-access error occurs.
      */
-    public java.sql.Date getDate(int parameterIndex) throws SQLException
-    {
+    public java.sql.Date getDate(int parameterIndex) throws SQLException {
         checkClosed();
-        checkIndex (parameterIndex, Types.DATE, "Date");     
-        return (java.sql.Date)callResult[parameterIndex-1];
+        checkIndex(parameterIndex, Types.DATE, "Date");
+        return (java.sql.Date) callResult[parameterIndex - 1];
     }
 
     /*
@@ -2490,11 +2469,10 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
      * @return the parameter value; if the value is SQL NULL, the result is null
      * @exception SQLException if a database-access error occurs.
      */
-    public java.sql.Time getTime(int parameterIndex) throws SQLException
-    {
+    public java.sql.Time getTime(int parameterIndex) throws SQLException {
         checkClosed();
-        checkIndex (parameterIndex, Types.TIME, "Time");
-        return (java.sql.Time)callResult[parameterIndex-1];
+        checkIndex(parameterIndex, Types.TIME, "Time");
+        return (java.sql.Time) callResult[parameterIndex - 1];
     }
 
     /*
@@ -2505,11 +2483,10 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
      * @exception SQLException if a database-access error occurs.
      */
     public java.sql.Timestamp getTimestamp(int parameterIndex)
-    throws SQLException
-    {
+            throws SQLException {
         checkClosed();
-        checkIndex (parameterIndex, Types.TIMESTAMP, "Timestamp");
-        return (java.sql.Timestamp)callResult[parameterIndex-1];
+        checkIndex(parameterIndex, Types.TIMESTAMP, "Timestamp");
+        return (java.sql.Timestamp) callResult[parameterIndex - 1];
     }
 
     // getObject returns a Java object for the parameter.
@@ -2533,43 +2510,42 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
      * @exception SQLException if a database-access error occurs.
      */
     public Object getObject(int parameterIndex)
-    throws SQLException
-    {
+            throws SQLException {
         checkClosed();
-        checkIndex (parameterIndex);        
-        return callResult[parameterIndex-1];
+        checkIndex(parameterIndex);
+        return callResult[parameterIndex - 1];
     }
 
     /*
      * Returns the SQL statement with the current template values
      * substituted.
      */
-    public String toString()
-    {
-        if (preparedQuery == null)
+    public String toString() {
+        if (preparedQuery == null) {
             return super.toString();
+        }
 
         return preparedQuery.query.toString(preparedParameters);
     }
 
 
     /*
-        * Note if s is a String it should be escaped by the caller to avoid SQL
-        * injection attacks.  It is not done here for efficency reasons as
-        * most calls to this method do not require escaping as the source
-        * of the string is known safe (i.e. Integer.toString())
+     * Note if s is a String it should be escaped by the caller to avoid SQL
+     * injection attacks.  It is not done here for efficency reasons as
+     * most calls to this method do not require escaping as the source
+     * of the string is known safe (i.e. Integer.toString())
      */
-    protected void bindLiteral(int paramIndex, String s, int oid) throws SQLException
-    {
-        if(adjustIndex)
+    protected void bindLiteral(int paramIndex, String s, int oid) throws SQLException {
+        if (adjustIndex) {
             paramIndex--;
+        }
         preparedParameters.setLiteralParameter(paramIndex, s, oid);
     }
 
-    protected void bindBytes(int paramIndex, byte[] b, int oid) throws SQLException
-    {
-        if(adjustIndex)
+    protected void bindBytes(int paramIndex, byte[] b, int oid) throws SQLException {
+        if (adjustIndex) {
             paramIndex--;
+        }
         preparedParameters.setBinaryParameter(paramIndex, b, oid);
     }
 
@@ -2578,71 +2554,75 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
      * e.g. setString directly calls bindString with no escaping;
      * the per-protocol ParameterList does escaping as needed.
      */
-    private void bindString(int paramIndex, String s, int oid) throws SQLException
-    {
-        if (adjustIndex)
+    private void bindString(int paramIndex, String s, int oid) throws SQLException {
+        if (adjustIndex) {
             paramIndex--;
-        preparedParameters.setStringParameter( paramIndex, s, oid);
+        }
+        preparedParameters.setStringParameter(paramIndex, s, oid);
     }
 
-    /** helperfunction for the getXXX calls to check isFunction and index == 1
+    /**
+     * helperfunction for the getXXX calls to check isFunction and index == 1
      * Compare BOTH type fields against the return type.
      */
-    protected void checkIndex (int parameterIndex, int type1, int type2, String getName)
-    throws SQLException
-    {
-        checkIndex (parameterIndex);
-        if (type1 != this.testReturn[parameterIndex-1] && type2 != this.testReturn[parameterIndex-1])
+    protected void checkIndex(int parameterIndex, int type1, int type2, String getName)
+            throws SQLException {
+        checkIndex(parameterIndex);
+        if (type1 != this.testReturn[parameterIndex - 1] && type2 != this.testReturn[parameterIndex - 1]) {
             throw new PSQLException(GT.tr("Parameter of type {0} was registered, but call to get{1} (sqltype={2}) was made.",
-                                          new Object[]{"java.sql.Types=" + testReturn[parameterIndex-1],
-                                                       getName,
-                                                       "java.sql.Types=" + type1}),
-                                    PSQLState.MOST_SPECIFIC_TYPE_DOES_NOT_MATCH);
+                    new Object[]{"java.sql.Types=" + testReturn[parameterIndex - 1],
+                        getName,
+                        "java.sql.Types=" + type1}),
+                    PSQLState.MOST_SPECIFIC_TYPE_DOES_NOT_MATCH);
+        }
     }
 
-    /** helperfunction for the getXXX calls to check isFunction and index == 1
+    /**
+     * helperfunction for the getXXX calls to check isFunction and index == 1
      */
-    protected void checkIndex (int parameterIndex, int type, String getName)
-    throws SQLException
-    {
-        checkIndex (parameterIndex);
-        if (type != this.testReturn[parameterIndex-1])
+    protected void checkIndex(int parameterIndex, int type, String getName)
+            throws SQLException {
+        checkIndex(parameterIndex);
+        if (type != this.testReturn[parameterIndex - 1]) {
             throw new PSQLException(GT.tr("Parameter of type {0} was registered, but call to get{1} (sqltype={2}) was made.",
-                                          new Object[]{"java.sql.Types=" + testReturn[parameterIndex-1],
-                                                       getName,
-                                                       "java.sql.Types=" + type}),
-                                    PSQLState.MOST_SPECIFIC_TYPE_DOES_NOT_MATCH);
+                    new Object[]{"java.sql.Types=" + testReturn[parameterIndex - 1],
+                        getName,
+                        "java.sql.Types=" + type}),
+                    PSQLState.MOST_SPECIFIC_TYPE_DOES_NOT_MATCH);
+        }
     }
 
-    private void checkIndex (int parameterIndex) throws SQLException
-    {
+    private void checkIndex(int parameterIndex) throws SQLException {
         checkIndex(parameterIndex, true);
     }
 
-    /** helperfunction for the getXXX calls to check isFunction and index == 1
-     * @param parameterIndex index of getXXX (index)
-     * check to make sure is a function and index == 1
+    /**
+     * helperfunction for the getXXX calls to check isFunction and index == 1
+     *
+     * @param parameterIndex index of getXXX (index) check to make sure is a
+     * function and index == 1
      */
-    private void checkIndex (int parameterIndex, boolean fetchingData) throws SQLException
-    {
-        if (!isFunction)
+    private void checkIndex(int parameterIndex, boolean fetchingData) throws SQLException {
+        if (!isFunction) {
             throw new PSQLException(GT.tr("A CallableStatement was declared, but no call to registerOutParameter(1, <some type>) was made."), PSQLState.STATEMENT_NOT_ALLOWED_IN_FUNCTION_CALL);
+        }
 
         if (fetchingData) {
-            if (!returnTypeSet)
+            if (!returnTypeSet) {
                 throw new PSQLException(GT.tr("No function outputs were registered."), PSQLState.OBJECT_NOT_IN_STATE);
+            }
 
-            if (callResult == null)
+            if (callResult == null) {
                 throw new PSQLException(GT.tr("Results cannot be retrieved from a CallableStatement before it is executed."), PSQLState.NO_DATA);
+            }
 
             lastIndex = parameterIndex;
         }
     }
 
-    
     public void setPrepareThreshold(int newThreshold) throws SQLException {
         checkClosed();
-       
+
         if (newThreshold < 0) {
             forceBinaryTransfers = true;
             newThreshold = 1;
@@ -2663,25 +2643,23 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
         return (preparedQuery != null && m_prepareThreshold != 0 && preparedQuery.getExecuteCount() + 1 >= m_prepareThreshold);
     }
 
-    protected void checkClosed() throws SQLException
-    {
-        if (isClosed)
+    protected void checkClosed() throws SQLException {
+        if (isClosed) {
             throw new PSQLException(GT.tr("This statement has been closed."),
-                                    PSQLState.OBJECT_NOT_IN_STATE);
+                    PSQLState.OBJECT_NOT_IN_STATE);
+        }
     }
 
     // ** JDBC 2 Extensions **
-
-    public void addBatch(String p_sql) throws SQLException
-    {
+    public void addBatch(String p_sql) throws SQLException {
         checkClosed();
 
-        if (preparedQuery != null)
+        if (preparedQuery != null) {
             throw new PSQLException(GT.tr("Can''t use query methods that take a query string on a PreparedStatement."),
-                                    PSQLState.WRONG_OBJECT_TYPE);
+                    PSQLState.WRONG_OBJECT_TYPE);
+        }
 
-        if (batchStatements == null)
-        {
+        if (batchStatements == null) {
             batchStatements = new ArrayList<Query>();
             batchParameters = new ArrayList<ParameterList>();
         }
@@ -2692,10 +2670,8 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
         batchParameters.add(null);
     }
 
-    public void clearBatch() throws SQLException
-    {
-        if (batchStatements != null)
-        {
+    public void clearBatch() throws SQLException {
+        if (batchStatements != null) {
             batchStatements.clear();
             batchParameters.clear();
         }
@@ -2704,8 +2680,8 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
     //
     // ResultHandler for batch queries.
     //
-
     private class BatchResultHandler implements ResultHandler {
+
         private BatchUpdateException batchException = null;
         private int resultIndex = 0;
 
@@ -2725,30 +2701,26 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
         public void handleResultRows(Query fromQuery, Field[] fields, List tuples, ResultCursor cursor) {
             if (!expectGeneratedKeys) {
                 handleError(new PSQLException(GT.tr("A result was returned when none was expected."),
-                                          PSQLState.TOO_MANY_RESULTS));
+                        PSQLState.TOO_MANY_RESULTS));
             } else {
                 if (generatedKeys == null) {
-                    try
-                    {
+                    try {
                         generatedKeys = AbstractJdbc2Statement.this.createResultSet(fromQuery, fields, tuples, cursor);
-                    }
-                    catch (SQLException e)
-                    {
+                    } catch (SQLException e) {
                         handleError(e);
-            
+
                     }
                 } else {
-                    ((AbstractJdbc2ResultSet)generatedKeys).addRows(tuples);
+                    ((AbstractJdbc2ResultSet) generatedKeys).addRows(tuples);
                 }
             }
         }
 
         public void handleCommandStatus(String status, int updateCount, long insertOID) {
-            if (resultIndex >= updateCounts.length)
-            {
+            if (resultIndex >= updateCounts.length) {
                 handleError(new PSQLException(GT.tr("Too many update results were returned."),
-                                              PSQLState.TOO_MANY_RESULTS));
-                return ;
+                        PSQLState.TOO_MANY_RESULTS));
+                return;
             }
 
             updateCounts[resultIndex++] = updateCount;
@@ -2759,42 +2731,44 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
         }
 
         public void handleError(SQLException newError) {
-            if (batchException == null)
-            {
+            if (batchException == null) {
                 int[] successCounts;
 
-                if (resultIndex >= updateCounts.length)
+                if (resultIndex >= updateCounts.length) {
                     successCounts = updateCounts;
-                else
-                {
+                } else {
                     successCounts = new int[resultIndex];
                     System.arraycopy(updateCounts, 0, successCounts, 0, resultIndex);
                 }
 
                 String queryString = "<unknown>";
-                if (resultIndex < queries.length)
+                if (resultIndex < queries.length) {
                     queryString = queries[resultIndex].toString(parameterLists[resultIndex]);
+                }
 
                 batchException = new BatchUpdateException(GT.tr("Batch entry {0} {1} was aborted.  Call getNextException to see the cause.",
-                                 new Object[]{resultIndex,
-                                               queryString}),
-                                 newError.getSQLState(),
-                                 successCounts);
+                        new Object[]{resultIndex,
+                            queryString}),
+                        newError.getSQLState(),
+                        successCounts);
             }
 
             batchException.setNextException(newError);
         }
 
         public void handleCompletion() throws SQLException {
-            if (batchException != null)
+            if (batchException != null) {
                 throw batchException;
+            }
         }
 
         public ResultSet getGeneratedKeys() {
             return generatedKeys;
         }
     }
+
     private class CallableBatchResultHandler implements ResultHandler {
+
         private BatchUpdateException batchException = null;
         private int resultIndex = 0;
 
@@ -2808,17 +2782,15 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
             this.updateCounts = updateCounts;
         }
 
-        public void handleResultRows(Query fromQuery, Field[] fields, List tuples, ResultCursor cursor) 
-        {
-            
+        public void handleResultRows(Query fromQuery, Field[] fields, List tuples, ResultCursor cursor) {
+
         }
 
         public void handleCommandStatus(String status, int updateCount, long insertOID) {
-            if (resultIndex >= updateCounts.length)
-            {
+            if (resultIndex >= updateCounts.length) {
                 handleError(new PSQLException(GT.tr("Too many update results were returned."),
-                                              PSQLState.TOO_MANY_RESULTS));
-                return ;
+                        PSQLState.TOO_MANY_RESULTS));
+                return;
             }
 
             updateCounts[resultIndex++] = updateCount;
@@ -2829,47 +2801,46 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
         }
 
         public void handleError(SQLException newError) {
-            if (batchException == null)
-            {
+            if (batchException == null) {
                 int[] successCounts;
 
-                if (resultIndex >= updateCounts.length)
+                if (resultIndex >= updateCounts.length) {
                     successCounts = updateCounts;
-                else
-                {
+                } else {
                     successCounts = new int[resultIndex];
                     System.arraycopy(updateCounts, 0, successCounts, 0, resultIndex);
                 }
 
                 String queryString = "<unknown>";
-                if (resultIndex < queries.length)
+                if (resultIndex < queries.length) {
                     queryString = queries[resultIndex].toString(parameterLists[resultIndex]);
+                }
 
                 batchException = new BatchUpdateException(GT.tr("Batch entry {0} {1} was aborted.  Call getNextException to see the cause.",
-                                 new Object[]{resultIndex,
-                                               queryString}),
-                                 newError.getSQLState(),
-                                 successCounts);
+                        new Object[]{resultIndex,
+                            queryString}),
+                        newError.getSQLState(),
+                        successCounts);
             }
 
             batchException.setNextException(newError);
         }
 
         public void handleCompletion() throws SQLException {
-            if (batchException != null)
+            if (batchException != null) {
                 throw batchException;
+            }
         }
     }
 
-    
-    public int[] executeBatch() throws SQLException
-    {
+    public int[] executeBatch() throws SQLException {
         checkClosed();
 
         closeForNextExecution();
 
-        if (batchStatements == null || batchStatements.isEmpty())
+        if (batchStatements == null || batchStatements.isEmpty()) {
             return new int[0];
+        }
 
         int size = batchStatements.size();
         int[] updateCounts = new int[size];
@@ -2907,8 +2878,7 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
         }
 
         // Only use named statements after we hit the threshold
-        if (preparedQuery != null)
-        {
+        if (preparedQuery != null) {
             preparedQuery.increaseExecuteCount(queries.length);
         }
         if (m_prepareThreshold == 0 || preparedQuery == null || preparedQuery.getExecuteCount() < m_prepareThreshold) {
@@ -2929,8 +2899,9 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
             flags |= QueryExecutor.QUERY_FORCE_DESCRIBE_PORTAL;
         }
 
-        if (connection.getAutoCommit())
+        if (connection.getAutoCommit()) {
             flags |= QueryExecutor.QUERY_SUPPRESS_BEGIN;
+        }
 
         if (preDescribe || forceBinaryTransfers) {
             // Do a client-server round trip, parsing and describing the query so we
@@ -2946,30 +2917,30 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
         }
 
         result = null;
-        
+
         ResultHandler handler;
-	if (isFunction) {
-		handler = new CallableBatchResultHandler(queries, parameterLists, updateCounts );
-	} else {
-		handler = new BatchResultHandler(queries, parameterLists, updateCounts, wantsGeneratedKeysAlways);
-	}
-        
-	try {
-	    startTimer();
-	    connection.getQueryExecutor().execute(queries,
-						  parameterLists,
-						  handler,
-						  maxrows,
-						  fetchSize,
-						  flags);
-	} finally {
-	    killTimerTask();
-	}
+        if (isFunction) {
+            handler = new CallableBatchResultHandler(queries, parameterLists, updateCounts);
+        } else {
+            handler = new BatchResultHandler(queries, parameterLists, updateCounts, wantsGeneratedKeysAlways);
+        }
+
+        try {
+            startTimer();
+            connection.getQueryExecutor().execute(queries,
+                    parameterLists,
+                    handler,
+                    maxrows,
+                    fetchSize,
+                    flags);
+        } finally {
+            killTimerTask();
+        }
 
         if (wantsGeneratedKeysAlways) {
-            generatedKeys = new ResultWrapper(((BatchResultHandler)handler).getGeneratedKeys());
+            generatedKeys = new ResultWrapper(((BatchResultHandler) handler).getGeneratedKeys());
         }
-            
+
         return updateCounts;
     }
 
@@ -2980,80 +2951,66 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
      *
      * @exception SQLException only because thats the spec.
      */
-    public void cancel() throws SQLException
-    {
-        if (!STATE_UPDATER.compareAndSet(this, STATE_IN_QUERY, STATE_CANCELLING))
-        {
+    public void cancel() throws SQLException {
+        if (!STATE_UPDATER.compareAndSet(this, STATE_IN_QUERY, STATE_CANCELLING)) {
             // Not in query, there's nothing to cancel
             return;
         }
-        try
-        {
+        try {
             // Synchronize on connection to avoid spinning in killTimerTask
-            synchronized (connection)
-            {
+            synchronized (connection) {
                 connection.cancelQuery();
             }
-        } finally
-        {
+        } finally {
             STATE_UPDATER.set(this, STATE_CANCELLED);
-            synchronized (connection)
-            {
+            synchronized (connection) {
                 connection.notifyAll(); // wake-up killTimerTask
             }
         }
     }
 
-    public Connection getConnection() throws SQLException
-    {
+    public Connection getConnection() throws SQLException {
         return (Connection) connection;
     }
 
-    public int getFetchDirection()
-    {
+    public int getFetchDirection() {
         return fetchdirection;
     }
 
-    public int getResultSetConcurrency()
-    {
+    public int getResultSetConcurrency() {
         return concurrency;
     }
 
-    public int getResultSetType()
-    {
+    public int getResultSetType() {
         return resultsettype;
     }
 
-    public void setFetchDirection(int direction) throws SQLException
-    {
-        switch (direction)
-        {
-        case ResultSet.FETCH_FORWARD:
-        case ResultSet.FETCH_REVERSE:
-        case ResultSet.FETCH_UNKNOWN:
-            fetchdirection = direction;
-            break;
-        default:
-            throw new PSQLException(GT.tr("Invalid fetch direction constant: {0}.", direction),
-                                    PSQLState.INVALID_PARAMETER_VALUE);
+    public void setFetchDirection(int direction) throws SQLException {
+        switch (direction) {
+            case ResultSet.FETCH_FORWARD:
+            case ResultSet.FETCH_REVERSE:
+            case ResultSet.FETCH_UNKNOWN:
+                fetchdirection = direction;
+                break;
+            default:
+                throw new PSQLException(GT.tr("Invalid fetch direction constant: {0}.", direction),
+                        PSQLState.INVALID_PARAMETER_VALUE);
         }
     }
 
-    public void setFetchSize(int rows) throws SQLException
-    {
+    public void setFetchSize(int rows) throws SQLException {
         checkClosed();
-        if (rows < 0)
+        if (rows < 0) {
             throw new PSQLException(GT.tr("Fetch size must be a value greater to or equal to 0."),
-                                    PSQLState.INVALID_PARAMETER_VALUE);
+                    PSQLState.INVALID_PARAMETER_VALUE);
+        }
         fetchSize = rows;
     }
 
-    public void addBatch() throws SQLException
-    {
+    public void addBatch() throws SQLException {
         checkClosed();
 
-        if (batchStatements == null)
-        {
+        if (batchStatements == null) {
             batchStatements = new ArrayList<Query>();
             batchParameters = new ArrayList<ParameterList>();
         }
@@ -3063,12 +3020,11 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
         batchParameters.add(preparedParameters.copy());
     }
 
-    public ResultSetMetaData getMetaData() throws SQLException
-    {
+    public ResultSetMetaData getMetaData() throws SQLException {
         checkClosed();
         ResultSet rs = getResultSet();
 
-        if (rs == null || ((AbstractJdbc2ResultSet)rs).isResultSetClosed() ) {
+        if (rs == null || ((AbstractJdbc2ResultSet) rs).isResultSetClosed()) {
             // OK, we haven't executed it yet, or it was closed
             // we've got to go to the backend
             // for more info.  We send the full query, but just don't
@@ -3083,18 +3039,17 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
             }
         }
 
-        if (rs != null)
+        if (rs != null) {
             return rs.getMetaData();
+        }
 
         return null;
     }
 
-    public void setArray(int i, java.sql.Array x) throws SQLException
-    {
+    public void setArray(int i, java.sql.Array x) throws SQLException {
         checkClosed();
 
-        if (null == x)
-        {
+        if (null == x) {
             setNull(i, Types.ARRAY);
             return;
         }
@@ -3103,12 +3058,12 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
         // literal from Array.toString(), such as the implementation we return
         // from ResultSet.getArray(). Eventually we need a proper implementation
         // here that works for any Array implementation.
-
         // Add special suffix for array identification
         String typename = x.getBaseTypeName() + "[]";
         int oid = connection.getTypeInfo().getPGType(typename);
-        if (oid == Oid.UNSPECIFIED)
+        if (oid == Oid.UNSPECIFIED) {
             throw new PSQLException(GT.tr("Unknown type {0}.", typename), PSQLState.INVALID_PARAMETER_TYPE);
+        }
 
         if (x instanceof AbstractJdbc2Array) {
             AbstractJdbc2Array arr = (AbstractJdbc2Array) x;
@@ -3117,83 +3072,61 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
                 return;
             }
         }
-        
+
         setString(i, x.toString(), oid);
     }
 
-    protected long createBlob(int i, InputStream inputStream, long length) throws SQLException
-    {
+    protected long createBlob(int i, InputStream inputStream, long length) throws SQLException {
         LargeObjectManager lom = connection.getLargeObjectAPI();
         long oid = lom.createLO();
         LargeObject lob = lom.open(oid);
         OutputStream outputStream = lob.getOutputStream();
         byte[] buf = new byte[4096];
-        try
-        {
+        try {
             long remaining;
-            if (length > 0)
-            {
+            if (length > 0) {
                 remaining = length;
-            }
-            else
-            {
+            } else {
                 remaining = Long.MAX_VALUE;
             }
-            int numRead = inputStream.read(buf, 0, (length > 0 && remaining < buf.length ? (int)remaining : buf.length));
-            while (numRead != -1 && remaining > 0)
-            {
+            int numRead = inputStream.read(buf, 0, (length > 0 && remaining < buf.length ? (int) remaining : buf.length));
+            while (numRead != -1 && remaining > 0) {
                 remaining -= numRead;
                 outputStream.write(buf, 0, numRead);
-                numRead = inputStream.read(buf, 0, (length > 0 && remaining < buf.length ? (int)remaining : buf.length));
+                numRead = inputStream.read(buf, 0, (length > 0 && remaining < buf.length ? (int) remaining : buf.length));
             }
-        }
-        catch (IOException se)
-        {
+        } catch (IOException se) {
             throw new PSQLException(GT.tr("Unexpected error writing large object to database."), PSQLState.UNEXPECTED_ERROR, se);
-        }
-        finally
-        {
-            try
-            {
+        } finally {
+            try {
                 outputStream.close();
-            }
-            catch ( Exception e )
-            {
+            } catch (Exception e) {
             }
         }
         return oid;
     }
 
-    public void setBlob(int i, Blob x) throws SQLException
-    {
+    public void setBlob(int i, Blob x) throws SQLException {
         checkClosed();
 
-        if (x == null)
-        {
+        if (x == null) {
             setNull(i, Types.BLOB);
             return;
         }
 
         InputStream inStream = x.getBinaryStream();
-        try
-        {
+        try {
             long oid = createBlob(i, inStream, x.length());
             setLong(i, oid);
-        }
-        finally
-        {
-            try
-            {
+        } finally {
+            try {
                 inStream.close();
-            }
-            catch ( Exception e )
-            {
+            } catch (Exception e) {
             }
         }
     }
 
-    public void setCharacterStream(int i, java.io.Reader x, int length) throws SQLException
-    {
+    public void setCharacterStream(int i, java.io.Reader x, int length) throws SQLException {
         checkClosed();
 
         if (x == null) {
@@ -3205,12 +3138,12 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
             return;
         }
 
-        if (length < 0)
+        if (length < 0) {
             throw new PSQLException(GT.tr("Invalid stream length {0}.", length),
-                                    PSQLState.INVALID_PARAMETER_VALUE);
+                    PSQLState.INVALID_PARAMETER_VALUE);
+        }
 
-        if (connection.haveMinimumCompatibleVersion(ServerVersion.v7_2))
-        {
+        if (connection.haveMinimumCompatibleVersion(ServerVersion.v7_2)) {
             //Version 7.2 supports CharacterStream for for the PG text types
             //As the spec/javadoc for this method indicate this is to be used for
             //large text values (i.e. LONGVARCHAR) PG doesn't have a separate
@@ -3219,28 +3152,24 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
             //setString() since there is no current way to stream the value to the server
             char[] l_chars = new char[length];
             int l_charsRead = 0;
-            try
-            {
-                while (true)
-                {
+            try {
+                while (true) {
                     int n = x.read(l_chars, l_charsRead, length - l_charsRead);
-                    if (n == -1)
+                    if (n == -1) {
                         break;
+                    }
 
                     l_charsRead += n;
 
-                    if (l_charsRead == length)
+                    if (l_charsRead == length) {
                         break;
+                    }
                 }
-            }
-            catch (IOException l_ioe)
-            {
+            } catch (IOException l_ioe) {
                 throw new PSQLException(GT.tr("Provided Reader failed."), PSQLState.UNEXPECTED_ERROR, l_ioe);
             }
             setString(i, new String(l_chars, 0, l_charsRead));
-        }
-        else
-        {
+        } else {
             //Version 7.1 only supported streams for LargeObjects
             //but the jdbc spec indicates that streams should be
             //available for LONGVARCHAR instead
@@ -3248,23 +3177,19 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
             long oid = lom.createLO();
             LargeObject lob = lom.open(oid);
             OutputStream los = lob.getOutputStream();
-            try
-            {
+            try {
                 // could be buffered, but then the OutputStream returned by LargeObject
                 // is buffered internally anyhow, so there would be no performance
                 // boost gained, if anything it would be worse!
                 int c = x.read();
                 int p = 0;
-                while (c > -1 && p < length)
-                {
+                while (c > -1 && p < length) {
                     los.write(c);
                     c = x.read();
                     p++;
                 }
                 los.close();
-            }
-            catch (IOException se)
-            {
+            } catch (IOException se) {
                 throw new PSQLException(GT.tr("Unexpected error writing large object to database."), PSQLState.UNEXPECTED_ERROR, se);
             }
             // lob is closed by the stream so don't call lob.close()
@@ -3272,12 +3197,10 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
         }
     }
 
-    public void setClob(int i, Clob x) throws SQLException
-    {
+    public void setClob(int i, Clob x) throws SQLException {
         checkClosed();
 
-        if (x == null)
-        {
+        if (x == null) {
             setNull(i, Types.CLOB);
             return;
         }
@@ -3290,46 +3213,38 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
         Charset connectionCharset = Charset.forName(connection.getEncoding().name());
         OutputStream los = lob.getOutputStream();
         Writer lw = new OutputStreamWriter(los, connectionCharset);
-        try
-        {
+        try {
             // could be buffered, but then the OutputStream returned by LargeObject
             // is buffered internally anyhow, so there would be no performance
             // boost gained, if anything it would be worse!
             int c = l_inStream.read();
             int p = 0;
-            while (c > -1 && p < l_length)
-            {
+            while (c > -1 && p < l_length) {
                 lw.write(c);
                 c = l_inStream.read();
                 p++;
             }
             lw.close();
-        }
-        catch (IOException se)
-        {
+        } catch (IOException se) {
             throw new PSQLException(GT.tr("Unexpected error writing large object to database."), PSQLState.UNEXPECTED_ERROR, se);
         }
         // lob is closed by the stream so don't call lob.close()
         setLong(i, oid);
     }
 
-    public void setNull(int i, int t, String s) throws SQLException
-    {
+    public void setNull(int i, int t, String s) throws SQLException {
         checkClosed();
         setNull(i, t);
     }
 
-    public void setRef(int i, Ref x) throws SQLException
-    {
+    public void setRef(int i, Ref x) throws SQLException {
         throw Driver.notImplemented(this.getClass(), "setRef(int,Ref)");
     }
 
-    public void setDate(int i, java.sql.Date d, java.util.Calendar cal) throws SQLException
-    {
+    public void setDate(int i, java.sql.Date d, java.util.Calendar cal) throws SQLException {
         checkClosed();
 
-        if (d == null)
-        {
+        if (d == null) {
             setNull(i, Types.DATE);
             return;
         }
@@ -3341,35 +3256,30 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
             preparedParameters.setBinaryParameter(i, val, Oid.DATE);
             return;
         }
-        
+
         // We must use UNSPECIFIED here, or inserting a Date-with-timezone into a
         // timestamptz field does an unexpected rotation by the server's TimeZone:
         //
         // We want to interpret 2005/01/01 with calendar +0100 as
         // "local midnight in +0100", but if we go via date it interprets it
         // as local midnight in the server's timezone:
-
         // template1=# select '2005-01-01+0100'::timestamptz;
         //       timestamptz       
         // ------------------------
         //  2005-01-01 02:00:00+03
         // (1 row)
-
         // template1=# select '2005-01-01+0100'::date::timestamptz;
         //       timestamptz       
         // ------------------------
         //  2005-01-01 00:00:00+03
         // (1 row)
-
         bindString(i, connection.getTimestampUtils().toString(cal, d), Oid.UNSPECIFIED);
     }
 
-    public void setTime(int i, Time t, java.util.Calendar cal) throws SQLException
-    {
+    public void setTime(int i, Time t, java.util.Calendar cal) throws SQLException {
         checkClosed();
 
-        if (t == null)
-        {
+        if (t == null) {
             setNull(i, Types.TIME);
             return;
         }
@@ -3378,7 +3288,7 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
 
         // If a PGTime is used, we can define the OID explicitly.
         if (t instanceof PGTime) {
-            PGTime pgTime = (PGTime)t;
+            PGTime pgTime = (PGTime) t;
             if (pgTime.getCalendar() == null) {
                 oid = Oid.TIME;
             } else {
@@ -3390,8 +3300,7 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
         bindString(i, connection.getTimestampUtils().toString(cal, t), oid);
     }
 
-    public void setTimestamp(int i, Timestamp t, java.util.Calendar cal) throws SQLException
-    {
+    public void setTimestamp(int i, Timestamp t, java.util.Calendar cal) throws SQLException {
         checkClosed();
 
         if (t == null) {
@@ -3399,7 +3308,7 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
             return;
         }
 
-        int oid = Oid.UNSPECIFIED;
+        int oid;
 
         // Use UNSPECIFIED as a compromise to get both TIMESTAMP and TIMESTAMPTZ working.
         // This is because you get this in a +1300 timezone:
@@ -3409,19 +3318,16 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
         // ------------------------
         //  2005-01-01 18:00:00+13
         // (1 row)
-
         // template1=# select '2005-01-01 15:00:00 +1000'::timestamp;
         //       timestamp      
         // ---------------------
         //  2005-01-01 15:00:00
         // (1 row)        
-
         // template1=# select '2005-01-01 15:00:00 +1000'::timestamptz::timestamp;
         //       timestamp      
         // ---------------------
         //  2005-01-01 18:00:00
         // (1 row)
-        
         // So we want to avoid doing a timestamptz -> timestamp conversion, as that
         // will first convert the timestamptz to an equivalent time in the server's
         // timezone (+1300, above), then turn it into a timestamp with the "wrong"
@@ -3430,104 +3336,96 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
         // the timezone part entirely. Since we don't know ahead of time what type
         // we're actually dealing with, UNSPECIFIED seems the lesser evil, even if it
         // does give more scope for type-mismatch errors being silently hidden.
-
         // If a PGTimestamp is used, we can define the OID explicitly.
         if (t instanceof PGTimestamp) {
-            PGTimestamp pgTimestamp = (PGTimestamp)t;
+            PGTimestamp pgTimestamp = (PGTimestamp) t;
             if (pgTimestamp.getCalendar() == null) {
                 oid = Oid.TIMESTAMP;
             } else {
                 oid = Oid.TIMESTAMPTZ;
                 cal = pgTimestamp.getCalendar();
             }
+        } else {
+            oid = cal == null ? Oid.TIMESTAMP : Oid.TIMESTAMPTZ;
         }
 
         bindString(i, connection.getTimestampUtils().toString(cal, t), oid);
     }
 
     // ** JDBC 2 Extensions for CallableStatement**
-
-    public java.sql.Array getArray(int i) throws SQLException
-    {
+    public java.sql.Array getArray(int i) throws SQLException {
         checkClosed();
         checkIndex(i, Types.ARRAY, "Array");
-        return (Array)callResult[i-1];
+        return (Array) callResult[i - 1];
     }
 
-    public java.math.BigDecimal getBigDecimal(int parameterIndex) throws SQLException
-    {
+    public java.math.BigDecimal getBigDecimal(int parameterIndex) throws SQLException {
         checkClosed();
-        checkIndex (parameterIndex, Types.NUMERIC, "BigDecimal");
-        return ((BigDecimal)callResult[parameterIndex-1]);
+        checkIndex(parameterIndex, Types.NUMERIC, "BigDecimal");
+        return ((BigDecimal) callResult[parameterIndex - 1]);
     }
 
-    public Blob getBlob(int i) throws SQLException
-    {
+    public Blob getBlob(int i) throws SQLException {
         throw Driver.notImplemented(this.getClass(), "getBlob(int)");
     }
 
-    public Clob getClob(int i) throws SQLException
-    {
+    public Clob getClob(int i) throws SQLException {
         throw Driver.notImplemented(this.getClass(), "getClob(int)");
     }
 
-    public Object getObjectImpl(int i, java.util.Map map) throws SQLException
-    {
+    public Object getObjectImpl(int i, java.util.Map map) throws SQLException {
         if (map == null || map.isEmpty()) {
             return getObject(i);
         }
         throw Driver.notImplemented(this.getClass(), "getObjectImpl(int,Map)");
     }
 
-    public Ref getRef(int i) throws SQLException
-    {
+    public Ref getRef(int i) throws SQLException {
         throw Driver.notImplemented(this.getClass(), "getRef(int)");
     }
 
-    public java.sql.Date getDate(int i, java.util.Calendar cal) throws SQLException
-    {
+    public java.sql.Date getDate(int i, java.util.Calendar cal) throws SQLException {
         checkClosed();
         checkIndex(i, Types.DATE, "Date");
 
-        if (callResult[i-1] == null)
+        if (callResult[i - 1] == null) {
             return null;
+        }
 
-        String value = callResult[i-1].toString();
+        String value = callResult[i - 1].toString();
         return connection.getTimestampUtils().toDate(cal, value);
     }
 
-    public Time getTime(int i, java.util.Calendar cal) throws SQLException
-    {
+    public Time getTime(int i, java.util.Calendar cal) throws SQLException {
         checkClosed();
         checkIndex(i, Types.TIME, "Time");
 
-        if (callResult[i-1] == null)
+        if (callResult[i - 1] == null) {
             return null;
+        }
 
-        String value = callResult[i-1].toString();
+        String value = callResult[i - 1].toString();
         return connection.getTimestampUtils().toTime(cal, value);
     }
 
-    public Timestamp getTimestamp(int i, java.util.Calendar cal) throws SQLException
-    {
+    public Timestamp getTimestamp(int i, java.util.Calendar cal) throws SQLException {
         checkClosed();
         checkIndex(i, Types.TIMESTAMP, "Timestamp");
 
-        if (callResult[i-1] == null)
+        if (callResult[i - 1] == null) {
             return null;
+        }
 
-        String value = callResult[i-1].toString();
+        String value = callResult[i - 1].toString();
         return connection.getTimestampUtils().toTimestamp(cal, value);
     }
 
     // no custom types allowed yet..
-    public void registerOutParameter(int parameterIndex, int sqlType, String typeName) throws SQLException
-    {
+    public void registerOutParameter(int parameterIndex, int sqlType, String typeName) throws SQLException {
         throw Driver.notImplemented(this.getClass(), "registerOutParameter(int,int,String)");
     }
 
-    private void startTimer()
-    {
+    private void startTimer() {
         /*
          * there shouldn't be any previous timer active, but better safe than
          * sorry.
@@ -3536,23 +3434,18 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
 
         STATE_UPDATER.set(this, STATE_IN_QUERY);
 
-        if (timeout == 0)
-        {
+        if (timeout == 0) {
             return;
         }
 
         TimerTask cancelTask = new TimerTask() {
-            public void run()
-            {
-                try
-                {
-                    if (!CANCEL_TIMER_UPDATER.compareAndSet(AbstractJdbc2Statement.this, this, null))
-                    {
+            public void run() {
+                try {
+                    if (!CANCEL_TIMER_UPDATER.compareAndSet(AbstractJdbc2Statement.this, this, null)) {
                         return; // Nothing to do here, statement has already finished and cleared cancelTimerTask reference
                     }
                     AbstractJdbc2Statement.this.cancel();
-                } catch (SQLException e)
-                {
+                } catch (SQLException e) {
                 }
             }
         };
@@ -3565,16 +3458,13 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
      * Clears {@link #cancelTimerTask} if any.
      * Returns true if and only if "cancel" timer task would never invoke {@link #cancel()}.
      */
-    private boolean cleanupTimer()
-    {
+    private boolean cleanupTimer() {
         TimerTask timerTask = CANCEL_TIMER_UPDATER.get(this);
-        if (timerTask == null)
-        {
+        if (timerTask == null) {
             // If timeout is zero, then timer task did not exist, so we safely report "all clear"
             return timeout == 0;
         }
-        if (!CANCEL_TIMER_UPDATER.compareAndSet(this, timerTask, null))
-        {
+        if (!CANCEL_TIMER_UPDATER.compareAndSet(this, timerTask, null)) {
             // Failed to update reference -> timer has just fired, so we must wait for the query state to become "cancelling".
             return false;
         }
@@ -3584,42 +3474,34 @@ public abstract class AbstractJdbc2Statement implements BaseStatement
         return true;
     }
 
-    private void killTimerTask()
-    {
+    private void killTimerTask() {
         boolean timerTaskIsClear = cleanupTimer();
         // The order is important here: in case we need to wait for the cancel task, the state must be
         // kept STATE_IN_QUERY, so cancelTask would be able to cancel the query.
         // It is believed that this case is very rare, so "additional cancel and wait below" would not harm it.
-        if (timerTaskIsClear && STATE_UPDATER.compareAndSet(this, STATE_IN_QUERY, STATE_IDLE))
-        {
+        if (timerTaskIsClear && STATE_UPDATER.compareAndSet(this, STATE_IN_QUERY, STATE_IDLE)) {
             return;
         }
 
         // Being here means someone managed to call .cancel() and our connection did not receive "timeout error"
         // We wait till state becomes "cancelled"
         boolean interrupted = false;
-        while (!STATE_UPDATER.compareAndSet(this, STATE_CANCELLED, STATE_IDLE))
-        {
-            synchronized (connection)
-            {
-                try
-                {
+        while (!STATE_UPDATER.compareAndSet(this, STATE_CANCELLED, STATE_IDLE)) {
+            synchronized (connection) {
+                try {
                     // Note: wait timeout here is irrelevant since synchronized(connection) would block until .cancel finishes
                     connection.wait(10);
-                } catch (InterruptedException e)
-                {
+                } catch (InterruptedException e) {
                     interrupted = true;
                 }
             }
         }
-        if (interrupted)
-        {
+        if (interrupted) {
             Thread.currentThread().interrupt();
         }
     }
 
-    protected boolean getForceBinaryTransfer()
-    {
-        return forceBinaryTransfers;        
+    protected boolean getForceBinaryTransfer() {
+        return forceBinaryTransfers;
     }
 }

--- a/org/postgresql/jdbc2/AbstractJdbc2Statement.java
+++ b/org/postgresql/jdbc2/AbstractJdbc2Statement.java
@@ -1,11 +1,12 @@
 /*-------------------------------------------------------------------------
- *
- * Copyright (c) 2004-2014, PostgreSQL Global Development Group
- *
- *
- *-------------------------------------------------------------------------
- */
+*
+* Copyright (c) 2004-2014, PostgreSQL Global Development Group
+*
+*
+*-------------------------------------------------------------------------
+*/
 package org.postgresql.jdbc2;
+
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -69,14 +70,13 @@ import org.postgresql.util.PSQLException;
 import org.postgresql.util.PSQLState;
 
 /**
- * This class defines methods of the jdbc2 specification. The real Statement
- * class (for jdbc2) is org.postgresql.jdbc2.Jdbc2Statement
+ * This class defines methods of the jdbc2 specification.
+ * The real Statement class (for jdbc2) is org.postgresql.jdbc2.Jdbc2Statement
  */
-public abstract class AbstractJdbc2Statement implements BaseStatement {
-
+public abstract class AbstractJdbc2Statement implements BaseStatement
+{
     /**
-     * Default state for use or not binary transfers. Can use only for testing
-     * purposes
+     * Default state for use or not binary transfers. Can use only for testing purposes
      */
     private static final boolean DEFAULT_FORCE_BINARY_TRANSFERS = Boolean.getBoolean("org.postgresql.forceBinary");
     // only for testing purposes. even single shot statements will use binary transfers
@@ -89,28 +89,23 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
     protected int fetchdirection = ResultSet.FETCH_FORWARD;  // fetch direction hint (currently ignored)
 
     /**
-     * Protects current statement from cancelTask starting, waiting for a bit,
-     * and waking up exactly on subsequent query execution. The idea is to
-     * atomically compare and swap the reference to the task, so the task can
-     * detect that statement executes different query than the one the
-     * cancelTask was created. Note: the field must be set/get/compareAndSet via
-     * {@link #CANCEL_TIMER_UPDATER} as per {@link AtomicReferenceFieldUpdater}
-     * javadoc.
+     * Protects current statement from cancelTask starting, waiting for a bit, and waking up exactly on subsequent query execution.
+     * The idea is to atomically compare and swap the reference to the task, so the task can detect that statement executes different
+     * query than the one the cancelTask was created.
+     * Note: the field must be set/get/compareAndSet via {@link #CANCEL_TIMER_UPDATER} as per {@link AtomicReferenceFieldUpdater} javadoc.
      */
     private volatile TimerTask cancelTimerTask = null;
-    private static final AtomicReferenceFieldUpdater<AbstractJdbc2Statement, TimerTask> CANCEL_TIMER_UPDATER
-            = AtomicReferenceFieldUpdater.newUpdater(AbstractJdbc2Statement.class, TimerTask.class, "cancelTimerTask");
+    private static final AtomicReferenceFieldUpdater<AbstractJdbc2Statement, TimerTask> CANCEL_TIMER_UPDATER =
+            AtomicReferenceFieldUpdater.newUpdater(AbstractJdbc2Statement.class, TimerTask.class, "cancelTimerTask");
 
     /**
-     * Protects statement from out-of-order cancels. It protects from both
-     * {@link #setQueryTimeout(int)} and {@link #cancel()} induced ones.
+     * Protects statement from out-of-order cancels. It protects from both {@link #setQueryTimeout(int)} and {@link #cancel()} induced ones.
      *
-     * .execute() and friends change statementState to STATE_IN_QUERY during
-     * execute. .cancel() ignores cancel request if state is IDLE. In case
-     * .execute() observes non-IN_QUERY state as it completes the query, it
-     * waits till STATE_CANCELLED. Note: the field must be set/get/compareAndSet
-     * via {@link #STATE_UPDATER} as per {@link AtomicIntegerFieldUpdater}
-     * javadoc.
+     * .execute() and friends change statementState to STATE_IN_QUERY during execute.
+     * .cancel() ignores cancel request if state is IDLE.
+     * In case .execute() observes non-IN_QUERY state as it completes the query, it waits till
+     * STATE_CANCELLED.
+     * Note: the field must be set/get/compareAndSet via {@link #STATE_UPDATER} as per {@link AtomicIntegerFieldUpdater} javadoc.
      */
     private volatile int statementState = STATE_IDLE;
     private final static int STATE_IDLE = 0;
@@ -118,79 +113,65 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
     private final static int STATE_CANCELLING = 2;
     private final static int STATE_CANCELLED = 3;
 
-    private static final AtomicIntegerFieldUpdater<AbstractJdbc2Statement> STATE_UPDATER
-            = AtomicIntegerFieldUpdater.newUpdater(AbstractJdbc2Statement.class, "statementState");
+    private static final AtomicIntegerFieldUpdater<AbstractJdbc2Statement> STATE_UPDATER =
+            AtomicIntegerFieldUpdater.newUpdater(AbstractJdbc2Statement.class, "statementState");
 
     /**
      * Does the caller of execute/executeUpdate want generated keys for this
-     * execution? This is set by Statement methods that have generated keys
+     * execution?  This is set by Statement methods that have generated keys
      * arguments and cleared after execution is complete.
      */
     protected boolean wantsGeneratedKeysOnce = false;
 
     /**
      * Was this PreparedStatement created to return generated keys for every
-     * execution? This is set at creation time and never cleared by execution.
+     * execution?  This is set at creation time and never cleared by
+     * execution.
      */
     public boolean wantsGeneratedKeysAlways = false;
 
     // The connection who created us
     protected final BaseConnection connection;
 
-    /**
-     * The warnings chain.
-     */
+    /** The warnings chain. */
     protected SQLWarning warnings = null;
-    /**
-     * The last warning of the warning chain.
-     */
+    /** The last warning of the warning chain. */
     protected SQLWarning lastWarning = null;
 
-    /**
-     * Maximum number of rows to return, 0 = unlimited
-     */
+    /** Maximum number of rows to return, 0 = unlimited */
     protected int maxrows = 0;
 
-    /**
-     * Number of rows to get in a batch.
-     */
+    /** Number of rows to get in a batch. */
     protected int fetchSize = 0;
 
-    /**
-     * Timeout (in milliseconds) for a query
-     */
+    /** Timeout (in milliseconds) for a query */
     protected int timeout = 0;
 
     protected boolean replaceProcessingEnabled = true;
 
-    /**
-     * The current results.
-     */
+    /** The current results. */
     protected ResultWrapper result = null;
 
-    /**
-     * The first unclosed result.
-     */
+    /** The first unclosed result. */
     protected ResultWrapper firstUnclosedResult = null;
 
-    /**
-     * Results returned by a statement that wants generated keys.
-     */
+    /** Results returned by a statement that wants generated keys. */
     protected ResultWrapper generatedKeys = null;
-
-    /**
-     * used to differentiate between new function call logic and old function
-     * call logic will be set to true if the server is < 8.1 or if we are using
-     * v2 protocol There is an exception to this where we are using v3, and the
+    
+    /** used to differentiate between new function call
+     * logic and old function call logic
+     * will be set to true if the server is < 8.1 or 
+     * if we are using v2 protocol
+     * There is an exception to this where we are using v3, and the
      * call does not have an out parameter before the call
      */
     protected boolean adjustIndex = false;
-
+    
     /*
      * Used to set adjustIndex above
      */
-    protected boolean outParmBeforeFunc = false;
-
+    protected boolean outParmBeforeFunc=false;
+    
     // Static variables for parsing SQL when replaceProcessing is true.
     private static final short IN_SQLCODE = 0;
     private static final short IN_STRING = 1;
@@ -200,7 +181,7 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
     private static final short ESC_FUNCTION = 4;
     private static final short ESC_OUTERJOIN = 5;
     private static final short ESC_ESCAPECHAR = 7;
-
+    
     protected final CachedQuery preparedQuery;        // Query fragments for prepared statement.
     protected final ParameterList preparedParameters; // Parameter values for prepared statement.
     protected Query lastSimpleQuery;
@@ -212,19 +193,21 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
     // functionReturnType contains the user supplied value to check
     // testReturn contains a modified version to make it easier to
     // check the getXXX methods..
-    private int[] functionReturnType;
-    private int[] testReturn;
+    private int []functionReturnType;
+    private int []testReturn;
     // returnTypeSet is true when a proper call to registerOutParameter has been made
     private boolean returnTypeSet;
-    protected Object[] callResult;
+    protected Object []callResult;
     protected int maxfieldSize = 0;
 
     public ResultSet createDriverResultSet(Field[] fields, List tuples)
-            throws SQLException {
+    throws SQLException
+    {
         return createResultSet(null, fields, tuples, null);
     }
 
-    public AbstractJdbc2Statement(AbstractJdbc2Connection c, int rsType, int rsConcurrency) throws SQLException {
+    public AbstractJdbc2Statement (AbstractJdbc2Connection c, int rsType, int rsConcurrency) throws SQLException
+    {
         this.connection = c;
         this.preparedQuery = null;
         this.preparedParameters = null;
@@ -236,12 +219,14 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
         setPrepareThreshold(c.getPrepareThreshold());
     }
 
-    public AbstractJdbc2Statement(AbstractJdbc2Connection connection, String sql, boolean isCallable, int rsType, int rsConcurrency) throws SQLException {
+    public AbstractJdbc2Statement(AbstractJdbc2Connection connection, String sql, boolean isCallable, int rsType, int rsConcurrency) throws SQLException
+    {
         this.connection = connection;
         this.lastSimpleQuery = null;
 
         CachedQuery cachedQuery = connection.borrowQuery(sql, isCallable);
-        if (isCallable) {
+        if (isCallable)
+        {
             this.isFunction = cachedQuery.isFunction;
             this.outParmBeforeFunc = cachedQuery.outParmBeforeFunc;
         }
@@ -250,7 +235,7 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
         this.preparedParameters = preparedQuery.query.createParameterList();
 
         if (isFunction) {
-            int inParamCount = preparedParameters.getInParameterCount() + 1;
+            int inParamCount =  preparedParameters.getInParameterCount() + 1;
             this.testReturn = new int[inParamCount];
             this.functionReturnType = new int[inParamCount];
         }
@@ -264,7 +249,8 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
     }
 
     public abstract ResultSet createResultSet(Query originalQuery, Field[] fields, List tuples, ResultCursor cursor)
-            throws SQLException;
+    throws SQLException;
+
 
     public BaseConnection getPGConnection() {
         return connection;
@@ -289,8 +275,8 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
     //
     // ResultHandler implementations for updates, queries, and either-or.
     //
-    public class StatementResultHandler implements ResultHandler {
 
+    public class StatementResultHandler implements ResultHandler {
         private SQLException error;
         private ResultWrapper results;
 
@@ -299,18 +285,20 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
         }
 
         private void append(ResultWrapper newResult) {
-            if (results == null) {
+            if (results == null)
                 results = newResult;
-            } else {
+            else
                 results.append(newResult);
-            }
         }
 
         public void handleResultRows(Query fromQuery, Field[] fields, List tuples, ResultCursor cursor) {
-            try {
+            try
+            {
                 ResultSet rs = AbstractJdbc2Statement.this.createResultSet(fromQuery, fields, tuples, cursor);
                 append(new ResultWrapper(rs));
-            } catch (SQLException e) {
+            }
+            catch (SQLException e)
+            {
                 handleError(e);
             }
         }
@@ -324,17 +312,15 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
         }
 
         public void handleError(SQLException newError) {
-            if (error == null) {
+            if (error == null)
                 error = newError;
-            } else {
+            else
                 error.setNextException(newError);
-            }
         }
 
         public void handleCompletion() throws SQLException {
-            if (error != null) {
+            if (error != null)
                 throw error;
-            }
         }
     }
 
@@ -345,43 +331,41 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
      * @return a ResulSet that contains the data produced by the query
      * @exception SQLException if a database access error occurs
      */
-    public java.sql.ResultSet executeQuery(String p_sql) throws SQLException {
-        if (preparedQuery != null) {
+    public java.sql.ResultSet executeQuery(String p_sql) throws SQLException
+    {
+        if (preparedQuery != null)
             throw new PSQLException(GT.tr("Can''t use query methods that take a query string on a PreparedStatement."),
-                    PSQLState.WRONG_OBJECT_TYPE);
-        }
+                                    PSQLState.WRONG_OBJECT_TYPE);
 
         if (forceBinaryTransfers) {
-            clearWarnings();
-            // Close any existing resultsets associated with this statement.
-            while (firstUnclosedResult != null) {
-                if (firstUnclosedResult.getResultSet() != null) {
-                    firstUnclosedResult.getResultSet().close();
+        	clearWarnings();
+                // Close any existing resultsets associated with this statement.
+                while (firstUnclosedResult != null)
+                {
+                   if (firstUnclosedResult.getResultSet() != null)
+                      firstUnclosedResult.getResultSet().close();
+                   firstUnclosedResult = firstUnclosedResult.getNext();
                 }
-                firstUnclosedResult = firstUnclosedResult.getNext();
-            }
 
-            PreparedStatement ps = connection.prepareStatement(p_sql, resultsettype, concurrency, getResultSetHoldability());
-            ps.setMaxFieldSize(getMaxFieldSize());
-            ps.setFetchSize(getFetchSize());
-            ps.setFetchDirection(getFetchDirection());
-            AbstractJdbc2ResultSet rs = (AbstractJdbc2ResultSet) ps.executeQuery();
-            rs.registerRealStatement(this);
+        	PreparedStatement ps = connection.prepareStatement(p_sql, resultsettype, concurrency, getResultSetHoldability());
+        	ps.setMaxFieldSize(getMaxFieldSize());
+        	ps.setFetchSize(getFetchSize());
+        	ps.setFetchDirection(getFetchDirection());
+        	AbstractJdbc2ResultSet rs = (AbstractJdbc2ResultSet) ps.executeQuery();
+        	rs.registerRealStatement(this);
 
-            result = firstUnclosedResult = new ResultWrapper(rs);
-            return rs;
+                result = firstUnclosedResult = new ResultWrapper(rs);
+        	return rs;
         }
 
-        if (!executeWithFlags(p_sql, 0)) {
+        if (!executeWithFlags(p_sql, 0))
             throw new PSQLException(GT.tr("No results were returned by the query."), PSQLState.NO_DATA);
-        }
 
-        if (result.getNext() != null) {
+        if (result.getNext() != null)
             throw new PSQLException(GT.tr("Multiple ResultSets were returned by the query."),
-                    PSQLState.TOO_MANY_RESULTS);
-        }
+                                    PSQLState.TOO_MANY_RESULTS);
 
-        return (ResultSet) result.getResultSet();
+        return (ResultSet)result.getResultSet();
     }
 
     /*
@@ -391,14 +375,13 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
      *   * query - never null
      * @exception SQLException if a database access error occurs
      */
-    public java.sql.ResultSet executeQuery() throws SQLException {
-        if (!executeWithFlags(0)) {
+    public java.sql.ResultSet executeQuery() throws SQLException
+    {
+        if (!executeWithFlags(0))
             throw new PSQLException(GT.tr("No results were returned by the query."), PSQLState.NO_DATA);
-        }
 
-        if (result.getNext() != null) {
+        if (result.getNext() != null)
             throw new PSQLException(GT.tr("Multiple ResultSets were returned by the query."), PSQLState.TOO_MANY_RESULTS);
-        }
 
         return (ResultSet) result.getResultSet();
     }
@@ -412,13 +395,14 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
      * @return either a row count, or 0 for SQL commands
      * @exception SQLException if a database access error occurs
      */
-    public int executeUpdate(String p_sql) throws SQLException {
-        if (preparedQuery != null) {
+    public int executeUpdate(String p_sql) throws SQLException
+    {
+        if (preparedQuery != null)
             throw new PSQLException(GT.tr("Can''t use query methods that take a query string on a PreparedStatement."),
-                    PSQLState.WRONG_OBJECT_TYPE);
-        }
-        if (isFunction) {
-            executeWithFlags(p_sql, 0);
+                                    PSQLState.WRONG_OBJECT_TYPE);
+        if( isFunction )
+        {
+            executeWithFlags(p_sql, 0);                
             return 0;
         }
 
@@ -428,7 +412,7 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
         while (iter != null) {
             if (iter.getResultSet() != null) {
                 throw new PSQLException(GT.tr("A result was returned when none was expected."),
-                        PSQLState.TOO_MANY_RESULTS);
+                    				  PSQLState.TOO_MANY_RESULTS);
 
             }
             iter = iter.getNext();
@@ -446,8 +430,10 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
      *   * 0 for SQL statements that return nothing.
      * @exception SQLException if a database access error occurs
      */
-    public int executeUpdate() throws SQLException {
-        if (isFunction) {
+    public int executeUpdate() throws SQLException
+    {
+        if( isFunction )
+        {
             executeWithFlags(0);
             return 0;
         }
@@ -458,7 +444,7 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
         while (iter != null) {
             if (iter.getResultSet() != null) {
                 throw new PSQLException(GT.tr("A result was returned when none was expected."),
-                        PSQLState.TOO_MANY_RESULTS);
+                    				  PSQLState.TOO_MANY_RESULTS);
 
             }
             iter = iter.getNext();
@@ -478,16 +464,17 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
      * an update count or there are no more results
      * @exception SQLException if a database access error occurs
      */
-    public boolean execute(String p_sql) throws SQLException {
-        if (preparedQuery != null) {
+    public boolean execute(String p_sql) throws SQLException
+    {
+        if (preparedQuery != null)
             throw new PSQLException(GT.tr("Can''t use query methods that take a query string on a PreparedStatement."),
-                    PSQLState.WRONG_OBJECT_TYPE);
-        }
+                                    PSQLState.WRONG_OBJECT_TYPE);
 
         return executeWithFlags(p_sql, 0);
     }
 
-    public boolean executeWithFlags(String p_sql, int flags) throws SQLException {
+    public boolean executeWithFlags(String p_sql, int flags) throws SQLException
+    {
         checkClosed();
         p_sql = replaceProcessing(p_sql, replaceProcessingEnabled, connection.getStandardConformingStrings());
         Query simpleQuery = connection.getQueryExecutor().createSimpleQuery(p_sql);
@@ -496,70 +483,73 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
         return (result != null && result.getResultSet() != null);
     }
 
-    public boolean execute() throws SQLException {
+    public boolean execute() throws SQLException
+    {
         return executeWithFlags(0);
     }
 
-    public boolean executeWithFlags(int flags) throws SQLException {
+    public boolean executeWithFlags(int flags) throws SQLException
+    {
         checkClosed();
-
+   
         execute(preparedQuery.query, preparedParameters, flags);
 
         // If we are executing and there are out parameters 
         // callable statement function set the return data
-        if (isFunction && returnTypeSet) {
-            if (result == null || result.getResultSet() == null) {
+        
+        if (isFunction && returnTypeSet )
+        {
+            if (result == null || result.getResultSet() == null)
                 throw new PSQLException(GT.tr("A CallableStatement was executed with nothing returned."), PSQLState.NO_DATA);
-            }
 
             ResultSet rs = result.getResultSet();
-            if (!rs.next()) {
+            if (!rs.next())
                 throw new PSQLException(GT.tr("A CallableStatement was executed with nothing returned."), PSQLState.NO_DATA);
-            }
 
             // figure out how many columns
             int cols = rs.getMetaData().getColumnCount();
-
-            int outParameterCount = preparedParameters.getOutParameterCount();
-
-            if (cols != outParameterCount) {
-                throw new PSQLException(GT.tr("A CallableStatement was executed with an invalid number of parameters"), PSQLState.SYNTAX_ERROR);
-            }
-
+            
+            int outParameterCount = preparedParameters.getOutParameterCount() ;
+            
+            if ( cols != outParameterCount )
+                throw new PSQLException(GT.tr("A CallableStatement was executed with an invalid number of parameters"),PSQLState.SYNTAX_ERROR);
+           
             // reset last result fetched (for wasNull)
             lastIndex = 0;
 
             // allocate enough space for all possible parameters without regard to in/out            
-            callResult = new Object[preparedParameters.getParameterCount() + 1];
-
+            callResult = new Object[preparedParameters.getParameterCount()+1];
+            
             // move them into the result set
-            for (int i = 0, j = 0; i < cols; i++, j++) {
+            for ( int i=0,j=0; i < cols; i++,j++)
+            {
                 // find the next out parameter, the assumption is that the functionReturnType 
                 // array will be initialized with 0 and only out parameters will have values
                 // other than 0. 0 is the value for java.sql.Types.NULL, which should not 
                 // conflict
-                while (j < functionReturnType.length && functionReturnType[j] == 0) {
-                    j++;
-                }
+                while( j< functionReturnType.length && functionReturnType[j]==0) j++;
+                
+                callResult[j] = rs.getObject(i+1);
+                int columnType = rs.getMetaData().getColumnType(i+1);
 
-                callResult[j] = rs.getObject(i + 1);
-                int columnType = rs.getMetaData().getColumnType(i + 1);
-
-                if (columnType != functionReturnType[j]) {
+                if (columnType != functionReturnType[j])
+                {
                     // this is here for the sole purpose of passing the cts
-                    if (columnType == Types.DOUBLE && functionReturnType[j] == Types.REAL) {
+                    if ( columnType == Types.DOUBLE && functionReturnType[j] == Types.REAL )
+                    {
                         // return it as a float
-                        if (callResult[j] != null) {
+                        if ( callResult[j] != null)
                             callResult[j] = ((Double) callResult[j]).floatValue();
-                        }
-                    } else {
-                        throw new PSQLException(GT.tr("A CallableStatement function was executed and the out parameter {0} was of type {1} however type {2} was registered.",
-                                new Object[]{i + 1,
-                                    "java.sql.Types=" + columnType, "java.sql.Types=" + functionReturnType[j]}),
-                                PSQLState.DATA_TYPE_MISMATCH);
+                    }
+                    else
+                    {    
+	                    throw new PSQLException (GT.tr("A CallableStatement function was executed and the out parameter {0} was of type {1} however type {2} was registered.",
+	                            new Object[]{i + 1,
+	                                "java.sql.Types=" + columnType, "java.sql.Types=" + functionReturnType[j] }),
+	                      PSQLState.DATA_TYPE_MISMATCH);
                     }
                 }
-
+                    
             }
             rs.close();
             result = null;
@@ -574,9 +564,11 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
         clearWarnings();
 
         // Close any existing resultsets associated with this statement.
-        while (firstUnclosedResult != null) {
+        while (firstUnclosedResult != null)
+        {
             ResultSet rs = firstUnclosedResult.getResultSet();
-            if (rs != null) {
+            if (rs != null)
+            {
                 rs.close();
             }
             firstUnclosedResult = firstUnclosedResult.getNext();
@@ -600,75 +592,76 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
         closeForNextExecution();
 
         // Enable cursor-based resultset if possible.
-        if (fetchSize > 0 && !wantsScrollableResultSet() && !connection.getAutoCommit() && !wantsHoldableResultSet()) {
+        if (fetchSize > 0 && !wantsScrollableResultSet() && !connection.getAutoCommit() && !wantsHoldableResultSet())
             flags |= QueryExecutor.QUERY_FORWARD_CURSOR;
-        }
 
-        if (wantsGeneratedKeysOnce || wantsGeneratedKeysAlways) {
+        if (wantsGeneratedKeysOnce || wantsGeneratedKeysAlways)
+        {
             flags |= QueryExecutor.QUERY_BOTH_ROWS_AND_STATUS;
 
             // If the no results flag is set (from executeUpdate)
             // clear it so we get the generated keys results.
             //
-            if ((flags & QueryExecutor.QUERY_NO_RESULTS) != 0) {
+            if ((flags & QueryExecutor.QUERY_NO_RESULTS) != 0)
                 flags &= ~(QueryExecutor.QUERY_NO_RESULTS);
-            }
         }
 
         // Only use named statements after we hit the threshold. Note that only
         // named statements can be transferred in binary format.
-        if (preparedQuery != null && preparedQuery.query == queryToExecute) {
+        if (preparedQuery != null && preparedQuery.query == queryToExecute)
+        {
             preparedQuery.increaseExecuteCount();
-            if ((m_prepareThreshold == 0 || preparedQuery.getExecuteCount() < m_prepareThreshold) && !forceBinaryTransfers) {
+            if ((m_prepareThreshold == 0 || preparedQuery.getExecuteCount() < m_prepareThreshold) && !forceBinaryTransfers)
                 flags |= QueryExecutor.QUERY_ONESHOT;
-            }
         }
 
-        if (connection.getAutoCommit()) {
+        if (connection.getAutoCommit())
             flags |= QueryExecutor.QUERY_SUPPRESS_BEGIN;
-        }
 
         // updateable result sets do not yet support binary updates
-        if (concurrency != ResultSet.CONCUR_READ_ONLY) {
+        if (concurrency != ResultSet.CONCUR_READ_ONLY)
             flags |= QueryExecutor.QUERY_NO_BINARY_TRANSFER;
-        }
 
-        if (queryToExecute.isEmpty()) {
+        if (queryToExecute.isEmpty())
+        {
             flags |= QueryExecutor.QUERY_SUPPRESS_BEGIN;
         }
 
         if (!queryToExecute.isStatementDescribed() && forceBinaryTransfers) {
-            int flags2 = flags | QueryExecutor.QUERY_DESCRIBE_ONLY;
-            StatementResultHandler handler2 = new StatementResultHandler();
-            connection.getQueryExecutor().execute(queryToExecute, queryParameters, handler2, 0, 0, flags2);
-            ResultWrapper result2 = handler2.getResults();
-            if (result2 != null) {
-                result2.getResultSet().close();
-            }
+                int flags2 = flags | QueryExecutor.QUERY_DESCRIBE_ONLY;
+                StatementResultHandler handler2 = new StatementResultHandler();
+                connection.getQueryExecutor().execute(queryToExecute, queryParameters, handler2, 0, 0, flags2);
+                ResultWrapper result2 = handler2.getResults();
+                if (result2 != null) {
+                    result2.getResultSet().close();
+                }
         }
 
         StatementResultHandler handler = new StatementResultHandler();
         result = null;
-        try {
+        try
+        {
             startTimer();
             connection.getQueryExecutor().execute(queryToExecute,
-                    queryParameters,
-                    handler,
-                    maxrows,
-                    fetchSize,
-                    flags);
-        } finally {
+                                                  queryParameters,
+                                                  handler,
+                                                  maxrows,
+                                                  fetchSize,
+                                                  flags);
+        }
+        finally
+        {
             killTimerTask();
         }
         result = firstUnclosedResult = handler.getResults();
 
-        if (wantsGeneratedKeysOnce || wantsGeneratedKeysAlways) {
+        if (wantsGeneratedKeysOnce || wantsGeneratedKeysAlways)
+        {
             generatedKeys = result;
             result = result.getNext();
 
-            if (wantsGeneratedKeysOnce) {
+            if (wantsGeneratedKeysOnce)
                 wantsGeneratedKeysOnce = false;
-            }
         }
 
     }
@@ -689,7 +682,8 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
      * @param name the new cursor name
      * @exception SQLException if a database access error occurs
      */
-    public void setCursorName(String name) throws SQLException {
+    public void setCursorName(String name) throws SQLException
+    {
         checkClosed();
         // No-op.
     }
@@ -706,12 +700,11 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
      * @return the current result as an update count.
      * @exception SQLException if a database access error occurs
      */
-
-    public int getUpdateCount() throws SQLException {
+    public int getUpdateCount() throws SQLException
+    {
         checkClosed();
-        if (result == null || result.getResultSet() != null) {
+        if (result == null || result.getResultSet() != null)
             return -1;
-        }
 
         return result.getUpdateCount();
     }
@@ -723,18 +716,18 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
      * @return true if the next ResultSet is valid
      * @exception SQLException if a database access error occurs
      */
-    public boolean getMoreResults() throws SQLException {
-        if (result == null) {
+    public boolean getMoreResults() throws SQLException
+    {
+        if (result == null)
             return false;
-        }
 
         result = result.getNext();
 
         // Close preceding resultsets.
-        while (firstUnclosedResult != result) {
-            if (firstUnclosedResult.getResultSet() != null) {
+        while (firstUnclosedResult != result)
+        {
+            if (firstUnclosedResult.getResultSet() != null)
                 firstUnclosedResult.getResultSet().close();
-            }
             firstUnclosedResult = firstUnclosedResult.getNext();
         }
 
@@ -749,7 +742,8 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
      * @return the current maximum row limit; zero means unlimited
      * @exception SQLException if a database access error occurs
      */
-    public int getMaxRows() throws SQLException {
+    public int getMaxRows() throws SQLException
+    {
         checkClosed();
         return maxrows;
     }
@@ -761,12 +755,12 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
      * @exception SQLException if a database access error occurs
      * @see getMaxRows
      */
-    public void setMaxRows(int max) throws SQLException {
+    public void setMaxRows(int max) throws SQLException
+    {
         checkClosed();
-        if (max < 0) {
+        if (max < 0)
             throw new PSQLException(GT.tr("Maximum number of rows must be a value grater than or equal to 0."),
-                    PSQLState.INVALID_PARAMETER_VALUE);
-        }
+                                    PSQLState.INVALID_PARAMETER_VALUE);
         maxrows = max;
     }
 
@@ -777,7 +771,8 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
      * @param enable true to enable; false to disable
      * @exception SQLException if a database access error occurs
      */
-    public void setEscapeProcessing(boolean enable) throws SQLException {
+    public void setEscapeProcessing(boolean enable) throws SQLException
+    {
         checkClosed();
         replaceProcessingEnabled = enable;
     }
@@ -790,7 +785,8 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
      * @return the current query timeout limit in seconds; 0 = unlimited
      * @exception SQLException if a database access error occurs
      */
-    public int getQueryTimeout() throws SQLException {
+    public int getQueryTimeout() throws SQLException
+    {
         return getQueryTimeoutMs() / 1000;
     }
 
@@ -800,7 +796,8 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
      * @param seconds - the new query timeout limit in seconds
      * @exception SQLException if a database access error occurs
      */
-    public void setQueryTimeout(int seconds) throws SQLException {
+    public void setQueryTimeout(int seconds) throws SQLException
+    {
         setQueryTimeoutMs(seconds * 1000);
     }
 
@@ -812,7 +809,8 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
      * @return the current query timeout limit in milliseconds; 0 = unlimited
      * @exception SQLException if a database access error occurs
      */
-    public int getQueryTimeoutMs() throws SQLException {
+    public int getQueryTimeoutMs() throws SQLException
+    {
         checkClosed();
         return timeout;
     }
@@ -823,25 +821,26 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
      * @param seconds - the new query timeout limit in milliseconds
      * @exception SQLException if a database access error occurs
      */
-    public void setQueryTimeoutMs(int millis) throws SQLException {
+    public void setQueryTimeoutMs(int millis) throws SQLException
+    {
         checkClosed();
 
-        if (millis < 0) {
+        if (millis < 0)
             throw new PSQLException(GT.tr("Query timeout must be a value greater than or equals to 0."),
-                    PSQLState.INVALID_PARAMETER_VALUE);
-        }
+                                    PSQLState.INVALID_PARAMETER_VALUE);
         timeout = millis;
     }
 
     /**
-     * This adds a warning to the warning chain. We track the tail of the
-     * warning chain as well to avoid O(N) behavior for adding a new warning to
-     * an existing chain. Some server functions which RAISE NOTICE (or
-     * equivalent) produce a ton of warnings.
-     *
+     * This adds a warning to the warning chain.  We track the
+     * tail of the warning chain as well to avoid O(N) behavior
+     * for adding a new warning to an existing chain.  Some
+     * server functions which RAISE NOTICE (or equivalent) produce
+     * a ton of warnings.
      * @param warn warning to add
      */
-    public void addWarning(SQLWarning warn) {
+    public void addWarning(SQLWarning warn)
+    {
         if (warnings == null) {
             warnings = warn;
             lastWarning = warn;
@@ -867,7 +866,8 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
      * @return the first SQLWarning on null
      * @exception SQLException if a database access error occurs
      */
-    public SQLWarning getWarnings() throws SQLException {
+    public SQLWarning getWarnings() throws SQLException
+    {
         checkClosed();
         return warnings;
     }
@@ -882,7 +882,8 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
      * @return the current max column size limit; zero means unlimited
      * @exception SQLException if a database access error occurs
      */
-    public int getMaxFieldSize() throws SQLException {
+    public int getMaxFieldSize() throws SQLException
+    {
         return maxfieldSize;
     }
 
@@ -892,12 +893,12 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
      * @param max the new max column size limit; zero means unlimited
      * @exception SQLException if a database access error occurs
      */
-    public void setMaxFieldSize(int max) throws SQLException {
+    public void setMaxFieldSize(int max) throws SQLException
+    {
         checkClosed();
-        if (max < 0) {
+        if (max < 0)
             throw new PSQLException(GT.tr("The maximum field size must be a value greater than or equal to 0."),
-                    PSQLState.INVALID_PARAMETER_VALUE);
-        }
+                                    PSQLState.INVALID_PARAMETER_VALUE);
         maxfieldSize = max;
     }
 
@@ -907,7 +908,8 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
      *
      * @exception SQLException if a database access error occurs
      */
-    public void clearWarnings() throws SQLException {
+    public void clearWarnings() throws SQLException
+    {
         warnings = null;
         lastWarning = null;
     }
@@ -919,12 +921,12 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
      * @return the current result set; null if there are no more
      * @exception SQLException if a database access error occurs (why?)
      */
-    public java.sql.ResultSet getResultSet() throws SQLException {
+    public java.sql.ResultSet getResultSet() throws SQLException
+    {
         checkClosed();
 
-        if (result == null) {
+        if (result == null)
             return null;
-        }
 
         return (ResultSet) result.getResultSet();
     }
@@ -941,14 +943,14 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
      *
      * @exception SQLException if a database access error occurs (why?)
      */
-    public void close() throws SQLException {
+    public void close() throws SQLException
+    {
         // closing an already closed Statement is a no-op.
-        if (isClosed) {
-            return;
-        }
+        if (isClosed)
+            return ;
 
         cleanupTimer();
-
+        
         closeForNextExecution();
 
         if (preparedQuery != null) {
@@ -967,8 +969,7 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
 
     /**
      * Statement finalizer is not required as "statement" at the database side
-     * is managed by a {@link java.lang.ref.PhantomReference} in
-     * {@link QueryExecutorImpl#processDeadParsedQueries()}.
+     * is managed by a {@link java.lang.ref.PhantomReference} in {@link QueryExecutorImpl#processDeadParsedQueries()}.
      */
 
     /*
@@ -982,14 +983,16 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
      * So, something like "select * from x where d={d '2001-10-09'}" would
      * return "select * from x where d= '2001-10-09'".
      */
-    static String replaceProcessing(String p_sql, boolean replaceProcessingEnabled, boolean standardConformingStrings) throws SQLException {
-        if (replaceProcessingEnabled) {
+    static String replaceProcessing(String p_sql, boolean replaceProcessingEnabled, boolean standardConformingStrings) throws SQLException
+    {
+        if (replaceProcessingEnabled)
+        {
             // Since escape codes can only appear in SQL CODE, we keep track
             // of if we enter a string or not.
             int len = p_sql.length();
             StringBuilder newsql = new StringBuilder(len);
-            int i = 0;
-            while (i < len) {
+            int i=0;
+            while (i<len){
                 i = parseSql(p_sql, i, newsql, false, standardConformingStrings);
                 // We need to loop here in case we encounter invalid
                 // SQL, consider: SELECT a FROM t WHERE (1 > 0)) ORDER BY a
@@ -1002,198 +1005,199 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
                 }
             }
             return newsql.toString();
-        } else {
+        }
+        else
+        {
             return p_sql;
         }
     }
-
+    
     /**
-     * parse the given sql from index i, appending it to the gven buffer until
-     * we hit an unmatched right parentheses or end of string. When the
-     * stopOnComma flag is set we also stop processing when a comma is found in
-     * sql text that isn't inside nested parenthesis.
+     * parse the given sql from index i, appending it to the gven buffer
+     * until we hit an unmatched right parentheses or end of string.  When
+     * the stopOnComma flag is set we also stop processing when a comma is
+     * found in sql text that isn't inside nested parenthesis.
      *
      * @param p_sql the original query text
      * @param i starting position for replacing
      * @param newsql where to write the replaced output
-     * @param stopOnComma should we stop after hitting the first comma in sql
-     * text?
+     * @param stopOnComma should we stop after hitting the first comma in sql text?
      * @param stdStrings whether standard_conforming_strings is on
      * @return the position we stopped processing at
      */
-    protected static int parseSql(String p_sql, int i, StringBuilder newsql, boolean stopOnComma,
-            boolean stdStrings) throws SQLException {
+    protected static int parseSql(String p_sql,int i,StringBuilder newsql, boolean stopOnComma,
+                                  boolean stdStrings)throws SQLException{
         short state = IN_SQLCODE;
         int len = p_sql.length();
-        int nestedParenthesis = 0;
-        boolean endOfNested = false;
+        int nestedParenthesis=0;
+        boolean endOfNested=false;
 
         // because of the ++i loop
         i--;
-        while (!endOfNested && ++i < len) {
+        while (!endOfNested && ++i < len)
+        {
             char c = p_sql.charAt(i);
-            switch (state) {
-                case IN_SQLCODE:
-                    if (c == '\'') // start of a string?
+            switch (state)
+            {
+            case IN_SQLCODE:
+                if (c == '\'')      // start of a string?
+                    state = IN_STRING;
+                else if (c == '"')      // start of a identifer?
+                    state = IN_IDENTIFIER;
+                else if (c=='(') { // begin nested sql
+                    nestedParenthesis++;
+                } else if (c==')') { // end of nested sql
+                    nestedParenthesis--;
+                    if (nestedParenthesis<0){
+                        endOfNested=true;
+                        break;
+                    }
+                } else if (stopOnComma && c==',' && nestedParenthesis==0) {
+                    endOfNested=true;
+                    break;
+                } else if (c == '{') {     // start of an escape code?
+                    if (i + 1 < len)
                     {
-                        state = IN_STRING;
-                    } else if (c == '"') // start of a identifer?
-                    {
-                        state = IN_IDENTIFIER;
-                    } else if (c == '(') { // begin nested sql
-                        nestedParenthesis++;
-                    } else if (c == ')') { // end of nested sql
-                        nestedParenthesis--;
-                        if (nestedParenthesis < 0) {
-                            endOfNested = true;
+                        char next = p_sql.charAt(i + 1);
+                        char nextnext = (i + 2 < len) ? p_sql.charAt(i + 2) : '\0';
+                        if (next == 'd' || next == 'D')
+                        {
+                            state = ESC_TIMEDATE;
+                            i++;
+                            newsql.append("DATE ");
                             break;
                         }
-                    } else if (stopOnComma && c == ',' && nestedParenthesis == 0) {
-                        endOfNested = true;
-                        break;
-                    } else if (c == '{') {     // start of an escape code?
-                        if (i + 1 < len) {
-                            char next = p_sql.charAt(i + 1);
-                            char nextnext = (i + 2 < len) ? p_sql.charAt(i + 2) : '\0';
-                            if (next == 'd' || next == 'D') {
-                                state = ESC_TIMEDATE;
+                        else if (next == 't' || next == 'T')
+                        {
+                            state = ESC_TIMEDATE;
+                            if (nextnext == 's' || nextnext == 'S'){
+                                // timestamp constant
+                                i+=2;
+                                newsql.append("TIMESTAMP ");
+                            }else{
+                                // time constant
                                 i++;
-                                newsql.append("DATE ");
-                                break;
-                            } else if (next == 't' || next == 'T') {
-                                state = ESC_TIMEDATE;
-                                if (nextnext == 's' || nextnext == 'S') {
-                                    // timestamp constant
-                                    i += 2;
-                                    newsql.append("TIMESTAMP ");
-                                } else {
-                                    // time constant
-                                    i++;
-                                    newsql.append("TIME ");
-                                }
-                                break;
-                            } else if (next == 'f' || next == 'F') {
-                                state = ESC_FUNCTION;
-                                i += (nextnext == 'n' || nextnext == 'N') ? 2 : 1;
-                                break;
-                            } else if (next == 'o' || next == 'O') {
-                                state = ESC_OUTERJOIN;
-                                i += (nextnext == 'j' || nextnext == 'J') ? 2 : 1;
-                                break;
-                            } else if (next == 'e' || next == 'E') { // we assume that escape is the only escape sequence beginning with e
-                                state = ESC_ESCAPECHAR;
-                                break;
+                                newsql.append("TIME ");
                             }
+                            break;
+                        }
+                        else if ( next == 'f' || next == 'F' )
+                        {
+                            state = ESC_FUNCTION;
+                            i += (nextnext == 'n' || nextnext == 'N') ? 2 : 1;
+                            break;
+                        }
+                        else if ( next == 'o' || next == 'O' )
+                        {
+                            state = ESC_OUTERJOIN;
+                            i += (nextnext == 'j' || nextnext == 'J') ? 2 : 1;
+                            break;
+                        }
+                        else if ( next == 'e' || next == 'E' )
+                        { // we assume that escape is the only escape sequence beginning with e
+                            state = ESC_ESCAPECHAR;
+                            break;
                         }
                     }
+                }
+                newsql.append(c);
+                break;
+
+            case IN_STRING:
+                if (c == '\'')       // end of string?
+                    state = IN_SQLCODE;
+                else if (c == '\\' && !stdStrings)      // a backslash?
+                    state = BACKSLASH;
+
+                newsql.append(c);
+                break;
+                
+            case IN_IDENTIFIER:
+                if (c == '"')       // end of identifier
+                    state = IN_SQLCODE;
+                newsql.append(c);
+                break;
+
+            case BACKSLASH:
+                state = IN_STRING;
+
+                newsql.append(c);
+                break;
+
+            case ESC_FUNCTION:
+                // extract function name
+                String functionName;
+                int posArgs = p_sql.indexOf('(',i);
+                if (posArgs!=-1){
+                    functionName=p_sql.substring(i,posArgs).trim();
+                    // extract arguments
+                    i= posArgs+1;// we start the scan after the first (
+                    StringBuilder args=new StringBuilder();
+                    i = parseSql(p_sql,i,args,false,stdStrings);
+                    // translate the function and parse arguments
+                    newsql.append(escapeFunction(functionName,args.toString(),stdStrings));
+                }
+                // go to the end of the function copying anything found
+                i++;
+                while (i<len && p_sql.charAt(i)!='}')
+                    newsql.append(p_sql.charAt(i++));
+                state = IN_SQLCODE; // end of escaped function (or query)
+                break;
+            case ESC_TIMEDATE:       
+            case ESC_OUTERJOIN:
+            case ESC_ESCAPECHAR:
+                if (c == '}')
+                    state = IN_SQLCODE;    // end of escape code.
+                else
                     newsql.append(c);
-                    break;
-
-                case IN_STRING:
-                    if (c == '\'') // end of string?
-                    {
-                        state = IN_SQLCODE;
-                    } else if (c == '\\' && !stdStrings) // a backslash?
-                    {
-                        state = BACKSLASH;
-                    }
-
-                    newsql.append(c);
-                    break;
-
-                case IN_IDENTIFIER:
-                    if (c == '"') // end of identifier
-                    {
-                        state = IN_SQLCODE;
-                    }
-                    newsql.append(c);
-                    break;
-
-                case BACKSLASH:
-                    state = IN_STRING;
-
-                    newsql.append(c);
-                    break;
-
-                case ESC_FUNCTION:
-                    // extract function name
-                    String functionName;
-                    int posArgs = p_sql.indexOf('(', i);
-                    if (posArgs != -1) {
-                        functionName = p_sql.substring(i, posArgs).trim();
-                        // extract arguments
-                        i = posArgs + 1;// we start the scan after the first (
-                        StringBuilder args = new StringBuilder();
-                        i = parseSql(p_sql, i, args, false, stdStrings);
-                        // translate the function and parse arguments
-                        newsql.append(escapeFunction(functionName, args.toString(), stdStrings));
-                    }
-                    // go to the end of the function copying anything found
-                    i++;
-                    while (i < len && p_sql.charAt(i) != '}') {
-                        newsql.append(p_sql.charAt(i++));
-                    }
-                    state = IN_SQLCODE; // end of escaped function (or query)
-                    break;
-                case ESC_TIMEDATE:
-                case ESC_OUTERJOIN:
-                case ESC_ESCAPECHAR:
-                    if (c == '}') {
-                        state = IN_SQLCODE;    // end of escape code.
-                    } else {
-                        newsql.append(c);
-                    }
-                    break;
+                break;
             } // end switch
         }
         return i;
     }
-
+    
     /**
      * generate sql for escaped functions
-     *
      * @param functionName the escaped function name
      * @param args the arguments for this functin
      * @param stdStrings whether standard_conforming_strings is on
      * @return the right postgreSql sql
      */
-    protected static String escapeFunction(String functionName, String args, boolean stdStrings) throws SQLException {
+    protected static String escapeFunction(String functionName, String args, boolean stdStrings) throws SQLException{
         // parse function arguments
         int len = args.length();
-        int i = 0;
+        int i=0;
         ArrayList parsedArgs = new ArrayList();
-        while (i < len) {
+        while (i<len){
             StringBuilder arg = new StringBuilder();
-            int lastPos = i;
-            i = parseSql(args, i, arg, true, stdStrings);
-            if (lastPos != i) {
+            int lastPos=i;
+            i=parseSql(args,i,arg,true,stdStrings);
+            if (lastPos!=i){
                 parsedArgs.add(arg);
             }
             i++;
         }
         // we can now tranlate escape functions
-        try {
+        try{
             Method escapeMethod = EscapedFunctions.getFunction(functionName);
-            return (String) escapeMethod.invoke(null, new Object[]{parsedArgs});
-        } catch (InvocationTargetException e) {
-            if (e.getTargetException() instanceof SQLException) {
+            return (String) escapeMethod.invoke(null,new Object[] {parsedArgs});
+        }catch(InvocationTargetException e){
+            if (e.getTargetException() instanceof SQLException)
                 throw (SQLException) e.getTargetException();
-            } else {
+            else
                 throw new PSQLException(e.getTargetException().getMessage(),
-                        PSQLState.SYSTEM_ERROR);
-            }
-        } catch (Exception e) {
+                                        PSQLState.SYSTEM_ERROR);
+        }catch (Exception e){
             // by default the function name is kept unchanged
             StringBuilder buf = new StringBuilder();
             buf.append(functionName).append('(');
-            for (int iArg = 0; iArg < parsedArgs.size(); iArg++) {
+            for (int iArg = 0;iArg<parsedArgs.size();iArg++){
                 buf.append(parsedArgs.get(iArg));
-                if (iArg != (parsedArgs.size() - 1)) {
+                if (iArg!=(parsedArgs.size()-1))
                     buf.append(',');
-                }
             }
             buf.append(')');
-            return buf.toString();
+            return buf.toString();    
         }
     }
 
@@ -1206,27 +1210,27 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
 
     /*
      * Returns the Last inserted/updated oid.  Deprecated in 7.2 because
-     * range of OID values is greater than a java signed int.
+      * range of OID values is greater than a java signed int.
      * @deprecated Replaced by getLastOID in 7.2
      */
-    public int getInsertedOID() throws SQLException {
+    public int getInsertedOID() throws SQLException
+    {
         checkClosed();
-        if (result == null) {
+        if (result == null)
             return 0;
-        }
         return (int) result.getInsertOID();
     }
 
     /*
      * Returns the Last inserted/updated oid.
      * @return OID of last insert
-     * @since 7.2
+      * @since 7.2
      */
-    public long getLastOID() throws SQLException {
+    public long getLastOID() throws SQLException
+    {
         checkClosed();
-        if (result == null) {
+        if (result == null)
             return 0;
-        }
         return result.getInsertOID();
     }
 
@@ -1239,77 +1243,81 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
      * @param sqlType the SQL type code defined in java.sql.Types
      * @exception SQLException if a database access error occurs
      */
-    public void setNull(int parameterIndex, int sqlType) throws SQLException {
+    public void setNull(int parameterIndex, int sqlType) throws SQLException
+    {
         checkClosed();
 
         int oid;
-        switch (sqlType) {
-            case Types.INTEGER:
-                oid = Oid.INT4;
-                break;
-            case Types.TINYINT:
-            case Types.SMALLINT:
-                oid = Oid.INT2;
-                break;
-            case Types.BIGINT:
-                oid = Oid.INT8;
-                break;
-            case Types.REAL:
-                oid = Oid.FLOAT4;
-                break;
-            case Types.DOUBLE:
-            case Types.FLOAT:
-                oid = Oid.FLOAT8;
-                break;
-            case Types.DECIMAL:
-            case Types.NUMERIC:
-                oid = Oid.NUMERIC;
-                break;
-            case Types.CHAR:
-                oid = Oid.BPCHAR;
-                break;
-            case Types.VARCHAR:
-            case Types.LONGVARCHAR:
-                oid = connection.getStringVarcharFlag() ? Oid.VARCHAR : Oid.UNSPECIFIED;
-                break;
-            case Types.DATE:
-                oid = Oid.DATE;
-                break;
-            case Types.TIME:
-            case Types.TIMESTAMP:
-                oid = Oid.TIMESTAMP;
-                break;
-            case Types.BIT:
-                oid = Oid.BOOL;
-                break;
-            case Types.BINARY:
-            case Types.VARBINARY:
-            case Types.LONGVARBINARY:
-                if (connection.haveMinimumCompatibleVersion(ServerVersion.v7_2)) {
-                    oid = Oid.BYTEA;
-                } else {
-                    oid = Oid.OID;
-                }
-                break;
-            case Types.BLOB:
-            case Types.CLOB:
+        switch (sqlType)
+        {
+        case Types.INTEGER:
+            oid = Oid.INT4;
+            break;
+        case Types.TINYINT:
+        case Types.SMALLINT:
+            oid = Oid.INT2;
+            break;
+        case Types.BIGINT:
+            oid = Oid.INT8;
+            break;
+        case Types.REAL:
+            oid = Oid.FLOAT4;
+            break;
+        case Types.DOUBLE:
+        case Types.FLOAT:				
+            oid = Oid.FLOAT8;
+            break;
+        case Types.DECIMAL:
+        case Types.NUMERIC:
+            oid = Oid.NUMERIC;
+            break;
+        case Types.CHAR:
+            oid = Oid.BPCHAR;
+            break;
+        case Types.VARCHAR:
+        case Types.LONGVARCHAR:
+            oid = connection.getStringVarcharFlag() ? Oid.VARCHAR : Oid.UNSPECIFIED;
+            break;
+        case Types.DATE:
+            oid = Oid.DATE;
+            break;
+        case Types.TIME:
+        case Types.TIMESTAMP:
+            oid = Oid.TIMESTAMP;
+            break;
+        case Types.BIT:
+            oid = Oid.BOOL;
+            break;
+        case Types.BINARY:
+        case Types.VARBINARY:
+        case Types.LONGVARBINARY:
+            if (connection.haveMinimumCompatibleVersion(ServerVersion.v7_2))
+            {
+                oid = Oid.BYTEA;
+            }
+            else
+            {
                 oid = Oid.OID;
-                break;
-            case Types.ARRAY:
-            case Types.DISTINCT:
-            case Types.STRUCT:
-            case Types.NULL:
-            case Types.OTHER:
-                oid = Oid.UNSPECIFIED;
-                break;
-            default:
-                // Bad Types value.
-                throw new PSQLException(GT.tr("Unknown Types value."), PSQLState.INVALID_PARAMETER_TYPE);
+            }
+            break;
+        case Types.BLOB:
+        case Types.CLOB:
+            oid = Oid.OID;
+            break;
+        case Types.ARRAY:
+        case Types.DISTINCT:
+        case Types.STRUCT:
+        case Types.NULL:
+        case Types.OTHER:
+            oid = Oid.UNSPECIFIED;
+            break;
+        default:
+            // Bad Types value.
+            throw new PSQLException(GT.tr("Unknown Types value."), PSQLState.INVALID_PARAMETER_TYPE);
         }
-        if (adjustIndex) {
+        if ( adjustIndex )
             parameterIndex--;
-        }
-        preparedParameters.setNull(parameterIndex, oid);
+        preparedParameters.setNull( parameterIndex, oid);
     }
 
     /*
@@ -1320,7 +1328,8 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
      * @param x the parameter value
      * @exception SQLException if a database access error occurs
      */
-    public void setBoolean(int parameterIndex, boolean x) throws SQLException {
+    public void setBoolean(int parameterIndex, boolean x) throws SQLException
+    {
         checkClosed();
         bindString(parameterIndex, x ? "1" : "0", Oid.BOOL);
     }
@@ -1333,7 +1342,8 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
      * @param x the parameter value
      * @exception SQLException if a database access error occurs
      */
-    public void setByte(int parameterIndex, byte x) throws SQLException {
+    public void setByte(int parameterIndex, byte x) throws SQLException
+    {
         setShort(parameterIndex, x);
     }
 
@@ -1345,7 +1355,8 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
      * @param x the parameter value
      * @exception SQLException if a database access error occurs
      */
-    public void setShort(int parameterIndex, short x) throws SQLException {
+    public void setShort(int parameterIndex, short x) throws SQLException
+    {
         checkClosed();
         if (connection.binaryTransferSend(Oid.INT2)) {
             byte[] val = new byte[2];
@@ -1364,8 +1375,9 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
      * @param x the parameter value
      * @exception SQLException if a database access error occurs
      */
-    public void setInt(int parameterIndex, int x) throws SQLException {
-        checkClosed();
+    public void setInt(int parameterIndex, int x) throws SQLException
+    {
+        checkClosed();         
         if (connection.binaryTransferSend(Oid.INT4)) {
             byte[] val = new byte[4];
             ByteConverter.int4(val, 0, x);
@@ -1383,7 +1395,8 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
      * @param x the parameter value
      * @exception SQLException if a database access error occurs
      */
-    public void setLong(int parameterIndex, long x) throws SQLException {
+    public void setLong(int parameterIndex, long x) throws SQLException
+    {
         checkClosed();
         if (connection.binaryTransferSend(Oid.INT8)) {
             byte[] val = new byte[8];
@@ -1402,7 +1415,8 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
      * @param x the parameter value
      * @exception SQLException if a database access error occurs
      */
-    public void setFloat(int parameterIndex, float x) throws SQLException {
+    public void setFloat(int parameterIndex, float x) throws SQLException
+    {
         checkClosed();
         if (connection.binaryTransferSend(Oid.FLOAT4)) {
             byte[] val = new byte[4];
@@ -1421,7 +1435,8 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
      * @param x the parameter value
      * @exception SQLException if a database access error occurs
      */
-    public void setDouble(int parameterIndex, double x) throws SQLException {
+    public void setDouble(int parameterIndex, double x) throws SQLException
+    {
         checkClosed();
         if (connection.binaryTransferSend(Oid.FLOAT8)) {
             byte[] val = new byte[8];
@@ -1441,13 +1456,13 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
      * @param x the parameter value
      * @exception SQLException if a database access error occurs
      */
-    public void setBigDecimal(int parameterIndex, BigDecimal x) throws SQLException {
+    public void setBigDecimal(int parameterIndex, BigDecimal x) throws SQLException
+    {
         checkClosed();
-        if (x == null) {
+        if (x == null)
             setNull(parameterIndex, Types.DECIMAL);
-        } else {
+        else
             bindLiteral(parameterIndex, x.toString(), Oid.NUMERIC);
-        }
     }
 
     /*
@@ -1460,7 +1475,8 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
      * @param x the parameter value
      * @exception SQLException if a database access error occurs
      */
-    public void setString(int parameterIndex, String x) throws SQLException {
+    public void setString(int parameterIndex, String x) throws SQLException
+    {
         checkClosed();
         setString(parameterIndex, x, getStringType());
     }
@@ -1469,17 +1485,18 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
         return (connection.getStringVarcharFlag() ? Oid.VARCHAR : Oid.UNSPECIFIED);
     }
 
-    protected void setString(int parameterIndex, String x, int oid) throws SQLException {
+    protected void setString(int parameterIndex, String x, int oid) throws SQLException
+    {
         // if the passed string is null, then set this column to null
         checkClosed();
-        if (x == null) {
-            if (adjustIndex) {
+        if (x == null)
+        {
+            if ( adjustIndex )
                 parameterIndex--;
-            }
-            preparedParameters.setNull(parameterIndex, oid);
-        } else {
-            bindString(parameterIndex, x, oid);
+            preparedParameters.setNull( parameterIndex, oid);
         }
+        else
+            bindString(parameterIndex, x, oid);
     }
 
     /*
@@ -1496,20 +1513,25 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
      * @param x the parameter value
      * @exception SQLException if a database access error occurs
      */
-    public void setBytes(int parameterIndex, byte[] x) throws SQLException {
+    public void setBytes(int parameterIndex, byte[] x) throws SQLException
+    {
         checkClosed();
 
-        if (null == x) {
+        if (null == x)
+        {
             setNull(parameterIndex, Types.VARBINARY);
-            return;
+            return ;
         }
 
-        if (connection.haveMinimumCompatibleVersion(ServerVersion.v7_2)) {
+        if (connection.haveMinimumCompatibleVersion(ServerVersion.v7_2))
+        {
             //Version 7.2 supports the bytea datatype for byte arrays
             byte[] copy = new byte[x.length];
             System.arraycopy(x, 0, copy, 0, x.length);
-            preparedParameters.setBytea(parameterIndex, copy, 0, x.length);
-        } else {
+            preparedParameters.setBytea( parameterIndex, copy, 0, x.length);
+        }
+        else
+        {
             //Version 7.1 and earlier support done as LargeObjects
             LargeObjectManager lom = connection.getLargeObjectAPI();
             long oid = lom.createLO();
@@ -1528,7 +1550,8 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
      * @param x the parameter value
      * @exception SQLException if a database access error occurs
      */
-    public void setDate(int parameterIndex, java.sql.Date x) throws SQLException {
+    public void setDate(int parameterIndex, java.sql.Date x) throws SQLException
+    {
         setDate(parameterIndex, x, null);
     }
 
@@ -1540,7 +1563,8 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
      * @param x the parameter value
      * @exception SQLException if a database access error occurs
      */
-    public void setTime(int parameterIndex, Time x) throws SQLException {
+    public void setTime(int parameterIndex, Time x) throws SQLException
+    {
         setTime(parameterIndex, x, null);
     }
 
@@ -1552,20 +1576,23 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
      * @param x the parameter value
      * @exception SQLException if a database access error occurs
      */
-    public void setTimestamp(int parameterIndex, Timestamp x) throws SQLException {
+    public void setTimestamp(int parameterIndex, Timestamp x) throws SQLException
+    {
         setTimestamp(parameterIndex, x, null);
     }
 
-    private void setCharacterStreamPost71(int parameterIndex, InputStream x, int length, String encoding) throws SQLException {
+    private void setCharacterStreamPost71(int parameterIndex, InputStream x, int length, String encoding) throws SQLException
+    {
 
-        if (x == null) {
+        if (x == null)
+        {
             setNull(parameterIndex, Types.VARCHAR);
-            return;
+            return ;
         }
-        if (length < 0) {
+        if (length < 0)
             throw new PSQLException(GT.tr("Invalid stream length {0}.", length),
-                    PSQLState.INVALID_PARAMETER_VALUE);
-        }
+                                    PSQLState.INVALID_PARAMETER_VALUE);
+
 
         //Version 7.2 supports AsciiStream for all PG text types (char, varchar, text)
         //As the spec/javadoc for this method indicate this is to be used for
@@ -1573,27 +1600,31 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
         //long varchar datatype, but with toast all text datatypes are capable of
         //handling very large values.  Thus the implementation ends up calling
         //setString() since there is no current way to stream the value to the server
-        try {
+        try
+        {
             InputStreamReader l_inStream = new InputStreamReader(x, encoding);
             char[] l_chars = new char[length];
             int l_charsRead = 0;
-            while (true) {
+            while (true)
+            {
                 int n = l_inStream.read(l_chars, l_charsRead, length - l_charsRead);
-                if (n == -1) {
+                if (n == -1)
                     break;
-                }
 
                 l_charsRead += n;
 
-                if (l_charsRead == length) {
+                if (l_charsRead == length)
                     break;
-                }
             }
 
             setString(parameterIndex, new String(l_chars, 0, l_charsRead), Oid.VARCHAR);
-        } catch (UnsupportedEncodingException l_uee) {
+        }
+        catch (UnsupportedEncodingException l_uee)
+        {
             throw new PSQLException(GT.tr("The JVM claims not to support the {0} encoding.", encoding), PSQLState.UNEXPECTED_ERROR, l_uee);
-        } catch (IOException l_ioe) {
+        }
+        catch (IOException l_ioe)
+        {
             throw new PSQLException(GT.tr("Provided InputStream failed."), PSQLState.UNEXPECTED_ERROR, l_ioe);
         }
     }
@@ -1614,11 +1645,15 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
      * @param length the number of bytes in the stream
      * @exception SQLException if a database access error occurs
      */
-    public void setAsciiStream(int parameterIndex, InputStream x, int length) throws SQLException {
+    public void setAsciiStream(int parameterIndex, InputStream x, int length) throws SQLException
+    {
         checkClosed();
-        if (connection.haveMinimumCompatibleVersion(ServerVersion.v7_2)) {
+        if (connection.haveMinimumCompatibleVersion(ServerVersion.v7_2))
+        {
             setCharacterStreamPost71(parameterIndex, x, length, "ASCII");
-        } else {
+        }
+        else
+        {
             //Version 7.1 supported only LargeObjects by treating everything
             //as binary data
             setBinaryStream(parameterIndex, x, length);
@@ -1640,11 +1675,15 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
      * @param x the parameter value
      * @exception SQLException if a database access error occurs
      */
-    public void setUnicodeStream(int parameterIndex, InputStream x, int length) throws SQLException {
+    public void setUnicodeStream(int parameterIndex, InputStream x, int length) throws SQLException
+    {
         checkClosed();
-        if (connection.haveMinimumCompatibleVersion(ServerVersion.v7_2)) {
+        if (connection.haveMinimumCompatibleVersion(ServerVersion.v7_2))
+        {
             setCharacterStreamPost71(parameterIndex, x, length, "UTF-8");
-        } else {
+        }
+        else
+        {
             //Version 7.1 supported only LargeObjects by treating everything
             //as binary data
             setBinaryStream(parameterIndex, x, length);
@@ -1665,20 +1704,22 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
      * @param x the parameter value
      * @exception SQLException if a database access error occurs
      */
-    public void setBinaryStream(int parameterIndex, InputStream x, int length) throws SQLException {
+    public void setBinaryStream(int parameterIndex, InputStream x, int length) throws SQLException
+    {
         checkClosed();
 
-        if (x == null) {
+        if (x == null)
+        {
             setNull(parameterIndex, Types.VARBINARY);
-            return;
+            return ;
         }
 
-        if (length < 0) {
+        if (length < 0)
             throw new PSQLException(GT.tr("Invalid stream length {0}.", length),
-                    PSQLState.INVALID_PARAMETER_VALUE);
-        }
+                                    PSQLState.INVALID_PARAMETER_VALUE);
 
-        if (connection.haveMinimumCompatibleVersion(ServerVersion.v7_2)) {
+        if (connection.haveMinimumCompatibleVersion(ServerVersion.v7_2))
+        {
             //Version 7.2 supports BinaryStream for for the PG bytea type
             //As the spec/javadoc for this method indicate this is to be used for
             //large binary values (i.e. LONGVARBINARY) PG doesn't have a separate
@@ -1686,7 +1727,9 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
             //handling very large values.
 
             preparedParameters.setBytea(parameterIndex, x, length);
-        } else {
+        }
+        else
+        {
             //Version 7.1 only supported streams for LargeObjects
             //but the jdbc spec indicates that streams should be
             //available for LONGVARBINARY instead
@@ -1694,19 +1737,23 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
             long oid = lom.createLO();
             LargeObject lob = lom.open(oid);
             OutputStream los = lob.getOutputStream();
-            try {
+            try
+            {
                 // could be buffered, but then the OutputStream returned by LargeObject
                 // is buffered internally anyhow, so there would be no performance
                 // boost gained, if anything it would be worse!
                 int c = x.read();
                 int p = 0;
-                while (c > -1 && p < length) {
+                while (c > -1 && p < length)
+                {
                     los.write(c);
                     c = x.read();
                     p++;
                 }
                 los.close();
-            } catch (IOException se) {
+            }
+            catch (IOException se)
+            {
                 throw new PSQLException(GT.tr("Provided InputStream failed."), PSQLState.UNEXPECTED_ERROR, se);
             }
             // lob is closed by the stream so don't call lob.close()
@@ -1724,7 +1771,8 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
      *
      * @exception SQLException if a database access error occurs
      */
-    public void clearParameters() throws SQLException {
+    public void clearParameters() throws SQLException
+    {
         preparedParameters.clear();
     }
 
@@ -1732,9 +1780,8 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
     private void setPGobject(int parameterIndex, PGobject x) throws SQLException {
         String typename = x.getType();
         int oid = connection.getTypeInfo().getPGType(typename);
-        if (oid == Oid.UNSPECIFIED) {
+        if (oid == Oid.UNSPECIFIED)
             throw new PSQLException(GT.tr("Unknown type {0}.", typename), PSQLState.INVALID_PARAMETER_TYPE);
-        }
 
         if ((x instanceof PGBinaryObject) && connection.binaryTransferSend(oid)) {
             PGBinaryObject binObj = (PGBinaryObject) x;
@@ -1745,12 +1792,11 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
             setString(parameterIndex, x.getValue(), oid);
         }
     }
-
+    
     private void setMap(int parameterIndex, Map x) throws SQLException {
         int oid = connection.getTypeInfo().getPGType("hstore");
-        if (oid == Oid.UNSPECIFIED) {
+        if (oid == Oid.UNSPECIFIED)
             throw new PSQLException(GT.tr("No hstore extension installed."), PSQLState.INVALID_PARAMETER_TYPE);
-        }
         if (connection.binaryTransferSend(oid)) {
             byte[] data = HStoreConverter.toBytes(x, connection.getEncoding());
             bindBytes(parameterIndex, data, oid);
@@ -1778,15 +1824,18 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
      *   * all other types this value will be ignored.
      * @exception SQLException if a database access error occurs
      */
-    public void setObject(int parameterIndex, Object in, int targetSqlType, int scale) throws SQLException {
+    public void setObject(int parameterIndex, Object in, int targetSqlType, int scale) throws SQLException
+    {
         checkClosed();
 
-        if (in == null) {
+        if (in == null)
+        {
             setNull(parameterIndex, targetSqlType);
-            return;
+            return ;
         }
 
-        switch (targetSqlType) {
+            switch (targetSqlType)
+        {
             case Types.INTEGER:
                 setInt(parameterIndex, castToInt(in));
                 break;
@@ -1816,12 +1865,13 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
                 setString(parameterIndex, castToString(in), getStringType());
                 break;
             case Types.DATE:
-                if (in instanceof java.sql.Date) {
-                    setDate(parameterIndex, (java.sql.Date) in);
-                } else {
+                if (in instanceof java.sql.Date)
+                    setDate(parameterIndex, (java.sql.Date)in);
+                else
+                {
                     java.sql.Date tmpd;
                     if (in instanceof java.util.Date) {
-                        tmpd = new java.sql.Date(((java.util.Date) in).getTime());
+                        tmpd = new java.sql.Date(((java.util.Date)in).getTime());
                     } else {
                         tmpd = connection.getTimestampUtils().toDate(null, in.toString());
                     }
@@ -1829,12 +1879,13 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
                 }
                 break;
             case Types.TIME:
-                if (in instanceof java.sql.Time) {
-                    setTime(parameterIndex, (java.sql.Time) in);
-                } else {
+                if (in instanceof java.sql.Time)
+                    setTime(parameterIndex, (java.sql.Time)in);
+                else
+                {
                     java.sql.Time tmpt;
                     if (in instanceof java.util.Date) {
-                        tmpt = new java.sql.Time(((java.util.Date) in).getTime());
+                        tmpt = new java.sql.Time(((java.util.Date)in).getTime());
                     } else {
                         tmpt = connection.getTimestampUtils().toTime(null, in.toString());
                     }
@@ -1842,12 +1893,13 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
                 }
                 break;
             case Types.TIMESTAMP:
-                if (in instanceof java.sql.Timestamp) {
-                    setTimestamp(parameterIndex, (java.sql.Timestamp) in);
-                } else {
+                if (in instanceof java.sql.Timestamp)
+                    setTimestamp(parameterIndex , (java.sql.Timestamp)in);
+                else
+                {
                     java.sql.Timestamp tmpts;
                     if (in instanceof java.util.Date) {
-                        tmpts = new java.sql.Timestamp(((java.util.Date) in).getTime());
+                        tmpts = new java.sql.Timestamp(((java.util.Date)in).getTime());
                     } else {
                         tmpts = connection.getTimestampUtils().toTimestamp(null, in.toString());
                     }
@@ -1863,38 +1915,40 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
                 setObject(parameterIndex, in);
                 break;
             case Types.BLOB:
-                if (in instanceof Blob) {
-                    setBlob(parameterIndex, (Blob) in);
-                } else if (in instanceof InputStream) {
+                if (in instanceof Blob)
+                {
+                    setBlob(parameterIndex, (Blob)in);
+                }
+                else if (in instanceof InputStream)
+                {
                     long oid = createBlob(parameterIndex, (InputStream) in, -1);
                     setLong(parameterIndex, oid);
-                } else {
-                    throw new PSQLException(GT.tr("Cannot cast an instance of {0} to type {1}", new Object[]{in.getClass().getName(), "Types.BLOB"}), PSQLState.INVALID_PARAMETER_TYPE);
+                }
+                else
+                {
+                    throw new PSQLException(GT.tr("Cannot cast an instance of {0} to type {1}", new Object[]{in.getClass().getName(),"Types.BLOB"}), PSQLState.INVALID_PARAMETER_TYPE);
                 }
                 break;
             case Types.CLOB:
-                if (in instanceof Clob) {
-                    setClob(parameterIndex, (Clob) in);
-                } else {
-                    throw new PSQLException(GT.tr("Cannot cast an instance of {0} to type {1}", new Object[]{in.getClass().getName(), "Types.CLOB"}), PSQLState.INVALID_PARAMETER_TYPE);
-                }
+                if (in instanceof Clob)
+                    setClob(parameterIndex, (Clob)in);
+                else
+                    throw new PSQLException(GT.tr("Cannot cast an instance of {0} to type {1}", new Object[]{in.getClass().getName(),"Types.CLOB"}), PSQLState.INVALID_PARAMETER_TYPE);
                 break;
             case Types.ARRAY:
-                if (in instanceof Array) {
-                    setArray(parameterIndex, (Array) in);
-                } else {
-                    throw new PSQLException(GT.tr("Cannot cast an instance of {0} to type {1}", new Object[]{in.getClass().getName(), "Types.ARRAY"}), PSQLState.INVALID_PARAMETER_TYPE);
-                }
+                if (in instanceof Array)
+                    setArray(parameterIndex, (Array)in);
+                else
+                    throw new PSQLException(GT.tr("Cannot cast an instance of {0} to type {1}", new Object[]{in.getClass().getName(),"Types.ARRAY"}), PSQLState.INVALID_PARAMETER_TYPE);
                 break;
             case Types.DISTINCT:
                 bindString(parameterIndex, in.toString(), Oid.UNSPECIFIED);
                 break;
             case Types.OTHER:
-                if (in instanceof PGobject) {
-                    setPGobject(parameterIndex, (PGobject) in);
-                } else {
+                if (in instanceof PGobject)
+                    setPGobject(parameterIndex, (PGobject)in);
+                else
                     bindString(parameterIndex, in.toString(), Oid.UNSPECIFIED);
-                }
                 break;
             default:
                 throw new PSQLException(GT.tr("Unsupported Types value: {0}", targetSqlType), PSQLState.INVALID_PARAMETER_TYPE);
@@ -1907,24 +1961,18 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
 
     private static int castToInt(final Object in) throws SQLException {
         try {
-            if (in instanceof String) {
+            if (in instanceof String)
                 return Integer.parseInt((String) in);
-            }
-            if (in instanceof Number) {
+            if (in instanceof Number)
                 return ((Number) in).intValue();
-            }
-            if (in instanceof java.util.Date) {
+            if (in instanceof java.util.Date)
                 return (int) ((java.util.Date) in).getTime();
-            }
-            if (in instanceof Boolean) {
+            if (in instanceof Boolean)
                 return (Boolean) in ? 1 : 0;
-            }
-            if (in instanceof Clob) {
+            if (in instanceof Clob)
                 return Integer.parseInt(asString((Clob) in));
-            }
-            if (in instanceof Character) {
+            if (in instanceof Character)
                 return Integer.parseInt(in.toString());
-            }
         } catch (final Exception e) {
             throw cannotCastException(in.getClass().getName(), "int", e);
         }
@@ -1933,24 +1981,18 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
 
     private static short castToShort(final Object in) throws SQLException {
         try {
-            if (in instanceof String) {
+            if (in instanceof String)
                 return Short.parseShort((String) in);
-            }
-            if (in instanceof Number) {
+            if (in instanceof Number)
                 return ((Number) in).shortValue();
-            }
-            if (in instanceof java.util.Date) {
+            if (in instanceof java.util.Date)
                 return (short) ((java.util.Date) in).getTime();
-            }
-            if (in instanceof Boolean) {
+            if (in instanceof Boolean)
                 return (Boolean) in ? (short) 1 : (short) 0;
-            }
-            if (in instanceof Clob) {
+            if (in instanceof Clob)
                 return Short.parseShort(asString((Clob) in));
-            }
-            if (in instanceof Character) {
+            if (in instanceof Character)
                 return Short.parseShort(in.toString());
-            }
         } catch (final Exception e) {
             throw cannotCastException(in.getClass().getName(), "short", e);
         }
@@ -1959,24 +2001,18 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
 
     private static long castToLong(final Object in) throws SQLException {
         try {
-            if (in instanceof String) {
+            if (in instanceof String)
                 return Long.parseLong((String) in);
-            }
-            if (in instanceof Number) {
+            if (in instanceof Number)
                 return ((Number) in).longValue();
-            }
-            if (in instanceof java.util.Date) {
+            if (in instanceof java.util.Date)
                 return ((java.util.Date) in).getTime();
-            }
-            if (in instanceof Boolean) {
+            if (in instanceof Boolean)
                 return (Boolean) in ? 1L : 0L;
-            }
-            if (in instanceof Clob) {
+            if (in instanceof Clob)
                 return Long.parseLong(asString((Clob) in));
-            }
-            if (in instanceof Character) {
+            if (in instanceof Character)
                 return Long.parseLong(in.toString());
-            }
         } catch (final Exception e) {
             throw cannotCastException(in.getClass().getName(), "long", e);
         }
@@ -1985,24 +2021,18 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
 
     private static float castToFloat(final Object in) throws SQLException {
         try {
-            if (in instanceof String) {
+            if (in instanceof String)
                 return Float.parseFloat((String) in);
-            }
-            if (in instanceof Number) {
+            if (in instanceof Number)
                 return ((Number) in).floatValue();
-            }
-            if (in instanceof java.util.Date) {
+            if (in instanceof java.util.Date)
                 return ((java.util.Date) in).getTime();
-            }
-            if (in instanceof Boolean) {
+            if (in instanceof Boolean)
                 return (Boolean) in ? 1f : 0f;
-            }
-            if (in instanceof Clob) {
+            if (in instanceof Clob)
                 return Float.parseFloat(asString((Clob) in));
-            }
-            if (in instanceof Character) {
+            if (in instanceof Character)
                 return Float.parseFloat(in.toString());
-            }
         } catch (final Exception e) {
             throw cannotCastException(in.getClass().getName(), "float", e);
         }
@@ -2011,24 +2041,18 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
 
     private static double castToDouble(final Object in) throws SQLException {
         try {
-            if (in instanceof String) {
+            if (in instanceof String)
                 return Double.parseDouble((String) in);
-            }
-            if (in instanceof Number) {
+            if (in instanceof Number)
                 return ((Number) in).doubleValue();
-            }
-            if (in instanceof java.util.Date) {
+            if (in instanceof java.util.Date)
                 return ((java.util.Date) in).getTime();
-            }
-            if (in instanceof Boolean) {
+            if (in instanceof Boolean)
                 return (Boolean) in ? 1d : 0d;
-            }
-            if (in instanceof Clob) {
+            if (in instanceof Clob)
                 return Double.parseDouble(asString((Clob) in));
-            }
-            if (in instanceof Character) {
+            if (in instanceof Character)
                 return Double.parseDouble(in.toString());
-            }
         } catch (final Exception e) {
             throw cannotCastException(in.getClass().getName(), "double", e);
         }
@@ -2037,29 +2061,28 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
 
     private static BigDecimal castToBigDecimal(final Object in, final int scale) throws SQLException {
         try {
-            BigDecimal rc = null;
-            if (in instanceof String) {
-                rc = new BigDecimal((String) in);
-            } else if (in instanceof BigDecimal) {
-                rc = ((BigDecimal) in);
-            } else if (in instanceof BigInteger) {
-                rc = new BigDecimal((BigInteger) in);
-            } else if (in instanceof Long || in instanceof Integer || in instanceof Short || in instanceof Byte) {
-                rc = BigDecimal.valueOf(((Number) in).longValue());
-            } else if (in instanceof Double || in instanceof Float) {
-                rc = BigDecimal.valueOf(((Number) in).doubleValue());
-            } else if (in instanceof java.util.Date) {
-                rc = BigDecimal.valueOf(((java.util.Date) in).getTime());
-            } else if (in instanceof Boolean) {
-                rc = (Boolean) in ? BigDecimal.ONE : BigDecimal.ZERO;
-            } else if (in instanceof Clob) {
-                rc = new BigDecimal(asString((Clob) in));
-            } else if (in instanceof Character) {
-                rc = new BigDecimal(new char[]{(Character) in});
-            }
-            if (rc != null) {
-                if (scale >= 0) {
-                    rc = rc.setScale(scale, RoundingMode.HALF_UP);
+            BigDecimal rc=null;
+            if (in instanceof String)
+                rc=new BigDecimal((String) in);
+            else if (in instanceof BigDecimal)
+                rc=((BigDecimal) in);
+            else if (in instanceof BigInteger)
+                rc=new BigDecimal((BigInteger) in);
+            else if (in instanceof Long || in instanceof Integer || in instanceof Short || in instanceof Byte)
+                rc=BigDecimal.valueOf(((Number) in).longValue());
+            else if (in instanceof Double || in instanceof Float)
+                rc=BigDecimal.valueOf(((Number) in).doubleValue());
+            else if (in instanceof java.util.Date)
+                rc=BigDecimal.valueOf(((java.util.Date) in).getTime());
+            else if (in instanceof Boolean)
+                rc=(Boolean) in ? BigDecimal.ONE : BigDecimal.ZERO;
+            else if (in instanceof Clob)
+                rc=new BigDecimal(asString((Clob) in));
+            else if (in instanceof Character)
+                rc=new BigDecimal(new char[] {(Character) in});
+            if (rc!=null) {
+                if (scale>=0) {
+                    rc=rc.setScale(scale,RoundingMode.HALF_UP);
                 }
                 return rc;
             }
@@ -2071,28 +2094,22 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
 
     private static boolean castToBoolean(final Object in) throws SQLException {
         try {
-            if (in instanceof String) {
+            if (in instanceof String)
                 return ((String) in).equalsIgnoreCase("true") || ((String) in).equals("1") || ((String) in).equalsIgnoreCase("t");
-            }
-            if (in instanceof BigDecimal) {
+            if (in instanceof BigDecimal)
                 return ((BigDecimal) in).signum() != 0;
-            }
-            if (in instanceof Number) {
+            if (in instanceof Number)
                 return ((Number) in).longValue() != 0L;
-            }
-            if (in instanceof java.util.Date) {
+            if (in instanceof java.util.Date)
                 return ((java.util.Date) in).getTime() != 0L;
-            }
-            if (in instanceof Boolean) {
+            if (in instanceof Boolean)
                 return (Boolean) in;
-            }
             if (in instanceof Clob) {
                 final String asString = asString((Clob) in);
                 return asString.equalsIgnoreCase("true") || asString.equals("1") || asString.equalsIgnoreCase("t");
             }
-            if (in instanceof Character) {
+            if (in instanceof Character)
                 return (Character) in == '1' || (Character) in == 't' || (Character) in == 'T';
-            }
         } catch (final Exception e) {
             throw cannotCastException(in.getClass().getName(), "boolean", e);
         }
@@ -2101,15 +2118,12 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
 
     private static String castToString(final Object in) throws SQLException {
         try {
-            if (in instanceof String) {
+            if (in instanceof String)
                 return (String) in;
-            }
-            if (in instanceof Number || in instanceof Boolean || in instanceof Character || in instanceof java.util.Date) {
+            if (in instanceof Number || in instanceof Boolean || in instanceof Character || in instanceof java.util.Date)
                 return in.toString();
-            }
-            if (in instanceof Clob) {
+            if (in instanceof Clob)
                 return asString((Clob) in);
-            }
         } catch (final Exception e) {
             throw cannotCastException(in.getClass().getName(), "String", e);
         }
@@ -2121,59 +2135,62 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
     }
 
     private static PSQLException cannotCastException(final String fromType, final String toType, final Exception cause) {
-        return new PSQLException(GT.tr("Cannot convert an instance of {0} to type {1}", new Object[]{fromType, toType}), PSQLState.INVALID_PARAMETER_TYPE, cause);
+        return new PSQLException(GT.tr("Cannot convert an instance of {0} to type {1}", new Object[] { fromType, toType }), PSQLState.INVALID_PARAMETER_TYPE, cause);
     }
 
-    public void setObject(int parameterIndex, Object x, int targetSqlType) throws SQLException {
+    public void setObject(int parameterIndex, Object x, int targetSqlType) throws SQLException
+    {
         setObject(parameterIndex, x, targetSqlType, -1);
     }
 
     /*
      * This stores an Object into a parameter.
      */
-    public void setObject(int parameterIndex, Object x) throws SQLException {
+    public void setObject(int parameterIndex, Object x) throws SQLException
+    {
         checkClosed();
-        if (x == null) {
+        if (x == null)
             setNull(parameterIndex, Types.OTHER);
-        } else if (x instanceof String) {
-            setString(parameterIndex, (String) x);
-        } else if (x instanceof BigDecimal) {
-            setBigDecimal(parameterIndex, (BigDecimal) x);
-        } else if (x instanceof Short) {
+        else if (x instanceof String)
+            setString(parameterIndex, (String)x);
+        else if (x instanceof BigDecimal)
+            setBigDecimal(parameterIndex, (BigDecimal)x);
+        else if (x instanceof Short)
             setShort(parameterIndex, (Short) x);
-        } else if (x instanceof Integer) {
+        else if (x instanceof Integer)
             setInt(parameterIndex, (Integer) x);
-        } else if (x instanceof Long) {
+        else if (x instanceof Long)
             setLong(parameterIndex, (Long) x);
-        } else if (x instanceof Float) {
+        else if (x instanceof Float)
             setFloat(parameterIndex, (Float) x);
-        } else if (x instanceof Double) {
+        else if (x instanceof Double)
             setDouble(parameterIndex, (Double) x);
-        } else if (x instanceof byte[]) {
-            setBytes(parameterIndex, (byte[]) x);
-        } else if (x instanceof java.sql.Date) {
-            setDate(parameterIndex, (java.sql.Date) x);
-        } else if (x instanceof Time) {
-            setTime(parameterIndex, (Time) x);
-        } else if (x instanceof Timestamp) {
-            setTimestamp(parameterIndex, (Timestamp) x);
-        } else if (x instanceof Boolean) {
+        else if (x instanceof byte[])
+            setBytes(parameterIndex, (byte[])x);
+        else if (x instanceof java.sql.Date)
+            setDate(parameterIndex, (java.sql.Date)x);
+        else if (x instanceof Time)
+            setTime(parameterIndex, (Time)x);
+        else if (x instanceof Timestamp)
+            setTimestamp(parameterIndex, (Timestamp)x);
+        else if (x instanceof Boolean)
             setBoolean(parameterIndex, (Boolean) x);
-        } else if (x instanceof Byte) {
+        else if (x instanceof Byte)
             setByte(parameterIndex, (Byte) x);
-        } else if (x instanceof Blob) {
-            setBlob(parameterIndex, (Blob) x);
-        } else if (x instanceof Clob) {
-            setClob(parameterIndex, (Clob) x);
-        } else if (x instanceof Array) {
-            setArray(parameterIndex, (Array) x);
-        } else if (x instanceof PGobject) {
-            setPGobject(parameterIndex, (PGobject) x);
-        } else if (x instanceof Character) {
-            setString(parameterIndex, ((Character) x).toString());
-        } else if (x instanceof Map) {
-            setMap(parameterIndex, (Map) x);
-        } else {
+        else if (x instanceof Blob)
+            setBlob(parameterIndex, (Blob)x);
+        else if (x instanceof Clob)
+            setClob(parameterIndex, (Clob)x);
+        else if (x instanceof Array)
+            setArray(parameterIndex, (Array)x);
+        else if (x instanceof PGobject)
+            setPGobject(parameterIndex, (PGobject)x);
+        else if (x instanceof Character)
+            setString(parameterIndex, ((Character)x).toString());
+        else if (x instanceof Map)
+            setMap(parameterIndex, (Map)x);
+        else
+        {
             // Can't infer a type.
             throw new PSQLException(GT.tr("Can''t infer the SQL type to use for an instance of {0}. Use setObject() with an explicit Types value to specify the type to use.", x.getClass().getName()), PSQLState.INVALID_PARAMETER_TYPE);
         }
@@ -2196,50 +2213,49 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
      * registerOutParameter that accepts a scale value
      * @exception SQLException if a database-access error occurs.
      */
-    public void registerOutParameter(int parameterIndex, int sqlType, boolean setPreparedParameters) throws SQLException {
+    public void registerOutParameter(int parameterIndex, int sqlType, boolean setPreparedParameters) throws SQLException
+    {
         checkClosed();
-        switch (sqlType) {
-            case Types.TINYINT:
-                // we don't have a TINYINT type use SMALLINT
-                sqlType = Types.SMALLINT;
-                break;
-            case Types.LONGVARCHAR:
-                sqlType = Types.VARCHAR;
-                break;
-            case Types.DECIMAL:
-                sqlType = Types.NUMERIC;
-                break;
-            case Types.FLOAT:
-                // float is the same as double
-                sqlType = Types.DOUBLE;
-                break;
-            case Types.VARBINARY:
-            case Types.LONGVARBINARY:
-                sqlType = Types.BINARY;
-                break;
-            default:
-                break;
+        switch( sqlType )
+        {
+	        case Types.TINYINT:
+			    // we don't have a TINYINT type use SMALLINT
+			    	sqlType = Types.SMALLINT;
+			    	break;
+			case Types.LONGVARCHAR:
+			    sqlType = Types.VARCHAR;
+				break;
+			case Types.DECIMAL:
+			    sqlType = Types.NUMERIC;
+				break;
+			case Types.FLOAT:
+			    // float is the same as double
+			    sqlType = Types.DOUBLE;
+				break;
+			case Types.VARBINARY:
+			case Types.LONGVARBINARY:
+			    sqlType = Types.BINARY;
+				break;
+			default:
+			    break;
         }
-        if (!isFunction) {
-            throw new PSQLException(GT.tr("This statement does not declare an OUT parameter.  Use '{' ?= call ... '}' to declare one."), PSQLState.STATEMENT_NOT_ALLOWED_IN_FUNCTION_CALL);
-        }
+        if (!isFunction)
+            throw new PSQLException (GT.tr("This statement does not declare an OUT parameter.  Use '{' ?= call ... '}' to declare one."), PSQLState.STATEMENT_NOT_ALLOWED_IN_FUNCTION_CALL);
         checkIndex(parameterIndex, false);
-
-        if (setPreparedParameters) {
-            preparedParameters.registerOutParameter(parameterIndex, sqlType);
-        }
+        
+        if( setPreparedParameters )
+            preparedParameters.registerOutParameter( parameterIndex, sqlType );
         // functionReturnType contains the user supplied value to check
         // testReturn contains a modified version to make it easier to
         // check the getXXX methods..
-        functionReturnType[parameterIndex - 1] = sqlType;
-        testReturn[parameterIndex - 1] = sqlType;
-
-        if (functionReturnType[parameterIndex - 1] == Types.CHAR
-                || functionReturnType[parameterIndex - 1] == Types.LONGVARCHAR) {
-            testReturn[parameterIndex - 1] = Types.VARCHAR;
-        } else if (functionReturnType[parameterIndex - 1] == Types.FLOAT) {
-            testReturn[parameterIndex - 1] = Types.REAL; // changes to streamline later error checking
-        }
+        functionReturnType[parameterIndex-1] = sqlType;
+        testReturn[parameterIndex-1] = sqlType;
+        
+        if (functionReturnType[parameterIndex-1] == Types.CHAR ||
+                functionReturnType[parameterIndex-1] == Types.LONGVARCHAR)
+            testReturn[parameterIndex-1] = Types.VARCHAR;
+        else if (functionReturnType[parameterIndex-1] == Types.FLOAT)
+            testReturn[parameterIndex-1] = Types.REAL; // changes to streamline later error checking
         returnTypeSet = true;
     }
 
@@ -2257,8 +2273,9 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
      * @exception SQLException if a database-access error occurs.
      */
     public void registerOutParameter(int parameterIndex, int sqlType,
-            int scale, boolean setPreparedParameters) throws SQLException {
-        registerOutParameter(parameterIndex, sqlType, setPreparedParameters); // ignore for now..
+                                     int scale, boolean setPreparedParameters) throws SQLException
+    {
+        registerOutParameter (parameterIndex, sqlType, setPreparedParameters); // ignore for now..
     }
 
     /*
@@ -2270,13 +2287,13 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
      * @return true if the last parameter read was SQL NULL
      * @exception SQLException if a database-access error occurs.
      */
-    public boolean wasNull() throws SQLException {
-        if (lastIndex == 0) {
+    public boolean wasNull() throws SQLException
+    {
+        if (lastIndex == 0)
             throw new PSQLException(GT.tr("wasNull cannot be call before fetching a result."), PSQLState.OBJECT_NOT_IN_STATE);
-        }
 
         // check to see if the last access threw an exception
-        return (callResult[lastIndex - 1] == null);
+        return (callResult[lastIndex-1] == null);
     }
 
     /*
@@ -2287,10 +2304,11 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
      * @return the parameter value; if the value is SQL NULL, the result is null
      * @exception SQLException if a database-access error occurs.
      */
-    public String getString(int parameterIndex) throws SQLException {
+    public String getString(int parameterIndex) throws SQLException
+    {
         checkClosed();
-        checkIndex(parameterIndex, Types.VARCHAR, "String");
-        return (String) callResult[parameterIndex - 1];
+        checkIndex (parameterIndex, Types.VARCHAR, "String");
+        return (String)callResult[parameterIndex-1];
     }
 
 
@@ -2301,13 +2319,13 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
      * @return the parameter value; if the value is SQL NULL, the result is false
      * @exception SQLException if a database-access error occurs.
      */
-    public boolean getBoolean(int parameterIndex) throws SQLException {
+    public boolean getBoolean(int parameterIndex) throws SQLException
+    {
         checkClosed();
-        checkIndex(parameterIndex, Types.BIT, "Boolean");
-        if (callResult[parameterIndex - 1] == null) {
+        checkIndex (parameterIndex, Types.BIT, "Boolean");
+        if (callResult[parameterIndex-1] == null)
             return false;
-        }
-
+        
         return (Boolean) callResult[parameterIndex - 1];
     }
 
@@ -2318,17 +2336,17 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
      * @return the parameter value; if the value is SQL NULL, the result is 0
      * @exception SQLException if a database-access error occurs.
      */
-    public byte getByte(int parameterIndex) throws SQLException {
+    public byte getByte(int parameterIndex) throws SQLException
+    {
         checkClosed();
         // fake tiny int with smallint
-        checkIndex(parameterIndex, Types.SMALLINT, "Byte");
-
-        if (callResult[parameterIndex - 1] == null) {
+        checkIndex (parameterIndex, Types.SMALLINT, "Byte");
+        
+        if (callResult[parameterIndex-1] == null)
             return 0;
-        }
-
-        return ((Integer) callResult[parameterIndex - 1]).byteValue();
-
+        
+        return ((Integer)callResult[parameterIndex-1]).byteValue();
+  
     }
 
     /*
@@ -2338,13 +2356,13 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
      * @return the parameter value; if the value is SQL NULL, the result is 0
      * @exception SQLException if a database-access error occurs.
      */
-    public short getShort(int parameterIndex) throws SQLException {
+    public short getShort(int parameterIndex) throws SQLException
+    {
         checkClosed();
-        checkIndex(parameterIndex, Types.SMALLINT, "Short");
-        if (callResult[parameterIndex - 1] == null) {
+        checkIndex (parameterIndex, Types.SMALLINT, "Short");
+        if (callResult[parameterIndex-1] == null)
             return 0;
-        }
-        return ((Integer) callResult[parameterIndex - 1]).shortValue();
+        return ((Integer)callResult[parameterIndex-1]).shortValue ();
     }
 
 
@@ -2355,13 +2373,13 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
      * @return the parameter value; if the value is SQL NULL, the result is 0
      * @exception SQLException if a database-access error occurs.
      */
-    public int getInt(int parameterIndex) throws SQLException {
+    public int getInt(int parameterIndex) throws SQLException
+    {
         checkClosed();
-        checkIndex(parameterIndex, Types.INTEGER, "Int");
-        if (callResult[parameterIndex - 1] == null) {
+        checkIndex (parameterIndex, Types.INTEGER, "Int");
+        if (callResult[parameterIndex-1] == null)
             return 0;
-        }
-
+        
         return (Integer) callResult[parameterIndex - 1];
     }
 
@@ -2372,13 +2390,13 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
      * @return the parameter value; if the value is SQL NULL, the result is 0
      * @exception SQLException if a database-access error occurs.
      */
-    public long getLong(int parameterIndex) throws SQLException {
+    public long getLong(int parameterIndex) throws SQLException
+    {
         checkClosed();
-        checkIndex(parameterIndex, Types.BIGINT, "Long");
-        if (callResult[parameterIndex - 1] == null) {
+        checkIndex (parameterIndex, Types.BIGINT, "Long");
+        if (callResult[parameterIndex-1] == null)
             return 0;
-        }
-
+        
         return (Long) callResult[parameterIndex - 1];
     }
 
@@ -2389,12 +2407,12 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
      * @return the parameter value; if the value is SQL NULL, the result is 0
      * @exception SQLException if a database-access error occurs.
      */
-    public float getFloat(int parameterIndex) throws SQLException {
+    public float getFloat(int parameterIndex) throws SQLException
+    {
         checkClosed();
-        checkIndex(parameterIndex, Types.REAL, "Float");
-        if (callResult[parameterIndex - 1] == null) {
+        checkIndex (parameterIndex, Types.REAL, "Float");
+        if (callResult[parameterIndex-1] == null)
             return 0;
-        }
 
         return (Float) callResult[parameterIndex - 1];
     }
@@ -2406,13 +2424,13 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
      * @return the parameter value; if the value is SQL NULL, the result is 0
      * @exception SQLException if a database-access error occurs.
      */
-    public double getDouble(int parameterIndex) throws SQLException {
+    public double getDouble(int parameterIndex) throws SQLException
+    {
         checkClosed();
-        checkIndex(parameterIndex, Types.DOUBLE, "Double");
-        if (callResult[parameterIndex - 1] == null) {
+        checkIndex (parameterIndex, Types.DOUBLE, "Double");
+        if (callResult[parameterIndex-1] == null)
             return 0;
-        }
-
+        
         return (Double) callResult[parameterIndex - 1];
     }
 
@@ -2428,10 +2446,11 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
      * @deprecated in Java2.0
      */
     public BigDecimal getBigDecimal(int parameterIndex, int scale)
-            throws SQLException {
+    throws SQLException
+    {
         checkClosed();
-        checkIndex(parameterIndex, Types.NUMERIC, "BigDecimal");
-        return ((BigDecimal) callResult[parameterIndex - 1]);
+        checkIndex (parameterIndex, Types.NUMERIC, "BigDecimal");
+        return ((BigDecimal)callResult[parameterIndex-1]);
     }
 
     /*
@@ -2442,10 +2461,11 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
      * @return the parameter value; if the value is SQL NULL, the result is null
      * @exception SQLException if a database-access error occurs.
      */
-    public byte[] getBytes(int parameterIndex) throws SQLException {
+    public byte[] getBytes(int parameterIndex) throws SQLException
+    {
         checkClosed();
-        checkIndex(parameterIndex, Types.VARBINARY, Types.BINARY, "Bytes");
-        return ((byte[]) callResult[parameterIndex - 1]);
+        checkIndex (parameterIndex, Types.VARBINARY, Types.BINARY, "Bytes");
+        return ((byte [])callResult[parameterIndex-1]);
     }
 
 
@@ -2456,10 +2476,11 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
      * @return the parameter value; if the value is SQL NULL, the result is null
      * @exception SQLException if a database-access error occurs.
      */
-    public java.sql.Date getDate(int parameterIndex) throws SQLException {
+    public java.sql.Date getDate(int parameterIndex) throws SQLException
+    {
         checkClosed();
-        checkIndex(parameterIndex, Types.DATE, "Date");
-        return (java.sql.Date) callResult[parameterIndex - 1];
+        checkIndex (parameterIndex, Types.DATE, "Date");     
+        return (java.sql.Date)callResult[parameterIndex-1];
     }
 
     /*
@@ -2469,10 +2490,11 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
      * @return the parameter value; if the value is SQL NULL, the result is null
      * @exception SQLException if a database-access error occurs.
      */
-    public java.sql.Time getTime(int parameterIndex) throws SQLException {
+    public java.sql.Time getTime(int parameterIndex) throws SQLException
+    {
         checkClosed();
-        checkIndex(parameterIndex, Types.TIME, "Time");
-        return (java.sql.Time) callResult[parameterIndex - 1];
+        checkIndex (parameterIndex, Types.TIME, "Time");
+        return (java.sql.Time)callResult[parameterIndex-1];
     }
 
     /*
@@ -2483,10 +2505,11 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
      * @exception SQLException if a database-access error occurs.
      */
     public java.sql.Timestamp getTimestamp(int parameterIndex)
-            throws SQLException {
+    throws SQLException
+    {
         checkClosed();
-        checkIndex(parameterIndex, Types.TIMESTAMP, "Timestamp");
-        return (java.sql.Timestamp) callResult[parameterIndex - 1];
+        checkIndex (parameterIndex, Types.TIMESTAMP, "Timestamp");
+        return (java.sql.Timestamp)callResult[parameterIndex-1];
     }
 
     // getObject returns a Java object for the parameter.
@@ -2510,42 +2533,43 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
      * @exception SQLException if a database-access error occurs.
      */
     public Object getObject(int parameterIndex)
-            throws SQLException {
+    throws SQLException
+    {
         checkClosed();
-        checkIndex(parameterIndex);
-        return callResult[parameterIndex - 1];
+        checkIndex (parameterIndex);        
+        return callResult[parameterIndex-1];
     }
 
     /*
      * Returns the SQL statement with the current template values
      * substituted.
      */
-    public String toString() {
-        if (preparedQuery == null) {
+    public String toString()
+    {
+        if (preparedQuery == null)
             return super.toString();
-        }
 
         return preparedQuery.query.toString(preparedParameters);
     }
 
 
     /*
-     * Note if s is a String it should be escaped by the caller to avoid SQL
-     * injection attacks.  It is not done here for efficency reasons as
-     * most calls to this method do not require escaping as the source
-     * of the string is known safe (i.e. Integer.toString())
+        * Note if s is a String it should be escaped by the caller to avoid SQL
+        * injection attacks.  It is not done here for efficency reasons as
+        * most calls to this method do not require escaping as the source
+        * of the string is known safe (i.e. Integer.toString())
      */
-    protected void bindLiteral(int paramIndex, String s, int oid) throws SQLException {
-        if (adjustIndex) {
+    protected void bindLiteral(int paramIndex, String s, int oid) throws SQLException
+    {
+        if(adjustIndex)
             paramIndex--;
-        }
         preparedParameters.setLiteralParameter(paramIndex, s, oid);
     }
 
-    protected void bindBytes(int paramIndex, byte[] b, int oid) throws SQLException {
-        if (adjustIndex) {
+    protected void bindBytes(int paramIndex, byte[] b, int oid) throws SQLException
+    {
+        if(adjustIndex)
             paramIndex--;
-        }
         preparedParameters.setBinaryParameter(paramIndex, b, oid);
     }
 
@@ -2554,75 +2578,71 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
      * e.g. setString directly calls bindString with no escaping;
      * the per-protocol ParameterList does escaping as needed.
      */
-    private void bindString(int paramIndex, String s, int oid) throws SQLException {
-        if (adjustIndex) {
+    private void bindString(int paramIndex, String s, int oid) throws SQLException
+    {
+        if (adjustIndex)
             paramIndex--;
-        }
-        preparedParameters.setStringParameter(paramIndex, s, oid);
+        preparedParameters.setStringParameter( paramIndex, s, oid);
     }
 
-    /**
-     * helperfunction for the getXXX calls to check isFunction and index == 1
+    /** helperfunction for the getXXX calls to check isFunction and index == 1
      * Compare BOTH type fields against the return type.
      */
-    protected void checkIndex(int parameterIndex, int type1, int type2, String getName)
-            throws SQLException {
-        checkIndex(parameterIndex);
-        if (type1 != this.testReturn[parameterIndex - 1] && type2 != this.testReturn[parameterIndex - 1]) {
+    protected void checkIndex (int parameterIndex, int type1, int type2, String getName)
+    throws SQLException
+    {
+        checkIndex (parameterIndex);
+        if (type1 != this.testReturn[parameterIndex-1] && type2 != this.testReturn[parameterIndex-1])
             throw new PSQLException(GT.tr("Parameter of type {0} was registered, but call to get{1} (sqltype={2}) was made.",
-                    new Object[]{"java.sql.Types=" + testReturn[parameterIndex - 1],
-                        getName,
-                        "java.sql.Types=" + type1}),
-                    PSQLState.MOST_SPECIFIC_TYPE_DOES_NOT_MATCH);
-        }
+                                          new Object[]{"java.sql.Types=" + testReturn[parameterIndex-1],
+                                                       getName,
+                                                       "java.sql.Types=" + type1}),
+                                    PSQLState.MOST_SPECIFIC_TYPE_DOES_NOT_MATCH);
     }
 
-    /**
-     * helperfunction for the getXXX calls to check isFunction and index == 1
+    /** helperfunction for the getXXX calls to check isFunction and index == 1
      */
-    protected void checkIndex(int parameterIndex, int type, String getName)
-            throws SQLException {
-        checkIndex(parameterIndex);
-        if (type != this.testReturn[parameterIndex - 1]) {
+    protected void checkIndex (int parameterIndex, int type, String getName)
+    throws SQLException
+    {
+        checkIndex (parameterIndex);
+        if (type != this.testReturn[parameterIndex-1])
             throw new PSQLException(GT.tr("Parameter of type {0} was registered, but call to get{1} (sqltype={2}) was made.",
-                    new Object[]{"java.sql.Types=" + testReturn[parameterIndex - 1],
-                        getName,
-                        "java.sql.Types=" + type}),
-                    PSQLState.MOST_SPECIFIC_TYPE_DOES_NOT_MATCH);
-        }
+                                          new Object[]{"java.sql.Types=" + testReturn[parameterIndex-1],
+                                                       getName,
+                                                       "java.sql.Types=" + type}),
+                                    PSQLState.MOST_SPECIFIC_TYPE_DOES_NOT_MATCH);
     }
 
-    private void checkIndex(int parameterIndex) throws SQLException {
+    private void checkIndex (int parameterIndex) throws SQLException
+    {
         checkIndex(parameterIndex, true);
     }
 
-    /**
-     * helperfunction for the getXXX calls to check isFunction and index == 1
-     *
-     * @param parameterIndex index of getXXX (index) check to make sure is a
-     * function and index == 1
+    /** helperfunction for the getXXX calls to check isFunction and index == 1
+     * @param parameterIndex index of getXXX (index)
+     * check to make sure is a function and index == 1
      */
-    private void checkIndex(int parameterIndex, boolean fetchingData) throws SQLException {
-        if (!isFunction) {
+    private void checkIndex (int parameterIndex, boolean fetchingData) throws SQLException
+    {
+        if (!isFunction)
             throw new PSQLException(GT.tr("A CallableStatement was declared, but no call to registerOutParameter(1, <some type>) was made."), PSQLState.STATEMENT_NOT_ALLOWED_IN_FUNCTION_CALL);
-        }
 
         if (fetchingData) {
-            if (!returnTypeSet) {
+            if (!returnTypeSet)
                 throw new PSQLException(GT.tr("No function outputs were registered."), PSQLState.OBJECT_NOT_IN_STATE);
-            }
 
-            if (callResult == null) {
+            if (callResult == null)
                 throw new PSQLException(GT.tr("Results cannot be retrieved from a CallableStatement before it is executed."), PSQLState.NO_DATA);
-            }
 
             lastIndex = parameterIndex;
         }
     }
 
+    
     public void setPrepareThreshold(int newThreshold) throws SQLException {
         checkClosed();
-
+       
         if (newThreshold < 0) {
             forceBinaryTransfers = true;
             newThreshold = 1;
@@ -2643,23 +2663,25 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
         return (preparedQuery != null && m_prepareThreshold != 0 && preparedQuery.getExecuteCount() + 1 >= m_prepareThreshold);
     }
 
-    protected void checkClosed() throws SQLException {
-        if (isClosed) {
+    protected void checkClosed() throws SQLException
+    {
+        if (isClosed)
             throw new PSQLException(GT.tr("This statement has been closed."),
-                    PSQLState.OBJECT_NOT_IN_STATE);
-        }
+                                    PSQLState.OBJECT_NOT_IN_STATE);
     }
 
     // ** JDBC 2 Extensions **
-    public void addBatch(String p_sql) throws SQLException {
+
+    public void addBatch(String p_sql) throws SQLException
+    {
         checkClosed();
 
-        if (preparedQuery != null) {
+        if (preparedQuery != null)
             throw new PSQLException(GT.tr("Can''t use query methods that take a query string on a PreparedStatement."),
-                    PSQLState.WRONG_OBJECT_TYPE);
-        }
+                                    PSQLState.WRONG_OBJECT_TYPE);
 
-        if (batchStatements == null) {
+        if (batchStatements == null)
+        {
             batchStatements = new ArrayList<Query>();
             batchParameters = new ArrayList<ParameterList>();
         }
@@ -2670,8 +2692,10 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
         batchParameters.add(null);
     }
 
-    public void clearBatch() throws SQLException {
-        if (batchStatements != null) {
+    public void clearBatch() throws SQLException
+    {
+        if (batchStatements != null)
+        {
             batchStatements.clear();
             batchParameters.clear();
         }
@@ -2680,8 +2704,8 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
     //
     // ResultHandler for batch queries.
     //
-    private class BatchResultHandler implements ResultHandler {
 
+    private class BatchResultHandler implements ResultHandler {
         private BatchUpdateException batchException = null;
         private int resultIndex = 0;
 
@@ -2701,26 +2725,30 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
         public void handleResultRows(Query fromQuery, Field[] fields, List tuples, ResultCursor cursor) {
             if (!expectGeneratedKeys) {
                 handleError(new PSQLException(GT.tr("A result was returned when none was expected."),
-                        PSQLState.TOO_MANY_RESULTS));
+                                          PSQLState.TOO_MANY_RESULTS));
             } else {
                 if (generatedKeys == null) {
-                    try {
+                    try
+                    {
                         generatedKeys = AbstractJdbc2Statement.this.createResultSet(fromQuery, fields, tuples, cursor);
-                    } catch (SQLException e) {
+                    }
+                    catch (SQLException e)
+                    {
                         handleError(e);
-
+            
                     }
                 } else {
-                    ((AbstractJdbc2ResultSet) generatedKeys).addRows(tuples);
+                    ((AbstractJdbc2ResultSet)generatedKeys).addRows(tuples);
                 }
             }
         }
 
         public void handleCommandStatus(String status, int updateCount, long insertOID) {
-            if (resultIndex >= updateCounts.length) {
+            if (resultIndex >= updateCounts.length)
+            {
                 handleError(new PSQLException(GT.tr("Too many update results were returned."),
-                        PSQLState.TOO_MANY_RESULTS));
-                return;
+                                              PSQLState.TOO_MANY_RESULTS));
+                return ;
             }
 
             updateCounts[resultIndex++] = updateCount;
@@ -2731,44 +2759,42 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
         }
 
         public void handleError(SQLException newError) {
-            if (batchException == null) {
+            if (batchException == null)
+            {
                 int[] successCounts;
 
-                if (resultIndex >= updateCounts.length) {
+                if (resultIndex >= updateCounts.length)
                     successCounts = updateCounts;
-                } else {
+                else
+                {
                     successCounts = new int[resultIndex];
                     System.arraycopy(updateCounts, 0, successCounts, 0, resultIndex);
                 }
 
                 String queryString = "<unknown>";
-                if (resultIndex < queries.length) {
+                if (resultIndex < queries.length)
                     queryString = queries[resultIndex].toString(parameterLists[resultIndex]);
-                }
 
                 batchException = new BatchUpdateException(GT.tr("Batch entry {0} {1} was aborted.  Call getNextException to see the cause.",
-                        new Object[]{resultIndex,
-                            queryString}),
-                        newError.getSQLState(),
-                        successCounts);
+                                 new Object[]{resultIndex,
+                                               queryString}),
+                                 newError.getSQLState(),
+                                 successCounts);
             }
 
             batchException.setNextException(newError);
         }
 
         public void handleCompletion() throws SQLException {
-            if (batchException != null) {
+            if (batchException != null)
                 throw batchException;
-            }
         }
 
         public ResultSet getGeneratedKeys() {
             return generatedKeys;
         }
     }
-
     private class CallableBatchResultHandler implements ResultHandler {
-
         private BatchUpdateException batchException = null;
         private int resultIndex = 0;
 
@@ -2782,15 +2808,17 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
             this.updateCounts = updateCounts;
         }
 
-        public void handleResultRows(Query fromQuery, Field[] fields, List tuples, ResultCursor cursor) {
-
+        public void handleResultRows(Query fromQuery, Field[] fields, List tuples, ResultCursor cursor) 
+        {
+            
         }
 
         public void handleCommandStatus(String status, int updateCount, long insertOID) {
-            if (resultIndex >= updateCounts.length) {
+            if (resultIndex >= updateCounts.length)
+            {
                 handleError(new PSQLException(GT.tr("Too many update results were returned."),
-                        PSQLState.TOO_MANY_RESULTS));
-                return;
+                                              PSQLState.TOO_MANY_RESULTS));
+                return ;
             }
 
             updateCounts[resultIndex++] = updateCount;
@@ -2801,46 +2829,47 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
         }
 
         public void handleError(SQLException newError) {
-            if (batchException == null) {
+            if (batchException == null)
+            {
                 int[] successCounts;
 
-                if (resultIndex >= updateCounts.length) {
+                if (resultIndex >= updateCounts.length)
                     successCounts = updateCounts;
-                } else {
+                else
+                {
                     successCounts = new int[resultIndex];
                     System.arraycopy(updateCounts, 0, successCounts, 0, resultIndex);
                 }
 
                 String queryString = "<unknown>";
-                if (resultIndex < queries.length) {
+                if (resultIndex < queries.length)
                     queryString = queries[resultIndex].toString(parameterLists[resultIndex]);
-                }
 
                 batchException = new BatchUpdateException(GT.tr("Batch entry {0} {1} was aborted.  Call getNextException to see the cause.",
-                        new Object[]{resultIndex,
-                            queryString}),
-                        newError.getSQLState(),
-                        successCounts);
+                                 new Object[]{resultIndex,
+                                               queryString}),
+                                 newError.getSQLState(),
+                                 successCounts);
             }
 
             batchException.setNextException(newError);
         }
 
         public void handleCompletion() throws SQLException {
-            if (batchException != null) {
+            if (batchException != null)
                 throw batchException;
-            }
         }
     }
 
-    public int[] executeBatch() throws SQLException {
+    
+    public int[] executeBatch() throws SQLException
+    {
         checkClosed();
 
         closeForNextExecution();
 
-        if (batchStatements == null || batchStatements.isEmpty()) {
+        if (batchStatements == null || batchStatements.isEmpty())
             return new int[0];
-        }
 
         int size = batchStatements.size();
         int[] updateCounts = new int[size];
@@ -2878,7 +2907,8 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
         }
 
         // Only use named statements after we hit the threshold
-        if (preparedQuery != null) {
+        if (preparedQuery != null)
+        {
             preparedQuery.increaseExecuteCount(queries.length);
         }
         if (m_prepareThreshold == 0 || preparedQuery == null || preparedQuery.getExecuteCount() < m_prepareThreshold) {
@@ -2899,9 +2929,8 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
             flags |= QueryExecutor.QUERY_FORCE_DESCRIBE_PORTAL;
         }
 
-        if (connection.getAutoCommit()) {
+        if (connection.getAutoCommit())
             flags |= QueryExecutor.QUERY_SUPPRESS_BEGIN;
-        }
 
         if (preDescribe || forceBinaryTransfers) {
             // Do a client-server round trip, parsing and describing the query so we
@@ -2917,30 +2946,30 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
         }
 
         result = null;
-
+        
         ResultHandler handler;
-        if (isFunction) {
-            handler = new CallableBatchResultHandler(queries, parameterLists, updateCounts);
-        } else {
-            handler = new BatchResultHandler(queries, parameterLists, updateCounts, wantsGeneratedKeysAlways);
-        }
-
-        try {
-            startTimer();
-            connection.getQueryExecutor().execute(queries,
-                    parameterLists,
-                    handler,
-                    maxrows,
-                    fetchSize,
-                    flags);
-        } finally {
-            killTimerTask();
-        }
+	if (isFunction) {
+		handler = new CallableBatchResultHandler(queries, parameterLists, updateCounts );
+	} else {
+		handler = new BatchResultHandler(queries, parameterLists, updateCounts, wantsGeneratedKeysAlways);
+	}
+        
+	try {
+	    startTimer();
+	    connection.getQueryExecutor().execute(queries,
+						  parameterLists,
+						  handler,
+						  maxrows,
+						  fetchSize,
+						  flags);
+	} finally {
+	    killTimerTask();
+	}
 
         if (wantsGeneratedKeysAlways) {
-            generatedKeys = new ResultWrapper(((BatchResultHandler) handler).getGeneratedKeys());
+            generatedKeys = new ResultWrapper(((BatchResultHandler)handler).getGeneratedKeys());
         }
-
+            
         return updateCounts;
     }
 
@@ -2951,66 +2980,80 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
      *
      * @exception SQLException only because thats the spec.
      */
-    public void cancel() throws SQLException {
-        if (!STATE_UPDATER.compareAndSet(this, STATE_IN_QUERY, STATE_CANCELLING)) {
+    public void cancel() throws SQLException
+    {
+        if (!STATE_UPDATER.compareAndSet(this, STATE_IN_QUERY, STATE_CANCELLING))
+        {
             // Not in query, there's nothing to cancel
             return;
         }
-        try {
+        try
+        {
             // Synchronize on connection to avoid spinning in killTimerTask
-            synchronized (connection) {
+            synchronized (connection)
+            {
                 connection.cancelQuery();
             }
-        } finally {
+        } finally
+        {
             STATE_UPDATER.set(this, STATE_CANCELLED);
-            synchronized (connection) {
+            synchronized (connection)
+            {
                 connection.notifyAll(); // wake-up killTimerTask
             }
         }
     }
 
-    public Connection getConnection() throws SQLException {
+    public Connection getConnection() throws SQLException
+    {
         return (Connection) connection;
     }
 
-    public int getFetchDirection() {
+    public int getFetchDirection()
+    {
         return fetchdirection;
     }
 
-    public int getResultSetConcurrency() {
+    public int getResultSetConcurrency()
+    {
         return concurrency;
     }
 
-    public int getResultSetType() {
+    public int getResultSetType()
+    {
         return resultsettype;
     }
 
-    public void setFetchDirection(int direction) throws SQLException {
-        switch (direction) {
-            case ResultSet.FETCH_FORWARD:
-            case ResultSet.FETCH_REVERSE:
-            case ResultSet.FETCH_UNKNOWN:
-                fetchdirection = direction;
-                break;
-            default:
-                throw new PSQLException(GT.tr("Invalid fetch direction constant: {0}.", direction),
-                        PSQLState.INVALID_PARAMETER_VALUE);
+    public void setFetchDirection(int direction) throws SQLException
+    {
+        switch (direction)
+        {
+        case ResultSet.FETCH_FORWARD:
+        case ResultSet.FETCH_REVERSE:
+        case ResultSet.FETCH_UNKNOWN:
+            fetchdirection = direction;
+            break;
+        default:
+            throw new PSQLException(GT.tr("Invalid fetch direction constant: {0}.", direction),
+                                    PSQLState.INVALID_PARAMETER_VALUE);
         }
     }
 
-    public void setFetchSize(int rows) throws SQLException {
+    public void setFetchSize(int rows) throws SQLException
+    {
         checkClosed();
-        if (rows < 0) {
+        if (rows < 0)
             throw new PSQLException(GT.tr("Fetch size must be a value greater to or equal to 0."),
-                    PSQLState.INVALID_PARAMETER_VALUE);
-        }
+                                    PSQLState.INVALID_PARAMETER_VALUE);
         fetchSize = rows;
     }
 
-    public void addBatch() throws SQLException {
+    public void addBatch() throws SQLException
+    {
         checkClosed();
 
-        if (batchStatements == null) {
+        if (batchStatements == null)
+        {
             batchStatements = new ArrayList<Query>();
             batchParameters = new ArrayList<ParameterList>();
         }
@@ -3020,11 +3063,12 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
         batchParameters.add(preparedParameters.copy());
     }
 
-    public ResultSetMetaData getMetaData() throws SQLException {
+    public ResultSetMetaData getMetaData() throws SQLException
+    {
         checkClosed();
         ResultSet rs = getResultSet();
 
-        if (rs == null || ((AbstractJdbc2ResultSet) rs).isResultSetClosed()) {
+        if (rs == null || ((AbstractJdbc2ResultSet)rs).isResultSetClosed() ) {
             // OK, we haven't executed it yet, or it was closed
             // we've got to go to the backend
             // for more info.  We send the full query, but just don't
@@ -3039,17 +3083,18 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
             }
         }
 
-        if (rs != null) {
+        if (rs != null)
             return rs.getMetaData();
-        }
 
         return null;
     }
 
-    public void setArray(int i, java.sql.Array x) throws SQLException {
+    public void setArray(int i, java.sql.Array x) throws SQLException
+    {
         checkClosed();
 
-        if (null == x) {
+        if (null == x)
+        {
             setNull(i, Types.ARRAY);
             return;
         }
@@ -3058,12 +3103,12 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
         // literal from Array.toString(), such as the implementation we return
         // from ResultSet.getArray(). Eventually we need a proper implementation
         // here that works for any Array implementation.
+
         // Add special suffix for array identification
         String typename = x.getBaseTypeName() + "[]";
         int oid = connection.getTypeInfo().getPGType(typename);
-        if (oid == Oid.UNSPECIFIED) {
+        if (oid == Oid.UNSPECIFIED)
             throw new PSQLException(GT.tr("Unknown type {0}.", typename), PSQLState.INVALID_PARAMETER_TYPE);
-        }
 
         if (x instanceof AbstractJdbc2Array) {
             AbstractJdbc2Array arr = (AbstractJdbc2Array) x;
@@ -3072,61 +3117,83 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
                 return;
             }
         }
-
+        
         setString(i, x.toString(), oid);
     }
 
-    protected long createBlob(int i, InputStream inputStream, long length) throws SQLException {
+    protected long createBlob(int i, InputStream inputStream, long length) throws SQLException
+    {
         LargeObjectManager lom = connection.getLargeObjectAPI();
         long oid = lom.createLO();
         LargeObject lob = lom.open(oid);
         OutputStream outputStream = lob.getOutputStream();
         byte[] buf = new byte[4096];
-        try {
+        try
+        {
             long remaining;
-            if (length > 0) {
+            if (length > 0)
+            {
                 remaining = length;
-            } else {
+            }
+            else
+            {
                 remaining = Long.MAX_VALUE;
             }
-            int numRead = inputStream.read(buf, 0, (length > 0 && remaining < buf.length ? (int) remaining : buf.length));
-            while (numRead != -1 && remaining > 0) {
+            int numRead = inputStream.read(buf, 0, (length > 0 && remaining < buf.length ? (int)remaining : buf.length));
+            while (numRead != -1 && remaining > 0)
+            {
                 remaining -= numRead;
                 outputStream.write(buf, 0, numRead);
-                numRead = inputStream.read(buf, 0, (length > 0 && remaining < buf.length ? (int) remaining : buf.length));
+                numRead = inputStream.read(buf, 0, (length > 0 && remaining < buf.length ? (int)remaining : buf.length));
             }
-        } catch (IOException se) {
+        }
+        catch (IOException se)
+        {
             throw new PSQLException(GT.tr("Unexpected error writing large object to database."), PSQLState.UNEXPECTED_ERROR, se);
-        } finally {
-            try {
+        }
+        finally
+        {
+            try
+            {
                 outputStream.close();
-            } catch (Exception e) {
+            }
+            catch ( Exception e )
+            {
             }
         }
         return oid;
     }
 
-    public void setBlob(int i, Blob x) throws SQLException {
+    public void setBlob(int i, Blob x) throws SQLException
+    {
         checkClosed();
 
-        if (x == null) {
+        if (x == null)
+        {
             setNull(i, Types.BLOB);
             return;
         }
 
         InputStream inStream = x.getBinaryStream();
-        try {
+        try
+        {
             long oid = createBlob(i, inStream, x.length());
             setLong(i, oid);
-        } finally {
-            try {
+        }
+        finally
+        {
+            try
+            {
                 inStream.close();
-            } catch (Exception e) {
+            }
+            catch ( Exception e )
+            {
             }
         }
     }
 
-    public void setCharacterStream(int i, java.io.Reader x, int length) throws SQLException {
+    public void setCharacterStream(int i, java.io.Reader x, int length) throws SQLException
+    {
         checkClosed();
 
         if (x == null) {
@@ -3138,12 +3205,12 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
             return;
         }
 
-        if (length < 0) {
+        if (length < 0)
             throw new PSQLException(GT.tr("Invalid stream length {0}.", length),
-                    PSQLState.INVALID_PARAMETER_VALUE);
-        }
+                                    PSQLState.INVALID_PARAMETER_VALUE);
 
-        if (connection.haveMinimumCompatibleVersion(ServerVersion.v7_2)) {
+        if (connection.haveMinimumCompatibleVersion(ServerVersion.v7_2))
+        {
             //Version 7.2 supports CharacterStream for for the PG text types
             //As the spec/javadoc for this method indicate this is to be used for
             //large text values (i.e. LONGVARCHAR) PG doesn't have a separate
@@ -3152,24 +3219,28 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
             //setString() since there is no current way to stream the value to the server
             char[] l_chars = new char[length];
             int l_charsRead = 0;
-            try {
-                while (true) {
+            try
+            {
+                while (true)
+                {
                     int n = x.read(l_chars, l_charsRead, length - l_charsRead);
-                    if (n == -1) {
+                    if (n == -1)
                         break;
-                    }
 
                     l_charsRead += n;
 
-                    if (l_charsRead == length) {
+                    if (l_charsRead == length)
                         break;
-                    }
                 }
-            } catch (IOException l_ioe) {
+            }
+            catch (IOException l_ioe)
+            {
                 throw new PSQLException(GT.tr("Provided Reader failed."), PSQLState.UNEXPECTED_ERROR, l_ioe);
             }
             setString(i, new String(l_chars, 0, l_charsRead));
-        } else {
+        }
+        else
+        {
             //Version 7.1 only supported streams for LargeObjects
             //but the jdbc spec indicates that streams should be
             //available for LONGVARCHAR instead
@@ -3177,19 +3248,23 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
             long oid = lom.createLO();
             LargeObject lob = lom.open(oid);
             OutputStream los = lob.getOutputStream();
-            try {
+            try
+            {
                 // could be buffered, but then the OutputStream returned by LargeObject
                 // is buffered internally anyhow, so there would be no performance
                 // boost gained, if anything it would be worse!
                 int c = x.read();
                 int p = 0;
-                while (c > -1 && p < length) {
+                while (c > -1 && p < length)
+                {
                     los.write(c);
                     c = x.read();
                     p++;
                 }
                 los.close();
-            } catch (IOException se) {
+            }
+            catch (IOException se)
+            {
                 throw new PSQLException(GT.tr("Unexpected error writing large object to database."), PSQLState.UNEXPECTED_ERROR, se);
             }
             // lob is closed by the stream so don't call lob.close()
@@ -3197,10 +3272,12 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
         }
     }
 
-    public void setClob(int i, Clob x) throws SQLException {
+    public void setClob(int i, Clob x) throws SQLException
+    {
         checkClosed();
 
-        if (x == null) {
+        if (x == null)
+        {
             setNull(i, Types.CLOB);
             return;
         }
@@ -3213,38 +3290,46 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
         Charset connectionCharset = Charset.forName(connection.getEncoding().name());
         OutputStream los = lob.getOutputStream();
         Writer lw = new OutputStreamWriter(los, connectionCharset);
-        try {
+        try
+        {
             // could be buffered, but then the OutputStream returned by LargeObject
             // is buffered internally anyhow, so there would be no performance
             // boost gained, if anything it would be worse!
             int c = l_inStream.read();
             int p = 0;
-            while (c > -1 && p < l_length) {
+            while (c > -1 && p < l_length)
+            {
                 lw.write(c);
                 c = l_inStream.read();
                 p++;
             }
             lw.close();
-        } catch (IOException se) {
+        }
+        catch (IOException se)
+        {
             throw new PSQLException(GT.tr("Unexpected error writing large object to database."), PSQLState.UNEXPECTED_ERROR, se);
         }
         // lob is closed by the stream so don't call lob.close()
         setLong(i, oid);
     }
 
-    public void setNull(int i, int t, String s) throws SQLException {
+    public void setNull(int i, int t, String s) throws SQLException
+    {
         checkClosed();
         setNull(i, t);
     }
 
-    public void setRef(int i, Ref x) throws SQLException {
+    public void setRef(int i, Ref x) throws SQLException
+    {
         throw Driver.notImplemented(this.getClass(), "setRef(int,Ref)");
     }
 
-    public void setDate(int i, java.sql.Date d, java.util.Calendar cal) throws SQLException {
+    public void setDate(int i, java.sql.Date d, java.util.Calendar cal) throws SQLException
+    {
         checkClosed();
 
-        if (d == null) {
+        if (d == null)
+        {
             setNull(i, Types.DATE);
             return;
         }
@@ -3256,30 +3341,35 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
             preparedParameters.setBinaryParameter(i, val, Oid.DATE);
             return;
         }
-
+        
         // We must use UNSPECIFIED here, or inserting a Date-with-timezone into a
         // timestamptz field does an unexpected rotation by the server's TimeZone:
         //
         // We want to interpret 2005/01/01 with calendar +0100 as
         // "local midnight in +0100", but if we go via date it interprets it
         // as local midnight in the server's timezone:
+
         // template1=# select '2005-01-01+0100'::timestamptz;
         //       timestamptz       
         // ------------------------
         //  2005-01-01 02:00:00+03
         // (1 row)
+
         // template1=# select '2005-01-01+0100'::date::timestamptz;
         //       timestamptz       
         // ------------------------
         //  2005-01-01 00:00:00+03
         // (1 row)
+
         bindString(i, connection.getTimestampUtils().toString(cal, d), Oid.UNSPECIFIED);
     }
 
-    public void setTime(int i, Time t, java.util.Calendar cal) throws SQLException {
+    public void setTime(int i, Time t, java.util.Calendar cal) throws SQLException
+    {
         checkClosed();
 
-        if (t == null) {
+        if (t == null)
+        {
             setNull(i, Types.TIME);
             return;
         }
@@ -3288,7 +3378,7 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
 
         // If a PGTime is used, we can define the OID explicitly.
         if (t instanceof PGTime) {
-            PGTime pgTime = (PGTime) t;
+            PGTime pgTime = (PGTime)t;
             if (pgTime.getCalendar() == null) {
                 oid = Oid.TIME;
             } else {
@@ -3300,7 +3390,8 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
         bindString(i, connection.getTimestampUtils().toString(cal, t), oid);
     }
 
-    public void setTimestamp(int i, Timestamp t, java.util.Calendar cal) throws SQLException {
+    public void setTimestamp(int i, Timestamp t, java.util.Calendar cal) throws SQLException
+    {
         checkClosed();
 
         if (t == null) {
@@ -3318,16 +3409,19 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
         // ------------------------
         //  2005-01-01 18:00:00+13
         // (1 row)
+
         // template1=# select '2005-01-01 15:00:00 +1000'::timestamp;
         //       timestamp      
         // ---------------------
         //  2005-01-01 15:00:00
         // (1 row)        
+
         // template1=# select '2005-01-01 15:00:00 +1000'::timestamptz::timestamp;
         //       timestamp      
         // ---------------------
         //  2005-01-01 18:00:00
         // (1 row)
+        
         // So we want to avoid doing a timestamptz -> timestamp conversion, as that
         // will first convert the timestamptz to an equivalent time in the server's
         // timezone (+1300, above), then turn it into a timestamp with the "wrong"
@@ -3336,9 +3430,10 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
         // the timezone part entirely. Since we don't know ahead of time what type
         // we're actually dealing with, UNSPECIFIED seems the lesser evil, even if it
         // does give more scope for type-mismatch errors being silently hidden.
+
         // If a PGTimestamp is used, we can define the OID explicitly.
         if (t instanceof PGTimestamp) {
-            PGTimestamp pgTimestamp = (PGTimestamp) t;
+            PGTimestamp pgTimestamp = (PGTimestamp)t;
             if (pgTimestamp.getCalendar() == null) {
                 oid = Oid.TIMESTAMP;
             } else {
@@ -3353,79 +3448,88 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
     }
 
     // ** JDBC 2 Extensions for CallableStatement**
-    public java.sql.Array getArray(int i) throws SQLException {
+
+    public java.sql.Array getArray(int i) throws SQLException
+    {
         checkClosed();
         checkIndex(i, Types.ARRAY, "Array");
-        return (Array) callResult[i - 1];
+        return (Array)callResult[i-1];
     }
 
-    public java.math.BigDecimal getBigDecimal(int parameterIndex) throws SQLException {
+    public java.math.BigDecimal getBigDecimal(int parameterIndex) throws SQLException
+    {
         checkClosed();
-        checkIndex(parameterIndex, Types.NUMERIC, "BigDecimal");
-        return ((BigDecimal) callResult[parameterIndex - 1]);
+        checkIndex (parameterIndex, Types.NUMERIC, "BigDecimal");
+        return ((BigDecimal)callResult[parameterIndex-1]);
     }
 
-    public Blob getBlob(int i) throws SQLException {
+    public Blob getBlob(int i) throws SQLException
+    {
         throw Driver.notImplemented(this.getClass(), "getBlob(int)");
     }
 
-    public Clob getClob(int i) throws SQLException {
+    public Clob getClob(int i) throws SQLException
+    {
         throw Driver.notImplemented(this.getClass(), "getClob(int)");
     }
 
-    public Object getObjectImpl(int i, java.util.Map map) throws SQLException {
+    public Object getObjectImpl(int i, java.util.Map map) throws SQLException
+    {
         if (map == null || map.isEmpty()) {
             return getObject(i);
         }
         throw Driver.notImplemented(this.getClass(), "getObjectImpl(int,Map)");
     }
 
-    public Ref getRef(int i) throws SQLException {
+    public Ref getRef(int i) throws SQLException
+    {
         throw Driver.notImplemented(this.getClass(), "getRef(int)");
     }
 
-    public java.sql.Date getDate(int i, java.util.Calendar cal) throws SQLException {
+    public java.sql.Date getDate(int i, java.util.Calendar cal) throws SQLException
+    {
         checkClosed();
         checkIndex(i, Types.DATE, "Date");
 
-        if (callResult[i - 1] == null) {
+        if (callResult[i-1] == null)
             return null;
-        }
 
-        String value = callResult[i - 1].toString();
+        String value = callResult[i-1].toString();
         return connection.getTimestampUtils().toDate(cal, value);
     }
 
-    public Time getTime(int i, java.util.Calendar cal) throws SQLException {
+    public Time getTime(int i, java.util.Calendar cal) throws SQLException
+    {
         checkClosed();
         checkIndex(i, Types.TIME, "Time");
 
-        if (callResult[i - 1] == null) {
+        if (callResult[i-1] == null)
             return null;
-        }
 
-        String value = callResult[i - 1].toString();
+        String value = callResult[i-1].toString();
         return connection.getTimestampUtils().toTime(cal, value);
     }
 
-    public Timestamp getTimestamp(int i, java.util.Calendar cal) throws SQLException {
+    public Timestamp getTimestamp(int i, java.util.Calendar cal) throws SQLException
+    {
         checkClosed();
         checkIndex(i, Types.TIMESTAMP, "Timestamp");
 
-        if (callResult[i - 1] == null) {
+        if (callResult[i-1] == null)
             return null;
-        }
 
-        String value = callResult[i - 1].toString();
+        String value = callResult[i-1].toString();
         return connection.getTimestampUtils().toTimestamp(cal, value);
     }
 
     // no custom types allowed yet..
-    public void registerOutParameter(int parameterIndex, int sqlType, String typeName) throws SQLException {
+    public void registerOutParameter(int parameterIndex, int sqlType, String typeName) throws SQLException
+    {
         throw Driver.notImplemented(this.getClass(), "registerOutParameter(int,int,String)");
     }
 
-    private void startTimer() {
+    private void startTimer()
+    {
         /*
          * there shouldn't be any previous timer active, but better safe than
          * sorry.
@@ -3434,18 +3538,23 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
 
         STATE_UPDATER.set(this, STATE_IN_QUERY);
 
-        if (timeout == 0) {
+        if (timeout == 0)
+        {
             return;
         }
 
         TimerTask cancelTask = new TimerTask() {
-            public void run() {
-                try {
-                    if (!CANCEL_TIMER_UPDATER.compareAndSet(AbstractJdbc2Statement.this, this, null)) {
+            public void run()
+            {
+                try
+                {
+                    if (!CANCEL_TIMER_UPDATER.compareAndSet(AbstractJdbc2Statement.this, this, null))
+                    {
                         return; // Nothing to do here, statement has already finished and cleared cancelTimerTask reference
                     }
                     AbstractJdbc2Statement.this.cancel();
-                } catch (SQLException e) {
+                } catch (SQLException e)
+                {
                 }
             }
         };
@@ -3458,13 +3567,16 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
      * Clears {@link #cancelTimerTask} if any.
      * Returns true if and only if "cancel" timer task would never invoke {@link #cancel()}.
      */
-    private boolean cleanupTimer() {
+    private boolean cleanupTimer()
+    {
         TimerTask timerTask = CANCEL_TIMER_UPDATER.get(this);
-        if (timerTask == null) {
+        if (timerTask == null)
+        {
             // If timeout is zero, then timer task did not exist, so we safely report "all clear"
             return timeout == 0;
         }
-        if (!CANCEL_TIMER_UPDATER.compareAndSet(this, timerTask, null)) {
+        if (!CANCEL_TIMER_UPDATER.compareAndSet(this, timerTask, null))
+        {
             // Failed to update reference -> timer has just fired, so we must wait for the query state to become "cancelling".
             return false;
         }
@@ -3474,34 +3586,42 @@ public abstract class AbstractJdbc2Statement implements BaseStatement {
         return true;
     }
 
-    private void killTimerTask() {
+    private void killTimerTask()
+    {
         boolean timerTaskIsClear = cleanupTimer();
         // The order is important here: in case we need to wait for the cancel task, the state must be
         // kept STATE_IN_QUERY, so cancelTask would be able to cancel the query.
         // It is believed that this case is very rare, so "additional cancel and wait below" would not harm it.
-        if (timerTaskIsClear && STATE_UPDATER.compareAndSet(this, STATE_IN_QUERY, STATE_IDLE)) {
+        if (timerTaskIsClear && STATE_UPDATER.compareAndSet(this, STATE_IN_QUERY, STATE_IDLE))
+        {
             return;
         }
 
         // Being here means someone managed to call .cancel() and our connection did not receive "timeout error"
         // We wait till state becomes "cancelled"
         boolean interrupted = false;
-        while (!STATE_UPDATER.compareAndSet(this, STATE_CANCELLED, STATE_IDLE)) {
-            synchronized (connection) {
-                try {
+        while (!STATE_UPDATER.compareAndSet(this, STATE_CANCELLED, STATE_IDLE))
+        {
+            synchronized (connection)
+            {
+                try
+                {
                     // Note: wait timeout here is irrelevant since synchronized(connection) would block until .cancel finishes
                     connection.wait(10);
-                } catch (InterruptedException e) {
+                } catch (InterruptedException e)
+                {
                     interrupted = true;
                 }
             }
         }
-        if (interrupted) {
+        if (interrupted)
+        {
             Thread.currentThread().interrupt();
         }
     }
 
-    protected boolean getForceBinaryTransfer() {
-        return forceBinaryTransfers;
+    protected boolean getForceBinaryTransfer()
+    {
+        return forceBinaryTransfers;        
     }
 }

--- a/org/postgresql/test/jdbc2/Jdbc2TestSuite.java
+++ b/org/postgresql/test/jdbc2/Jdbc2TestSuite.java
@@ -62,6 +62,7 @@ public class Jdbc2TestSuite extends TestSuite
         suite.addTestSuite(TimezoneTest.class);
         suite.addTestSuite(PGTimeTest.class);
         suite.addTestSuite(PGTimestampTest.class);
+        suite.addTestSuite(JdbcTimestampTest.class);
 
         // PreparedStatement
         suite.addTestSuite(PreparedStatementTest.class);

--- a/org/postgresql/test/jdbc2/Jdbc2TestSuite.java
+++ b/org/postgresql/test/jdbc2/Jdbc2TestSuite.java
@@ -45,7 +45,7 @@ public class Jdbc2TestSuite extends TestSuite
         suite.addTestSuite(EncodingTest.class);
         suite.addTestSuite(ColumnSanitiserDisabledTest.class);
         suite.addTestSuite(ColumnSanitiserEnabledTest.class);
-	suite.addTestSuite(VersionTest.class);
+        suite.addTestSuite(VersionTest.class);
 
         // Connectivity/Protocols
 

--- a/org/postgresql/test/jdbc2/JdbcTimestampTest.java
+++ b/org/postgresql/test/jdbc2/JdbcTimestampTest.java
@@ -58,31 +58,33 @@ public class JdbcTimestampTest extends TestCase
     public void testParameterIsNull() throws SQLException{
         long moment = 1450276739098L;
         PreparedStatement insertStmt = con.prepareStatement("INSERT INTO " + TEST_TABLE + " VALUES (?, ?)");
-        insertStmt.setTimestamp(1, new java.sql.Timestamp(moment++));
-        insertStmt.setTimestamp(2, new java.sql.Timestamp(moment++));
-        assertEquals(1, insertStmt.executeUpdate());
-        insertStmt.setTimestamp(1, new java.sql.Timestamp(moment++));
-        insertStmt.setTimestamp(2, new java.sql.Timestamp(moment++));
-        assertEquals(1, insertStmt.executeUpdate());
-        insertStmt.setTimestamp(1, new java.sql.Timestamp(moment++));
-        insertStmt.setTimestamp(2, new java.sql.Timestamp(moment++));
-        assertEquals(1, insertStmt.executeUpdate());
+        int testRows = 3;
+        for(int i = 0; i < testRows; i++){
+            insertStmt.setTimestamp(1, new java.sql.Timestamp(moment++));
+            insertStmt.setTimestamp(2, new java.sql.Timestamp(moment++));
+            assertEquals("insert in " + TEST_TABLE + " failed", 1, insertStmt.executeUpdate());
+        }
         insertStmt.close();
         PreparedStatement selectStmt = con.prepareStatement("Select * from " + TEST_TABLE + " Where ts = ? or ? is null");
         selectStmt.setTimestamp(1, new java.sql.Timestamp(moment++));
         selectStmt.setTimestamp(2, new java.sql.Timestamp(moment++));
         ResultSet rs1 = selectStmt.executeQuery();
-        assertFalse(rs1.next());
+        int rows1 = 0;
+        while(rs1.next()){
+            ++rows1;
+        }
         rs1.close();
+        assertEquals("Particular moment is found in " + TEST_TABLE, 0, rows1);
         
         selectStmt.setTimestamp(1, new java.sql.Timestamp(moment++));
         selectStmt.setTimestamp(2, null);
         ResultSet rs2 = selectStmt.executeQuery();
-        assertTrue(rs2.next());
-        assertTrue(rs2.next());
-        assertTrue(rs2.next());
-        assertFalse(rs2.next());
+        int rows2 = 0;
+        while(rs2.next()){
+            ++rows2;
+        }
         rs2.close();
+        assertEquals("Not all records are fetched from " + TEST_TABLE, testRows, rows2);
         selectStmt.close();
     }
     

--- a/org/postgresql/test/jdbc2/JdbcTimestampTest.java
+++ b/org/postgresql/test/jdbc2/JdbcTimestampTest.java
@@ -56,26 +56,26 @@ public class JdbcTimestampTest extends TestCase
     }
 
     public void testParameterIsNull() throws SQLException{
-        long now = System.currentTimeMillis();
+        long moment = 1450276739098L;
         PreparedStatement insertStmt = con.prepareStatement("INSERT INTO " + TEST_TABLE + " VALUES (?, ?)");
-        insertStmt.setTimestamp(1, new java.sql.Timestamp(now++));
-        insertStmt.setTimestamp(2, new java.sql.Timestamp(now++));
+        insertStmt.setTimestamp(1, new java.sql.Timestamp(moment++));
+        insertStmt.setTimestamp(2, new java.sql.Timestamp(moment++));
         assertEquals(1, insertStmt.executeUpdate());
-        insertStmt.setTimestamp(1, new java.sql.Timestamp(now++));
-        insertStmt.setTimestamp(2, new java.sql.Timestamp(now++));
+        insertStmt.setTimestamp(1, new java.sql.Timestamp(moment++));
+        insertStmt.setTimestamp(2, new java.sql.Timestamp(moment++));
         assertEquals(1, insertStmt.executeUpdate());
-        insertStmt.setTimestamp(1, new java.sql.Timestamp(now++));
-        insertStmt.setTimestamp(2, new java.sql.Timestamp(now++));
+        insertStmt.setTimestamp(1, new java.sql.Timestamp(moment++));
+        insertStmt.setTimestamp(2, new java.sql.Timestamp(moment++));
         assertEquals(1, insertStmt.executeUpdate());
         insertStmt.close();
         PreparedStatement selectStmt = con.prepareStatement("Select * from " + TEST_TABLE + " Where ts = ? or ? is null");
-        selectStmt.setTimestamp(1, new java.sql.Timestamp(now++));
-        selectStmt.setTimestamp(2, new java.sql.Timestamp(now++));
+        selectStmt.setTimestamp(1, new java.sql.Timestamp(moment++));
+        selectStmt.setTimestamp(2, new java.sql.Timestamp(moment++));
         ResultSet rs1 = selectStmt.executeQuery();
         assertFalse(rs1.next());
         rs1.close();
         
-        selectStmt.setTimestamp(1, new java.sql.Timestamp(now++));
+        selectStmt.setTimestamp(1, new java.sql.Timestamp(moment++));
         selectStmt.setTimestamp(2, null);
         ResultSet rs2 = selectStmt.executeQuery();
         assertTrue(rs2.next());
@@ -95,15 +95,15 @@ public class JdbcTimestampTest extends TestCase
      */
     public void testTimeInsertAndSelect() throws SQLException
     {
-        final long now = System.currentTimeMillis();
-        verifyInsertAndSelect(new PGTimestamp(now), true);
-        verifyInsertAndSelect(new PGTimestamp(now), false);
+        final long moment = 1450276827047L;
+        verifyInsertAndSelect(new PGTimestamp(moment), true);
+        verifyInsertAndSelect(new PGTimestamp(moment), false);
 
-        verifyInsertAndSelect(new PGTimestamp(now, Calendar.getInstance(TimeZone.getTimeZone("GMT"))), true);
-        verifyInsertAndSelect(new PGTimestamp(now, Calendar.getInstance(TimeZone.getTimeZone("GMT"))), false);
+        verifyInsertAndSelect(new PGTimestamp(moment, Calendar.getInstance(TimeZone.getTimeZone("GMT"))), true);
+        verifyInsertAndSelect(new PGTimestamp(moment, Calendar.getInstance(TimeZone.getTimeZone("GMT"))), false);
 
-        verifyInsertAndSelect(new PGTimestamp(now, Calendar.getInstance(TimeZone.getTimeZone("GMT+01:00"))), true);
-        verifyInsertAndSelect(new PGTimestamp(now, Calendar.getInstance(TimeZone.getTimeZone("GMT+01:00"))), false);
+        verifyInsertAndSelect(new PGTimestamp(moment, Calendar.getInstance(TimeZone.getTimeZone("GMT+01:00"))), true);
+        verifyInsertAndSelect(new PGTimestamp(moment, Calendar.getInstance(TimeZone.getTimeZone("GMT+01:00"))), false);
     }
 
     /**

--- a/org/postgresql/test/jdbc2/JdbcTimestampTest.java
+++ b/org/postgresql/test/jdbc2/JdbcTimestampTest.java
@@ -1,0 +1,214 @@
+/*-------------------------------------------------------------------------
+*
+* Copyright (c) 2004-2014, PostgreSQL Global Development Group
+*
+*
+*-------------------------------------------------------------------------
+*/
+package org.postgresql.test.jdbc2;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Timestamp;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Properties;
+import java.util.TimeZone;
+
+import junit.framework.TestCase;
+
+import org.postgresql.PGProperty;
+import org.postgresql.test.TestUtil;
+import org.postgresql.util.PGTimestamp;
+
+/**
+ * Tests {@link java.sql.Timestamp and PGTimestamp} in various scenarios including setTimestamp, setObject for both
+ * <code>timestamp with time zone</code> and <code>timestamp without time zone</code> data types.
+ */
+public class JdbcTimestampTest extends TestCase
+{
+    /** The name of the test table. */
+    private static final String TEST_TABLE = "testjdbctimestamp";
+
+    /** The database connection. */
+    private Connection con;
+
+    public JdbcTimestampTest(final String name)
+    {
+        super(name);
+    }
+
+    protected void setUp() throws Exception
+    {
+        Properties props = new Properties();
+        props.setProperty(PGProperty.STRICT_TIMESTAMP.getName(), "true");
+        con = TestUtil.openDB(props);
+        TestUtil.createTable(con, TEST_TABLE, "ts timestamp, tz timestamp with time zone");
+    }
+
+    protected void tearDown() throws Exception
+    {
+        TestUtil.dropTable(con, TEST_TABLE);
+        TestUtil.closeDB(con);
+    }
+
+    public void testParameterIsNull() throws SQLException{
+        long now = System.currentTimeMillis();
+        PreparedStatement insertStmt = con.prepareStatement("INSERT INTO " + TEST_TABLE + " VALUES (?, ?)");
+        insertStmt.setTimestamp(1, new java.sql.Timestamp(now++));
+        insertStmt.setTimestamp(2, new java.sql.Timestamp(now++));
+        assertEquals(1, insertStmt.executeUpdate());
+        insertStmt.setTimestamp(1, new java.sql.Timestamp(now++));
+        insertStmt.setTimestamp(2, new java.sql.Timestamp(now++));
+        assertEquals(1, insertStmt.executeUpdate());
+        insertStmt.setTimestamp(1, new java.sql.Timestamp(now++));
+        insertStmt.setTimestamp(2, new java.sql.Timestamp(now++));
+        assertEquals(1, insertStmt.executeUpdate());
+        insertStmt.close();
+        PreparedStatement selectStmt = con.prepareStatement("Select * from " + TEST_TABLE + " Where ts = ? or ? is null");
+        selectStmt.setTimestamp(1, new java.sql.Timestamp(now++));
+        selectStmt.setTimestamp(2, new java.sql.Timestamp(now++));
+        ResultSet rs1 = selectStmt.executeQuery();
+        assertFalse(rs1.next());
+        rs1.close();
+        
+        selectStmt.setTimestamp(1, new java.sql.Timestamp(now++));
+        selectStmt.setTimestamp(2, null);
+        ResultSet rs2 = selectStmt.executeQuery();
+        assertTrue(rs2.next());
+        assertTrue(rs2.next());
+        assertTrue(rs2.next());
+        assertFalse(rs2.next());
+        rs2.close();
+        selectStmt.close();
+    }
+    
+    /**
+     * Tests inserting and selecting <code>PGTimestamp</code> objects with
+     * <code>timestamp</code> and <code>timestamp with time zone</code> columns.
+     *
+     * @throws SQLException
+     *            if a JDBC or database problem occurs.
+     */
+    public void testTimeInsertAndSelect() throws SQLException
+    {
+        final long now = System.currentTimeMillis();
+        verifyInsertAndSelect(new PGTimestamp(now), true);
+        verifyInsertAndSelect(new PGTimestamp(now), false);
+
+        verifyInsertAndSelect(new PGTimestamp(now, Calendar.getInstance(TimeZone.getTimeZone("GMT"))), true);
+        verifyInsertAndSelect(new PGTimestamp(now, Calendar.getInstance(TimeZone.getTimeZone("GMT"))), false);
+
+        verifyInsertAndSelect(new PGTimestamp(now, Calendar.getInstance(TimeZone.getTimeZone("GMT+01:00"))), true);
+        verifyInsertAndSelect(new PGTimestamp(now, Calendar.getInstance(TimeZone.getTimeZone("GMT+01:00"))), false);
+    }
+
+    /**
+     * Verifies that inserting the given <code>PGTimestamp</code> as a timestamp 
+     * string and an object produces the same results.
+     *
+     * @param timestamp
+     *           the timestamp to test.
+     * @param useSetObject
+     *           <code>true</code> if the setObject method should be used instead
+     *           of setTimestamp.
+     * @throws SQLException
+     *            if a JDBC or database problem occurs.
+     */
+    private void verifyInsertAndSelect(PGTimestamp timestamp, boolean useSetObject) throws SQLException
+    {
+        // Construct the INSERT statement of a casted timestamp string.
+        String sql;
+        if (timestamp.getCalendar() != null)
+        {
+            sql = "INSERT INTO " + TEST_TABLE + " VALUES (?::timestamp with time zone, ?::timestamp with time zone)";
+        }
+        else
+        {
+            sql = "INSERT INTO " + TEST_TABLE + " VALUES (?::timestamp, ?::timestamp)";
+        }
+
+        SimpleDateFormat sdf = createSimpleDateFormat(timestamp);
+
+        // Insert the timestamps as casted strings.
+        PreparedStatement pstmt1 = con.prepareStatement(sql);
+        pstmt1.setString(1, sdf.format(timestamp));
+        pstmt1.setString(2, sdf.format(timestamp));
+        assertEquals(1, pstmt1.executeUpdate());
+
+        // Insert the timestamps as PGTimestamp objects.
+        PreparedStatement pstmt2 = con.prepareStatement("INSERT INTO " + TEST_TABLE + " VALUES (?, ?)");
+
+        if (useSetObject)
+        {
+            pstmt2.setObject(1, new java.sql.Timestamp(timestamp.getTime()));
+            pstmt2.setObject(2, timestamp);
+        }
+        else
+        {
+            pstmt2.setTimestamp(1, new java.sql.Timestamp(timestamp.getTime()));
+            pstmt2.setTimestamp(2, timestamp);
+        }
+
+        assertEquals(1, pstmt2.executeUpdate());
+
+        // Query the values back out.
+        Statement stmt = con.createStatement();
+
+        ResultSet rs = stmt.executeQuery(TestUtil.selectSQL(TEST_TABLE, "ts,tz"));
+        assertNotNull(rs);
+
+        // Read the casted string values.
+        assertTrue(rs.next());
+
+        Timestamp ts1 = rs.getTimestamp(1);
+        Timestamp tz1 = rs.getTimestamp(2);
+
+        // System.out.println(pstmt1 + " -> " + ts1 + ", " + sdf.format(tz1));
+
+        // Read the PGTimestamp values.
+        assertTrue(rs.next());
+
+        Timestamp ts2 = rs.getTimestamp(1);
+        Timestamp tz2 = rs.getTimestamp(2);
+
+        // System.out.println(pstmt2 + " -> " + ts2 + ", " + sdf.format(tz2));
+
+        // Verify that the first and second versions match.
+        assertEquals(ts1, ts2);
+        assertEquals(tz1, tz2);
+
+        // Clean up.
+        assertEquals(2, stmt.executeUpdate("DELETE FROM " + TEST_TABLE));
+        stmt.close();
+        pstmt2.close();
+        pstmt1.close();
+    }
+
+    /**
+     * Creates a <code>SimpleDateFormat</code> that is appropriate for the given timestamp.
+     *
+     * @param timestamp
+     *           the timestamp object.
+     * @return the new format instance.
+     */
+    private SimpleDateFormat createSimpleDateFormat(PGTimestamp timestamp)
+    {
+        String pattern = "yyyy-MM-dd HH:mm:ss.SSS";
+        if (timestamp.getCalendar() != null)
+        {
+            pattern += " Z";
+        }
+
+        SimpleDateFormat sdf = new SimpleDateFormat(pattern);
+        if (timestamp.getCalendar() != null)
+        {
+            sdf.setTimeZone(timestamp.getCalendar().getTimeZone());
+        }
+        return sdf;
+    }
+    
+}


### PR DESCRIPTION
setTimeStamp(int i, Timestamp t, java.util.Calendar cal) method loses information about type of a value.
It finds a calendar for time soze offset calculations from PGTimestamp only!
Instead, it should use information from a client code (`cal` parameter) or from both sources.
setNull(int parameterIndex, int sqlType) loses information about type of a timestamp also.

Please, fix timestamps type information!
