### PR TITLE
Filter DatabaseMetaData 

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -386,7 +386,12 @@ public enum PGProperty {
    * Configure optimization to enable batch insert re-writing.
    */
   REWRITE_BATCHED_INSERTS ("reWriteBatchedInserts", "false",
-      "Enable optimization to rewrite and collapse compatible INSERT statements that are batched.");
+      "Enable optimization to rewrite and collapse compatible INSERT statements that are batched."),
+  /**
+   * Enable mode to filter out the names of database objects for which the current user has no privileges granted from appearing in the DatabaseMetaData returned by the driver.
+   */
+  HIDE_UNPRIVILEGED_OBJECTS("hideUnprivilegedObjects", "false",
+        "Enable hiding of database objects for which the current user has no privileges granted from the DatabaseMetaData");
 
   private String _name;
   private String _defaultValue;

--- a/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
+++ b/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
@@ -1277,4 +1277,20 @@ public abstract class BaseDataSource implements Referenceable {
   public void setReWriteBatchedInserts(boolean reWrite) {
     PGProperty.REWRITE_BATCHED_INSERTS.set(properties, reWrite);
   }
+
+  /**
+   * @see PGProperty#HIDE_UNPRIVILEGED_OBJECTS
+   * @return boolean indicating property is enabled or not.
+   */
+  public boolean getHideUnprivilegedObjects() {
+    return PGProperty.HIDE_UNPRIVILEGED_OBJECTS.getBoolean(properties);
+  }
+
+  /**
+   * @see PGProperty#HIDE_UNPRIVILEGED_OBJECTS
+   * @param hideUnprivileged boolean value to set the property in the properties collection
+   */
+  public void setHideUnprivilegedObjects(boolean hideUnprivileged) {
+    PGProperty.HIDE_UNPRIVILEGED_OBJECTS.set(properties, hideUnprivileged);
+  }
 }

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
@@ -127,6 +127,8 @@ public class PgConnection implements BaseConnection {
   private boolean autoCommit = true;
   // Connection's readonly state.
   private boolean readOnly = false;
+  // Filter out database objects for which the current user has no privileges granted from the DatabaseMetaData
+  private boolean  hideUnprivilegedObjects ;
 
   // Bind String to UNSPECIFIED or VARCHAR?
   private final boolean bindStringAsVarchar;
@@ -227,6 +229,7 @@ public class PgConnection implements BaseConnection {
     if (PGProperty.READ_ONLY.getBoolean(info)) {
       setReadOnly(true);
     }
+    this.hideUnprivilegedObjects = PGProperty.HIDE_UNPRIVILEGED_OBJECTS.getBoolean(info);
 
     // Formats that currently have binary protocol support
     Set<Integer> binaryOids = new HashSet<Integer>();
@@ -926,6 +929,10 @@ public class PgConnection implements BaseConnection {
   public String getCatalog() throws SQLException {
     checkClosed();
     return queryExecutor.getDatabase();
+  }
+
+  public boolean getHideUnprivilegedObjects() {
+    return hideUnprivilegedObjects;
   }
 
   /**

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
@@ -158,7 +158,8 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
    * explicitly.
    *
    * @return the database product name
-   * @throws SQLException if a database access error occurs
+   *
+   * @exception SQLException if a database access error occurs
    */
   public String getDatabaseProductName() throws SQLException {
     return "PostgreSQL";

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
@@ -54,6 +54,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
 
   private int NAMEDATALEN = 0; // length for name datatype
   private int INDEX_MAX_KEYS = 0; // maximum number of keys in an index.
+
   protected int getMaxIndexKeys() throws SQLException {
     if (INDEX_MAX_KEYS == 0) {
       String sql;

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
@@ -9,7 +9,6 @@
 package org.postgresql.jdbc;
 
 import org.postgresql.Driver;
-import org.postgresql.PGProperty;
 import org.postgresql.core.BaseStatement;
 import org.postgresql.core.Field;
 import org.postgresql.core.Oid;
@@ -54,6 +53,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
 
   private int NAMEDATALEN = 0; // length for name datatype
   private int INDEX_MAX_KEYS = 0; // maximum number of keys in an index.
+
   protected int getMaxIndexKeys() throws SQLException {
     if (INDEX_MAX_KEYS == 0) {
       String sql;
@@ -158,8 +158,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
    * explicitly.
    *
    * @return the database product name
-   *
-   * @exception SQLException if a database access error occurs
+   * @throws SQLException if a database access error occurs
    */
   public String getDatabaseProductName() throws SQLException {
     return "PostgreSQL";
@@ -196,7 +195,8 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
   }
 
   /**
-   * Does the database use a file for each table? Well, not really, since it doesn't use local files.
+   * Does the database use a file for each table? Well, not really, since it doesn't use local
+   * files.
    *
    * @return true if so
    * @throws SQLException if a database access error occurs
@@ -921,12 +921,10 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
     if (level == Connection.TRANSACTION_SERIALIZABLE
         || level == Connection.TRANSACTION_READ_COMMITTED) {
       return true;
-    } else if (connection.haveMinimumServerVersion(ServerVersion.v8_0)
-        && (level == Connection.TRANSACTION_READ_UNCOMMITTED
-            || level == Connection.TRANSACTION_REPEATABLE_READ)) {
-      return true;
     } else {
-      return false;
+      return connection.haveMinimumServerVersion(ServerVersion.v8_0)
+          && (level == Connection.TRANSACTION_READ_UNCOMMITTED
+          || level == Connection.TRANSACTION_REPEATABLE_READ);
     }
   }
 
@@ -1011,7 +1009,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
       if (procedureNamePattern != null) {
         sql += " AND p.proname LIKE " + escapeQuotes(procedureNamePattern);
       }
-      if(connection.getHideUnprivilegedObjects()) {
+      if (connection.getHideUnprivilegedObjects()) {
         sql += " AND has_function_privilege(p.oid,'EXECUTE')";
       }
       sql += " ORDER BY PROCEDURE_SCHEM, PROCEDURE_NAME, p.oid::text ";
@@ -1055,7 +1053,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
 
   protected ResultSet getProcedureColumns(int jdbcVersion, String catalog,
       String schemaPattern, String procedureNamePattern, String columnNamePattern)
-          throws SQLException {
+      throws SQLException {
     int columns = 13;
     if (jdbcVersion >= 4) {
       columns += 7;
@@ -1344,7 +1342,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
       if (schemaPattern != null && !"".equals(schemaPattern)) {
         select += " AND n.nspname LIKE " + escapeQuotes(schemaPattern);
       }
-      if(connection.getHideUnprivilegedObjects()) {
+      if (connection.getHideUnprivilegedObjects()) {
         select += " AND has_table_privilege(c.oid, "
             + " 'SELECT, INSERT, UPDATE, DELETE, RULE, REFERENCES, TRIGGER')";
       }
@@ -1539,7 +1537,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
       if (schemaPattern != null && !"".equals(schemaPattern)) {
         sql += " AND nspname LIKE " + escapeQuotes(schemaPattern);
       }
-      if(connection.getHideUnprivilegedObjects()) {
+      if (connection.getHideUnprivilegedObjects()) {
         sql += " AND has_schema_privilege(nspname, 'USAGE, CREATE')";
       }
       sql += " ORDER BY TABLE_SCHEM";
@@ -1779,7 +1777,8 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
       }
 
       tuple[10] = connection.encodeString(Integer.toString(rs.getBoolean("attnotnull")
-          ? java.sql.DatabaseMetaData.columnNoNulls : java.sql.DatabaseMetaData.columnNullable)); // Nullable
+          ? java.sql.DatabaseMetaData.columnNoNulls
+          : java.sql.DatabaseMetaData.columnNullable)); // Nullable
       tuple[11] = rs.getBytes("description"); // Description (if any)
       tuple[12] = rs.getBytes("adsrc"); // Column default
       tuple[13] = null; // sql data type (unused)
@@ -1797,7 +1796,8 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
         tuple[20] = null; // SCOPE_TABLE
         tuple[21] = baseTypeOid == 0 ? null
             : connection
-                .encodeString(Integer.toString(connection.getTypeInfo().getSQLType(baseTypeOid))); // SOURCE_DATA_TYPE
+                .encodeString(Integer.toString(
+                    connection.getTypeInfo().getSQLType(baseTypeOid))); // SOURCE_DATA_TYPE
       }
 
       if (jdbcVersion >= 4) {
@@ -2078,7 +2078,8 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
    * Add the user described by the given acl to the Lists of users with the privileges described by
    * the acl.
    */
-  private static void addACLPrivileges(String acl, Map<String, Map<String, List<String[]>>> privileges) {
+  private static void addACLPrivileges(String acl,
+      Map<String, Map<String, List<String[]>>> privileges) {
     int equalIndex = acl.lastIndexOf("=");
     int slashIndex = acl.lastIndexOf("/");
     if (equalIndex == -1) {
@@ -2179,7 +2180,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
    * name to a List of usernames who have that permission.
    *
    * @param aclArray ACL array
-   * @param owner owner
+   * @param owner    owner
    * @return a Map mapping the SQL permission name
    */
   public Map<String, Map<String, List<String[]>>> parseACL(String aclArray, String owner) {
@@ -2393,17 +2394,17 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
 
   /**
    * @param primaryCatalog primary catalog
-   * @param primarySchema primary schema
-   * @param primaryTable if provided will get the keys exported by this table
+   * @param primarySchema  primary schema
+   * @param primaryTable   if provided will get the keys exported by this table
    * @param foreignCatalog foreign catalog
-   * @param foreignSchema foreign schema
-   * @param foreignTable if provided will get the keys imported by this table
+   * @param foreignSchema  foreign schema
+   * @param foreignTable   if provided will get the keys imported by this table
    * @return ResultSet
    * @throws SQLException if something wrong happens
    */
   protected ResultSet getImportedExportedKeys(String primaryCatalog, String primarySchema,
       String primaryTable, String foreignCatalog, String foreignSchema, String foreignTable)
-          throws SQLException {
+      throws SQLException {
     Field f[] = new Field[14];
 
     f[0] = new Field("PKTABLE_CAT", Oid.VARCHAR);
@@ -2737,7 +2738,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
 
   public ResultSet getCrossReference(String primaryCatalog, String primarySchema,
       String primaryTable, String foreignCatalog, String foreignSchema, String foreignTable)
-          throws SQLException {
+      throws SQLException {
     return getImportedExportedKeys(primaryCatalog, primarySchema, primaryTable, foreignCatalog,
         foreignSchema, foreignTable);
   }
@@ -2771,7 +2772,8 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
       sql = "SELECT t.typname,t.oid FROM pg_catalog.pg_type t"
           + " JOIN pg_catalog.pg_namespace n ON (t.typnamespace = n.oid) "
           + " WHERE n.nspname  != 'pg_toast'";
-       if(connection.getHideUnprivilegedObjects() && connection.haveMinimumServerVersion(ServerVersion.v9_2)) {
+      if (connection.getHideUnprivilegedObjects() && connection.haveMinimumServerVersion(
+          ServerVersion.v9_2)) {
         sql += " AND has_type_privilege(t.oid, 'USAGE')";
       }
     } else {
@@ -3081,7 +3083,8 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
         + " end as data_type, pg_catalog.obj_description(t.oid, 'pg_type')  "
         + "as remarks, CASE WHEN t.typtype = 'd' then  (select CASE";
 
-    for (Iterator<String> i = connection.getTypeInfo().getPGTypeNamesWithSQLTypes(); i.hasNext(); ) {
+    for (Iterator<String> i = connection.getTypeInfo().getPGTypeNamesWithSQLTypes();
+         i.hasNext(); ) {
       String pgType = i.next();
       int sqlType = connection.getTypeInfo().getSQLType(pgType);
       sql += " when typname = " + escapeQuotes(pgType) + " then " + sqlType;
@@ -3137,8 +3140,9 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
       toAdd += " and n.nspname like " + escapeQuotes(schemaPattern);
     }
     sql += toAdd;
-    if(connection.getHideUnprivilegedObjects() && connection.haveMinimumServerVersion(ServerVersion.v9_2)) {
-     sql += " AND has_type_privilege(t.oid, 'USAGE')";
+    if (connection.getHideUnprivilegedObjects() && connection.haveMinimumServerVersion(
+        ServerVersion.v9_2)) {
+      sql += " AND has_type_privilege(t.oid, 'USAGE')";
     }
     sql += " order by data_type, type_schem, type_name";
     return createMetaDataStatement().executeQuery(sql);

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc4/DatabaseMetaDataHideUnprivilegedObjectsTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc4/DatabaseMetaDataHideUnprivilegedObjectsTest.java
@@ -1,0 +1,455 @@
+/*-------------------------------------------------------------------------
+*
+* Copyright (c) 2004-2016, PostgreSQL Global Development Group
+*
+*
+*-------------------------------------------------------------------------
+*/
+package org.postgresql.test.jdbc4;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertThat;
+
+import org.postgresql.test.TestUtil;
+import org.postgresql.PGProperty;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.fail;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+/**
+ * Tests that database objects for which the current user has no privileges are filtered out from
+ * the DatabaseMetaData depending on whether the connection parameter hideUnprivilegedObjects is
+ * set to true.
+ */
+public class DatabaseMetaDataHideUnprivilegedObjectsTest {
+  public static final String COLUMNS = "digit int4, name text";
+  private static Connection hidingCon;
+  private static Connection nonhidingCon;
+  private static Connection privilegedCon;
+  private static DatabaseMetaData hidingDatabaseMetaData;
+  private static DatabaseMetaData nonhidingDatabaseMetaData;
+
+  @BeforeClass
+  public static void setUp() throws Exception {
+    Properties props = new Properties();
+    privilegedCon = TestUtil.openPrivilegedDB();
+    Statement stmt = privilegedCon.createStatement();
+
+    createTestDataObjectsWithRangeOfPrivilegesInSchema("high_privileges_schema");
+    // Grant Test User ALL privileges on schema.
+    stmt.executeUpdate("GRANT ALL ON SCHEMA high_privileges_schema TO " + TestUtil.getUser());
+    stmt.executeUpdate("REVOKE ALL ON SCHEMA high_privileges_schema FROM public");
+
+    createTestDataObjectsWithRangeOfPrivilegesInSchema("low_privileges_schema");
+    // Grant Test User USAGE privileges on schema.
+    stmt.executeUpdate("GRANT USAGE ON SCHEMA low_privileges_schema TO " + TestUtil.getUser());
+    stmt.executeUpdate("REVOKE ALL ON SCHEMA low_privileges_schema FROM public");
+
+    createTestDataObjectsWithRangeOfPrivilegesInSchema("no_privileges_schema");
+    // Revoke ALL privileges from Test User USAGE on schema.
+    stmt.executeUpdate("REVOKE ALL ON SCHEMA no_privileges_schema FROM " + TestUtil.getUser());
+    stmt.executeUpdate("REVOKE ALL ON SCHEMA no_privileges_schema FROM public");
+
+    stmt.close();
+
+    nonhidingDatabaseMetaData = getNonHidingDatabaseMetaData(props);
+    hidingDatabaseMetaData = getHidingDatabaseMetaData(props);
+  }
+
+  private static DatabaseMetaData getHidingDatabaseMetaData(Properties props) throws Exception {
+    PGProperty.HIDE_UNPRIVILEGED_OBJECTS.set(props, true);
+    hidingCon = TestUtil.openDB(props);
+    if (isSuperUser(hidingCon)) {
+      fail("Test for hiding database objects will not work while:" + TestUtil.getUser()
+          + " has a SUPERUSER role.");
+    }
+    return hidingCon.getMetaData();
+  }
+
+  private static DatabaseMetaData getNonHidingDatabaseMetaData(Properties props) throws Exception {
+    nonhidingCon = TestUtil.openDB(props);
+    return nonhidingCon.getMetaData();
+  }
+
+  private static void createTestDataObjectsWithRangeOfPrivilegesInSchema(String schema)
+      throws SQLException {
+    TestUtil.createSchema(privilegedCon, schema);
+    createSimpleTablesInSchema(schema,
+        new String[]{"owned_table", "all_grants_table", "insert_granted_table",
+            "select_granted_table", "no_grants_table"});
+
+    Statement stmt = privilegedCon.createStatement();
+    stmt.executeUpdate(
+        "CREATE FUNCTION " + schema + "."
+            + "execute_granted_add_function(integer, integer) RETURNS integer AS 'select $1 + $2;' LANGUAGE SQL IMMUTABLE  RETURNS NULL ON NULL INPUT");
+    stmt.executeUpdate(
+        "CREATE FUNCTION " + schema + "."
+            + "no_grants_add_function(integer, integer) RETURNS integer AS 'select $1 + $2;' LANGUAGE SQL IMMUTABLE  RETURNS NULL ON NULL INPUT");
+    stmt.executeUpdate(
+        "CREATE OR REPLACE VIEW " + schema + "." + "select_granted_view AS SELECT name FROM "
+            + schema + "." + "select_granted_table");
+    stmt.executeUpdate(
+        "CREATE OR REPLACE VIEW " + schema + "." + "no_grants_view AS SELECT name FROM " + schema
+            + "." + "owned_table");
+    stmt.executeUpdate(
+        "CREATE TYPE " + schema + "." + "usage_granted_composite_type AS (f1 int, f2 text)");
+    stmt.executeUpdate(
+        "CREATE TYPE " + schema + "." + "no_grants_composite_type AS (f1 int, f2 text)");
+    stmt.executeUpdate(
+        "CREATE DOMAIN " + schema + "." + "usage_granted_us_postal_code_domain CHAR(5) NOT NULL");
+    stmt.executeUpdate(
+        "CREATE DOMAIN " + schema + "." + "no_grants_us_postal_code_domain AS CHAR(5) NOT NULL");
+    stmt.executeUpdate(
+        "REVOKE ALL ON TYPE " + schema + "." + "usage_granted_composite_type FROM public RESTRICT");
+    stmt.executeUpdate(
+        "REVOKE ALL ON TYPE " + schema + "." + "no_grants_composite_type FROM public RESTRICT");
+    stmt.executeUpdate("GRANT USAGE on TYPE " + schema + "." + "usage_granted_composite_type TO "
+        + TestUtil.getUser());
+    stmt.executeUpdate(
+        "REVOKE ALL ON TYPE " + schema + "."
+            + "usage_granted_us_postal_code_domain FROM public RESTRICT");
+    stmt.executeUpdate(
+        "REVOKE ALL ON TYPE " + schema + "."
+            + "no_grants_us_postal_code_domain FROM public RESTRICT");
+    stmt.executeUpdate(
+        "GRANT USAGE on TYPE " + schema + "." + "usage_granted_us_postal_code_domain TO "
+            + TestUtil.getUser());
+    stmt.executeUpdate(
+        "REVOKE ALL ON ALL FUNCTIONS IN SCHEMA " + schema + " FROM public RESTRICT");
+    stmt.executeUpdate(
+        "REVOKE ALL ON ALL FUNCTIONS IN SCHEMA " + schema + " FROM " + TestUtil.getUser()
+            + " RESTRICT");
+    stmt.executeUpdate(
+        "REVOKE ALL ON ALL TABLES IN SCHEMA " + schema + " FROM public RESTRICT");
+    stmt.executeUpdate(
+        "REVOKE ALL ON ALL TABLES IN SCHEMA " + schema + " FROM " + TestUtil.getUser()
+            + " RESTRICT");
+    stmt.executeUpdate(
+        "GRANT ALL ON FUNCTION " + schema + "."
+            + "execute_granted_add_function(integer, integer) TO "
+            + TestUtil.getUser());
+    stmt.executeUpdate(
+        "ALTER TABLE " + schema + "." + "owned_table OWNER TO " + TestUtil.getUser());
+    stmt.executeUpdate(
+        "GRANT ALL ON TABLE " + schema + "." + "all_grants_table TO " + TestUtil.getUser());
+    stmt.executeUpdate("GRANT INSERT ON TABLE " + schema + "." + "insert_granted_table TO "
+        + TestUtil.getUser());
+    stmt.executeUpdate("GRANT SELECT ON TABLE " + schema + "." + "select_granted_table TO "
+        + TestUtil.getUser());
+    stmt.executeUpdate("GRANT SELECT ON TABLE " + schema + "." + "select_granted_view TO "
+        + TestUtil.getUser());
+    stmt.close();
+  }
+
+  private static void createSimpleTablesInSchema(String schema, String[] tables
+  ) throws SQLException {
+    for (String tableName : tables) {
+      TestUtil.createTable(privilegedCon, schema + "." + tableName,
+          COLUMNS);
+    }
+  }
+
+  @AfterClass
+  public static void tearDown() throws SQLException {
+    TestUtil.closeDB(hidingCon);
+    TestUtil.closeDB(nonhidingCon);
+    TestUtil.dropSchema(privilegedCon, "high_privileges_schema");
+    TestUtil.dropSchema(privilegedCon, "low_privileges_schema");
+    TestUtil.dropSchema(privilegedCon, "no_privileges_schema");
+    TestUtil.closeDB(privilegedCon);
+  }
+
+  private static boolean isSuperUser(Connection connection) throws SQLException {
+    // Check if we're operating as a superuser.
+    Statement st = connection.createStatement();
+    st.executeQuery("SHOW is_superuser;");
+    ResultSet rs = st.getResultSet();
+    rs.next(); // One row is guaranteed
+    boolean connIsSuper = rs.getString(1).equalsIgnoreCase("on");
+    st.close();
+    return connIsSuper;
+  }
+
+  @Test
+  public void testGetSchemas() throws SQLException {
+    List<String> schemasWithHiding = getSchemaNames(hidingDatabaseMetaData);
+    assertThat(schemasWithHiding,
+        hasItems("pg_catalog", "information_schema",
+            "high_privileges_schema", "low_privileges_schema"));
+    assertThat(schemasWithHiding,
+        not(hasItem("no_privileges_schema")));
+
+    List<String> schemasWithNoHiding = getSchemaNames(nonhidingDatabaseMetaData);
+    assertThat(schemasWithNoHiding,
+        hasItems("pg_catalog", "information_schema",
+            "high_privileges_schema", "low_privileges_schema", "no_privileges_schema"));
+  }
+
+  List<String> getSchemaNames(DatabaseMetaData databaseMetaData) throws SQLException {
+    List<String> schemaNames = new ArrayList<String>();
+    ResultSet rs = databaseMetaData.getSchemas();
+    while (rs.next()) {
+      schemaNames.add(rs.getString("TABLE_SCHEM"));
+    }
+    return schemaNames;
+  }
+
+  @Test
+  public void testGetTables() throws SQLException {
+    List<String> tablesWithHiding = getTableNames(hidingDatabaseMetaData, "high_privileges_schema");
+
+    assertThat(tablesWithHiding,
+        hasItems(
+            "owned_table",
+            "all_grants_table",
+            "insert_granted_table",
+            "select_granted_table"));
+    assertThat(tablesWithHiding,
+        not(hasItem("no_grants_table")));
+
+    List<String> tablesWithNoHiding =
+        getTableNames(nonhidingDatabaseMetaData, "high_privileges_schema");
+    assertThat(tablesWithNoHiding,
+        hasItems(
+            "owned_table",
+            "all_grants_table",
+            "insert_granted_table",
+            "select_granted_table",
+            "no_grants_table"));
+
+    tablesWithHiding = getTableNames(hidingDatabaseMetaData, "low_privileges_schema");
+
+    assertThat(tablesWithHiding,
+        hasItems(
+            "owned_table",
+            "all_grants_table",
+            "insert_granted_table",
+            "select_granted_table"));
+    assertThat(tablesWithHiding,
+        not(hasItem("no_grants_table")));
+
+    tablesWithNoHiding =
+        getTableNames(nonhidingDatabaseMetaData, "low_privileges_schema");
+    assertThat(tablesWithNoHiding,
+        hasItems(
+            "owned_table",
+            "all_grants_table",
+            "insert_granted_table",
+            "select_granted_table",
+            "no_grants_table"));
+
+    // Or should the the tables names not be returned because the schema is not visible?
+    tablesWithHiding = getTableNames(hidingDatabaseMetaData, "no_privileges_schema");
+
+    assertThat(tablesWithHiding,
+        hasItems(
+            "owned_table",
+            "all_grants_table",
+            "insert_granted_table",
+            "select_granted_table"));
+    assertThat(tablesWithHiding,
+        not(hasItem("no_grants_table")));
+
+    tablesWithNoHiding =
+        getTableNames(nonhidingDatabaseMetaData, "no_privileges_schema");
+    assertThat(tablesWithNoHiding,
+        hasItems(
+            "owned_table",
+            "all_grants_table",
+            "insert_granted_table",
+            "select_granted_table",
+            "no_grants_table"));
+
+  }
+
+  List<String> getTableNames(DatabaseMetaData databaseMetaData, String schemaPattern)
+      throws SQLException {
+    List<String> tableNames = new ArrayList<String>();
+    ResultSet rs = databaseMetaData.getTables(null, schemaPattern, null, new String[]{"TABLE"});
+    while (rs.next()) {
+      tableNames.add(rs.getString("TABLE_NAME"));
+    }
+    return tableNames;
+  }
+
+  @Test
+  public void testGetViews() throws SQLException {
+    List<String> viewsWithHiding = getViewNames(hidingDatabaseMetaData, "high_privileges_schema");
+
+    assertThat(viewsWithHiding,
+        hasItems(
+            "select_granted_view"));
+    assertThat(viewsWithHiding,
+        not(hasItem("no_grants_view")));
+
+    List<String> viewsWithNoHiding =
+        getViewNames(nonhidingDatabaseMetaData, "high_privileges_schema");
+    assertThat(viewsWithNoHiding,
+        hasItems(
+            "select_granted_view",
+            "no_grants_view"));
+
+    viewsWithHiding = getViewNames(hidingDatabaseMetaData, "low_privileges_schema");
+
+    assertThat(viewsWithHiding,
+        hasItems(
+            "select_granted_view"));
+    assertThat(viewsWithHiding,
+        not(hasItem("no_grants_view")));
+
+    viewsWithNoHiding =
+        getViewNames(nonhidingDatabaseMetaData, "low_privileges_schema");
+    assertThat(viewsWithNoHiding,
+        hasItems(
+            "select_granted_view",
+            "no_grants_view"));
+
+    // Or should the the view names not be returned because the schema is not visible?
+    viewsWithHiding = getViewNames(hidingDatabaseMetaData, "no_privileges_schema");
+
+    assertThat(viewsWithHiding,
+        hasItems(
+            "select_granted_view"));
+    assertThat(viewsWithHiding,
+        not(hasItem("no_grants_view")));
+
+    viewsWithNoHiding =
+        getViewNames(nonhidingDatabaseMetaData, "no_privileges_schema");
+    assertThat(viewsWithNoHiding,
+        hasItems(
+            "select_granted_view",
+            "no_grants_view"));
+
+  }
+
+  List<String> getViewNames(DatabaseMetaData databaseMetaData, String schemaPattern)
+      throws SQLException {
+    List<String> viewNames = new ArrayList<String>();
+    ResultSet rs = databaseMetaData.getTables(null, schemaPattern, null, new String[]{"VIEW"});
+    while (rs.next()) {
+      viewNames.add(rs.getString("TABLE_NAME"));
+    }
+    return viewNames;
+  }
+
+  @Test
+  public void testGetFunctions() throws SQLException {
+    List<String> functionsWithHiding =
+        getFunctionNames(hidingDatabaseMetaData, "high_privileges_schema");
+    assertThat(functionsWithHiding,
+        hasItem("execute_granted_add_function"));
+    assertThat(functionsWithHiding,
+        not(hasItem("no_grants_add_function")));
+
+    List<String> functionsWithNoHiding =
+        getFunctionNames(nonhidingDatabaseMetaData, "high_privileges_schema");
+    assertThat(functionsWithNoHiding,
+        hasItems("execute_granted_add_function", "no_grants_add_function"));
+
+    functionsWithHiding =
+        getFunctionNames(hidingDatabaseMetaData, "low_privileges_schema");
+    assertThat(functionsWithHiding,
+        hasItem("execute_granted_add_function"));
+    assertThat(functionsWithHiding,
+        not(hasItem("no_grants_add_function")));
+
+    functionsWithNoHiding =
+        getFunctionNames(nonhidingDatabaseMetaData, "low_privileges_schema");
+    assertThat(functionsWithNoHiding,
+        hasItems("execute_granted_add_function", "no_grants_add_function"));
+
+    // Or should the the function names not be returned because the schema is not visible?
+    functionsWithHiding =
+        getFunctionNames(hidingDatabaseMetaData, "no_privileges_schema");
+    assertThat(functionsWithHiding,
+        hasItem("execute_granted_add_function"));
+    assertThat(functionsWithHiding,
+        not(hasItem("no_grants_add_function")));
+
+    functionsWithNoHiding =
+        getFunctionNames(nonhidingDatabaseMetaData, "no_privileges_schema");
+    assertThat(functionsWithNoHiding,
+        hasItems("execute_granted_add_function", "no_grants_add_function"));
+
+  }
+
+  List<String> getFunctionNames(DatabaseMetaData databaseMetaData, String schemaPattern)
+      throws SQLException {
+    List<String> functionNames = new ArrayList<String>();
+    ResultSet rs = databaseMetaData.getFunctions(null, schemaPattern, null);
+    while (rs.next()) {
+      // TODO: According to JDBC JavaDoc, column should be called FUNCTION_NAME.
+      functionNames.add(rs.getString("PROCEDURE_NAME"));
+    }
+    return functionNames;
+  }
+
+  @Test
+  /*
+   *  According to the JDBC JavaDoc, the applicable UDTs are: JAVA_OBJECT, STRUCT, or DISTINCT.
+   */
+  public void testGetUDTs() throws SQLException {
+    List<String> typesWithHiding = getTypeNames(hidingDatabaseMetaData, "high_privileges_schema");
+    assertThat(typesWithHiding,
+        hasItems("usage_granted_composite_type", "usage_granted_us_postal_code_domain"));
+    assertThat(typesWithHiding,
+        not(hasItems("no_grants_composite_type", "no_grants_us_postal_code_domain")));
+    List<String> typesWithNoHiding =
+        getTypeNames(nonhidingDatabaseMetaData, "high_privileges_schema");
+    assertThat(typesWithNoHiding,
+        hasItems("usage_granted_composite_type", "no_grants_composite_type",
+            "usage_granted_us_postal_code_domain", "no_grants_us_postal_code_domain"));
+
+    typesWithHiding = getTypeNames(hidingDatabaseMetaData, "low_privileges_schema");
+    assertThat(typesWithHiding,
+        hasItems("usage_granted_composite_type", "usage_granted_us_postal_code_domain"));
+    assertThat(typesWithHiding,
+        not(hasItems("no_grants_composite_type", "no_grants_us_postal_code_domain")));
+    typesWithNoHiding =
+        getTypeNames(nonhidingDatabaseMetaData, "low_privileges_schema");
+    assertThat(typesWithNoHiding,
+        hasItems("usage_granted_composite_type", "no_grants_composite_type",
+            "usage_granted_us_postal_code_domain", "no_grants_us_postal_code_domain"));
+
+    // Or should the the types names not be returned because the schema is not visible?
+    typesWithHiding = getTypeNames(hidingDatabaseMetaData, "no_privileges_schema");
+    assertThat(typesWithHiding,
+        hasItems("usage_granted_composite_type", "usage_granted_us_postal_code_domain"));
+    assertThat(typesWithHiding,
+        not(hasItems("no_grants_composite_type", "no_grants_us_postal_code_domain")));
+    typesWithNoHiding =
+        getTypeNames(nonhidingDatabaseMetaData, "no_privileges_schema");
+    assertThat(typesWithNoHiding,
+        hasItems("usage_granted_composite_type", "no_grants_composite_type",
+            "usage_granted_us_postal_code_domain", "no_grants_us_postal_code_domain"));
+  }
+
+  /*
+  From the Postgres JDBC driver source code, we are mapping the types:
+      java.sql.Types.DISTINCT to the Postgres type:  TYPTYPE_COMPOSITE  'c'   # composite (e.g., table's rowtype)
+      java.sql.Types.STRUCT   to the Postgres type:  TYPTYPE_DOMAIN     'd'   # domain over another type
+   */
+  List<String> getTypeNames(DatabaseMetaData databaseMetaData, String schemaPattern)
+      throws SQLException {
+    List<String> typeNames = new ArrayList<String>();
+    ResultSet rs = databaseMetaData.getUDTs(null, schemaPattern, null, null);
+    while (rs.next()) {
+      typeNames.add(rs.getString("TYPE_NAME"));
+    }
+    return typeNames;
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc4/DatabaseMetaDataHideUnprivilegedObjectsTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc4/DatabaseMetaDataHideUnprivilegedObjectsTest.java
@@ -5,21 +5,21 @@
 *
 *-------------------------------------------------------------------------
 */
+
 package org.postgresql.test.jdbc4;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
-import org.postgresql.test.TestUtil;
 import org.postgresql.PGProperty;
+import org.postgresql.test.TestUtil;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
-import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.fail;
 
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc4/Jdbc4TestSuite.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc4/Jdbc4TestSuite.java
@@ -39,6 +39,7 @@ public class Jdbc4TestSuite extends TestSuite {
     suite.addTestSuite(PGCopyInputStreamTest.class);
     suite.addTestSuite(BlobTest.class);
     suite.addTest(new JUnit4TestAdapter(BinaryStreamTest.class));
+    suite.addTest(new JUnit4TestAdapter(DatabaseMetaDataHideUnprivilegedObjectsTest.class));
 
     Connection connection = TestUtil.openDB();
     try {


### PR DESCRIPTION
... to show only the items for which the current user has access.

I named the connection parameter:
    **hideUnprivilegedObjects**
and defaulted it to 'false'.

This works for me.  I did not add a test case. If I did so, it would need to use the privileged user. Let me know if that's what you'd like me to do.

Thanks.
