### PR TITLE
packaging: sync spec file with Fedora package

### DIFF
--- a/packaging/rpm/.srpmgen
+++ b/packaging/rpm/.srpmgen
@@ -6,4 +6,5 @@ spec: postgresql-jdbc.spec
 
 source0:
   git_archive:
-    prefix: postgresql-jdbc-9.5.git
+    prefix: pgjdbc-REL9.5.git
+    tarball_base: REL9.5.git

--- a/packaging/rpm/fedora-image/Dockerfile
+++ b/packaging/rpm/fedora-image/Dockerfile
@@ -1,4 +1,4 @@
-FROM index.docker.io/fedora:23
+FROM index.docker.io/fedora:24
 MAINTAINER pgjdbc team
 
 ENV HOME=/rpm

--- a/packaging/rpm/fedora-image/srpmgen
+++ b/packaging/rpm/fedora-image/srpmgen
@@ -30,9 +30,14 @@ sub obtain_source
         chomp ($topleveldir);
 
         my $pfx = $config->{prefix};
-        system ("git archive --remote $topleveldir --prefix $pfx/ HEAD | gzip > $pfx.tar.gz");
+        my $tarball_base = $pfx;
+        info ("generating tarball $tarball_base.tar.gz from git repository");
+        if (defined ($config->{tarball_base})) {
+            $tarball_base = $config->{tarball_base};
+        }
+        system ("git archive --remote $topleveldir --prefix $pfx/ HEAD | gzip > $tarball_base.tar.gz");
         if ($? >> 8) {
-            die ("can't generate tarball $pfx.tar.gz");
+            die ("can't generate tarball $tarball_base.tar.gz");
         }
         return;
     }

--- a/packaging/rpm/postgresql-jdbc.spec.tpl
+++ b/packaging/rpm/postgresql-jdbc.spec.tpl
@@ -38,7 +38,7 @@
 %global upstreamrel	git
 %global upstreammajor	9.5
 %global source_path	pgjdbc/src/main/java/org/postgresql
-%global parent_ver	1.0.8
+%global parent_ver	1.1.0
 %global parent_poms_builddir	./pgjdbc-parent-poms
 
 %global pgjdbc_mvn_options -DwaffleEnabled=false -DosgiEnabled=false \\\


### PR DESCRIPTION
Fedora maintainers have done big cleanup and simplification so it
is worth to sync the spec file here.

Also, as it is now suggested to build from github release tarball,
which is not 100% perfect, this commit fixes the 'srpmgen' tool so
it is able to generate equivalent tarball directly from git repo.