### PR TITLE
squid:S1206 - equals(Object obj) and hashCode() should be overridden in pairs

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/util/PGmoney.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/PGmoney.java
@@ -67,6 +67,16 @@ public class PGmoney extends PGobject implements Serializable, Cloneable {
     }
   }
 
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = super.hashCode();
+    long temp;
+    temp = Double.doubleToLongBits(val);
+    result = prime * result + (int) (temp ^ (temp >>> 32));
+    return result;
+  }
+
   public boolean equals(Object obj) {
     if (obj instanceof PGmoney) {
       PGmoney p = (PGmoney) obj;

--- a/pgjdbc/src/main/java/org/postgresql/xa/RecoveredXid.java
+++ b/pgjdbc/src/main/java/org/postgresql/xa/RecoveredXid.java
@@ -30,6 +30,16 @@ class RecoveredXid implements Xid {
     return branchQualifier;
   }
 
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + Arrays.hashCode(branchQualifier);
+    result = prime * result + formatId;
+    result = prime * result + Arrays.hashCode(globalTransactionId);
+    return result;
+  }
+
   public boolean equals(Object o) {
     if (o == this) {
       // optimization for the common case.


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1206 - equals(Object obj) and hashCode() should be overridden in pairs.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1206
Please let me know if you have any questions.
George Kankava