### PR TITLE
Resolving issue #524 from pgjdbc

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgArray.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgArray.java
@@ -881,7 +881,7 @@ public class PgArray implements java.sql.Array {
   }
 
   public String toString() {
-    if (fieldString == null) {
+    if (fieldString == null && fieldBytes != null) {
       try {
         Object array = readBinaryArray(1,0);
         java.sql.Array tmpArray = connection.createArrayOf(getBaseTypeName(), (Object[]) array);

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ArrayTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ArrayTest.java
@@ -8,8 +8,10 @@
 
 package org.postgresql.test.jdbc2;
 
+import org.postgresql.core.BaseConnection;
 import org.postgresql.geometric.PGbox;
 import org.postgresql.geometric.PGpoint;
+import org.postgresql.jdbc.PgArray;
 import org.postgresql.test.TestUtil;
 
 import org.junit.Assert;
@@ -265,12 +267,13 @@ public class ArrayTest extends BaseTest4 {
     Assert.assertEquals(1, i[0].intValue());
     Assert.assertNull(i[1]);
     Assert.assertEquals(3, i[2].intValue());
-    rs = stmt.executeQuery("SELECT null::int[]");
-    Assert.assertTrue(rs.next());
-    Assert.assertNull(rs.getArray(1));
   }
 
-
+  @Test
+  public void testNullFieldString() throws SQLException {
+    Array arr = new PgArray((BaseConnection) conn, 1, (String) null);
+    Assert.assertNull(arr.toString());
+  }
 
   @Test
   public void testUnknownArrayType() throws SQLException {

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ArrayTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ArrayTest.java
@@ -265,7 +265,12 @@ public class ArrayTest extends BaseTest4 {
     Assert.assertEquals(1, i[0].intValue());
     Assert.assertNull(i[1]);
     Assert.assertEquals(3, i[2].intValue());
+    rs = stmt.executeQuery("SELECT null::int[]");
+    Assert.assertTrue(rs.next());
+    Assert.assertNull(rs.getArray(1));
   }
+
+
 
   @Test
   public void testUnknownArrayType() throws SQLException {


### PR DESCRIPTION
This is to resolve the issue proposed. Adds a minor check that the fieldBytes aren't null before proceeding to reconstruct.