### PR TITLE
bug: fix not enscaped special symbol that fail build

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/Parser.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/Parser.java
@@ -958,6 +958,7 @@ public class Parser {
    * @param replaceProcessingEnabled whether replace_processing_enabled is on
    * @param standardConformingStrings whether standard_conforming_strings is on
    * @return PostgreSQL-compatible SQL
+   * @throws SQLException if given SQL is wrong
    */
   public static String replaceProcessing(String p_sql, boolean replaceProcessingEnabled,
       boolean standardConformingStrings) throws SQLException {

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
@@ -2135,7 +2135,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
   /**
    * Take the a String representing an array of ACLs and return a Map mapping the SQL permission
    * name to a List of usernames who have that permission.
-   * For instance: SELECT -> user1 -> list of [grantor, grantable]
+   * For instance: {@code SELECT -> user1 -> list of [grantor, grantable]}
    *
    * @param aclArray ACL array
    * @param owner owner


### PR DESCRIPTION
Current master branch state not pass travis build, because fail on javadocs generation.

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:2.10.3:jar (attach-javadocs) on project postgresql: MavenReportException: Error while generating Javadoc:
[ERROR] Exit code: 1 - /home/fol/project/open-source/pgjdbc/pgjdbc/target/gen-src/org/postgresql/core/Parser.java:962: warning: no @throws for java.sql.SQLException
[ERROR] public static String replaceProcessing(String p_sql, boolean replaceProcessingEnabled,
[ERROR] ^
[ERROR] /home/fol/project/open-source/pgjdbc/pgjdbc/target/gen-src/org/postgresql/jdbc/PgDatabaseMetaData.java:2138: error: bad use of '>'
[ERROR] * For instance: SELECT -> user1 -> list of [grantor, grantable]
[ERROR] ^
[ERROR] /home/fol/project/open-source/pgjdbc/pgjdbc/target/gen-src/org/postgresql/jdbc/PgDatabaseMetaData.java:2138: error: bad use of '>'
[ERROR] * For instance: SELECT -> user1 -> list of [grantor, grantable]
[ERROR] ^
[ERROR]
[ERROR] Command line was: /usr/lib/jvm/java-8-oracle/bin/javadoc -J-Xmx2048m @options
[ERROR]
[ERROR] Refer to the generated Javadoc files in '/home/fol/project/open-source/pgjdbc/pgjdbc/target/apidocs' dir.
[ERROR] -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]

```