### PR TITLE
squid:S1488 -  Local Variables should not be declared and then immediately returned or thrown

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/fastpath/Fastpath.java
+++ b/pgjdbc/src/main/java/org/postgresql/fastpath/Fastpath.java
@@ -100,9 +100,7 @@ public class Fastpath {
     }
 
     // Run it.
-    byte[] returnValue = executor.fastpathCall(fnId, params, connection.getAutoCommit());
-
-    return returnValue;
+    return executor.fastpathCall(fnId, params, connection.getAutoCommit());
   }
 
   /**
@@ -167,8 +165,7 @@ public class Fastpath {
     }
 
     if (returnValue.length == 4) {
-      int i = ByteConverter.int4(returnValue, 0);
-      return i;
+      return ByteConverter.int4(returnValue, 0);
     } else {
       throw new PSQLException(GT.tr(
           "Fastpath call {0} - No result was returned or wrong size while expecting an integer.",
@@ -192,8 +189,7 @@ public class Fastpath {
           PSQLState.NO_DATA);
     }
     if (returnValue.length == 8) {
-      long l = ByteConverter.int8(returnValue, 0);
-      return l;
+      return ByteConverter.int8(returnValue, 0);
 
     } else {
       throw new PSQLException(

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
@@ -3103,9 +3103,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
     }
     sql += toAdd;
     sql += " order by data_type, type_schem, type_name";
-    java.sql.ResultSet rs = createMetaDataStatement().executeQuery(sql);
-
-    return rs;
+    return createMetaDataStatement().executeQuery(sql);
   }
 
 

--- a/pgjdbc/src/main/java/org/postgresql/osgi/PGDataSourceFactory.java
+++ b/pgjdbc/src/main/java/org/postgresql/osgi/PGDataSourceFactory.java
@@ -85,8 +85,7 @@ public class PGDataSourceFactory implements DataSourceFactory {
       throw new PSQLException(GT.tr("Unsupported properties: {0}", props.stringPropertyNames()),
           PSQLState.INVALID_PARAMETER_VALUE);
     }
-    org.postgresql.Driver driver = new org.postgresql.Driver();
-    return driver;
+    return new org.postgresql.Driver();
   }
 
   private DataSource createPoolingDataSource(Properties props) throws SQLException {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1488 -  Local Variables should not be declared and then immediately returned or thrown.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1488
Please let me know if you have any questions.
George Kankava