### PR TITLE
fix: make sure executeBatch returns error response for rows that would not get into database

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/PGStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/PGStream.java
@@ -72,6 +72,7 @@ public class PGStream {
   /**
    * Constructor: Connect to the PostgreSQL back end and return a stream connection.
    *
+   * @param socketFactory socket factory
    * @param hostSpec the host and port to connect to
    * @throws IOException if an IOException occurs below it.
    * @deprecated use {@link #PGStream(SocketFactory, org.postgresql.util.HostSpec, int)}

--- a/pgjdbc/src/main/java/org/postgresql/core/QueryExecutor.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/QueryExecutor.java
@@ -10,6 +10,7 @@
 package org.postgresql.core;
 
 import org.postgresql.copy.CopyOperation;
+import org.postgresql.jdbc.BatchResultHandler;
 
 import java.sql.SQLException;
 
@@ -24,7 +25,7 @@ import java.sql.SQLException;
  * {@link #createParameterizedQuery})
  * <li>execution methods for created Query objects (
  * {@link #execute(Query, ParameterList, ResultHandler, int, int, int)} for single queries and
- * {@link #execute(Query[], ParameterList[], ResultHandler, int, int, int)} for batches of queries)
+ * {@link #execute(Query[], ParameterList[], BatchResultHandler, int, int, int)} for batches of queries)
  * <li>a fastpath call interface ({@link #createFastpathParameters} and {@link #fastpathCall}).
  * </ul>
  *
@@ -142,7 +143,7 @@ public interface QueryExecutor {
    * @param flags a combination of QUERY_* flags indicating how to handle the query.
    * @throws SQLException if query execution fails
    */
-  void execute(Query[] queries, ParameterList[] parameterLists, ResultHandler handler, int maxRows,
+  void execute(Query[] queries, ParameterList[] parameterLists, BatchResultHandler handler, int maxRows,
       int fetchSize, int flags) throws SQLException;
 
   /**

--- a/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
+++ b/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
@@ -954,6 +954,7 @@ public abstract class BaseDataSource implements Referenceable {
   }
 
   /**
+   * @return socket factory class name
    * @see PGProperty#SOCKET_FACTORY
    */
   public String getSocketFactory() {
@@ -961,6 +962,7 @@ public abstract class BaseDataSource implements Referenceable {
   }
 
   /**
+   * @param socketFactoryClassName socket factory class name
    * @see PGProperty#SOCKET_FACTORY
    */
   public void setSocketFactory(String socketFactoryClassName) {
@@ -968,6 +970,7 @@ public abstract class BaseDataSource implements Referenceable {
   }
 
   /**
+   * @return socket factory argument
    * @see PGProperty#SOCKET_FACTORY_ARG
    */
   public String getSocketFactoryArg() {
@@ -975,6 +978,7 @@ public abstract class BaseDataSource implements Referenceable {
   }
 
   /**
+   * @param socketFactoryArg socket factory argument
    * @see PGProperty#SOCKET_FACTORY_ARG
    */
   public void setSocketFactoryArg(String socketFactoryArg) {

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgCallableStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgCallableStatement.java
@@ -11,7 +11,6 @@ package org.postgresql.jdbc;
 import org.postgresql.Driver;
 import org.postgresql.core.ParameterList;
 import org.postgresql.core.Query;
-import org.postgresql.core.ResultHandler;
 import org.postgresql.util.GT;
 import org.postgresql.util.PSQLException;
 import org.postgresql.util.PSQLState;
@@ -435,7 +434,7 @@ class PgCallableStatement extends PgPreparedStatement implements CallableStateme
   }
 
   @Override
-  protected ResultHandler createBatchHandler(int[] updateCounts, Query[] queries,
+  protected BatchResultHandler createBatchHandler(int[] updateCounts, Query[] queries,
       ParameterList[] parameterLists) {
     return new CallableBatchResultHandler(this, queries, parameterLists, updateCounts);
   }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BaseTest4.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BaseTest4.java
@@ -1,0 +1,34 @@
+package org.postgresql.test.jdbc2;
+
+import org.postgresql.PGProperty;
+import org.postgresql.test.TestUtil;
+
+import org.junit.After;
+import org.junit.Before;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Properties;
+
+public class BaseTest4 {
+  protected Connection con;
+
+  protected void updateProperties(Properties props) {
+  }
+
+  protected void forceBinary(Properties props) {
+    PGProperty.PREPARE_THRESHOLD.set(props, -1);
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    Properties props = new Properties();
+    updateProperties(props);
+    con = TestUtil.openDB(props);
+  }
+
+  @After
+  public void tearDown() throws SQLException {
+    TestUtil.closeDB(con);
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BatchFailureTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BatchFailureTest.java
@@ -1,0 +1,269 @@
+package org.postgresql.test.jdbc2;
+
+import org.postgresql.test.TestUtil;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.sql.BatchUpdateException;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+
+@RunWith(Parameterized.class)
+public class BatchFailureTest extends BaseTest4 {
+  private final BatchType batchType;
+  private final AutoCommit autoCommit;
+  private final FailMode failMode;
+  private final FailPosition failPosition;
+  private final BinaryMode binaryMode;
+
+  enum BinaryMode {
+    REGULAR, FORCE;
+  }
+
+  enum AutoCommit {
+    YES, NO;
+  }
+
+  enum BatchType {
+    SIMPLE {
+      @Override
+      public Statement createStatement(Connection con) throws SQLException {
+        return con.createStatement();
+      }
+    },
+    PREPARED {
+      @Override
+      public Statement createStatement(Connection con) throws SQLException {
+        return con.prepareStatement("INSERT INTO batchUpdCnt(id) VALUES (?)");
+      }
+    },
+    PREPARED_WITH_GENERATED {
+      @Override
+      public Statement createStatement(Connection con) throws SQLException {
+        return con.prepareStatement("INSERT INTO batchUpdCnt(id) VALUES (?)", new String[]{"id"});
+      }
+    };
+
+    public abstract Statement createStatement(Connection con) throws SQLException;
+
+    public void addRow(Statement statement, String value) throws SQLException {
+      switch (this) {
+        case SIMPLE:
+          statement.addBatch("INSERT INTO batchUpdCnt(id) VALUES ('" + value + "')");
+          break;
+        case PREPARED:
+        case PREPARED_WITH_GENERATED:
+          PreparedStatement ps = (PreparedStatement) statement;
+          ps.setString(1, value);
+          ps.addBatch();
+          break;
+      }
+    }
+  }
+
+  enum FailMode {
+    NO_FAIL_JUST_INSERTS, NO_FAIL_SELECT,
+    FAIL_VIA_SELECT_PARSE, FAIL_VIA_SELECT_RUNTIME,
+    FAIL_VIA_DUP_KEY;
+
+    public boolean supports(BatchType batchType) {
+      return batchType != BatchType.SIMPLE ^ this.name().contains("SELECT");
+    }
+
+    public void injectFailure(Statement statement, BatchType batchType) throws SQLException {
+      switch (this) {
+        case NO_FAIL_JUST_INSERTS:
+          break;
+        case NO_FAIL_SELECT:
+          statement.addBatch("select 1 union all select 2");
+          break;
+        case FAIL_VIA_SELECT_RUNTIME:
+          statement.addBatch("select 0/count(*) where 1=2");
+          break;
+        case FAIL_VIA_SELECT_PARSE:
+          statement.addBatch("seeeeleeeect 1");
+          break;
+        case FAIL_VIA_DUP_KEY:
+          batchType.addRow(statement, "key-2");
+          break;
+        default:
+          throw new IllegalArgumentException("Unexpected value " + this);
+      }
+    }
+  }
+
+  enum FailPosition {
+    NONE, FIRST_ROW, SECOND_ROW, MIDDLE, ALMOST_LAST_ROW, LAST_ROW;
+
+    public boolean supports(FailMode mode) {
+      return this == NONE ^ mode.name().startsWith("FAIL");
+    }
+  }
+
+  public BatchFailureTest(BatchType batchType, AutoCommit autoCommit,
+      FailMode failMode, FailPosition failPosition, BinaryMode binaryMode) {
+    this.batchType = batchType;
+    this.autoCommit = autoCommit;
+    this.failMode = failMode;
+    this.failPosition = failPosition;
+    this.binaryMode = binaryMode;
+  }
+
+  @Parameterized.Parameters(name = "{index}: batchTest(mode={2}, position={3}, autoCommit={1}, batchType={0}, generateKeys={1}, binary={4})")
+  public static Iterable<Object[]> data() {
+    Collection<Object[]> ids = new ArrayList<Object[]>();
+    for (BatchType batchType : BatchType.values()) {
+      for (FailMode failMode : FailMode.values()) {
+        if (!failMode.supports(batchType)) {
+          continue;
+        }
+        for (FailPosition failPosition : FailPosition.values()) {
+          if (!failPosition.supports(failMode)) {
+            continue;
+          }
+          for (AutoCommit autoCommit : AutoCommit.values()) {
+            for (BinaryMode binaryMode : BinaryMode.values()) {
+              ids.add(new Object[]{batchType, autoCommit, failMode, failPosition, binaryMode});
+            }
+          }
+        }
+      }
+    }
+    return ids;
+  }
+
+  @Override
+  protected void updateProperties(Properties props) {
+    if (binaryMode == BinaryMode.FORCE) {
+      forceBinary(props);
+    }
+  }
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    TestUtil.createTable(con, "batchUpdCnt", "id varchar(512) primary key, data varchar(512)");
+    Statement stmt = con.createStatement();
+    stmt.executeUpdate("INSERT INTO batchUpdCnt(id) VALUES ('key-2')");
+    stmt.close();
+    con.setAutoCommit(autoCommit == AutoCommit.YES);
+  }
+
+  @Test
+  public void run() throws SQLException {
+    Statement statement = batchType.createStatement(con);
+
+    int minBatchResults = 0;
+    int pos = 0;
+    if (failPosition == FailPosition.FIRST_ROW) {
+      failMode.injectFailure(statement, batchType);
+      pos++;
+      minBatchResults = pos;
+    }
+
+    batchType.addRow(statement, "key-1");
+    pos++;
+
+    if (failPosition == FailPosition.SECOND_ROW) {
+      failMode.injectFailure(statement, batchType);
+      pos++;
+      minBatchResults = pos;
+    }
+
+    for (int i = 0; i < 1000; i++) {
+      batchType.addRow(statement, "key_" + i);
+      pos++;
+      if (failPosition == FailPosition.ALMOST_LAST_ROW && i == 997
+          || failPosition == FailPosition.MIDDLE && i == 500) {
+        failMode.injectFailure(statement, batchType);
+        pos++;
+        minBatchResults = pos;
+      }
+    }
+
+    if (failPosition == FailPosition.LAST_ROW) {
+      failMode.injectFailure(statement, batchType);
+      pos++;
+      minBatchResults = pos;
+    }
+
+    List<String> keys = new ArrayList<String>();
+    int[] batchResult;
+    int expectedRows = 1;
+    try {
+      batchResult = statement.executeBatch();
+      Assert.assertTrue("Expecting BatchUpdateException due to " + failMode
+              + ", executeBatch returned " + Arrays.toString(batchResult),
+          failPosition == FailPosition.NONE);
+      expectedRows = pos + 1; // +1 since key-2 is already in the DB
+    } catch (BatchUpdateException ex) {
+      batchResult = ex.getUpdateCounts();
+      Assert.assertTrue("Should not fail since fail mode should be " + failMode
+              + ", executeBatch returned " + Arrays.toString(batchResult),
+          failPosition != FailPosition.NONE);
+
+      for (int i : batchResult) {
+        if (i != Statement.EXECUTE_FAILED) {
+          expectedRows++;
+        }
+      }
+
+      Assert.assertTrue("Batch should fail at row " + minBatchResults
+              + ", thus at least " + minBatchResults
+              + " items should be returned, actual result is " + batchResult.length + " items, "
+              + Arrays.toString(batchResult),
+          batchResult.length >= minBatchResults);
+    } finally {
+      if (batchType == BatchType.PREPARED_WITH_GENERATED) {
+        ResultSet rs = statement.getGeneratedKeys();
+        while (rs.next()) {
+          keys.add(rs.getString(1));
+        }
+      }
+      statement.close();
+    }
+
+    if (!con.getAutoCommit()) {
+      con.commit();
+    }
+
+    int finalCount = getBatchUpdCount();
+    Assert.assertEquals(
+        "Number of new rows in batchUpdCnt should match number of non-error betchResult items"
+            + Arrays.toString(batchResult),
+        expectedRows - 1, finalCount - 1);
+
+    if (batchType != BatchType.PREPARED_WITH_GENERATED) {
+      return;
+    }
+
+    if (finalCount > 1) {
+      Assert.assertFalse((finalCount - 1) + " rows were inserted, thus expecting generated keys",
+          keys.isEmpty());
+    }
+    Set<String> uniqueKeys = new HashSet<String>(keys);
+    Assert.assertEquals("Generated keys should be unique: " + keys, keys.size(), uniqueKeys.size());
+    Assert.assertEquals("Number of generated keys should match the number of inserted rows" + keys,
+        keys.size(), finalCount - 1);
+  }
+
+  private int getBatchUpdCount() throws SQLException {
+    PreparedStatement ps = con.prepareStatement("select count(*) from batchUpdCnt");
+    ResultSet rs = ps.executeQuery();
+    Assert.assertTrue("count(*) must return 1 row", rs.next());
+    return rs.getInt(1);
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/Jdbc2TestSuite.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/Jdbc2TestSuite.java
@@ -11,6 +11,7 @@ package org.postgresql.test.jdbc2;
 import org.postgresql.test.CursorFetchBinaryTest;
 import org.postgresql.test.TestUtil;
 
+import junit.framework.JUnit4TestAdapter;
 import junit.framework.TestSuite;
 
 import java.sql.Connection;
@@ -73,6 +74,7 @@ public class Jdbc2TestSuite extends TestSuite {
     // BatchExecute
     suite.addTestSuite(BatchExecuteTest.class);
     suite.addTestSuite(BatchExecuteBinaryTest.class);
+    suite.addTest(new JUnit4TestAdapter(BatchFailureTest.class));
 
 
     // Other misc tests, based on previous problems users have had or specific


### PR DESCRIPTION
Previously, executeBatch did not consider that under error condition, a part of the batch might get rolled back.

closes #502