### PR TITLE
Add point type info to Client

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/Oid.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/Oid.java
@@ -71,6 +71,7 @@ public class Oid {
   public static final int XML = 142;
   public static final int XML_ARRAY = 143;
   public static final int POINT = 600;
+  public static final int POINT_ARRAY = 1017;
   public static final int BOX = 603;
   public static final int JSONB_ARRAY = 3807;
   public static final int JSON = 114;

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
@@ -92,7 +92,8 @@ public class TypeInfoCache implements TypeInfo {
       {"timestamp", Oid.TIMESTAMP, Types.TIMESTAMP, "java.sql.Timestamp", Oid.TIMESTAMP_ARRAY},
       {"timestamptz", Oid.TIMESTAMPTZ, Types.TIMESTAMP, "java.sql.Timestamp",
           Oid.TIMESTAMPTZ_ARRAY},
-      {"json", Oid.JSON, Types.VARCHAR, "java.lang.String", Oid.JSON_ARRAY}
+      {"json", Oid.JSON, Types.VARCHAR, "java.lang.String", Oid.JSON_ARRAY},
+      {"point", Oid.POINT, Types.OTHER, "org.postgresql.geometric.PGpoint", Oid.POINT_ARRAY}
   };
 
   /**


### PR DESCRIPTION
This is a very minor performance improvement. It adds `point` type info
to the client in order to avoid the execution of a query to retrieve the
oid of the `point` type.