### PR TITLE
fix: incorrect binary data format in bind parameter X when using batch execution

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/v3/DescribeRequest.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/DescribeRequest.java
@@ -17,11 +17,13 @@ class DescribeRequest {
   public final SimpleQuery query;
   public final SimpleParameterList parameterList;
   public final boolean describeOnly;
+  public final String statementName;
 
   public DescribeRequest(SimpleQuery query, SimpleParameterList parameterList,
-      boolean describeOnly) {
+      boolean describeOnly, String statementName) {
     this.query = query;
     this.parameterList = parameterList;
     this.describeOnly = describeOnly;
+    this.statementName = statementName;
   }
 }

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -1526,7 +1526,10 @@ public class QueryExecutorImpl implements QueryExecutor {
     }
     pgStream.SendChar(0); // end message
 
-    pendingDescribeStatementQueue.add(new DescribeRequest(query, params, describeOnly));
+    // Note: statement name can change over time for the same query object
+    // Thus we take a snapshot of the query name
+    pendingDescribeStatementQueue.add(
+        new DescribeRequest(query, params, describeOnly, query.getStatementName()));
     pendingDescribePortalQueue.add(query);
     query.setStatementDescribed(true);
     query.setPortalDescribed(true);
@@ -1838,7 +1841,8 @@ public class QueryExecutorImpl implements QueryExecutor {
           SimpleQuery query = describeData.query;
           SimpleParameterList params = describeData.parameterList;
           boolean describeOnly = describeData.describeOnly;
-          String origStatementName = query.getStatementName();
+          // This might differ from query.getStatementName if the query was re-prepared
+          String origStatementName = describeData.statementName;
 
           int numParams = pgStream.ReceiveInteger2();
 


### PR DESCRIPTION
Some batch executions might result in "incorrect binary data format" if using non-exact data types (e.g. date) and bind different data types for the same bind position across executions.

Reported here: https://www.postgresql.org/message-id/681cd4467be74455a6e599b3838164f5%40EX2013-DB01.adesso.local