### PR TITLE
Fix interpretation of empty but set "ssl" connection property

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/v2/ConnectionFactoryImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v2/ConnectionFactoryImpl.java
@@ -63,7 +63,7 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
     if (sslmode == null) { // Fall back to the ssl property
       // assume "true" if the property is set but empty
       requireSSL = trySSL = PGProperty.SSL.getBoolean(info)
-        || PGProperty.SSL.get(info) != null && PGProperty.SSL.get(info).equals("");
+        || PGProperty.SSL.get(info) != null && "".equals(PGProperty.SSL.get(info));
     } else {
       if ("disable".equals(sslmode)) {
         requireSSL = trySSL = false;

--- a/pgjdbc/src/main/java/org/postgresql/core/v2/ConnectionFactoryImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v2/ConnectionFactoryImpl.java
@@ -61,7 +61,9 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
     boolean trySSL;
     String sslmode = PGProperty.SSL_MODE.get(info);
     if (sslmode == null) { // Fall back to the ssl property
-      requireSSL = trySSL = PGProperty.SSL.getBoolean(info);
+      // assume "true" if the property is set but empty
+      requireSSL = trySSL = PGProperty.SSL.getBoolean(info)
+        || PGProperty.SSL.get(info) != null && PGProperty.SSL.get(info).equals("");
     } else {
       if ("disable".equals(sslmode)) {
         requireSSL = trySSL = false;

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java
@@ -76,7 +76,9 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
     boolean trySSL;
     String sslmode = PGProperty.SSL_MODE.get(info);
     if (sslmode == null) { // Fall back to the ssl property
-      requireSSL = trySSL = PGProperty.SSL.getBoolean(info);
+      // assume "true" if the property is set but empty
+      requireSSL = trySSL = PGProperty.SSL.getBoolean(info)
+        || PGProperty.SSL.get(info) != null && PGProperty.SSL.get(info).equals("");
     } else {
       if ("disable".equals(sslmode)) {
         requireSSL = trySSL = false;

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java
@@ -78,7 +78,7 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
     if (sslmode == null) { // Fall back to the ssl property
       // assume "true" if the property is set but empty
       requireSSL = trySSL = PGProperty.SSL.getBoolean(info)
-        || PGProperty.SSL.get(info) != null && PGProperty.SSL.get(info).equals("");
+        || PGProperty.SSL.get(info) != null && "".equals(PGProperty.SSL.get(info));
     } else {
       if ("disable".equals(sslmode)) {
         requireSSL = trySSL = false;

--- a/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
+++ b/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
@@ -464,7 +464,7 @@ public abstract class BaseDataSource implements Referenceable {
   public boolean getSsl() {
     // "true" if "ssl" is set but empty
     return PGProperty.SSL.getBoolean(properties)
-      || PGProperty.SSL.get(properties) != null && PGProperty.SSL.get(properties).equals("");
+      || PGProperty.SSL.get(properties) != null && "".equals(PGProperty.SSL.get(properties));
   }
 
   /**

--- a/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
+++ b/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
@@ -453,7 +453,7 @@ public abstract class BaseDataSource implements Referenceable {
     if (enabled) {
       PGProperty.SSL.set(properties, true);
     } else {
-      PGProperty.SSL.set(properties, null);
+      PGProperty.SSL.set(properties, false);
     }
   }
 
@@ -462,7 +462,9 @@ public abstract class BaseDataSource implements Referenceable {
    * @see PGProperty#SSL
    */
   public boolean getSsl() {
-    return PGProperty.SSL.isPresent(properties);
+    // "true" if "ssl" is set but empty
+    return PGProperty.SSL.getBoolean(properties)
+      || PGProperty.SSL.get(properties) != null && PGProperty.SSL.get(properties).equals("");
   }
 
   /**


### PR DESCRIPTION
Commit a6a61be858fd3fff53003b78f061d60cd04710d1 ignored the case that
the "ssl" property is set but empty, which means "true" according to
the documentation.
The consequence is that no SSL connection is attempted in this case.

This should fix #528.