### PR TITLE
Only resolve hostname if not using a SOCKS proxy

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/PGStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/PGStream.java
@@ -59,6 +59,9 @@ public class PGStream {
 
     Socket socket = socketFactory.createSocket();
     if (!socket.isConnected()) {
+      // When using a SOCKS proxy, the host might not be resolvable locally,
+      // thus we defer resolution until the traffic reaches the proxy. If there
+      // is no proxy, we must resolve the host to an IP to connect the socket.
       InetSocketAddress address = System.getProperty("socksProxyHost") == null
           ? new InetSocketAddress(hostSpec.getHost(), hostSpec.getPort())
           : InetSocketAddress.createUnresolved(hostSpec.getHost(), hostSpec.getPort());

--- a/pgjdbc/src/main/java/org/postgresql/core/PGStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/PGStream.java
@@ -59,9 +59,9 @@ public class PGStream {
 
     Socket socket = socketFactory.createSocket();
     if (!socket.isConnected()) {
-      InetSocketAddress address = System.getProperty("socksProxyHost") == null ?
-          new InetSocketAddress(hostSpec.getHost(), hostSpec.getPort()) :
-          InetSocketAddress.createUnresolved(hostSpec.getHost(), hostSpec.getPort());
+      InetSocketAddress address = System.getProperty("socksProxyHost") == null
+          ? new InetSocketAddress(hostSpec.getHost(), hostSpec.getPort())
+          : InetSocketAddress.createUnresolved(hostSpec.getHost(), hostSpec.getPort());
       socket.connect(address, timeout);
     }
     changeSocket(socket);

--- a/pgjdbc/src/main/java/org/postgresql/core/PGStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/PGStream.java
@@ -59,7 +59,10 @@ public class PGStream {
 
     Socket socket = socketFactory.createSocket();
     if (!socket.isConnected()) {
-      socket.connect(new InetSocketAddress(hostSpec.getHost(), hostSpec.getPort()), timeout);
+      InetSocketAddress address = System.getProperty("socksProxyHost") == null ?
+          new InetSocketAddress(hostSpec.getHost(), hostSpec.getPort()) :
+          InetSocketAddress.createUnresolved(hostSpec.getHost(), hostSpec.getPort());
+      socket.connect(address, timeout);
     }
     changeSocket(socket);
     setEncoding(Encoding.getJVMEncoding("UTF-8"));


### PR DESCRIPTION
This PR adds a check for a SOCKS proxy before resolving the hostname of the database.

## Problem
If the database connection is passed through a SOCKS proxy, DNS resolution might not be possible from the Java process and the should be deferred so it can occur at the proxy.

## Example to Reproduce
I've created [an app on Github to reproduce this problem](https://github.com/jkutner/pg-socket-socks-test), which you can test by deploying for free on Heroku by clicking this button:

[![Deploy to Heroku](https://www.herokucdn.com/deploy/button.png)](https://dashboard.heroku.com/new?button-url=https%3A%2F%2Fgithub.com%2Fkissaten%2Fspring-petclinic&template=https%3A%2F%2Fgithub.com%2Fjkutner%2Fpg-socket-socks-test)

By default, it uses a SOCKS proxy that runs alongside the app (on the same server), which works. But if you set the `SOCKS_URL` to your own SOCKS proxy running somewhere else, it will fail.

In this case, the behavior is somewhat the opposite of the problem I described above. That's because the IP address resolved in the Java process (running on Heroku) is a *private* IP, which Amazon Web Services can route internally. But when that private IP is passed through an external SOCKS proxy, the IP is unreachable. When the hostname is passed through the SOCKS proxy, it resolves to the *public* IP address.

## Possible Enchancements
I know that it might not be preferable to check for `System.getProperty("socksProxyHost")` directly. I'll be happy to change this to use a URL parameter like `resolveHostname=false` or something similar.