### PR TITLE
fix: cache timezone in Prepared Statement and Result Set

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
@@ -63,6 +63,8 @@ import java.time.LocalTime;
 import java.time.OffsetDateTime;
 //#endif
 import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
 import java.util.Map;
 import java.util.TimeZone;
 import java.util.UUID;
@@ -1418,6 +1420,9 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
       }
     }
 
+    if (cal == null) {
+      cal = getDefaultCalendar();
+    }
     bindString(i, connection.getTimestampUtils().toString(cal, t), oid);
   }
 
@@ -1471,7 +1476,9 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
         cal = pgTimestamp.getCalendar();
       }
     }
-
+    if (cal == null) {
+      cal = getDefaultCalendar();
+    }
     bindString(i, connection.getTimestampUtils().toString(cal, t), oid);
   }
 
@@ -1636,6 +1643,24 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
 
   public void setURL(int parameterIndex, java.net.URL x) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "setURL(int,URL)");
+  }
+
+  private Calendar defaultCalendar;
+
+  @Override
+  public int[] executeBatch() throws SQLException {
+    try {
+      return super.executeBatch();
+    } finally {
+      defaultCalendar = null;
+    }
+  }
+
+  private Calendar getDefaultCalendar() {
+    if (defaultCalendar == null) {
+      defaultCalendar = new GregorianCalendar();
+    }
+    return defaultCalendar;
   }
 
   public ParameterMetaData getParameterMetaData() throws SQLException {

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
@@ -159,11 +159,15 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
   }
 
   public boolean executeWithFlags(int flags) throws SQLException {
-    checkClosed();
+    try {
+      checkClosed();
 
-    execute(preparedQuery.query, preparedParameters, flags);
+      execute(preparedQuery.query, preparedParameters, flags);
 
-    return (result != null && result.getResultSet() != null);
+      return (result != null && result.getResultSet() != null);
+    } finally {
+      defaultCalendar = null;
+    }
   }
 
   protected boolean isOneShotQuery(Query query) {

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
@@ -64,7 +64,6 @@ import java.time.OffsetDateTime;
 //#endif
 import java.util.ArrayList;
 import java.util.Calendar;
-import java.util.GregorianCalendar;
 import java.util.Map;
 import java.util.TimeZone;
 import java.util.UUID;
@@ -166,7 +165,7 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
 
       return (result != null && result.getResultSet() != null);
     } finally {
-      defaultCalendar = null;
+      defaultTimeZone = null;
     }
   }
 
@@ -1400,6 +1399,9 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
     // 2005-01-01 00:00:00+03
     // (1 row)
 
+    if (cal == null) {
+      cal = getDefaultCalendar();
+    }
     bindString(i, connection.getTimestampUtils().toString(cal, d), Oid.UNSPECIFIED);
   }
 
@@ -1649,22 +1651,23 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
     throw Driver.notImplemented(this.getClass(), "setURL(int,URL)");
   }
 
-  private Calendar defaultCalendar;
-
   @Override
   public int[] executeBatch() throws SQLException {
     try {
       return super.executeBatch();
     } finally {
-      defaultCalendar = null;
+      defaultTimeZone = null;
     }
   }
 
+  private TimeZone defaultTimeZone;
+
   private Calendar getDefaultCalendar() {
-    if (defaultCalendar == null) {
-      defaultCalendar = new GregorianCalendar();
+    Calendar sharedCalendar = connection.getTimestampUtils().getSharedCalendar(defaultTimeZone);
+    if (defaultTimeZone == null) {
+      defaultTimeZone = sharedCalendar.getTimeZone();
     }
-    return defaultCalendar;
+    return sharedCalendar;
   }
 
   public ParameterMetaData getParameterMetaData() throws SQLException {

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
@@ -488,10 +488,13 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
       return null;
     }
 
+    if (cal == null) {
+      cal = getDefaultCalendar();
+    }
     if (isBinary(i)) {
       int col = i - 1;
       int oid = fields[col].getOID();
-      TimeZone tz = cal == null ? null : cal.getTimeZone();
+      TimeZone tz = cal.getTimeZone();
       if (oid == Oid.DATE) {
         return connection.getTimestampUtils().toDateBin(tz, this_row[col]);
       } else if (oid == Oid.TIMESTAMP || oid == Oid.TIMESTAMPTZ) {
@@ -518,10 +521,13 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
       return null;
     }
 
+    if (cal == null) {
+      cal = getDefaultCalendar();
+    }
     if (isBinary(i)) {
       int col = i - 1;
       int oid = fields[col].getOID();
-      TimeZone tz = cal == null ? null : cal.getTimeZone();
+      TimeZone tz = cal.getTimeZone();
       if (oid == Oid.TIME || oid == Oid.TIMETZ) {
         return connection.getTimestampUtils().toTimeBin(tz, this_row[col]);
       } else if (oid == Oid.TIMESTAMP || oid == Oid.TIMESTAMPTZ) {
@@ -549,12 +555,15 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
       return null;
     }
 
+    if (cal == null) {
+      cal = getDefaultCalendar();
+    }
     int col = i - 1;
     int oid = fields[col].getOID();
     if (isBinary(i)) {
       if (oid == Oid.TIMESTAMPTZ || oid == Oid.TIMESTAMP) {
         boolean hasTimeZone = oid == Oid.TIMESTAMPTZ;
-        TimeZone tz = cal == null ? null : cal.getTimeZone();
+        TimeZone tz = cal.getTimeZone();
         return connection.getTimestampUtils().toTimestampBin(tz, this_row[col], hasTimeZone);
       } else {
         // JDBC spec says getTimestamp of Time and Date must be supported
@@ -600,7 +609,8 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
               PSQLState.DATA_TYPE_MISMATCH);
     }
     if (isBinary(i)) {
-      return connection.getTimestampUtils().toLocalDateTimeBin(this_row[col]);
+      TimeZone timeZone = getDefaultCalendar().getTimeZone();
+      return connection.getTimestampUtils().toLocalDateTimeBin(timeZone, this_row[col]);
     }
 
     String string = getString(i);
@@ -3615,4 +3625,15 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
     }
     throw new SQLException("Cannot unwrap to " + iface.getName());
   }
+
+  private TimeZone defaultTimeZone;
+
+  private Calendar getDefaultCalendar() {
+    Calendar sharedCalendar = connection.getTimestampUtils().getSharedCalendar(defaultTimeZone);
+    if (defaultTimeZone == null) {
+      defaultTimeZone = sharedCalendar.getTimeZone();
+    }
+    return sharedCalendar;
+  }
+
 }

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
@@ -3257,7 +3257,7 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
       //#endif
       ) {
         Timestamp timestampValue = getTimestamp(columnIndex);
-        Calendar calendar = Calendar.getInstance();
+        Calendar calendar = Calendar.getInstance(getDefaultCalendar().getTimeZone());
         calendar.setTimeInMillis(timestampValue.getTime());
         return type.cast(calendar);
       } else {

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/TimestampUtils.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/TimestampUtils.java
@@ -454,8 +454,21 @@ public class TimestampUtils {
   }
 
   private Calendar setupCalendar(Calendar cal) {
+    TimeZone timeZone = cal == null ? null : cal.getTimeZone();
+    return getSharedCalendar(timeZone);
+  }
+
+  /**
+   * Get a shared calendar, applying the supplied time zone or the default time zone if null.
+   *
+   * @return The shared calendar.
+   */
+  public Calendar getSharedCalendar(TimeZone timeZone) {
+    if (timeZone == null) {
+      timeZone = getDefaultTz();
+    }
     Calendar tmp = calendarWithUserTz;
-    tmp.setTimeZone(cal == null ? getDefaultTz() : cal.getTimeZone());
+    tmp.setTimeZone(timeZone);
     return tmp;
   }
 
@@ -943,7 +956,7 @@ public class TimestampUtils {
    * @return The parsed local date time object.
    * @throws PSQLException If binary format could not be parsed.
    */
-  public LocalDateTime toLocalDateTimeBin(byte[] bytes)  throws PSQLException {
+  public LocalDateTime toLocalDateTimeBin(TimeZone tz, byte[] bytes) throws PSQLException {
 
     ParsedBinaryTimestamp parsedTimestamp = this.toParsedTimestampBin(null, bytes, true);
     if (parsedTimestamp.infinity == Infinity.POSITIVE) {

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/TimestampUtils.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/TimestampUtils.java
@@ -958,7 +958,7 @@ public class TimestampUtils {
    */
   public LocalDateTime toLocalDateTimeBin(TimeZone tz, byte[] bytes) throws PSQLException {
 
-    ParsedBinaryTimestamp parsedTimestamp = this.toParsedTimestampBin(null, bytes, true);
+    ParsedBinaryTimestamp parsedTimestamp = this.toParsedTimestampBin(tz, bytes, true);
     if (parsedTimestamp.infinity == Infinity.POSITIVE) {
       return LocalDateTime.MAX;
     } else if (parsedTimestamp.infinity == Infinity.NEGATIVE) {

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/TimezoneCachingTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/TimezoneCachingTest.java
@@ -26,10 +26,9 @@ import java.util.TimeZone;
 public class TimezoneCachingTest extends BaseTest {
 
   /**
-   * Test to check the internal calendar for timezone of a prepared statement is set/cleared as
-   * expected.
+   * Test to check the internal cached timezone of a prepared statement is set/cleared as expected.
    */
-  public void testTimezonePreparedStatementCachedCalendarInstance() throws SQLException {
+  public void testPreparedStatementCachedTimezoneInstance() throws SQLException {
     Timestamp ts = new Timestamp(2016 - 1900, 1 - 1, 31, 0, 0, 0, 0);
     Date date = new Date(2016 - 1900, 1 - 1, 31);
     Time time = new Time(System.currentTimeMillis());
@@ -91,9 +90,9 @@ public class TimezoneCachingTest extends BaseTest {
   }
 
   /**
-   * Test to check the internal calendar for timezone of a prepared statement is used as expected.
+   * Test to check the internal cached timezone of a prepared statement is used as expected.
    */
-  public void testTimezonePreparedStatementCachedCalendarUsage() throws SQLException {
+  public void testPreparedStatementCachedTimezoneUsage() throws SQLException {
     Timestamp ts = new Timestamp(2016 - 1900, 1 - 1, 31, 0, 0, 0, 0);
     Statement stmt = null;
     PreparedStatement pstmt = null;
@@ -143,9 +142,9 @@ public class TimezoneCachingTest extends BaseTest {
   }
 
   /**
-   * Test to check the internal calendar for timezone of a result set is set/cleared as expected.
+   * Test to check the internal cached timezone of a result set is set/cleared as expected.
    */
-  public void testTimezoneResultSetCachedCalendarInstance() throws SQLException {
+  public void testResultSetCachedTimezoneInstance() throws SQLException {
     Timestamp ts = new Timestamp(2016 - 1900, 1 - 1, 31, 0, 0, 0, 0);
     Statement stmt = null;
     PreparedStatement pstmt = null;
@@ -196,9 +195,9 @@ public class TimezoneCachingTest extends BaseTest {
   }
 
   /**
-   * Test to check the internal calendar for timezone of a result set is used as expected.
+   * Test to check the internal cached timezone of a result set is used as expected.
    */
-  public void testTimezoneResultSetCachedCalendarUsage() throws SQLException {
+  public void testResultSetCachedTimezoneUsage() throws SQLException {
     Timestamp ts = new Timestamp(2016 - 1900, 1 - 1, 31, 0, 0, 0, 0);
     Statement stmt = null;
     PreparedStatement pstmt = null;

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/TimezoneCachingTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/TimezoneCachingTest.java
@@ -40,49 +40,49 @@ public class TimezoneCachingTest extends BaseTest {
       pstmt = con.prepareStatement("INSERT INTO testtz VALUES (?,?)");
       assertEquals(
           "Cache never initialized: must be null",
-          getTimeZoneCache(pstmt), null);
+          null, getTimeZoneCache(pstmt));
       pstmt.setInt(1, 1);
       assertEquals(
           "Cache never initialized: must be null",
-          getTimeZoneCache(pstmt), null);
+          null, getTimeZoneCache(pstmt));
       pstmt.setTimestamp(2, ts);
       assertEquals(
           "Cache initialized by setTimestamp(xx): must not be null",
-          getTimeZoneCache(pstmt), tz);
+          tz, getTimeZoneCache(pstmt));
       pstmt.addBatch();
       assertEquals(
           "Cache was initialized, addBatch does not change that: must not be null",
-          getTimeZoneCache(pstmt), tz);
+          tz, getTimeZoneCache(pstmt));
       pstmt.setInt(1, 2);
       pstmt.setNull(2, java.sql.Types.DATE);
       assertEquals(
           "Cache was initialized, setNull does not change that: must not be null",
-          getTimeZoneCache(pstmt), tz);
+          tz, getTimeZoneCache(pstmt));
       pstmt.addBatch();
       assertEquals(
           "Cache was initialized, addBatch does not change that: must not be null",
-          getTimeZoneCache(pstmt), tz);
+          tz, getTimeZoneCache(pstmt));
       pstmt.executeBatch();
       assertEquals(
           "Cache reset by executeBatch(): must be null",
-          getTimeZoneCache(pstmt), null);
+          null, getTimeZoneCache(pstmt));
       pstmt.setInt(1, 3);
       assertEquals(
           "Cache not initialized: must be null",
-          getTimeZoneCache(pstmt), null);
+          null, getTimeZoneCache(pstmt));
       pstmt.setInt(1, 4);
       pstmt.setNull(2, java.sql.Types.DATE);
       assertEquals(
           "Cache was not initialized, setNull does not change that: must be null",
-          getTimeZoneCache(pstmt), null);
+          null, getTimeZoneCache(pstmt));
       pstmt.setTimestamp(2, ts);
       assertEquals(
           "Cache initialized by setTimestamp(xx): must not be null",
-          getTimeZoneCache(pstmt), tz);
+          tz, getTimeZoneCache(pstmt));
       pstmt.clearParameters();
       assertEquals(
           "Cache was initialized, clearParameters does not change that: must not be null",
-          getTimeZoneCache(pstmt), tz);
+          tz, getTimeZoneCache(pstmt));
       pstmt.setInt(1, 5);
       pstmt.setTimestamp(2, ts);
       pstmt.addBatch();
@@ -91,37 +91,37 @@ public class TimezoneCachingTest extends BaseTest {
       pstmt = con.prepareStatement("UPDATE testtz SET col2 = ? WHERE col1 = 1");
       assertEquals(
           "Cache not initialized: must be null",
-          getTimeZoneCache(pstmt), null);
+          null, getTimeZoneCache(pstmt));
       pstmt.setDate(1, date);
       assertEquals(
           "Cache initialized by setDate(xx): must not be null",
-          getTimeZoneCache(pstmt), tz);
+          tz, getTimeZoneCache(pstmt));
       pstmt.execute();
       assertEquals(
           "Cache reset by execute(): must be null",
-          getTimeZoneCache(pstmt), null);
+          null, getTimeZoneCache(pstmt));
       pstmt.setDate(1, date);
       assertEquals(
           "Cache initialized by setDate(xx): must not be null",
-          getTimeZoneCache(pstmt), tz);
+          tz, getTimeZoneCache(pstmt));
       pstmt.executeUpdate();
       assertEquals(
           "Cache reset by executeUpdate(): must be null",
-          getTimeZoneCache(pstmt), null);
+          null, getTimeZoneCache(pstmt));
       pstmt.setTime(1, time);
       assertEquals(
           "Cache initialized by setTime(xx): must not be null",
-          getTimeZoneCache(pstmt), tz);
+          tz, getTimeZoneCache(pstmt));
       pstmt.close();
       pstmt = con.prepareStatement("SELECT * FROM testtz WHERE col2 = ?");
       pstmt.setDate(1, date);
       assertEquals(
           "Cache initialized by setDate(xx): must not be null",
-          getTimeZoneCache(pstmt), tz);
+          tz, getTimeZoneCache(pstmt));
       pstmt.executeQuery();
       assertEquals(
           "Cache reset by executeQuery(): must be null",
-          getTimeZoneCache(pstmt), null);
+          null, getTimeZoneCache(pstmt));
     } finally {
       TestUtil.closeQuietly(pstmt);
     }
@@ -246,28 +246,28 @@ public class TimezoneCachingTest extends BaseTest {
       stmt = con.createStatement();
       rs = stmt.executeQuery("SELECT col1, col2 FROM testtz");
       rs.next();
-      assertEquals("Cache never initialized: must be null", getTimeZoneCache(rs), null);
+      assertEquals("Cache never initialized: must be null", null, getTimeZoneCache(rs));
       rs.getInt(1);
-      assertEquals("Cache never initialized: must be null", getTimeZoneCache(rs), null);
+      assertEquals("Cache never initialized: must be null", null, getTimeZoneCache(rs));
       rs.getTimestamp(2);
       assertEquals("Cache initialized by getTimestamp(x): must not be null",
-          getTimeZoneCache(rs), tz);
+          tz, getTimeZoneCache(rs));
       rs.close();
       rs = stmt.executeQuery("SELECT col1, col2 FROM testtz");
       rs.next();
       rs.getInt(1);
-      assertEquals("Cache never initialized: must be null", getTimeZoneCache(rs), null);
+      assertEquals("Cache never initialized: must be null", null, getTimeZoneCache(rs));
       rs.getObject(2);
       assertEquals("Cache initialized by getObject(x) on a DATE column: must not be null",
-          getTimeZoneCache(rs), tz);
+          tz, getTimeZoneCache(rs));
       rs.close();
       rs = stmt.executeQuery("SELECT col1, col2 FROM testtz");
       rs.next();
-      assertEquals("Cache should NOT be set", getTimeZoneCache(rs), null);
+      assertEquals("Cache should NOT be set", null, getTimeZoneCache(rs));
       rs.getInt(1);
-      assertEquals("Cache never initialized: must be null", getTimeZoneCache(rs), null);
+      assertEquals("Cache never initialized: must be null", null, getTimeZoneCache(rs));
       rs.getDate(2);
-      assertEquals("Cache initialized by getDate(x): must not be null", getTimeZoneCache(rs), tz);
+      assertEquals("Cache initialized by getDate(x): must not be null", tz, getTimeZoneCache(rs));
       rs.close();
     } finally {
       TestUtil.closeQuietly(rs);
@@ -355,7 +355,7 @@ public class TimezoneCachingTest extends BaseTest {
     Timestamp dbTs = rs.getTimestamp(1);
     rs.close();
     TimeZone.setDefault(prevTz);
-    assertEquals(checkText, dbTs, ts);
+    assertEquals(checkText, ts, dbTs);
   }
 
   private TimeZone getTimeZoneCache(Object stmt) {

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/TimezoneCachingTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/TimezoneCachingTest.java
@@ -34,93 +34,94 @@ public class TimezoneCachingTest extends BaseTest {
     Timestamp ts = new Timestamp(2016 - 1900, 1 - 1, 31, 0, 0, 0, 0);
     Date date = new Date(2016 - 1900, 1 - 1, 31);
     Time time = new Time(System.currentTimeMillis());
+    TimeZone tz = TimeZone.getDefault();
     PreparedStatement pstmt = null;
     try {
       pstmt = con.prepareStatement("INSERT INTO testtz VALUES (?,?)");
-      assertTrue(
+      assertEquals(
           "Cache never initialized: must be null",
-          getTimeZoneCache(pstmt) == null);
+          getTimeZoneCache(pstmt), null);
       pstmt.setInt(1, 1);
-      assertTrue(
+      assertEquals(
           "Cache never initialized: must be null",
-          getTimeZoneCache(pstmt) == null);
+          getTimeZoneCache(pstmt), null);
       pstmt.setTimestamp(2, ts);
-      assertTrue(
+      assertEquals(
           "Cache initialized by setTimestamp(xx): must not be null",
-          getTimeZoneCache(pstmt) != null);
+          getTimeZoneCache(pstmt), tz);
       pstmt.addBatch();
-      assertTrue(
+      assertEquals(
           "Cache was initialized, addBatch does not change that: must not be null",
-          getTimeZoneCache(pstmt) != null);
+          getTimeZoneCache(pstmt), tz);
       pstmt.setInt(1, 2);
       pstmt.setNull(2, java.sql.Types.DATE);
-      assertTrue(
+      assertEquals(
           "Cache was initialized, setNull does not change that: must not be null",
-          getTimeZoneCache(pstmt) != null);
+          getTimeZoneCache(pstmt), tz);
       pstmt.addBatch();
-      assertTrue(
+      assertEquals(
           "Cache was initialized, addBatch does not change that: must not be null",
-          getTimeZoneCache(pstmt) != null);
+          getTimeZoneCache(pstmt), tz);
       pstmt.executeBatch();
-      assertTrue(
+      assertEquals(
           "Cache reset by executeBatch(): must be null",
-          getTimeZoneCache(pstmt) == null);
+          getTimeZoneCache(pstmt), null);
       pstmt.setInt(1, 3);
-      assertTrue(
+      assertEquals(
           "Cache not initialized: must be null",
-          getTimeZoneCache(pstmt) == null);
+          getTimeZoneCache(pstmt), null);
       pstmt.setInt(1, 4);
       pstmt.setNull(2, java.sql.Types.DATE);
-      assertTrue(
+      assertEquals(
           "Cache was not initialized, setNull does not change that: must be null",
-          getTimeZoneCache(pstmt) == null);
+          getTimeZoneCache(pstmt), null);
       pstmt.setTimestamp(2, ts);
-      assertTrue(
+      assertEquals(
           "Cache initialized by setTimestamp(xx): must not be null",
-          getTimeZoneCache(pstmt) != null);
+          getTimeZoneCache(pstmt), tz);
       pstmt.clearParameters();
-      assertTrue(
+      assertEquals(
           "Cache was initialized, clearParameters does not change that: must not be null",
-          getTimeZoneCache(pstmt) != null);
+          getTimeZoneCache(pstmt), tz);
       pstmt.setInt(1, 5);
       pstmt.setTimestamp(2, ts);
       pstmt.addBatch();
       pstmt.executeBatch();
       pstmt.close();
       pstmt = con.prepareStatement("UPDATE testtz SET col2 = ? WHERE col1 = 1");
-      assertTrue(
+      assertEquals(
           "Cache not initialized: must be null",
-          getTimeZoneCache(pstmt) == null);
+          getTimeZoneCache(pstmt), null);
       pstmt.setDate(1, date);
-      assertTrue(
+      assertEquals(
           "Cache initialized by setDate(xx): must not be null",
-          getTimeZoneCache(pstmt) != null);
+          getTimeZoneCache(pstmt), tz);
       pstmt.execute();
-      assertTrue(
+      assertEquals(
           "Cache reset by execute(): must be null",
-          getTimeZoneCache(pstmt) == null);
+          getTimeZoneCache(pstmt), null);
       pstmt.setDate(1, date);
-      assertTrue(
+      assertEquals(
           "Cache initialized by setDate(xx): must not be null",
-          getTimeZoneCache(pstmt) != null);
+          getTimeZoneCache(pstmt), tz);
       pstmt.executeUpdate();
-      assertTrue(
+      assertEquals(
           "Cache reset by executeUpdate(): must be null",
-          getTimeZoneCache(pstmt) == null);
+          getTimeZoneCache(pstmt), null);
       pstmt.setTime(1, time);
-      assertTrue(
+      assertEquals(
           "Cache initialized by setTime(xx): must not be null",
-          getTimeZoneCache(pstmt) != null);
+          getTimeZoneCache(pstmt), tz);
       pstmt.close();
       pstmt = con.prepareStatement("SELECT * FROM testtz WHERE col2 = ?");
       pstmt.setDate(1, date);
-      assertTrue(
+      assertEquals(
           "Cache initialized by setDate(xx): must not be null",
-          getTimeZoneCache(pstmt) != null);
+          getTimeZoneCache(pstmt), tz);
       pstmt.executeQuery();
-      assertTrue(
+      assertEquals(
           "Cache reset by executeQuery(): must be null",
-          getTimeZoneCache(pstmt) == null);
+          getTimeZoneCache(pstmt), null);
     } finally {
       TestUtil.closeQuietly(pstmt);
     }
@@ -145,27 +146,20 @@ public class TimezoneCachingTest extends BaseTest {
       pstmt = con.prepareStatement("INSERT INTO testtz VALUES(1, ?)");
       pstmt.setTimestamp(1, ts);
       pstmt.executeUpdate();
-      assertTrue(
-          "Default is tz2, was saved as tz1, expecting tz1",
-          checkTimestamp(stmt, ts, tz1));
+      checkTimestamp("Default is tz2, was saved as tz1, expecting tz1", stmt, ts, tz1);
       pstmt.close();
-
       pstmt = con.prepareStatement("UPDATE testtz SET col2 = ? WHERE col1 = ?");
       pstmt.setTimestamp(1, ts);
       TimeZone.setDefault(tz2);
       pstmt.setInt(2, 1);
       pstmt.addBatch();
       pstmt.executeBatch();
-      assertTrue(
-          "Default is tz2, but was saved as tz1, expecting tz1",
-          checkTimestamp(stmt, ts, tz1));
+      checkTimestamp("Default is tz2, but was saved as tz1, expecting tz1", stmt, ts, tz1);
       pstmt.setTimestamp(1, ts);
       pstmt.setInt(2, 1);
       pstmt.addBatch();
       pstmt.executeBatch();
-      assertTrue(
-          "Default is tz2, was saved as tz2, expecting tz2",
-          checkTimestamp(stmt, ts, tz2));
+      checkTimestamp("Default is tz2, was saved as tz2, expecting tz2", stmt, ts, tz2);
       pstmt.setTimestamp(1, ts);
       pstmt.setInt(2, 1);
       pstmt.clearParameters();
@@ -174,16 +168,14 @@ public class TimezoneCachingTest extends BaseTest {
       pstmt.setInt(2, 1);
       pstmt.addBatch();
       pstmt.executeBatch();
-      assertTrue(
+      checkTimestamp(
           "Default is tz1, but was first saved as tz2, next save used tz2 cache, expecting tz2",
-          checkTimestamp(stmt, ts, tz2));
+          stmt, ts, tz2);
       pstmt.setTimestamp(1, ts, c3);
       pstmt.setInt(2, 1);
       pstmt.addBatch();
       pstmt.executeBatch();
-      assertTrue(
-          "Explicit use of tz3, expecting tz3",
-          checkTimestamp(stmt, ts, tz3));
+      checkTimestamp("Explicit use of tz3, expecting tz3", stmt, ts, tz3);
       pstmt.setTimestamp(1, ts, c3);
       pstmt.setInt(2, 1);
       pstmt.addBatch();
@@ -191,9 +183,7 @@ public class TimezoneCachingTest extends BaseTest {
       pstmt.setInt(2, 1);
       pstmt.addBatch();
       pstmt.executeBatch();
-      assertTrue(
-          "Last set explicitly used tz4, expecting tz4",
-          checkTimestamp(stmt, ts, tz4));
+      checkTimestamp("Last set explicitly used tz4, expecting tz4", stmt, ts, tz4);
       pstmt.setTimestamp(1, ts, c3);
       pstmt.setInt(2, 1);
       pstmt.addBatch();
@@ -204,9 +194,7 @@ public class TimezoneCachingTest extends BaseTest {
       pstmt.setInt(2, 1);
       pstmt.addBatch();
       pstmt.executeBatch();
-      assertTrue(
-          "Last set explicitly used tz4, expecting tz4",
-          checkTimestamp(stmt, ts, tz4));
+      checkTimestamp("Last set explicitly used tz4, expecting tz4", stmt, ts, tz4);
       pstmt.setTimestamp(1, ts, c3);
       pstmt.setInt(2, 1);
       pstmt.addBatch();
@@ -214,9 +202,9 @@ public class TimezoneCachingTest extends BaseTest {
       pstmt.setInt(2, 1);
       pstmt.addBatch();
       pstmt.executeBatch();
-      assertTrue(
-          "Default is tz1, was first saved as tz1, last save used tz1 cache, expecting tz1",
-          checkTimestamp(stmt, ts, tz1));
+      checkTimestamp(
+          "Default is tz1, was first saved as tz1, last save used tz1 cache, expecting tz1", stmt,
+          ts, tz1);
       pstmt.setTimestamp(1, ts);
       pstmt.setInt(2, 1);
       pstmt.addBatch();
@@ -227,9 +215,9 @@ public class TimezoneCachingTest extends BaseTest {
       pstmt.setInt(2, 1);
       pstmt.addBatch();
       pstmt.executeBatch();
-      assertTrue(
-          "Default is tz1, was first saved as tz1, last save used tz1 cache, expecting tz1",
-          checkTimestamp(stmt, ts, tz1));
+      checkTimestamp(
+          "Default is tz1, was first saved as tz1, last save used tz1 cache, expecting tz1", stmt,
+          ts, tz1);
     } catch (BatchUpdateException ex) {
       SQLException nextException = ex.getNextException();
       nextException.printStackTrace();
@@ -245,6 +233,7 @@ public class TimezoneCachingTest extends BaseTest {
    */
   public void testResultSetCachedTimezoneInstance() throws SQLException {
     Timestamp ts = new Timestamp(2016 - 1900, 1 - 1, 31, 0, 0, 0, 0);
+    TimeZone tz = TimeZone.getDefault();
     Statement stmt = null;
     PreparedStatement pstmt = null;
     ResultSet rs = null;
@@ -257,28 +246,28 @@ public class TimezoneCachingTest extends BaseTest {
       stmt = con.createStatement();
       rs = stmt.executeQuery("SELECT col1, col2 FROM testtz");
       rs.next();
-      assertTrue("Cache never initialized: must be null", getTimeZoneCache(rs) == null);
+      assertEquals("Cache never initialized: must be null", getTimeZoneCache(rs), null);
       rs.getInt(1);
-      assertTrue("Cache never initialized: must be null", getTimeZoneCache(rs) == null);
+      assertEquals("Cache never initialized: must be null", getTimeZoneCache(rs), null);
       rs.getTimestamp(2);
-      assertTrue("Cache initialized by getTimestamp(x): must not be null",
-          getTimeZoneCache(rs) != null);
+      assertEquals("Cache initialized by getTimestamp(x): must not be null",
+          getTimeZoneCache(rs), tz);
       rs.close();
       rs = stmt.executeQuery("SELECT col1, col2 FROM testtz");
       rs.next();
       rs.getInt(1);
-      assertTrue("Cache never initialized: must be null", getTimeZoneCache(rs) == null);
+      assertEquals("Cache never initialized: must be null", getTimeZoneCache(rs), null);
       rs.getObject(2);
-      assertTrue("Cache initialized by getObject(x) on a DATE column: must not be null",
-          getTimeZoneCache(rs) != null);
+      assertEquals("Cache initialized by getObject(x) on a DATE column: must not be null",
+          getTimeZoneCache(rs), tz);
       rs.close();
       rs = stmt.executeQuery("SELECT col1, col2 FROM testtz");
       rs.next();
-      assertTrue("Cache should NOT be set", getTimeZoneCache(rs) == null);
+      assertEquals("Cache should NOT be set", getTimeZoneCache(rs), null);
       rs.getInt(1);
-      assertTrue("Cache never initialized: must be null", getTimeZoneCache(rs) == null);
+      assertEquals("Cache never initialized: must be null", getTimeZoneCache(rs), null);
       rs.getDate(2);
-      assertTrue("Cache initialized by getDate(x): must not be null", getTimeZoneCache(rs) != null);
+      assertEquals("Cache initialized by getDate(x): must not be null", getTimeZoneCache(rs), tz);
       rs.close();
     } finally {
       TestUtil.closeQuietly(rs);
@@ -357,7 +346,8 @@ public class TimezoneCachingTest extends BaseTest {
     }
   }
 
-  private boolean checkTimestamp(Statement stmt, Timestamp ts, TimeZone tz) throws SQLException {
+  private void checkTimestamp(String checkText, Statement stmt, Timestamp ts, TimeZone tz)
+      throws SQLException {
     TimeZone prevTz = TimeZone.getDefault();
     TimeZone.setDefault(tz);
     ResultSet rs = stmt.executeQuery("SELECT col2 FROM testtz");
@@ -365,7 +355,7 @@ public class TimezoneCachingTest extends BaseTest {
     Timestamp dbTs = rs.getTimestamp(1);
     rs.close();
     TimeZone.setDefault(prevTz);
-    return dbTs.equals(ts);
+    assertEquals(checkText, dbTs, ts);
   }
 
   private TimeZone getTimeZoneCache(Object stmt) {

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/TimezoneCachingTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/TimezoneCachingTest.java
@@ -8,7 +8,6 @@
 
 package org.postgresql.test.jdbc2;
 
-import org.postgresql.PGProperty;
 import org.postgresql.test.TestUtil;
 
 import java.lang.reflect.Field;
@@ -22,7 +21,6 @@ import java.sql.Time;
 import java.sql.Timestamp;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
-import java.util.Properties;
 import java.util.TimeZone;
 
 public class TimezoneCachingTest extends BaseTest {
@@ -371,10 +369,6 @@ public class TimezoneCachingTest extends BaseTest {
 
   public TimezoneCachingTest(String name) {
     super(name);
-    try {
-      Class.forName("org.postgresql.Driver");
-    } catch (Exception ex) {
-    }
   }
 
   /* Set up the fixture for this test case: a connection to a database with
@@ -402,10 +396,4 @@ public class TimezoneCachingTest extends BaseTest {
     super.tearDown();
   }
 
-  @Override
-  protected void updateProperties(Properties props) {
-    props.setProperty(PGProperty.REWRITE_BATCHED_INSERTS.getName(),
-        Boolean.TRUE.toString());
-    props.setProperty(PGProperty.PREPARE_THRESHOLD.getName(), "1");
-  }
 }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/TimezoneCachingTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/TimezoneCachingTest.java
@@ -382,10 +382,6 @@ public class TimezoneCachingTest extends BaseTest {
     TestUtil.createTable(con, "testtz", "col1 INTEGER, col2 TIMESTAMP");
 
     stmt.close();
-
-    /* Generally recommended with batch updates. By default we run all
-    tests in this test case with autoCommit disabled. */
-    con.setAutoCommit(false);
   }
 
   // Tear down the fixture for this test case.

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/TimezoneCachingTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/TimezoneCachingTest.java
@@ -1,0 +1,304 @@
+/*-------------------------------------------------------------------------
+ *
+ * Copyright (c) 2003-2016, PostgreSQL Global Development Group
+ *
+ *
+ *-------------------------------------------------------------------------
+ */
+
+package org.postgresql.test.jdbc2;
+
+import org.postgresql.PGProperty;
+import org.postgresql.test.TestUtil;
+
+import java.lang.reflect.Field;
+import java.sql.BatchUpdateException;
+import java.sql.Date;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.util.Properties;
+import java.util.TimeZone;
+
+public class TimezoneCachingTest extends BaseTest {
+
+  /**
+   * Test to check the internal calendar for timezone of a prepared statement is set/cleared as
+   * expected.
+   */
+  public void testTimezonePreparedStatementCachedCalendarInstance() throws SQLException {
+    Timestamp ts = new Timestamp(2016 - 1900, 1 - 1, 31, 0, 0, 0, 0);
+    Date date = new Date(2016 - 1900, 1 - 1, 31);
+    Time time = new Time(System.currentTimeMillis());
+    PreparedStatement pstmt = null;
+    try {
+      pstmt = con.prepareStatement("INSERT INTO testtz VALUES (?,?)");
+      assertTrue("Cache should NOT be set", getTimeZoneCache(pstmt) == null);
+      pstmt.setInt(1, 1);
+      assertTrue("Cache should NOT be set", getTimeZoneCache(pstmt) == null);
+      pstmt.setTimestamp(2, ts);
+      assertTrue("Cache should be set", getTimeZoneCache(pstmt) != null);
+      pstmt.addBatch();
+      assertTrue("Cache should be set", getTimeZoneCache(pstmt) != null);
+      pstmt.setInt(1, 2);
+      pstmt.setNull(2, java.sql.Types.DATE);
+      assertTrue("Cache should be set", getTimeZoneCache(pstmt) != null);
+      pstmt.addBatch();
+      assertTrue("Cache should be set", getTimeZoneCache(pstmt) != null);
+      pstmt.executeBatch();
+      assertTrue("Cache should NOT be set", getTimeZoneCache(pstmt) == null);
+      pstmt.setInt(1, 3);
+      assertTrue("Cache should NOT be set", getTimeZoneCache(pstmt) == null);
+      pstmt.setInt(1, 4);
+      pstmt.setNull(2, java.sql.Types.DATE);
+      assertTrue("Cache should NOT be set", getTimeZoneCache(pstmt) == null);
+      pstmt.setTimestamp(2, ts);
+      assertTrue("Cache should be set", getTimeZoneCache(pstmt) != null);
+      pstmt.clearParameters();
+      assertTrue("Cache should be set", getTimeZoneCache(pstmt) != null);
+      pstmt.setInt(1, 5);
+      pstmt.setTimestamp(2, ts);
+      pstmt.addBatch();
+      pstmt.executeBatch();
+      pstmt.close();
+      pstmt = con.prepareStatement("UPDATE testtz SET col2 = ? WHERE col1 = 1");
+      assertTrue("Cache should NOT be set", getTimeZoneCache(pstmt) == null);
+      pstmt.setDate(1, date);
+      assertTrue("Cache should be set", getTimeZoneCache(pstmt) != null);
+      pstmt.execute();
+      assertTrue("Cache should NOT be set", getTimeZoneCache(pstmt) == null);
+      pstmt.setDate(1, date);
+      assertTrue("Cache should be set", getTimeZoneCache(pstmt) != null);
+      pstmt.executeUpdate();
+      pstmt.setTime(1, time);
+      assertTrue("Cache should be set", getTimeZoneCache(pstmt) != null);
+      pstmt.close();
+      pstmt = con.prepareStatement("SELECT * FROM testtz WHERE col2 = ?");
+      assertTrue("Cache should NOT be set", getTimeZoneCache(pstmt) == null);
+      pstmt.setDate(1, date);
+      assertTrue("Cache should be set", getTimeZoneCache(pstmt) != null);
+      pstmt.executeQuery();
+      assertTrue("Cache should NOT be set", getTimeZoneCache(pstmt) == null);
+    } finally {
+      if (null != pstmt) {
+        pstmt.close();
+      }
+      con.rollback();
+    }
+  }
+
+  /**
+   * Test to check the internal calendar for timezone of a prepared statement is used as expected.
+   */
+  public void testTimezonePreparedStatementCachedCalendarUsage() throws SQLException {
+    Timestamp ts = new Timestamp(2016 - 1900, 1 - 1, 31, 0, 0, 0, 0);
+    Statement stmt = null;
+    PreparedStatement pstmt = null;
+    TimeZone tz1 = TimeZone.getTimeZone("GMT+8:00");
+    TimeZone tz2 = TimeZone.getTimeZone("GMT-2:00");
+    try {
+      stmt = con.createStatement();
+      TimeZone.setDefault(tz1);
+      pstmt = con.prepareStatement("INSERT INTO testtz VALUES(1, ?)");
+      pstmt.setTimestamp(1, ts);
+      pstmt.executeUpdate();
+      assertTrue("Timestamps not set properly", checkTimestamp(stmt, ts, tz1));
+      pstmt.close();
+      pstmt = con.prepareStatement("UPDATE testtz SET col2 = ? WHERE col1 = ?");
+      pstmt.setTimestamp(1, ts);
+      TimeZone.setDefault(tz2);
+      pstmt.setInt(2, 1);
+      pstmt.addBatch();
+      pstmt.executeBatch();
+      assertTrue("Timezone mismatch", checkTimestamp(stmt, ts, tz1));
+      pstmt.setTimestamp(1, ts);
+      pstmt.setInt(2, 1);
+      pstmt.addBatch();
+      pstmt.executeBatch();
+      assertTrue("Timezone mismatch", checkTimestamp(stmt, ts, tz2));
+      pstmt.setTimestamp(1, ts);
+      pstmt.setInt(2, 1);
+      pstmt.clearParameters();
+      TimeZone.setDefault(tz1);
+      pstmt.setTimestamp(1, ts);
+      pstmt.setInt(2, 1);
+      pstmt.executeBatch();
+      assertTrue("Timezone mismatch", checkTimestamp(stmt, ts, tz2));
+    } catch (BatchUpdateException ex) {
+      SQLException nextException = ex.getNextException();
+      nextException.printStackTrace();
+    } finally {
+      TimeZone.setDefault(null);
+      if (null != pstmt) {
+        pstmt.close();
+      }
+      if (null != stmt) {
+        stmt.close();
+      }
+      con.rollback();
+    }
+  }
+
+  /**
+   * Test to check the internal calendar for timezone of a result set is set/cleared as expected.
+   */
+  public void testTimezoneResultSetCachedCalendarInstance() throws SQLException {
+    Timestamp ts = new Timestamp(2016 - 1900, 1 - 1, 31, 0, 0, 0, 0);
+    Statement stmt = null;
+    PreparedStatement pstmt = null;
+    ResultSet rs = null;
+    try {
+      pstmt = con.prepareStatement("INSERT INTO testtz VALUES (?,?)");
+      pstmt.setInt(1, 1);
+      pstmt.setTimestamp(2, ts);
+      pstmt.addBatch();
+      pstmt.executeBatch();
+      stmt = con.createStatement();
+      rs = stmt.executeQuery("SELECT col1, col2 FROM testtz");
+      rs.next();
+      assertTrue("Cache should NOT be set", getTimeZoneCache(rs) == null);
+      rs.getInt(1);
+      assertTrue("Cache should NOT be set", getTimeZoneCache(rs) == null);
+      rs.getTimestamp(2);
+      assertTrue("Cache should be set", getTimeZoneCache(rs) != null);
+      rs.close();
+      rs = stmt.executeQuery("SELECT col1, col2 FROM testtz");
+      rs.next();
+      assertTrue("Cache should NOT be set", getTimeZoneCache(rs) == null);
+      rs.getInt(1);
+      assertTrue("Cache should NOT be set", getTimeZoneCache(rs) == null);
+      rs.getObject(2);
+      assertTrue("Cache should be set", getTimeZoneCache(rs) != null);
+      rs.close();
+      rs = stmt.executeQuery("SELECT col1, col2 FROM testtz");
+      rs.next();
+      assertTrue("Cache should NOT be set", getTimeZoneCache(rs) == null);
+      rs.getInt(1);
+      assertTrue("Cache should NOT be set", getTimeZoneCache(rs) == null);
+      rs.getDate(2);
+      assertTrue("Cache should be set", getTimeZoneCache(rs) != null);
+      rs.close();
+    } finally {
+      if (null != rs) {
+        rs.close();
+      }
+      if (null != pstmt) {
+        pstmt.close();
+      }
+      if (null != stmt) {
+        stmt.close();
+      }
+      con.rollback();
+    }
+  }
+
+  /**
+   * Test to check the internal calendar for timezone of a result set is used as expected.
+   */
+  public void testTimezoneResultSetCachedCalendarUsage() throws SQLException {
+    Timestamp ts = new Timestamp(2016 - 1900, 1 - 1, 31, 0, 0, 0, 0);
+    Statement stmt = null;
+    PreparedStatement pstmt = null;
+    ResultSet rs = null;
+    TimeZone tz1 = TimeZone.getTimeZone("GMT+8:00");
+    TimeZone tz2 = TimeZone.getTimeZone("GMT-2:00");
+    try {
+      TimeZone.setDefault(tz1);
+      pstmt = con.prepareStatement("INSERT INTO testtz VALUES (?,?)");
+      pstmt.setInt(1, 1);
+      pstmt.setTimestamp(2, ts);
+      pstmt.addBatch();
+      pstmt.executeBatch();
+      stmt = con.createStatement();
+      rs = stmt.executeQuery("SELECT col1, col2 FROM testtz");
+      rs.next();
+      rs.getInt(1);
+      assertTrue("Timestamps sould be in same time zone", rs.getTimestamp(2).equals(ts));
+      rs.close();
+      rs = stmt.executeQuery("SELECT col1, col2 FROM testtz");
+      rs.next();
+      rs.getInt(1);
+      TimeZone.setDefault(tz2);
+      assertTrue("Timestamps sould NOT be in same time zone", !rs.getTimestamp(2).equals(ts));
+      TimeZone.setDefault(tz1);
+      assertTrue("Timestamps sould NOT be in same time zone", !rs.getTimestamp(2).equals(ts));
+      rs.close();
+    } finally {
+      TimeZone.setDefault(null);
+      if (null != rs) {
+        rs.close();
+      }
+      if (null != pstmt) {
+        pstmt.close();
+      }
+      if (null != stmt) {
+        stmt.close();
+      }
+      con.rollback();
+    }
+  }
+
+  private boolean checkTimestamp(Statement stmt, Timestamp ts, TimeZone tz) throws SQLException {
+    TimeZone prevTz = TimeZone.getDefault();
+    TimeZone.setDefault(tz);
+    ResultSet rs = stmt.executeQuery("SELECT col2 FROM testtz");
+    rs.next();
+    Timestamp dbTs = rs.getTimestamp(1);
+    rs.close();
+    TimeZone.setDefault(prevTz);
+    return dbTs.equals(ts);
+  }
+
+  private TimeZone getTimeZoneCache(Object stmt) {
+    try {
+      Field defaultTimeZoneField = stmt.getClass().getDeclaredField("defaultTimeZone");
+      defaultTimeZoneField.setAccessible(true);
+      return (TimeZone) defaultTimeZoneField.get(stmt);
+    } catch (Exception e) {
+    }
+    return null;
+  }
+
+  public TimezoneCachingTest(String name) {
+    super(name);
+    try {
+      Class.forName("org.postgresql.Driver");
+    } catch (Exception ex) {
+    }
+  }
+
+  /* Set up the fixture for this test case: a connection to a database with
+  a table for this test. */
+  protected void setUp() throws Exception {
+    super.setUp();
+    Statement stmt = con.createStatement();
+
+    /* Drop the test table if it already exists for some reason. It is
+    not an error if it doesn't exist. */
+    TestUtil.createTable(con, "testtz", "col1 INTEGER, col2 TIMESTAMP");
+
+    stmt.close();
+
+    /* Generally recommended with batch updates. By default we run all
+    tests in this test case with autoCommit disabled. */
+    con.setAutoCommit(false);
+  }
+
+  // Tear down the fixture for this test case.
+  protected void tearDown() throws SQLException {
+    con.setAutoCommit(true);
+
+    TestUtil.dropTable(con, "testtz");
+    super.tearDown();
+  }
+
+  @Override
+  protected void updateProperties(Properties props) {
+    props.setProperty(PGProperty.REWRITE_BATCHED_INSERTS.getName(),
+        Boolean.TRUE.toString());
+    props.setProperty(PGProperty.PREPARE_THRESHOLD.getName(), "1");
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/TimezoneCachingTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/TimezoneCachingTest.java
@@ -37,52 +37,90 @@ public class TimezoneCachingTest extends BaseTest {
     PreparedStatement pstmt = null;
     try {
       pstmt = con.prepareStatement("INSERT INTO testtz VALUES (?,?)");
-      assertTrue("Cache should NOT be set", getTimeZoneCache(pstmt) == null);
+      assertTrue(
+          "Cache never initialized: must be null",
+          getTimeZoneCache(pstmt) == null);
       pstmt.setInt(1, 1);
-      assertTrue("Cache should NOT be set", getTimeZoneCache(pstmt) == null);
+      assertTrue(
+          "Cache never initialized: must be null",
+          getTimeZoneCache(pstmt) == null);
       pstmt.setTimestamp(2, ts);
-      assertTrue("Cache should be set", getTimeZoneCache(pstmt) != null);
+      assertTrue(
+          "Cache initialized by setTimestamp(xx): must not be null",
+          getTimeZoneCache(pstmt) != null);
       pstmt.addBatch();
-      assertTrue("Cache should be set", getTimeZoneCache(pstmt) != null);
+      assertTrue(
+          "Cache was initialized, addBatch does not change that: must not be null",
+          getTimeZoneCache(pstmt) != null);
       pstmt.setInt(1, 2);
       pstmt.setNull(2, java.sql.Types.DATE);
-      assertTrue("Cache should be set", getTimeZoneCache(pstmt) != null);
+      assertTrue(
+          "Cache was initialized, setNull does not change that: must not be null",
+          getTimeZoneCache(pstmt) != null);
       pstmt.addBatch();
-      assertTrue("Cache should be set", getTimeZoneCache(pstmt) != null);
+      assertTrue(
+          "Cache was initialized, addBatch does not change that: must not be null",
+          getTimeZoneCache(pstmt) != null);
       pstmt.executeBatch();
-      assertTrue("Cache should NOT be set", getTimeZoneCache(pstmt) == null);
+      assertTrue(
+          "Cache reset by executeBatch(): must be null",
+          getTimeZoneCache(pstmt) == null);
       pstmt.setInt(1, 3);
-      assertTrue("Cache should NOT be set", getTimeZoneCache(pstmt) == null);
+      assertTrue(
+          "Cache not initialized: must be null",
+          getTimeZoneCache(pstmt) == null);
       pstmt.setInt(1, 4);
       pstmt.setNull(2, java.sql.Types.DATE);
-      assertTrue("Cache should NOT be set", getTimeZoneCache(pstmt) == null);
+      assertTrue(
+          "Cache was not initialized, setNull does not change that: must be null",
+          getTimeZoneCache(pstmt) == null);
       pstmt.setTimestamp(2, ts);
-      assertTrue("Cache should be set", getTimeZoneCache(pstmt) != null);
+      assertTrue(
+          "Cache initialized by setTimestamp(xx): must not be null",
+          getTimeZoneCache(pstmt) != null);
       pstmt.clearParameters();
-      assertTrue("Cache should be set", getTimeZoneCache(pstmt) != null);
+      assertTrue(
+          "Cache was initialized, clearParameters does not change that: must not be null",
+          getTimeZoneCache(pstmt) != null);
       pstmt.setInt(1, 5);
       pstmt.setTimestamp(2, ts);
       pstmt.addBatch();
       pstmt.executeBatch();
       pstmt.close();
       pstmt = con.prepareStatement("UPDATE testtz SET col2 = ? WHERE col1 = 1");
-      assertTrue("Cache should NOT be set", getTimeZoneCache(pstmt) == null);
+      assertTrue(
+          "Cache not initialized: must be null",
+          getTimeZoneCache(pstmt) == null);
       pstmt.setDate(1, date);
-      assertTrue("Cache should be set", getTimeZoneCache(pstmt) != null);
+      assertTrue(
+          "Cache initialized by setDate(xx): must not be null",
+          getTimeZoneCache(pstmt) != null);
       pstmt.execute();
-      assertTrue("Cache should NOT be set", getTimeZoneCache(pstmt) == null);
+      assertTrue(
+          "Cache reset by execute(): must be null",
+          getTimeZoneCache(pstmt) == null);
       pstmt.setDate(1, date);
-      assertTrue("Cache should be set", getTimeZoneCache(pstmt) != null);
+      assertTrue(
+          "Cache initialized by setDate(xx): must not be null",
+          getTimeZoneCache(pstmt) != null);
       pstmt.executeUpdate();
+      assertTrue(
+          "Cache reset by executeUpdate(): must be null",
+          getTimeZoneCache(pstmt) == null);
       pstmt.setTime(1, time);
-      assertTrue("Cache should be set", getTimeZoneCache(pstmt) != null);
+      assertTrue(
+          "Cache initialized by setTime(xx): must not be null",
+          getTimeZoneCache(pstmt) != null);
       pstmt.close();
       pstmt = con.prepareStatement("SELECT * FROM testtz WHERE col2 = ?");
-      assertTrue("Cache should NOT be set", getTimeZoneCache(pstmt) == null);
       pstmt.setDate(1, date);
-      assertTrue("Cache should be set", getTimeZoneCache(pstmt) != null);
+      assertTrue(
+          "Cache initialized by setDate(xx): must not be null",
+          getTimeZoneCache(pstmt) != null);
       pstmt.executeQuery();
-      assertTrue("Cache should NOT be set", getTimeZoneCache(pstmt) == null);
+      assertTrue(
+          "Cache reset by executeQuery(): must be null",
+          getTimeZoneCache(pstmt) == null);
     } finally {
       TestUtil.closeQuietly(pstmt);
     }
@@ -107,20 +145,27 @@ public class TimezoneCachingTest extends BaseTest {
       pstmt = con.prepareStatement("INSERT INTO testtz VALUES(1, ?)");
       pstmt.setTimestamp(1, ts);
       pstmt.executeUpdate();
-      assertTrue("Timestamps not set properly", checkTimestamp(stmt, ts, tz1));
+      assertTrue(
+          "Default is tz2, was saved as tz1, expecting tz1",
+          checkTimestamp(stmt, ts, tz1));
       pstmt.close();
+
       pstmt = con.prepareStatement("UPDATE testtz SET col2 = ? WHERE col1 = ?");
       pstmt.setTimestamp(1, ts);
       TimeZone.setDefault(tz2);
       pstmt.setInt(2, 1);
       pstmt.addBatch();
       pstmt.executeBatch();
-      assertTrue("Timezone mismatch", checkTimestamp(stmt, ts, tz1));
+      assertTrue(
+          "Default is tz2, but was saved as tz1, expecting tz1",
+          checkTimestamp(stmt, ts, tz1));
       pstmt.setTimestamp(1, ts);
       pstmt.setInt(2, 1);
       pstmt.addBatch();
       pstmt.executeBatch();
-      assertTrue("Timezone mismatch", checkTimestamp(stmt, ts, tz2));
+      assertTrue(
+          "Default is tz2, was saved as tz2, expecting tz2",
+          checkTimestamp(stmt, ts, tz2));
       pstmt.setTimestamp(1, ts);
       pstmt.setInt(2, 1);
       pstmt.clearParameters();
@@ -129,12 +174,16 @@ public class TimezoneCachingTest extends BaseTest {
       pstmt.setInt(2, 1);
       pstmt.addBatch();
       pstmt.executeBatch();
-      assertTrue("Timezone mismatch", checkTimestamp(stmt, ts, tz2));
+      assertTrue(
+          "Default is tz1, but was first saved as tz2, next save used tz2 cache, expecting tz2",
+          checkTimestamp(stmt, ts, tz2));
       pstmt.setTimestamp(1, ts, c3);
       pstmt.setInt(2, 1);
       pstmt.addBatch();
       pstmt.executeBatch();
-      assertTrue("Timezone mismatch", checkTimestamp(stmt, ts, tz3));
+      assertTrue(
+          "Explicit use of tz3, expecting tz3",
+          checkTimestamp(stmt, ts, tz3));
       pstmt.setTimestamp(1, ts, c3);
       pstmt.setInt(2, 1);
       pstmt.addBatch();
@@ -142,7 +191,9 @@ public class TimezoneCachingTest extends BaseTest {
       pstmt.setInt(2, 1);
       pstmt.addBatch();
       pstmt.executeBatch();
-      assertTrue("Timezone mismatch", checkTimestamp(stmt, ts, tz4));
+      assertTrue(
+          "Last set explicitly used tz4, expecting tz4",
+          checkTimestamp(stmt, ts, tz4));
       pstmt.setTimestamp(1, ts, c3);
       pstmt.setInt(2, 1);
       pstmt.addBatch();
@@ -153,7 +204,9 @@ public class TimezoneCachingTest extends BaseTest {
       pstmt.setInt(2, 1);
       pstmt.addBatch();
       pstmt.executeBatch();
-      assertTrue("Timezone mismatch", checkTimestamp(stmt, ts, tz4));
+      assertTrue(
+          "Last set explicitly used tz4, expecting tz4",
+          checkTimestamp(stmt, ts, tz4));
       pstmt.setTimestamp(1, ts, c3);
       pstmt.setInt(2, 1);
       pstmt.addBatch();
@@ -161,7 +214,9 @@ public class TimezoneCachingTest extends BaseTest {
       pstmt.setInt(2, 1);
       pstmt.addBatch();
       pstmt.executeBatch();
-      assertTrue("Timezone mismatch", checkTimestamp(stmt, ts, tz1));
+      assertTrue(
+          "Default is tz1, was first saved as tz1, last save used tz1 cache, expecting tz1",
+          checkTimestamp(stmt, ts, tz1));
       pstmt.setTimestamp(1, ts);
       pstmt.setInt(2, 1);
       pstmt.addBatch();
@@ -172,7 +227,9 @@ public class TimezoneCachingTest extends BaseTest {
       pstmt.setInt(2, 1);
       pstmt.addBatch();
       pstmt.executeBatch();
-      assertTrue("Timezone mismatch", checkTimestamp(stmt, ts, tz1));
+      assertTrue(
+          "Default is tz1, was first saved as tz1, last save used tz1 cache, expecting tz1",
+          checkTimestamp(stmt, ts, tz1));
     } catch (BatchUpdateException ex) {
       SQLException nextException = ex.getNextException();
       nextException.printStackTrace();
@@ -200,27 +257,28 @@ public class TimezoneCachingTest extends BaseTest {
       stmt = con.createStatement();
       rs = stmt.executeQuery("SELECT col1, col2 FROM testtz");
       rs.next();
-      assertTrue("Cache should NOT be set", getTimeZoneCache(rs) == null);
+      assertTrue("Cache never initialized: must be null", getTimeZoneCache(rs) == null);
       rs.getInt(1);
-      assertTrue("Cache should NOT be set", getTimeZoneCache(rs) == null);
+      assertTrue("Cache never initialized: must be null", getTimeZoneCache(rs) == null);
       rs.getTimestamp(2);
-      assertTrue("Cache should be set", getTimeZoneCache(rs) != null);
+      assertTrue("Cache initialized by getTimestamp(x): must not be null",
+          getTimeZoneCache(rs) != null);
       rs.close();
       rs = stmt.executeQuery("SELECT col1, col2 FROM testtz");
       rs.next();
-      assertTrue("Cache should NOT be set", getTimeZoneCache(rs) == null);
       rs.getInt(1);
-      assertTrue("Cache should NOT be set", getTimeZoneCache(rs) == null);
+      assertTrue("Cache never initialized: must be null", getTimeZoneCache(rs) == null);
       rs.getObject(2);
-      assertTrue("Cache should be set", getTimeZoneCache(rs) != null);
+      assertTrue("Cache initialized by getObject(x) on a DATE column: must not be null",
+          getTimeZoneCache(rs) != null);
       rs.close();
       rs = stmt.executeQuery("SELECT col1, col2 FROM testtz");
       rs.next();
       assertTrue("Cache should NOT be set", getTimeZoneCache(rs) == null);
       rs.getInt(1);
-      assertTrue("Cache should NOT be set", getTimeZoneCache(rs) == null);
+      assertTrue("Cache never initialized: must be null", getTimeZoneCache(rs) == null);
       rs.getDate(2);
-      assertTrue("Cache should be set", getTimeZoneCache(rs) != null);
+      assertTrue("Cache initialized by getDate(x): must not be null", getTimeZoneCache(rs) != null);
       rs.close();
     } finally {
       TestUtil.closeQuietly(rs);
@@ -240,10 +298,12 @@ public class TimezoneCachingTest extends BaseTest {
     TimeZone tz1 = TimeZone.getTimeZone("GMT+8:00");
     TimeZone tz2 = TimeZone.getTimeZone("GMT-2:00");
     Calendar c1 = new GregorianCalendar(tz1);
+    Calendar c2 = new GregorianCalendar(tz2);
     try {
       TimeZone.setDefault(tz1);
       pstmt = con.prepareStatement("INSERT INTO testtz VALUES (?,?)");
       pstmt.setInt(1, 1);
+      // We are in tz1, so timestamp added as tz1.
       pstmt.setTimestamp(2, ts);
       pstmt.addBatch();
       pstmt.executeBatch();
@@ -251,24 +311,43 @@ public class TimezoneCachingTest extends BaseTest {
       rs = stmt.executeQuery("SELECT col1, col2 FROM testtz");
       rs.next();
       rs.getInt(1);
-      assertTrue("Timestamps sould be in same time zone", rs.getTimestamp(2).equals(ts));
+      assertTrue(
+          "Current TZ is tz1, empty cache to be initialized to tz1 => retrieve in tz1, timestamps must be equal",
+          rs.getTimestamp(2).equals(ts));
       rs.close();
       rs = stmt.executeQuery("SELECT col1, col2 FROM testtz");
       rs.next();
       rs.getInt(1);
       TimeZone.setDefault(tz2);
-      assertTrue("Timestamps sould NOT be in same time zone", !rs.getTimestamp(2).equals(ts));
-      assertTrue("Timestamp sould be in calendar time zone", rs.getTimestamp(2, c1).equals(ts));
-      assertTrue("Timestamps sould NOT be in same time zone", !rs.getTimestamp(2).equals(ts));
+      assertTrue(
+          "Current TZ is tz2, empty cache to be initialized to tz2 => retrieve in tz2, timestamps cannot be equal",
+          !rs.getTimestamp(2).equals(ts));
+      assertTrue(
+          "Explicit tz1 calendar, so timestamps must be equal",
+          rs.getTimestamp(2, c1).equals(ts));
+      assertTrue(
+          "Cache was initialized to tz2, so timestamps cannot be equal",
+          !rs.getTimestamp(2).equals(ts));
       TimeZone.setDefault(tz1);
-      assertTrue("Timestamps sould NOT be in same time zone", !rs.getTimestamp(2).equals(ts));
+      assertTrue(
+          "Cache was initialized to tz2, so timestamps cannot be equal",
+          !rs.getTimestamp(2).equals(ts));
       rs.close();
       rs = stmt.executeQuery("SELECT col1, col2 FROM testtz");
       rs.next();
       rs.getInt(1);
-      assertTrue("Timestamp sould be in calendar time zone", rs.getTimestamp(2, c1).equals(ts));
-      assertTrue("Timestamps sould be in same time zone", rs.getTimestamp(2).equals(ts));
-      assertTrue("Timestamp sould be in calendar time zone", rs.getTimestamp(2, c1).equals(ts));
+      assertTrue(
+          "Explicit tz2 calendar, so timestamps cannot be equal",
+          !rs.getTimestamp(2, c2).equals(ts));
+      assertTrue(
+          "Current TZ is tz1, empty cache to be initialized to tz1 => retrieve in tz1, timestamps must be equal",
+          rs.getTimestamp(2).equals(ts));
+      assertTrue(
+          "Explicit tz2 calendar, so timestamps cannot be equal",
+          !rs.getTimestamp(2, c2).equals(ts));
+      assertTrue(
+          "Explicit tz2 calendar, so timestamps must be equal",
+          rs.getTimestamp(2, c1).equals(ts));
       rs.close();
     } finally {
       TimeZone.setDefault(null);


### PR DESCRIPTION
This is to fix issue #508 
I don't know all the details, but I think the same timezeone could be used for the lifetime of a prepared statement between the time parameters are added until they are executed. So I lazy create a calendar at first `setDate/Time/Timestamp(xx)` which I clear at `executeBatch()`.