### PR TITLE
Deliver instance of SSLSocketFactory in configuration

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -476,6 +476,17 @@ public enum PGProperty {
   }
 
   /**
+   * Returns the value of the connection parameters according to the given {@code Properties} or null.
+   * This is an Object from underlying Hashtable&lt;Object,Object> and can deliver anything,
+   * not just Strings.
+   *
+   * @param properties properties to take actual value from
+   */
+  public Object getObject(Properties properties) {
+      return properties.get(_name);
+    }
+
+  /**
    * Set the value for this connection parameter in the given {@code Properties}
    *
    * @param properties properties in which the value should be set

--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -477,10 +477,11 @@ public enum PGProperty {
 
   /**
    * Returns the value of the connection parameters according to the given {@code Properties} or null.
-   * This is an Object from underlying Hashtable&lt;Object,Object> and can deliver anything,
+   * This is an Object from underlying Hashtable&lt;Object,Object&gt; and can deliver anything,
    * not just Strings.
    *
    * @param properties properties to take actual value from
+   * @return connection parameter Object
    */
   public Object getObject(Properties properties) {
     return properties.get(_name);

--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -483,8 +483,8 @@ public enum PGProperty {
    * @param properties properties to take actual value from
    */
   public Object getObject(Properties properties) {
-      return properties.get(_name);
-    }
+    return properties.get(_name);
+  }
 
   /**
    * Set the value for this connection parameter in the given {@code Properties}

--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -184,7 +184,7 @@ public enum PGProperty {
   SSL_MODE("sslmode", null, "Parameter governing the use of SSL"),
 
   /**
-   * Classname of the SSL Factory to use (instance of {@code javax.net.ssl.SSLSocketFactory}).
+   * Classname or actual instance of the SSL Factory to use (instance of {@code javax.net.ssl.SSLSocketFactory}).
    */
   SSL_FACTORY("sslfactory", null, "Provide a SSLSocketFactory class when using SSL."),
 
@@ -195,7 +195,7 @@ public enum PGProperty {
       "Argument forwarded to constructor of SSLSocketFactory class."),
 
   /**
-   * Classname of the SSL HostnameVerifier to use (instance of {@code
+   * Classname or actual instance of the SSL HostnameVerifier to use (instance of {@code
    * javax.net.ssl.HostnameVerifier}).
    */
   SSL_HOSTNAME_VERIFIER("sslhostnameverifier", null,

--- a/pgjdbc/src/main/java/org/postgresql/ssl/MakeSSL.java
+++ b/pgjdbc/src/main/java/org/postgresql/ssl/MakeSSL.java
@@ -79,7 +79,7 @@ public class MakeSSL extends ObjectFactory {
         // Property delivered the HostnameVerifier
         hvn = (HostnameVerifier)sslhostnameverifier;
       } else {
-        // Property delivered the class name to be instantiated 
+        // Property delivered the class name to be instantiated
         try {
           hvn = (HostnameVerifier) instantiate((String)sslhostnameverifier, info, false, null);
         } catch (Exception e) {

--- a/pgjdbc/src/main/java/org/postgresql/ssl/MakeSSL.java
+++ b/pgjdbc/src/main/java/org/postgresql/ssl/MakeSSL.java
@@ -35,7 +35,7 @@ public class MakeSSL extends ObjectFactory {
     String sslmode = PGProperty.SSL_MODE.get(info);
     // Use the default factory if no specific factory is requested
     // unless sslmode is set
-    Object classname = PGProperty.SSL_FACTORY.get(info);
+    Object classname = PGProperty.SSL_FACTORY.getObject(info);
     if (classname == null) {
       // If sslmode is set, use the libp compatible factory
       if (sslmode != null) {
@@ -72,7 +72,7 @@ public class MakeSSL extends ObjectFactory {
           PSQLState.CONNECTION_FAILURE, ex);
     }
 
-    Object sslhostnameverifier = PGProperty.SSL_HOSTNAME_VERIFIER.get(info);
+    Object sslhostnameverifier = PGProperty.SSL_HOSTNAME_VERIFIER.getObject(info);
     if (sslhostnameverifier != null) {
       final HostnameVerifier hvn;
       if (sslhostnameverifier instanceof HostnameVerifier) {


### PR DESCRIPTION
Pg-issue#762: Deliver instance of SSLSocketFactory in runtime setup.

This is simply an addition to the original behaviour described here:
.  https://jdbc.postgresql.org/documentation/head/connect.html
An addition where the property setter can also be used like this:
.  props.put("sslfactory", mySSLSocketFactory);
Similarly:
.  props.put("sslhostnameverifier", myHostnameVerifier);
(Using underlying Hashtable instead of Properties API.)

If these two new property behaviours are used, all other SSL properties
are not reached in code flow at all.

This mode is useful when application infrastructure already knows
how to handle SSL socket creation and TLS peer authentication,
including TrustManager processing, client key usage, etc.