### PR TITLE
fix: support PostgreSQL 9.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,13 @@ matrix:
       sudo: required
       dist: trusty
       env:
+        - PG_VERSION=9.6
+        - XA=true
+        - COVERAGE=Y
+    - jdk: oraclejdk8
+      sudo: required
+      dist: trusty
+      env:
         - PG_VERSION=9.5
         - XA=true
         - COVERAGE=Y
@@ -120,7 +127,7 @@ matrix:
         postgresql: "9.4"
       env:
         - PG_VERSION=9.4
-        - MVN_CUSTOM_ARGS='-DwaffleEnabled=false -DosgiEnabled=false -DexcludePackageNames=org.postgresql.osgi:org.postgresql.sspi'
+        - NO_WAFFLE_NO_OSGI=Y
 
 # Deploy snapshots to Maven Central
 after_success:

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ For problems with this driver, refer to driver's [home page](http://jdbc.postgre
 Most people do not need to compile PgJDBC. You can download prebuilt versions of the driver 
 from the [Postgresql JDBC site](http://jdbc.postgresql.org/) or using your chosen dependency management tool:
 
+## Supported PostgreSQL versions
+
+Pgjdbc regression tests are run against PostgreSQL 8.4, 9.1, 9.2, 9.3, 9.4, 9.5, 9.6.
+
 ### Maven
 ```xml
 <dependency>

--- a/pgjdbc/src/main/java/org/postgresql/core/ServerVersion.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/ServerVersion.java
@@ -26,7 +26,9 @@ public enum ServerVersion implements Version {
   v9_2("9.2.0"),
   v9_3("9.3.0"),
   v9_4("9.4.0"),
-  v9_5("9.5.0"),;
+  v9_5("9.5.0"),
+  v9_6("9.6.0"),
+  ;
 
   private final int version;
 

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
@@ -2853,13 +2853,16 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
           + "  END AS TYPE, "
           + "  (i.keys).n AS ORDINAL_POSITION, "
           + "  trim(both '\"' from pg_catalog.pg_get_indexdef(ci.oid, (i.keys).n, false)) AS COLUMN_NAME, "
-          + "  CASE am.amcanorder "
-          + "    WHEN true THEN CASE i.indoption[(i.keys).n - 1] & 1 "
-          + "      WHEN 1 THEN 'D' "
-          + "      ELSE 'A' "
-          + "    END "
-          + "    ELSE NULL "
-          + "  END AS ASC_OR_DESC, "
+          // TODO: Implement ASC_OR_DESC for PostgreSQL 9.6+
+          + (connection.haveMinimumServerVersion(ServerVersion.v9_6)
+          ? "NULL AS ASC_OR_DESC, "
+          : "  CASE am.amcanorder "
+              + "    WHEN true THEN CASE i.indoption[(i.keys).n - 1] & 1 "
+              + "      WHEN 1 THEN 'D' "
+              + "      ELSE 'A' "
+              + "    END "
+              + "    ELSE NULL "
+              + "  END AS ASC_OR_DESC, ")
           + "  ci.reltuples AS CARDINALITY, "
           + "  ci.relpages AS PAGES, "
           + "  pg_catalog.pg_get_expr(i.indpred, i.indrelid) AS FILTER_CONDITION "

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseMetaDataTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseMetaDataTest.java
@@ -8,6 +8,7 @@
 
 package org.postgresql.test.jdbc2;
 
+import org.postgresql.core.ServerVersion;
 import org.postgresql.test.TestUtil;
 
 import junit.framework.TestCase;
@@ -588,12 +589,22 @@ public class DatabaseMetaDataTest extends TestCase {
     assertTrue(rs.next());
     assertEquals("idx_a_d", rs.getString("INDEX_NAME"));
     assertEquals("id", rs.getString("COLUMN_NAME"));
-    assertEquals("A", rs.getString("ASC_OR_DESC"));
+    if (TestUtil.haveMinimumServerVersion(con, ServerVersion.v9_6)) {
+      assertNull("ASC_OR_DESC for index is not yet supported for PostgreSQL 9.6",
+          rs.getString("ASC_OR_DESC"));
+    } else {
+      assertEquals("A", rs.getString("ASC_OR_DESC"));
+    }
 
     assertTrue(rs.next());
     assertEquals("idx_a_d", rs.getString("INDEX_NAME"));
     assertEquals("quest", rs.getString("COLUMN_NAME"));
-    assertEquals("D", rs.getString("ASC_OR_DESC"));
+    if (TestUtil.haveMinimumServerVersion(con, ServerVersion.v9_6)) {
+      assertNull("ASC_OR_DESC for index is not yet supported for PostgreSQL 9.6",
+          rs.getString("ASC_OR_DESC"));
+    } else {
+      assertEquals("D", rs.getString("ASC_OR_DESC"));
+    }
   }
 
   public void testPartialIndexInfo() throws SQLException {

--- a/travis_deploy.sh
+++ b/travis_deploy.sh
@@ -3,7 +3,10 @@ set -x -e
 
 # Skip tests and checkstype to speed up snapshot deployment
 MVN_ARGS="clean deploy -B -V -DskipTests -Dcheckstyle.skip=true -Dskip.assembly=true --settings settings.xml"
-MVN_ARGS="$MVN_ARGS $MVN_CUSTOM_ARGS"
+if [[ "${NO_WAFFLE_NO_OSGI}" == *"Y"* ]];
+then
+    MVN_ARGS="$MVN_ARGS -DwaffleEnabled=false -DosgiEnabled=false -DexcludePackageNames=org.postgresql.osgi:org.postgresql.sspi"
+fi
 
 if [[ "${TRAVIS_JDK_VERSION}" == *"jdk6"* ]];
 then

--- a/travis_install_dependencies.sh
+++ b/travis_install_dependencies.sh
@@ -6,7 +6,7 @@ sudo service postgresql stop
 sudo cp /etc/postgresql/9.1/main/pg_hba.conf ./
 sudo apt-get remove postgresql libpq-dev libpq5 postgresql-client-common postgresql-common -qq --purge
 source /etc/lsb-release
-echo "deb http://apt.postgresql.org/pub/repos/apt/ $DISTRIB_CODENAME-pgdg main" > pgdg.list
+echo "deb http://apt.postgresql.org/pub/repos/apt/ $DISTRIB_CODENAME-pgdg main ${PG_VERSION}" > pgdg.list
 sudo mv pgdg.list /etc/apt/sources.list.d/
 wget --quiet -O - https://apt.postgresql.org/pub/repos/apt/ACCC4CF8.asc | sudo apt-key add -
 sudo apt-get update


### PR DESCRIPTION
This PR adds PostgreSQL 9.6 regression test.

`org.postgresql.jdbc.PgDatabaseMetaData#getIndexInfo` is changed to return `NULL AS ASC_OR_DESC` for 9.6+.

9.6 does not have `pg_am.amcanorder`, thus `getIndexInfo` failed as the following:
```
testPartialIndexInfo(org.postgresql.test.jdbc2.DatabaseMetaDataTest)  Time elapsed: 0.055 sec  <<< ERROR!
org.postgresql.util.PSQLException: ERROR: column am.amcanorder does not exist
  Position: 427
	at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2299)
	at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2015)
	at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:210)
	at org.postgresql.jdbc.PgStatement.execute(PgStatement.java:425)
	at org.postgresql.jdbc.PgStatement.executeWithFlags(PgStatement.java:322)
	at org.postgresql.jdbc.PgStatement.executeQuery(PgStatement.java:285)
	at org.postgresql.jdbc.PgDatabaseMetaData.getIndexInfo(PgDatabaseMetaData.java:2952)
	at org.postgresql.test.jdbc2.DatabaseMetaDataTest.testPartialIndexInfo(DatabaseMetaDataTest.java:605)
```