### PR TITLE
fix: improve handling of getBoolean and setObject

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/BooleanTypeUtil.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/BooleanTypeUtil.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2017, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.jdbc;
+
+import org.postgresql.util.GT;
+import org.postgresql.util.PSQLException;
+import org.postgresql.util.PSQLState;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Helper class to handle boolean type of PostgreSQL.
+ * <p>
+ * Based on values accepted by the PostgreSQL server:
+ * https://www.postgresql.org/docs/current/static/datatype-boolean.html
+ */
+class BooleanTypeUtil {
+
+  private static final Logger LOGGER = Logger.getLogger(BooleanTypeUtil.class.getName());
+
+  private BooleanTypeUtil() {
+  }
+
+  /**
+   * Cast an Object value to the corresponding boolean value.
+   *
+   * @param in Object to cast into boolean
+   * @return boolean value corresponding to the cast of the object
+   * @throws PSQLException PSQLState.CANNOT_COERCE
+   */
+  static boolean castToBoolean(final Object in) throws PSQLException {
+    LOGGER.log(Level.FINE, "Object to cast: {0}", in);
+    if (in instanceof Boolean) {
+      return (Boolean) in;
+    }
+    if (in instanceof String) {
+      return from((String) in);
+    }
+    if (in instanceof Character) {
+      return from((Character) in);
+    }
+    if (in instanceof Number) {
+      return from((Number) in, in.getClass().getName());
+    }
+    throw cannotCoerceException(in.getClass().getName());
+  }
+
+  private static boolean from(final String strval) throws PSQLException {
+    // Leading or trailing whitespace is ignored, and case does not matter.
+    final String val = strval.trim();
+    if ("1".equals(val) || "true".equalsIgnoreCase(val)
+        || "t".equalsIgnoreCase(val) || "yes".equalsIgnoreCase(val)
+        || "y".equalsIgnoreCase(val) || "on".equalsIgnoreCase(val)) {
+      return true;
+    }
+    if ("0".equals(val) || "false".equalsIgnoreCase(val)
+        || "f".equalsIgnoreCase(val) || "no".equalsIgnoreCase(val)
+        || "n".equalsIgnoreCase(val) || "off".equalsIgnoreCase(val)) {
+      return false;
+    }
+    throw cannotCoerceException("String", val);
+  }
+
+  private static boolean from(final Character charval) throws PSQLException {
+    if ('1' == charval || 't' == charval || 'T' == charval
+        || 'y' == charval || 'Y' == charval) {
+      return true;
+    }
+    if ('0' == charval || 'f' == charval || 'F' == charval
+        || 'n' == charval || 'N' == charval) {
+      return false;
+    }
+    throw cannotCoerceException("Character", charval.toString());
+  }
+
+  private static boolean from(final Number numval, final String className) throws PSQLException {
+    // Handles BigDecimal, Byte, Short, Integer, Long Float, Double
+    // based on the widening primitive conversions.
+    double value = numval.doubleValue();
+    if (value == 1.0d) {
+      return true;
+    }
+    if (value == 0.0d) {
+      return false;
+    }
+    throw cannotCoerceException(className, String.valueOf(numval));
+  }
+
+  private static PSQLException cannotCoerceException(final String fromType) {
+    LOGGER.log(Level.FINE, "Cannot cast type {0} to boolean", fromType);
+    return new PSQLException(GT.tr("Cannot cast type {0} to boolean", fromType),
+        PSQLState.CANNOT_COERCE);
+  }
+
+  private static PSQLException cannotCoerceException(final String fromType, final String value) {
+    LOGGER.log(Level.FINE, "Cannot cast type {0} to boolean: \"{1}\"", new Object[]{fromType, value});
+    return new PSQLException(GT.tr("Cannot cast type {0} to boolean: \"{1}\"", fromType, value),
+        PSQLState.CANNOT_COERCE);
+  }
+
+}

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgArray.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgArray.java
@@ -577,9 +577,9 @@ public class PgArray implements java.sql.Array {
 
         if (dims > 1 || useObjects) {
           oa[length++] = o == null ? null
-              : (dims > 1 ? buildArray((PgArrayList) o, 0, -1) : PgResultSet.toBoolean((String) o));
+            : (dims > 1 ? buildArray((PgArrayList) o, 0, -1) : BooleanTypeUtil.castToBoolean((String) o));
         } else {
-          pa[length++] = o == null ? false : PgResultSet.toBoolean((String) o);
+          pa[length++] = o == null ? false : BooleanTypeUtil.castToBoolean((String) o);
         }
       }
     } else if (type == Types.SMALLINT || type == Types.INTEGER) {

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
@@ -169,12 +169,10 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
   protected Object internalGetObject(int columnIndex, Field field) throws SQLException {
     switch (getSQLType(columnIndex)) {
       case Types.BOOLEAN:
+      case Types.BIT:
         return getBoolean(columnIndex);
       case Types.SQLXML:
         return getSQLXML(columnIndex);
-      case Types.BIT:
-        // Also Types.BOOLEAN in JDBC3
-        return getBoolean(columnIndex) ? Boolean.TRUE : Boolean.FALSE;
       case Types.TINYINT:
       case Types.SMALLINT:
       case Types.INTEGER:
@@ -1893,6 +1891,29 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
     }
   }
 
+  /**
+   * Retrieves the value of the designated column in the current row of this <code>ResultSet</code>
+   * object as a <code>boolean</code> in the Java programming language.
+   * <p>
+   * If the designated column has a Character datatype and is one of the following values: "1",
+   * "true", "t", "yes", "y" or "on", a value of <code>true</code> is returned. If the designated
+   * column has a Character datatype and is one of the following values: "0", "false", "f", "no",
+   * "n" or "off", a value of <code>false</code> is returned. Leading or trailing whitespace is
+   * ignored, and case does not matter.
+   * <p>
+   * If the designated column has a Numeric datatype and is a 1, a value of <code>true</code> is
+   * returned. If the designated column has a Numeric datatype and is a 0, a value of
+   * <code>false</code> is returned.
+   *
+   * @param columnIndex the first column is 1, the second is 2, ...
+   * @return the column value; if the value is SQL <code>NULL</code>, the value returned is
+   * <code>false</code>
+   * @exception SQLException if the columnIndex is not valid; if a database access error occurs or
+   * this method is called on a closed result set
+   * @see <a href="https://www.postgresql.org/docs/current/static/datatype-boolean.html">PostgreSQL
+   * Boolean Type</a>
+   */
+  @Override
   public boolean getBoolean(int columnIndex) throws SQLException {
     checkResultSet(columnIndex);
     if (wasNullFlag) {
@@ -1901,10 +1922,10 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
 
     if (isBinary(columnIndex)) {
       int col = columnIndex - 1;
-      return readDoubleValue(this_row[col], fields[col].getOID(), "boolean") == 1;
+      return BooleanTypeUtil.castToBoolean(readDoubleValue(this_row[col], fields[col].getOID(), "boolean"));
     }
 
-    return toBoolean(getString(columnIndex));
+    return BooleanTypeUtil.castToBoolean(getString(columnIndex));
   }
 
   private static final BigInteger BYTEMAX = new BigInteger(Byte.toString(Byte.MAX_VALUE));
@@ -2415,6 +2436,7 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
     return getString(findColumn(columnName));
   }
 
+  @Override
   public boolean getBoolean(String columnName) throws SQLException {
     return getBoolean(findColumn(columnName));
   }
@@ -2733,28 +2755,6 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
   }
 
   // ----------------- Formatting Methods -------------------
-
-  public static boolean toBoolean(String s) {
-    if (s != null) {
-      s = s.trim();
-
-      if (s.equalsIgnoreCase("t") || s.equalsIgnoreCase("true") || s.equals("1")) {
-        return true;
-      }
-
-      if (s.equalsIgnoreCase("f") || s.equalsIgnoreCase("false") || s.equals("0")) {
-        return false;
-      }
-
-      try {
-        if (Double.parseDouble(s) == 1) {
-          return true;
-        }
-      } catch (NumberFormatException e) {
-      }
-    }
-    return false; // SQL NULL
-  }
 
   private static final BigInteger INTMAX = new BigInteger(Integer.toString(Integer.MAX_VALUE));
   private static final BigInteger INTMIN = new BigInteger(Integer.toString(Integer.MIN_VALUE));

--- a/pgjdbc/src/main/java/org/postgresql/util/PSQLState.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/PSQLState.java
@@ -107,6 +107,7 @@ public class PSQLState implements java.io.Serializable {
   public final static PSQLState DATA_TYPE_MISMATCH = new PSQLState("42821");
   public final static PSQLState UNDEFINED_FUNCTION = new PSQLState("42883");
   public final static PSQLState INVALID_NAME = new PSQLState("42602");
+  public final static PSQLState CANNOT_COERCE = new PSQLState("42846");
 
   public final static PSQLState OUT_OF_MEMORY = new PSQLState("53200");
   public final static PSQLState OBJECT_NOT_IN_STATE = new PSQLState("55000");

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PreparedStatementTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PreparedStatementTest.java
@@ -21,7 +21,6 @@ import org.junit.runners.Parameterized;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.File;
 import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
@@ -59,6 +58,9 @@ public class PreparedStatementTest extends BaseTest4 {
     TestUtil.createTable(con, "texttable", "ch char(3), te text, vc varchar(3)");
     TestUtil.createTable(con, "intervaltable", "i interval");
     TestUtil.createTable(con, "inttable", "a int");
+    TestUtil.createTable(con, "bool_tab", "bool_val boolean, null_val boolean, tf_val boolean, "
+        + "truefalse_val boolean, yn_val boolean, yesno_val boolean, "
+        + "onoff_val boolean, onezero_val boolean");
   }
 
   @Override
@@ -67,6 +69,7 @@ public class PreparedStatementTest extends BaseTest4 {
     TestUtil.dropTable(con, "texttable");
     TestUtil.dropTable(con, "intervaltable");
     TestUtil.dropTable(con, "inttable");
+    TestUtil.dropTable(con, "bool_tab");
     super.tearDown();
   }
 
@@ -512,13 +515,16 @@ public class PreparedStatementTest extends BaseTest4 {
 
   @Test
   public void testBoolean() throws SQLException {
-    PreparedStatement pstmt = con.prepareStatement(
-        "CREATE TEMP TABLE bool_tab (bool_val boolean, null_val boolean, tf_val boolean, "
-        + "truefalse_val boolean, yn_val boolean, yesno_val boolean, onoff_val boolean, onezero_val boolean)");
-    pstmt.executeUpdate();
-    pstmt.close();
+    testBoolean(0);
+    testBoolean(1);
+    testBoolean(5);
+    testBoolean(-1);
+  }
 
-    pstmt = con.prepareStatement("insert into bool_tab values (?,?,?,?,?,?,?,?)");
+  public void testBoolean(int prepareThreshold) throws SQLException {
+    PreparedStatement pstmt = con.prepareStatement("insert into bool_tab values (?,?,?,?,?,?,?,?)");
+    ((org.postgresql.PGStatement) pstmt).setPrepareThreshold(prepareThreshold);
+
     // Test TRUE values
     pstmt.setBoolean(1, true);
     pstmt.setObject(1, Boolean.TRUE);
@@ -552,36 +558,20 @@ public class PreparedStatementTest extends BaseTest4 {
     pstmt.setObject(8, '0', Types.BOOLEAN);
     assertEquals("one row inserted, false values", 1, pstmt.executeUpdate());
     // Test weird values
-    pstmt.setObject(1, new java.util.Date(0), Types.BOOLEAN);
+    pstmt.setObject(1, (byte) 0, Types.BOOLEAN);
     pstmt.setObject(2, BigDecimal.ONE, Types.BOOLEAN);
     pstmt.setObject(3, 0L, Types.BOOLEAN);
     pstmt.setObject(4, 0x1, Types.BOOLEAN);
-    pstmt.setObject(5, 0, Types.BOOLEAN);
+    pstmt.setObject(5, new Float(0), Types.BOOLEAN);
+    pstmt.setObject(5, 1.0d, Types.BOOLEAN);
+    pstmt.setObject(5, 0.0f, Types.BOOLEAN);
     pstmt.setObject(6, Integer.valueOf("1"), Types.BOOLEAN);
+    pstmt.setObject(7, new java.math.BigInteger("0"), Types.BOOLEAN);
     pstmt.clearParameters();
-
-    try {
-      pstmt.setObject(1, "this is not boolean", Types.BOOLEAN);
-      fail();
-    } catch (SQLException e) {
-      assertEquals(e.getMessage(), "Cannot convert an instance of String to type boolean");
-    }
-    try {
-      pstmt.setObject(1, 'X', Types.BOOLEAN);
-      fail();
-    } catch (SQLException e) {
-      assertEquals(e.getMessage(), "Cannot convert an instance of Character to type boolean");
-    }
-    try {
-      File obj = new File("");
-      pstmt.setObject(1, obj, Types.BOOLEAN);
-      fail();
-    } catch (SQLException e) {
-      assertEquals(e.getMessage(), "Cannot convert an instance of java.io.File to type boolean");
-    }
-
     pstmt.close();
+
     pstmt = con.prepareStatement("select * from bool_tab");
+    ((org.postgresql.PGStatement) pstmt).setPrepareThreshold(prepareThreshold);
     ResultSet rs = pstmt.executeQuery();
 
     assertTrue(rs.next());
@@ -607,6 +597,83 @@ public class PreparedStatementTest extends BaseTest4 {
     assertFalse("expected false, received " + rs.getBoolean(8), rs.getBoolean(8));
 
     rs.close();
+    pstmt.close();
+
+    pstmt = con.prepareStatement("TRUNCATE TABLE bool_tab");
+    pstmt.executeUpdate();
+    pstmt.close();
+  }
+
+  @Test
+  public void testBadBoolean() throws SQLException {
+    PreparedStatement pstmt = con.prepareStatement("INSERT INTO bad_bool VALUES (?)");
+    try {
+      pstmt.setObject(1, "this is not boolean", Types.BOOLEAN);
+      fail();
+    } catch (SQLException e) {
+      assertEquals(e.getSQLState(), org.postgresql.util.PSQLState.CANNOT_COERCE.getState());
+    }
+    try {
+      pstmt.setObject(1, 'X', Types.BOOLEAN);
+      fail();
+    } catch (SQLException e) {
+      assertEquals(e.getSQLState(), org.postgresql.util.PSQLState.CANNOT_COERCE.getState());
+    }
+    try {
+      java.io.File obj = new java.io.File("");
+      pstmt.setObject(1, obj, Types.BOOLEAN);
+      fail();
+    } catch (SQLException e) {
+      assertEquals(e.getSQLState(), org.postgresql.util.PSQLState.CANNOT_COERCE.getState());
+    }
+    try {
+      pstmt.setObject(1, "1.0", Types.BOOLEAN);
+      fail();
+    } catch (SQLException e) {
+      assertEquals(e.getSQLState(), org.postgresql.util.PSQLState.CANNOT_COERCE.getState());
+    }
+    try {
+      pstmt.setObject(1, "-1", Types.BOOLEAN);
+      fail();
+    } catch (SQLException e) {
+      assertEquals(e.getSQLState(), org.postgresql.util.PSQLState.CANNOT_COERCE.getState());
+    }
+    try {
+      pstmt.setObject(1, "ok", Types.BOOLEAN);
+      fail();
+    } catch (SQLException e) {
+      assertEquals(e.getSQLState(), org.postgresql.util.PSQLState.CANNOT_COERCE.getState());
+    }
+    try {
+      pstmt.setObject(1, 0.99f, Types.BOOLEAN);
+      fail();
+    } catch (SQLException e) {
+      assertEquals(e.getSQLState(), org.postgresql.util.PSQLState.CANNOT_COERCE.getState());
+    }
+    try {
+      pstmt.setObject(1, -0.01d, Types.BOOLEAN);
+      fail();
+    } catch (SQLException e) {
+      assertEquals(e.getSQLState(), org.postgresql.util.PSQLState.CANNOT_COERCE.getState());
+    }
+    try {
+      pstmt.setObject(1, new java.sql.Date(0), Types.BOOLEAN);
+      fail();
+    } catch (SQLException e) {
+      assertEquals(e.getSQLState(), org.postgresql.util.PSQLState.CANNOT_COERCE.getState());
+    }
+    try {
+      pstmt.setObject(1, new java.math.BigInteger("1000"), Types.BOOLEAN);
+      fail();
+    } catch (SQLException e) {
+      assertEquals(e.getSQLState(), org.postgresql.util.PSQLState.CANNOT_COERCE.getState());
+    }
+    try {
+      pstmt.setObject(1, Math.PI, Types.BOOLEAN);
+      fail();
+    } catch (SQLException e) {
+      assertEquals(e.getSQLState(), org.postgresql.util.PSQLState.CANNOT_COERCE.getState());
+    }
     pstmt.close();
   }
 
@@ -662,18 +729,27 @@ public class PreparedStatementTest extends BaseTest4 {
     pstmt.setObject(2, minStringFloat, Types.FLOAT);
     pstmt.setNull(3, Types.FLOAT);
     pstmt.executeUpdate();
+    pstmt.setObject(1, "1.0", Types.FLOAT);
+    pstmt.setObject(2, "0.0", Types.FLOAT);
+    pstmt.setNull(3, Types.FLOAT);
+    pstmt.executeUpdate();
     pstmt.close();
 
     pstmt = con.prepareStatement("select * from float_tab");
     ResultSet rs = pstmt.executeQuery();
     assertTrue(rs.next());
 
-    assertTrue("expected true,received " + rs.getObject(1),
-        ((Double) rs.getObject(1)).equals(maxFloat));
-    assertTrue("expected false,received " + rs.getBoolean(2),
-        ((Double) rs.getObject(2)).equals(minFloat));
+    assertTrue(((Double) rs.getObject(1)).equals(maxFloat));
+    assertTrue(((Double) rs.getObject(2)).equals(minFloat));
+    assertTrue(rs.getDouble(1) == maxFloat);
+    assertTrue(rs.getDouble(2) == minFloat);
     rs.getFloat(3);
     assertTrue(rs.wasNull());
+
+    assertTrue(rs.next());
+    assertTrue("expected true, received " + rs.getBoolean(1), rs.getBoolean(1) == true);
+    assertTrue("expected false,received " + rs.getBoolean(2), rs.getBoolean(2) == false);
+
     rs.close();
     pstmt.close();
 

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ResultSetTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ResultSetTest.java
@@ -50,20 +50,46 @@ public class ResultSetTest extends BaseTest4 {
     TestUtil.createTable(con, "testint", "a int");
     stmt.executeUpdate("INSERT INTO testint VALUES (12345)");
 
-    TestUtil.createTable(con, "testbool", "a boolean");
+    // Boolean Tests
+    TestUtil.createTable(con, "testboolstring", "a varchar(30), b boolean");
+    stmt.executeUpdate("INSERT INTO testboolstring VALUES('1 ', true)");
+    stmt.executeUpdate("INSERT INTO testboolstring VALUES('0', false)");
+    stmt.executeUpdate("INSERT INTO testboolstring VALUES(' t', true)");
+    stmt.executeUpdate("INSERT INTO testboolstring VALUES('f', false)");
+    stmt.executeUpdate("INSERT INTO testboolstring VALUES('True', true)");
+    stmt.executeUpdate("INSERT INTO testboolstring VALUES('      False   ', false)");
+    stmt.executeUpdate("INSERT INTO testboolstring VALUES('yes', true)");
+    stmt.executeUpdate("INSERT INTO testboolstring VALUES('  no  ', false)");
+    stmt.executeUpdate("INSERT INTO testboolstring VALUES('y', true)");
+    stmt.executeUpdate("INSERT INTO testboolstring VALUES('n', false)");
+    stmt.executeUpdate("INSERT INTO testboolstring VALUES('oN', true)");
+    stmt.executeUpdate("INSERT INTO testboolstring VALUES('oFf', false)");
+    stmt.executeUpdate("INSERT INTO testboolstring VALUES('OK', null)");
+    stmt.executeUpdate("INSERT INTO testboolstring VALUES('NOT', null)");
+    stmt.executeUpdate("INSERT INTO testboolstring VALUES('not a boolean', null)");
+    stmt.executeUpdate("INSERT INTO testboolstring VALUES('1.0', null)");
+    stmt.executeUpdate("INSERT INTO testboolstring VALUES('0.0', null)");
+
+    TestUtil.createTable(con, "testboolfloat", "a float4, b boolean");
+    stmt.executeUpdate("INSERT INTO testboolfloat VALUES('1.0'::real, true)");
+    stmt.executeUpdate("INSERT INTO testboolfloat VALUES('0.0'::real, false)");
+    stmt.executeUpdate("INSERT INTO testboolfloat VALUES(1.000::real, true)");
+    stmt.executeUpdate("INSERT INTO testboolfloat VALUES(0.000::real, false)");
+    stmt.executeUpdate("INSERT INTO testboolfloat VALUES('1.001'::real, null)");
+    stmt.executeUpdate("INSERT INTO testboolfloat VALUES('-1.001'::real, null)");
+    stmt.executeUpdate("INSERT INTO testboolfloat VALUES(123.4::real, null)");
+    stmt.executeUpdate("INSERT INTO testboolfloat VALUES(1.234e2::real, null)");
+    stmt.executeUpdate("INSERT INTO testboolfloat VALUES(100.00e-2::real, true)");
+
+    TestUtil.createTable(con, "testboolint", "a bigint, b boolean");
+    stmt.executeUpdate("INSERT INTO testboolint VALUES(1, true)");
+    stmt.executeUpdate("INSERT INTO testboolint VALUES(0, false)");
+    stmt.executeUpdate("INSERT INTO testboolint VALUES(-1, null)");
+    stmt.executeUpdate("INSERT INTO testboolint VALUES(9223372036854775807, null)");
+    stmt.executeUpdate("INSERT INTO testboolint VALUES(-9223372036854775808, null)");
+    // End Boolean Tests
 
     // TestUtil.createTable(con, "testbit", "a bit");
-
-    TestUtil.createTable(con, "testboolstring", "a varchar(30)");
-
-    stmt.executeUpdate("INSERT INTO testboolstring VALUES('true')");
-    stmt.executeUpdate("INSERT INTO testboolstring VALUES('false')");
-    stmt.executeUpdate("INSERT INTO testboolstring VALUES('t')");
-    stmt.executeUpdate("INSERT INTO testboolstring VALUES('f')");
-    stmt.executeUpdate("INSERT INTO testboolstring VALUES('1.0')");
-    stmt.executeUpdate("INSERT INTO testboolstring VALUES('0.0')");
-    stmt.executeUpdate("INSERT INTO testboolstring VALUES('TRUE')");
-    stmt.executeUpdate("INSERT INTO testboolstring VALUES('this is not true')");
 
     TestUtil.createTable(con, "testnumeric", "a numeric");
     stmt.executeUpdate("INSERT INTO testnumeric VALUES('1.0')");
@@ -105,9 +131,10 @@ public class ResultSetTest extends BaseTest4 {
     TestUtil.dropTable(con, "testrs");
     TestUtil.dropTable(con, "teststring");
     TestUtil.dropTable(con, "testint");
-    TestUtil.dropTable(con, "testbool");
     // TestUtil.dropTable(con, "testbit");
     TestUtil.dropTable(con, "testboolstring");
+    TestUtil.dropTable(con, "testboolfloat");
+    TestUtil.dropTable(con, "testboolint");
     TestUtil.dropTable(con, "testnumeric");
     TestUtil.dropTable(con, "testpgobject");
     super.tearDown();
@@ -186,63 +213,52 @@ public class ResultSetTest extends BaseTest4 {
     assertEquals("12", new String(rs.getBytes(1)));
   }
 
-  public void booleanTests(boolean useServerPrepare) throws SQLException {
-    java.sql.PreparedStatement pstmt = con.prepareStatement("insert into testbool values (?)");
-    if (useServerPrepare) {
-      ((org.postgresql.PGStatement) pstmt).setUseServerPrepare(true);
-    }
-
-    pstmt.setObject(1, new Float(0), java.sql.Types.BIT);
-    pstmt.executeUpdate();
-
-    pstmt.setObject(1, new Float(1), java.sql.Types.BIT);
-    pstmt.executeUpdate();
-
-    pstmt.setObject(1, "False", java.sql.Types.BIT);
-    pstmt.executeUpdate();
-
-    pstmt.setObject(1, "True", java.sql.Types.BIT);
-    pstmt.executeUpdate();
-
-    ResultSet rs = con.createStatement().executeQuery("select * from testbool");
-    for (int i = 0; i < 2; i++) {
-      assertTrue(rs.next());
-      assertEquals(false, rs.getBoolean(1));
-      assertTrue(rs.next());
-      assertEquals(true, rs.getBoolean(1));
-    }
-
-    /*
-     * pstmt = con.prepareStatement("insert into testbit values (?)");
-     *
-     * pstmt.setObject(1, new Float(0), java.sql.Types.BIT); pstmt.executeUpdate();
-     *
-     * pstmt.setObject(1, new Float(1), java.sql.Types.BIT); pstmt.executeUpdate();
-     *
-     * pstmt.setObject(1, "false", java.sql.Types.BIT); pstmt.executeUpdate();
-     *
-     * pstmt.setObject(1, "true", java.sql.Types.BIT); pstmt.executeUpdate();
-     *
-     * rs = con.createStatement().executeQuery("select * from testbit");
-     *
-     * for (int i = 0;i<2; i++) { assertTrue(rs.next()); assertEquals(false, rs.getBoolean(1));
-     * assertTrue(rs.next()); assertEquals(true, rs.getBoolean(1)); }
-     */
-
-    rs = con.createStatement().executeQuery("select * from testboolstring");
-
-    for (int i = 0; i < 4; i++) {
-      assertTrue(rs.next());
-      assertEquals(true, rs.getBoolean(1));
-      assertTrue(rs.next());
-      assertEquals(false, rs.getBoolean(1));
-    }
+  @Test
+  public void testBooleanString() throws SQLException {
+    testBoolean("testboolstring", 0);
+    testBoolean("testboolstring", 1);
+    testBoolean("testboolstring", 5);
+    testBoolean("testboolstring", -1);
   }
 
   @Test
-  public void testBoolean() throws SQLException {
-    booleanTests(true);
-    booleanTests(false);
+  public void testBooleanFloat() throws SQLException {
+    testBoolean("testboolfloat", 0);
+    testBoolean("testboolfloat", 1);
+    testBoolean("testboolfloat", 5);
+    testBoolean("testboolfloat", -1);
+  }
+
+  @Test
+  public void testBooleanInt() throws SQLException {
+    testBoolean("testboolint", 0);
+    testBoolean("testboolint", 1);
+    testBoolean("testboolint", 5);
+    testBoolean("testboolint", -1);
+  }
+
+  public void testBoolean(String table, int prepareThreshold) throws SQLException {
+    PreparedStatement pstmt = con.prepareStatement("select a, b from " + table);
+    ((org.postgresql.PGStatement) pstmt).setPrepareThreshold(prepareThreshold);
+    ResultSet rs = pstmt.executeQuery();
+    while (rs.next()) {
+      rs.getBoolean(2);
+      Boolean expected = rs.wasNull() ? null : rs.getBoolean(2); // Hack to get SQL NULL
+      if (expected != null) {
+        assertEquals(expected, rs.getBoolean(1));
+      } else {
+        // expected value with null are bad values
+        try {
+          rs.getBoolean(1);
+          fail();
+        } catch (SQLException e) {
+          assertEquals(e.getSQLState(), org.postgresql.util.PSQLState.CANNOT_COERCE.getState());
+        }
+      }
+
+    }
+    rs.close();
+    pstmt.close();
   }
 
   @Test


### PR DESCRIPTION
This merge the code used to cast to boolean in getBoolean and setObject, it allows only valid values and reject wrong values.

This follows the specification more close and proper support the boolean types of PostgreSQL.