### PR TITLE
Avoid ClassLoader leaks caused by SharedTimer

### DIFF
--- a/pgjdbc/pom.xml
+++ b/pgjdbc/pom.xml
@@ -34,6 +34,15 @@
     <jdbc.specification.version.nodot>42</jdbc.specification.version.nodot>
     <skip.assembly>false</skip.assembly>
   </properties>
+  
+  <dependencies>
+    <dependency>
+      <groupId>se.jiderhamn</groupId>
+      <artifactId>classloader-leak-test-framework</artifactId>
+      <version>1.1.1</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
 
   <profiles>
     <profile>

--- a/pgjdbc/src/test/java/org/postgresql/test/util/SharedTimerClassLoaderLeakTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/util/SharedTimerClassLoaderLeakTest.java
@@ -1,0 +1,32 @@
+package org.postgresql.test.util;
+
+import org.postgresql.Driver;
+
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import se.jiderhamn.classloader.PackagesLoadedOutsideClassLoader;
+import se.jiderhamn.classloader.leak.JUnitClassloaderRunner;
+import se.jiderhamn.classloader.leak.Leaks;
+
+/**
+ * Test case that verifies that the use of {@link org.postgresql.util.SharedTimer} within
+ * {@link org.postgresql.Driver} does not cause ClassLoader leaks
+ * @author Mattias Jiderhamn
+ */
+@RunWith(JUnitClassloaderRunner.class)
+@PackagesLoadedOutsideClassLoader(packages = "org.postgresql", addToDefaults = true)
+public class SharedTimerClassLoaderLeakTest {
+
+  /** Starting a {@link org.postgresql.util.SharedTimer} should not cause ClassLoader leaks */
+  @Leaks(false)
+  @Test
+  public void sharedTimerDoesNotCauseLeak() {
+    Driver.getSharedTimer().getTimer(); // Start timer
+  }
+
+  @After
+  public void tearDown() {
+    Driver.getSharedTimer().releaseTimer();
+  }
+}


### PR DESCRIPTION
Back in PR #197 an attempt was made to avoid ClassLoader leaks by introducing `SharedTimer`. However, since the `TimerThread` started by `SharedTimer` inherits the `contextClassLoader` of the currently executing thread this could still cause leaks in an environment where a connection pool is shared between multiple ClassLoaders such as multiple web applications or multiple instances (redeploys) of the same web application, so that `Connection`s are kept open longer than the lifespan of the ClassLoader.

Likewise the inherited `AccessControlContext` of the `TimeThread` will likely contain `ProtectionDomain`s with references to calling classes and thus their ClassLoader, also leading to potential leaks under the same circumstances.