### PR TITLE
feat: Adaptive fetch size base on record size in bytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ In addition to the standard connection parameters the driver supports a number o
 | preparedStatementCacheQueries | Integer | 256     | Specifies the maximum number of entries in per-connection cache of prepared statements. A value of 0 disables the cache. |
 | preparedStatementCacheSizeMiB | Integer | 5       | Specifies the maximum size (in megabytes) of a per-connection prepared statement cache. A value of 0 disables the cache. |
 | defaultRowFetchSize           | Integer | 0       | Positive number of rows that should be fetched from the database when more rows are needed for ResultSet by each fetch iteration |
+| defaultRowFetchSizeInBytes    | Long    | 0       | Specifies the maximum size (in bytes) of ResultSet that should be fetched from the database when more rows are needed for ResultSet by each fetch iteration |
 | loginTimeout                  | Integer | 0       | Specify how long to wait for establishment of a database connection.|
 | connectTimeout                | Integer | 10      | The timeout value used for socket connect operations. |
 | socketTimeout                 | Integer | 0       | The timeout value used for socket read operations. |

--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -468,47 +468,7 @@ public enum PGProperty {
           + "to the database specified in the dbname parameter, "
           + "which will allow the connection to be used for logical replication "
           + "from that database. "
-          + "(backend >= 9.4)"),
-
-  /**
-   * Specify the driver behavior for not defined manually fetch size, it can be some default fetch size
-   * or fetch size that calculates base on rows size in bytes. Available values: default, adaptive.
-   *
-   * @see PGProperty#DEFAULT_ROW_FETCH_SIZE
-   * @see PGProperty#ADAPTIVE_FETCH_SIZE_MODE_ROW_FETCH_IN_BYTES
-   */
-  FETCH_SIZE_MODE(
-      "fetchSizeMode",
-      "default",
-      "Specify the driver behavior for not defined manually fetch size, it can be some default fetch size"
-          + " or fetch size that calculates base on rows size in bytes",
-      false,
-      "default",
-      "adaptive"
-  ),
-
-  /**
-   * Specifies default fetch size in bytes if fetch size not define manually. Property
-   * {@link PGProperty#FETCH_SIZE_MODE} should be also set to "adaptive" to enable the driver estimate
-   * fetch size base on rows size.
-   */
-  ADAPTIVE_FETCH_SIZE_MODE_ROW_FETCH_IN_BYTES(
-      "fetchSizeMode.adaptive.fetchSizeInBytes",
-      "0",
-      "Specifies default fetch size in bytes if fetch size not define manually."
-  ),
-
-  /**
-   * Double value define smooth factor for average function that calculate fetch size base on
-   * previous fetch. This property work only together with {@link PGProperty#FETCH_SIZE_MODE},
-   * {@link PGProperty#ADAPTIVE_FETCH_SIZE_MODE_ROW_FETCH_IN_BYTES}
-   * <p>Value should satisfy next rule: 0 &gt; smoothingFactor &lt; 1
-   */
-  ADAPTIVE_FETCH_SIZE_MODE_AVERAGE_SMOOTHING_FACTOR(
-      "fetchSizeMode.adaptive.average.smoothingFactor",
-      "0.5",
-      "Double value defint smooth factor for average function that calculate fetch size base on previous fetch"
-  );
+          + "(backend >= 9.4)");
 
   private String _name;
   private String _defaultValue;

--- a/pgjdbc/src/main/java/org/postgresql/core/fetchsize/AverageBytesFetchSizeProvider.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/fetchsize/AverageBytesFetchSizeProvider.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2016, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.core.fetchsize;
+
+import java.util.List;
+
+/**
+ * Adaptive fetch size to wait fetch size in bytes base on average size last extracted records
+ */
+public class AverageBytesFetchSizeProvider implements FetchSizeProvider {
+  private final long waitFetchSizeInBytes;
+  private final double smoothingFactor;
+
+  private double avgRowSize;
+  private int lastCalculateFetchSize;
+
+  /**
+   * @param waitFetchSizeInBytes positive number bytes that can be extract from database by one
+   *                             round trip, really count bytes extract from database by one round
+   *                             trip flexible and depends on average size rows already extract from
+   *                             database
+   * @param defaultFetchSize     initial fetch size that should be use for get enough samples for
+   *                             calculate fetch size for next round trip. If the value is large
+   *                             enough it can be reason for OOM on table with huge rows, but also
+   *                             if the value is small enough it can be reason for not correct rows
+   *                             size estimate.
+   * @param smoothingFactor      0 &gt; smoothingFactor &lt; 1
+   */
+  public AverageBytesFetchSizeProvider(
+      long waitFetchSizeInBytes,
+      int defaultFetchSize,
+      double smoothingFactor
+  ) {
+    if (waitFetchSizeInBytes <= 0) {
+      throw new IllegalArgumentException("FetchSizeInBytes should be great than 0");
+    }
+    this.waitFetchSizeInBytes = waitFetchSizeInBytes;
+
+    if (smoothingFactor < 0 || smoothingFactor > 1) {
+      throw new IllegalArgumentException("SmoothingFactor should be between 0 and 1");
+    }
+    this.smoothingFactor = smoothingFactor;
+    if (defaultFetchSize == 0) {
+      defaultFetchSize = 10;
+    }
+    this.lastCalculateFetchSize = defaultFetchSize;
+  }
+
+  @Override
+  public int getNextFetchSize(List<byte[][]> previousFetch) {
+    long bytes_fetched = 0;
+    for (byte[][] record : previousFetch) {
+      for (byte[] value : record) {
+        bytes_fetched += value.length;
+      }
+    }
+
+    double lastAvgRowSize = bytes_fetched / previousFetch.size();
+
+    if (avgRowSize == 0) {
+      avgRowSize = lastAvgRowSize;
+    }
+
+    /**
+     * calculate average row size base on previous experience by use exponential smoothing
+     * https://en.wikipedia.org/wiki/Exponential_smoothing
+     */
+    avgRowSize = smoothingFactor * avgRowSize + (1 - smoothingFactor) * lastAvgRowSize;
+
+    long calclFetchSize = Math.round(waitFetchSizeInBytes / avgRowSize);
+    if (calclFetchSize > Integer.MAX_VALUE) {
+      lastCalculateFetchSize = Integer.MAX_VALUE;
+    } else {
+      lastCalculateFetchSize = (int) calclFetchSize;
+    }
+
+    /**
+     * Fetch by one record for statement with huge tuple
+     */
+    if (lastCalculateFetchSize <= 0) {
+      lastCalculateFetchSize = 1;
+    }
+
+    return lastCalculateFetchSize;
+  }
+
+  @Override
+  public int getFetchSize() {
+    return lastCalculateFetchSize;
+  }
+}

--- a/pgjdbc/src/main/java/org/postgresql/core/fetchsize/AverageBytesFetchSizeProviderFactory.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/fetchsize/AverageBytesFetchSizeProviderFactory.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2016, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.core.fetchsize;
+
+
+public class AverageBytesFetchSizeProviderFactory implements FetchSizeProviderFactory {
+  private final long waitFetchSizeInBytes;
+  private final double smoothingFactor;
+
+  /**
+   * @param waitFetchSizeInBytes positive number bytes that can be extract from database by one
+   *                             round trip, really count bytes extract from database by one round
+   *                             trip flexible and depends on average size rows already extract from
+   *                             database
+   * @param smoothingFactor      0 &gt; smoothingFactor &lt; 1
+   */
+  public AverageBytesFetchSizeProviderFactory(
+      long waitFetchSizeInBytes,
+      double smoothingFactor
+  ) {
+    this.waitFetchSizeInBytes = waitFetchSizeInBytes;
+    this.smoothingFactor = smoothingFactor;
+  }
+
+  @Override
+  public FetchSizeProvider getProvider(int defaultFetchSize) {
+    return new AverageBytesFetchSizeProvider(waitFetchSizeInBytes, defaultFetchSize, smoothingFactor);
+  }
+}

--- a/pgjdbc/src/main/java/org/postgresql/core/fetchsize/ConstantFetchSize.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/fetchsize/ConstantFetchSize.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2016, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.core.fetchsize;
+
+
+import java.util.List;
+
+/**
+ * Default implementation for fetch size provide that always return constant fetch size.
+ */
+public class ConstantFetchSize implements FetchSizeProvider {
+  private final int fetchSize;
+
+  public ConstantFetchSize(int fetchSize) {
+    this.fetchSize = fetchSize;
+  }
+
+  @Override
+  public int getNextFetchSize(List<byte[][]> previousFetch) {
+    return fetchSize;
+  }
+
+  @Override
+  public int getFetchSize() {
+    return fetchSize;
+  }
+}

--- a/pgjdbc/src/main/java/org/postgresql/core/fetchsize/ConstantFetchSizeFactory.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/fetchsize/ConstantFetchSizeFactory.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2016, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.core.fetchsize;
+
+
+public class ConstantFetchSizeFactory implements FetchSizeProviderFactory {
+  @Override
+  public FetchSizeProvider getProvider(int defaultFetchSize) {
+    return new ConstantFetchSize(defaultFetchSize);
+  }
+}

--- a/pgjdbc/src/main/java/org/postgresql/core/fetchsize/FetchSizeProvider.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/fetchsize/FetchSizeProvider.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2016, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.core.fetchsize;
+
+import java.util.List;
+
+/**
+ * Provider implementation allow adapt fetch size base on data that receive last times. Provider
+ * also can return as fetch size zero and it will means that should be extracted whole by one round
+ * trip to postgres.
+ */
+public interface FetchSizeProvider {
+  /**
+   * Calculate next fetch size based on data that was received last time
+   *
+   * @param previousFetch not null list with rows that was receive last time
+   * @return the positive number of result set rows that should be extract from backend by next
+   * round trip
+   */
+  int getNextFetchSize(List<byte[][]> previousFetch);
+
+  /**
+   * Fetch size that was use previous round trip or default fetch size
+   *
+   * @return the positive number of result set rows that retrieves from backend by one round trip
+   */
+  int getFetchSize();
+}

--- a/pgjdbc/src/main/java/org/postgresql/core/fetchsize/FetchSizeProviderFactory.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/fetchsize/FetchSizeProviderFactory.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2016, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.core.fetchsize;
+
+public interface FetchSizeProviderFactory {
+  /**
+   * @param defaultFetchSize default fetch size that should be use as initial fetch size if provider
+   *                         can't estimate fetch size without samples
+   * @return create instance of fetch size provider
+   */
+  FetchSizeProvider getProvider(int defaultFetchSize);
+}

--- a/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
+++ b/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
@@ -419,6 +419,38 @@ public abstract class BaseDataSource implements CommonDataSource, Referenceable 
   }
 
   /**
+   * @param sizeInBytes default fetch size in bytes
+   * @see PGProperty#DEFAULT_ROW_FETCH_SIZE_IN_BYTES
+   */
+  public void setDefaultRowFetchSizeInBytes(long sizeInBytes) {
+    PGProperty.DEFAULT_ROW_FETCH_SIZE_IN_BYTES.set(properties, String.valueOf(sizeInBytes));
+  }
+
+  /**
+   * @return default fetch size in bytes
+   * @see PGProperty#DEFAULT_ROW_FETCH_SIZE_IN_BYTES
+   */
+  public long getDefaultRowFetchSizeInBytes() {
+    return PGProperty.DEFAULT_ROW_FETCH_SIZE_IN_BYTES.getLongNoCheck(properties);
+  }
+
+  /**
+   * @param factor smoothing factor for function that estimates average rows size for query
+   * @see PGProperty#ROWS_SIZE_ESTIMATE_SMOOTHING_FACTOR
+   */
+  public void setRowsSizeEstimateSmoothingFactor(double factor) {
+    PGProperty.ROWS_SIZE_ESTIMATE_SMOOTHING_FACTOR.set(properties, String.valueOf(factor));
+  }
+
+  /**
+   * @return smoothing factor for function that estimates average rows size for query
+   * @see PGProperty#ROWS_SIZE_ESTIMATE_SMOOTHING_FACTOR
+   */
+  public double getRowsSizeEstimateSmoothingFactor() {
+    return PGProperty.ROWS_SIZE_ESTIMATE_SMOOTHING_FACTOR.getDoubleNoCheck(properties);
+  }
+
+  /**
    * @param unknownLength unknown length
    * @see PGProperty#UNKNOWN_LENGTH
    */

--- a/pgjdbc/src/test/java/org/postgresql/core/fetchsize/AdaptiveFetchSizeTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/core/fetchsize/AdaptiveFetchSizeTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2016, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.core.fetchsize;
+
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assume.assumeThat;
+
+import org.postgresql.PGProperty;
+import org.postgresql.jdbc.PreferQueryMode;
+import org.postgresql.test.TestUtil;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Properties;
+
+
+public class AdaptiveFetchSizeTest {
+
+  private Connection connection;
+
+  @Before
+  public void setUp() throws Exception {
+    String queryModeStr = PGProperty.PREFER_QUERY_MODE.get(System.getProperties());
+    PreferQueryMode queryMode = PreferQueryMode.of(queryModeStr);
+
+
+    assumeThat("FetchSize parameter work only with extended query protocol(v3)",
+        queryMode,
+        allOf(
+            not(equalTo(PreferQueryMode.EXTENDED_FOR_PREPARED)),
+            not(equalTo(PreferQueryMode.SIMPLE))
+        )
+    );
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    if (connection != null) {
+      TestUtil.closeDB(connection);
+    }
+  }
+
+  @Test
+  public void testResultFetchSizeFirstlyEqualToInitFetchSize() throws Exception {
+    final int initFetchSize = 5;
+    Properties properties = new Properties();
+    PGProperty.DEFAULT_ROW_FETCH_SIZE.set(properties, initFetchSize);
+    PGProperty.DEFAULT_ROW_FETCH_SIZE_IN_BYTES.set(properties, "100");
+
+    connection = openConnection(properties);
+    connection.setAutoCommit(false);
+
+    Statement statement = connection.createStatement();
+    ResultSet resultSet =
+        statement.executeQuery("SELECT generate_series(1,50) AS id, md5(random()::text) AS descr");
+
+    int fetchSize = resultSet.getFetchSize();
+    resultSet.close();
+    statement.close();
+
+    assertThat("Adaptive fetch size can't work without samples, that why first fetch size equal "
+            + "to default fetch size, so we should see it value via ResultSet#getFetchSize",
+        fetchSize, equalTo(initFetchSize)
+    );
+  }
+
+  @Test
+  public void testFetchSizeChangesAfterFewRoundTrip() throws Exception {
+    final int initFetchSize = 5;
+    Properties properties = new Properties();
+    PGProperty.DEFAULT_ROW_FETCH_SIZE.set(properties, initFetchSize);
+    PGProperty.DEFAULT_ROW_FETCH_SIZE_IN_BYTES.set(properties, "100");
+
+    connection = openConnection(properties);
+
+    Statement statement = connection.createStatement();
+    ResultSet resultSet =
+        statement.executeQuery(
+            "SELECT generate_series(1,1000) AS id, md5(random()::text) AS descr");
+
+    int index = 0;
+    while (index < 600 && resultSet.next()) {
+      index++;
+    }
+
+    int fetchSize = resultSet.getFetchSize();
+
+    resultSet.close();
+    statement.close();
+
+    assertThat("ResultSet#getFetchSize always show last fetch size that "
+            + "was use for last round trip to database",
+        fetchSize, not(equalTo(initFetchSize))
+    );
+  }
+
+  @Test
+  public void testFetchSizeAdaptOnHugeRecordAfterFewRoundTrips() throws Exception {
+    final int initFetchSize = 5;
+    Properties properties = new Properties();
+    PGProperty.DEFAULT_ROW_FETCH_SIZE.set(properties, initFetchSize);
+    PGProperty.DEFAULT_ROW_FETCH_SIZE_IN_BYTES.set(properties, "2000");
+
+    connection = openConnection(properties);
+
+    TestUtil.createTable(connection, "test_adaptive_fetch_size", "id int primary key, b text");
+
+    Statement statement = connection.createStatement();
+    statement.executeUpdate(
+        "INSERT INTO test_adaptive_fetch_size SELECT generate_series(1,1000) AS id, md5(random()::text) AS b"
+    );
+    statement.close();
+
+    statement = connection.createStatement();
+    statement.executeUpdate(
+        "UPDATE test_adaptive_fetch_size SET b = b||b||b||b||b||b||b||b||b||b||b where id > 800");
+    statement.close();
+
+    statement = connection.createStatement();
+    ResultSet resultSet =
+        statement.executeQuery("select * from test_adaptive_fetch_size order by id");
+
+    skipRecords(resultSet, initFetchSize + 2);
+    int firstFetchSizeEstimate = resultSet.getFetchSize();
+    skipRecords(resultSet, 900);
+    int secondFetchSizeEstimate = resultSet.getFetchSize();
+
+    resultSet.close();
+    statement.close();
+
+    assertThat("In this case we check how fetch size adapts on data, first N rows was small enough "
+            + "but then was only huge record, so, fetch size should less "
+            + "than during fetch small records",
+        secondFetchSizeEstimate < firstFetchSizeEstimate,
+        equalTo(true)
+    );
+  }
+
+  private void skipRecords(ResultSet resultSet, int size) throws SQLException {
+    int index = 0;
+    while (index < size && resultSet.next()) {
+      index++;
+    }
+  }
+
+  private Connection openConnection(Properties properties) throws Exception {
+    Connection connection = TestUtil.openDB(properties);
+    connection.setAutoCommit(false);
+
+    return connection;
+  }
+
+}

--- a/pgjdbc/src/test/java/org/postgresql/core/fetchsize/AverageBytesFetchSizeProviderTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/core/fetchsize/AverageBytesFetchSizeProviderTest.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2016, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.core.fetchsize;
+
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertThat;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+
+public class AverageBytesFetchSizeProviderTest {
+
+  @Test
+  public void initFetchSizeEqualToDefaultFetchSize() throws Exception {
+    final int waitSize = 10;
+    AverageBytesFetchSizeProvider provider =
+        new AverageBytesFetchSizeProvider(123, waitSize, 0.5);
+
+    assertThat(provider.getFetchSize(), CoreMatchers.equalTo(waitSize));
+  }
+
+  @Test
+  public void testAdaptFetchSizeBySamples() throws Exception {
+    final int initSize = 10;
+    final long waitBytes = 200;
+
+    AverageBytesFetchSizeProvider provider =
+        new AverageBytesFetchSizeProvider(waitBytes, initSize, 0.5);
+
+
+    List<byte[][]> rows = new ArrayList<byte[][]>();
+    for (int index = 0; index < 10; index++) {
+      rows.add(new byte[1][10]);
+    }
+
+    provider.getNextFetchSize(rows);
+
+    assertThat(provider.getFetchSize(), not(equalTo(initSize)));
+  }
+
+  @Test
+  public void testEstimateFetchSizeCanNotLoadMoreThanSpecifiedSizeInBytes() throws Exception {
+    final int initSize = 10;
+    final long waitBytes = 200;
+    final int sizeOfSingleRow = 10;
+
+    AverageBytesFetchSizeProvider provider =
+        new AverageBytesFetchSizeProvider(waitBytes, initSize, 0.5);
+
+
+    List<byte[][]> rows = new ArrayList<byte[][]>();
+    for (int index = 0; index < initSize; index++) {
+      rows.add(new byte[1][sizeOfSingleRow]);
+    }
+
+    int estimatedFetchSize = provider.getNextFetchSize(rows);
+
+    long estemateFetchSizeInBytes = estimatedFetchSize * sizeOfSingleRow;
+
+    assertThat("Estimated fetch size can not exceed specified fetch size in bytes, "
+            + "because it can reason of OOM, estimatedFetchSizeInBytes equal to "
+            + estemateFetchSizeInBytes
+            + " and bytes limit equal to "
+            + waitBytes,
+        estemateFetchSizeInBytes <= waitBytes, equalTo(true)
+    );
+  }
+
+  @Test
+  public void testMinimalFetchSizeEqualToOneForReallyHugeRecords() throws Exception {
+    final int initSize = 20;
+    final long limitBytes = 200;
+    final int sizeOfSingleRow = (int) limitBytes * 5;
+
+    AverageBytesFetchSizeProvider provider =
+        new AverageBytesFetchSizeProvider(limitBytes, initSize, 0.5);
+
+
+    List<byte[][]> rows = new ArrayList<byte[][]>();
+    for (int index = 0; index < initSize; index++) {
+      rows.add(new byte[1][sizeOfSingleRow]);
+    }
+
+    int estimatedFetchSize = provider.getNextFetchSize(rows);
+
+    assertThat("When single record of table huge than specified fetch size in bytes "
+            + "we should start fetch by one record, because if as result estimate "
+            + "we return zero it will means that next round trip try load "
+            + "all records for statement and fail with OOM",
+        estimatedFetchSize, CoreMatchers.equalTo(1)
+    );
+  }
+
+  @Test
+  public void testConsiderPreviousSamplesToNewEstimates() throws Exception {
+    final int initSize = 10;
+    final long limitBytes = 1000;
+    final int sizeOfSmallSingleRow = 10;
+    final int sizeOfHugeSingleRow = 50;
+
+    AverageBytesFetchSizeProvider provider =
+        new AverageBytesFetchSizeProvider(limitBytes, initSize, 0.5);
+
+    List<byte[][]> smallRows = new ArrayList<byte[][]>();
+    for (int index = 0; index < provider.getFetchSize(); index++) {
+      smallRows.add(new byte[1][sizeOfSmallSingleRow]);
+    }
+
+    int firstEstimateFetchSize = provider.getNextFetchSize(smallRows);
+
+    List<byte[][]> hugeRows = new ArrayList<byte[][]>();
+    for (int index = 0; index < provider.getFetchSize(); index++) {
+      hugeRows.add(new byte[1][sizeOfHugeSingleRow]);
+    }
+
+    int secondEstimateFetchSize = provider.getNextFetchSize(hugeRows);
+
+    assertThat("FetchSizeProvider should consider all previous samples to estimate rows size, "
+            + "for example we can receive small rows and then receive huge, in that case after receive "
+            + "huge rows fetch size should be reduced. In this test as first estimate was receive "
+            + firstEstimateFetchSize
+            + " on the second estimate was received "
+            + secondEstimateFetchSize,
+        secondEstimateFetchSize < firstEstimateFetchSize, equalTo(true)
+    );
+  }
+
+  @Test
+  public void testSmoothFactorAffectFetchSize() throws Exception {
+    final int initSize = 10;
+    final long limitBytes = 1000;
+    final int sizeOfSmallSingleRow = 10;
+    final int sizeOfHugeSingleRow = 50;
+
+    List<byte[][]> smallRows = new ArrayList<byte[][]>();
+    for (int index = 0; index < initSize; index++) {
+      smallRows.add(new byte[1][sizeOfSmallSingleRow]);
+    }
+
+    List<byte[][]> hugeRows = new ArrayList<byte[][]>();
+    for (int index = 0; index < initSize * 2; index++) {
+      hugeRows.add(new byte[1][sizeOfHugeSingleRow]);
+    }
+
+    AverageBytesFetchSizeProvider firstProvider =
+        new AverageBytesFetchSizeProvider(limitBytes, initSize, 0.9);
+    AverageBytesFetchSizeProvider secondProvider =
+        new AverageBytesFetchSizeProvider(limitBytes, initSize, 0.1);
+
+    firstProvider.getNextFetchSize(smallRows);
+    int estimateFirstProvider = firstProvider.getNextFetchSize(hugeRows);
+
+    secondProvider.getNextFetchSize(smallRows);
+    int estimateSecondProvider = secondProvider.getNextFetchSize(hugeRows);
+
+    assertThat("Smaller smoothing factor more more sensitive to spikes",
+        estimateSecondProvider < estimateFirstProvider,
+        equalTo(true)
+    );
+  }
+
+  @Test
+  public void testFetchSizeCanNotBeGreatThemIntegerMax() throws Exception {
+    final int initSize = 10;
+    final long limitBytes = Long.MAX_VALUE;
+    final int sizeOfSmallSingleRow = 1;
+
+    AverageBytesFetchSizeProvider provider =
+        new AverageBytesFetchSizeProvider(limitBytes, initSize, 0.5);
+
+    List<byte[][]> rows = new ArrayList<byte[][]>();
+    for (int index = 0; index < initSize; index++) {
+      rows.add(new byte[1][sizeOfSmallSingleRow]);
+    }
+
+    int estimatedFetchSize = provider.getNextFetchSize(rows);
+    assertThat(estimatedFetchSize, equalTo(Integer.MAX_VALUE));
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/core/fetchsize/FetchSizeTestSuite.java
+++ b/pgjdbc/src/test/java/org/postgresql/core/fetchsize/FetchSizeTestSuite.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2016, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.core.fetchsize;
+
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+@RunWith(Suite.class)
+@SuiteClasses({
+    AdaptiveFetchSizeTest.class,
+    AverageBytesFetchSizeProviderTest.class})
+public class FetchSizeTestSuite {
+
+}

--- a/pgjdbc/src/test/java/org/postgresql/test/TestUtil.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/TestUtil.java
@@ -518,7 +518,7 @@ public class TestUtil {
   public static void dropTable(Connection con, String table) throws SQLException {
     Statement stmt = con.createStatement();
     try {
-      String sql = "DROP TABLE " + table + " CASCADE ";
+      String sql = "DROP TABLE IF EXISTS " + table + " CASCADE ";
       stmt.executeUpdate(sql);
     } catch (SQLException ex) {
       // Since every create table issues a drop table


### PR DESCRIPTION
This feature allow avoid OOM during fetch many data from huge table and
also unlike defaultFetchSize not degradate performance of small tables,
because fetch size estimates on records that was already fetch.

Current version postgresql protocol(v3) not supports ability specify
fetchSizeInBytes that why this feature implements on driver size.
For estimate fetchsize for next round trip to database calculates average
size by previous rows and also applies exponential smoothing.

To configure adaptive fetch size was introduce next properties:
fetchSizeMode=adaptive
defaultRowFetchSize=100
fetchSizeMode.adaptive.fetchSizeInBytes=1000000
fetchSizeMode.adaptive.average.smoothingFactor=0.5

PR shoul solve problems describe in #292
