### PR TITLE
Code debt reduction on #491 PR.

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/NativeQuery.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/NativeQuery.java
@@ -19,7 +19,7 @@ public class NativeQuery {
 
   public final String nativeSql;
   public final int[] bindPositions;
-  public final DMLCommand command;
+  public final SqlCommand command;
 
   static {
     for (int i = 1; i < BIND_NAMES.length; i++) {
@@ -27,11 +27,11 @@ public class NativeQuery {
     }
   }
 
-  public NativeQuery(String nativeSql, DMLCommand dml) {
+  public NativeQuery(String nativeSql, SqlCommand dml) {
     this(nativeSql, NO_BINDS, dml);
   }
 
-  public NativeQuery(String nativeSql, int[] bindPositions, DMLCommand dml) {
+  public NativeQuery(String nativeSql, int[] bindPositions, SqlCommand dml) {
     this.nativeSql = nativeSql;
     this.bindPositions =
         bindPositions == null || bindPositions.length == 0 ? NO_BINDS : bindPositions;
@@ -83,7 +83,7 @@ public class NativeQuery {
     return BIND_NAMES.length;
   }
 
-  public DMLCommand getCommand() {
+  public SqlCommand getCommand() {
     return command;
   }
 }

--- a/pgjdbc/src/main/java/org/postgresql/core/Parser.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/Parser.java
@@ -43,7 +43,7 @@ public class Parser {
       boolean isBatchedReWriteConfigured) {
     if (!withParameters && !splitStatements) {
       return Collections.singletonList(new NativeQuery(query,
-        DMLCommand.createStatementTypeInfo(DMLCommandType.BLANK)));
+        SqlCommand.createStatementTypeInfo(SqlCommandType.BLANK)));
     }
 
     int fragmentStart = 0;
@@ -58,7 +58,7 @@ public class Parser {
     int afterValuesParens = 0;
     boolean isInsertPresent = false;
     boolean isReturningPresent = false;
-    DMLCommandType current = DMLCommandType.BLANK;
+    SqlCommandType current = SqlCommandType.BLANK;
 
     boolean whitespaceOnly = true;
     for (int i = 0; i < aChars.length; ++i) {
@@ -131,7 +131,7 @@ public class Parser {
               }
 
               nativeQueries.add(new NativeQuery(nativeSql.toString(),
-                  toIntArray(bindPositions), DMLCommand.createStatementTypeInfo(
+                  toIntArray(bindPositions), SqlCommand.createStatementTypeInfo(
                   current, isBatchedReWriteConfigured, isCurrentReWriteCompatible,
                   isReturningPresent, isAutoCommit, nativeQueries.size())));
             }
@@ -140,7 +140,7 @@ public class Parser {
               bindPositions.clear();
             }
             nativeSql.setLength(0);
-            current = DMLCommandType.BLANK;
+            current = SqlCommandType.BLANK;
             isReturningPresent = false;
           }
           break;
@@ -148,7 +148,7 @@ public class Parser {
         case 'd':
         case 'D':
           if (Parser.parseDeleteKeyword(aChars, i)) {
-            current = DMLCommandType.DELETE;
+            current = SqlCommandType.DELETE;
             i += 5;
           }
           break;
@@ -159,7 +159,7 @@ public class Parser {
             if ( !isInsertPresent && (nativeQueries == null ? true : nativeQueries.size() == 0)) {
               isCurrentReWriteCompatible = true;
               isInsertPresent = true;
-              current = DMLCommandType.INSERT;
+              current = SqlCommandType.INSERT;
             } else {
               isCurrentReWriteCompatible = false;
             }
@@ -170,7 +170,7 @@ public class Parser {
         case 'm':
         case 'M':
           if (Parser.parseMoveKeyword(aChars, i)) {
-            current = DMLCommandType.MOVE;
+            current = SqlCommandType.MOVE;
             i += 3;
           }
           break;
@@ -187,7 +187,7 @@ public class Parser {
         case 'u':
         case 'U':
           if (Parser.parseUpdateKeyword(aChars, i)) {
-            current = DMLCommandType.UPDATE;
+            current = SqlCommandType.UPDATE;
             i += 5;
           }
           break;
@@ -214,7 +214,7 @@ public class Parser {
     }
 
     NativeQuery lastQuery = new NativeQuery(nativeSql.toString(),
-        toIntArray(bindPositions), DMLCommand.createStatementTypeInfo(current,
+        toIntArray(bindPositions), SqlCommand.createStatementTypeInfo(current,
         isBatchedReWriteConfigured, isCurrentReWriteCompatible,
         isReturningPresent, isAutoCommit, (nativeQueries == null ? 0 :
         nativeQueries.size())));

--- a/pgjdbc/src/main/java/org/postgresql/core/QueryExecutor.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/QueryExecutor.java
@@ -110,7 +110,8 @@ public interface QueryExecutor {
    * Execute a Query, passing results to a provided ResultHandler.
    *
    * @param query the query to execute; must be a query returned from calling
-   *        {@link #createSimpleQuery(String, boolean)} or {@link #createParameterizedQuery(String, boolean)} on this
+   *        {@link #createSimpleQuery(String, boolean, boolean)} or
+   *        {@link #createParameterizedQuery(String, boolean, boolean)} on this
    *        QueryExecutor object.
    * @param parameters the parameters for the query. Must be non-<code>null</code> if the query
    *        takes parameters. Must be a parameter object returned by
@@ -129,7 +130,8 @@ public interface QueryExecutor {
    * Execute several Query, passing results to a provided ResultHandler.
    *
    * @param queries the queries to execute; each must be a query returned from calling
-   *        {@link #createSimpleQuery(String, boolean)} or {@link #createParameterizedQuery(String, boolean)}
+   *        {@link #createSimpleQuery(String, boolean, boolean)} or
+   *        {@link #createParameterizedQuery(String, boolean, boolean)}
    *         on this QueryExecutor object.
    * @param parameterLists the parameter lists for the queries. The parameter lists correspond 1:1
    *        to the queries passed in the <code>queries</code> array. Each must be non-
@@ -164,9 +166,10 @@ public interface QueryExecutor {
    *
    * @param sql the SQL for the query to create
    * @param autocommit indicating when connection has autocommit enabled.
+   * @param allowReWriteBatchedInserts indicates the optimization is enabled
    * @return a new Query object
    */
-  Query createSimpleQuery(String sql, boolean autocommit);
+  Query createSimpleQuery(String sql, boolean autocommit, boolean allowReWriteBatchedInserts);
 
   /**
    * Create a parameterized Query object suitable for execution by this QueryExecutor. The provided
@@ -176,9 +179,11 @@ public interface QueryExecutor {
    *
    * @param sql the SQL for the query to create, with '?' placeholders for parameters.
    * @param autocommit indicating when connection has autocommit enabled.
+   * @param allowReWriteBatchedInserts indicates the optimization is enabled
    * @return a new Query object
    */
-  Query createParameterizedQuery(String sql, boolean autocommit); // Parsed for parameter placeholders ('?')
+  Query createParameterizedQuery(String sql, boolean autocommit, boolean allowReWriteBatchedInserts);
+  // Parsed for parameter placeholders ('?')
 
   /**
    * Prior to attempting to retrieve notifications, we need to pull any recently received

--- a/pgjdbc/src/main/java/org/postgresql/core/SetupQueryRunner.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/SetupQueryRunner.java
@@ -65,7 +65,7 @@ public class SetupQueryRunner {
   public static byte[][] run(ProtocolConnection protoConnection, String queryString,
       boolean wantResults) throws SQLException {
     QueryExecutor executor = protoConnection.getQueryExecutor();
-    Query query = executor.createSimpleQuery(queryString, false);
+    Query query = executor.createSimpleQuery(queryString, false, false);
     SimpleResultHandler handler = new SimpleResultHandler();
 
     int flags = QueryExecutor.QUERY_ONESHOT | QueryExecutor.QUERY_SUPPRESS_BEGIN;

--- a/pgjdbc/src/main/java/org/postgresql/core/SqlCommand.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/SqlCommand.java
@@ -8,21 +8,19 @@
 
 package org.postgresql.core;
 
-import static org.postgresql.core.DMLCommandType.INSERT;
-
 /**
  * Data Modification Language inspection support.
  *
  * @author Jeremy Whiting jwhiting@redhat.com
  *
  */
-public class DMLCommand {
+public class SqlCommand {
 
   public boolean isBatchedReWriteCompatible() {
     return batchedReWriteCompatible;
   }
 
-  public DMLCommandType getType() {
+  public SqlCommandType getType() {
     return commandType;
   }
 
@@ -30,35 +28,35 @@ public class DMLCommand {
     return parsedSQLhasRETURNINGKeyword;
   }
 
-  public static DMLCommand createStatementTypeInfo(DMLCommandType type,
+  public static SqlCommand createStatementTypeInfo(SqlCommandType type,
       boolean isBatchedReWritePropertyConfigured,
       boolean isBatchedReWriteCompatible, boolean isRETURNINGkeywordPresent,
       boolean autocommit, int priorQueryCount) {
-    return new DMLCommand(type, isBatchedReWritePropertyConfigured,
+    return new SqlCommand(type, isBatchedReWritePropertyConfigured,
         isBatchedReWriteCompatible, isRETURNINGkeywordPresent, autocommit,
         priorQueryCount);
   }
 
-  public static DMLCommand createStatementTypeInfo(DMLCommandType type) {
-    return new DMLCommand(type, false, false, false, false,0);
+  public static SqlCommand createStatementTypeInfo(SqlCommandType type) {
+    return new SqlCommand(type, false, false, false, false,0);
   }
 
-  public static DMLCommand createStatementTypeInfo(DMLCommandType type,
+  public static SqlCommand createStatementTypeInfo(SqlCommandType type,
       boolean isRETURNINGkeywordPresent) {
-    return new DMLCommand(type, false, false, isRETURNINGkeywordPresent, false,0);
+    return new SqlCommand(type, false, false, isRETURNINGkeywordPresent, false,0);
   }
 
-  private DMLCommand(DMLCommandType type, boolean isBatchedReWriteConfigured,
+  private SqlCommand(SqlCommandType type, boolean isBatchedReWriteConfigured,
       boolean isCompatible, boolean isPresent, boolean isautocommitConfigured,
       int priorQueryCount) {
     commandType = type;
     parsedSQLhasRETURNINGKeyword = isPresent;
-    batchedReWriteCompatible = (type == INSERT) && isBatchedReWriteConfigured
+    batchedReWriteCompatible = type.canSupportBatchedReWrite() && isBatchedReWriteConfigured
         && isCompatible && !isautocommitConfigured
         && !isPresent && priorQueryCount == 0;
   }
 
-  private final DMLCommandType commandType;
+  private final SqlCommandType commandType;
   private final boolean parsedSQLhasRETURNINGKeyword;
   private final boolean batchedReWriteCompatible;
 }

--- a/pgjdbc/src/main/java/org/postgresql/core/SqlCommandType.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/SqlCommandType.java
@@ -14,7 +14,7 @@ package org.postgresql.core;
  *
  */
 
-public enum DMLCommandType {
+public enum SqlCommandType {
 
   INSERT(true),
   /**
@@ -35,7 +35,7 @@ public enum DMLCommandType {
 
   private final boolean canSupportBatchedReWrite;
 
-  private DMLCommandType(boolean reWriteSupport) {
+  private SqlCommandType(boolean reWriteSupport) {
     canSupportBatchedReWrite = reWriteSupport;
   }
 

--- a/pgjdbc/src/main/java/org/postgresql/core/v2/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v2/QueryExecutorImpl.java
@@ -48,11 +48,13 @@ public class QueryExecutorImpl implements QueryExecutor {
   // Query parsing
   //
 
-  public Query createSimpleQuery(String sql, boolean autocommit) {
+  public Query createSimpleQuery(String sql, boolean autocommit,
+      boolean allowReWriteBatchedInserts) {
     return new V2Query(sql, false, protoConnection);
   }
 
-  public Query createParameterizedQuery(String sql, boolean autocommit) {
+  public Query createParameterizedQuery(String sql, boolean autocommit,
+      boolean allowReWriteBatchedInserts) {
     return new V2Query(sql, true, protoConnection);
   }
 
@@ -120,7 +122,7 @@ public class QueryExecutorImpl implements QueryExecutor {
 
       try {
         // Create and issue a dummy query to use the existing prefix infrastructure
-        V2Query query = (V2Query) createSimpleQuery("", false);
+        V2Query query = (V2Query) createSimpleQuery("", false, false);
         SimpleParameterList params = (SimpleParameterList) query.createParameterList();
         sendQuery(query, params, "BEGIN");
         processResults(query, handler, 0, 0);

--- a/pgjdbc/src/main/java/org/postgresql/core/v2/V2Query.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v2/V2Query.java
@@ -9,13 +9,13 @@
 
 package org.postgresql.core.v2;
 
-import org.postgresql.core.DMLCommand;
-import org.postgresql.core.DMLCommandType;
 import org.postgresql.core.NativeQuery;
 import org.postgresql.core.ParameterList;
 import org.postgresql.core.Parser;
 import org.postgresql.core.ProtocolConnection;
 import org.postgresql.core.Query;
+import org.postgresql.core.SqlCommand;
+import org.postgresql.core.SqlCommandType;
 
 import java.util.List;
 
@@ -32,7 +32,7 @@ class V2Query implements Query {
     assert queries.size() <= 1 : "Exactly one query expected in V2. " + queries.size()
         + " queries given.";
 
-    nativeQuery = queries.isEmpty() ? new NativeQuery("", DMLCommand.createStatementTypeInfo(DMLCommandType.BLANK)) : queries.get(0);
+    nativeQuery = queries.isEmpty() ? new NativeQuery("", SqlCommand.createStatementTypeInfo(SqlCommandType.BLANK)) : queries.get(0);
   }
 
   public ParameterList createParameterList() {

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -11,8 +11,6 @@ package org.postgresql.core.v3;
 
 import org.postgresql.PGProperty;
 import org.postgresql.copy.CopyOperation;
-import org.postgresql.core.DMLCommand;
-import org.postgresql.core.DMLCommandType;
 import org.postgresql.core.Field;
 import org.postgresql.core.Logger;
 import org.postgresql.core.NativeQuery;
@@ -26,6 +24,8 @@ import org.postgresql.core.Query;
 import org.postgresql.core.QueryExecutor;
 import org.postgresql.core.ResultCursor;
 import org.postgresql.core.ResultHandler;
+import org.postgresql.core.SqlCommand;
+import org.postgresql.core.SqlCommandType;
 import org.postgresql.core.Utils;
 import org.postgresql.jdbc.BatchResultHandler;
 import org.postgresql.jdbc.TimestampUtils;
@@ -60,7 +60,6 @@ public class QueryExecutorImpl implements QueryExecutor {
     this.logger = logger;
 
     this.allowEncodingChanges = PGProperty.ALLOW_ENCODING_CHANGES.getBoolean(info);
-    this.allowReWriteBatchedInserts = PGProperty.REWRITE_BATCHED_INSERTS.getBoolean(info);
   }
 
   /**
@@ -136,15 +135,18 @@ public class QueryExecutorImpl implements QueryExecutor {
   // Query parsing
   //
 
-  public Query createSimpleQuery(String sql, boolean autocommit) {
-    return parseQuery(sql, false, autocommit);
+  public Query createSimpleQuery(String sql, boolean autocommit,
+      boolean allowReWriteBatchedInserts) {
+    return parseQuery(sql, false, autocommit, allowReWriteBatchedInserts);
   }
 
-  public Query createParameterizedQuery(String sql, boolean autocommit) {
-    return parseQuery(sql, true, autocommit);
+  public Query createParameterizedQuery(String sql, boolean autocommit,
+      boolean allowReWriteBatchedInserts) {
+    return parseQuery(sql, true, autocommit, allowReWriteBatchedInserts);
   }
 
-  private Query parseQuery(String query, boolean withParameters, boolean autocommit) {
+  private Query parseQuery(String query, boolean withParameters, boolean autocommit,
+      boolean allowReWriteBatchedInserts) {
 
     List<NativeQuery> queries = Parser.parseJdbcSql(query,
         protoConnection.getStandardConformingStrings(), withParameters, true,
@@ -1342,7 +1344,8 @@ public class QueryExecutorImpl implements QueryExecutor {
     }
 
     pendingParseQueue.add(query);
-    if (allowReWriteBatchedInserts && query instanceof BatchedQueryDecorator) { // not waiting for async message
+    if (query.getNativeQuery().getCommand().isBatchedReWriteCompatible()) {
+      // not waiting for async message
       ((BatchedQueryDecorator) query).registerQueryParsedStatus(true);
     }
   }
@@ -2396,8 +2399,6 @@ public class QueryExecutorImpl implements QueryExecutor {
   private final PGStream pgStream;
   private final Logger logger;
   private final boolean allowEncodingChanges;
-  private final boolean allowReWriteBatchedInserts;
-
 
   /**
    * The estimated server response size since we last consumed the input stream from the server, in
@@ -2410,7 +2411,7 @@ public class QueryExecutorImpl implements QueryExecutor {
   private int estimatedReceiveBufferBytes = 0;
 
   private final SimpleQuery beginTransactionQuery =
-      new SimpleQuery(new NativeQuery("BEGIN", new int[0], DMLCommand.createStatementTypeInfo(DMLCommandType.BLANK)), null);
+      new SimpleQuery(new NativeQuery("BEGIN", new int[0], SqlCommand.createStatementTypeInfo(SqlCommandType.BLANK)), null);
 
-  private final SimpleQuery EMPTY_QUERY = new SimpleQuery(new NativeQuery("", new int[0], DMLCommand.createStatementTypeInfo(DMLCommandType.BLANK)), null);
+  private final SimpleQuery EMPTY_QUERY = new SimpleQuery(new NativeQuery("", new int[0], SqlCommand.createStatementTypeInfo(SqlCommandType.BLANK)), null);
 }

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/CachedQueryCreateAction.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/CachedQueryCreateAction.java
@@ -46,7 +46,8 @@ class CachedQueryCreateAction implements LruCache.CreateAction<Object, CachedQue
       isFunction = false;
       outParmBeforeFunc = false;
     }
-    Query query = connection.getQueryExecutor().createParameterizedQuery(parsedSql, connection.getAutoCommit());
+    Query query = connection.getQueryExecutor().createParameterizedQuery(parsedSql, connection.getAutoCommit(),
+        connection.isReWriteBatchedInsertsEnabled());
     return new CachedQuery(key, query, isFunction, outParmBeforeFunc);
   }
 }

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
@@ -331,8 +331,10 @@ public class PgConnection implements BaseConnection {
         });
 
     // Initialize common queries.
-    commitQuery = getQueryExecutor().createSimpleQuery("COMMIT", getAutoCommit());
-    rollbackQuery = getQueryExecutor().createSimpleQuery("ROLLBACK", getAutoCommit());
+    commitQuery = getQueryExecutor().createSimpleQuery("COMMIT", getAutoCommit(),
+        isReWriteBatchedInsertsEnabled());
+    rollbackQuery = getQueryExecutor().createSimpleQuery("ROLLBACK", getAutoCommit(),
+        isReWriteBatchedInsertsEnabled());
 
     int unknownLength = PGProperty.UNKNOWN_LENGTH.getInt(info);
 

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgStatement.java
@@ -318,7 +318,8 @@ public class PgStatement implements Statement, BaseStatement {
     checkClosed();
     p_sql = replaceProcessing(p_sql, replaceProcessingEnabled,
         connection.getStandardConformingStrings());
-    Query simpleQuery = connection.getQueryExecutor().createSimpleQuery(p_sql, connection.getAutoCommit());
+    Query simpleQuery = connection.getQueryExecutor().createSimpleQuery(p_sql, connection.getAutoCommit(),
+        connection.isReWriteBatchedInsertsEnabled());
     execute(simpleQuery, null, QueryExecutor.QUERY_ONESHOT | flags);
     this.lastSimpleQuery = simpleQuery;
     return (result != null && result.getResultSet() != null);
@@ -909,7 +910,8 @@ public class PgStatement implements Statement, BaseStatement {
     p_sql = replaceProcessing(p_sql, replaceProcessingEnabled,
         connection.getStandardConformingStrings());
 
-    batchStatements.add(connection.getQueryExecutor().createSimpleQuery(p_sql, connection.getAutoCommit()));
+    batchStatements.add(connection.getQueryExecutor().createSimpleQuery(p_sql, connection.getAutoCommit(),
+        connection.isReWriteBatchedInsertsEnabled()));
     batchParameters.add(null);
   }
 

--- a/pgjdbc/src/test/java/org/postgresql/core/ParserTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/core/ParserTest.java
@@ -1,0 +1,74 @@
+/*-------------------------------------------------------------------------
+ *
+ * Copyright (c) 2003-2016, PostgreSQL Global Development Group
+ *
+ *
+ *-------------------------------------------------------------------------
+ */
+
+package org.postgresql.core;
+
+import junit.framework.TestCase;
+
+import org.junit.Assert;
+
+/**
+ * Test cases for the Parser.
+
+ * @author Jeremy Whiting jwhiting@redhat.com
+ *
+ */
+public class ParserTest extends TestCase {
+
+  /**
+   * Test to make sure delete command is detected by parser and detected via
+   * api. Mix up the case of the command to check detection continues to work.
+   */
+  public void testDeleteCommandParsing() {
+    char[] command = new char[6];
+    "DELETE".getChars(0, 6, command, 0);
+    Assert.assertTrue("Failed to correctly parse upper case command.", Parser.parseDeleteKeyword(command, 0));
+    "DelEtE".getChars(0, 6, command, 0);
+    Assert.assertTrue("Failed to correctly parse mixed case command.", Parser.parseDeleteKeyword(command, 0));
+    "deleteE".getChars(0, 6, command, 0);
+    Assert.assertTrue("Failed to correctly parse mixed case command.", Parser.parseDeleteKeyword(command, 0));
+    "delete".getChars(0, 6, command, 0);
+    Assert.assertTrue("Failed to correctly parse lower case command.", Parser.parseDeleteKeyword(command, 0));
+    "Delete".getChars(0, 6, command, 0);
+    Assert.assertTrue("Failed to correctly parse mixed case command.", Parser.parseDeleteKeyword(command, 0));
+  }
+
+  /**
+   * Test UPDATE command parsing.
+   */
+  public void testUpdateCommandParsing() {
+    char[] command = new char[6];
+    "UPDATE".getChars(0, 6, command, 0);
+    Assert.assertTrue("Failed to correctly parse upper case command.", Parser.parseUpdateKeyword(command, 0));
+    "UpDateE".getChars(0, 6, command, 0);
+    Assert.assertTrue("Failed to correctly parse mixed case command.", Parser.parseUpdateKeyword(command, 0));
+    "updatE".getChars(0, 6, command, 0);
+    Assert.assertTrue("Failed to correctly parse mixed case command.", Parser.parseUpdateKeyword(command, 0));
+    "Update".getChars(0, 6, command, 0);
+    Assert.assertTrue("Failed to correctly parse mixed case command.", Parser.parseUpdateKeyword(command, 0));
+    "update".getChars(0, 6, command, 0);
+    Assert.assertTrue("Failed to correctly parse lower case command.", Parser.parseUpdateKeyword(command, 0));
+  }
+
+  /**
+   * Update MOVE command parsing.
+   */
+  public void testMoveCommandParsing() {
+    char[] command = new char[4];
+    "MOVE".getChars(0, 4, command, 0);
+    Assert.assertTrue("Failed to correctly parse upper case command.", Parser.parseMoveKeyword(command, 0));
+    "mOVe".getChars(0, 4, command, 0);
+    Assert.assertTrue("Failed to correctly parse mixed case command.", Parser.parseMoveKeyword(command, 0));
+    "movE".getChars(0, 4, command, 0);
+    Assert.assertTrue("Failed to correctly parse mixed case command.", Parser.parseMoveKeyword(command, 0));
+    "Move".getChars(0, 4, command, 0);
+    Assert.assertTrue("Failed to correctly parse mixed case command.", Parser.parseMoveKeyword(command, 0));
+    "move".getChars(0, 4, command, 0);
+    Assert.assertTrue("Failed to correctly parse lower case command.", Parser.parseMoveKeyword(command, 0));
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/core/SqlCommandTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/core/SqlCommandTest.java
@@ -1,0 +1,31 @@
+/*-------------------------------------------------------------------------
+ *
+ * Copyright (c) 2003-2016, PostgreSQL Global Development Group
+ *
+ *
+ *-------------------------------------------------------------------------
+ */
+
+package org.postgresql.core;
+
+import org.junit.Assert;
+
+/**
+ * Tests to check the DMLCommand operates as expected.
+ *
+ * @author Jeremy Whiting jwhiting@redhat.com
+ *
+ */
+public class SqlCommandTest {
+
+  /**
+   * Test to check the is returning keyword present check method provides the
+   * correct return value. The create method does not parse the sql.
+   * Instead the {@code org.postgresql.core.Parser} does parsing and calls
+   * create with the correct value.
+   */
+  public void testCreateDMLCommandWithReturningProperty() {
+    SqlCommand com = SqlCommand.createStatementTypeInfo(SqlCommandType.BLANK, true);
+    Assert.assertTrue(com.isReturningKeywordPresent());
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/Jdbc2TestSuite.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/Jdbc2TestSuite.java
@@ -8,6 +8,7 @@
 
 package org.postgresql.test.jdbc2;
 
+import org.postgresql.core.ParserTest;
 import org.postgresql.core.v2.V2ParameterListTests;
 import org.postgresql.core.v3.V3ParameterListTests;
 import org.postgresql.jdbc.DeepBatchedInsertStatementTest;
@@ -118,6 +119,8 @@ public class Jdbc2TestSuite extends TestSuite {
 
     suite.addTestSuite(V2ParameterListTests.class);
     suite.addTestSuite(V3ParameterListTests.class);
+
+    suite.addTestSuite(ParserTest.class);
 
     Connection conn = TestUtil.openDB();
     if (TestUtil.isProtocolVersion(conn, 3)) {

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc3/CompositeQueryParseTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc3/CompositeQueryParseTest.java
@@ -1,8 +1,8 @@
 package org.postgresql.test.jdbc3;
 
-import org.postgresql.core.DMLCommandType;
 import org.postgresql.core.NativeQuery;
 import org.postgresql.core.Parser;
+import org.postgresql.core.SqlCommandType;
 
 import junit.framework.TestCase;
 
@@ -84,7 +84,7 @@ public class CompositeQueryParseTest extends TestCase {
 
     queries = Parser.parseJdbcSql("select 1 as returning", true, true, false, true, true);
     query = queries.get(0);
-    assertFalse("This is not an insert command", query.command.getType() == DMLCommandType.INSERT);
+    assertFalse("This is not an insert command", query.command.getType() == SqlCommandType.INSERT);
     assertTrue("Returning is OK here as it is not an insert command ", query.command.isReturningKeywordPresent());
 
   }
@@ -92,11 +92,11 @@ public class CompositeQueryParseTest extends TestCase {
   public void testHasDelete() {
     List<NativeQuery> queries = Parser.parseJdbcSql("DeLeTe from foo where a=1", true, true, false, true, true);
     NativeQuery query = queries.get(0);
-    assertTrue("This is a delete command", query.command.getType() == DMLCommandType.DELETE);
+    assertTrue("This is a delete command", query.command.getType() == SqlCommandType.DELETE);
 
     queries = Parser.parseJdbcSql("update foo set (a=?,b=?,c=?)", true, true, false, true, true);
     query = queries.get(0);
-    assertFalse("This is not a delete command", query.command.getType() == DMLCommandType.DELETE);
+    assertFalse("This is not a delete command", query.command.getType() == SqlCommandType.DELETE);
 
   }
 
@@ -105,11 +105,11 @@ public class CompositeQueryParseTest extends TestCase {
 
     List<NativeQuery> queries = Parser.parseJdbcSql("MoVe NEXT FROM FOO", true, true, false, true, true);
     NativeQuery query = queries.get(0);
-    assertTrue("This is a move command", query.command.getType() == DMLCommandType.MOVE);
+    assertTrue("This is a move command", query.command.getType() == SqlCommandType.MOVE);
 
     queries = Parser.parseJdbcSql("update foo set (a=?,b=?,c=?)", true, true, false, true, true);
     query = queries.get(0);
-    assertFalse("This is not a move command", query.command.getType() == DMLCommandType.MOVE);
+    assertFalse("This is not a move command", query.command.getType() == SqlCommandType.MOVE);
 
   }
 
@@ -117,15 +117,15 @@ public class CompositeQueryParseTest extends TestCase {
 
     List<NativeQuery> queries = Parser.parseJdbcSql("InSeRt into foo (a,b,c) values (?,?,?) returning a", true, true, false, true, true);
     NativeQuery query = queries.get(0);
-    assertTrue("This is an insert command", query.command.getType() == DMLCommandType.INSERT);
+    assertTrue("This is an insert command", query.command.getType() == SqlCommandType.INSERT);
 
     queries = Parser.parseJdbcSql("update foo set (a=?,b=?,c=?)", true, true, false, true, true);
     query = queries.get(0);
-    assertFalse("This is not an insert command", query.command.getType() == DMLCommandType.INSERT);
+    assertFalse("This is not an insert command", query.command.getType() == SqlCommandType.INSERT);
 
     queries = Parser.parseJdbcSql("select 1 as insert", true, true, false, true, true);
     query = queries.get(0);
-    assertFalse("This is not insert command", query.command.getType() == DMLCommandType.INSERT);
+    assertFalse("This is not insert command", query.command.getType() == SqlCommandType.INSERT);
   }
 
   public void testMultipleEmptyQueries() {


### PR DESCRIPTION
 This PR will contribute some additional test cases for the already merged batched insert re-write optimisation. 

The test cases smoke out an existing defect that causes setting of the optimisation on the Connection object to be ignored.
 The other test cases increase test coverage of the Parser. Based on the coverage report generated on #491 .