### PR TITLE
config: move version of checkstyle to property

### DIFF
--- a/pgjdbc/pom.xml
+++ b/pgjdbc/pom.xml
@@ -33,6 +33,7 @@
     <jdbc.specification.version>4.2</jdbc.specification.version>
     <jdbc.specification.version.nodot>42</jdbc.specification.version.nodot>
     <skip.assembly>false</skip.assembly>
+    <checkstyle.version>6.13</checkstyle.version>
   </properties>
 
   <profiles>
@@ -260,7 +261,7 @@
             <dependency>
               <groupId>com.puppycrawl.tools</groupId>
               <artifactId>checkstyle</artifactId>
-              <version>6.13</version>
+              <version>${checkstyle.version}</version>
             </dependency>
           </dependencies>
           <configuration>


### PR DESCRIPTION
if this PR is merged it become possible for checkstyle team to enforce no regression on sources of pgjdbc.
pgjdbc will be used in checkstyle's CI for each commit verification.

checkstyle/checkstyle#3670
