### PR TITLE
perf: use cached instance of UTF8Encoding

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/Encoding.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/Encoding.java
@@ -12,13 +12,15 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Reader;
 import java.io.Writer;
+import java.nio.charset.Charset;
 import java.util.HashMap;
 
 /**
  * Representation of a particular character encoding.
  */
 public class Encoding {
-  private static final Encoding DEFAULT_ENCODING = new Encoding(null);
+  private static final Encoding DEFAULT_ENCODING = new Encoding();
+  private static final Encoding UTF8_ENCODING = new UTF8Encoding();
 
   /*
    * Preferred JVM encodings for backend encodings.
@@ -28,10 +30,9 @@ public class Encoding {
   static {
     //Note: this list should match the set of supported server
     // encodings found in backend/util/mb/encnames.c
-    encodings.put("SQL_ASCII", new String[]{"ASCII", "us-ascii"});
+    encodings.put("SQL_ASCII", new String[]{"ASCII", "US-ASCII"});
     encodings.put("UNICODE", new String[]{"UTF-8", "UTF8"});
-    encodings.put("UTF8",
-        new String[]{"UTF-8", "UTF8"}); // 8.1's canonical name for UNICODE changed.
+    encodings.put("UTF8", new String[]{"UTF-8", "UTF8"});
     encodings.put("LATIN1", new String[]{"ISO8859_1"});
     encodings.put("LATIN2", new String[]{"ISO8859_2"});
     encodings.put("LATIN3", new String[]{"ISO8859_3"});
@@ -73,7 +74,22 @@ public class Encoding {
   private final String encoding;
   private final boolean fastASCIINumbers;
 
+  /**
+   * Uses the default charset of the JVM.
+   */
+  private Encoding() {
+    this(Charset.defaultCharset().name());
+  }
+
+  /**
+   * Use the charset passed as parameter.
+   *
+   * @param encoding charset name to use
+   */
   protected Encoding(String encoding) {
+    if (encoding == null) {
+      throw new NullPointerException("Null encoding charset not supported");
+    }
     this.encoding = encoding;
     fastASCIINumbers = testAsciiNumbers();
   }
@@ -96,14 +112,13 @@ public class Encoding {
    * default JVM encoding if the specified encoding is unavailable.
    */
   public static Encoding getJVMEncoding(String jvmEncoding) {
-    if (isAvailable(jvmEncoding)) {
-      if (jvmEncoding.equals("UTF-8") || jvmEncoding.equals("UTF8")) {
-        return new UTF8Encoding(jvmEncoding);
-      } else {
-        return new Encoding(jvmEncoding);
-      }
+    if ("UTF-8".equals(jvmEncoding) || "UTF8".equals(jvmEncoding)) {
+      return UTF8_ENCODING;
+    }
+    if (Charset.isSupported(jvmEncoding)) {
+      return new Encoding(jvmEncoding);
     } else {
-      return defaultEncoding();
+      return DEFAULT_ENCODING;
     }
   }
 
@@ -115,14 +130,17 @@ public class Encoding {
    * default JVM encoding if the specified encoding is unavailable.
    */
   public static Encoding getDatabaseEncoding(String databaseEncoding) {
+    // Test UTF-8 first and return the cached instance.
+    if ("UTF8".equals(databaseEncoding)) {
+      return UTF8_ENCODING;
+    }
     // If the backend encoding is known and there is a suitable
     // encoding in the JVM we use that. Otherwise we fall back
     // to the default encoding of the JVM.
-
     String[] candidates = encodings.get(databaseEncoding);
     if (candidates != null) {
       for (String candidate : candidates) {
-        if (isAvailable(candidate)) {
+        if (Charset.isSupported(candidate)) {
           return new Encoding(candidate);
         }
       }
@@ -130,12 +148,12 @@ public class Encoding {
 
     // Try the encoding name directly -- maybe the charset has been
     // provided by the user.
-    if (isAvailable(databaseEncoding)) {
+    if (Charset.isSupported(databaseEncoding)) {
       return new Encoding(databaseEncoding);
     }
 
     // Fall back to default JVM encoding.
-    return defaultEncoding();
+    return DEFAULT_ENCODING;
   }
 
   /**
@@ -144,7 +162,7 @@ public class Encoding {
    * @return the JVM encoding name used by this instance.
    */
   public String name() {
-    return encoding;
+    return Charset.isSupported(encoding) ? Charset.forName(encoding).name() : encoding;
   }
 
   /**
@@ -157,10 +175,6 @@ public class Encoding {
   public byte[] encode(String s) throws IOException {
     if (s == null) {
       return null;
-    }
-
-    if (encoding == null) {
-      return s.getBytes();
     }
 
     return s.getBytes(encoding);
@@ -177,10 +191,6 @@ public class Encoding {
    * @throws IOException if something goes wrong
    */
   public String decode(byte[] encodedString, int offset, int length) throws IOException {
-    if (encoding == null) {
-      return new String(encodedString, offset, length);
-    }
-
     return new String(encodedString, offset, length, encoding);
   }
 
@@ -203,10 +213,6 @@ public class Encoding {
    * @throws IOException if something goes wrong
    */
   public Reader getDecodingReader(InputStream in) throws IOException {
-    if (encoding == null) {
-      return new InputStreamReader(in);
-    }
-
     return new InputStreamReader(in, encoding);
   }
 
@@ -218,10 +224,6 @@ public class Encoding {
    * @throws IOException if something goes wrong
    */
   public Writer getEncodingWriter(OutputStream out) throws IOException {
-    if (encoding == null) {
-      return new OutputStreamWriter(out);
-    }
-
     return new OutputStreamWriter(out, encoding);
   }
 
@@ -234,23 +236,8 @@ public class Encoding {
     return DEFAULT_ENCODING;
   }
 
-  /**
-   * Test if an encoding is available in the JVM.
-   *
-   * @param encodingName the JVM encoding name to test
-   * @return true iff the encoding is supported
-   */
-  private static boolean isAvailable(String encodingName) {
-    try {
-      "DUMMY".getBytes(encodingName); //NOSONAR
-      return true;
-    } catch (java.io.UnsupportedEncodingException e) {
-      return false;
-    }
-  }
-
   public String toString() {
-    return (encoding == null ? "<default JVM encoding>" : encoding);
+    return encoding;
   }
 
   /**

--- a/pgjdbc/src/main/java/org/postgresql/core/UTF8Encoding.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/UTF8Encoding.java
@@ -17,8 +17,8 @@ class UTF8Encoding extends Encoding {
 
   private char[] decoderArray = new char[1024];
 
-  UTF8Encoding(String jvmEncoding) {
-    super(jvmEncoding);
+  UTF8Encoding() {
+    super("UTF-8");
   }
 
   // helper for decode

--- a/ubenchmark/src/main/java/org/postgresql/benchmark/encoding/UTF8Decoding.java
+++ b/ubenchmark/src/main/java/org/postgresql/benchmark/encoding/UTF8Decoding.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2016, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.benchmark.encoding;
+
+import org.postgresql.core.Encoding;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.nio.charset.Charset;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Tests the performance of UTF-8 decoding. UTF-8 is used a lot, so we need to know the performance
+ */
+@Fork(value = 1, jvmArgsPrepend = "-Xmx128m")
+@Measurement(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@State(Scope.Thread)
+@Threads(1)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class UTF8Decoding {
+
+  @Param({"1", "5", "10", "50", "100"})
+  public int length;
+
+  private byte[] sourceByte;
+  private static final Charset UTF_8 = Charset.forName("UTF-8");
+
+  @Setup
+  public void setup() {
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < length; i++) {
+      sb.append("Привет мир, ");
+      sb.append("こんにちは世界, ");
+      sb.append("Hola mundo, ");
+    }
+    sourceByte = sb.toString().getBytes(UTF_8);
+  }
+
+  @Benchmark
+  public String decodeUTF8Encoding() throws java.io.IOException {
+    Encoding enc = Encoding.getJVMEncoding("UTF-8");
+    return enc.decode(sourceByte);
+  }
+
+  @Benchmark
+  public String decodeUTF8String() throws java.io.UnsupportedEncodingException {
+    return new String(sourceByte, "UTF-8");
+  }
+
+  @Benchmark
+  public String decodeUTF8Charset() {
+    return new String(sourceByte, UTF_8);
+  }
+
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder()
+        .include(UTF8Decoding.class.getSimpleName())
+        .detectJvmArgs()
+        .build();
+
+    new Runner(opt).run();
+  }
+}


### PR DESCRIPTION
UTF-8 is widely used, but getJVMEncoding("UTF-8") create an instance of UTF8Encoding every time is invoked.

I have made some benchmark with an without the cached instance to test:

Not cached:

```
Benchmark                        (length)   Mode  Cnt     Score     Error   Units
UTF8Decoding.decodeUTF8Charset          1  thrpt   10  7706.293 ± 132.422  ops/ms
UTF8Decoding.decodeUTF8Charset          5  thrpt   10  1909.705 ±  25.287  ops/ms
UTF8Decoding.decodeUTF8Charset         10  thrpt   10   927.120 ±  13.210  ops/ms
UTF8Decoding.decodeUTF8Charset         50  thrpt   10   209.248 ±   0.785  ops/ms
UTF8Decoding.decodeUTF8Charset        100  thrpt   10   104.701 ±   1.076  ops/ms
UTF8Decoding.decodeUTF8Encoding         1  thrpt   10  2223.683 ± 103.110  ops/ms
UTF8Decoding.decodeUTF8Encoding         5  thrpt   10  1255.175 ±  15.962  ops/ms
UTF8Decoding.decodeUTF8Encoding        10  thrpt   10   749.291 ±  16.330  ops/ms
UTF8Decoding.decodeUTF8Encoding        50  thrpt   10   211.071 ±   2.109  ops/ms
UTF8Decoding.decodeUTF8Encoding       100  thrpt   10   109.175 ±   2.378  ops/ms
UTF8Decoding.decodeUTF8String           1  thrpt   10  7828.925 ±  92.167  ops/ms
UTF8Decoding.decodeUTF8String           5  thrpt   10  1965.839 ±  21.366  ops/ms
UTF8Decoding.decodeUTF8String          10  thrpt   10   967.460 ±  23.336  ops/ms
UTF8Decoding.decodeUTF8String          50  thrpt   10   208.636 ±   1.733  ops/ms
UTF8Decoding.decodeUTF8String         100  thrpt   10   103.265 ±   2.513  ops/ms
```

Cached:
```
Benchmark                        (length)   Mode  Cnt     Score     Error   Units
UTF8Decoding.decodeUTF8Charset          1  thrpt   10  7637.046 ± 267.301  ops/ms
UTF8Decoding.decodeUTF8Charset          5  thrpt   10  1871.278 ±  27.822  ops/ms
UTF8Decoding.decodeUTF8Charset         10  thrpt   10   937.776 ±  13.518  ops/ms
UTF8Decoding.decodeUTF8Charset         50  thrpt   10   201.614 ±   3.559  ops/ms
UTF8Decoding.decodeUTF8Charset        100  thrpt   10    98.741 ±   1.853  ops/ms
UTF8Decoding.decodeUTF8Encoding         1  thrpt   10  9132.184 ± 221.186  ops/ms
UTF8Decoding.decodeUTF8Encoding         5  thrpt   10  2030.480 ±  31.955  ops/ms
UTF8Decoding.decodeUTF8Encoding        10  thrpt   10   992.970 ±  22.472  ops/ms
UTF8Decoding.decodeUTF8Encoding        50  thrpt   10   205.029 ±   6.675  ops/ms
UTF8Decoding.decodeUTF8Encoding       100  thrpt   10   101.645 ±   2.056  ops/ms
UTF8Decoding.decodeUTF8String           1  thrpt   10  7600.416 ± 176.502  ops/ms
UTF8Decoding.decodeUTF8String           5  thrpt   10  1964.778 ±  37.164  ops/ms
UTF8Decoding.decodeUTF8String          10  thrpt   10   906.809 ±  27.079  ops/ms
UTF8Decoding.decodeUTF8String          50  thrpt   10   195.896 ±   2.378  ops/ms
UTF8Decoding.decodeUTF8String         100  thrpt   10   100.058 ±   1.674  ops/ms
```