### PR TITLE
fix: deprecated PGPoolingDataSource

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/ds/PGPoolingDataSource.java
+++ b/pgjdbc/src/main/java/org/postgresql/ds/PGPoolingDataSource.java
@@ -54,7 +54,11 @@ import javax.sql.PooledConnection;
  * </p>
  *
  * @author Aaron Mulder (ammulder@chariotsolutions.com)
+ *
+ * @deprecated Since 42.0.0, instead of this class you should use a fully featured connection pool
+ * like HikariCP, vibur-dbcp, commons-dbcp, c3p0, etc.
  */
+@Deprecated
 public class PGPoolingDataSource extends BaseDataSource implements DataSource {
   protected static ConcurrentMap<String, PGPoolingDataSource> dataSources =
       new ConcurrentHashMap<String, PGPoolingDataSource>();

--- a/pgjdbc/src/main/java/org/postgresql/jdbc2/optional/ConnectionPool.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc2/optional/ConnectionPool.java
@@ -7,5 +7,9 @@ package org.postgresql.jdbc2.optional;
 
 import org.postgresql.ds.PGConnectionPoolDataSource;
 
+/**
+ * @deprecated Please use {@link PGConnectionPoolDataSource}
+ */
+@Deprecated
 public class ConnectionPool extends PGConnectionPoolDataSource {
 }

--- a/pgjdbc/src/main/java/org/postgresql/jdbc2/optional/PoolingDataSource.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc2/optional/PoolingDataSource.java
@@ -7,5 +7,9 @@ package org.postgresql.jdbc2.optional;
 
 import org.postgresql.ds.PGPoolingDataSource;
 
+/**
+ * @deprecated Since 42.0.0, see {@link PGPoolingDataSource}
+ */
+@Deprecated
 public class PoolingDataSource extends PGPoolingDataSource {
 }

--- a/pgjdbc/src/main/java/org/postgresql/jdbc2/optional/SimpleDataSource.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc2/optional/SimpleDataSource.java
@@ -7,5 +7,9 @@ package org.postgresql.jdbc2.optional;
 
 import org.postgresql.ds.PGSimpleDataSource;
 
+/**
+ * @deprecated Please use {@link PGSimpleDataSource}
+ */
+@Deprecated
 public class SimpleDataSource extends PGSimpleDataSource {
 }

--- a/pgjdbc/src/main/java/org/postgresql/jdbc3/Jdbc3ConnectionPool.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc3/Jdbc3ConnectionPool.java
@@ -7,5 +7,9 @@ package org.postgresql.jdbc3;
 
 import org.postgresql.ds.PGConnectionPoolDataSource;
 
+/**
+ * @deprecated Please use {@link PGConnectionPoolDataSource}
+ */
+@Deprecated
 public class Jdbc3ConnectionPool extends PGConnectionPoolDataSource {
 }

--- a/pgjdbc/src/main/java/org/postgresql/jdbc3/Jdbc3PoolingDataSource.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc3/Jdbc3PoolingDataSource.java
@@ -7,5 +7,9 @@ package org.postgresql.jdbc3;
 
 import org.postgresql.ds.PGPoolingDataSource;
 
+/**
+ * @deprecated Since 42.0.0, see {@link PGPoolingDataSource}
+ */
+@Deprecated
 public class Jdbc3PoolingDataSource extends PGPoolingDataSource {
 }

--- a/pgjdbc/src/main/java/org/postgresql/jdbc3/Jdbc3SimpleDataSource.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc3/Jdbc3SimpleDataSource.java
@@ -7,5 +7,9 @@ package org.postgresql.jdbc3;
 
 import org.postgresql.ds.PGSimpleDataSource;
 
+/**
+ * @deprecated Please use {@link PGSimpleDataSource}
+ */
+@Deprecated
 public class Jdbc3SimpleDataSource extends PGSimpleDataSource {
 }


### PR DESCRIPTION
Deprecated PGPoolingDataSource instead of this class you should use a fully featured connection pool
like HikariCP, vibur-dbcp, commons-dbcp, c3p0, etc.

It also deprecates the backwards compatibility classes of DataSource with a link
to the correct implementation.

closes #729