### PR TITLE
feat: support Types.REF_CURSOR

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/Oid.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/Oid.java
@@ -76,6 +76,8 @@ public class Oid {
   public static final int JSONB_ARRAY = 3807;
   public static final int JSON = 114;
   public static final int JSON_ARRAY = 199;
+  public static final int REF_CURSOR = 1790;
+  public static final int REF_CURSOR_ARRAY = 2201;
 
   /**
    * Returns the name of the oid as string.

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgCallableStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgCallableStatement.java
@@ -133,6 +133,12 @@ class PgCallableStatement extends PgPreparedStatement implements CallableStateme
           if (callResult[j] != null) {
             callResult[j] = ((Double) callResult[j]).floatValue();
           }
+          //#if mvn.project.property.postgresql.jdbc.spec >= "JDBC4.2"
+        } else if (columnType == Types.REF_CURSOR && functionReturnType[j] == Types.OTHER) {
+          // For backwards compatibility reasons we support that ref cursors can be
+          // registered with both Types.OTHER and Types.REF_CURSOR so we allow
+          // this specific mismatch
+          //#endif
         } else {
           throw new PSQLException(GT.tr(
               "A CallableStatement function was executed and the out parameter {0} was of type {1} however type {2} was registered.",

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
@@ -3153,7 +3153,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
   }
 
   public boolean supportsRefCursors() throws SQLException {
-    return false;
+    return true;
   }
 
   public RowIdLifetime getRowIdLifetime() throws SQLException {

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
@@ -67,8 +67,6 @@ public class TypeInfoCache implements TypeInfo {
   // 2 - sql type
   // 3 - java class
   // 4 - array type oid
-  // 5 - conditional minimum server version
-  // 6 - conditional minimum JDK build version
   private static final Object types[][] = {
       {"int2", Oid.INT2, Types.SMALLINT, "java.lang.Integer", Oid.INT2_ARRAY},
       {"int4", Oid.INT4, Types.INTEGER, "java.lang.Integer", Oid.INT4_ARRAY},
@@ -92,6 +90,9 @@ public class TypeInfoCache implements TypeInfo {
       {"timestamp", Oid.TIMESTAMP, Types.TIMESTAMP, "java.sql.Timestamp", Oid.TIMESTAMP_ARRAY},
       {"timestamptz", Oid.TIMESTAMPTZ, Types.TIMESTAMP, "java.sql.Timestamp",
           Oid.TIMESTAMPTZ_ARRAY},
+      //#if mvn.project.property.postgresql.jdbc.spec >= "JDBC4.2"
+      {"refcursor", Oid.REF_CURSOR, Types.REF_CURSOR, "java.sql.ResultSet", Oid.REF_CURSOR_ARRAY},
+      //#endif
       {"json", Oid.JSON, Types.VARCHAR, "java.lang.String", Oid.JSON_ARRAY},
       {"point", Oid.POINT, Types.OTHER, "org.postgresql.geometric.PGpoint", Oid.POINT_ARRAY}
   };

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/RefCursorTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/RefCursorTest.java
@@ -14,8 +14,10 @@ import static org.junit.Assert.assertTrue;
 
 import org.postgresql.test.TestUtil;
 
+import org.junit.Assume;
 import org.junit.Test;
 
+import java.lang.reflect.Field;
 import java.sql.CallableStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
@@ -23,12 +25,21 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Types;
 
-/*
+/**
  * RefCursor ResultSet tests. This test case is basically the same as the ResultSet test case.
  *
- * @author Nic Ferrier <nferrier@tapsellferrier.co.uk>
+ * <p>For backwards compatibility reasons we verify that ref cursors can be
+ * registered with both {@link Types#OTHER} and {@link Types#REF_CURSOR}.</p>
+ *
+ * @author Nic Ferrier (nferrier@tapsellferrier.co.uk)
  */
 public class RefCursorTest extends BaseTest4 {
+
+  // before Java 7 there was no official ref cursor support in jdbc
+  private boolean supportsRefCursor;
+  // the rests are compiled with Java 6 and 7 as well so referencing
+  // Types#REF_CURSOR directly would result in a compile error
+  private int refCursorType;
 
   @Override
   public void setUp() throws Exception {
@@ -55,6 +66,19 @@ public class RefCursorTest extends BaseTest4 {
         + "return v_resset; end;' LANGUAGE plpgsql;");
     stmt.close();
     con.setAutoCommit(false);
+
+    // if the public field Types#REF_CURSOR is present we're Java 8 or later
+    try {
+      Field refCursorFiled = Types.class.getDeclaredField("REF_CURSOR");
+      refCursorType = (Integer) refCursorFiled.get(null);
+      supportsRefCursor = true;
+    } catch (NoSuchFieldException e) {
+      supportsRefCursor = false;
+    }
+  }
+
+  private void assumeRefCursorSupported() {
+    Assume.assumeTrue(this.supportsRefCursor);
   }
 
   @Override
@@ -68,10 +92,24 @@ public class RefCursorTest extends BaseTest4 {
   }
 
   @Test
-  public void testResult() throws SQLException {
+  public void testResultOther() throws SQLException {
     assumeCallableStatementsSupported();
+
+    testResult(Types.OTHER);
+  }
+
+  @Test
+  public void testResultRefCursor() throws SQLException {
+    assumeCallableStatementsSupported();
+    assumeRefCursorSupported();
+
+    testResult(this.refCursorType);
+  }
+
+
+  private void testResult(int outParameterSqlType) throws SQLException {
     CallableStatement call = con.prepareCall("{ ? = call testspg__getRefcursor () }");
-    call.registerOutParameter(1, Types.OTHER);
+    call.registerOutParameter(1, outParameterSqlType);
     call.execute();
     ResultSet rs = (ResultSet) call.getObject(1);
 
@@ -94,30 +132,57 @@ public class RefCursorTest extends BaseTest4 {
     assertTrue(rs.getInt(1) == 9);
 
     assertTrue(!rs.next());
+    rs.close();
 
     call.close();
   }
 
 
   @Test
-  public void testEmptyResult() throws SQLException {
+  public void testEmptyResultOther() throws SQLException {
     assumeCallableStatementsSupported();
+
+    testEmptyResult(Types.OTHER);
+  }
+
+  @Test
+  public void testEmptyResultRefCursor() throws SQLException {
+    assumeCallableStatementsSupported();
+    assumeRefCursorSupported();
+
+    testEmptyResult(this.refCursorType);
+  }
+
+  private void testEmptyResult(int outParameterSqlType) throws SQLException {
     CallableStatement call = con.prepareCall("{ ? = call testspg__getEmptyRefcursor () }");
-    call.registerOutParameter(1, Types.OTHER);
+    call.registerOutParameter(1, outParameterSqlType);
     call.execute();
 
     ResultSet rs = (ResultSet) call.getObject(1);
     assertTrue(!rs.next());
+    rs.close();
 
     call.close();
   }
 
   @Test
-  public void testMetaData() throws SQLException {
+  public void testMetaDataOther() throws SQLException {
     assumeCallableStatementsSupported();
 
+    testMetaData(Types.OTHER);
+  }
+
+  @Test
+  public void testMetaDataRefCursor() throws SQLException {
+    assumeCallableStatementsSupported();
+    assumeRefCursorSupported();
+
+    testMetaData(this.refCursorType);
+  }
+
+  private void testMetaData(int outParameterSqlType) throws SQLException {
     CallableStatement call = con.prepareCall("{ ? = call testspg__getRefcursor () }");
-    call.registerOutParameter(1, Types.OTHER);
+    call.registerOutParameter(1, outParameterSqlType);
     call.execute();
 
     ResultSet rs = (ResultSet) call.getObject(1);
@@ -132,11 +197,24 @@ public class RefCursorTest extends BaseTest4 {
   }
 
   @Test
-  public void testResultType() throws SQLException {
+  public void testResultTypeOther() throws SQLException {
     assumeCallableStatementsSupported();
+
+    testResultType(Types.OTHER);
+  }
+
+  @Test
+  public void testResultTypeRefCursor() throws SQLException {
+    assumeCallableStatementsSupported();
+    assumeRefCursorSupported();
+
+    testResultType(this.refCursorType);
+  }
+
+  private void testResultType(int outParameterSqlType) throws SQLException {
     CallableStatement call = con.prepareCall("{ ? = call testspg__getRefcursor () }",
-        ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet.CONCUR_READ_ONLY);
-    call.registerOutParameter(1, Types.OTHER);
+            ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet.CONCUR_READ_ONLY);
+    call.registerOutParameter(1, outParameterSqlType);
     call.execute();
     ResultSet rs = (ResultSet) call.getObject(1);
 
@@ -145,6 +223,8 @@ public class RefCursorTest extends BaseTest4 {
 
     assertTrue(rs.last());
     assertEquals(6, rs.getRow());
+    rs.close();
+    call.close();
   }
 
 }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc42/SimpleJdbc42Test.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc42/SimpleJdbc42Test.java
@@ -8,6 +8,8 @@
 
 package org.postgresql.test.jdbc42;
 
+import static org.junit.Assert.assertTrue;
+
 import org.postgresql.test.TestUtil;
 
 import org.junit.After;
@@ -38,6 +40,6 @@ public class SimpleJdbc42Test {
    */
   @Test
   public void testDatabaseMetaData() throws Exception {
-    _conn.getMetaData().supportsRefCursors();
+    assertTrue(_conn.getMetaData().supportsRefCursors());
   }
 }


### PR DESCRIPTION
JDBC 4.2 officially supports ref cursors through Types.REF_CURSOR.
Previously users had to use Types.OTHER for registering a ref cursor
out parameter. It is important to preserve this behavior in order to
keep existing code working.

This commit includes the following changes:

 - register the type REF_CURSOR in TypeInfoCache
 - register the REF_CURSOR Oid
 - slightly relax the function return type check to continue allowing
   registering ref cursors with OTHER
 - add tests that verify ref cursors can be registered with both
   REF_CURSOR and OTHER
 - update PgDatabaseMetaData to report that we support ref cursors
 - update SimpleJdbc42Test to verify we correctly report ref cursor
   support

Fixes #633