### PR TITLE
refactor: Remove ClassCastException catch

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/copy/CopyManager.java
+++ b/pgjdbc/src/main/java/org/postgresql/copy/CopyManager.java
@@ -48,26 +48,24 @@ public class CopyManager {
   }
 
   public CopyIn copyIn(String sql) throws SQLException {
-    CopyOperation op = null;
-    try {
-      op = queryExecutor.startCopy(sql, connection.getAutoCommit());
+    CopyOperation op = queryExecutor.startCopy(sql, connection.getAutoCommit());
+    if (op == null || op instanceof CopyIn) {
       return (CopyIn) op;
-    } catch (ClassCastException cce) {
+    } else {
       op.cancelCopy();
       throw new PSQLException(GT.tr("Requested CopyIn but got {0}", op.getClass().getName()),
-          PSQLState.WRONG_OBJECT_TYPE, cce);
+              PSQLState.WRONG_OBJECT_TYPE);
     }
   }
 
   public CopyOut copyOut(String sql) throws SQLException {
-    CopyOperation op = null;
-    try {
-      op = queryExecutor.startCopy(sql, connection.getAutoCommit());
+    CopyOperation op = queryExecutor.startCopy(sql, connection.getAutoCommit());
+    if (op == null || op instanceof CopyOut) {
       return (CopyOut) op;
-    } catch (ClassCastException cce) {
+    } else {
       op.cancelCopy();
       throw new PSQLException(GT.tr("Requested CopyOut but got {0}", op.getClass().getName()),
-          PSQLState.WRONG_OBJECT_TYPE, cce);
+              PSQLState.WRONG_OBJECT_TYPE);
     }
   }
 


### PR DESCRIPTION
CopyManager has two catches for ClassCastException. This ins't very
nice and can easily be changed to do a check before the cast.