### PR TITLE
Only connect the socket if the socket factory created an unconneced socket

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/PGStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/PGStream.java
@@ -61,7 +61,9 @@ public class PGStream {
     this.hostSpec = hostSpec;
 
     Socket socket = socketFactory.createSocket();
-    socket.connect(new InetSocketAddress(hostSpec.getHost(), hostSpec.getPort()), timeout);
+    if (!socket.isConnected()) {
+      socket.connect(new InetSocketAddress(hostSpec.getHost(), hostSpec.getPort()), timeout);
+    }
     changeSocket(socket);
     setEncoding(Encoding.getJVMEncoding("UTF-8"));
 


### PR DESCRIPTION
This is useful if the socket factory creates the complete connection, for example when using Unix sockets that create completely connected sockets.
