### PR TITLE
bug: fix drop replication slot on 9.4 for tests

### DIFF
--- a/pgjdbc/src/test/java/org/postgresql/replication/LogicalReplicationStatusTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/replication/LogicalReplicationStatusTest.java
@@ -15,8 +15,6 @@ import org.postgresql.PGProperty;
 import org.postgresql.test.TestUtil;
 import org.postgresql.test.util.rules.ServerVersionRule;
 import org.postgresql.test.util.rules.annotation.HaveMinimalServerVersion;
-import org.postgresql.util.PSQLException;
-import org.postgresql.util.PSQLState;
 
 import org.junit.After;
 import org.junit.Before;
@@ -51,39 +49,16 @@ public class LogicalReplicationStatusTest {
     replicationConnection = openReplicationConnection();
     TestUtil.createTable(sqlConnection, "test_logic_table",
         "pk serial primary key, name varchar(100)");
-    Statement st = sqlConnection.createStatement();
-    st.execute(
-        "SELECT * FROM pg_create_logical_replication_slot('" + SLOT_NAME + "', 'test_decoding')");
-    st.close();
+
+    TestUtil.recreateLogicalReplicationSlot(sqlConnection, SLOT_NAME, "test_decoding");
   }
 
   @After
   public void tearDown() throws Exception {
     replicationConnection.close();
     TestUtil.dropTable(sqlConnection, "test_logic_table");
-
-    dropReplicationSlot();
+    TestUtil.dropReplicationSlot(sqlConnection, SLOT_NAME);
     sqlConnection.close();
-  }
-
-  private void dropReplicationSlot() throws SQLException {
-    try {
-      Statement dropStatement = sqlConnection.createStatement();
-      dropStatement.execute("select pg_drop_replication_slot('" + SLOT_NAME + "')");
-      dropStatement.close();
-    } catch (PSQLException e) {
-      //slot is active
-      if (PSQLState.OBJECT_IN_USE.equals(new PSQLState(e.getSQLState()))) {
-        Statement terminateStatement = sqlConnection.createStatement();
-        terminateStatement.execute("select pg_terminate_backend(active_pid) from pg_replication_slots "
-            + "where active = true and slot_name='" + SLOT_NAME + "'"
-        );
-        terminateStatement.close();
-        dropReplicationSlot();
-      } else {
-        throw e;
-      }
-    }
   }
 
   @Test()

--- a/pgjdbc/src/test/java/org/postgresql/replication/LogicalReplicationTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/replication/LogicalReplicationTest.java
@@ -70,40 +70,16 @@ public class LogicalReplicationTest {
     replConnection = openReplicationConnection();
     TestUtil.createTable(sqlConnection, "test_logic_table",
         "pk serial primary key, name varchar(100)");
-    Statement st = sqlConnection.createStatement();
-    st.execute(
-        "SELECT * FROM pg_create_logical_replication_slot('" + SLOT_NAME + "', 'test_decoding')");
-    st.close();
+
+    TestUtil.recreateLogicalReplicationSlot(sqlConnection, SLOT_NAME, "test_decoding");
   }
 
   @After
   public void tearDown() throws Exception {
     replConnection.close();
     TestUtil.dropTable(sqlConnection, "test_logic_table");
-
-    dropReplicationSlot();
+    TestUtil.dropReplicationSlot(sqlConnection, SLOT_NAME);
     sqlConnection.close();
-  }
-
-  private void dropReplicationSlot() throws SQLException {
-    try {
-      Statement dropStatement = sqlConnection.createStatement();
-      dropStatement.execute("select pg_drop_replication_slot('" + SLOT_NAME + "')");
-      dropStatement.close();
-    } catch (PSQLException e) {
-      //slot is active
-      if (PSQLState.OBJECT_IN_USE.equals(new PSQLState(e.getSQLState()))) {
-        Statement terminateStatement = sqlConnection.createStatement();
-        terminateStatement.execute(
-            "select pg_terminate_backend(active_pid) from pg_replication_slots "
-                + "where active = true and slot_name='" + SLOT_NAME + "'"
-        );
-        terminateStatement.close();
-        dropReplicationSlot();
-      } else {
-        throw e;
-      }
-    }
   }
 
   @Test(timeout = 1000)

--- a/pgjdbc/src/test/java/org/postgresql/replication/ReplicationSlotTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/replication/ReplicationSlotTest.java
@@ -206,11 +206,9 @@ public class ReplicationSlotTest {
     return result;
   }
 
-  private void dropReplicationSlot() throws SQLException {
+  private void dropReplicationSlot() throws SQLException, InterruptedException {
     if (slotName != null) {
-      Statement dropStatement = sqlConnection.createStatement();
-      dropStatement.execute("select pg_drop_replication_slot('" + slotName + "')");
-      dropStatement.close();
+      TestUtil.dropReplicationSlot(sqlConnection, slotName);
     }
   }
 

--- a/pgjdbc/src/test/java/org/postgresql/replication/ReplicationSlotTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/replication/ReplicationSlotTest.java
@@ -206,7 +206,7 @@ public class ReplicationSlotTest {
     return result;
   }
 
-  private void dropReplicationSlot() throws SQLException, InterruptedException {
+  private void dropReplicationSlot() throws Exception {
     if (slotName != null) {
       TestUtil.dropReplicationSlot(sqlConnection, slotName);
     }


### PR DESCRIPTION
Postgresql 9.4 doesn't have PID in pg_replication_slots view, so we can't terminate replication session. Instead of it, we wait until postgresql after `replicationConnection.close()` change replication slot status to not active.

```
testReplicationRestartFromLastFeedbackPosition(org.postgresql.replication.LogicalReplicationTest)  Time elapsed: 0.038 sec  <<< ERROR!
org.postgresql.util.PSQLException: ERROR: column "active_pid" does not exist
  Position: 29
	at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2480)
	at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2180)
	at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:294)
	at org.postgresql.jdbc.PgStatement.executeInternal(PgStatement.java:430)
	at org.postgresql.jdbc.PgStatement.execute(PgStatement.java:356)
	at org.postgresql.jdbc.PgStatement.executeWithFlags(PgStatement.java:303)
	at org.postgresql.jdbc.PgStatement.executeCachedSql(PgStatement.java:289)
	at org.postgresql.jdbc.PgStatement.executeWithFlags(PgStatement.java:266)
	at org.postgresql.jdbc.PgStatement.execute(PgStatement.java:262)
	at org.postgresql.replication.LogicalReplicationTest.dropReplicationSlot(LogicalReplicationTest.java:97)
	at org.postgresql.replication.LogicalReplicationTest.tearDown(LogicalReplicationTest.java:84)
```

Current solution it's WA on bug describe in
https://www.postgresql.org/message-id/CAFgjRd3hdYOa33m69TbeOfNNer2BZbwa8FFjt2V5VFzTBvUU3w%40mail.gmail.com