### PR TITLE
fix: Do not swallow security exceptions

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/ssl/SingleCertValidatingFactory.java
+++ b/pgjdbc/src/main/java/org/postgresql/ssl/SingleCertValidatingFactory.java
@@ -151,11 +151,8 @@ public class SingleCertValidatingFactory extends WrappedFactory {
 
         public SingleCertTrustManager(InputStream in) throws IOException, GeneralSecurityException {
             KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
-            try {
-                // Note: KeyStore requires it be loaded even if you don't load anything into it:
-                ks.load(null);
-            } catch (Exception e) {
-            }
+            // Note: KeyStore requires it be loaded even if you don't load anything into it:
+            ks.load(null);
             CertificateFactory cf = CertificateFactory.getInstance("X509");
             cert = (X509Certificate) cf.generateCertificate(in);
             ks.setCertificateEntry(UUID.randomUUID().toString(), cert);

--- a/pgjdbc/src/main/java/org/postgresql/util/MD5Digest.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/MD5Digest.java
@@ -15,6 +15,7 @@ package org.postgresql.util;
  */
 
 import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 
 public class MD5Digest
 {
@@ -56,9 +57,9 @@ public class MD5Digest
             hex_digest[1] = (byte) 'd';
             hex_digest[2] = (byte) '5';
         }
-        catch (Exception e)
+        catch (NoSuchAlgorithmException e)
         {
-            ; // "MessageDigest failure; " + e
+            throw new RuntimeException("MessageDigest failure; ", e);
         }
 
         return hex_digest;


### PR DESCRIPTION
There are two cases where the driver currently swallows security
exceptions. The first is in MD5Digest and the second is in
SingleCertValidatingFactory. In both cases the code will result in
partially initialized objects being used which will result in follow up
exceptions later on. These will be hard to track down since the
original exception was swallowed.

Wrap and propagate security exceptions instead of swallowing them.