### PR TITLE
feat: implement getObject

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
@@ -40,6 +40,8 @@ import java.io.Reader;
 import java.io.UnsupportedEncodingException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.sql.Array;
 import java.sql.Blob;
 import java.sql.Clob;
@@ -57,7 +59,15 @@ import java.sql.Statement;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.sql.Types;
+//#if mvn.project.property.postgresql.jdbc.spec >= "JDBC4.2"
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+//#endif
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -3122,7 +3132,204 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
   }
 
   public <T> T getObject(int columnIndex, Class<T> type) throws SQLException {
-    throw org.postgresql.Driver.notImplemented(this.getClass(), "getObject(int, Class<T>)");
+    if (type == null) {
+      throw new SQLException("type ist null");
+    }
+    int sqlType = getSQLType(columnIndex);
+    if (type == BigDecimal.class) {
+      if (sqlType == Types.NUMERIC || sqlType == Types.DECIMAL) {
+        return type.cast(getBigDecimal(columnIndex));
+      } else {
+        throw new SQLException("conversion to " + type + " from " + sqlType + " not supported");
+      }
+    } else if (type == String.class) {
+      if (sqlType == Types.CHAR || sqlType == Types.VARCHAR) {
+        return type.cast(getString(columnIndex));
+      } else {
+        throw new SQLException("conversion to " + type + " from " + sqlType + " not supported");
+      }
+    } else if (type == Boolean.class) {
+      if (sqlType == Types.BOOLEAN || sqlType == Types.BIT) {
+        boolean booleanValue = getBoolean(columnIndex);
+        if (wasNull()) {
+          return null;
+        }
+        return type.cast(booleanValue);
+      } else {
+        throw new SQLException("conversion to " + type + " from " + sqlType + " not supported");
+      }
+    } else if (type == Integer.class) {
+      if (sqlType == Types.SMALLINT || sqlType == Types.INTEGER) {
+        int intValue = getInt(columnIndex);
+        if (wasNull()) {
+          return null;
+        }
+        return type.cast(intValue);
+      } else {
+        throw new SQLException("conversion to " + type + " from " + sqlType + " not supported");
+      }
+    } else if (type == Long.class) {
+      if (sqlType == Types.BIGINT) {
+        long longValue = getLong(columnIndex);
+        if (wasNull()) {
+          return null;
+        }
+        return type.cast(longValue);
+      } else {
+        throw new SQLException("conversion to " + type + " from " + sqlType + " not supported");
+      }
+    } else if (type == Float.class) {
+      if (sqlType == Types.REAL) {
+        float floatValue = getFloat(columnIndex);
+        if (wasNull()) {
+          return null;
+        }
+        return type.cast(floatValue);
+      } else {
+        throw new SQLException("conversion to " + type + " from " + sqlType + " not supported");
+      }
+    } else if (type == Double.class) {
+      if (sqlType == Types.FLOAT || sqlType == Types.DOUBLE) {
+        double doubleValue = getDouble(columnIndex);
+        if (wasNull()) {
+          return null;
+        }
+        return type.cast(doubleValue);
+      } else {
+        throw new SQLException("conversion to " + type + " from " + sqlType + " not supported");
+      }
+    } else if (type == Date.class) {
+      if (sqlType == Types.DATE) {
+        return type.cast(getDate(columnIndex));
+      } else {
+        throw new SQLException("conversion to " + type + " from " + sqlType + " not supported");
+      }
+    } else if (type == Time.class) {
+      if (sqlType == Types.TIME) {
+        return type.cast(getTime(columnIndex));
+      } else {
+        throw new SQLException("conversion to " + type + " from " + sqlType + " not supported");
+      }
+    } else if (type == Timestamp.class) {
+      if (sqlType == Types.TIMESTAMP
+              //#if mvn.project.property.postgresql.jdbc.spec >= "JDBC4.2"
+              || sqlType == Types.TIMESTAMP_WITH_TIMEZONE
+      //#endif
+      ) {
+        return type.cast(getTimestamp(columnIndex));
+      } else {
+        throw new SQLException("conversion to " + type + " from " + sqlType + " not supported");
+      }
+    } else if (type == Calendar.class) {
+      if (sqlType == Types.TIMESTAMP
+              //#if mvn.project.property.postgresql.jdbc.spec >= "JDBC4.2"
+              || sqlType == Types.TIMESTAMP_WITH_TIMEZONE
+      //#endif
+      ) {
+        Timestamp timestampValue = getTimestamp(columnIndex);
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTimeInMillis(timestampValue.getTime());
+        return type.cast(calendar);
+      } else {
+        throw new SQLException("conversion to " + type + " from " + sqlType + " not supported");
+      }
+    } else if (type == Blob.class) {
+      if (sqlType == Types.BLOB || sqlType == Types.BINARY || sqlType == Types.BIGINT) {
+        return type.cast(getBlob(columnIndex));
+      } else {
+        throw new SQLException("conversion to " + type + " from " + sqlType + " not supported");
+      }
+    } else if (type == Clob.class) {
+      if (sqlType == Types.CLOB || sqlType == Types.BIGINT) {
+        return type.cast(getClob(columnIndex));
+      } else {
+        throw new SQLException("conversion to " + type + " from " + sqlType + " not supported");
+      }
+    } else if (type == NClob.class) {
+      if (sqlType == Types.NCLOB) {
+        return type.cast(getNClob(columnIndex));
+      } else {
+        throw new SQLException("conversion to " + type + " from " + sqlType + " not supported");
+      }
+    } else if (type == Array.class) {
+      if (sqlType == Types.ARRAY) {
+        return type.cast(getArray(columnIndex));
+      } else {
+        throw new SQLException("conversion to " + type + " from " + sqlType + " not supported");
+      }
+    } else if (type == SQLXML.class) {
+      if (sqlType == Types.SQLXML) {
+        return type.cast(getSQLXML(columnIndex));
+      } else {
+        throw new SQLException("conversion to " + type + " from " + sqlType + " not supported");
+      }
+    } else if (type == UUID.class) {
+      return type.cast(getObject(columnIndex));
+    } else if (type == InetAddress.class) {
+      Object addressString = getObject(columnIndex);
+      if (addressString == null) {
+        return null;
+      }
+      try {
+        return type.cast(InetAddress.getByName(((PGobject) addressString).getValue()));
+      } catch (UnknownHostException e) {
+        throw new SQLException("could not create inet address from string '" + addressString + "'");
+      }
+      // JSR-310 support
+      //#if mvn.project.property.postgresql.jdbc.spec >= "JDBC4.2"
+    } else if (type == LocalDate.class) {
+      if (sqlType == Types.DATE) {
+        Date dateValue = getDate(columnIndex);
+        if (wasNull()) {
+          return null;
+        }
+        return type.cast(dateValue.toLocalDate());
+      } else {
+        throw new SQLException("conversion to " + type + " from " + sqlType + " not supported");
+      }
+    } else if (type == LocalTime.class) {
+      if (sqlType == Types.TIME) {
+        Time timeValue = getTime(columnIndex);
+        if (wasNull()) {
+          return null;
+        }
+        return type.cast(timeValue.toLocalTime());
+      } else {
+        throw new SQLException("conversion to " + type + " from " + sqlType + " not supported");
+      }
+    } else if (type == LocalDateTime.class) {
+      if (sqlType == Types.TIMESTAMP) {
+        Timestamp timestampValue = getTimestamp(columnIndex);
+        if (wasNull()) {
+          return null;
+        }
+        return type.cast(timestampValue.toLocalDateTime());
+      } else {
+        throw new SQLException("conversion to " + type + " from " + sqlType + " not supported");
+      }
+    } else if (type == OffsetDateTime.class) {
+      if (sqlType == Types.TIMESTAMP_WITH_TIMEZONE || sqlType == Types.TIMESTAMP) {
+        Timestamp timestampValue = getTimestamp(columnIndex);
+        if (wasNull()) {
+          return null;
+        }
+        // Postgres stores everything in UTC and does not keep original time zone
+        OffsetDateTime offsetDateTime = OffsetDateTime.ofInstant(timestampValue.toInstant(), ZoneOffset.UTC);
+        return type.cast(offsetDateTime);
+      } else {
+        throw new SQLException("conversion to " + type + " from " + sqlType + " not supported");
+      }
+      //#endif
+    } else if (PGobject.class.isAssignableFrom(type)) {
+      Object object;
+      if (isBinary(columnIndex)) {
+        object = connection.getObject(getPGType(columnIndex), null, this_row[columnIndex - 1]);
+      } else {
+        object = connection.getObject(getPGType(columnIndex), getString(columnIndex), null);
+      }
+      return type.cast(object);
+    }
+    throw new SQLException("unsupported conversion to " + type);
   }
 
   public <T> T getObject(String columnLabel, Class<T> type) throws SQLException {

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc4/jdbc41/GetObjectTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc4/jdbc41/GetObjectTest.java
@@ -1,0 +1,842 @@
+package org.postgresql.test.jdbc4.jdbc41;
+
+
+import org.postgresql.core.BaseConnection;
+import org.postgresql.core.ServerVersion;
+import org.postgresql.geometric.PGbox;
+import org.postgresql.geometric.PGcircle;
+import org.postgresql.geometric.PGline;
+import org.postgresql.geometric.PGlseg;
+import org.postgresql.geometric.PGpath;
+import org.postgresql.geometric.PGpoint;
+import org.postgresql.geometric.PGpolygon;
+import org.postgresql.test.TestUtil;
+import org.postgresql.util.PGInterval;
+import org.postgresql.util.PGmoney;
+
+import junit.framework.TestCase;
+
+import org.junit.Assert;
+
+import java.math.BigDecimal;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.sql.Array;
+import java.sql.Blob;
+import java.sql.Clob;
+import java.sql.Connection;
+import java.sql.Date;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.SQLXML;
+import java.sql.Statement;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.TimeZone;
+import java.util.UUID;
+
+import javax.sql.rowset.serial.SerialBlob;
+import javax.sql.rowset.serial.SerialClob;
+
+public class GetObjectTest extends TestCase {
+
+  private static final TimeZone UTC = TimeZone.getTimeZone("UTC"); // +0000 always
+  private static final TimeZone GMT03 = TimeZone.getTimeZone("GMT+03"); // +0300 always
+  private static final TimeZone GMT05 = TimeZone.getTimeZone("GMT-05"); // -0500 always
+  private static final TimeZone GMT13 = TimeZone.getTimeZone("GMT+13"); // +1300 always
+
+  private Connection _conn;
+
+  public GetObjectTest(String name) {
+    super(name);
+  }
+
+  protected void setUp() throws Exception {
+    _conn = TestUtil.openDB();
+    TestUtil.createTable(_conn, "table1", "varchar_column varchar(16), "
+            + "char_column char(10), "
+            + "boolean_column boolean,"
+            + "smallint_column smallint,"
+            + "integer_column integer,"
+            + "bigint_column bigint,"
+            + "decimal_column decimal,"
+            + "numeric_column numeric,"
+            // smallserial requires 9.2 or later
+            + (((BaseConnection) _conn).haveMinimumServerVersion(ServerVersion.v9_2) ? "smallserial_column smallserial," : "")
+            + "serial_column serial,"
+            + "bigserial_column bigserial,"
+            + "real_column real,"
+            + "double_column double precision,"
+            + "timestamp_without_time_zone_column timestamp without time zone,"
+            + "timestamp_with_time_zone_column timestamp with time zone,"
+            + "date_column date,"
+            + "time_without_time_zone_column time without time zone,"
+            + "time_with_time_zone_column time with time zone,"
+            + "blob_column bytea,"
+            + "lob_column oid,"
+            + "array_column text[],"
+            + "point_column point,"
+            + "line_column line,"
+            + "lseg_column lseg,"
+            + "box_column box,"
+            + "path_column path,"
+            + "polygon_column polygon,"
+            + "circle_column circle,"
+            + "money_column money,"
+            + "interval_column interval,"
+            + "uuid_column uuid,"
+            + "inet_column inet,"
+            + "cidr_column cidr,"
+            + "macaddr_column macaddr,"
+            + "xml_column xml"
+    );
+  }
+
+  protected void tearDown() throws SQLException {
+    TestUtil.dropTable(_conn, "table1");
+    TestUtil.closeDB( _conn );
+  }
+
+  /**
+   * Test the behavior getObject for string columns.
+   */
+  public void testGetString() throws SQLException {
+    Statement stmt = _conn.createStatement();
+    stmt.executeUpdate(TestUtil.insertSQL("table1","varchar_column,char_column","'varchar_value','char_value'"));
+
+    ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("table1", "varchar_column, char_column"));
+    try {
+      assertTrue(rs.next());
+      assertEquals("varchar_value", rs.getObject("varchar_column", String.class));
+      assertEquals("varchar_value", rs.getObject(1, String.class));
+      assertEquals("char_value", rs.getObject("char_column", String.class));
+      assertEquals("char_value", rs.getObject(2, String.class));
+    } finally {
+      rs.close();
+    }
+  }
+
+  /**
+   * Test the behavior getObject for string columns.
+   */
+  public void testGetClob() throws SQLException {
+    Statement stmt = _conn.createStatement();
+    _conn.setAutoCommit(false);
+    try {
+      char[] data = new char[]{'d', 'e', 'a', 'd', 'b', 'e', 'e', 'f'};
+      PreparedStatement insertPS = _conn.prepareStatement(TestUtil.insertSQL("table1", "lob_column", "?"));
+      try {
+        insertPS.setObject(1, new SerialClob(data), Types.CLOB);
+        insertPS.executeUpdate();
+      } finally {
+        insertPS.close();
+      }
+
+      ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("table1", "lob_column"));
+      try {
+        assertTrue(rs.next());
+        Clob blob = rs.getObject("lob_column", Clob.class);
+        assertEquals(data.length, blob.length());
+        assertEquals(new String(data), blob.getSubString(1, data.length));
+        blob.free();
+
+        blob = rs.getObject(1, Clob.class);
+        assertEquals(data.length, blob.length());
+        assertEquals(new String(data), blob.getSubString(1, data.length));
+        blob.free();
+      } finally {
+        rs.close();
+      }
+    } finally {
+      _conn.setAutoCommit(true);
+    }
+  }
+
+  /**
+   * Test the behavior getObject for big decimal columns.
+   */
+  public void testGetBigDecimal() throws SQLException {
+    Statement stmt = _conn.createStatement();
+    stmt.executeUpdate(TestUtil.insertSQL("table1","decimal_column,numeric_column","0.1,0.1"));
+
+    ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("table1", "decimal_column, numeric_column"));
+    try {
+      assertTrue(rs.next());
+      assertEquals(new BigDecimal("0.1"), rs.getObject("decimal_column", BigDecimal.class));
+      assertEquals(new BigDecimal("0.1"), rs.getObject(1, BigDecimal.class));
+      assertEquals(new BigDecimal("0.1"), rs.getObject("numeric_column", BigDecimal.class));
+      assertEquals(new BigDecimal("0.1"), rs.getObject(2, BigDecimal.class));
+    } finally {
+      rs.close();
+    }
+  }
+
+  /**
+   * Test the behavior getObject for timestamp columns.
+   */
+  public void testGetTimestamp() throws SQLException {
+    Statement stmt = _conn.createStatement();
+    stmt.executeUpdate(TestUtil.insertSQL("table1","timestamp_without_time_zone_column","TIMESTAMP '2004-10-19 10:23:54'"));
+
+    ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("table1", "timestamp_without_time_zone_column"));
+    try {
+      assertTrue(rs.next());
+      Calendar calendar = GregorianCalendar.getInstance();
+      calendar.clear();
+      calendar.set(Calendar.YEAR, 2004);
+      calendar.set(Calendar.MONTH, Calendar.OCTOBER);
+      calendar.set(Calendar.DAY_OF_MONTH, 19);
+      calendar.set(Calendar.HOUR_OF_DAY, 10);
+      calendar.set(Calendar.MINUTE, 23);
+      calendar.set(Calendar.SECOND, 54);
+      Timestamp expectedNoZone = new Timestamp(calendar.getTimeInMillis());
+      assertEquals(expectedNoZone, rs.getObject("timestamp_without_time_zone_column", Timestamp.class));
+      assertEquals(expectedNoZone, rs.getObject(1, Timestamp.class));
+    } finally {
+      rs.close();
+    }
+  }
+
+  /**
+   * Test the behavior getObject for timestamp columns.
+   */
+  public void testGetTimestampWithTimeZone() throws SQLException {
+    runGetTimestampWithTimeZone(UTC, "Z");
+    runGetTimestampWithTimeZone(GMT03, "+03:00");
+    runGetTimestampWithTimeZone(GMT05, "-05:00");
+    runGetTimestampWithTimeZone(GMT13, "+13:00");
+  }
+
+  private void runGetTimestampWithTimeZone(TimeZone timeZone, String zoneString) throws SQLException {
+    Statement stmt = _conn.createStatement();
+    try {
+      stmt.executeUpdate(TestUtil.insertSQL("table1","timestamp_with_time_zone_column","TIMESTAMP WITH TIME ZONE '2004-10-19 10:23:54" + zoneString + "'"));
+
+      ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("table1", "timestamp_with_time_zone_column"));
+      try {
+        assertTrue(rs.next());
+
+        Calendar calendar = GregorianCalendar.getInstance(timeZone);
+        calendar.clear();
+        calendar.set(Calendar.YEAR, 2004);
+        calendar.set(Calendar.MONTH, Calendar.OCTOBER);
+        calendar.set(Calendar.DAY_OF_MONTH, 19);
+        calendar.set(Calendar.HOUR_OF_DAY, 10);
+        calendar.set(Calendar.MINUTE, 23);
+        calendar.set(Calendar.SECOND, 54);
+        Timestamp expectedWithZone = new Timestamp(calendar.getTimeInMillis());
+        assertEquals(expectedWithZone, rs.getObject("timestamp_with_time_zone_column", Timestamp.class));
+        assertEquals(expectedWithZone, rs.getObject(1, Timestamp.class));
+      } finally {
+        rs.close();
+      }
+      stmt.executeUpdate("DELETE FROM table1");
+    } finally {
+      stmt.close();
+    }
+  }
+
+  /**
+   * Test the behavior getObject for timestamp columns.
+   */
+  public void testGetCalendar() throws SQLException {
+    Statement stmt = _conn.createStatement();
+    stmt.executeUpdate(TestUtil.insertSQL("table1","timestamp_without_time_zone_column,timestamp_with_time_zone_column","TIMESTAMP '2004-10-19 10:23:54', TIMESTAMP '2004-10-19 10:23:54+02'"));
+
+    ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("table1", "timestamp_without_time_zone_column, timestamp_with_time_zone_column"));
+    try {
+      assertTrue(rs.next());
+      Calendar calendar = GregorianCalendar.getInstance();
+      calendar.clear();
+      calendar.set(Calendar.YEAR, 2004);
+      calendar.set(Calendar.MONTH, Calendar.OCTOBER);
+      calendar.set(Calendar.DAY_OF_MONTH, 19);
+      calendar.set(Calendar.HOUR_OF_DAY, 10);
+      calendar.set(Calendar.MINUTE, 23);
+      calendar.set(Calendar.SECOND, 54);
+      long expected = calendar.getTimeInMillis();
+      assertEquals(expected, rs.getObject("timestamp_without_time_zone_column", Calendar.class).getTimeInMillis());
+      assertEquals(expected, rs.getObject(1, Calendar.class).getTimeInMillis());
+      calendar.setTimeZone(TimeZone.getTimeZone("GMT+2:00"));
+      expected = calendar.getTimeInMillis();
+      assertEquals(expected, rs.getObject("timestamp_with_time_zone_column", Calendar.class).getTimeInMillis());
+      assertEquals(expected, rs.getObject(2, Calendar.class).getTimeInMillis());
+    } finally {
+      rs.close();
+    }
+  }
+
+  /**
+   * Test the behavior getObject for date columns.
+   */
+  public void testGetDate() throws SQLException {
+    Statement stmt = _conn.createStatement();
+    stmt.executeUpdate(TestUtil.insertSQL("table1","date_column","DATE '1999-01-08'"));
+
+    ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("table1", "date_column"));
+    try {
+      assertTrue(rs.next());
+      Calendar calendar = GregorianCalendar.getInstance();
+      calendar.clear();
+      calendar.set(Calendar.YEAR, 1999);
+      calendar.set(Calendar.MONTH, Calendar.JANUARY);
+      calendar.set(Calendar.DAY_OF_MONTH, 8);
+      Date expectedNoZone = new Date(calendar.getTimeInMillis());
+      assertEquals(expectedNoZone, rs.getObject("date_column", Date.class));
+      assertEquals(expectedNoZone, rs.getObject(1, Date.class));
+    } finally {
+      rs.close();
+    }
+  }
+
+  /**
+   * Test the behavior getObject for time columns.
+   */
+  public void testGetTime() throws SQLException {
+    Statement stmt = _conn.createStatement();
+    stmt.executeUpdate(TestUtil.insertSQL("table1","time_without_time_zone_column","TIME '04:05:06'"));
+
+    ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("table1", "time_without_time_zone_column"));
+    try {
+      assertTrue(rs.next());
+      Calendar calendar = GregorianCalendar.getInstance();
+      calendar.clear();
+      calendar.set(Calendar.YEAR, 1970);
+      calendar.set(Calendar.MONTH, Calendar.JANUARY);
+      calendar.set(Calendar.DAY_OF_MONTH, 1);
+      calendar.set(Calendar.HOUR, 4);
+      calendar.set(Calendar.MINUTE, 5);
+      calendar.set(Calendar.SECOND, 6);
+      Time expectedNoZone = new Time(calendar.getTimeInMillis());
+      assertEquals(expectedNoZone, rs.getObject("time_without_time_zone_column", Time.class));
+      assertEquals(expectedNoZone, rs.getObject(1, Time.class));
+    } finally {
+      rs.close();
+    }
+  }
+
+  /**
+   * Test the behavior getObject for integer columns.
+   */
+  public void testGetInteger() throws SQLException {
+    Statement stmt = _conn.createStatement();
+    stmt.executeUpdate(TestUtil.insertSQL("table1","smallint_column, integer_column","1, 2"));
+
+    ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("table1", "smallint_column, integer_column"));
+    try {
+      assertTrue(rs.next());
+      assertEquals(Integer.valueOf(1), rs.getObject("smallint_column", Integer.class));
+      assertEquals(Integer.valueOf(1), rs.getObject(1, Integer.class));
+      assertEquals(Integer.valueOf(2), rs.getObject("integer_column", Integer.class));
+      assertEquals(Integer.valueOf(2), rs.getObject(2, Integer.class));
+    } finally {
+      rs.close();
+    }
+  }
+
+  /**
+   * Test the behavior getObject for integer columns.
+   */
+  public void testGetIntegerNull() throws SQLException {
+    Statement stmt = _conn.createStatement();
+    stmt.executeUpdate(TestUtil.insertSQL("table1","smallint_column, integer_column","NULL, NULL"));
+
+    ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("table1", "smallint_column, integer_column"));
+    try {
+      assertTrue(rs.next());
+      assertNull(rs.getObject("smallint_column", Integer.class));
+      assertNull(rs.getObject(1, Integer.class));
+      assertNull(rs.getObject("integer_column", Integer.class));
+      assertNull(rs.getObject(2, Integer.class));
+    } finally {
+      rs.close();
+    }
+  }
+
+  /**
+   * Test the behavior getObject for long columns.
+   */
+  public void testGetLong() throws SQLException {
+    Statement stmt = _conn.createStatement();
+    stmt.executeUpdate(TestUtil.insertSQL("table1","bigint_column","2147483648"));
+
+    ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("table1", "bigint_column"));
+    try {
+      assertTrue(rs.next());
+      assertEquals(Long.valueOf(2147483648L), rs.getObject("bigint_column", Long.class));
+      assertEquals(Long.valueOf(2147483648L), rs.getObject(1, Long.class));
+    } finally {
+      rs.close();
+    }
+  }
+
+  /**
+   * Test the behavior getObject for long columns.
+   */
+  public void testGetLongNull() throws SQLException {
+    Statement stmt = _conn.createStatement();
+    stmt.executeUpdate(TestUtil.insertSQL("table1","bigint_column","NULL"));
+
+    ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("table1", "bigint_column"));
+    try {
+      assertTrue(rs.next());
+      assertNull(rs.getObject("bigint_column", Long.class));
+      assertNull(rs.getObject(1, Long.class));
+    } finally {
+      rs.close();
+    }
+  }
+
+  /**
+   * Test the behavior getObject for double columns.
+   */
+  public void testGetDouble() throws SQLException {
+    Statement stmt = _conn.createStatement();
+    stmt.executeUpdate(TestUtil.insertSQL("table1","double_column","1.0"));
+
+    ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("table1", "double_column"));
+    try {
+      assertTrue(rs.next());
+      assertEquals(Double.valueOf(1.0d), rs.getObject("double_column", Double.class));
+      assertEquals(Double.valueOf(1.0d), rs.getObject(1, Double.class));
+    } finally {
+      rs.close();
+    }
+  }
+
+  /**
+   * Test the behavior getObject for double columns.
+   */
+  public void testGetDoubleNull() throws SQLException {
+    Statement stmt = _conn.createStatement();
+    stmt.executeUpdate(TestUtil.insertSQL("table1","double_column","NULL"));
+
+    ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("table1", "double_column"));
+    try {
+      assertTrue(rs.next());
+      assertNull(rs.getObject("double_column", Double.class));
+      assertNull(rs.getObject(1, Double.class));
+    } finally {
+      rs.close();
+    }
+  }
+
+  /**
+   * Test the behavior getObject for float columns.
+   */
+  public void testGetFloat() throws SQLException {
+    Statement stmt = _conn.createStatement();
+    stmt.executeUpdate(TestUtil.insertSQL("table1","real_column","1.0"));
+
+    ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("table1", "real_column"));
+    try {
+      assertTrue(rs.next());
+      assertEquals(Float.valueOf(1.0f), rs.getObject("real_column", Float.class));
+      assertEquals(Float.valueOf(1.0f), rs.getObject(1, Float.class));
+    } finally {
+      rs.close();
+    }
+  }
+
+  /**
+   * Test the behavior getObject for float columns.
+   */
+  public void testGetFloatNull() throws SQLException {
+    Statement stmt = _conn.createStatement();
+    stmt.executeUpdate(TestUtil.insertSQL("table1","real_column","NULL"));
+
+    ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("table1", "real_column"));
+    try {
+      assertTrue(rs.next());
+      assertNull(rs.getObject("real_column", Float.class));
+      assertNull(rs.getObject(1, Float.class));
+    } finally {
+      rs.close();
+    }
+  }
+
+  /**
+   * Test the behavior getObject for serial columns.
+   */
+  public void testGetSerial() throws SQLException {
+    if (!((BaseConnection) _conn).haveMinimumServerVersion(ServerVersion.v9_2)) {
+      // smallserial requires 9.2 or later
+      return;
+    }
+    Statement stmt = _conn.createStatement();
+    stmt.executeUpdate(TestUtil.insertSQL("table1","smallserial_column, serial_column","1, 2"));
+
+    ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("table1", "smallserial_column, serial_column"));
+    try {
+      assertTrue(rs.next());
+      assertEquals(Integer.valueOf(1), rs.getObject("smallserial_column", Integer.class));
+      assertEquals(Integer.valueOf(1), rs.getObject(1, Integer.class));
+      assertEquals(Integer.valueOf(2), rs.getObject("serial_column", Integer.class));
+      assertEquals(Integer.valueOf(2), rs.getObject(2, Integer.class));
+    } finally {
+      rs.close();
+    }
+  }
+
+  /**
+   * Test the behavior getObject for boolean columns.
+   */
+  public void testGetBoolean() throws SQLException {
+    Statement stmt = _conn.createStatement();
+    stmt.executeUpdate(TestUtil.insertSQL("table1","boolean_column","TRUE"));
+
+    ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("table1", "boolean_column"));
+    try {
+      assertTrue(rs.next());
+      assertTrue(rs.getObject("boolean_column", Boolean.class));
+      assertTrue(rs.getObject(1, Boolean.class));
+    } finally {
+      rs.close();
+    }
+  }
+
+  /**
+   * Test the behavior getObject for boolean columns.
+   */
+  public void testGetBooleanNull() throws SQLException {
+    Statement stmt = _conn.createStatement();
+    stmt.executeUpdate(TestUtil.insertSQL("table1","boolean_column","NULL"));
+
+    ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("table1", "boolean_column"));
+    try {
+      assertTrue(rs.next());
+      assertNull(rs.getObject("boolean_column", Boolean.class));
+      assertNull(rs.getObject(1, Boolean.class));
+    } finally {
+      rs.close();
+    }
+  }
+
+  /**
+   * Test the behavior getObject for xml columns.
+   */
+  public void testGetBlob() throws SQLException {
+    Statement stmt = _conn.createStatement();
+    _conn.setAutoCommit(false);
+    try {
+      byte[] data = new byte[]{(byte) 0xDE, (byte) 0xAD, (byte) 0xBE, (byte) 0xEF};
+      PreparedStatement insertPS = _conn.prepareStatement(TestUtil.insertSQL("table1", "lob_column", "?"));
+      try {
+        insertPS.setObject(1, new SerialBlob(data), Types.BLOB);
+        insertPS.executeUpdate();
+      } finally {
+        insertPS.close();
+      }
+
+      ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("table1", "lob_column"));
+      try {
+        assertTrue(rs.next());
+        Blob blob = rs.getObject("lob_column", Blob.class);
+        assertEquals(data.length, blob.length());
+        Assert.assertArrayEquals(data, blob.getBytes(1, data.length));
+        blob.free();
+
+        blob = rs.getObject(1, Blob.class);
+        assertEquals(data.length, blob.length());
+        Assert.assertArrayEquals(data, blob.getBytes(1, data.length));
+        blob.free();
+      } finally {
+        rs.close();
+      }
+    } finally {
+      _conn.setAutoCommit(true);
+    }
+  }
+
+  /**
+   * Test the behavior getObject for array columns.
+   */
+  public void testGetArray() throws SQLException {
+    Statement stmt = _conn.createStatement();
+    String[] data = new String[]{"java", "jdbc"};
+    stmt.executeUpdate(TestUtil.insertSQL("table1","array_column","'{\"java\", \"jdbc\"}'"));
+
+    ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("table1", "array_column"));
+    try {
+      assertTrue(rs.next());
+      Array array = rs.getObject("array_column", Array.class);
+      Assert.assertArrayEquals(data, (String[]) array.getArray());
+      array.free();
+
+      array = rs.getObject(1, Array.class);
+      Assert.assertArrayEquals(data, (String[]) array.getArray());
+      array.free();
+    } finally {
+      rs.close();
+    }
+  }
+
+  /**
+   * Test the behavior getObject for xml columns.
+   */
+  public void testGetXml() throws SQLException {
+    Statement stmt = _conn.createStatement();
+    String content = "<book><title>Manual</title></book>";
+    stmt.executeUpdate(TestUtil.insertSQL("table1","xml_column","XMLPARSE (DOCUMENT '<?xml version=\"1.0\"?><book><title>Manual</title></book>')"));
+
+    ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("table1", "xml_column"));
+    try {
+      assertTrue(rs.next());
+      SQLXML sqlXml = rs.getObject("xml_column", SQLXML.class);
+      assertEquals(content, sqlXml.getString());
+      sqlXml.free();
+
+      sqlXml = rs.getObject(1, SQLXML.class);
+      assertEquals(content, sqlXml.getString());
+      sqlXml.free();
+    } finally {
+      rs.close();
+    }
+  }
+
+  /**
+   * Test the behavior getObject for money columns.
+   */
+  public void testGetMoney() throws SQLException {
+    Statement stmt = _conn.createStatement();
+    String expected = "12.34";
+    stmt.executeUpdate(TestUtil.insertSQL("table1","money_column","'12.34'::float8::numeric::money"));
+
+    ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("table1", "money_column"));
+    try {
+      assertTrue(rs.next());
+      PGmoney money = rs.getObject("money_column", PGmoney.class);
+      assertTrue(money.getValue().endsWith(expected));
+
+      money = rs.getObject(1, PGmoney.class);
+      assertTrue(money.getValue().endsWith(expected));
+    } finally {
+      rs.close();
+    }
+  }
+
+  /**
+   * Test the behavior getObject for point columns.
+   */
+  public void testGetPoint() throws SQLException {
+    Statement stmt = _conn.createStatement();
+    PGpoint expected = new PGpoint(1.0d, 2.0d);
+    stmt.executeUpdate(TestUtil.insertSQL("table1","point_column","point '(1, 2)'"));
+
+    ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("table1", "point_column"));
+    try {
+      assertTrue(rs.next());
+      assertEquals(expected, rs.getObject("point_column", PGpoint.class));
+      assertEquals(expected, rs.getObject(1, PGpoint.class));
+    } finally {
+      rs.close();
+    }
+  }
+
+  /**
+   * Test the behavior getObject for line columns.
+   */
+  public void testGetLine() throws SQLException {
+    if (!((BaseConnection) _conn).haveMinimumServerVersion(ServerVersion.v9_4)) {
+      // only 9.4 and later ship with full line support by default
+      return;
+    }
+
+    Statement stmt = _conn.createStatement();
+    PGline expected = new PGline(1.0d, 2.0d, 3.0d);
+    stmt.executeUpdate(TestUtil.insertSQL("table1","line_column","line '{1, 2, 3}'"));
+
+    ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("table1", "line_column"));
+    try {
+      assertTrue(rs.next());
+      assertEquals(expected, rs.getObject("line_column", PGline.class));
+      assertEquals(expected, rs.getObject(1, PGline.class));
+    } finally {
+      rs.close();
+    }
+  }
+
+  /**
+   * Test the behavior getObject for lseg columns.
+   */
+  public void testGetLineseg() throws SQLException {
+    Statement stmt = _conn.createStatement();
+    PGlseg expected = new PGlseg(1.0d, 2.0d, 3.0d, 4.0d);
+    stmt.executeUpdate(TestUtil.insertSQL("table1","lseg_column","lseg '[(1, 2), (3, 4)]'"));
+
+    ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("table1", "lseg_column"));
+    try {
+      assertTrue(rs.next());
+      assertEquals(expected, rs.getObject("lseg_column", PGlseg.class));
+      assertEquals(expected, rs.getObject(1, PGlseg.class));
+    } finally {
+      rs.close();
+    }
+  }
+
+  /**
+   * Test the behavior getObject for box columns.
+   */
+  public void testGetBox() throws SQLException {
+    Statement stmt = _conn.createStatement();
+    PGbox expected = new PGbox(1.0d, 2.0d, 3.0d, 4.0d);
+    stmt.executeUpdate(TestUtil.insertSQL("table1","box_column","box '((1, 2), (3, 4))'"));
+
+    ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("table1", "box_column"));
+    try {
+      assertTrue(rs.next());
+      assertEquals(expected, rs.getObject("box_column", PGbox.class));
+      assertEquals(expected, rs.getObject(1, PGbox.class));
+    } finally {
+      rs.close();
+    }
+  }
+
+  /**
+   * Test the behavior getObject for path columns.
+   */
+  public void testGetPath() throws SQLException {
+    Statement stmt = _conn.createStatement();
+    PGpath expected = new PGpath(new PGpoint[]{new PGpoint(1.0d, 2.0d), new PGpoint(3.0d, 4.0d)}, true);
+    stmt.executeUpdate(TestUtil.insertSQL("table1","path_column","path '[(1, 2), (3, 4)]'"));
+
+    ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("table1", "path_column"));
+    try {
+      assertTrue(rs.next());
+      assertEquals(expected, rs.getObject("path_column", PGpath.class));
+      assertEquals(expected, rs.getObject(1, PGpath.class));
+    } finally {
+      rs.close();
+    }
+  }
+
+  /**
+   * Test the behavior getObject for polygon columns.
+   */
+  public void testGetPolygon() throws SQLException {
+    Statement stmt = _conn.createStatement();
+    PGpolygon expected = new PGpolygon(new PGpoint[]{new PGpoint(1.0d, 2.0d), new PGpoint(3.0d, 4.0d)});
+    stmt.executeUpdate(TestUtil.insertSQL("table1","polygon_column","polygon '((1, 2), (3, 4))'"));
+
+    ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("table1", "polygon_column"));
+    try {
+      assertTrue(rs.next());
+      assertEquals(expected, rs.getObject("polygon_column", PGpolygon.class));
+      assertEquals(expected, rs.getObject(1, PGpolygon.class));
+    } finally {
+      rs.close();
+    }
+  }
+
+  /**
+   * Test the behavior getObject for circle columns.
+   */
+  public void testGetCircle() throws SQLException {
+    Statement stmt = _conn.createStatement();
+    PGcircle expected = new PGcircle(1.0d, 2.0d, 3.0d);
+    stmt.executeUpdate(TestUtil.insertSQL("table1","circle_column","circle '<(1, 2), 3>'"));
+
+    ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("table1", "circle_column"));
+    try {
+      assertTrue(rs.next());
+      assertEquals(expected, rs.getObject("circle_column", PGcircle.class));
+      assertEquals(expected, rs.getObject(1, PGcircle.class));
+    } finally {
+      rs.close();
+    }
+  }
+
+  /**
+   * Test the behavior getObject for interval columns.
+   */
+  public void testGetInterval() throws SQLException {
+    Statement stmt = _conn.createStatement();
+    PGInterval expected = new PGInterval(0, 0, 3, 4, 5, 6.0d);
+    stmt.executeUpdate(TestUtil.insertSQL("table1","interval_column","interval '3 4:05:06'"));
+
+    ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("table1", "interval_column"));
+    try {
+      assertTrue(rs.next());
+      assertEquals(expected, rs.getObject("interval_column", PGInterval.class));
+      assertEquals(expected, rs.getObject(1, PGInterval.class));
+    } finally {
+      rs.close();
+    }
+  }
+
+  /**
+   * Test the behavior getObject for uuid columns.
+   */
+  public void testGetUuid() throws SQLException {
+    Statement stmt = _conn.createStatement();
+    String expected = "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11";
+    stmt.executeUpdate(TestUtil.insertSQL("table1","uuid_column","'" + expected + "'"));
+
+    ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("table1", "uuid_column"));
+    try {
+      assertTrue(rs.next());
+      assertEquals(UUID.fromString(expected), rs.getObject("uuid_column", UUID.class));
+      assertEquals(UUID.fromString(expected), rs.getObject(1, UUID.class));
+    } finally {
+      rs.close();
+    }
+  }
+
+  /**
+   * Test the behavior getObject for inet columns.
+   */
+  public void testGetInetAddressNull() throws SQLException, UnknownHostException {
+    Statement stmt = _conn.createStatement();
+    stmt.executeUpdate(TestUtil.insertSQL("table1","inet_column","NULL"));
+
+    ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("table1", "inet_column"));
+    try {
+      assertTrue(rs.next());
+      assertNull(rs.getObject("inet_column", InetAddress.class));
+      assertNull(rs.getObject(1, InetAddress.class));
+    } finally {
+      rs.close();
+    }
+  }
+
+  /**
+   * Test the behavior getObject for inet columns.
+   */
+  public void testGetInet4Address() throws SQLException, UnknownHostException {
+    Statement stmt = _conn.createStatement();
+    String expected = "192.168.100.128";
+    stmt.executeUpdate(TestUtil.insertSQL("table1","inet_column","'" + expected + "'"));
+
+    ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("table1", "inet_column"));
+    try {
+      assertTrue(rs.next());
+      assertEquals(InetAddress.getByName(expected), rs.getObject("inet_column", InetAddress.class));
+      assertEquals(InetAddress.getByName(expected), rs.getObject(1, InetAddress.class));
+    } finally {
+      rs.close();
+    }
+  }
+
+  /**
+   * Test the behavior getObject for inet columns.
+   */
+  public void testGetInet6Address() throws SQLException, UnknownHostException {
+    Statement stmt = _conn.createStatement();
+    String expected = "2001:4f8:3:ba:2e0:81ff:fe22:d1f1";
+    stmt.executeUpdate(TestUtil.insertSQL("table1","inet_column","'" + expected + "'"));
+
+    ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("table1", "inet_column"));
+    try {
+      assertTrue(rs.next());
+      assertEquals(InetAddress.getByName(expected), rs.getObject("inet_column", InetAddress.class));
+      assertEquals(InetAddress.getByName(expected), rs.getObject(1, InetAddress.class));
+    } finally {
+      rs.close();
+    }
+  }
+
+}

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc4/jdbc41/Jdbc41TestSuite.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc4/jdbc41/Jdbc41TestSuite.java
@@ -25,6 +25,7 @@ public class Jdbc41TestSuite extends TestSuite {
     suite.addTestSuite(SchemaTest.class);
     suite.addTestSuite(AbortTest.class);
     suite.addTestSuite(CloseOnCompletionTest.class);
+    suite.addTestSuite(GetObjectTest.class);
 
     return suite;
   }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc42/GetObject310Test.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc42/GetObject310Test.java
@@ -1,0 +1,131 @@
+package org.postgresql.test.jdbc42;
+
+import org.postgresql.test.TestUtil;
+
+import junit.framework.TestCase;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+public class GetObject310Test extends TestCase {
+
+  private static final ZoneOffset UTC = ZoneOffset.UTC; // +0000 always
+  private static final ZoneOffset GMT03 = ZoneOffset.of("+03:00"); // +0300 always
+  private static final ZoneOffset GMT05 = ZoneOffset.of("-05:00"); // -0500 always
+  private static final ZoneOffset GMT13 = ZoneOffset.of("+13:00"); // +1300 always
+
+  private Connection _conn;
+
+  public GetObject310Test(String name) {
+    super(name);
+  }
+
+  protected void setUp() throws Exception {
+    _conn = TestUtil.openDB();
+    TestUtil.createTable(_conn, "table1", "timestamp_without_time_zone_column timestamp without time zone,"
+            + "timestamp_with_time_zone_column timestamp with time zone,"
+            + "date_column date,"
+            + "time_without_time_zone_column time without time zone,"
+            + "time_with_time_zone_column time with time zone"
+    );
+  }
+
+  protected void tearDown() throws SQLException {
+    TestUtil.dropTable(_conn, "table1");
+    TestUtil.closeDB( _conn );
+  }
+
+  /**
+   * Test the behavior getObject for date columns.
+   */
+  public void testGetLocalDate() throws SQLException {
+    Statement stmt = _conn.createStatement();
+    stmt.executeUpdate(TestUtil.insertSQL("table1","date_column","DATE '1999-01-08'"));
+
+    ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("table1", "date_column"));
+    try {
+      assertTrue(rs.next());
+      LocalDate localDate = LocalDate.of(1999, 1, 8);
+      assertEquals(localDate, rs.getObject("date_column", LocalDate.class));
+      assertEquals(localDate, rs.getObject(1, LocalDate.class));
+    } finally {
+      rs.close();
+    }
+  }
+
+  /**
+   * Test the behavior getObject for time columns.
+   */
+  public void testGetLocalTime() throws SQLException {
+    Statement stmt = _conn.createStatement();
+    stmt.executeUpdate(TestUtil.insertSQL("table1","time_without_time_zone_column","TIME '04:05:06'"));
+
+    ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("table1", "time_without_time_zone_column"));
+    try {
+      assertTrue(rs.next());
+      LocalTime localTime = LocalTime.of(4, 5, 6);
+      assertEquals(localTime, rs.getObject("time_without_time_zone_column", LocalTime.class));
+      assertEquals(localTime, rs.getObject(1, LocalTime.class));
+    } finally {
+      rs.close();
+    }
+  }
+
+  /**
+   * Test the behavior getObject for timestamp columns.
+   */
+  public void testGetLocalDateTime() throws SQLException {
+    Statement stmt = _conn.createStatement();
+    stmt.executeUpdate(TestUtil.insertSQL("table1","timestamp_without_time_zone_column","TIMESTAMP '2004-10-19 10:23:54'"));
+
+    ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("table1", "timestamp_without_time_zone_column"));
+    try {
+      assertTrue(rs.next());
+      LocalDateTime localDateTime = LocalDateTime.of(2004, 10, 19, 10, 23, 54);
+      assertEquals(localDateTime, rs.getObject("timestamp_without_time_zone_column", LocalDateTime.class));
+      assertEquals(localDateTime, rs.getObject(1, LocalDateTime.class));
+    } finally {
+      rs.close();
+    }
+  }
+
+  /**
+   * Test the behavior getObject for timestamp with time zone columns.
+   */
+  public void testGetTimestampWithTimeZone() throws SQLException {
+    runGetOffsetDateTime(UTC);
+    runGetOffsetDateTime(GMT03);
+    runGetOffsetDateTime(GMT05);
+    runGetOffsetDateTime(GMT13);
+  }
+
+  private void runGetOffsetDateTime(ZoneOffset offset) throws SQLException {
+    Statement stmt = _conn.createStatement();
+    try {
+      stmt.executeUpdate(TestUtil.insertSQL("table1","timestamp_with_time_zone_column","TIMESTAMP WITH TIME ZONE '2004-10-19 10:23:54" + offset.toString() + "'"));
+
+      ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("table1", "timestamp_with_time_zone_column"));
+      try {
+        assertTrue(rs.next());
+        LocalDateTime localDateTime = LocalDateTime.of(2004, 10, 19, 10, 23, 54);
+
+        OffsetDateTime offsetDateTime = localDateTime.atOffset(offset).withOffsetSameInstant(ZoneOffset.UTC);
+        assertEquals(offsetDateTime, rs.getObject("timestamp_with_time_zone_column", OffsetDateTime.class));
+        assertEquals(offsetDateTime, rs.getObject(1, OffsetDateTime.class));
+      } finally {
+        rs.close();
+      }
+      stmt.executeUpdate("DELETE FROM table1");
+    } finally {
+      stmt.close();
+    }
+  }
+
+}

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc42/Jdbc42TestSuite.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc42/Jdbc42TestSuite.java
@@ -13,7 +13,7 @@ import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 @RunWith(Suite.class)
-@SuiteClasses({SimpleJdbc42Test.class, CustomizeDefaultFetchSizeTest.class})
+@SuiteClasses({SimpleJdbc42Test.class, CustomizeDefaultFetchSizeTest.class, GetObject310Test.class})
 public class Jdbc42TestSuite {
 
 }


### PR DESCRIPTION
ResultSet#getObject(int/String, Class) is required for JSR-310 support
in JDBC 4.2.

The following types which are defined by the JDBC specification are
supported:

 * BigDecimal
 * String
 * Boolean
 * Integer
 * Long
 * Float
 * Double
 * Date
 * Time
 * Timestamp
 * Calendar
 * Blob
 * Clob
 * Array
 * SQLXML
 * LocalDate (if in JDBC 4.2)
 * LocalTime (if in JDBC 4.2)
 * LocalDateTime (if in JDBC 4.2)
 * OffsetDateTime (if in JDBC 4.2), the offset is always 0 since
   PostgreS stores everything in UTC

in addition the following PostgreS extensions are supported:

 * UUID
 * InetAddress
 * PGbox
 * PGcircle
 * PGline
 * PGlseg
 * PGmoney
 * PGpath
 * PGpoint
 * PGpolygon
 * PGInterval

Currently missing are `bytea` (`bytea[]`) `cidr`, `macaddr`,
`tsvector`, `tsquery` and `ZonedDateTime` (not defined by the JDBC
specification).

Implement ResultSet#getObject(int/String, Class).