### PR TITLE
Only execute "SET application_name" if name has changed

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
@@ -1362,6 +1362,10 @@ public class PgConnection implements BaseConnection {
       if (value == null) {
         value = "";
       }
+      final String oldValue = _clientInfo.getProperty(name, "");
+      if (value.equals(oldValue)) {
+        return;
+      }
 
       try {
         StringBuilder sql = new StringBuilder("SET application_name = '");


### PR DESCRIPTION
glassfish3's connection pool implementation insist on calling setClientInfo:
- after connecting
- when getting a pooled connection
- when returning a connection to the pool
- before every statement

While this is clearly ... erm ... "suboptimal behaviour" in glassfish,
I don't see a reason to issue the query if ApplicationName hasn't changed.

Also see: http://www.postgresql.org/message-id/flat/CADK3HHJKRq09otwqtv3rtnDh9h_LqFvBz+BHKgHjZgtnybvF1g@mail.gmail.com