### PR TITLE
Removing autocommit configuration parameter for version > 9.5

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/v2/ConnectionFactoryImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v2/ConnectionFactoryImpl.java
@@ -483,15 +483,15 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
       }
 
       String sql = "begin; ";
-	  
-	  // server configuration parameter autocommit was deprecated 
-	  // and non-operational on version 9.5
-	  if (dbVersion.compareTo("9.5") < 0) {
+
+      // server configuration parameter autocommit was deprecated 
+      // and non-operational on version 9.5
+      if (dbVersion.compareTo("9.5") < 0) {
         sql += "set autocommit = on; ";
       }
 
-	  sql += "set client_encoding = 'UTF8'; ";
-	  
+      sql += "set client_encoding = 'UTF8'; ";
+
       if (dbVersion.compareTo("9.0") >= 0) {
         sql += "SET extra_float_digits=3; ";
       } else if (dbVersion.compareTo("7.4") >= 0) {

--- a/pgjdbc/src/main/java/org/postgresql/core/v2/ConnectionFactoryImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v2/ConnectionFactoryImpl.java
@@ -484,7 +484,7 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
 
       String sql = "begin; ";
 
-      // server configuration parameter autocommit was deprecated 
+      // server configuration parameter autocommit was deprecated
       // and non-operational on version 9.5
       if (dbVersion.compareTo("9.5") < 0) {
         sql += "set autocommit = on; ";

--- a/pgjdbc/src/main/java/org/postgresql/core/v2/ConnectionFactoryImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v2/ConnectionFactoryImpl.java
@@ -482,7 +482,16 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
         logger.debug("Switching to UTF8 client_encoding");
       }
 
-      String sql = "begin; set autocommit = on; set client_encoding = 'UTF8'; ";
+      String sql = "begin; ";
+	  
+	  // server configuration parameter autocommit was deprecated 
+	  // and non-operational on version 9.5
+	  if (dbVersion.compareTo("9.5") < 0) {
+        sql += "set autocommit = on; ";
+      }
+
+	  sql += "set client_encoding = 'UTF8'; ";
+	  
       if (dbVersion.compareTo("9.0") >= 0) {
         sql += "SET extra_float_digits=3; ";
       } else if (dbVersion.compareTo("7.4") >= 0) {


### PR DESCRIPTION
According to the [release notes](https://www.postgresql.org/docs/9.5/static/release-9-5.html):

> Remove server configuration parameter autocommit, which was already deprecated and non-operational (Tom Lane)

This pull request only adds the autocommit for versions < 9.5.