### PR TITLE
feat: include root cause exception in case transaction fails

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/BatchResultHandler.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/BatchResultHandler.java
@@ -145,10 +145,12 @@ public class BatchResultHandler extends ResultHandlerBase {
         queryString = queries[resultIndex].toString(parameterLists[resultIndex]);
       }
 
-      super.handleError(new BatchUpdateException(
-          GT.tr("Batch entry {0} {1} was aborted: {2}  Call getNextException to see the cause.",
+      BatchUpdateException batchException = new BatchUpdateException(
+          GT.tr("Batch entry {0} {1} was aborted: {2}  Call getNextException to see other errors in the batch.",
               resultIndex, queryString, newError.getMessage()),
-          newError.getSQLState(), uncompressUpdateCount()));
+          newError.getSQLState(), uncompressUpdateCount());
+      batchException.initCause(newError);
+      super.handleError(batchException);
     }
     resultIndex++;
 
@@ -166,6 +168,7 @@ public class BatchResultHandler extends ResultHandlerBase {
             batchException.getSQLState(),
             uncompressUpdateCount()
         );
+        newException.initCause(batchException.getCause());
         SQLException next = batchException.getNextException();
         if (next != null) {
           newException.setNextException(next);

--- a/pgjdbc/src/main/java/org/postgresql/util/PSQLException.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/PSQLException.java
@@ -15,16 +15,15 @@ public class PSQLException extends SQLException {
   private ServerErrorMessage _serverError;
 
   public PSQLException(String msg, PSQLState state, Throwable cause) {
-    super(msg, state == null ? null : state.getState());
-    initCause(cause);
+    super(msg, state == null ? null : state.getState(), cause);
   }
 
   public PSQLException(String msg, PSQLState state) {
-    this(msg, state, null);
+    super(msg, state == null ? null : state.getState());
   }
 
   public PSQLException(ServerErrorMessage serverError) {
-    this(serverError.toString(), new PSQLState(serverError.getSQLState()));
+    super(serverError.toString(), serverError.getSQLState());
     _serverError = serverError;
   }
 


### PR DESCRIPTION
In case transaction fails (i.e. 'current transaction is aborted, commands ignored until end of transaction block'), the initial error is included to the exception chain, so it is easier to analyze.

Example (note how `RootCauseSqlExceptionTestSuite.killTransaction` is included into caused by stack):
```
org.postgresql.util.PSQLException: ERROR: current transaction is aborted, commands ignored until end of transaction block
	at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2463)
	at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2158)
	at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:291)
	at org.postgresql.jdbc.PgStatement.executeInternal(PgStatement.java:432)
	at org.postgresql.jdbc.PgStatement.execute(PgStatement.java:358)
	at org.postgresql.jdbc.PgStatement.executeWithFlags(PgStatement.java:305)
	at org.postgresql.jdbc.PgStatement.executeCachedSql(PgStatement.java:291)
	at org.postgresql.jdbc.PgStatement.executeWithFlags(PgStatement.java:269)
	at org.postgresql.jdbc.PgStatement.execute(PgStatement.java:265)
	at org.postgresql.jdbc.RootCauseSqlExceptionTestSuite.simpleExecute(RootCauseSqlExceptionTestSuite.java:54)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:497)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:117)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:42)
	at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:253)
	at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:84)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:497)
	at com.intellij.rt.execution.application.AppMain.main(AppMain.java:147)
Caused by: org.postgresql.util.PSQLException: ERROR: division by zero
	at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2463)
	at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2158)
	at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:291)
	at org.postgresql.jdbc.PgStatement.executeInternal(PgStatement.java:432)
	at org.postgresql.jdbc.PgStatement.execute(PgStatement.java:358)
	at org.postgresql.jdbc.PgStatement.executeWithFlags(PgStatement.java:305)
	at org.postgresql.jdbc.PgStatement.executeCachedSql(PgStatement.java:291)
	at org.postgresql.jdbc.PgStatement.executeWithFlags(PgStatement.java:269)
	at org.postgresql.jdbc.PgStatement.execute(PgStatement.java:265)
	at org.postgresql.jdbc.RootCauseSqlExceptionTestSuite.killTransaction(RootCauseSqlExceptionTestSuite.java:33)
	at org.postgresql.jdbc.RootCauseSqlExceptionTestSuite.simpleExecute(RootCauseSqlExceptionTestSuite.java:50)
	... 29 more
```

Batch example:
```
java.sql.BatchUpdateException: Batch entry 0 select 1 was aborted: ERROR: current transaction is aborted, commands ignored until end of transaction block  Call getNextException to see other errors in the batch.
	at org.postgresql.jdbc.BatchResultHandler.handleError(BatchResultHandler.java:150)
	at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2159)
	at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:463)
	at org.postgresql.jdbc.PgStatement.executeBatch(PgStatement.java:794)
	at org.postgresql.jdbc.RootCauseSqlExceptionTestSuite.batchExecute(RootCauseSqlExceptionTestSuite.java:69)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:497)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:117)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:42)
	at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:253)
	at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:84)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:497)
	at com.intellij.rt.execution.application.AppMain.main(AppMain.java:147)
Caused by: org.postgresql.util.PSQLException: ERROR: current transaction is aborted, commands ignored until end of transaction block
	at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2463)
	at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2158)
	... 32 more
Caused by: org.postgresql.util.PSQLException: ERROR: division by zero
	at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2463)
	at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2158)
	at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:291)
	at org.postgresql.jdbc.PgStatement.executeInternal(PgStatement.java:432)
	at org.postgresql.jdbc.PgStatement.execute(PgStatement.java:358)
	at org.postgresql.jdbc.PgStatement.executeWithFlags(PgStatement.java:305)
	at org.postgresql.jdbc.PgStatement.executeCachedSql(PgStatement.java:291)
	at org.postgresql.jdbc.PgStatement.executeWithFlags(PgStatement.java:269)
	at org.postgresql.jdbc.PgStatement.execute(PgStatement.java:265)
	at org.postgresql.jdbc.RootCauseSqlExceptionTestSuite.killTransaction(RootCauseSqlExceptionTestSuite.java:33)
	at org.postgresql.jdbc.RootCauseSqlExceptionTestSuite.batchExecute(RootCauseSqlExceptionTestSuite.java:64)
	... 29 more
```