### PR TITLE
bug: fail during parsin 10devel version

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/ServerVersion.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/ServerVersion.java
@@ -28,6 +28,7 @@ public enum ServerVersion implements Version {
   v9_4("9.4.0"),
   v9_5("9.5.0"),
   v9_6("9.6.0"),
+  v10("10.0.0")
   ;
 
   private final int version;
@@ -142,8 +143,7 @@ public enum ServerVersion implements Version {
     if (serverVersion.charAt(parsepos.getIndex()) == '.') {
       parsepos.setIndex(parsepos.getIndex() + 1);
     } else {
-      /* Unexpected version format */
-      return 0;
+      return vers;
     }
 
     /*

--- a/pgjdbc/src/test/java/org/postgresql/test/util/ServerVersionTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/util/ServerVersionTest.java
@@ -1,0 +1,46 @@
+package org.postgresql.test.util;
+
+import org.postgresql.core.ServerVersion;
+import org.postgresql.core.Version;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+
+public class ServerVersionTest {
+
+  @Test
+  public void testParseFullFormat() throws Exception {
+    Version version = ServerVersion.from("9.6.0");
+
+    Assert.assertEquals(version, ServerVersion.v9_6);
+  }
+
+  @Test
+  public void test96GreatThan95() throws Exception {
+    boolean result = ServerVersion.v9_6.getVersionNum() >= ServerVersion.v9_5.getVersionNum();
+    Assert.assertTrue(result);
+  }
+
+  @Test
+  public void testParse83devel() throws Exception {
+    Version version = ServerVersion.from("8.3devel");
+
+    Assert.assertEquals(version, ServerVersion.v8_3);
+  }
+
+  @Test
+  public void testParse10devel() throws Exception {
+    Version version = ServerVersion.from("10devel");
+
+    Assert.assertEquals(version, ServerVersion.v10);
+  }
+
+  @Test
+  public void test10develGreatThan95() throws Exception {
+    Version version = ServerVersion.from("10devel");
+
+    boolean result = version.getVersionNum() >= ServerVersion.v9_5.getVersionNum();
+    Assert.assertTrue(result);
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/test/util/UtilTestSuite.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/util/UtilTestSuite.java
@@ -1,0 +1,10 @@
+package org.postgresql.test.util;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+    ServerVersionTest.class})
+public class UtilTestSuite {
+}


### PR DESCRIPTION
Number of HEAD postgresql is **10devel** https://github.com/postgres/postgres/commit/ca9112a424ff68ec4f2ef67b47122f7d61412964
but ServerVersion parse it as 0.

This commit fix few tests that base on version for #630