### PR TITLE
squid:S2325 - private methods that don't access instance data should be static

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java
@@ -280,7 +280,7 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
    *
    * @return The current JVM time zone in postgresql format.
    */
-  private String createPostgresTimeZone() {
+  private static String createPostgresTimeZone() {
     String tz = TimeZone.getDefault().getID();
     if (tz.length() <= 3 || !tz.startsWith("GMT")) {
       return tz;

--- a/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
+++ b/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
@@ -1133,7 +1133,7 @@ public abstract class BaseDataSource implements Referenceable {
     }
   }
 
-  private String getReferenceProperty(Reference ref, String propertyName) {
+  private static String getReferenceProperty(Reference ref, String propertyName) {
     RefAddr addr = ref.get(propertyName);
     if (addr == null) {
       return null;

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
@@ -2059,7 +2059,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
    * Add the user described by the given acl to the Lists of users with the privileges described by
    * the acl.
    */
-  private void addACLPrivileges(String acl, Map<String, Map<String, List<String[]>>> privileges) {
+  private static void addACLPrivileges(String acl, Map<String, Map<String, List<String[]>>> privileges) {
     int equalIndex = acl.lastIndexOf("=");
     int slashIndex = acl.lastIndexOf("/");
     if (equalIndex == -1) {

--- a/pgjdbc/src/main/java/org/postgresql/util/PGInterval.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/PGInterval.java
@@ -375,7 +375,7 @@ public class PGInterval extends PGobject implements Serializable, Cloneable {
    * @return integer parsed from string value
    * @throws NumberFormatException if the string contains invalid chars
    */
-  private int nullSafeIntGet(String value) throws NumberFormatException {
+  private static int nullSafeIntGet(String value) throws NumberFormatException {
     return (value == null) ? 0 : Integer.parseInt(value);
   }
 
@@ -386,7 +386,7 @@ public class PGInterval extends PGobject implements Serializable, Cloneable {
    * @return double parsed from string value
    * @throws NumberFormatException if the string contains invalid chars
    */
-  private double nullSafeDoubleGet(String value) throws NumberFormatException {
+  private static double nullSafeDoubleGet(String value) throws NumberFormatException {
     return (value == null) ? 0 : Double.parseDouble(value);
   }
 

--- a/pgjdbc/src/main/java/org/postgresql/util/StreamWrapper.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/StreamWrapper.java
@@ -159,7 +159,7 @@ public class StreamWrapper {
     return "<stream of " + length + " bytes>";
   }
 
-  private int copyStream(InputStream inputStream, OutputStream outputStream, int limit)
+  private static int copyStream(InputStream inputStream, OutputStream outputStream, int limit)
       throws IOException {
     int totalLength = 0;
     byte[] buffer = new byte[2048];

--- a/ubenchmark/src/main/java/org/postgresql/benchmark/profilers/FlightRecorderProfiler.java
+++ b/ubenchmark/src/main/java/org/postgresql/benchmark/profilers/FlightRecorderProfiler.java
@@ -50,7 +50,7 @@ public class FlightRecorderProfiler implements ExternalProfiler {
             + params.getBenchmark() + "_" + sb + ".jfr");
   }
 
-  private long getDurationSeconds(IterationParams warmup) {
+  private static long getDurationSeconds(IterationParams warmup) {
     return warmup.getTime().convertTo(TimeUnit.SECONDS) * warmup.getCount();
   }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S2325 - private methods that don't access instance data should be static.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS2325
Please let me know if you have any questions.
George Kankava