### PR TITLE
refactor: use standardcharset for encoding

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/Utils.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/Utils.java
@@ -9,9 +9,9 @@ package org.postgresql.core;
 import org.postgresql.util.GT;
 import org.postgresql.util.PSQLException;
 import org.postgresql.util.PSQLState;
+import org.postgresql.util.StandardCharsets;
 
 import java.io.IOException;
-import java.nio.charset.Charset;
 import java.sql.SQLException;
 
 /**
@@ -34,12 +34,6 @@ public class Utils {
   }
 
   /**
-   * Keep a local copy of the UTF-8 Charset so we can avoid synchronization overhead from looking up
-   * the Charset by name as String.getBytes(String) requires.
-   */
-  private final static Charset utf8Charset = Charset.forName("UTF-8");
-
-  /**
    * Encode a string as UTF-8.
    *
    * @param str the string to encode
@@ -50,7 +44,7 @@ public class Utils {
     // for performance measurements.
     // In OracleJDK 6u65, 7u55, and 8u40 String.getBytes(Charset) is
     // 3 times faster than other JDK approaches.
-    return str.getBytes(utf8Charset);
+    return str.getBytes(StandardCharsets.UTF_8);
   }
 
   /**
@@ -194,4 +188,5 @@ public class Utils {
   public static int parseServerVersionStr(String serverVersion) throws NumberFormatException {
     return ServerVersion.parseServerVersionStr(serverVersion);
   }
+
 }

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java
@@ -28,6 +28,7 @@ import org.postgresql.util.MD5Digest;
 import org.postgresql.util.PSQLException;
 import org.postgresql.util.PSQLState;
 import org.postgresql.util.ServerErrorMessage;
+import org.postgresql.util.StandardCharsets;
 import org.postgresql.util.UnixCrypt;
 
 import java.io.IOException;
@@ -393,8 +394,8 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
     int length = 4 + 4;
     byte[][] encodedParams = new byte[params.size() * 2][];
     for (int i = 0; i < params.size(); ++i) {
-      encodedParams[i * 2] = params.get(i)[0].getBytes("UTF-8");
-      encodedParams[i * 2 + 1] = params.get(i)[1].getBytes("UTF-8");
+      encodedParams[i * 2] = params.get(i)[0].getBytes(StandardCharsets.UTF_8);
+      encodedParams[i * 2 + 1] = params.get(i)[1].getBytes(StandardCharsets.UTF_8);
       length += encodedParams[i * 2].length + 1 + encodedParams[i * 2 + 1].length + 1;
     }
 
@@ -464,7 +465,7 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
 
                 if (logger.logDebug()) {
                   logger.debug(
-                      " <=BE AuthenticationReqCrypt(salt='" + new String(salt, "US-ASCII") + "')");
+                      " <=BE AuthenticationReqCrypt(salt='" + new String(salt, StandardCharsets.US_ASCII) + "')");
                 }
 
                 if (password == null) {
@@ -474,11 +475,11 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
                       PSQLState.CONNECTION_REJECTED);
                 }
 
-                byte[] encodedResult = UnixCrypt.crypt(salt, password.getBytes("UTF-8"));
+                byte[] encodedResult = UnixCrypt.crypt(salt, password.getBytes(StandardCharsets.UTF_8));
 
                 if (logger.logDebug()) {
                   logger.debug(
-                      " FE=> Password(crypt='" + new String(encodedResult, "US-ASCII") + "')");
+                      " FE=> Password(crypt='" + new String(encodedResult, StandardCharsets.US_ASCII) + "')");
                 }
 
                 pgStream.sendChar('p');
@@ -505,10 +506,10 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
                 }
 
                 byte[] digest =
-                    MD5Digest.encode(user.getBytes("UTF-8"), password.getBytes("UTF-8"), md5Salt);
+                    MD5Digest.encode(user.getBytes(StandardCharsets.UTF_8), password.getBytes(StandardCharsets.UTF_8), md5Salt);
 
                 if (logger.logDebug()) {
-                  logger.debug(" FE=> Password(md5digest=" + new String(digest, "US-ASCII") + ")");
+                  logger.debug(" FE=> Password(md5digest=" + new String(digest, StandardCharsets.US_ASCII) + ")");
                 }
 
                 pgStream.sendChar('p');
@@ -533,7 +534,7 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
                       PSQLState.CONNECTION_REJECTED);
                 }
 
-                byte[] encodedPassword = password.getBytes("UTF-8");
+                byte[] encodedPassword = password.getBytes(StandardCharsets.UTF_8);
 
                 pgStream.sendChar('p');
                 pgStream.sendInteger4(4 + encodedPassword.length + 1);

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
@@ -26,6 +26,7 @@ import org.postgresql.util.PGobject;
 import org.postgresql.util.PSQLException;
 import org.postgresql.util.PSQLState;
 import org.postgresql.util.ReaderInputStream;
+import org.postgresql.util.StandardCharsets;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -33,7 +34,6 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Reader;
-import java.io.UnsupportedEncodingException;
 import java.io.Writer;
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -402,8 +402,8 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
     setTimestamp(parameterIndex, x, null);
   }
 
-  private void setCharacterStreamPost71(int parameterIndex, InputStream x, int length,
-      String encoding) throws SQLException {
+  private void setCharacterStream(int parameterIndex, InputStream x, int length,
+      Charset encoding) throws SQLException {
 
     if (x == null) {
       setNull(parameterIndex, Types.VARCHAR);
@@ -438,9 +438,6 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
       }
 
       setString(parameterIndex, new String(l_chars, 0, l_charsRead), Oid.VARCHAR);
-    } catch (UnsupportedEncodingException l_uee) {
-      throw new PSQLException(GT.tr("The JVM claims not to support the {0} encoding.", encoding),
-          PSQLState.UNEXPECTED_ERROR, l_uee);
     } catch (IOException l_ioe) {
       throw new PSQLException(GT.tr("Provided InputStream failed."), PSQLState.UNEXPECTED_ERROR,
           l_ioe);
@@ -449,13 +446,12 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
 
   public void setAsciiStream(int parameterIndex, InputStream x, int length) throws SQLException {
     checkClosed();
-    setCharacterStreamPost71(parameterIndex, x, length, "ASCII");
+    setCharacterStream(parameterIndex, x, length, StandardCharsets.US_ASCII);
   }
 
   public void setUnicodeStream(int parameterIndex, InputStream x, int length) throws SQLException {
     checkClosed();
-
-    setCharacterStreamPost71(parameterIndex, x, length, "UTF-8");
+    setCharacterStream(parameterIndex, x, length, StandardCharsets.UTF_8);
   }
 
   public void setBinaryStream(int parameterIndex, InputStream x, int length) throws SQLException {

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
@@ -24,6 +24,7 @@ import org.postgresql.util.PGobject;
 import org.postgresql.util.PGtokenizer;
 import org.postgresql.util.PSQLException;
 import org.postgresql.util.PSQLState;
+import org.postgresql.util.StandardCharsets;
 
 import java.io.ByteArrayInputStream;
 import java.io.CharArrayReader;
@@ -31,7 +32,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
-import java.io.UnsupportedEncodingException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.InetAddress;
@@ -1066,7 +1066,7 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
     }
 
     try {
-      InputStreamReader reader = new InputStreamReader(x, "ASCII");
+      InputStreamReader reader = new InputStreamReader(x, StandardCharsets.US_ASCII);
       char data[] = new char[length];
       int numRead = 0;
       while (true) {
@@ -1082,9 +1082,6 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
         }
       }
       updateString(columnIndex, new String(data, 0, numRead));
-    } catch (UnsupportedEncodingException uee) {
-      throw new PSQLException(GT.tr("The JVM claims not to support the encoding: {0}", "ASCII"),
-          PSQLState.UNEXPECTED_ERROR, uee);
     } catch (IOException ie) {
       throw new PSQLException(GT.tr("Provided InputStream failed."), null, ie);
     }
@@ -1714,14 +1711,8 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
             if (isBinary(columnIndex + 1)) {
               rowBuffer[columnIndex] = (byte[]) valueObject;
             } else {
-              try {
-                rowBuffer[columnIndex] =
-                    PGbytea.toPGString((byte[]) valueObject).getBytes("ISO-8859-1");
-              } catch (UnsupportedEncodingException e) {
-                throw new PSQLException(
-                    GT.tr("The JVM claims not to support the encoding: {0}", "ISO-8859-1"),
-                    PSQLState.UNEXPECTED_ERROR, e);
-              }
+              rowBuffer[columnIndex] =
+                  PGbytea.toPGString((byte[]) valueObject).getBytes(StandardCharsets.ISO_8859_1);
             }
             break;
 
@@ -2364,12 +2355,7 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
     // long string datatype, but with toast the text datatype is capable of
     // handling very large values. Thus the implementation ends up calling
     // getString() since there is no current way to stream the value from the server
-    try {
-      return new ByteArrayInputStream(getString(columnIndex).getBytes("ASCII"));
-    } catch (UnsupportedEncodingException l_uee) {
-      throw new PSQLException(GT.tr("The JVM claims not to support the encoding: {0}", "ASCII"),
-          PSQLState.UNEXPECTED_ERROR, l_uee);
-    }
+    return new ByteArrayInputStream(getString(columnIndex).getBytes(StandardCharsets.US_ASCII));
   }
 
   public InputStream getUnicodeStream(int columnIndex) throws SQLException {
@@ -2384,12 +2370,7 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
     // long string datatype, but with toast the text datatype is capable of
     // handling very large values. Thus the implementation ends up calling
     // getString() since there is no current way to stream the value from the server
-    try {
-      return new ByteArrayInputStream(getString(columnIndex).getBytes("UTF-8"));
-    } catch (UnsupportedEncodingException l_uee) {
-      throw new PSQLException(GT.tr("The JVM claims not to support the encoding: {0}", "UTF-8"),
-          PSQLState.UNEXPECTED_ERROR, l_uee);
-    }
+    return new ByteArrayInputStream(getString(columnIndex).getBytes(StandardCharsets.UTF_8));
   }
 
   public InputStream getBinaryStream(int columnIndex) throws SQLException {

--- a/pgjdbc/src/main/java/org/postgresql/ssl/SingleCertValidatingFactory.java
+++ b/pgjdbc/src/main/java/org/postgresql/ssl/SingleCertValidatingFactory.java
@@ -6,6 +6,7 @@
 package org.postgresql.ssl;
 
 import org.postgresql.util.GT;
+import org.postgresql.util.StandardCharsets;
 
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
@@ -179,7 +180,7 @@ public class SingleCertValidatingFactory extends WrappedFactory {
           throw new GeneralSecurityException(GT.tr(
               "The environment variable containing the server's SSL certificate must not be empty."));
         }
-        in = new ByteArrayInputStream(cert.getBytes("UTF-8"));
+        in = new ByteArrayInputStream(cert.getBytes(StandardCharsets.UTF_8));
       } else if (sslFactoryArg.startsWith(SYS_PROP_PREFIX)) {
         String name = sslFactoryArg.substring(SYS_PROP_PREFIX.length());
         String cert = System.getProperty(name);
@@ -187,9 +188,9 @@ public class SingleCertValidatingFactory extends WrappedFactory {
           throw new GeneralSecurityException(GT.tr(
               "The system property containing the server's SSL certificate must not be empty."));
         }
-        in = new ByteArrayInputStream(cert.getBytes("UTF-8"));
+        in = new ByteArrayInputStream(cert.getBytes(StandardCharsets.UTF_8));
       } else if (sslFactoryArg.startsWith("-----BEGIN CERTIFICATE-----")) {
-        in = new ByteArrayInputStream(sslFactoryArg.getBytes("UTF-8"));
+        in = new ByteArrayInputStream(sslFactoryArg.getBytes(StandardCharsets.UTF_8));
       } else {
         throw new GeneralSecurityException(GT.tr(
             "The sslfactoryarg property must start with the prefix file:, classpath:, env:, sys:, or -----BEGIN CERTIFICATE-----."));

--- a/pgjdbc/src/main/java/org/postgresql/util/ReaderInputStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/ReaderInputStream.java
@@ -11,7 +11,6 @@ import java.io.Reader;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.CharacterCodingException;
-import java.nio.charset.Charset;
 import java.nio.charset.CharsetEncoder;
 import java.nio.charset.CoderResult;
 
@@ -24,8 +23,6 @@ import java.nio.charset.CoderResult;
  */
 public class ReaderInputStream extends InputStream {
   private static final int DEFAULT_CHAR_BUFFER_SIZE = 8 * 1024;
-
-  private static final Charset UTF_8 = Charset.forName("UTF-8");
 
   private final Reader reader;
   private final CharsetEncoder encoder;
@@ -60,7 +57,7 @@ public class ReaderInputStream extends InputStream {
     }
 
     this.reader = reader;
-    this.encoder = UTF_8.newEncoder();
+    this.encoder = StandardCharsets.UTF_8.newEncoder();
     // encoder.maxBytesPerChar() always returns 3.0 for UTF-8
     this.bbuf = ByteBuffer.allocate(3 * charBufferSize);
     this.bbuf.flip(); // prepare for subsequent write

--- a/pgjdbc/src/main/java/org/postgresql/util/StandardCharsets.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/StandardCharsets.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2016, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.util;
+
+import java.nio.charset.Charset;
+
+/**
+ * Constant definitions for the standard {@link java.nio.charset.Charset Charsets}. These
+ * charsets are guaranteed to be available on every implementation of the Java platform.
+ * <p>
+ * For use until the driver drop support for Java 6. With Java 7 and up
+ * simply replace this with {@link java.nio.charset.StandardCharsets}
+ */
+public final class StandardCharsets {
+
+  private StandardCharsets() {
+  }
+
+  /**
+   * Seven-bit ASCII, a.k.a. ISO646-US, a.k.a. the Basic Latin block of the
+   * Unicode character set
+   */
+  public static final Charset US_ASCII = Charset.forName("US-ASCII");
+
+  /**
+   * ISO Latin Alphabet No. 1, a.k.a. ISO-LATIN-1
+   */
+  public static final Charset ISO_8859_1 = Charset.forName("ISO-8859-1");
+
+  /**
+   * Eight-bit UCS Transformation Format
+   */
+  public static final Charset UTF_8 = Charset.forName("UTF-8");
+
+  /**
+   * Sixteen-bit UCS Transformation Format, big-endian byte order
+   */
+  public static final Charset UTF_16BE = Charset.forName("UTF-16BE");
+
+  /**
+   * Sixteen-bit UCS Transformation Format, little-endian byte order
+   */
+  public static final Charset UTF_16LE = Charset.forName("UTF-16LE");
+
+  /**
+   * Sixteen-bit UCS Transformation Format, byte order identified by an
+   * optional byte-order mark
+   */
+  public static final Charset UTF_16 = Charset.forName("UTF-16");
+}

--- a/ubenchmark/pom.xml
+++ b/ubenchmark/pom.xml
@@ -42,10 +42,6 @@ POSSIBILITY OF SUCH DAMAGE.
   <description>PostgreSQL JDBC Driver - benchmarks</description>
   <url>https://github.com/pgjdbc/pgjdbc</url>
 
-  <prerequisites>
-    <maven>3.0</maven>
-  </prerequisites>
-
   <dependencies>
     <dependency>
       <groupId>org.openjdk.jmh</groupId>
@@ -67,7 +63,7 @@ POSSIBILITY OF SUCH DAMAGE.
   </dependencies>
 
   <properties>
-    <jmh.version>1.12</jmh.version>
+    <jmh.version>1.17.3</jmh.version>
     <uberjar.name>benchmarks</uberjar.name>
     <current.jdk>1.8</current.jdk>
     <javac.target>${current.jdk}</javac.target>

--- a/ubenchmark/src/main/java/org/postgresql/benchmark/encoding/UTF8Encoding.java
+++ b/ubenchmark/src/main/java/org/postgresql/benchmark/encoding/UTF8Encoding.java
@@ -56,7 +56,9 @@ public class UTF8Encoding {
   public void setup() {
     StringBuilder sb = new StringBuilder();
     for (int i = 0; i < length; i++) {
-      sb.append("Hello мир,");
+      sb.append("Привет мир, ");
+      sb.append("こんにちは世界, ");
+      sb.append("Hola mundo, ");
     }
     source = sb.toString();
     encoder = UTF_8.newEncoder();
@@ -77,7 +79,12 @@ public class UTF8Encoding {
   }
 
   @Benchmark
-  public byte[] string_getBytes() {
+  public byte[] string_getBytes() throws java.io.UnsupportedEncodingException {
+    return source.getBytes("UTF-8");
+  }
+
+  @Benchmark
+  public byte[] charset_getBytes() {
     return source.getBytes(UTF_8);
   }
 


### PR DESCRIPTION
Use the Charset version instead of the String version of String.getBytes

closes #707 