### PR TITLE
makes escape processing strict according to JDBC spec

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/Parser.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/Parser.java
@@ -1058,10 +1058,9 @@ public class Parser {
               // skip first state, it's not a escape code state
               for (int j = 1; j < availableStates.length; j++) {
                 SqlParseState availableState = availableStates[j];
-                int matched = SqlParseState.matchEscapeCode(p_sql, i + 1,
-                        availableState.escapeKeyword, availableState.allowedValues);
-                if (matched > 0) {
-                  i += matched;
+                int matchedPosition = availableState.getMatchedPosition(p_sql, i + 1);
+                if (matchedPosition > 0) {
+                  i += matchedPosition;
                   if (availableState.replacementKeyword != null) {
                     newsql.append(availableState.replacementKeyword);
                   }
@@ -1191,11 +1190,11 @@ public class Parser {
       this.replacementKeyword = replacementKeyword;
     }
 
-    private static int matchEscapeCode(char[] p_sql, int pos, char[] keyword, char[] val) {
+    private int getMatchedPosition(char[] p_sql, int pos) {
       int newPos = pos;
 
       // check for the keyword
-      for (char c : keyword) {
+      for (char c : escapeKeyword) {
         if (newPos >= p_sql.length) {
           return 0;
         }
@@ -1215,7 +1214,7 @@ public class Parser {
         curr = p_sql[++newPos];
       }
       boolean valid = false;
-      for (char c : val) {
+      for (char c : allowedValues) {
         if (curr == c || (c == '0' && Character.isAlphabetic(curr))) {
           valid = true;
         }

--- a/pgjdbc/src/main/java/org/postgresql/core/Parser.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/Parser.java
@@ -1168,24 +1168,24 @@ public class Parser {
   // Static variables for parsing SQL when replaceProcessing is true.
   private enum SqlParseState {
     IN_SQLCODE,
-    ESC_DATE(new char[]{'d'}, SINGLE_QUOTE, "DATE "),
-    ESC_TIME(new char[]{'t'}, SINGLE_QUOTE, "TIME "),
+    ESC_DATE("d", SINGLE_QUOTE, "DATE "),
+    ESC_TIME("t", SINGLE_QUOTE, "TIME "),
 
-    ESC_TIMESTAMP(new char[]{'t','s'}, SINGLE_QUOTE, "TIMESTAMP "),
-    ESC_FUNCTION(new char[]{'f','n'}, QUOTE_OR_ALPHABETIC_MARKER, null),
-    ESC_OUTERJOIN(new char[]{'o','j'}, QUOTE_OR_ALPHABETIC_MARKER, null),
-    ESC_ESCAPECHAR(new char[]{'e','s','c','a','p','e'}, SINGLE_QUOTE, "ESCAPE ");
+    ESC_TIMESTAMP("ts", SINGLE_QUOTE, "TIMESTAMP "),
+    ESC_FUNCTION("fn", QUOTE_OR_ALPHABETIC_MARKER, null),
+    ESC_OUTERJOIN("oj", QUOTE_OR_ALPHABETIC_MARKER, null),
+    ESC_ESCAPECHAR("escape", SINGLE_QUOTE, "ESCAPE ");
 
     private final char[] escapeKeyword;
     private final char[] allowedValues;
     private final String replacementKeyword;
 
     SqlParseState() {
-      this(new char[0], new char[0], null);
+      this("", new char[0], null);
     }
 
-    SqlParseState(char[] escapeKeyword, char[] allowedValues, String replacementKeyword) {
-      this.escapeKeyword = escapeKeyword;
+    SqlParseState(String escapeKeyword, char[] allowedValues, String replacementKeyword) {
+      this.escapeKeyword = escapeKeyword.toCharArray();
       this.allowedValues = allowedValues;
       this.replacementKeyword = replacementKeyword;
     }

--- a/pgjdbc/src/main/java/org/postgresql/core/Parser.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/Parser.java
@@ -1217,7 +1217,7 @@ public class Parser {
       }
       boolean valid = false;
       for (char c : allowedValues) {
-        if (curr == c || (c == '0' && Character.isAlphabetic(curr))) {
+        if (curr == c || (c == '0' && Character.isLetter(curr))) {
           valid = true;
         }
       }

--- a/pgjdbc/src/main/java/org/postgresql/core/Parser.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/Parser.java
@@ -16,7 +16,9 @@ import org.postgresql.util.PSQLState;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.sql.SQLException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Basic query parser infrastructure.

--- a/pgjdbc/src/test/java/org/postgresql/core/ParserTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/core/ParserTest.java
@@ -103,4 +103,25 @@ public class ParserTest extends TestCase {
     "select".getChars(0, 6, command, 0);
     Assert.assertTrue("Failed to correctly parse lower case command.", Parser.parseSelectKeyword(command, 0));
   }
+
+  public void testEscapeProcessing() throws Exception {
+    Assert.assertEquals("DATE '1999-01-09'", Parser.replaceProcessing("{d '1999-01-09'}", true, false));
+    Assert.assertEquals("DATE '1999-01-09'", Parser.replaceProcessing("{D  '1999-01-09'}", true, false));
+    Assert.assertEquals("TIME '20:00:03'", Parser.replaceProcessing("{t '20:00:03'}", true, false));
+    Assert.assertEquals("TIME '20:00:03'", Parser.replaceProcessing("{T '20:00:03'}", true, false));
+    Assert.assertEquals("TIMESTAMP '1999-01-09 20:11:11.123455'", Parser.replaceProcessing("{ts '1999-01-09 20:11:11.123455'}", true, false));
+    Assert.assertEquals("TIMESTAMP '1999-01-09 20:11:11.123455'", Parser.replaceProcessing("{Ts '1999-01-09 20:11:11.123455'}", true, false));
+
+    Assert.assertEquals("user", Parser.replaceProcessing("{fn user()}", true, false));
+    Assert.assertEquals("cos(1)", Parser.replaceProcessing("{fn cos(1)}", true, false));
+    Assert.assertEquals("extract(week from DATE '2005-01-24')", Parser.replaceProcessing("{fn week({d '2005-01-24'})}", true, false));
+
+    Assert.assertEquals("\"T1\" LEFT OUTER JOIN t2 ON \"T1\".id = t2.id",
+            Parser.replaceProcessing("{oj \"T1\" LEFT OUTER JOIN t2 ON \"T1\".id = t2.id}", true, false));
+
+    Assert.assertEquals("ESCAPE '_'", Parser.replaceProcessing("{escape '_'}", true, false));
+
+    // nothing should be changed in that case, no valid escape code
+    Assert.assertEquals("{obj : 1}", Parser.replaceProcessing("{obj : 1}", true, false));
+  }
 }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ConnectionTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ConnectionTest.java
@@ -109,7 +109,7 @@ public class ConnectionTest extends TestCase {
   public void testNativeSQL() throws Exception {
     // test a simple escape
     con = TestUtil.openDB();
-    assertEquals("DATE  '2005-01-24'", con.nativeSQL("{d '2005-01-24'}"));
+    assertEquals("DATE '2005-01-24'", con.nativeSQL("{d '2005-01-24'}"));
   }
 
   /*

--- a/ubenchmark/src/main/java/org/postgresql/benchmark/escaping/EscapeProcessing.java
+++ b/ubenchmark/src/main/java/org/postgresql/benchmark/escaping/EscapeProcessing.java
@@ -13,8 +13,12 @@ import java.util.concurrent.TimeUnit;
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 public class EscapeProcessing {
 
+    private String fnEscapeSQL = "{fn week({d '2005-01-24'})}";
+    private boolean replaceProcessingEnabled = true;
+    private boolean standardConformingStrings = false;
+
     @Benchmark
-    public void escapeFunctionWithDate() throws Exception {
-        Parser.replaceProcessing("{fn week({d '2005-01-24'})}", true, false);
+    public String escapeFunctionWithDate() throws Exception {
+        return Parser.replaceProcessing(fnEscapeSQL, replaceProcessingEnabled, standardConformingStrings);
     }
 }

--- a/ubenchmark/src/main/java/org/postgresql/benchmark/escaping/EscapeProcessing.java
+++ b/ubenchmark/src/main/java/org/postgresql/benchmark/escaping/EscapeProcessing.java
@@ -1,7 +1,16 @@
 package org.postgresql.benchmark.escaping;
 
-import org.openjdk.jmh.annotations.*;
 import org.postgresql.core.Parser;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.concurrent.TimeUnit;
 
@@ -13,12 +22,12 @@ import java.util.concurrent.TimeUnit;
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 public class EscapeProcessing {
 
-    private String fnEscapeSQL = "{fn week({d '2005-01-24'})}";
-    private boolean replaceProcessingEnabled = true;
-    private boolean standardConformingStrings = false;
+  private String fnEscapeSQL = "{fn week({d '2005-01-24'})}";
+  private boolean replaceProcessingEnabled = true;
+  private boolean standardConformingStrings = false;
 
-    @Benchmark
-    public String escapeFunctionWithDate() throws Exception {
-        return Parser.replaceProcessing(fnEscapeSQL, replaceProcessingEnabled, standardConformingStrings);
-    }
+  @Benchmark
+  public String escapeFunctionWithDate() throws Exception {
+    return Parser.replaceProcessing(fnEscapeSQL, replaceProcessingEnabled, standardConformingStrings);
+  }
 }

--- a/ubenchmark/src/main/java/org/postgresql/benchmark/escaping/EscapeProcessing.java
+++ b/ubenchmark/src/main/java/org/postgresql/benchmark/escaping/EscapeProcessing.java
@@ -1,0 +1,20 @@
+package org.postgresql.benchmark.escaping;
+
+import org.openjdk.jmh.annotations.*;
+import org.postgresql.core.Parser;
+
+import java.util.concurrent.TimeUnit;
+
+@Measurement(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@State(Scope.Thread)
+@Threads(1)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class EscapeProcessing {
+
+    @Benchmark
+    public void escapeFunctionWithDate() throws Exception {
+        Parser.replaceProcessing("{fn week({d '2005-01-24'})}", true, false);
+    }
+}


### PR DESCRIPTION
Before, escape code parsing was very lenient and invalid escape code formats were accidentally processed.

I've also added a JMH benchmark, so it seems that my new implementation even runs slightly faster:

### MASTER
Result "escapeFunctionWithDate":
  677.556 ±(99.9%) 7.699 ns/op [Average]
  (min, avg, max) = (638.185, 677.556, 741.213), stdev = 22.701
  CI (99.9%): [669.856, 685.255] (assumes normal distribution)

### s/strict-escape-processing
Result "escapeFunctionWithDate":
  666.126 ±(99.9%) 5.878 ns/op [Average]
  (min, avg, max) = (633.941, 666.126, 704.415), stdev = 17.333
  CI (99.9%): [660.247, 672.004] (assumes normal distribution)

Reason for coming across this is that at crate (https://github.com/crate/crate), we've experimentally implemented the PostgreSQL wire protocol for client connections. crate supports object literals like e.g. `{ o1 = 'string'}` (http://crate.readthedocs.io/en/latest/sql/data_types.html#object-literals) which were wrongly interpreted as an outerjoin escape code by the existing implementation. 
