### PR TITLE
fix: Don't break when there is no column metadata

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSetMetaData.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSetMetaData.java
@@ -64,7 +64,8 @@ public class PgResultSetMetaData implements ResultSetMetaData, PGResultSetMetaDa
   public boolean isAutoIncrement(int column) throws SQLException {
     fetchFieldMetaData();
     Field field = getField(column);
-    return field.getMetadata().autoIncrement;
+    FieldMetadata metadata = field.getMetadata();
+    return metadata != null && metadata.autoIncrement;
   }
 
   /*

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc3/CompositeTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc3/CompositeTest.java
@@ -36,9 +36,12 @@ public class CompositeTest extends TestCase {
         "l bigint[], n nestedcompositetest[], s simplecompositetest");
     TestUtil.createTable(_conn, "compositetabletest",
         "s simplecompositetest, cc \"Composites\".\"ComplexCompositeTest\"[]");
+    TestUtil.createTable(_conn, "\"Composites\".\"Table\"",
+        "s simplecompositetest, cc \"Composites\".\"ComplexCompositeTest\"[]");
   }
 
   protected void tearDown() throws SQLException {
+    TestUtil.dropTable(_conn, "\"Composites\".\"Table\"");
     TestUtil.dropTable(_conn, "compositetabletest");
     TestUtil.dropType(_conn, "\"Composites\".\"ComplexCompositeTest\"");
     TestUtil.dropType(_conn, "nestedcompositetest");
@@ -107,7 +110,7 @@ public class CompositeTest extends TestCase {
     assertTrue(rs.next());
     PGobject pgo2 = (PGobject) rs.getObject(1);
     Array pgarr2 = (Array) rs.getObject(2);
-    assertEquals("public.simplecompositetest", pgo2.getType());
+    assertEquals("simplecompositetest", pgo2.getType());
     assertEquals("\"Composites\".\"ComplexCompositeTest\"", pgarr2.getBaseTypeName());
     Object[] pgobjarr2 = (Object[]) pgarr2.getArray();
     assertEquals(1, pgobjarr2.length);
@@ -135,5 +138,43 @@ public class CompositeTest extends TestCase {
     assertEquals(2, items.length);
     assertNull(items[0]);
     assertNull(items[1]);
+  }
+
+  public void testTableMetadata() throws SQLException {
+    PreparedStatement pstmt = _conn.prepareStatement("INSERT INTO compositetabletest VALUES(?, ?)");
+    PGobject pgo1 = new PGobject();
+    pgo1.setType("public.simplecompositetest");
+    pgo1.setValue("(1,2.2,)");
+    pstmt.setObject(1, pgo1);
+    String[] ctArr = new String[1];
+    ctArr[0] = "(\"{1,2}\",{},\"(1,2.2,)\")";
+    Array pgarr1 = _conn.createArrayOf("\"Composites\".\"ComplexCompositeTest\"", ctArr);
+    pstmt.setArray(2, pgarr1);
+    int res = pstmt.executeUpdate();
+    assertEquals(1, res);
+    pstmt = _conn.prepareStatement("SELECT t FROM compositetabletest t");
+    ResultSet rs = pstmt.executeQuery();
+    assertTrue(rs.next());
+    String name = rs.getMetaData().getColumnTypeName(1);
+    assertEquals("compositetabletest", name);
+  }
+
+  public void testComplexTableNameMetadata() throws SQLException {
+    PreparedStatement pstmt = _conn.prepareStatement("INSERT INTO \"Composites\".\"Table\" VALUES(?, ?)");
+    PGobject pgo1 = new PGobject();
+    pgo1.setType("public.simplecompositetest");
+    pgo1.setValue("(1,2.2,)");
+    pstmt.setObject(1, pgo1);
+    String[] ctArr = new String[1];
+    ctArr[0] = "(\"{1,2}\",{},\"(1,2.2,)\")";
+    Array pgarr1 = _conn.createArrayOf("\"Composites\".\"ComplexCompositeTest\"", ctArr);
+    pstmt.setArray(2, pgarr1);
+    int res = pstmt.executeUpdate();
+    assertEquals(1, res);
+    pstmt = _conn.prepareStatement("SELECT t FROM \"Composites\".\"Table\" t");
+    ResultSet rs = pstmt.executeQuery();
+    assertTrue(rs.next());
+    String name = rs.getMetaData().getColumnTypeName(1);
+    assertEquals("\"Composites\".\"Table\"", name);
   }
 }


### PR DESCRIPTION
It's possible to use Postgres in an object oriented way.
Driver shouldn't break since some of it's assumptions are not valid in those usages.

"SELECT t FROM table t" will return the whole object, instead of some column inside it.
In those cases FieldMetadata doesn't make too much sense, since it's not returning the field, but rather a whole tuple.

Changed the test not to break (removal of public.) since this is ommited when object is on search path.