### PR TITLE
test: avoid "The connection attempt failed" in ConnectTimeoutTest. testTimeout

### DIFF
--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ConnectTimeoutTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ConnectTimeoutTest.java
@@ -11,9 +11,10 @@ import java.sql.SQLException;
 import java.util.Properties;
 
 public class ConnectTimeoutTest extends TestCase {
-  private static final String UNREACHABLE_HOST = "1.0.0.0";
-  private static final String UNREACHABLE_URL = "jdbc:postgresql://" + UNREACHABLE_HOST + "/test";
-  private static final int CONNECT_TIMEOUT = 10;
+  // The IP below is non-routable (see http://stackoverflow.com/a/904609/1261287)
+  private static final String UNREACHABLE_HOST = "10.255.255.1";
+  private static final String UNREACHABLE_URL = "jdbc:postgresql://" + UNREACHABLE_HOST + ":5432/test";
+  private static final int CONNECT_TIMEOUT = 5;
 
   @Override
   protected void setUp() throws Exception {


### PR DESCRIPTION
Hopefully this will solve the following issue when running Travis:
```
Unexpected org.postgresql.util.PSQLException: The connection attempt failed.
	at junit.framework.Assert.fail(Assert.java:57)
	at junit.framework.Assert.assertTrue(Assert.java:22)
	at org.postgresql.test.jdbc2.ConnectTimeoutTest.testTimeout(ConnectTimeoutTest.java:35)
```