### PR TITLE
refactor: add missing override on methods

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgCallableStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgCallableStatement.java
@@ -57,6 +57,7 @@ class PgCallableStatement extends PgPreparedStatement implements CallableStateme
     }
   }
 
+  @Override
   public int executeUpdate() throws SQLException {
     if (isFunction) {
       executeWithFlags(0);
@@ -65,10 +66,12 @@ class PgCallableStatement extends PgPreparedStatement implements CallableStateme
     return super.executeUpdate();
   }
 
+  @Override
   public Object getObject(int i, Map<String, Class<?>> map) throws SQLException {
     return getObjectImpl(i, map);
   }
 
+  @Override
   public Object getObject(String s, Map<String, Class<?>> map) throws SQLException {
     return getObjectImpl(s, map);
   }
@@ -235,6 +238,7 @@ class PgCallableStatement extends PgPreparedStatement implements CallableStateme
     registerOutParameter(parameterIndex, sqlType, setPreparedParameters); // ignore for now..
   }
 
+  @Override
   public boolean wasNull() throws SQLException {
     if (lastIndex == 0) {
       throw new PSQLException(GT.tr("wasNull cannot be call before fetching a result."),
@@ -245,12 +249,14 @@ class PgCallableStatement extends PgPreparedStatement implements CallableStateme
     return (callResult[lastIndex - 1] == null);
   }
 
+  @Override
   public String getString(int parameterIndex) throws SQLException {
     checkClosed();
     checkIndex(parameterIndex, Types.VARCHAR, "String");
     return (String) callResult[parameterIndex - 1];
   }
 
+  @Override
   public boolean getBoolean(int parameterIndex) throws SQLException {
     checkClosed();
     checkIndex(parameterIndex, Types.BIT, "Boolean");
@@ -261,6 +267,7 @@ class PgCallableStatement extends PgPreparedStatement implements CallableStateme
     return (Boolean) callResult[parameterIndex - 1];
   }
 
+  @Override
   public byte getByte(int parameterIndex) throws SQLException {
     checkClosed();
     // fake tiny int with smallint
@@ -274,6 +281,7 @@ class PgCallableStatement extends PgPreparedStatement implements CallableStateme
 
   }
 
+  @Override
   public short getShort(int parameterIndex) throws SQLException {
     checkClosed();
     checkIndex(parameterIndex, Types.SMALLINT, "Short");
@@ -283,6 +291,7 @@ class PgCallableStatement extends PgPreparedStatement implements CallableStateme
     return ((Integer) callResult[parameterIndex - 1]).shortValue();
   }
 
+  @Override
   public int getInt(int parameterIndex) throws SQLException {
     checkClosed();
     checkIndex(parameterIndex, Types.INTEGER, "Int");
@@ -293,6 +302,7 @@ class PgCallableStatement extends PgPreparedStatement implements CallableStateme
     return (Integer) callResult[parameterIndex - 1];
   }
 
+  @Override
   public long getLong(int parameterIndex) throws SQLException {
     checkClosed();
     checkIndex(parameterIndex, Types.BIGINT, "Long");
@@ -303,6 +313,7 @@ class PgCallableStatement extends PgPreparedStatement implements CallableStateme
     return (Long) callResult[parameterIndex - 1];
   }
 
+  @Override
   public float getFloat(int parameterIndex) throws SQLException {
     checkClosed();
     checkIndex(parameterIndex, Types.REAL, "Float");
@@ -313,6 +324,7 @@ class PgCallableStatement extends PgPreparedStatement implements CallableStateme
     return (Float) callResult[parameterIndex - 1];
   }
 
+  @Override
   public double getDouble(int parameterIndex) throws SQLException {
     checkClosed();
     checkIndex(parameterIndex, Types.DOUBLE, "Double");
@@ -323,36 +335,42 @@ class PgCallableStatement extends PgPreparedStatement implements CallableStateme
     return (Double) callResult[parameterIndex - 1];
   }
 
+  @Override
   public BigDecimal getBigDecimal(int parameterIndex, int scale) throws SQLException {
     checkClosed();
     checkIndex(parameterIndex, Types.NUMERIC, "BigDecimal");
     return ((BigDecimal) callResult[parameterIndex - 1]);
   }
 
+  @Override
   public byte[] getBytes(int parameterIndex) throws SQLException {
     checkClosed();
     checkIndex(parameterIndex, Types.VARBINARY, Types.BINARY, "Bytes");
     return ((byte[]) callResult[parameterIndex - 1]);
   }
 
+  @Override
   public java.sql.Date getDate(int parameterIndex) throws SQLException {
     checkClosed();
     checkIndex(parameterIndex, Types.DATE, "Date");
     return (java.sql.Date) callResult[parameterIndex - 1];
   }
 
+  @Override
   public java.sql.Time getTime(int parameterIndex) throws SQLException {
     checkClosed();
     checkIndex(parameterIndex, Types.TIME, "Time");
     return (java.sql.Time) callResult[parameterIndex - 1];
   }
 
+  @Override
   public java.sql.Timestamp getTimestamp(int parameterIndex) throws SQLException {
     checkClosed();
     checkIndex(parameterIndex, Types.TIMESTAMP, "Timestamp");
     return (java.sql.Timestamp) callResult[parameterIndex - 1];
   }
 
+  @Override
   public Object getObject(int parameterIndex) throws SQLException {
     checkClosed();
     checkIndex(parameterIndex);
@@ -441,22 +459,26 @@ class PgCallableStatement extends PgPreparedStatement implements CallableStateme
     return new CallableBatchResultHandler(this, queries, parameterLists);
   }
 
+  @Override
   public java.sql.Array getArray(int i) throws SQLException {
     checkClosed();
     checkIndex(i, Types.ARRAY, "Array");
     return (Array) callResult[i - 1];
   }
 
+  @Override
   public java.math.BigDecimal getBigDecimal(int parameterIndex) throws SQLException {
     checkClosed();
     checkIndex(parameterIndex, Types.NUMERIC, "BigDecimal");
     return ((BigDecimal) callResult[parameterIndex - 1]);
   }
 
+  @Override
   public Blob getBlob(int i) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "getBlob(int)");
   }
 
+  @Override
   public Clob getClob(int i) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "getClob(int)");
   }
@@ -468,10 +490,12 @@ class PgCallableStatement extends PgPreparedStatement implements CallableStateme
     throw Driver.notImplemented(this.getClass(), "getObjectImpl(int,Map)");
   }
 
+  @Override
   public Ref getRef(int i) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "getRef(int)");
   }
 
+  @Override
   public java.sql.Date getDate(int i, java.util.Calendar cal) throws SQLException {
     checkClosed();
     checkIndex(i, Types.DATE, "Date");
@@ -484,6 +508,7 @@ class PgCallableStatement extends PgPreparedStatement implements CallableStateme
     return connection.getTimestampUtils().toDate(cal, value);
   }
 
+  @Override
   public Time getTime(int i, java.util.Calendar cal) throws SQLException {
     checkClosed();
     checkIndex(i, Types.TIME, "Time");
@@ -496,6 +521,7 @@ class PgCallableStatement extends PgPreparedStatement implements CallableStateme
     return connection.getTimestampUtils().toTime(cal, value);
   }
 
+  @Override
   public Timestamp getTimestamp(int i, java.util.Calendar cal) throws SQLException {
     checkClosed();
     checkIndex(i, Types.TIMESTAMP, "Timestamp");
@@ -508,368 +534,456 @@ class PgCallableStatement extends PgPreparedStatement implements CallableStateme
     return connection.getTimestampUtils().toTimestamp(cal, value);
   }
 
+  @Override
   public void registerOutParameter(int parameterIndex, int sqlType, String typeName)
       throws SQLException {
     throw Driver.notImplemented(this.getClass(), "registerOutParameter(int,int,String)");
   }
 
   //#if mvn.project.property.postgresql.jdbc.spec >= "JDBC4.2"
+  @Override
   public void setObject(String parameterName, Object x, java.sql.SQLType targetSqlType,
       int scaleOrLength) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "setObject");
   }
 
+  @Override
   public void setObject(String parameterName, Object x, java.sql.SQLType targetSqlType)
       throws SQLException {
     throw Driver.notImplemented(this.getClass(), "setObject");
   }
 
+  @Override
   public void registerOutParameter(int parameterIndex, java.sql.SQLType sqlType)
       throws SQLException {
     throw Driver.notImplemented(this.getClass(), "registerOutParameter");
   }
 
+  @Override
   public void registerOutParameter(int parameterIndex, java.sql.SQLType sqlType, int scale)
       throws SQLException {
     throw Driver.notImplemented(this.getClass(), "registerOutParameter");
   }
 
+  @Override
   public void registerOutParameter(int parameterIndex, java.sql.SQLType sqlType, String typeName)
       throws SQLException {
     throw Driver.notImplemented(this.getClass(), "registerOutParameter");
   }
 
+  @Override
   public void registerOutParameter(String parameterName, java.sql.SQLType sqlType)
       throws SQLException {
     throw Driver.notImplemented(this.getClass(), "registerOutParameter");
   }
 
+  @Override
   public void registerOutParameter(String parameterName, java.sql.SQLType sqlType, int scale)
       throws SQLException {
     throw Driver.notImplemented(this.getClass(), "registerOutParameter");
   }
 
+  @Override
   public void registerOutParameter(String parameterName, java.sql.SQLType sqlType, String typeName)
       throws SQLException {
     throw Driver.notImplemented(this.getClass(), "registerOutParameter");
   }
   //#endif
 
+  @Override
   public RowId getRowId(int parameterIndex) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "getRowId(int)");
   }
 
+  @Override
   public RowId getRowId(String parameterName) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "getRowId(String)");
   }
 
+  @Override
   public void setRowId(String parameterName, RowId x) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "setRowId(String, RowId)");
   }
 
+  @Override
   public void setNString(String parameterName, String value) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "setNString(String, String)");
   }
 
+  @Override
   public void setNCharacterStream(String parameterName, Reader value, long length)
       throws SQLException {
     throw Driver.notImplemented(this.getClass(), "setNCharacterStream(String, Reader, long)");
   }
 
+  @Override
   public void setNCharacterStream(String parameterName, Reader value) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "setNCharacterStream(String, Reader)");
   }
 
+  @Override
   public void setCharacterStream(String parameterName, Reader value, long length)
       throws SQLException {
     throw Driver.notImplemented(this.getClass(), "setCharacterStream(String, Reader, long)");
   }
 
+  @Override
   public void setCharacterStream(String parameterName, Reader value) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "setCharacterStream(String, Reader)");
   }
 
+  @Override
   public void setBinaryStream(String parameterName, InputStream value, long length)
       throws SQLException {
     throw Driver.notImplemented(this.getClass(), "setBinaryStream(String, InputStream, long)");
   }
 
+  @Override
   public void setBinaryStream(String parameterName, InputStream value) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "setBinaryStream(String, InputStream)");
   }
 
+  @Override
   public void setAsciiStream(String parameterName, InputStream value, long length)
       throws SQLException {
     throw Driver.notImplemented(this.getClass(), "setAsciiStream(String, InputStream, long)");
   }
 
+  @Override
   public void setAsciiStream(String parameterName, InputStream value) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "setAsciiStream(String, InputStream)");
   }
 
+  @Override
   public void setNClob(String parameterName, NClob value) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "setNClob(String, NClob)");
   }
 
+  @Override
   public void setClob(String parameterName, Reader reader, long length) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "setClob(String, Reader, long)");
   }
 
+  @Override
   public void setClob(String parameterName, Reader reader) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "setClob(String, Reader)");
   }
 
+  @Override
   public void setBlob(String parameterName, InputStream inputStream, long length)
       throws SQLException {
     throw Driver.notImplemented(this.getClass(), "setBlob(String, InputStream, long)");
   }
 
+  @Override
   public void setBlob(String parameterName, InputStream inputStream) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "setBlob(String, InputStream)");
   }
 
+  @Override
   public void setBlob(String parameterName, Blob x) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "setBlob(String, Blob)");
   }
 
+  @Override
   public void setClob(String parameterName, Clob x) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "setClob(String, Clob)");
   }
 
+  @Override
   public void setNClob(String parameterName, Reader reader, long length) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "setNClob(String, Reader, long)");
   }
 
+  @Override
   public void setNClob(String parameterName, Reader reader) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "setNClob(String, Reader)");
   }
 
+  @Override
   public NClob getNClob(int parameterIndex) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "getNClob(int)");
   }
 
+  @Override
   public NClob getNClob(String parameterName) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "getNClob(String)");
   }
 
+  @Override
   public void setSQLXML(String parameterName, SQLXML xmlObject) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "setSQLXML(String, SQLXML)");
   }
 
+  @Override
   public SQLXML getSQLXML(int parameterIndex) throws SQLException {
     checkClosed();
     checkIndex(parameterIndex, Types.SQLXML, "SQLXML");
     return (SQLXML) callResult[parameterIndex - 1];
   }
 
+  @Override
   public SQLXML getSQLXML(String parameterIndex) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "getSQLXML(String)");
   }
 
+  @Override
   public String getNString(int parameterIndex) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "getNString(int)");
   }
 
+  @Override
   public String getNString(String parameterName) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "getNString(String)");
   }
 
+  @Override
   public Reader getNCharacterStream(int parameterIndex) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "getNCharacterStream(int)");
   }
 
+  @Override
   public Reader getNCharacterStream(String parameterName) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "getNCharacterStream(String)");
   }
 
+  @Override
   public Reader getCharacterStream(int parameterIndex) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "getCharacterStream(int)");
   }
 
+  @Override
   public Reader getCharacterStream(String parameterName) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "getCharacterStream(String)");
   }
 
+  //#if mvn.project.property.postgresql.jdbc.spec >= "JDBC4.1"
+  @Override
   public <T> T getObject(int parameterIndex, Class<T> type) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "getObject(int, Class<T>)");
   }
 
+  @Override
   public <T> T getObject(String parameterName, Class<T> type) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "getObject(String, Class<T>)");
   }
+  //#endif
 
+  @Override
   public void registerOutParameter(String parameterName, int sqlType) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "registerOutParameter(String,int)");
   }
 
+  @Override
   public void registerOutParameter(String parameterName, int sqlType, int scale)
       throws SQLException {
     throw Driver.notImplemented(this.getClass(), "registerOutParameter(String,int,int)");
   }
 
+  @Override
   public void registerOutParameter(String parameterName, int sqlType, String typeName)
       throws SQLException {
     throw Driver.notImplemented(this.getClass(), "registerOutParameter(String,int,String)");
   }
 
+  @Override
   public java.net.URL getURL(int parameterIndex) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "getURL(String)");
   }
 
+  @Override
   public void setURL(String parameterName, java.net.URL val) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "setURL(String,URL)");
   }
 
+  @Override
   public void setNull(String parameterName, int sqlType) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "setNull(String,int)");
   }
 
+  @Override
   public void setBoolean(String parameterName, boolean x) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "setBoolean(String,boolean)");
   }
 
+  @Override
   public void setByte(String parameterName, byte x) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "setByte(String,byte)");
   }
 
+  @Override
   public void setShort(String parameterName, short x) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "setShort(String,short)");
   }
 
+  @Override
   public void setInt(String parameterName, int x) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "setInt(String,int)");
   }
 
+  @Override
   public void setLong(String parameterName, long x) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "setLong(String,long)");
   }
 
+  @Override
   public void setFloat(String parameterName, float x) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "setFloat(String,float)");
   }
 
+  @Override
   public void setDouble(String parameterName, double x) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "setDouble(String,double)");
   }
 
+  @Override
   public void setBigDecimal(String parameterName, BigDecimal x) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "setBigDecimal(String,BigDecimal)");
   }
 
+  @Override
   public void setString(String parameterName, String x) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "setString(String,String)");
   }
 
+  @Override
   public void setBytes(String parameterName, byte x[]) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "setBytes(String,byte)");
   }
 
+  @Override
   public void setDate(String parameterName, java.sql.Date x) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "setDate(String,Date)");
   }
 
+  @Override
   public void setTime(String parameterName, Time x) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "setTime(String,Time)");
   }
 
+  @Override
   public void setTimestamp(String parameterName, Timestamp x) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "setTimestamp(String,Timestamp)");
   }
 
+  @Override
   public void setAsciiStream(String parameterName, InputStream x, int length) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "setAsciiStream(String,InputStream,int)");
   }
 
+  @Override
   public void setBinaryStream(String parameterName, InputStream x, int length) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "setBinaryStream(String,InputStream,int)");
   }
 
+  @Override
   public void setObject(String parameterName, Object x, int targetSqlType, int scale)
       throws SQLException {
     throw Driver.notImplemented(this.getClass(), "setObject(String,Object,int,int)");
   }
 
+  @Override
   public void setObject(String parameterName, Object x, int targetSqlType) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "setObject(String,Object,int)");
   }
 
+  @Override
   public void setObject(String parameterName, Object x) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "setObject(String,Object)");
   }
 
+  @Override
   public void setCharacterStream(String parameterName, Reader reader, int length)
       throws SQLException {
     throw Driver.notImplemented(this.getClass(), "setCharacterStream(String,Reader,int)");
   }
 
+  @Override
   public void setDate(String parameterName, java.sql.Date x, Calendar cal) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "setDate(String,Date,Calendar)");
   }
 
+  @Override
   public void setTime(String parameterName, Time x, Calendar cal) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "setTime(String,Time,Calendar)");
   }
 
+  @Override
   public void setTimestamp(String parameterName, Timestamp x, Calendar cal) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "setTimestamp(String,Timestamp,Calendar)");
   }
 
+  @Override
   public void setNull(String parameterName, int sqlType, String typeName) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "setNull(String,int,String)");
   }
 
+  @Override
   public String getString(String parameterName) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "getString(String)");
   }
 
+  @Override
   public boolean getBoolean(String parameterName) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "getBoolean(String)");
   }
 
+  @Override
   public byte getByte(String parameterName) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "getByte(String)");
   }
 
+  @Override
   public short getShort(String parameterName) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "getShort(String)");
   }
 
+  @Override
   public int getInt(String parameterName) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "getInt(String)");
   }
 
+  @Override
   public long getLong(String parameterName) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "getLong(String)");
   }
 
+  @Override
   public float getFloat(String parameterName) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "getFloat(String)");
   }
 
+  @Override
   public double getDouble(String parameterName) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "getDouble(String)");
   }
 
+  @Override
   public byte[] getBytes(String parameterName) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "getBytes(String)");
   }
 
+  @Override
   public java.sql.Date getDate(String parameterName) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "getDate(String)");
   }
 
+  @Override
   public Time getTime(String parameterName) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "getTime(String)");
   }
 
+  @Override
   public Timestamp getTimestamp(String parameterName) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "getTimestamp(String)");
   }
 
+  @Override
   public Object getObject(String parameterName) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "getObject(String)");
   }
 
+  @Override
   public BigDecimal getBigDecimal(String parameterName) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "getBigDecimal(String)");
   }
@@ -878,26 +992,32 @@ class PgCallableStatement extends PgPreparedStatement implements CallableStateme
     throw Driver.notImplemented(this.getClass(), "getObject(String,Map)");
   }
 
+  @Override
   public Ref getRef(String parameterName) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "getRef(String)");
   }
 
+  @Override
   public Blob getBlob(String parameterName) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "getBlob(String)");
   }
 
+  @Override
   public Clob getClob(String parameterName) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "getClob(String)");
   }
 
+  @Override
   public Array getArray(String parameterName) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "getArray(String)");
   }
 
+  @Override
   public java.sql.Date getDate(String parameterName, Calendar cal) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "getDate(String,Calendar)");
   }
 
+  @Override
   public Time getTime(String parameterName, Calendar cal) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "getTime(String,Calendar)");
   }
@@ -906,10 +1026,12 @@ class PgCallableStatement extends PgPreparedStatement implements CallableStateme
     throw Driver.notImplemented(this.getClass(), "getTimestamp(String,Calendar)");
   }
 
+  @Override
   public java.net.URL getURL(String parameterName) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "getURL(String)");
   }
 
+  @Override
   public void registerOutParameter(int parameterIndex, int sqlType) throws SQLException {
     // if this isn't 8.1 or we are using protocol version 2 then we don't
     // register the parameter
@@ -923,6 +1045,7 @@ class PgCallableStatement extends PgPreparedStatement implements CallableStateme
     registerOutParameter(parameterIndex, sqlType, !adjustIndex);
   }
 
+  @Override
   public void registerOutParameter(int parameterIndex, int sqlType, int scale) throws SQLException {
     // ignore scale for now
     registerOutParameter(parameterIndex, sqlType);

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
@@ -353,6 +353,7 @@ public class PgConnection implements BaseConnection {
 
   private final TimestampUtils timestampUtils;
 
+  @Override
   public TimestampUtils getTimestampUtils() {
     return timestampUtils;
   }
@@ -362,31 +363,37 @@ public class PgConnection implements BaseConnection {
    */
   protected Map<String, Class<?>> typemap;
 
+  @Override
   public java.sql.Statement createStatement() throws SQLException {
     // We now follow the spec and default to TYPE_FORWARD_ONLY.
     return createStatement(java.sql.ResultSet.TYPE_FORWARD_ONLY,
         java.sql.ResultSet.CONCUR_READ_ONLY);
   }
 
+  @Override
   public java.sql.PreparedStatement prepareStatement(String sql) throws SQLException {
     return prepareStatement(sql, java.sql.ResultSet.TYPE_FORWARD_ONLY,
         java.sql.ResultSet.CONCUR_READ_ONLY);
   }
 
+  @Override
   public java.sql.CallableStatement prepareCall(String sql) throws SQLException {
     return prepareCall(sql, java.sql.ResultSet.TYPE_FORWARD_ONLY,
         java.sql.ResultSet.CONCUR_READ_ONLY);
   }
 
+  @Override
   public Map<String, Class<?>> getTypeMap() throws SQLException {
     checkClosed();
     return typemap;
   }
 
+  @Override
   public QueryExecutor getQueryExecutor() {
     return queryExecutor;
   }
 
+  @Override
   public ReplicationProtocol getReplicationProtocol() {
     return queryExecutor.getReplicationProtocol();
   }
@@ -406,10 +413,12 @@ public class PgConnection implements BaseConnection {
 
   }
 
+  @Override
   public ResultSet execSQLQuery(String s) throws SQLException {
     return execSQLQuery(s, ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
   }
 
+  @Override
   public ResultSet execSQLQuery(String s, int resultSetType, int resultSetConcurrency)
       throws SQLException {
     BaseStatement stat = (BaseStatement) createStatement(resultSetType, resultSetConcurrency);
@@ -433,6 +442,7 @@ public class PgConnection implements BaseConnection {
     return stat.getResultSet();
   }
 
+  @Override
   public void execSQLUpdate(String s) throws SQLException {
     BaseStatement stmt = (BaseStatement) createStatement();
     if (stmt.executeWithFlags(s, QueryExecutor.QUERY_NO_METADATA | QueryExecutor.QUERY_NO_RESULTS
@@ -449,32 +459,6 @@ public class PgConnection implements BaseConnection {
     }
 
     stmt.close();
-  }
-
-  /**
-   * In SQL, a result table can be retrieved through a cursor that is named. The current row of a
-   * result can be updated or deleted using a positioned update/delete statement that references the
-   * cursor name.
-   * <p>
-   * We do not support positioned update/delete, so this is a no-op.
-   *
-   * @param cursor the cursor name
-   * @throws SQLException if a database access error occurs
-   */
-  public void setCursorName(String cursor) throws SQLException {
-    checkClosed();
-    // No-op.
-  }
-
-  /**
-   * getCursorName gets the cursor name.
-   *
-   * @return the current cursor name
-   * @throws SQLException if a database access error occurs
-   */
-  public String getCursorName() throws SQLException {
-    checkClosed();
-    return null;
   }
 
   /**
@@ -500,6 +484,7 @@ public class PgConnection implements BaseConnection {
     return queryExecutor.getUser();
   }
 
+  @Override
   public Fastpath getFastpathAPI() throws SQLException {
     checkClosed();
     if (fastpath == null) {
@@ -511,6 +496,7 @@ public class PgConnection implements BaseConnection {
   // This holds a reference to the Fastpath API if already open
   private Fastpath fastpath = null;
 
+  @Override
   public LargeObjectManager getLargeObjectAPI() throws SQLException {
     checkClosed();
     if (largeobject == null) {
@@ -536,6 +522,7 @@ public class PgConnection implements BaseConnection {
    *
    * @exception SQLException if value is not correct for this type
    */
+  @Override
   public Object getObject(String type, String value, byte[] byteValue) throws SQLException {
     if (typemap != null) {
       Class<?> c = typemap.get(type);
@@ -592,6 +579,7 @@ public class PgConnection implements BaseConnection {
     return new TypeInfoCache(conn, unknownLength);
   }
 
+  @Override
   public TypeInfo getTypeInfo() {
     return _typeCache;
   }
@@ -653,12 +641,14 @@ public class PgConnection implements BaseConnection {
    *
    * {@inheritDoc}
    */
+  @Override
   public void close() throws SQLException {
     releaseTimer();
     queryExecutor.close();
     openStackTrace = null;
   }
 
+  @Override
   public String nativeSQL(String sql) throws SQLException {
     checkClosed();
     CachedQuery cachedQuery = queryExecutor.createQuery(sql, false, true);
@@ -666,6 +656,7 @@ public class PgConnection implements BaseConnection {
     return cachedQuery.query.getNativeSql();
   }
 
+  @Override
   public synchronized SQLWarning getWarnings() throws SQLException {
     checkClosed();
     SQLWarning newWarnings = queryExecutor.getWarnings(); // NB: also clears them.
@@ -678,13 +669,14 @@ public class PgConnection implements BaseConnection {
     return firstWarning;
   }
 
+  @Override
   public synchronized void clearWarnings() throws SQLException {
     checkClosed();
     queryExecutor.getWarnings(); // Clear and discard.
     firstWarning = null;
   }
 
-
+  @Override
   public void setReadOnly(boolean readOnly) throws SQLException {
     checkClosed();
     if (queryExecutor.getTransactionState() != TransactionState.IDLE) {
@@ -703,11 +695,13 @@ public class PgConnection implements BaseConnection {
     LOGGER.log(Level.FINE, "  setReadOnly = {0}", readOnly);
   }
 
+  @Override
   public boolean isReadOnly() throws SQLException {
     checkClosed();
     return readOnly;
   }
 
+  @Override
   public void setAutoCommit(boolean autoCommit) throws SQLException {
     checkClosed();
 
@@ -723,6 +717,7 @@ public class PgConnection implements BaseConnection {
     LOGGER.log(Level.FINE, "  setAutoCommit = {0}", autoCommit);
   }
 
+  @Override
   public boolean getAutoCommit() throws SQLException {
     checkClosed();
     return this.autoCommit;
@@ -748,6 +743,7 @@ public class PgConnection implements BaseConnection {
     }
   }
 
+  @Override
   public void commit() throws SQLException {
     checkClosed();
 
@@ -768,7 +764,7 @@ public class PgConnection implements BaseConnection {
     }
   }
 
-
+  @Override
   public void rollback() throws SQLException {
     checkClosed();
 
@@ -782,10 +778,12 @@ public class PgConnection implements BaseConnection {
     }
   }
 
+  @Override
   public TransactionState getTransactionState() {
     return queryExecutor.getTransactionState();
   }
 
+  @Override
   public int getTransactionIsolation() throws SQLException {
     checkClosed();
 
@@ -818,6 +816,7 @@ public class PgConnection implements BaseConnection {
     return Connection.TRANSACTION_READ_COMMITTED; // Best guess.
   }
 
+  @Override
   public void setTransactionIsolation(int level) throws SQLException {
     checkClosed();
 
@@ -854,11 +853,13 @@ public class PgConnection implements BaseConnection {
     }
   }
 
+  @Override
   public void setCatalog(String catalog) throws SQLException {
     checkClosed();
     // no-op
   }
 
+  @Override
   public String getCatalog() throws SQLException {
     checkClosed();
     return queryExecutor.getDatabase();
@@ -871,6 +872,7 @@ public class PgConnection implements BaseConnection {
    * Greenham</a> who hit a problem where multiple clients didn't close the connection, and once a
    * fortnight enough clients were open to kill the postgres server.
    */
+  @Override
   protected void finalize() throws Throwable {
     try {
       if (openStackTrace != null) {
@@ -984,6 +986,7 @@ public class PgConnection implements BaseConnection {
    * Handler for transaction queries
    */
   private class TransactionCommandHandler extends ResultHandlerBase {
+    @Override
     public void handleCompletion() throws SQLException {
       SQLWarning warning = getWarning();
       if (warning != null) {
@@ -993,10 +996,12 @@ public class PgConnection implements BaseConnection {
     }
   }
 
+  @Override
   public int getPrepareThreshold() {
     return prepareThreshold;
   }
 
+  @Override
   public void setDefaultFetchSize(int fetchSize) throws SQLException {
     if (fetchSize < 0) {
       throw new PSQLException(GT.tr("Fetch size must be a value greater to or equal to 0."),
@@ -1007,10 +1012,12 @@ public class PgConnection implements BaseConnection {
     LOGGER.log(Level.FINE, "  setDefaultFetchSize = {0}", fetchSize);
   }
 
+  @Override
   public int getDefaultFetchSize() {
     return defaultFetchSize;
   }
 
+  @Override
   public void setPrepareThreshold(int newThreshold) {
     this.prepareThreshold = newThreshold;
     LOGGER.log(Level.FINE, "  setPrepareThreshold = {0}", newThreshold);
@@ -1029,6 +1036,7 @@ public class PgConnection implements BaseConnection {
     typemap = map;
   }
 
+  @Override
   public Logger getLogger() {
     return LOGGER;
   }
@@ -1037,12 +1045,14 @@ public class PgConnection implements BaseConnection {
     return queryExecutor.getProtocolVersion();
   }
 
+  @Override
   public boolean getStringVarcharFlag() {
     return bindStringAsVarchar;
   }
 
   private CopyManager copyManager = null;
 
+  @Override
   public CopyManager getCopyAPI() throws SQLException {
     checkClosed();
     if (copyManager == null) {
@@ -1051,14 +1061,17 @@ public class PgConnection implements BaseConnection {
     return copyManager;
   }
 
+  @Override
   public boolean binaryTransferSend(int oid) {
     return queryExecutor.useBinaryForSend(oid);
   }
 
+  @Override
   public int getBackendPID() {
     return queryExecutor.getBackendPID();
   }
 
+  @Override
   public boolean isColumnSanitiserDisabled() {
     return this.disableColumnSanitiser;
   }
@@ -1404,11 +1417,13 @@ public class PgConnection implements BaseConnection {
     throw org.postgresql.Driver.notImplemented(this.getClass(), "createQueryObject(Class<T>)");
   }
 
+  @Override
   public boolean isWrapperFor(Class<?> iface) throws SQLException {
     checkClosed();
     return iface.isAssignableFrom(getClass());
   }
 
+  @Override
   public <T> T unwrap(Class<T> iface) throws SQLException {
     checkClosed();
     if (iface.isAssignableFrom(getClass())) {
@@ -1417,6 +1432,8 @@ public class PgConnection implements BaseConnection {
     throw new SQLException("Cannot unwrap to " + iface.getName());
   }
 
+  //#if mvn.project.property.postgresql.jdbc.spec >= "JDBC4.1"
+  @Override
   public String getSchema() throws SQLException {
     checkClosed();
     Statement stmt = createStatement();
@@ -1435,6 +1452,7 @@ public class PgConnection implements BaseConnection {
     }
   }
 
+  @Override
   public void setSchema(String schema) throws SQLException {
     checkClosed();
     Statement stmt = createStatement();
@@ -1455,11 +1473,13 @@ public class PgConnection implements BaseConnection {
   }
 
   public class AbortCommand implements Runnable {
+    @Override
     public void run() {
       abort();
     }
   }
 
+  @Override
   public void abort(Executor executor) throws SQLException {
     if (isClosed()) {
       return;
@@ -1475,13 +1495,16 @@ public class PgConnection implements BaseConnection {
     }
   }
 
+  @Override
   public void setNetworkTimeout(Executor executor, int milliseconds) throws SQLException {
     throw org.postgresql.Driver.notImplemented(this.getClass(), "setNetworkTimeout(Executor, int)");
   }
 
+  @Override
   public int getNetworkTimeout() throws SQLException {
     throw org.postgresql.Driver.notImplemented(this.getClass(), "getNetworkTimeout()");
   }
+  //#endif
 
   @Override
   public void setHoldability(int holdability) throws SQLException {
@@ -1566,24 +1589,28 @@ public class PgConnection implements BaseConnection {
     pgSavepoint.invalidate();
   }
 
+  @Override
   public Statement createStatement(int resultSetType, int resultSetConcurrency)
       throws SQLException {
     checkClosed();
     return createStatement(resultSetType, resultSetConcurrency, getHoldability());
   }
 
+  @Override
   public PreparedStatement prepareStatement(String sql, int resultSetType, int resultSetConcurrency)
       throws SQLException {
     checkClosed();
     return prepareStatement(sql, resultSetType, resultSetConcurrency, getHoldability());
   }
 
+  @Override
   public CallableStatement prepareCall(String sql, int resultSetType, int resultSetConcurrency)
       throws SQLException {
     checkClosed();
     return prepareCall(sql, resultSetType, resultSetConcurrency, getHoldability());
   }
 
+  @Override
   public PreparedStatement prepareStatement(String sql, int autoGeneratedKeys) throws SQLException {
     if (autoGeneratedKeys != Statement.RETURN_GENERATED_KEYS) {
       return prepareStatement(sql);
@@ -1592,6 +1619,7 @@ public class PgConnection implements BaseConnection {
     return prepareStatement(sql, (String[]) null);
   }
 
+  @Override
   public PreparedStatement prepareStatement(String sql, int columnIndexes[]) throws SQLException {
     if (columnIndexes != null && columnIndexes.length == 0) {
       return prepareStatement(sql);
@@ -1602,6 +1630,7 @@ public class PgConnection implements BaseConnection {
         PSQLState.NOT_IMPLEMENTED);
   }
 
+  @Override
   public PreparedStatement prepareStatement(String sql, String columnNames[]) throws SQLException {
     if (columnNames != null && columnNames.length == 0) {
       return prepareStatement(sql);

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
@@ -100,6 +100,7 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
     setPoolable(true); // As per JDBC spec: prepared and callable statements are poolable by
   }
 
+  @Override
   public java.sql.ResultSet executeQuery(String p_sql) throws SQLException {
     throw new PSQLException(
         GT.tr("Can''t use query methods that take a query string on a PreparedStatement."),
@@ -113,6 +114,7 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
    *
    * @exception SQLException if a database access error occurs
    */
+  @Override
   public java.sql.ResultSet executeQuery() throws SQLException {
     if (!executeWithFlags(0)) {
       throw new PSQLException(GT.tr("No results were returned by the query."), PSQLState.NO_DATA);
@@ -126,12 +128,14 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
     return result.getResultSet();
   }
 
+  @Override
   public int executeUpdate(String p_sql) throws SQLException {
     throw new PSQLException(
         GT.tr("Can''t use query methods that take a query string on a PreparedStatement."),
         PSQLState.WRONG_OBJECT_TYPE);
   }
 
+  @Override
   public int executeUpdate() throws SQLException {
     executeWithFlags(QueryExecutor.QUERY_NO_RESULTS);
 
@@ -148,16 +152,19 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
     return getUpdateCount();
   }
 
+  @Override
   public boolean execute(String p_sql) throws SQLException {
     throw new PSQLException(
         GT.tr("Can''t use query methods that take a query string on a PreparedStatement."),
         PSQLState.WRONG_OBJECT_TYPE);
   }
 
+  @Override
   public boolean execute() throws SQLException {
     return executeWithFlags(0);
   }
 
+  @Override
   public boolean executeWithFlags(int flags) throws SQLException {
     try {
       checkClosed();
@@ -174,6 +181,7 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
     }
   }
 
+  @Override
   protected boolean isOneShotQuery(CachedQuery cachedQuery) {
     if (cachedQuery == null) {
       cachedQuery = preparedQuery;
@@ -202,6 +210,7 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
     super.close();
   }
 
+  @Override
   public void setNull(int parameterIndex, int sqlType) throws SQLException {
     checkClosed();
 
@@ -279,16 +288,19 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
     preparedParameters.setNull(parameterIndex, oid);
   }
 
+  @Override
   public void setBoolean(int parameterIndex, boolean x) throws SQLException {
     checkClosed();
     // The key words TRUE and FALSE are the preferred (SQL-compliant) usage.
     bindLiteral(parameterIndex, x ? "TRUE" : "FALSE", Oid.BOOL);
   }
 
+  @Override
   public void setByte(int parameterIndex, byte x) throws SQLException {
     setShort(parameterIndex, x);
   }
 
+  @Override
   public void setShort(int parameterIndex, short x) throws SQLException {
     checkClosed();
     if (connection.binaryTransferSend(Oid.INT2)) {
@@ -300,6 +312,7 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
     bindLiteral(parameterIndex, Integer.toString(x), Oid.INT2);
   }
 
+  @Override
   public void setInt(int parameterIndex, int x) throws SQLException {
     checkClosed();
     if (connection.binaryTransferSend(Oid.INT4)) {
@@ -311,6 +324,7 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
     bindLiteral(parameterIndex, Integer.toString(x), Oid.INT4);
   }
 
+  @Override
   public void setLong(int parameterIndex, long x) throws SQLException {
     checkClosed();
     if (connection.binaryTransferSend(Oid.INT8)) {
@@ -322,6 +336,7 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
     bindLiteral(parameterIndex, Long.toString(x), Oid.INT8);
   }
 
+  @Override
   public void setFloat(int parameterIndex, float x) throws SQLException {
     checkClosed();
     if (connection.binaryTransferSend(Oid.FLOAT4)) {
@@ -333,6 +348,7 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
     bindLiteral(parameterIndex, Float.toString(x), Oid.FLOAT8);
   }
 
+  @Override
   public void setDouble(int parameterIndex, double x) throws SQLException {
     checkClosed();
     if (connection.binaryTransferSend(Oid.FLOAT8)) {
@@ -344,6 +360,7 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
     bindLiteral(parameterIndex, Double.toString(x), Oid.FLOAT8);
   }
 
+  @Override
   public void setBigDecimal(int parameterIndex, BigDecimal x) throws SQLException {
     checkClosed();
     if (x == null) {
@@ -353,6 +370,7 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
     }
   }
 
+  @Override
   public void setString(int parameterIndex, String x) throws SQLException {
     checkClosed();
     setString(parameterIndex, x, getStringType());
@@ -375,6 +393,7 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
     }
   }
 
+  @Override
   public void setBytes(int parameterIndex, byte[] x) throws SQLException {
     checkClosed();
 
@@ -389,14 +408,17 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
     preparedParameters.setBytea(parameterIndex, copy, 0, x.length);
   }
 
+  @Override
   public void setDate(int parameterIndex, java.sql.Date x) throws SQLException {
     setDate(parameterIndex, x, null);
   }
 
+  @Override
   public void setTime(int parameterIndex, Time x) throws SQLException {
     setTime(parameterIndex, x, null);
   }
 
+  @Override
   public void setTimestamp(int parameterIndex, Timestamp x) throws SQLException {
     setTimestamp(parameterIndex, x, null);
   }
@@ -446,17 +468,20 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
     }
   }
 
+  @Override
   public void setAsciiStream(int parameterIndex, InputStream x, int length) throws SQLException {
     checkClosed();
     setCharacterStreamPost71(parameterIndex, x, length, "ASCII");
   }
 
+  @Override
   public void setUnicodeStream(int parameterIndex, InputStream x, int length) throws SQLException {
     checkClosed();
 
     setCharacterStreamPost71(parameterIndex, x, length, "UTF-8");
   }
 
+  @Override
   public void setBinaryStream(int parameterIndex, InputStream x, int length) throws SQLException {
     checkClosed();
 
@@ -478,6 +503,7 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
     preparedParameters.setBytea(parameterIndex, x, length);
   }
 
+  @Override
   public void clearParameters() throws SQLException {
     preparedParameters.clear();
   }
@@ -899,6 +925,7 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
         PSQLState.INVALID_PARAMETER_TYPE, cause);
   }
 
+  @Override
   public void setObject(int parameterIndex, Object x, int targetSqlType) throws SQLException {
     setObject(parameterIndex, x, targetSqlType, -1);
   }
@@ -906,6 +933,7 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
   /*
    * This stores an Object into a parameter.
    */
+  @Override
   public void setObject(int parameterIndex, Object x) throws SQLException {
     checkClosed();
     if (x == null) {
@@ -975,6 +1003,7 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
    *
    * @return SQL statement with the current template values substituted
    */
+  @Override
   public String toString() {
     if (preparedQuery == null) {
       return super.toString();
@@ -1023,11 +1052,13 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
     preparedParameters.setStringParameter(paramIndex, s, oid);
   }
 
+  @Override
   public boolean isUseServerPrepare() {
     return (preparedQuery != null && m_prepareThreshold != 0
         && preparedQuery.getExecuteCount() + 1 >= m_prepareThreshold);
   }
 
+  @Override
   public void addBatch(String p_sql) throws SQLException {
     checkClosed();
 
@@ -1036,6 +1067,7 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
         PSQLState.WRONG_OBJECT_TYPE);
   }
 
+  @Override
   public void addBatch() throws SQLException {
     checkClosed();
     if (batchStatements == null) {
@@ -1050,6 +1082,7 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
     }
   }
 
+  @Override
   public ResultSetMetaData getMetaData() throws SQLException {
     checkClosed();
     ResultSet rs = getResultSet();
@@ -1078,6 +1111,7 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
     return null;
   }
 
+  @Override
   public void setArray(int i, java.sql.Array x) throws SQLException {
     checkClosed();
 
@@ -1143,6 +1177,7 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
     return oid;
   }
 
+  @Override
   public void setBlob(int i, Blob x) throws SQLException {
     checkClosed();
 
@@ -1181,6 +1216,7 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
     }
   }
 
+  @Override
   public void setCharacterStream(int i, java.io.Reader x, int length) throws SQLException {
     checkClosed();
 
@@ -1203,6 +1239,7 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
     setString(i, readerToString(x, length));
   }
 
+  @Override
   public void setClob(int i, Clob x) throws SQLException {
     checkClosed();
 
@@ -1239,15 +1276,18 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
     setLong(i, oid);
   }
 
+  @Override
   public void setNull(int i, int t, String s) throws SQLException {
     checkClosed();
     setNull(i, t);
   }
 
+  @Override
   public void setRef(int i, Ref x) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "setRef(int,Ref)");
   }
 
+  @Override
   public void setDate(int i, java.sql.Date d, java.util.Calendar cal) throws SQLException {
     checkClosed();
 
@@ -1289,6 +1329,7 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
     bindString(i, connection.getTimestampUtils().toString(cal, d), Oid.UNSPECIFIED);
   }
 
+  @Override
   public void setTime(int i, Time t, java.util.Calendar cal) throws SQLException {
     checkClosed();
 
@@ -1316,6 +1357,7 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
     bindString(i, connection.getTimestampUtils().toString(cal, t), oid);
   }
 
+  @Override
   public void setTimestamp(int i, Timestamp t, java.util.Calendar cal) throws SQLException {
     checkClosed();
 
@@ -1399,42 +1441,53 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
     return new PgParameterMetaData(conn, oids);
   }
 
-
   //#if mvn.project.property.postgresql.jdbc.spec >= "JDBC4.2"
+  @Override
   public void setObject(int parameterIndex, Object x, java.sql.SQLType targetSqlType,
       int scaleOrLength) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "setObject");
   }
 
+  @Override
   public void setObject(int parameterIndex, Object x, java.sql.SQLType targetSqlType)
       throws SQLException {
     throw Driver.notImplemented(this.getClass(), "setObject");
   }
+
+  @Override
+  public long executeLargeUpdate() throws SQLException {
+    throw Driver.notImplemented(this.getClass(), "executeLargeUpdate");
+  }
   //#endif
 
-
+  @Override
   public void setRowId(int parameterIndex, RowId x) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "setRowId(int, RowId)");
   }
 
+  @Override
   public void setNString(int parameterIndex, String value) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "setNString(int, String)");
   }
 
+  @Override
   public void setNCharacterStream(int parameterIndex, Reader value, long length)
       throws SQLException {
     throw Driver.notImplemented(this.getClass(), "setNCharacterStream(int, Reader, long)");
   }
 
+  @Override
   public void setNCharacterStream(int parameterIndex, Reader value) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "setNCharacterStream(int, Reader)");
   }
 
+  @Override
   public void setCharacterStream(int parameterIndex, Reader value, long length)
       throws SQLException {
     throw Driver.notImplemented(this.getClass(), "setCharacterStream(int, Reader, long)");
   }
 
+  @Override
   public void setCharacterStream(int parameterIndex, Reader value) throws SQLException {
     if (connection.getPreferQueryMode() == PreferQueryMode.SIMPLE) {
       String s = (value != null) ? readerToString(value, Integer.MAX_VALUE) : null;
@@ -1445,6 +1498,7 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
     setObject(parameterIndex, is, Types.LONGVARCHAR);
   }
 
+  @Override
   public void setBinaryStream(int parameterIndex, InputStream value, long length)
       throws SQLException {
     if (length > Integer.MAX_VALUE) {
@@ -1454,31 +1508,38 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
     preparedParameters.setBytea(parameterIndex, value, (int) length);
   }
 
+  @Override
   public void setBinaryStream(int parameterIndex, InputStream value) throws SQLException {
     preparedParameters.setBytea(parameterIndex, value);
   }
 
+  @Override
   public void setAsciiStream(int parameterIndex, InputStream value, long length)
       throws SQLException {
     throw Driver.notImplemented(this.getClass(), "setAsciiStream(int, InputStream, long)");
   }
 
+  @Override
   public void setAsciiStream(int parameterIndex, InputStream value) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "setAsciiStream(int, InputStream)");
   }
 
+  @Override
   public void setNClob(int parameterIndex, NClob value) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "setNClob(int, NClob)");
   }
 
+  @Override
   public void setClob(int parameterIndex, Reader reader, long length) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "setClob(int, Reader, long)");
   }
 
+  @Override
   public void setClob(int parameterIndex, Reader reader) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "setClob(int, Reader)");
   }
 
+  @Override
   public void setBlob(int parameterIndex, InputStream inputStream, long length)
       throws SQLException {
     checkClosed();
@@ -1497,6 +1558,7 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
     setLong(parameterIndex, oid);
   }
 
+  @Override
   public void setBlob(int parameterIndex, InputStream inputStream) throws SQLException {
     checkClosed();
 
@@ -1509,14 +1571,17 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
     setLong(parameterIndex, oid);
   }
 
+  @Override
   public void setNClob(int parameterIndex, Reader reader, long length) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "setNClob(int, Reader, long)");
   }
 
+  @Override
   public void setNClob(int parameterIndex, Reader reader) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "setNClob(int, Reader)");
   }
 
+  @Override
   public void setSQLXML(int parameterIndex, SQLXML xmlObject) throws SQLException {
     checkClosed();
     if (xmlObject == null || xmlObject.getString() == null) {
@@ -1537,6 +1602,7 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
     }
   }
 
+  @Override
   public void setURL(int parameterIndex, java.net.URL x) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "setURL(int,URL)");
   }
@@ -1562,6 +1628,7 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
     return sharedCalendar;
   }
 
+  @Override
   public ParameterMetaData getParameterMetaData() throws SQLException {
     int flags = QueryExecutor.QUERY_ONESHOT | QueryExecutor.QUERY_DESCRIBE_ONLY
         | QueryExecutor.QUERY_SUPPRESS_BEGIN;
@@ -1575,7 +1642,6 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
     }
 
     return null;
-
   }
 
   @Override

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgStatement.java
@@ -151,6 +151,7 @@ public class PgStatement implements Statement, BaseStatement {
     this.rsHoldability = rsHoldability;
   }
 
+  @Override
   public ResultSet createResultSet(Query originalQuery, Field[] fields, List<byte[][]> tuples,
       ResultCursor cursor) throws SQLException {
     PgResultSet newResult = new PgResultSet(originalQuery, this, fields, tuples, cursor,
@@ -169,6 +170,7 @@ public class PgStatement implements Statement, BaseStatement {
     return null;
   }
 
+  @Override
   public int getFetchSize() {
     return fetchSize;
   }
@@ -227,6 +229,7 @@ public class PgStatement implements Statement, BaseStatement {
     }
   }
 
+  @Override
   public java.sql.ResultSet executeQuery(String p_sql) throws SQLException {
     if (!executeWithFlags(p_sql, 0)) {
       throw new PSQLException(GT.tr("No results were returned by the query."), PSQLState.NO_DATA);
@@ -240,6 +243,7 @@ public class PgStatement implements Statement, BaseStatement {
     return result.getResultSet();
   }
 
+  @Override
   public int executeUpdate(String p_sql) throws SQLException {
     executeWithFlags(p_sql, QueryExecutor.QUERY_NO_RESULTS);
 
@@ -256,10 +260,12 @@ public class PgStatement implements Statement, BaseStatement {
     return getUpdateCount();
   }
 
+  @Override
   public boolean execute(String p_sql) throws SQLException {
     return executeWithFlags(p_sql, 0);
   }
 
+  @Override
   public boolean executeWithFlags(String sql, int flags) throws SQLException {
     return executeCachedSql(sql, flags, NO_RETURNING_COLUMNS);
   }
@@ -293,6 +299,7 @@ public class PgStatement implements Statement, BaseStatement {
     return res;
   }
 
+  @Override
   public boolean executeWithFlags(CachedQuery simpleQuery, int flags) throws SQLException {
     checkClosed();
     if (connection.getPreferQueryMode().compareTo(PreferQueryMode.EXTENDED) < 0) {
@@ -302,6 +309,7 @@ public class PgStatement implements Statement, BaseStatement {
     return (result != null && result.getResultSet() != null);
   }
 
+  @Override
   public boolean executeWithFlags(int flags) throws SQLException {
     checkClosed();
     throw new PSQLException(GT.tr("Can''t use executeWithFlags(int) on a Statement."),
@@ -341,11 +349,8 @@ public class PgStatement implements Statement, BaseStatement {
       return true;
     }
     cachedQuery.increaseExecuteCount();
-    if ((m_prepareThreshold == 0 || cachedQuery.getExecuteCount() < m_prepareThreshold)
-        && !getForceBinaryTransfer()) {
-      return true;
-    }
-    return false;
+    return (m_prepareThreshold == 0 || cachedQuery.getExecuteCount() < m_prepareThreshold)
+        && !getForceBinaryTransfer();
   }
 
   protected final void execute(CachedQuery cachedQuery, ParameterList queryParameters, int flags)
@@ -443,6 +448,7 @@ public class PgStatement implements Statement, BaseStatement {
 
   }
 
+  @Override
   public void setCursorName(String name) throws SQLException {
     checkClosed();
     // No-op.
@@ -452,6 +458,7 @@ public class PgStatement implements Statement, BaseStatement {
   // see #close()
   protected boolean isClosed = false;
 
+  @Override
   public int getUpdateCount() throws SQLException {
     checkClosed();
     if (result == null || result.getResultSet() != null) {
@@ -461,6 +468,7 @@ public class PgStatement implements Statement, BaseStatement {
     return result.getUpdateCount();
   }
 
+  @Override
   public boolean getMoreResults() throws SQLException {
     if (result == null) {
       return false;
@@ -479,11 +487,13 @@ public class PgStatement implements Statement, BaseStatement {
     return (result != null && result.getResultSet() != null);
   }
 
+  @Override
   public int getMaxRows() throws SQLException {
     checkClosed();
     return maxrows;
   }
 
+  @Override
   public void setMaxRows(int max) throws SQLException {
     checkClosed();
     if (max < 0) {
@@ -494,15 +504,18 @@ public class PgStatement implements Statement, BaseStatement {
     maxrows = max;
   }
 
+  @Override
   public void setEscapeProcessing(boolean enable) throws SQLException {
     checkClosed();
     replaceProcessingEnabled = enable;
   }
 
+  @Override
   public int getQueryTimeout() throws SQLException {
     return getQueryTimeoutMs() / 1000;
   }
 
+  @Override
   public void setQueryTimeout(int seconds) throws SQLException {
     setQueryTimeoutMs(seconds * 1000);
   }
@@ -552,15 +565,18 @@ public class PgStatement implements Statement, BaseStatement {
     }
   }
 
+  @Override
   public SQLWarning getWarnings() throws SQLException {
     checkClosed();
     return warnings;
   }
 
+  @Override
   public int getMaxFieldSize() throws SQLException {
     return maxfieldSize;
   }
 
+  @Override
   public void setMaxFieldSize(int max) throws SQLException {
     checkClosed();
     if (max < 0) {
@@ -571,11 +587,13 @@ public class PgStatement implements Statement, BaseStatement {
     maxfieldSize = max;
   }
 
+  @Override
   public void clearWarnings() throws SQLException {
     warnings = null;
     lastWarning = null;
   }
 
+  @Override
   public java.sql.ResultSet getResultSet() throws SQLException {
     checkClosed();
 
@@ -592,6 +610,7 @@ public class PgStatement implements Statement, BaseStatement {
    *
    * {@inheritDoc}
    */
+  @Override
   public void close() throws SQLException {
     // closing an already closed Statement is a no-op.
     if (isClosed) {
@@ -611,6 +630,7 @@ public class PgStatement implements Statement, BaseStatement {
    *
    */
 
+  @Override
   public long getLastOID() throws SQLException {
     checkClosed();
     if (result == null) {
@@ -619,7 +639,8 @@ public class PgStatement implements Statement, BaseStatement {
     return result.getInsertOID();
   }
 
-  public void setPrepareThreshold(int newThreshold) throws SQLException {
+  @Override
+  public final void setPrepareThreshold(int newThreshold) throws SQLException {
     checkClosed();
 
     if (newThreshold < 0) {
@@ -630,14 +651,17 @@ public class PgStatement implements Statement, BaseStatement {
     this.m_prepareThreshold = newThreshold;
   }
 
+  @Override
   public int getPrepareThreshold() {
     return m_prepareThreshold;
   }
 
+  @Override
   public void setUseServerPrepare(boolean flag) throws SQLException {
     setPrepareThreshold(flag ? 1 : 0);
   }
 
+  @Override
   public boolean isUseServerPrepare() {
     return false;
   }
@@ -651,6 +675,7 @@ public class PgStatement implements Statement, BaseStatement {
 
   // ** JDBC 2 Extensions **
 
+  @Override
   public void addBatch(String p_sql) throws SQLException {
     checkClosed();
 
@@ -666,6 +691,7 @@ public class PgStatement implements Statement, BaseStatement {
     batchParameters.add(null);
   }
 
+  @Override
   public void clearBatch() throws SQLException {
     if (batchStatements != null) {
       batchStatements.clear();
@@ -679,6 +705,7 @@ public class PgStatement implements Statement, BaseStatement {
         wantsGeneratedKeysAlways);
   }
 
+  @Override
   public int[] executeBatch() throws SQLException {
     checkClosed();
 
@@ -801,6 +828,7 @@ public class PgStatement implements Statement, BaseStatement {
     return handler.getUpdateCount();
   }
 
+  @Override
   public void cancel() throws SQLException {
     if (!STATE_UPDATER.compareAndSet(this, StatementCancelState.IN_QUERY, StatementCancelState.CANCELING)) {
       // Not in query, there's nothing to cancel
@@ -819,22 +847,27 @@ public class PgStatement implements Statement, BaseStatement {
     }
   }
 
+  @Override
   public Connection getConnection() throws SQLException {
     return connection;
   }
 
+  @Override
   public int getFetchDirection() {
     return fetchdirection;
   }
 
+  @Override
   public int getResultSetConcurrency() {
     return concurrency;
   }
 
+  @Override
   public int getResultSetType() {
     return resultsettype;
   }
 
+  @Override
   public void setFetchDirection(int direction) throws SQLException {
     switch (direction) {
       case ResultSet.FETCH_FORWARD:
@@ -848,7 +881,8 @@ public class PgStatement implements Statement, BaseStatement {
     }
   }
 
-  public void setFetchSize(int rows) throws SQLException {
+  @Override
+  public final void setFetchSize(int rows) throws SQLException {
     checkClosed();
     if (rows < 0) {
       throw new PSQLException(GT.tr("Fetch size must be a value greater to or equal to 0."),
@@ -870,6 +904,7 @@ public class PgStatement implements Statement, BaseStatement {
     }
 
     TimerTask cancelTask = new TimerTask() {
+      @Override
       public void run() {
         try {
           if (!CANCEL_TIMER_UPDATER.compareAndSet(PgStatement.this, this, null)) {
@@ -943,60 +978,71 @@ public class PgStatement implements Statement, BaseStatement {
     return forceBinaryTransfers;
   }
 
+  //#if mvn.project.property.postgresql.jdbc.spec >= "JDBC4.2"
+  @Override
   public long getLargeUpdateCount() throws SQLException {
     throw Driver.notImplemented(this.getClass(), "getLargeUpdateCount");
   }
 
+  @Override
   public void setLargeMaxRows(long max) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "setLargeMaxRows");
   }
 
+  @Override
   public long getLargeMaxRows() throws SQLException {
     throw Driver.notImplemented(this.getClass(), "getLargeMaxRows");
   }
 
+  @Override
   public long[] executeLargeBatch() throws SQLException {
     throw Driver.notImplemented(this.getClass(), "executeLargeBatch");
   }
 
+  @Override
   public long executeLargeUpdate(String sql) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "executeLargeUpdate");
   }
 
+  @Override
   public long executeLargeUpdate(String sql, int autoGeneratedKeys) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "executeLargeUpdate");
   }
 
+  @Override
   public long executeLargeUpdate(String sql, int columnIndexes[]) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "executeLargeUpdate");
   }
 
+  @Override
   public long executeLargeUpdate(String sql, String columnNames[]) throws SQLException {
     throw Driver.notImplemented(this.getClass(), "executeLargeUpdate");
   }
+  //#endif
 
-  public long executeLargeUpdate() throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "executeLargeUpdate");
-  }
-
+  @Override
   public boolean isClosed() throws SQLException {
     return isClosed;
   }
 
+  @Override
   public void setPoolable(boolean poolable) throws SQLException {
     checkClosed();
     this.poolable = poolable;
   }
 
+  @Override
   public boolean isPoolable() throws SQLException {
     checkClosed();
     return poolable;
   }
 
+  @Override
   public boolean isWrapperFor(Class<?> iface) throws SQLException {
     return iface.isAssignableFrom(getClass());
   }
 
+  @Override
   public <T> T unwrap(Class<T> iface) throws SQLException {
     if (iface.isAssignableFrom(getClass())) {
       return iface.cast(this);
@@ -1004,13 +1050,17 @@ public class PgStatement implements Statement, BaseStatement {
     throw new SQLException("Cannot unwrap to " + iface.getName());
   }
 
+  //#if mvn.project.property.postgresql.jdbc.spec >= "JDBC4.1"
+  @Override
   public void closeOnCompletion() throws SQLException {
     closeOnCompletion = true;
   }
 
+  @Override
   public boolean isCloseOnCompletion() throws SQLException {
     return closeOnCompletion;
   }
+  //#endif
 
   protected void checkCompletion() throws SQLException {
     if (!closeOnCompletion) {
@@ -1035,6 +1085,7 @@ public class PgStatement implements Statement, BaseStatement {
     }
   }
 
+  @Override
   public boolean getMoreResults(int current) throws SQLException {
     // CLOSE_CURRENT_RESULT
     if (current == Statement.CLOSE_CURRENT_RESULT && result != null
@@ -1062,6 +1113,7 @@ public class PgStatement implements Statement, BaseStatement {
     return (result != null && result.getResultSet() != null);
   }
 
+  @Override
   public ResultSet getGeneratedKeys() throws SQLException {
     checkClosed();
     if (generatedKeys == null || generatedKeys.getResultSet() == null) {
@@ -1071,6 +1123,7 @@ public class PgStatement implements Statement, BaseStatement {
     return generatedKeys.getResultSet();
   }
 
+  @Override
   public int executeUpdate(String sql, int autoGeneratedKeys) throws SQLException {
     if (autoGeneratedKeys == Statement.NO_GENERATED_KEYS) {
       return executeUpdate(sql);
@@ -1079,6 +1132,7 @@ public class PgStatement implements Statement, BaseStatement {
     return executeUpdate(sql, (String[]) null);
   }
 
+  @Override
   public int executeUpdate(String sql, int columnIndexes[]) throws SQLException {
     if (columnIndexes == null || columnIndexes.length == 0) {
       return executeUpdate(sql);
@@ -1088,6 +1142,7 @@ public class PgStatement implements Statement, BaseStatement {
         PSQLState.NOT_IMPLEMENTED);
   }
 
+  @Override
   public int executeUpdate(String sql, String columnNames[]) throws SQLException {
     if (columnNames != null && columnNames.length == 0) {
       return executeUpdate(sql);
@@ -1100,6 +1155,7 @@ public class PgStatement implements Statement, BaseStatement {
     return getUpdateCount();
   }
 
+  @Override
   public boolean execute(String sql, int autoGeneratedKeys) throws SQLException {
     if (autoGeneratedKeys == Statement.NO_GENERATED_KEYS) {
       return execute(sql);
@@ -1107,6 +1163,7 @@ public class PgStatement implements Statement, BaseStatement {
     return execute(sql, (String[]) null);
   }
 
+  @Override
   public boolean execute(String sql, int columnIndexes[]) throws SQLException {
     if (columnIndexes != null && columnIndexes.length == 0) {
       return execute(sql);
@@ -1116,6 +1173,7 @@ public class PgStatement implements Statement, BaseStatement {
         PSQLState.NOT_IMPLEMENTED);
   }
 
+  @Override
   public boolean execute(String sql, String columnNames[]) throws SQLException {
     if (columnNames != null && columnNames.length == 0) {
       return execute(sql);
@@ -1125,10 +1183,12 @@ public class PgStatement implements Statement, BaseStatement {
     return executeCachedSql(sql, 0, columnNames);
   }
 
+  @Override
   public int getResultSetHoldability() throws SQLException {
     return rsHoldability;
   }
 
+  @Override
   public ResultSet createDriverResultSet(Field[] fields, List<byte[][]> tuples)
       throws SQLException {
     return createResultSet(null, fields, tuples, null);


### PR DESCRIPTION
Add missing `@Override` on methods from PgConnection, PgCallableStatement, PgPreparedStatement, PgStatement and PgResultSet.

Additionally add preprocessor to methods that should not be exposed to lower JDBC versions.