### PR TITLE
Make tests independent from server LC_MESSAGES

### DIFF
--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/GeometricTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/GeometricTest.java
@@ -127,7 +127,7 @@ public class GeometricTest extends TestCase {
           checkReadWrite(new PGline(), columnName);
           fail("Expected a PGSQLException to be thrown");
         } catch (PSQLException e) {
-          assertTrue(e.getMessage().contains("A and B cannot both be zero"));
+          assertEquals("22P02", e.getSQLState());
         }
       }
 

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/GeometricTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/GeometricTest.java
@@ -125,7 +125,7 @@ public class GeometricTest extends TestCase {
       if (roundTripToDatabase) {
         try {
           checkReadWrite(new PGline(), columnName);
-          fail("Expected a PGSQLException to be thrown");
+          fail("Expected a PSQLException to be thrown");
         } catch (PSQLException e) {
           assertEquals("22P02", e.getSQLState());
         }


### PR DESCRIPTION
This is the only test that fails if the server locale is not English, or en_US, or whatever.

The comment on this code actually says it tests whether the server throws "an exception". The original code checked the nature of the exception, so this does, too.

(Note: I did not set up to run the SSL or XA tests, so they were skipped.)