### PR TITLE
refactor: Remove pgTypeName null check

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
@@ -252,9 +252,7 @@ public class TypeInfoCache implements TypeInfo {
     }
     rs.close();
 
-    if (pgTypeName != null) {
-      _pgNameToSQLType.put(pgTypeName, type);
-    }
+    _pgNameToSQLType.put(pgTypeName, type);
     return type;
   }
 


### PR DESCRIPTION
There is a null check for the pgTypeName parameter at the end of
TypeInfoCache.getSQLType(String). However at the start of this method
pgTypeName.endsWith("[]") is called. pgTypeName is never assigned. If
follows that pgTypeName can never be null at the end of the method.