### PR TITLE
perf: Add guards around debug log statements

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/Driver.java
+++ b/pgjdbc/src/main/java/org/postgresql/Driver.java
@@ -149,7 +149,8 @@ public class Driver implements java.sql.Driver
             return merged; // Give up on finding defaults.
         }
 
-        logger.debug("Loading driver configuration via classloader " + cl);
+        if (logger.logDebug())
+            logger.debug("Loading driver configuration via classloader " + cl);
 
         // When loading the driver config files we don't want settings found
         // in later files in the classpath to override settings specified in
@@ -164,7 +165,8 @@ public class Driver implements java.sql.Driver
 
         for (int i=urls.size()-1; i>=0; i--) {
             URL url = urls.get(i);
-            logger.debug("Loading driver configuration from: " + url);
+            if (logger.logDebug())
+                logger.debug("Loading driver configuration from: " + url);
             InputStream is = url.openStream();
             merged.load(is);
             is.close();
@@ -267,12 +269,14 @@ public class Driver implements java.sql.Driver
         // parse URL and add more properties
         if ((props = parseURL(url, props)) == null)
         {
-            logger.debug("Error in url: " + url);
+            if (logger.logDebug())
+                logger.debug("Error in url: " + url);
             return null;
         }
         try
         {
-            logger.debug("Connecting with URL: " + url);
+            if (logger.logDebug())
+                logger.debug("Connecting with URL: " + url);
 
             // Enforce login timeout, if specified, by running the connection
             // attempt in a separate thread. If we hit the timeout without the
@@ -660,7 +664,8 @@ public class Driver implements java.sql.Driver
             } catch (NumberFormatException e) {
                 // Log level isn't set yet, so this doesn't actually 
                 // get printed.
-                logger.debug("Couldn't parse loginTimeout value: " + timeout);
+                if (logger.logDebug())
+                    logger.debug("Couldn't parse loginTimeout value: " + timeout);
             }
         }
         return (long) DriverManager.getLoginTimeout() * 1000;

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java
@@ -559,7 +559,8 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
                                     logger);
                             
                             useSSPI = sspiClient.isSSPISupported();
-                            logger.debug("SSPI support detected: " + useSSPI);
+                            if (logger.logDebug())
+                                logger.debug("SSPI support detected: " + useSSPI);
                         
                             if (!useSSPI) {
                                 /* No need to dispose() if no SSPI used */
@@ -570,7 +571,8 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
                                             PSQLState.CONNECTION_UNABLE_TO_CONNECT);
                             }
                             
-                            logger.debug("Using SSPI: " + useSSPI + ", gsslib="+gsslib+" and SSPI support detected");
+                            if (logger.logDebug())
+                                logger.debug("Using SSPI: " + useSSPI + ", gsslib="+gsslib+" and SSPI support detected");
                         }
 
                         if (useSSPI)

--- a/pgjdbc/src/main/java/org/postgresql/sspi/SSPIClient.java
+++ b/pgjdbc/src/main/java/org/postgresql/sspi/SSPIClient.java
@@ -137,7 +137,8 @@ public class SSPIClient {
 	     */
 		final String securityPackage = enableNegotiate ? "negotiate" : "kerberos";
 		
-		logger.debug("Beginning SSPI/Kerberos negotiation with SSPI package: " + securityPackage);
+		if (logger.logDebug())
+		    logger.debug("Beginning SSPI/Kerberos negotiation with SSPI package: " + securityPackage);
 
 		try {
     		/* 


### PR DESCRIPTION
Some debug log statements that construct messages using string
concatenation are not surrounded by guard statements. This results in
unnecessary allocation when debug logging is not enabled.

Add guards around debug log statements where necessary.