### PR TITLE
feat: support SQLException#getErrorCode()

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/util/PSQLException.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/PSQLException.java
@@ -14,17 +14,24 @@ public class PSQLException extends SQLException {
 
   private ServerErrorMessage _serverError;
 
-  public PSQLException(String msg, PSQLState state, Throwable cause) {
-    super(msg, state == null ? null : state.getState());
-    initCause(cause);
+  public PSQLException(String msg, String state, int vendorCode, Throwable cause) {
+    super(msg, state, vendorCode, cause);
+  }
+
+  public PSQLException(String msg, PSQLState state, int vendorCode) {
+    this(msg, state == null ? null : state.getState(), vendorCode, null);
   }
 
   public PSQLException(String msg, PSQLState state) {
-    this(msg, state, null);
+    this(msg, state, 0);
+  }
+
+  public PSQLException(String msg, PSQLState state, Throwable cause) {
+    this(msg, state == null ? null : state.getState(), 0, cause);
   }
 
   public PSQLException(ServerErrorMessage serverError) {
-    this(serverError.toString(), new PSQLState(serverError.getSQLState()));
+    this(serverError.toString(), new PSQLState(serverError.getSQLState()), serverError.getErrorCode());
     _serverError = serverError;
   }
 

--- a/pgjdbc/src/main/java/org/postgresql/util/PSQLWarning.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/PSQLWarning.java
@@ -15,6 +15,7 @@ public class PSQLWarning extends SQLWarning {
   private ServerErrorMessage serverError;
 
   public PSQLWarning(ServerErrorMessage err) {
+    super(err.toString(), err.getSQLState(), err.getErrorCode(), null);
     this.serverError = err;
   }
 

--- a/pgjdbc/src/main/java/org/postgresql/util/ServerErrorMessage.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/ServerErrorMessage.java
@@ -69,6 +69,20 @@ public class ServerErrorMessage implements Serializable {
     }
   }
 
+  public int getErrorCode() {
+    String sqlState = this.getSQLState();
+    if (sqlState == null) {
+      // default of SQLException
+      return 0;
+    }
+    try {
+      return Integer.parseInt(sqlState);
+    } catch (NumberFormatException e) {
+      // default of SQLException
+      return 0;
+    }
+  }
+
   public String getSQLState() {
     return m_mesgParts.get(SQLSTATE);
   }


### PR DESCRIPTION
Currently SQLException#getErrorCode() always returns 0 since it is
never set. The only way to get the error code is through PSQLState
which is a String. Some frameworks like Spring use the error code to do
exception translation. Currently they have to fall back to PSQLState.

This commit includes the following changes.

 - set the error code for exceptions
 - set the error code for warnings