### PR TITLE
feat: implement `setCharacterStream(int, Reader, long)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Notable changes since version 42.0.0, read the complete [History of Changes](htt
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
+### Added
+* feat: implement `PreparedStatement.setCharacterStream(int, Reader, long)`, which threw `SQLFeatureNotSupportedException`. It behaves like the `int` overload: the driver reads at most `length` characters from the `Reader` into memory and binds them as a string, and a `length` above 2147483647 fails with `Object is too large to send over the protocol.` [PR #706](https://github.com/pgjdbc/pgjdbc/pull/706)
+
 ### Fixed
 * fix: `PGStream.skip` no longer loops forever when the connection ends while the driver is discarding bytes, and no longer mistakes a stream that skips nothing for one that has ended. `InputStream.skip` may return zero with more data still coming, which a stream supplied through the `socketFactory` property is free to do; the driver now reads a byte in that case and treats only `-1` as the end [PR #4358](https://github.com/pgjdbc/pgjdbc/pull/4358)
 * fix: `LargeObjectManager` operations now work inside an active XA transaction. Since 42.7.13 an XA branch keeps the caller's `autoCommit=true`, and the guard rejected large objects as if the connection were idle. It now checks the server transaction state (`getTransactionState()`) instead of `autoCommit`, so a genuine auto-commit connection with no open transaction is still refused [Issue #4309](https://github.com/pgjdbc/pgjdbc/issues/4309) [PR #4310](https://github.com/pgjdbc/pgjdbc/pull/4310)

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
@@ -1324,14 +1324,24 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
   @Override
   public void setCharacterStream(@Positive int i, @Nullable Reader x,
       @NonNegative int length) throws SQLException {
+    setCharacterStream(i, x, (long) length);
+  }
+
+  @Override
+  public void setCharacterStream(@Positive int parameterIndex, @Nullable Reader value,
+      @NonNegative @IntRange(from = 0, to = Integer.MAX_VALUE) long length) throws SQLException {
     checkClosed();
 
-    if (x == null) {
-      setNull(i, Types.VARCHAR);
+    if (value == null) {
+      setNull(parameterIndex, Types.VARCHAR);
       return;
     }
 
-    if (length < 0) {
+    //noinspection ConstantConditions
+    if (length > Integer.MAX_VALUE) {
+      throw new PSQLException(GT.tr("Object is too large to send over the protocol."),
+          PSQLState.NUMERIC_CONSTANT_OUT_OF_RANGE);
+    } else if (length < 0) {
       throw new PSQLException(GT.tr("Invalid stream length {0}.", length),
           PSQLState.INVALID_PARAMETER_VALUE);
     }
@@ -1342,7 +1352,7 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
     // long varchar datatype, but with toast all the text datatypes are capable of
     // handling very large values. Thus the implementation ends up calling
     // setString() since there is no current way to stream the value to the server
-    setString(i, readerToString(x, length));
+    setString(parameterIndex, readerToString(value, (int) length));
   }
 
   @Override
@@ -1607,14 +1617,8 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
 
   @Override
   public void setCharacterStream(@Positive int parameterIndex,
-      @Nullable Reader value, @NonNegative long length)
-      throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "setCharacterStream(int, Reader, long)");
-  }
-
-  @Override
-  public void setCharacterStream(@Positive int parameterIndex,
       @Nullable Reader value) throws SQLException {
+    checkClosed();
     if (connection.getPreferQueryMode() == PreferQueryMode.SIMPLE) {
       String s = value != null ? readerToString(value, Integer.MAX_VALUE) : null;
       setString(parameterIndex, s);

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
@@ -1325,14 +1325,14 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
   }
 
   @Override
-  public void setCharacterStream(@Positive int i, @Nullable Reader x,
+  public void setCharacterStream(@Positive int parameterIndex, @Nullable Reader value,
       @NonNegative int length) throws SQLException {
-    setCharacterStream(i, x, (long) length);
+    setCharacterStream(parameterIndex, value, (long) length);
   }
 
   @Override
   public void setCharacterStream(@Positive int parameterIndex, @Nullable Reader value,
-      @NonNegative @IntRange(from = 0, to = Integer.MAX_VALUE) long length) throws SQLException {
+      @NonNegative long length) throws SQLException {
     checkClosed();
 
     if (value == null) {
@@ -1340,21 +1340,17 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
       return;
     }
 
-    //noinspection ConstantConditions
     if (length > Integer.MAX_VALUE) {
       throw new PSQLException(GT.tr("Object is too large to send over the protocol."),
           PSQLState.NUMERIC_CONSTANT_OUT_OF_RANGE);
     } else if (length < 0) {
-      throw new PSQLException(GT.tr("Invalid stream length {0}.", length),
+      throw new PSQLException(GT.tr("Invalid stream length {0}.", Long.toString(length)),
           PSQLState.INVALID_PARAMETER_VALUE);
     }
 
-    // Version 7.2 supports CharacterStream for the PG text types
-    // As the spec/javadoc for this method indicate this is to be used for
-    // large text values (i.e. LONGVARCHAR) PG doesn't have a separate
-    // long varchar datatype, but with toast all the text datatypes are capable of
-    // handling very large values. Thus the implementation ends up calling
-    // setString() since there is no current way to stream the value to the server
+    // Bind through setString, as the int overload always has, so the parameter type follows the
+    // stringtype connection property. Outside simple query mode, setCharacterStream(int, Reader)
+    // streams the value instead and binds it as text.
     setString(parameterIndex, readerToString(value, (int) length));
   }
 

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
@@ -1327,14 +1327,24 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
   @Override
   public void setCharacterStream(@Positive int i, @Nullable Reader x,
       @NonNegative int length) throws SQLException {
+    setCharacterStream(i, x, (long) length);
+  }
+
+  @Override
+  public void setCharacterStream(@Positive int parameterIndex, @Nullable Reader value,
+      @NonNegative @IntRange(from = 0, to = Integer.MAX_VALUE) long length) throws SQLException {
     checkClosed();
 
-    if (x == null) {
-      setNull(i, Types.VARCHAR);
+    if (value == null) {
+      setNull(parameterIndex, Types.VARCHAR);
       return;
     }
 
-    if (length < 0) {
+    //noinspection ConstantConditions
+    if (length > Integer.MAX_VALUE) {
+      throw new PSQLException(GT.tr("Object is too large to send over the protocol."),
+          PSQLState.NUMERIC_CONSTANT_OUT_OF_RANGE);
+    } else if (length < 0) {
       throw new PSQLException(GT.tr("Invalid stream length {0}.", length),
           PSQLState.INVALID_PARAMETER_VALUE);
     }
@@ -1345,7 +1355,7 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
     // long varchar datatype, but with toast all the text datatypes are capable of
     // handling very large values. Thus the implementation ends up calling
     // setString() since there is no current way to stream the value to the server
-    setString(i, readerToString(x, length));
+    setString(parameterIndex, readerToString(value, (int) length));
   }
 
   @Override
@@ -1610,14 +1620,8 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
 
   @Override
   public void setCharacterStream(@Positive int parameterIndex,
-      @Nullable Reader value, @NonNegative long length)
-      throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "setCharacterStream(int, Reader, long)");
-  }
-
-  @Override
-  public void setCharacterStream(@Positive int parameterIndex,
       @Nullable Reader value) throws SQLException {
+    checkClosed();
     if (connection.getPreferQueryMode() == PreferQueryMode.SIMPLE) {
       String s = value != null ? readerToString(value, Integer.MAX_VALUE) : null;
       setString(parameterIndex, s);

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc4/CharacterStreamTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc4/CharacterStreamTest.java
@@ -6,7 +6,6 @@
 package org.postgresql.test.jdbc4;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import org.postgresql.test.TestUtil;
 import org.postgresql.test.jdbc2.BaseTest4;
@@ -16,7 +15,6 @@ import org.junit.jupiter.api.Test;
 import java.io.Reader;
 import java.io.StringReader;
 import java.sql.PreparedStatement;
-import java.sql.SQLFeatureNotSupportedException;
 
 public class CharacterStreamTest extends BaseTest4 {
 
@@ -54,11 +52,7 @@ public class CharacterStreamTest extends BaseTest4 {
     try {
       Reader reader = data != null ? new StringReader(data) : null;
       long length = data != null ? data.length() : 0;
-      try {
-        insertPS.setCharacterStream(1, reader, length);
-      } catch (SQLFeatureNotSupportedException e) {
-        assumeTrue(false, "PreparedStatement.setCharacterStream(int, Reader, long) is not implemented");
-      }
+      insertPS.setCharacterStream(1, reader, length);
       insertPS.executeUpdate();
     } finally {
       TestUtil.closeQuietly(insertPS);

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc4/CharacterStreamTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc4/CharacterStreamTest.java
@@ -5,18 +5,46 @@
 
 package org.postgresql.test.jdbc4;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.params.provider.Arguments.argumentSet;
 
+import org.postgresql.jdbc.PreferQueryMode;
 import org.postgresql.test.TestUtil;
 import org.postgresql.test.jdbc2.BaseTest4;
+import org.postgresql.util.PSQLState;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
+import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
 import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.stream.Stream;
 
+@ParameterizedClass
+@MethodSource("data")
 public class CharacterStreamTest extends BaseTest4 {
+
+  public CharacterStreamTest(PreferQueryMode preferQueryMode) {
+    setPreferQueryMode(preferQueryMode);
+  }
+
+  // setCharacterStream(int, Reader) takes a separate path in simple query mode
+  public static Iterable<Object[]> data() {
+    return Arrays.asList(
+        new Object[]{PreferQueryMode.EXTENDED},
+        new Object[]{PreferQueryMode.SIMPLE});
+  }
 
   private static final String TEST_TABLE_NAME = "charstream";
   private static final String TEST_COLUMN_NAME = "cs";
@@ -218,5 +246,146 @@ public class CharacterStreamTest extends BaseTest4 {
     String data = getTestData(200 * 1024);
     insertStreamUnknownLength(data);
     validateContent(data);
+  }
+
+  private void insertWithLongLength(String data, long length) throws SQLException {
+    try (PreparedStatement ps = con.prepareStatement(_insert)) {
+      ps.setCharacterStream(1, new StringReader(data), length);
+      ps.executeUpdate();
+    }
+  }
+
+  @Test
+  public void longLengthShorterThanTheReaderBindsTheFirstLengthChars() throws Exception {
+    insertWithLongLength("abcdef", 3L);
+    validateContent("abc");
+  }
+
+  @Test
+  public void longLengthLongerThanTheReaderBindsTheWholeReader() throws Exception {
+    insertWithLongLength("abc", 10L);
+    validateContent("abc");
+  }
+
+  @Test
+  public void longLengthZeroBindsAnEmptyString() throws Exception {
+    insertWithLongLength("abc", 0L);
+    validateContent("");
+  }
+
+  @Test
+  public void longLengthIntegerMaxValueIsAccepted() throws Exception {
+    insertWithLongLength("abc", Integer.MAX_VALUE);
+    validateContent("abc");
+  }
+
+  // U+1F600 is two chars in UTF-16, and length counts chars, not code points
+  @Test
+  public void longLengthCountsUtf16Chars() throws Exception {
+    insertWithLongLength("😀xyz", 3L);
+    validateContent("😀x");
+  }
+
+  @ParameterizedTest
+  @ValueSource(longs = {Integer.MAX_VALUE + 1L, Long.MAX_VALUE})
+  public void longLengthAboveIntegerMaxValueIsRejected(long length) throws SQLException {
+    try (PreparedStatement ps = con.prepareStatement(_insert)) {
+      SQLException e = assertThrows(SQLException.class,
+          () -> ps.setCharacterStream(1, new StringReader("abc"), length));
+      assertEquals(PSQLState.NUMERIC_CONSTANT_OUT_OF_RANGE.getState(), e.getSQLState(),
+          () -> "setCharacterStream(1, reader, " + length + "L)");
+    }
+  }
+
+  // (int) Long.MIN_VALUE is 0, so a sign check made after the narrowing cast would accept it, and
+  // MessageFormat would print its digits grouped
+  @ParameterizedTest
+  @ValueSource(longs = {-1L, Long.MIN_VALUE})
+  public void negativeLongLengthIsRejectedAndReportedWithUngroupedDigits(long length)
+      throws SQLException {
+    try (PreparedStatement ps = con.prepareStatement(_insert)) {
+      SQLException e = assertThrows(SQLException.class,
+          () -> ps.setCharacterStream(1, new StringReader("abc"), length));
+      String call = "setCharacterStream(1, reader, " + length + "L)";
+      String digits = Long.toString(length);
+      String message = String.valueOf(e.getMessage());
+      assertAll(
+          () -> assertEquals(PSQLState.INVALID_PARAMETER_VALUE.getState(), e.getSQLState(),
+              call + ", SQLState"),
+          () -> assertTrue(message.contains(digits),
+              () -> call + ", message: expected to contain <" + digits + "> but was <" + message
+                  + ">"));
+    }
+  }
+
+  @Test
+  public void intLengthShorterThanTheReaderBindsTheFirstLengthChars() throws Exception {
+    try (PreparedStatement ps = con.prepareStatement(_insert)) {
+      ps.setCharacterStream(1, new StringReader("abcdef"), 3);
+      ps.executeUpdate();
+    }
+    validateContent("abc");
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {-1, Integer.MIN_VALUE})
+  public void negativeIntLengthIsRejected(int length) throws SQLException {
+    try (PreparedStatement ps = con.prepareStatement(_insert)) {
+      SQLException e = assertThrows(SQLException.class,
+          () -> ps.setCharacterStream(1, new StringReader("abc"), length));
+      assertEquals(PSQLState.INVALID_PARAMETER_VALUE.getState(), e.getSQLState(),
+          () -> "setCharacterStream(1, reader, " + length + ")");
+    }
+  }
+
+  interface CharacterStreamSetter {
+    void set(PreparedStatement ps, Reader reader) throws SQLException;
+  }
+
+  static Stream<Arguments> characterStreamSetters() {
+    return Stream.of(
+        argumentSet("setCharacterStream(int, Reader, long)",
+            (CharacterStreamSetter) (ps, reader) -> ps.setCharacterStream(1, reader, 3L)),
+        argumentSet("setCharacterStream(int, Reader, int)",
+            (CharacterStreamSetter) (ps, reader) -> ps.setCharacterStream(1, reader, 3)),
+        argumentSet("setCharacterStream(int, Reader)",
+            (CharacterStreamSetter) (ps, reader) -> ps.setCharacterStream(1, reader)));
+  }
+
+  /**
+   * Counts the calls to {@code read}, so a test can check that the driver never read from it.
+   */
+  private static final class ReadCountingReader extends StringReader {
+    int reads;
+
+    ReadCountingReader(String s) {
+      super(s);
+    }
+
+    @Override
+    public int read() throws IOException {
+      reads++;
+      return super.read();
+    }
+
+    @Override
+    public int read(char[] cbuf, int off, int len) throws IOException {
+      reads++;
+      return super.read(cbuf, off, len);
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("characterStreamSetters")
+  public void closedStatementIsRejectedBeforeTheReaderIsRead(CharacterStreamSetter setter)
+      throws SQLException {
+    PreparedStatement ps = con.prepareStatement(_insert);
+    ps.close();
+    ReadCountingReader reader = new ReadCountingReader("abc");
+    SQLException e = assertThrows(SQLException.class, () -> setter.set(ps, reader));
+    assertAll(
+        () -> assertEquals(PSQLState.OBJECT_NOT_IN_STATE.getState(), e.getSQLState(),
+            "SQLState"),
+        () -> assertEquals(0, reader.reads, "calls to Reader.read"));
   }
 }


### PR DESCRIPTION
## Why

`PreparedStatement.setCharacterStream(int, Reader, long)` threw `SQLFeatureNotSupportedException` with `Method org.postgresql.jdbc.PgPreparedStatement.setCharacterStream(int, Reader, long) is not yet implemented.` (SQLState 0A000), while the `int` overload works. The `PreparedStatement` javadoc lists no `SQLFeatureNotSupportedException` for this method, so the driver broke its contract.

## What

The `long` overload does what the `int` overload did, and the `int` overload now delegates to it: the driver reads at most `length` characters from the `Reader` into a `String` and binds it with `setString`, so the parameter type follows the `stringtype` connection property.

- A `length` above 2147483647 is refused with `Object is too large to send over the protocol.` (SQLState 42820), the same check `setBinaryStream(int, InputStream, long)` makes. The limit comes from the Java `String` the driver builds and counts characters. The limit a user reaches first is the server's: PostgreSQL accepts a Bind message of at most 1 GB, so a larger value fails when the statement executes.
- A negative `length` is refused with `Invalid stream length {0}.` (SQLState 22023), as before. Both overloads now print the length without digit grouping, so `Long.MIN_VALUE` appears as `-9223372036854775808` rather than `-9,223,372,036,854,775,808`.
- `setCharacterStream(int, Reader)` now checks for a closed statement first. In simple query mode it used to read the whole `Reader` before it threw.

The overload does not reuse the streaming path that `setCharacterStream(int, Reader)` takes outside simple query mode. That path binds `text`, so callers of the `int` overload would get a different parameter type: with `stringtype=unspecified`, an insert into an `integer` column works through `setString` and fails with SQLState 42804 through the streaming path.

Carried over unchanged from the `int` overload: the whole value is held in memory, a `Reader` longer than `length` is truncated, and a shorter one is bound as it is.

## Verification

`CharacterStreamTest` now runs in extended and simple query mode. New tests cover a length shorter and longer than the `Reader`, zero, `Integer.MAX_VALUE`, lengths above it and below zero, UTF-16 counting, the `int` overload after delegation, and a closed statement for all three overloads. On master, the closed-statement case for `setCharacterStream(int, Reader)` fails only in simple query mode, which is the one mode where the `Reader` was read before the exception.

## Scope

The first commit is @bd-infor's original change, rebased onto master. The second adds the tests, the comment and annotation fixes, and the CHANGELOG entry.

Left out of this change:

- `setAsciiStream(int, InputStream, long)` still throws `SQLFeatureNotSupportedException`, although its javadoc has no such clause either. The `setNCharacterStream` overloads still throw too, which JDBC allows.
- `setBinaryStream(int, InputStream)` has no `checkClosed()`, so a closed statement accepts the value.
- `setBinaryStream(int, InputStream, long)`, `setBlob(int, InputStream, long)`, and the `setAsciiStream` and `setUnicodeStream` path still print the length in `Invalid stream length {0}.` with digit grouping.
- SQLState 42820 for `Object is too large to send over the protocol.` is not a PostgreSQL code. `setBinaryStream` uses it too, so the two should change together.
