### PR TITLE
fix: do not convert ?, ? to $1, $2 when statement.executeQuery(String) is used

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/CachedQueryCreateAction.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/CachedQueryCreateAction.java
@@ -8,6 +8,7 @@
 
 package org.postgresql.core;
 
+import org.postgresql.jdbc.PreferQueryMode;
 import org.postgresql.util.LruCache;
 
 import java.sql.SQLException;
@@ -56,7 +57,7 @@ class CachedQueryCreateAction implements LruCache.CreateAction<Object, CachedQue
       outParmBeforeFunc = false;
     }
     boolean isParameterized = key instanceof String || queryKey.isParameterized;
-    boolean splitStatements = isParameterized;
+    boolean splitStatements = isParameterized || queryExecutor.getPreferQueryMode().compareTo(PreferQueryMode.EXTENDED) >= 0;
 
     String[] returningColumns;
     if (key instanceof QueryWithReturningColumnsKey) {

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgStatement.java
@@ -271,7 +271,8 @@ public class PgStatement implements Statement, BaseStatement {
 
   private boolean executeCachedSql(String sql, int flags, String[] columnNames) throws SQLException {
     PreferQueryMode preferQueryMode = connection.getPreferQueryMode();
-    boolean shouldUseParameterized = preferQueryMode.compareTo(PreferQueryMode.EXTENDED) >= 0;
+    // Simple statements should not replace ?, ? with $1, $2
+    boolean shouldUseParameterized = false;
     QueryExecutor queryExecutor = connection.getQueryExecutor();
     Object key = queryExecutor
         .createQueryKey(sql, replaceProcessingEnabled, shouldUseParameterized, columnNames);
@@ -663,7 +664,8 @@ public class PgStatement implements Statement, BaseStatement {
       batchParameters = new ArrayList<ParameterList>();
     }
 
-    boolean shouldUseParameterized = connection.getPreferQueryMode().compareTo(PreferQueryMode.EXTENDED) >= 0;
+    // Simple statements should not replace ?, ? with $1, $2
+    boolean shouldUseParameterized = false;
     CachedQuery cachedQuery = connection.createQuery(p_sql, replaceProcessingEnabled, shouldUseParameterized);
     batchStatements.add(cachedQuery.query);
     batchParameters.add(null);

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc4/JsonbTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc4/JsonbTest.java
@@ -1,0 +1,63 @@
+/*-------------------------------------------------------------------------
+*
+* Copyright (c) 2004-2016, PostgreSQL Global Development Group
+*
+*
+*-------------------------------------------------------------------------
+*/
+
+package org.postgresql.test.jdbc4;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.postgresql.test.TestUtil;
+import org.postgresql.test.jdbc2.BaseTest4;
+
+import org.junit.Assume;
+import org.junit.Test;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+public class JsonbTest extends BaseTest4 {
+
+  public void setUp() throws Exception {
+    super.setUp();
+    Assume.assumeTrue("jsonb requires PostgreSQL 9.4+", TestUtil.haveMinimumServerVersion(con, "9.4"));
+    TestUtil.createTable(con, "jsonbtest", "detail jsonb");
+    Statement stmt = con.createStatement();
+    stmt.executeUpdate("INSERT INTO jsonbtest (detail) VALUES ('{\"a\": 1}')");
+    stmt.executeUpdate("INSERT INTO jsonbtest (detail) VALUES ('{\"b\": 1}')");
+    stmt.executeUpdate("INSERT INTO jsonbtest (detail) VALUES ('{\"c\": 1}')");
+    stmt.close();
+  }
+
+  public void tearDown() throws SQLException {
+    TestUtil.dropTable(con, "jsonbtest");
+    super.tearDown();
+  }
+
+  @Test
+  public void testJsonbNonPreparedStatement() throws SQLException {
+    Statement stmt = con.createStatement();
+
+    ResultSet rs = stmt.executeQuery("SELECT count(1) FROM jsonbtest WHERE detail ? 'a' = false;");
+    assertTrue(rs.next());
+    assertEquals(2, rs.getInt(1));
+    rs.close();
+    stmt.close();
+  }
+
+  @Test
+  public void testJsonbPreparedStatement() throws SQLException {
+    PreparedStatement stmt = con.prepareStatement("SELECT count(1) FROM jsonbtest WHERE detail ?? 'a' = false;");
+    ResultSet rs = stmt.executeQuery();
+    assertTrue(rs.next());
+    assertEquals(2, rs.getInt(1));
+    rs.close();
+    stmt.close();
+  }
+}


### PR DESCRIPTION
closes #643