### PR TITLE
fix:regression from previous behaviour where setObject(index,object,V…

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
@@ -912,17 +912,15 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
       if (in instanceof String) {
         return (String) in;
       }
-      if (in instanceof Number || in instanceof Boolean || in instanceof Character
-          || in instanceof java.util.Date) {
-        return in.toString();
-      }
       if (in instanceof Clob) {
         return asString((Clob) in);
       }
+      //this behaviour is possibly atypical but the driver has done this historically
+      return in.toString();
+
     } catch (final Exception e) {
       throw cannotCastException(in.getClass().getName(), "String", e);
     }
-    throw cannotCastException(in.getClass().getName(), "String");
   }
 
   private static PSQLException cannotCastException(final String fromType, final String toType) {

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
@@ -915,7 +915,7 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
       if (in instanceof Clob) {
         return asString((Clob) in);
       }
-      //this behaviour is possibly atypical but the driver has done this historically
+      // convert any unknown objects to string.
       return in.toString();
 
     } catch (final Exception e) {


### PR DESCRIPTION
…ARHCAR) should call getString if it can't cast it to a string