### PR TITLE
Require Waffle 1.8.1 for building.

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/sspi/SSPIClient.java
+++ b/pgjdbc/src/main/java/org/postgresql/sspi/SSPIClient.java
@@ -160,7 +160,7 @@ public class SSPIClient {
 
         sspiContext = new WindowsSecurityContextImpl();
         sspiContext.setPrincipalName(targetName);
-        sspiContext.setCredentialsHandle(clientCredentials.getHandle());
+        sspiContext.setCredentialsHandle(clientCredentials);
         sspiContext.setSecurityPackage(securityPackage);
         sspiContext.initialize(null, null, targetName);
       } catch (Win32Exception ex) {


### PR DESCRIPTION
Track the Waffle API change made as part of fixing a resource leak in versions before 1.7.5. This change depends on pgjdbc-parent-poms#5.