### PR TITLE
refactor: remove checks for jdk version 1.4 (tests)

### DIFF
--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/TimeTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/TimeTest.java
@@ -95,13 +95,8 @@ public class TimeTest {
     timestamp = rs.getTimestamp(1);
     assertNotNull(timestamp);
 
-    // Pre 1.4 JVM's considered the nanos field completely separate
-    // and wouldn't return it in getTime()
-    if (TestUtil.haveMinimumJVMVersion("1.4")) {
-      assertEquals(100, extractMillis(timestamp.getTime()));
-    } else {
-      assertEquals(100, extractMillis(timestamp.getTime() + timestamp.getNanos() / 1000000));
-    }
+    assertEquals(100, extractMillis(timestamp.getTime()));
+
     assertEquals(100000000, timestamp.getNanos());
 
     Time timetz = rs.getTime(2);
@@ -109,14 +104,8 @@ public class TimeTest {
     assertEquals(10, extractMillis(timetz.getTime()));
     timestamptz = rs.getTimestamp(2);
     assertNotNull(timestamptz);
+    assertEquals(10, extractMillis(timestamptz.getTime()));
 
-    // Pre 1.4 JVM's considered the nanos field completely separate
-    // and wouldn't return it in getTime()
-    if (TestUtil.haveMinimumJVMVersion("1.4")) {
-      assertEquals(10, extractMillis(timestamptz.getTime()));
-    } else {
-      assertEquals(10, extractMillis(timestamptz.getTime() + timestamptz.getNanos() / 1000000));
-    }
     assertEquals(10000000, timestamptz.getNanos());
 
     assertTrue(rs.next());

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/optional/OptionalTestSuite.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/optional/OptionalTestSuite.java
@@ -5,7 +5,6 @@
 
 package org.postgresql.test.jdbc2.optional;
 
-import junit.framework.TestSuite;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
@@ -21,6 +20,6 @@ import org.junit.runners.Suite;
         ConnectionPoolTest.class,
         PoolingDataSourceTest.class,
         CaseOptimiserDataSourceTest.class})
-public class OptionalTestSuite extends TestSuite {
+public class OptionalTestSuite {
 
 }


### PR DESCRIPTION
remove checks for jdk version 1.4 in the tests