### PR TITLE
test: ignore tests that don't apply to Pg8.2 and Pg8.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,12 +60,6 @@ matrix:
         - COVERAGE=Y
         - NO_HSTORE=Y
         - CREATE_PLPGSQL=Y
-    - env: # this has to match the environment for 8.3 below
-        - PG_VERSION=8.3
-        - XA=true
-        - COVERAGE=Y
-        - NO_HSTORE=Y
-        - CREATE_PLPGSQL=Y
   include:
     - env:
         - FEDORA_CI=Y

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/CopyTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/CopyTest.java
@@ -327,6 +327,11 @@ public class CopyTest extends TestCase {
   }
 
   public void testLockReleaseOnCancelFailure() throws SQLException, InterruptedException {
+    if (!TestUtil.haveMinimumServerVersion(con, ServerVersion.v8_4)) {
+      // pg_backend_pid() requires PostgreSQL 8.4+
+      return;
+    }
+
     // This is a fairly complex test because it is testing a
     // deadlock that only occurs when the connection to postgres
     // is broken during a copy operation. We'll start a copy

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/optional/ConnectionPoolTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/optional/ConnectionPoolTest.java
@@ -10,10 +10,12 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import org.postgresql.PGConnection;
+import org.postgresql.core.ServerVersion;
 import org.postgresql.ds.PGConnectionPoolDataSource;
 import org.postgresql.jdbc2.optional.ConnectionPool;
 import org.postgresql.test.TestUtil;
 
+import org.junit.Assume;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
@@ -323,6 +325,10 @@ public class ConnectionPoolTest extends BaseDataSourceTest {
       PooledConnection pc = getPooledConnection();
       con = pc.getConnection();
       assertTrue(!con.isClosed());
+
+      Assume.assumeTrue("pg_terminate_backend requires PostgreSQL 8.4+",
+          TestUtil.haveMinimumServerVersion(con, ServerVersion.v8_4));
+
       int pid = ((PGConnection) con).getBackendPID();
 
       Connection adminCon = TestUtil.openPrivilegedDB();

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc3/StringTypeParameterTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc3/StringTypeParameterTest.java
@@ -31,7 +31,7 @@ public class StringTypeParameterTest extends TestCase {
       props.put("stringtype", stringType);
     }
     _conn = TestUtil.openDB(props);
-    if (TestUtil.haveMinimumServerVersion(_conn, ServerVersion.v8_3)) {
+    if (!TestUtil.haveMinimumServerVersion(_conn, ServerVersion.v8_3)) {
       return false;
     }
     TestUtil.createEnumType(_conn, "mood", "'happy', 'sad'");

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc4/ArrayTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc4/ArrayTest.java
@@ -327,6 +327,9 @@ public class ArrayTest extends BaseTest4 {
 
   @Test
   public void testGetArrayOfComposites() throws SQLException {
+    Assume.assumeTrue("array_agg(expression) requires PostgreSQL 8.4+",
+        TestUtil.haveMinimumServerVersion(_conn, ServerVersion.v8_4));
+
     PreparedStatement insert_parent_pstmt =
         _conn.prepareStatement("INSERT INTO arrcompprnttest (name) "
             + "VALUES ('aParent');");
@@ -392,6 +395,9 @@ public class ArrayTest extends BaseTest4 {
 
   @Test
   public void testCasingComposite() throws SQLException {
+    Assume.assumeTrue("Arrays of composite types requires PostgreSQL 8.3+",
+        TestUtil.haveMinimumServerVersion(_conn, ServerVersion.v8_3));
+
     PGobject cc = new PGobject();
     cc.setType("\"CorrectCasing\"");
     cc.setValue("(1)");
@@ -439,6 +445,9 @@ public class ArrayTest extends BaseTest4 {
 
   @Test
   public void testEvilCasing() throws SQLException {
+    Assume.assumeTrue("Arrays of composite types requires PostgreSQL 8.3+",
+        TestUtil.haveMinimumServerVersion(_conn, ServerVersion.v8_3));
+
     PGobject cc = new PGobject();
     cc.setType("\"Evil.Table\"");
     cc.setValue("(1)");


### PR DESCRIPTION
Some tests requiere features not available in PostgreSQL 8.2 and PostgreSQL 8.3, this PR ignore the test that won't work on it.