### PR TITLE
Postgres Driver Issue when using Java 1.7 and TLS 1.2 (#702 - Option #2)

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/ssl/MakeSSL.java
+++ b/pgjdbc/src/main/java/org/postgresql/ssl/MakeSSL.java
@@ -23,6 +23,14 @@ import javax.net.ssl.SSLSocketFactory;
 
 public class MakeSSL extends ObjectFactory {
 
+  public static String getSSLContextProtocol(String defaultProtocol) {
+	  String protocol = System.getProperty("pg.jdbc.sslContext.protocol");
+	  if (protocol != null) {
+		  return protocol;
+	  }
+	  return defaultProtocol;
+  }
+  
   public static void convert(PGStream stream, Properties info, Logger logger)
       throws PSQLException, IOException {
     logger.debug("converting regular socket connection to ssl");

--- a/pgjdbc/src/main/java/org/postgresql/ssl/jdbc4/LibPQFactory.java
+++ b/pgjdbc/src/main/java/org/postgresql/ssl/jdbc4/LibPQFactory.java
@@ -59,7 +59,7 @@ public class LibPQFactory extends WrappedFactory implements HostnameVerifier {
   public LibPQFactory(Properties info) throws PSQLException {
     try {
       sslmode = PGProperty.SSL_MODE.get(info);
-      SSLContext ctx = SSLContext.getInstance("TLS"); // or "SSL" ?
+      SSLContext ctx = SSLContext.getInstance(MakeSSL.getSSLContextProtocol("TLS")); // or "SSL" ?
 
       // Determinig the default file location
       String pathsep = System.getProperty("file.separator");


### PR DESCRIPTION
This is a less invasive change request than my previous pull. It allows the SSL protocol to be specified using a Java environment variable. This change only affects the one default SSL Factory and does not attempt to modify the others which makes this change less invasive.