### PR TITLE
fix: use SQLWarning(String reason) constructor for correct DriverMana…

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/util/PSQLWarning.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/PSQLWarning.java
@@ -13,6 +13,7 @@ public class PSQLWarning extends SQLWarning {
   private ServerErrorMessage serverError;
 
   public PSQLWarning(ServerErrorMessage err) {
+    super(err.toString(), err.getSQLState());
     this.serverError = err;
   }
 

--- a/pgjdbc/src/main/java/org/postgresql/util/PSQLWarning.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/PSQLWarning.java
@@ -17,14 +17,6 @@ public class PSQLWarning extends SQLWarning {
     this.serverError = err;
   }
 
-  public String toString() {
-    return serverError.toString();
-  }
-
-  public String getSQLState() {
-    return serverError.getSQLState();
-  }
-
   public String getMessage() {
     return serverError.getMessage();
   }

--- a/pgjdbc/src/test/java/org/postgresql/util/PSQLWarningTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/util/PSQLWarningTest.java
@@ -5,26 +5,33 @@
 
 package org.postgresql.util;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.postgresql.test.TestUtil;
 
 import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
-import java.io.UnsupportedEncodingException;
+import java.sql.Connection;
 import java.sql.DriverManager;
+import java.sql.Statement;
+
 
 public class PSQLWarningTest {
 
   @Test
-  public void testPSQLLogsToDriverManagerMessage() throws UnsupportedEncodingException  {
+  public void testPSQLLogsToDriverManagerMessage() throws Exception {
+    Connection con = TestUtil.openDB();
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     DriverManager.setLogWriter(new PrintWriter(new OutputStreamWriter(baos, "ASCII")));
 
-    ServerErrorMessage warnMsg = new ServerErrorMessage(
-        "SNOTICE\u0000C42P06\u0000Mschema \"customschema\" already exists, skipping\u0000Fschemacmds.c\u0000L100\u0000RCreateSchemaCommand\u0000\u0000");
-    PSQLWarning warning = new PSQLWarning(warnMsg);
-    assertEquals("SQLWarning: reason(NOTICE: schema \"customschema\" already exists, skipping) SQLState(42P06)\n", baos.toString());
+    Statement stmt = con.createStatement();
+    stmt.execute("DO language plpgsql $$ BEGIN RAISE NOTICE 'test notice'; END $$;");
+    assertTrue(baos.toString().contains("NOTICE: test notice"));
+
+    stmt.close();
+    con.close();
   }
 }

--- a/pgjdbc/src/test/java/org/postgresql/util/PSQLWarningTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/util/PSQLWarningTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2016, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.util;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.io.UnsupportedEncodingException;
+import java.sql.DriverManager;
+
+public class PSQLWarningTest {
+
+  @Test
+  public void testPSQLLogsToDriverManagerMessage() throws UnsupportedEncodingException  {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    DriverManager.setLogWriter(new PrintWriter(new OutputStreamWriter(baos, "ASCII")));
+
+    ServerErrorMessage warnMsg = new ServerErrorMessage(
+        "SNOTICE\u0000C42P06\u0000Mschema \"customschema\" already exists, skipping\u0000Fschemacmds.c\u0000L100\u0000RCreateSchemaCommand\u0000\u0000");
+    PSQLWarning warning = new PSQLWarning(warnMsg);
+    assertEquals("SQLWarning: reason(NOTICE: schema \"customschema\" already exists, skipping) SQLState(42P06)\n", baos.toString());
+  }
+}


### PR DESCRIPTION
…ger logging

Previously, the default constructor was used which only logs "SQLWarning: ", but no information about the warning.