### PR TITLE
fix: ensure executeBatch() does not use server-side prepared statements when prepareThreshold=0

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgStatement.java
@@ -736,7 +736,7 @@ public class PgStatement implements Statement, BaseStatement {
         // If executing the same query twice in a batch, make sure the statement
         // is server-prepared. In other words, "oneshot" only if the query is one in the batch
         // or the queries are different
-        && isOneShotQuery(null)) {
+        || isOneShotQuery(null)) {
       flags |= QueryExecutor.QUERY_ONESHOT;
     } else {
       // If a batch requests generated keys and isn't already described,

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BaseTest4.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BaseTest4.java
@@ -69,4 +69,8 @@ public class BaseTest4 {
     Assume.assumeTrue("callable statements are not fully supported in simple protocol execution mode",
         preferQueryMode.compareTo(PreferQueryMode.EXTENDED) >= 0);
   }
+
+  public void assumeBinaryModeRegular() {
+    Assume.assumeTrue(binaryMode == BinaryMode.REGULAR);
+  }
 }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PreparedStatementTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PreparedStatementTest.java
@@ -11,6 +11,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import org.postgresql.jdbc.PgStatement;
 import org.postgresql.jdbc.PreferQueryMode;
 import org.postgresql.test.TestUtil;
 import org.postgresql.test.util.BrokenInputStream;
@@ -986,6 +987,57 @@ public class PreparedStatementTest extends BaseTest4 {
       assertEquals(2, rs.getInt(1));
       rs.close();
     }
+    pstmt.close();
+  }
+
+  @Test
+  public void testBatchWithPrepareThreshold() throws SQLException {
+    assumeBinaryModeRegular();
+
+    PreparedStatement pstmt = con.prepareStatement("CREATE temp TABLE batch_tab_threshold5 (id bigint, val bigint)");
+    pstmt.executeUpdate();
+    pstmt.close();
+
+    // When using a prepareThreshold of 5, a batch update should use server-side prepare
+    pstmt = con.prepareStatement("INSERT INTO batch_tab_threshold5 (id, val) VALUES (?,?)");
+    ((PgStatement) pstmt).setPrepareThreshold(5);
+    for (int p = 0; p < 5; p++) {
+      for (int i = 0; i <= 5; i++) {
+        pstmt.setLong(1, i);
+        pstmt.setLong(2, i);
+        pstmt.addBatch();
+      }
+      pstmt.executeBatch();
+    }
+    pstmt.close();
+    pstmt = con.prepareStatement("select count(*) from pg_prepared_statements where statement = 'INSERT INTO batch_tab_threshold5 (id, val) VALUES ($1,$2)'");
+    ResultSet rs = pstmt.executeQuery();
+    assertTrue(rs.next());
+    assertEquals(1, rs.getInt(1));
+    rs.close();
+    pstmt.close();
+
+    pstmt = con.prepareStatement("CREATE temp TABLE batch_tab_threshold0 (id bigint, val bigint)");
+    pstmt.executeUpdate();
+    pstmt.close();
+
+    // When using a prepareThreshold of 0, a batch update should not use server-side prepare
+    pstmt = con.prepareStatement("INSERT INTO batch_tab_threshold0 (id, val) VALUES (?,?)");
+    ((PgStatement) pstmt).setPrepareThreshold(0);
+    for (int p = 0; p < 5; p++) {
+      for (int i = 0; i <= 5; i++) {
+        pstmt.setLong(1, i);
+        pstmt.setLong(2, i);
+        pstmt.addBatch();
+      }
+      pstmt.executeBatch();
+    }
+    pstmt.close();
+    pstmt = con.prepareStatement("select count(*) from pg_prepared_statements where statement = 'INSERT INTO batch_tab_threshold0 (id, val) VALUES ($1,$2)'");
+    rs = pstmt.executeQuery();
+    assertTrue(rs.next());
+    assertEquals(0, rs.getInt(1));
+    rs.close();
     pstmt.close();
   }
 

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PreparedStatementTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PreparedStatementTest.java
@@ -16,6 +16,7 @@ import org.postgresql.jdbc.PreferQueryMode;
 import org.postgresql.test.TestUtil;
 import org.postgresql.test.util.BrokenInputStream;
 
+import org.junit.Assume;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -993,6 +994,8 @@ public class PreparedStatementTest extends BaseTest4 {
   @Test
   public void testBatchWithPrepareThreshold() throws SQLException {
     assumeBinaryModeRegular();
+    Assume.assumeTrue("simple protocol only does not support prepared statement requests",
+        preferQueryMode != PreferQueryMode.SIMPLE);
 
     PreparedStatement pstmt = con.prepareStatement("CREATE temp TABLE batch_tab_threshold5 (id bigint, val bigint)");
     pstmt.executeUpdate();

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PreparedStatementTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PreparedStatementTest.java
@@ -992,7 +992,7 @@ public class PreparedStatementTest extends BaseTest4 {
   }
 
   @Test
-  public void testBatchWithPrepareThreshold() throws SQLException {
+  public void testBatchWithPrepareThreshold5() throws SQLException {
     assumeBinaryModeRegular();
     Assume.assumeTrue("simple protocol only does not support prepared statement requests",
         preferQueryMode != PreferQueryMode.SIMPLE);
@@ -1019,8 +1019,15 @@ public class PreparedStatementTest extends BaseTest4 {
     assertEquals(1, rs.getInt(1));
     rs.close();
     pstmt.close();
+  }
 
-    pstmt = con.prepareStatement("CREATE temp TABLE batch_tab_threshold0 (id bigint, val bigint)");
+  @Test
+  public void testBatchWithPrepareThreshold0() throws SQLException {
+    assumeBinaryModeRegular();
+    Assume.assumeTrue("simple protocol only does not support prepared statement requests",
+        preferQueryMode != PreferQueryMode.SIMPLE);
+
+    PreparedStatement pstmt = con.prepareStatement("CREATE temp TABLE batch_tab_threshold0 (id bigint, val bigint)");
     pstmt.executeUpdate();
     pstmt.close();
 
@@ -1037,7 +1044,7 @@ public class PreparedStatementTest extends BaseTest4 {
     }
     pstmt.close();
     pstmt = con.prepareStatement("select count(*) from pg_prepared_statements where statement = 'INSERT INTO batch_tab_threshold0 (id, val) VALUES ($1,$2)'");
-    rs = pstmt.executeQuery();
+    ResultSet rs = pstmt.executeQuery();
     assertTrue(rs.next());
     assertEquals(0, rs.getInt(1));
     rs.close();


### PR DESCRIPTION
Prevents usage of preparedStatements in `executeBatch` when `prepareThreshold` is set to 0