### PR TITLE
fix: copy src/main/resources

### DIFF
--- a/pgjdbc/pom.xml
+++ b/pgjdbc/pom.xml
@@ -240,13 +240,16 @@
   <build>
     <resources>
       <resource>
+        <directory>src/main/resources</directory>
+      </resource>
+      <resource>
         <directory>../</directory>
         <includes>
           <include>LICENSE</include>
         </includes>
       </resource>
     </resources>
-  
+
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Maven needs to specify the src/main/resources directory when another resources is specified.