### PR TITLE
Make replication docs use PREFER_QUERY_MODE

### DIFF
--- a/docs/documentation/head/replication.md
+++ b/docs/documentation/head/replication.md
@@ -98,6 +98,7 @@ execute SQL commands, and can only be used with replication API. This is a restr
     PGProperty.PASSWORD.set(props, "postgres");
     PGProperty.ASSUME_MIN_SERVER_VERSION.set(props, "9.4");
     PGProperty.REPLICATION.set(props, "database");
+    PGProperty.PREFER_QUERY_MODE.set(props, "simple");
 
     Connection con = DriverManager.getConnection(url, props);
     PGConnection replConnection = con.unwrap(PGConnection.class);


### PR DESCRIPTION
The follow prop must be set:

```
PGProperty.PREFER_QUERY_MODE.set(props, "simple");
```

on a replication connection to create replication slots. The
docs demonstrate this in the full example near the bottom of
the page but not at the top where it shows creating a slot
thru pgjdbc.

fixes #759