### PR TITLE
fix: add a socket timeout on cancel requests

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java
@@ -224,7 +224,7 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
 
         // Do final startup.
         ProtocolConnectionImpl protoConnection =
-            new ProtocolConnectionImpl(newStream, user, database, info, logger, connectTimeout);
+            new ProtocolConnectionImpl(newStream, user, database, info, logger, connectTimeout, socketTimeout);
         readStartupMessages(newStream, protoConnection, logger);
 
         // Check Master or Slave

--- a/pgjdbc/src/test/java/org/postgresql/core/v3/V3ParameterListTests.java
+++ b/pgjdbc/src/test/java/org/postgresql/core/v3/V3ParameterListTests.java
@@ -68,6 +68,6 @@ public class V3ParameterListTests extends BaseTest {
     SocketFactory socketFactory = SocketFactoryFactory.getSocketFactory(System.getProperties());
     HostSpec hostSpec = new HostSpec(TestUtil.getServer(), TestUtil.getPort());
     pci = new ProtocolConnectionImpl(new PGStream(socketFactory, hostSpec), "",
-        "", new Properties(), new Logger(), 5000);
+        "", new Properties(), new Logger(), 5000, 5000);
   }
 }


### PR DESCRIPTION
When a query times out, PgStatement.cancel can get stuck in
connection.cancelQuery while synchronized on the Connection object. This can
block PgStatement.killTimerTask from completing, which resulted in these
connections getting stuck in an unusable stack in our connection pool.

This deadlock only reproduced for us under high load with intermittent DB connectivity.