### PR TITLE
fix: datasource can not get a connection if the driver is not registered

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/ds/PGConnectionPoolDataSource.java
+++ b/pgjdbc/src/main/java/org/postgresql/ds/PGConnectionPoolDataSource.java
@@ -30,19 +30,13 @@ import javax.sql.PooledConnection;
  * these properties are declared in the superclass.
  * </p>
  *
- * <p>
- * This implementation supports JDK 1.3 and higher.
- * </p>
- *
  * @author Aaron Mulder (ammulder@chariotsolutions.com)
  */
 public class PGConnectionPoolDataSource extends BaseDataSource
     implements ConnectionPoolDataSource, Serializable {
   private boolean defaultAutoCommit = true;
 
-  /**
-   * Gets a description of this DataSource.
-   */
+  @Override
   public String getDescription() {
     return "ConnectionPoolDataSource from " + org.postgresql.util.DriverInfo.DRIVER_FULL_NAME;
   }
@@ -54,6 +48,7 @@ public class PGConnectionPoolDataSource extends BaseDataSource
    * @throws java.sql.SQLException Occurs when the physical database connection cannot be
    *         established.
    */
+  @Override
   public PooledConnection getPooledConnection() throws SQLException {
     return new PGPooledConnection(getConnection(), defaultAutoCommit);
   }
@@ -65,6 +60,7 @@ public class PGConnectionPoolDataSource extends BaseDataSource
    * @throws java.sql.SQLException Occurs when the physical database connection cannot be
    *         established.
    */
+  @Override
   public PooledConnection getPooledConnection(String user, String password) throws SQLException {
     return new PGPooledConnection(getConnection(user, password), defaultAutoCommit);
   }

--- a/pgjdbc/src/main/java/org/postgresql/ds/PGSimpleDataSource.java
+++ b/pgjdbc/src/main/java/org/postgresql/ds/PGSimpleDataSource.java
@@ -23,11 +23,10 @@ import javax.sql.DataSource;
  * @author Aaron Mulder (ammulder@chariotsolutions.com)
  */
 public class PGSimpleDataSource extends BaseDataSource implements DataSource, Serializable {
-  /**
-   * Gets a description of this DataSource.
-   */
+
+  @Override
   public String getDescription() {
-    return "Non-Pooling DataSource from " + org.postgresql.util.DriverInfo.DRIVER_FULL_NAME;
+    return "Simple DataSource from " + org.postgresql.util.DriverInfo.DRIVER_FULL_NAME;
   }
 
   private void writeObject(ObjectOutputStream out) throws IOException {
@@ -38,10 +37,12 @@ public class PGSimpleDataSource extends BaseDataSource implements DataSource, Se
     readBaseObject(in);
   }
 
+  @Override
   public boolean isWrapperFor(Class<?> iface) throws SQLException {
     return iface.isAssignableFrom(getClass());
   }
 
+  @Override
   public <T> T unwrap(Class<T> iface) throws SQLException {
     if (iface.isAssignableFrom(getClass())) {
       return iface.cast(this);

--- a/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
+++ b/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
@@ -76,11 +76,15 @@ public abstract class BaseDataSource implements CommonDataSource, Referenceable 
    */
   public Connection getConnection(String user, String password) throws SQLException {
     try {
-      Connection con = DriverManager.getConnection(getUrl(), user, password);
-      if (LOGGER.isLoggable(Level.FINE)) {
-        LOGGER.log(Level.FINE, "Created a {0} for {1} at {2}", new Object[]{getDescription(), user, getUrl()});
+      if (org.postgresql.Driver.isRegistered()) {
+        Connection con = DriverManager.getConnection(getUrl(), user, password);
+        if (LOGGER.isLoggable(Level.FINE)) {
+          LOGGER.log(Level.FINE, "Created a {0} for {1} at {2}", new Object[]{getDescription(), user, getUrl()});
+        }
+        return con;
+      } else {
+        throw new SQLException("Driver is not registered.");
       }
-      return con;
     } catch (SQLException e) {
       LOGGER.log(Level.SEVERE, "Failed to create a {0} for {1} at {2}: {3}",
           new Object[]{getDescription(), user, getUrl(), e});
@@ -986,6 +990,7 @@ public abstract class BaseDataSource implements CommonDataSource, Referenceable 
   }
 
   /**
+   * @return replication parameter for startup message
    * @see PGProperty#REPLICATION
    */
   public String getReplication() {
@@ -1135,6 +1140,7 @@ public abstract class BaseDataSource implements CommonDataSource, Referenceable 
     return new Reference(getClass().getName(), PGObjectFactory.class.getName(), null);
   }
 
+  @Override
   public Reference getReference() throws NamingException {
     Reference ref = createReference();
     ref.add(new StringRefAddr("serverName", serverName));
@@ -1260,6 +1266,7 @@ public abstract class BaseDataSource implements CommonDataSource, Referenceable 
   }
 
   //#if mvn.project.property.postgresql.jdbc.spec >= "JDBC4.1"
+  @Override
   public java.util.logging.Logger getParentLogger() {
     return Logger.getLogger("org.postgresql");
   }


### PR DESCRIPTION
The current DataSource implementation relies in DriverManager to get a connection, but the DriverManager requires that the driver is registered and when the org.postgresql.Driver is called it's automatically registered in a static initializer block, but for the DataSource class it is not called.

To trigger the register of the driver, simply make a call to org.postgresql.Driver.isRegistered() which checks if the driver is registered and initialize the class if not.

closes #768