### PR TITLE
perf: Cache server version number

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/v3/ProtocolConnectionImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/ProtocolConnectionImpl.java
@@ -57,7 +57,7 @@ class ProtocolConnectionImpl implements ProtocolConnection {
     public int getServerVersionNum() {
         if (serverVersionNum != 0)
             return serverVersionNum;
-        return Utils.parseServerVersionStr(serverVersion);
+        return serverVersionNum = Utils.parseServerVersionStr(serverVersion);
     }
 
     public synchronized boolean getStandardConformingStrings()


### PR DESCRIPTION
Save version number after parsing it from string.
No need to recalculate it again.

This improves Statement.setObject(int, UUID) which ckecks for server version.