### PR TITLE
Add basic tests for SSPI authentication.

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -9,6 +9,7 @@ username=test
 password=test
 privilegedUser=postgres
 privilegedPassword=
+sspiusername=testsspi
 preparethreshold=5
 loglevel=0
 protocolVersion=0

--- a/pgjdbc/pom.xml
+++ b/pgjdbc/pom.xml
@@ -133,6 +133,9 @@
                 <exclude>org/postgresql/sspi/NTDSAPIWrapper.java</exclude>
                 <exclude>org/postgresql/sspi/SSPIClient.java</exclude>
               </excludes>
+              <testExcludes>
+                <exclude>org/postgresql/test/sspi/*.java</exclude>
+              </testExcludes>
             </configuration>
           </plugin>
         </plugins>

--- a/pgjdbc/src/main/java/org/postgresql/util/PSQLState.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/PSQLState.java
@@ -91,6 +91,7 @@ public class PSQLState implements java.io.Serializable {
   public final static PSQLState TRANSACTION_STATE_INVALID = new PSQLState("25000");
   public final static PSQLState ACTIVE_SQL_TRANSACTION = new PSQLState("25001");
   public final static PSQLState NO_ACTIVE_SQL_TRANSACTION = new PSQLState("25P01");
+  public final static PSQLState INVALID_AUTHORIZATION_SPECIFICATION = new PSQLState("28000");
 
   public final static PSQLState STATEMENT_NOT_ALLOWED_IN_FUNCTION_CALL = new PSQLState("2F003");
 

--- a/pgjdbc/src/test/java/org/postgresql/test/TestUtil.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/TestUtil.java
@@ -121,6 +121,13 @@ public class TestUtil {
   }
 
   /*
+   * Returns the user for SSPI authentication tests
+   */
+  public static String getSSPIUser() {
+    return System.getProperty("sspiusername");
+  }
+
+  /*
    * postgres like user
    */
   public static String getPrivilegedUser() {
@@ -266,7 +273,11 @@ public class TestUtil {
   public static java.sql.Connection openDB(Properties props) throws Exception {
     initDriver();
 
-    String user = getUser();
+	// Allow properties to override the user name.
+    String user = props.getProperty("username");
+    if (user == null) {
+        user = getUser();
+    }
     if (user == null) {
       throw new IllegalArgumentException(
           "user name is not specified. Please specify 'username' property via -D or build.properties");

--- a/pgjdbc/src/test/java/org/postgresql/test/TestUtil.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/TestUtil.java
@@ -273,10 +273,10 @@ public class TestUtil {
   public static java.sql.Connection openDB(Properties props) throws Exception {
     initDriver();
 
-	// Allow properties to override the user name.
+    // Allow properties to override the user name.
     String user = props.getProperty("username");
     if (user == null) {
-        user = getUser();
+      user = getUser();
     }
     if (user == null) {
       throw new IllegalArgumentException(

--- a/pgjdbc/src/test/java/org/postgresql/test/sspi/SSPITest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/sspi/SSPITest.java
@@ -4,10 +4,14 @@ import org.postgresql.test.TestUtil;
 import org.postgresql.util.PSQLException;
 import org.postgresql.util.PSQLState;
 
+import org.junit.BeforeClass;
 import org.junit.Test;
+
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeThat;
 
 import java.sql.Connection;
 import java.sql.Statement;
@@ -20,6 +24,16 @@ import java.util.Properties;
  * configuration.
  */
 public class SSPITest {
+
+    /*
+     * SSPI only exists on Windows.
+     */
+    @BeforeClass
+    public static void checkPlatform() {
+        assumeThat("SSPI not supported on this platform",
+                   System.getProperty("os.name").toLowerCase(),
+                   containsString("windows"));
+    }
 
     /*
      * Tests that SSPI login succeeds and a query can be run.

--- a/pgjdbc/src/test/java/org/postgresql/test/sspi/SSPITest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/sspi/SSPITest.java
@@ -1,0 +1,53 @@
+package org.postgresql.test.sspi;
+
+import org.postgresql.test.TestUtil;
+import org.postgresql.util.PSQLException;
+import org.postgresql.util.PSQLState;
+
+import junit.framework.TestCase;
+
+import java.sql.Connection;
+import java.sql.Statement;
+import java.util.Properties;
+
+/*
+ * These tests require a working SSPI authentication setup
+ * in the database server that allows the executing user
+ * to authenticate as the "sspiusername" in the build
+ * configuration.
+ */
+public class SSPITest extends TestCase {
+
+    /*
+     * Tests that SSPI login succeeds and a query can be run.
+     */
+    public void testAuthorized() throws Exception {
+        Properties props = new Properties();
+        props.setProperty("username", TestUtil.getSSPIUser());
+        Connection con = TestUtil.openDB(props);
+
+        Statement stmt = con.createStatement();
+        stmt.executeQuery("SELECT 1");
+
+        TestUtil.closeDB(con);
+    }
+
+    /*
+     * Tests that SSPI login fails with an unknown/unauthorized
+     * user name.
+     */
+    public void testUnauthorized() throws Exception {
+        Properties props = new Properties();
+        props.setProperty("username", "invalid" + TestUtil.getSSPIUser());
+
+        try {
+            Connection con = TestUtil.openDB(props);
+            TestUtil.closeDB(con);
+            fail("Expected a PSQLException");
+        } catch (PSQLException e) {
+            assertEquals(PSQLState.INVALID_AUTHORIZATION_SPECIFICATION.getState(), e.getSQLState());
+        }
+    }
+
+}
+

--- a/pgjdbc/src/test/java/org/postgresql/test/sspi/SSPITest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/sspi/SSPITest.java
@@ -4,7 +4,10 @@ import org.postgresql.test.TestUtil;
 import org.postgresql.util.PSQLException;
 import org.postgresql.util.PSQLState;
 
-import junit.framework.TestCase;
+import org.junit.Test;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 import java.sql.Connection;
 import java.sql.Statement;
@@ -16,11 +19,12 @@ import java.util.Properties;
  * to authenticate as the "sspiusername" in the build
  * configuration.
  */
-public class SSPITest extends TestCase {
+public class SSPITest {
 
     /*
      * Tests that SSPI login succeeds and a query can be run.
      */
+    @Test
     public void testAuthorized() throws Exception {
         Properties props = new Properties();
         props.setProperty("username", TestUtil.getSSPIUser());
@@ -36,6 +40,7 @@ public class SSPITest extends TestCase {
      * Tests that SSPI login fails with an unknown/unauthorized
      * user name.
      */
+    @Test
     public void testUnauthorized() throws Exception {
         Properties props = new Properties();
         props.setProperty("username", "invalid" + TestUtil.getSSPIUser());
@@ -45,7 +50,7 @@ public class SSPITest extends TestCase {
             TestUtil.closeDB(con);
             fail("Expected a PSQLException");
         } catch (PSQLException e) {
-            assertEquals(PSQLState.INVALID_AUTHORIZATION_SPECIFICATION.getState(), e.getSQLState());
+            assertThat(e.getSQLState(), is(PSQLState.INVALID_AUTHORIZATION_SPECIFICATION.getState()));
         }
     }
 

--- a/pgjdbc/src/test/java/org/postgresql/test/sspi/SSPITestSuite.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/sspi/SSPITestSuite.java
@@ -1,24 +1,15 @@
 package org.postgresql.test.sspi;
 
-import junit.framework.JUnit4TestAdapter;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
 
 /*
  * Executes all known tests for SSPI.
  */
-public class SSPITestSuite extends TestSuite {
-
-  /*
-   * The main entry point for JUnit
-   */
-  public static TestSuite suite() throws Exception {
-    TestSuite suite = new TestSuite();
-
-    // Add one line per class in our test cases.
-    suite.addTestSuite(SSPITest.class);
-
-    // That's all folks.
-    return suite;
-  }
-
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+	SSPITest.class
+})
+public class SSPITestSuite {
+	// Empty.
 }

--- a/pgjdbc/src/test/java/org/postgresql/test/sspi/SSPITestSuite.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/sspi/SSPITestSuite.java
@@ -7,9 +7,7 @@ import org.junit.runners.Suite;
  * Executes all known tests for SSPI.
  */
 @RunWith(Suite.class)
-@Suite.SuiteClasses({
-	SSPITest.class
-})
+@Suite.SuiteClasses({ SSPITest.class })
 public class SSPITestSuite {
-	// Empty.
+  // Empty.
 }

--- a/pgjdbc/src/test/java/org/postgresql/test/sspi/SSPITestSuite.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/sspi/SSPITestSuite.java
@@ -1,0 +1,24 @@
+package org.postgresql.test.sspi;
+
+import junit.framework.JUnit4TestAdapter;
+import junit.framework.TestSuite;
+
+/*
+ * Executes all known tests for SSPI.
+ */
+public class SSPITestSuite extends TestSuite {
+
+  /*
+   * The main entry point for JUnit
+   */
+  public static TestSuite suite() throws Exception {
+    TestSuite suite = new TestSuite();
+
+    // Add one line per class in our test cases.
+    suite.addTestSuite(SSPITest.class);
+
+    // That's all folks.
+    return suite;
+  }
+
+}


### PR DESCRIPTION
- Both successful and unsuccessful authentication is tested, the latter to ensure that a configuration mistake (such as a "trust" line left in pg_hba.conf) has not caused *both* tests to succeed when they should have failed.

- ~~Setting up to run these tests is not entirely (or at all) trivial; it requires running the database server as an account that is capable of SSPI authentication (such as a virtual service account, e.g. "NT SERVICE\PostgreSQL") on both domain member and non-member systems, or a domain user account.~~

- Additionally, both pg_hba.conf and, in most cases, pg_ident.conf must be configured. In particular, the user account that runs the tests must be permitted to authenticate as the database role configured in build.properties.

- The tests are not run when Waffle is disabled. I would have preferred to have a separate option to turn them off even when building with Waffle because the setup is so difficult. I could not think of a way to make Maven do this, mostly because profiles cannot be chained, and profile activation cannot use two variables, for example (!enableWaffle || disableSSPITests).

- There is an intermittent problem where testUnauthorized() fails because it gets the wrong exception: It expects SQLSTATE 28000 from the server, but sometimes it gets 08001 generated internally in the driver. No idea what causes that. I did not want to blindly accept any error as proof of failed authentication.
