### PR TITLE
refactor: use varargs

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/util/ServerErrorMessage.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/ServerErrorMessage.java
@@ -203,7 +203,7 @@ public class ServerErrorMessage implements Serializable {
       String l_routine = m_mesgParts.get(ROUTINE);
       if (l_file != null || l_line != null || l_routine != null) {
         l_totalMessage.append("\n  ").append(GT.tr("Location: File: {0}, Routine: {1}, Line: {2}",
-            new Object[]{l_file, l_routine, l_line}));
+            l_file, l_routine, l_line));
       }
       l_message = m_mesgParts.get(SQLSTATE);
       if (l_message != null) {


### PR DESCRIPTION
use varargs instead of new Object[]{...}
delete "final" from "private static" methods (fix warnings from https://github.com/pgjdbc/pgjdbc/issues/586)