### PR TITLE
fix: load the ssl configuration property when defined through 

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/v2/ConnectionFactoryImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v2/ConnectionFactoryImpl.java
@@ -61,7 +61,7 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
     boolean trySSL;
     String sslmode = PGProperty.SSL_MODE.get(info);
     if (sslmode == null) { // Fall back to the ssl property
-      requireSSL = trySSL = PGProperty.SSL.isPresent(info);
+      requireSSL = trySSL = PGProperty.SSL.getBoolean(info);
     } else {
       if ("disable".equals(sslmode)) {
         requireSSL = trySSL = false;

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java
@@ -76,7 +76,7 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
     boolean trySSL;
     String sslmode = PGProperty.SSL_MODE.get(info);
     if (sslmode == null) { // Fall back to the ssl property
-      requireSSL = trySSL = PGProperty.SSL.isPresent(info);
+      requireSSL = trySSL = PGProperty.SSL.getBoolean(info);
     } else {
       if ("disable".equals(sslmode)) {
         requireSSL = trySSL = false;


### PR DESCRIPTION
 This PR fixes #492 to configure ssl when defined as Properties.
 The change updates both v2 and v3.