### PR TITLE
Update default password for tests.

### DIFF
--- a/pgjdbc/src/test/java/org/postgresql/test/README
+++ b/pgjdbc/src/test/java/org/postgresql/test/README
@@ -58,7 +58,7 @@ loss of data. We recommend you assign the following names:
 
   database: test
   username: test
-  password: password
+  password: test
 
 These names correspond with the default names set for the test suite
 in $JDBC_SRC/build.xml. If you have chosen other names you need to


### PR DESCRIPTION
This README is out of date, but it is linked from the one in the root, so it should be corrected.