### PR TITLE
Add json type info to Client

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/Oid.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/Oid.java
@@ -73,6 +73,8 @@ public class Oid {
   public static final int POINT = 600;
   public static final int BOX = 603;
   public static final int JSONB_ARRAY = 3807;
+  public static final int JSON = 114;
+  public static final int JSON_ARRAY = 199;
 
   /**
    * Returns the name of the oid as string.

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
@@ -92,6 +92,7 @@ public class TypeInfoCache implements TypeInfo {
       {"timestamp", Oid.TIMESTAMP, Types.TIMESTAMP, "java.sql.Timestamp", Oid.TIMESTAMP_ARRAY},
       {"timestamptz", Oid.TIMESTAMPTZ, Types.TIMESTAMP, "java.sql.Timestamp",
           Oid.TIMESTAMPTZ_ARRAY},
+      {"json", Oid.JSON, Types.VARCHAR, "java.lang.String", Oid.JSON_ARRAY}
   };
 
   /**

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc4/ArrayTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc4/ArrayTest.java
@@ -114,6 +114,30 @@ public class ArrayTest extends BaseTest4 {
   }
 
   @Test
+  public void testCreateArrayOfMultiJson() throws SQLException {
+    PreparedStatement pstmt = _conn.prepareStatement("SELECT ?::json[]");
+    PGobject p1 = new PGobject();
+    p1.setType("json");
+    p1.setValue("{\"x\": 10}");
+
+    PGobject p2 = new PGobject();
+    p2.setType("json");
+    p2.setValue("{\"x\": 20}");
+    PGobject in[] = new PGobject[] { p1, p2 };
+    pstmt.setArray(1, _conn.createArrayOf("json", in));
+
+    ResultSet rs = pstmt.executeQuery();
+    Assert.assertTrue(rs.next());
+    Array arr = rs.getArray(1);
+    ResultSet arrRs = arr.getResultSet();
+    Assert.assertTrue(arrRs.next());
+    Assert.assertEquals(in[0].getValue(), arrRs.getObject(2));
+
+    Assert.assertTrue(arrRs.next());
+    Assert.assertEquals(in[1].getValue(), arrRs.getObject(2));
+  }
+
+  @Test
   public void testCreateArrayWithNonStandardDelimiter() throws SQLException {
     PGbox in[] = new PGbox[2];
     in[0] = new PGbox(1, 2, 3, 4);


### PR DESCRIPTION
This is a very minor performance improvement. It adds `json` type info
to the client in order to avoid the execution of a query to retrieve the
oid of the `json` type.