### PR TITLE
resolve violations from checkstyle 7.4

### DIFF
--- a/pgjdbc/pom.xml
+++ b/pgjdbc/pom.xml
@@ -33,7 +33,7 @@
     <jdbc.specification.version>4.2</jdbc.specification.version>
     <jdbc.specification.version.nodot>42</jdbc.specification.version.nodot>
     <skip.assembly>false</skip.assembly>
-    <checkstyle.version>6.13</checkstyle.version>
+    <checkstyle.version>7.4</checkstyle.version>
   </properties>
 
   <profiles>

--- a/pgjdbc/src/main/checkstyle/checks.xml
+++ b/pgjdbc/src/main/checkstyle/checks.xml
@@ -74,11 +74,13 @@
     <module name="LeftCurly">
       <property name="maxLineLength" value="100"/>
     </module>
-    <module name="RightCurly"/>
+    <module name="RightCurly">
+      <property name="tokens" value="LITERAL_TRY, LITERAL_CATCH, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_DO"/>
+    </module>
     <module name="RightCurly">
       <property name="option" value="alone"/>
       <property name="tokens"
-                value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, LITERAL_DO, STATIC_INIT, INSTANCE_INIT"/>
+                value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, STATIC_INIT, INSTANCE_INIT"/>
     </module>
     <module name="WhitespaceAround">
       <property name="allowEmptyConstructors" value="true"/>

--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -369,7 +369,7 @@ public enum PGProperty {
   /**
    * Configure optimization to enable batch insert re-writing.
    */
-  REWRITE_BATCHED_INSERTS ("reWriteBatchedInserts", "false",
+  REWRITE_BATCHED_INSERTS("reWriteBatchedInserts", "false",
       "Enable optimization to rewrite and collapse compatible INSERT statements that are batched."),
 
   /**

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/CopyDualImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/CopyDualImpl.java
@@ -5,7 +5,6 @@
 
 package org.postgresql.core.v3;
 
-
 import org.postgresql.copy.CopyDual;
 import org.postgresql.util.PSQLException;
 

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/replication/V3PGReplicationStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/replication/V3PGReplicationStream.java
@@ -5,7 +5,6 @@
 
 package org.postgresql.core.v3.replication;
 
-
 import org.postgresql.copy.CopyDual;
 import org.postgresql.core.Logger;
 import org.postgresql.replication.LogSequenceNumber;

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/replication/V3ReplicationProtocol.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/replication/V3ReplicationProtocol.java
@@ -5,7 +5,6 @@
 
 package org.postgresql.core.v3.replication;
 
-
 import org.postgresql.copy.CopyDual;
 import org.postgresql.core.Logger;
 import org.postgresql.core.PGStream;

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgStatement.java
@@ -5,7 +5,6 @@
 
 package org.postgresql.jdbc;
 
-
 import org.postgresql.Driver;
 import org.postgresql.core.BaseConnection;
 import org.postgresql.core.BaseStatement;

--- a/pgjdbc/src/main/java/org/postgresql/largeobject/LargeObjectManager.java
+++ b/pgjdbc/src/main/java/org/postgresql/largeobject/LargeObjectManager.java
@@ -5,7 +5,6 @@
 
 package org.postgresql.largeobject;
 
-
 import org.postgresql.core.BaseConnection;
 import org.postgresql.fastpath.Fastpath;
 import org.postgresql.fastpath.FastpathArg;

--- a/pgjdbc/src/main/java/org/postgresql/replication/LogSequenceNumber.java
+++ b/pgjdbc/src/main/java/org/postgresql/replication/LogSequenceNumber.java
@@ -5,7 +5,6 @@
 
 package org.postgresql.replication;
 
-
 import java.nio.ByteBuffer;
 
 /**

--- a/pgjdbc/src/main/java/org/postgresql/replication/PGReplicationConnectionImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/replication/PGReplicationConnectionImpl.java
@@ -5,7 +5,6 @@
 
 package org.postgresql.replication;
 
-
 import org.postgresql.core.BaseConnection;
 import org.postgresql.replication.fluent.ChainedCreateReplicationSlotBuilder;
 import org.postgresql.replication.fluent.ChainedStreamBuilder;

--- a/pgjdbc/src/main/java/org/postgresql/replication/PGReplicationStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/replication/PGReplicationStream.java
@@ -5,7 +5,6 @@
 
 package org.postgresql.replication;
 
-
 import org.postgresql.replication.fluent.CommonOptions;
 import org.postgresql.replication.fluent.logical.LogicalReplicationOptions;
 

--- a/pgjdbc/src/main/java/org/postgresql/replication/fluent/AbstractStreamBuilder.java
+++ b/pgjdbc/src/main/java/org/postgresql/replication/fluent/AbstractStreamBuilder.java
@@ -5,7 +5,6 @@
 
 package org.postgresql.replication.fluent;
 
-
 import org.postgresql.replication.LogSequenceNumber;
 
 import java.util.concurrent.TimeUnit;

--- a/pgjdbc/src/main/java/org/postgresql/replication/fluent/ChainedCommonStreamBuilder.java
+++ b/pgjdbc/src/main/java/org/postgresql/replication/fluent/ChainedCommonStreamBuilder.java
@@ -5,7 +5,6 @@
 
 package org.postgresql.replication.fluent;
 
-
 import org.postgresql.replication.LogSequenceNumber;
 
 import java.util.concurrent.TimeUnit;

--- a/pgjdbc/src/main/java/org/postgresql/replication/fluent/ChainedStreamBuilder.java
+++ b/pgjdbc/src/main/java/org/postgresql/replication/fluent/ChainedStreamBuilder.java
@@ -5,7 +5,6 @@
 
 package org.postgresql.replication.fluent;
 
-
 import org.postgresql.replication.fluent.logical.ChainedLogicalStreamBuilder;
 import org.postgresql.replication.fluent.physical.ChainedPhysicalStreamBuilder;
 

--- a/pgjdbc/src/main/java/org/postgresql/replication/fluent/ReplicationCreateSlotBuilder.java
+++ b/pgjdbc/src/main/java/org/postgresql/replication/fluent/ReplicationCreateSlotBuilder.java
@@ -5,7 +5,6 @@
 
 package org.postgresql.replication.fluent;
 
-
 import org.postgresql.core.BaseConnection;
 import org.postgresql.replication.fluent.logical.ChainedLogicalCreateSlotBuilder;
 import org.postgresql.replication.fluent.logical.LogicalCreateSlotBuilder;

--- a/pgjdbc/src/main/java/org/postgresql/replication/fluent/ReplicationStreamBuilder.java
+++ b/pgjdbc/src/main/java/org/postgresql/replication/fluent/ReplicationStreamBuilder.java
@@ -5,7 +5,6 @@
 
 package org.postgresql.replication.fluent;
 
-
 import org.postgresql.core.BaseConnection;
 import org.postgresql.core.ReplicationProtocol;
 import org.postgresql.replication.PGReplicationStream;

--- a/pgjdbc/src/main/java/org/postgresql/replication/fluent/logical/ChainedLogicalStreamBuilder.java
+++ b/pgjdbc/src/main/java/org/postgresql/replication/fluent/logical/ChainedLogicalStreamBuilder.java
@@ -5,7 +5,6 @@
 
 package org.postgresql.replication.fluent.logical;
 
-
 import org.postgresql.replication.PGReplicationStream;
 import org.postgresql.replication.fluent.ChainedCommonStreamBuilder;
 

--- a/pgjdbc/src/main/java/org/postgresql/replication/fluent/logical/LogicalReplicationOptions.java
+++ b/pgjdbc/src/main/java/org/postgresql/replication/fluent/logical/LogicalReplicationOptions.java
@@ -5,7 +5,6 @@
 
 package org.postgresql.replication.fluent.logical;
 
-
 import org.postgresql.replication.fluent.CommonOptions;
 
 import java.util.Properties;

--- a/pgjdbc/src/main/java/org/postgresql/replication/fluent/logical/LogicalStreamBuilder.java
+++ b/pgjdbc/src/main/java/org/postgresql/replication/fluent/logical/LogicalStreamBuilder.java
@@ -5,7 +5,6 @@
 
 package org.postgresql.replication.fluent.logical;
 
-
 import org.postgresql.replication.LogSequenceNumber;
 import org.postgresql.replication.PGReplicationStream;
 import org.postgresql.replication.fluent.AbstractStreamBuilder;

--- a/pgjdbc/src/main/java/org/postgresql/replication/fluent/logical/StartLogicalReplicationCallback.java
+++ b/pgjdbc/src/main/java/org/postgresql/replication/fluent/logical/StartLogicalReplicationCallback.java
@@ -5,7 +5,6 @@
 
 package org.postgresql.replication.fluent.logical;
 
-
 import org.postgresql.replication.PGReplicationStream;
 
 import java.sql.SQLException;

--- a/pgjdbc/src/main/java/org/postgresql/replication/fluent/physical/PhysicalCreateSlotBuilder.java
+++ b/pgjdbc/src/main/java/org/postgresql/replication/fluent/physical/PhysicalCreateSlotBuilder.java
@@ -5,7 +5,6 @@
 
 package org.postgresql.replication.fluent.physical;
 
-
 import org.postgresql.core.BaseConnection;
 import org.postgresql.replication.fluent.AbstractCreateSlotBuilder;
 

--- a/pgjdbc/src/main/java/org/postgresql/replication/fluent/physical/PhysicalStreamBuilder.java
+++ b/pgjdbc/src/main/java/org/postgresql/replication/fluent/physical/PhysicalStreamBuilder.java
@@ -5,7 +5,6 @@
 
 package org.postgresql.replication.fluent.physical;
 
-
 import org.postgresql.replication.LogSequenceNumber;
 import org.postgresql.replication.PGReplicationStream;
 import org.postgresql.replication.fluent.AbstractStreamBuilder;

--- a/pgjdbc/src/main/java/org/postgresql/util/PGmoney.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/PGmoney.java
@@ -6,7 +6,6 @@
 
 package org.postgresql.util;
 
-
 import java.io.Serializable;
 import java.sql.SQLException;
 

--- a/pgjdbc/src/test/java/org/postgresql/replication/LogicalReplicationStatusTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/replication/LogicalReplicationStatusTest.java
@@ -5,7 +5,6 @@
 
 package org.postgresql.replication;
 
-
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;

--- a/pgjdbc/src/test/java/org/postgresql/replication/LogicalReplicationTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/replication/LogicalReplicationTest.java
@@ -5,7 +5,6 @@
 
 package org.postgresql.replication;
 
-
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;

--- a/pgjdbc/src/test/java/org/postgresql/replication/ReplicationSlotTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/replication/ReplicationSlotTest.java
@@ -5,7 +5,6 @@
 
 package org.postgresql.replication;
 
-
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 

--- a/pgjdbc/src/test/java/org/postgresql/test/util/rules/ServerVersionRule.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/util/rules/ServerVersionRule.java
@@ -5,7 +5,6 @@
 
 package org.postgresql.test.util.rules;
 
-
 import org.postgresql.core.ServerVersion;
 import org.postgresql.core.Version;
 import org.postgresql.jdbc.PgConnection;


### PR DESCRIPTION
Issue #724 

1) extra space was removed
2) fix RightCurly configuration problem, the same update was done in checkstyle project, (checkstyle/checkstyle#3678). DO_WHILE was moved from one RightCurly configuration to another.
3) validation of CallableQueryKey.java is skipped as maintainers do not want fix violation of missed equals() for now