### PR TITLE
inappropriate statement sharing

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -1362,7 +1362,7 @@ public class QueryExecutorImpl extends QueryExecutorBase {
       // the SimpleParameterList's internal array that might be modified
       // under us.
       query.setStatementName(statementName, deallocateEpoch);
-      query.setStatementTypes(typeOIDs.clone());
+      query.setOriginalStatementTypes(typeOIDs.clone());
       registerParsedQuery(query, statementName);
     }
 
@@ -1961,7 +1961,7 @@ public class QueryExecutorImpl extends QueryExecutorBase {
           if ((origStatementName == null && query.getStatementName() == null)
               || (origStatementName != null
                   && origStatementName.equals(query.getStatementName()))) {
-            query.setStatementTypes(params.getTypeOIDs().clone());
+            query.setDescribedStatementTypes(params.getTypeOIDs().clone());
           }
 
           if (describeOnly) {

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/SimpleQuery.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/SimpleQuery.java
@@ -114,8 +114,16 @@ class SimpleQuery implements Query {
     this.deallocateEpoch = deallocateEpoch;
   }
 
-  void setStatementTypes(int[] paramTypes) {
+  void setDescribedStatementTypes(int[] paramTypes) {
+    assert originalTypes == null || paramTypes.length == originalTypes.length
+        : String.format("paramTypes:%1$d originalTypes:%2$d", paramTypes.length,
+        paramTypes == null ? -1 : originalTypes.length);
     this.preparedTypes = paramTypes;
+  }
+
+  void setOriginalStatementTypes(int[] paramTypes) {
+    this.preparedTypes = paramTypes;
+    this.originalTypes = paramTypes;
   }
 
   int[] getStatementTypes() {
@@ -139,7 +147,11 @@ class SimpleQuery implements Query {
         paramTypes == null ? -1 : preparedTypes.length);
     // Check for compatible types.
     for (int i = 0; i < paramTypes.length; ++i) {
-      if (paramTypes[i] != Oid.UNSPECIFIED && paramTypes[i] != preparedTypes[i]) {
+      if (paramTypes[i] == Oid.UNSPECIFIED) {
+        if ((originalTypes != null) && (originalTypes[i] != Oid.UNSPECIFIED)) {
+          return false;
+        }
+      } else if (paramTypes[i] != preparedTypes[i]) {
         return false;
       }
     }
@@ -312,6 +324,7 @@ class SimpleQuery implements Query {
   private final boolean sanitiserDisabled;
   private PhantomReference<?> cleanupRef;
   private int[] preparedTypes;
+  private int[] originalTypes;
   private short deallocateEpoch;
 
   private Integer cachedMaxResultRowSize;

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PreparedStatementTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PreparedStatementTest.java
@@ -30,6 +30,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.sql.Timestamp;
 import java.sql.Types;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -1009,6 +1010,35 @@ public class PreparedStatementTest extends BaseTest4 {
       rs.close();
     }
     pstmt.close();
+  }
+
+  @Test
+  public void testSetTimeAndTimestamp() throws SQLException {
+    PreparedStatement ps = con.prepareStatement("SELECT ?::timestamp");
+    try {
+      Timestamp ts = new Timestamp(1474997614836L);
+      for (int i = 0; i < 3; ++i) {
+        ResultSet rs;
+        ps.setNull(1, Types.DATE);
+        rs = ps.executeQuery();
+        try {
+          assertTrue(rs.next());
+          assertNull(rs.getObject(1));
+        } finally {
+          rs.close();
+        }
+        ps.setTimestamp(1, ts);
+        rs = ps.executeQuery();
+        try {
+          assertTrue(rs.next());
+          assertEquals(ts, rs.getObject(1));
+        } finally {
+          rs.close();
+        }
+      }
+    } finally {
+      ps.close();
+    }
   }
 
 }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PreparedStatementTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PreparedStatementTest.java
@@ -1026,7 +1026,7 @@ public class PreparedStatementTest extends BaseTest4 {
         rs = ps.executeQuery();
         try {
           assertTrue(rs.next());
-          assertNull(rs.getObject(1));
+          assertNull("NULL DATE converted to TIMESTAMP should return NULL value on getObject", rs.getObject(1));
         } finally {
           rs.close();
         }
@@ -1036,8 +1036,7 @@ public class PreparedStatementTest extends BaseTest4 {
         rs = ps.executeQuery();
         try {
           assertTrue(rs.next());
-          // If an inappropriate caching occurred, then we'll get the data narrowing (TIMESTAMP -> DATE)
-          assertEquals(ts, rs.getObject(1));
+          assertEquals("Looks like we got a narrowing of the data (TIMESTAMP -> DATE). It might caused by inappropriate caching of the statement.", ts, rs.getObject(1));
         } finally {
           rs.close();
         }


### PR DESCRIPTION
Add more parameter type checks into `SimpleQuery.isPreparedFor` for Oid.UNSPECIFIED parameter type.
This commit addresses issue  #648
