### PR TITLE
feat: improve waiting for notifications by providing a timeout option

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/PGConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGConnection.java
@@ -33,10 +33,10 @@ public interface PGConnection {
 
   /**
    * This method returns any notifications that have been received since the last call to this
-   * method. Returns null if there have been no notifications. A timeout can be speficied so the
+   * method. Returns null if there have been no notifications. A timeout can be specified so the
    * driver waits for notifications.
    *
-   * @param timeout when 0, blocks forever. when &gt; 0, blocks up to the specified number of millies
+   * @param timeoutMillis when 0, blocks forever. when &gt; 0, blocks up to the specified number of millies
    *        or until at least one notification has been received. If more than one notification is
    *        about to be received, these will be returned in one batch.
    * @return notifications that have been received

--- a/pgjdbc/src/main/java/org/postgresql/PGConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGConnection.java
@@ -36,8 +36,8 @@ public interface PGConnection {
    * method. Returns null if there have been no notifications. A timeout can be speficied so the
    * driver waits for notifications.
    *
-   * @param timeout when 0, waits forever. when >0, waits up to the specified number of millies or
-   *        until at least one notification has been received. If more than one notification is
+   * @param timeout when 0, blocks forever. when &gt; 0, blocks up to the specified number of millies
+   *        or until at least one notification has been received. If more than one notification is
    *        about to be received, these will be returned in one batch.
    * @return notifications that have been received
    * @throws SQLException if something wrong happens

--- a/pgjdbc/src/main/java/org/postgresql/PGConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGConnection.java
@@ -32,6 +32,20 @@ public interface PGConnection {
   PGNotification[] getNotifications() throws SQLException;
 
   /**
+   * This method returns any notifications that have been received since the last call to this
+   * method. Returns null if there have been no notifications. A timeout can be speficied so the 
+   * driver waits for notifications.
+   *
+   * @param timeout when 0, waits forever. when >0, waits up to the specified number of millies or
+   *        until at least one notification has been received. If more than one notification is 
+   *        about to be received, these will be returned in one batch.
+   * @return notifications that have been received
+   * @throws SQLException if something wrong happens
+   * @since 43
+   */
+  PGNotification[] getNotifications(int timeoutMillis) throws SQLException;
+
+  /**
    * This returns the COPY API for the current connection.
    *
    * @return COPY API for the current connection

--- a/pgjdbc/src/main/java/org/postgresql/PGConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGConnection.java
@@ -33,11 +33,11 @@ public interface PGConnection {
 
   /**
    * This method returns any notifications that have been received since the last call to this
-   * method. Returns null if there have been no notifications. A timeout can be speficied so the 
+   * method. Returns null if there have been no notifications. A timeout can be speficied so the
    * driver waits for notifications.
    *
    * @param timeout when 0, waits forever. when >0, waits up to the specified number of millies or
-   *        until at least one notification has been received. If more than one notification is 
+   *        until at least one notification has been received. If more than one notification is
    *        about to be received, these will be returned in one batch.
    * @return notifications that have been received
    * @throws SQLException if something wrong happens

--- a/pgjdbc/src/main/java/org/postgresql/core/QueryExecutor.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/QueryExecutor.java
@@ -217,6 +217,16 @@ public interface QueryExecutor extends TypeTransferModeRegistry {
    */
   void processNotifies() throws SQLException;
 
+  /**
+   * Prior to attempting to retrieve notifications, we need to pull any recently received
+   * notifications off of the network buffers. The notification retrieval in ProtocolConnection
+   * cannot do this as it is prone to deadlock, so the higher level caller must be responsible which
+   * requires exposing this method. This variant supports blocking for the given time in millis.
+   *
+   * @throws SQLException if and error occurs while fetching notifications
+   */
+  void processNotifies(int timeoutMillis) throws SQLException;
+  
   //
   // Fastpath interface.
   //

--- a/pgjdbc/src/main/java/org/postgresql/core/QueryExecutor.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/QueryExecutor.java
@@ -226,7 +226,7 @@ public interface QueryExecutor extends TypeTransferModeRegistry {
    * @throws SQLException if and error occurs while fetching notifications
    */
   void processNotifies(int timeoutMillis) throws SQLException;
-  
+
   //
   // Fastpath interface.
   //

--- a/pgjdbc/src/main/java/org/postgresql/core/QueryExecutorBase.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/QueryExecutorBase.java
@@ -375,4 +375,8 @@ public abstract class QueryExecutorBase implements QueryExecutor {
   public void setFlushCacheOnDeallocate(boolean flushCacheOnDeallocate) {
     this.flushCacheOnDeallocate = flushCacheOnDeallocate;
   }
+
+  protected boolean hasNotifications() {
+    return notifications.size() > 0;
+  }
 }

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -664,6 +664,11 @@ public class QueryExecutorImpl extends QueryExecutorBase {
       return;
     }
 
+    if (hasNotifications()) {
+      // No need to timeout when there are already notifications. We just check for more in this case.
+      timeoutMillis = -1;
+    }
+
     boolean useTimeout = timeoutMillis > 0;
     long startTime = 0;
     if (useTimeout) {
@@ -672,11 +677,11 @@ public class QueryExecutorImpl extends QueryExecutorBase {
 
     try {
       while (pgStream.hasMessagePending() || timeoutMillis >= 0 ) {
-        if (useTimeout) {
+        if (useTimeout && timeoutMillis >= 0) {
           setSocketTimeout(timeoutMillis);
         }
         int c = pgStream.receiveChar();
-        if (useTimeout) {
+        if (useTimeout && timeoutMillis >= 0) {
           setSocketTimeout(0); // Don't timeout after first char
         }
         switch (c) {

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -671,8 +671,15 @@ public class QueryExecutorImpl extends QueryExecutorBase {
 
     boolean useTimeout = timeoutMillis > 0;
     long startTime = 0;
+    int oldTimeout = 0;
     if (useTimeout) {
       startTime = System.currentTimeMillis();
+      try {
+        oldTimeout = pgStream.getSocket().getSoTimeout();
+      } catch (SocketException e) {
+        throw new PSQLException(GT.tr("An error occurred while trying to get the socket "
+          + "timeout."), PSQLState.CONNECTION_FAILURE, e);
+      }
     }
 
     try {
@@ -716,7 +723,7 @@ public class QueryExecutorImpl extends QueryExecutorBase {
           PSQLState.CONNECTION_FAILURE, ioe);
     } finally {
       if (useTimeout) {
-        setSocketTimeout(0);
+        setSocketTimeout(oldTimeout);
       }
     }
   }

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -653,9 +653,9 @@ public class QueryExecutorImpl extends QueryExecutorBase {
   }
 
   /**
-   * @param timeoutMillis when >0, block for this time
+   * @param timeoutMillis when &gt; 0, block for this time
    *                      when =0, block forever
-   *                      when <0, don't block
+   *                      when &lt; 0, don't block
    */
   public synchronized void processNotifies(int timeoutMillis) throws SQLException {
     waitOnLock();

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -649,9 +649,9 @@ public class QueryExecutorImpl extends QueryExecutorBase {
 
   // Just for API compatibility with previous versions.
   public synchronized void processNotifies() throws SQLException {
-	  processNotifies(-1);
+    processNotifies(-1);
   }
-	  
+
   /**
    * @param timeoutMillis when >0, block for this time
    *                      when =0, block forever
@@ -666,18 +666,18 @@ public class QueryExecutorImpl extends QueryExecutorBase {
 
     boolean useTimeout = timeoutMillis > 0;
     long startTime = 0;
-    if( useTimeout ) {
-		startTime = System.currentTimeMillis();
+    if (useTimeout) {
+      startTime = System.currentTimeMillis();
     }
 
     try {
       while (pgStream.hasMessagePending() || timeoutMillis >= 0 ) {
-    	if( useTimeout ) {
-        	setSocketTimeout(timeoutMillis);
-    	}
+        if (useTimeout) {
+          setSocketTimeout(timeoutMillis);
+        }
         int c = pgStream.receiveChar();
-        if( useTimeout ) {
-    		setSocketTimeout(0); // Don't timeout after first char
+        if (useTimeout) {
+          setSocketTimeout(0); // Don't timeout after first char
         }
         switch (c) {
           case 'A': // Asynchronous Notify
@@ -690,13 +690,13 @@ public class QueryExecutorImpl extends QueryExecutorBase {
           case 'N': // Notice Response (warnings / info)
             SQLWarning warning = receiveNoticeResponse();
             addWarning(warning);
-            if( useTimeout ) {
-                long newTimeMillis = System.currentTimeMillis();
-                timeoutMillis += startTime - newTimeMillis; // Overflows after 49 days, ignore that
-                startTime = newTimeMillis;
-                if( timeoutMillis == 0 ) {
-                	timeoutMillis = -1; // Don't accidentially wait forever
-                }
+            if (useTimeout) {
+              long newTimeMillis = System.currentTimeMillis();
+              timeoutMillis += startTime - newTimeMillis; // Overflows after 49 days, ignore that
+              startTime = newTimeMillis;
+              if (timeoutMillis == 0) {
+                timeoutMillis = -1; // Don't accidentially wait forever
+              }
             }
             break;
           default:
@@ -705,27 +705,27 @@ public class QueryExecutorImpl extends QueryExecutorBase {
         }
       }
     } catch (SocketTimeoutException ioe) {
-    	// No notifications this time...
+      // No notifications this time...
     } catch (IOException ioe) {
       throw new PSQLException(GT.tr("An I/O error occurred while sending to the backend."),
           PSQLState.CONNECTION_FAILURE, ioe);
     } finally {
-    	if( useTimeout ) {
-    		setSocketTimeout(0);
-    	}
+      if (useTimeout) {
+        setSocketTimeout(0);
+      }
     }
   }
 
   private void setSocketTimeout(int millis) throws PSQLException {
-		try {
-			Socket s = pgStream.getSocket();
-			if( !s.isClosed() ) { // Is this check required?
-     			pgStream.getSocket().setSoTimeout(millis);
-			}
-		} catch (SocketException e) {
-		      throw new PSQLException(GT.tr("An error occured while trying to reset the socket timeout."),
-		              PSQLState.CONNECTION_FAILURE, e);
-		}
+    try {
+      Socket s = pgStream.getSocket();
+      if (!s.isClosed()) { // Is this check required?
+        pgStream.getSocket().setSoTimeout(millis);
+      }
+    } catch (SocketException e) {
+      throw new PSQLException(GT.tr("An error occurred while trying to reset the socket timeout."),
+        PSQLState.CONNECTION_FAILURE, e);
+    }
   }
 
   private byte[] receiveFastpathResult() throws IOException, SQLException {

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -45,6 +45,9 @@ import java.io.IOException;
 import java.lang.ref.PhantomReference;
 import java.lang.ref.Reference;
 import java.lang.ref.ReferenceQueue;
+import java.net.Socket;
+import java.net.SocketException;
+import java.net.SocketTimeoutException;
 import java.sql.SQLException;
 import java.sql.SQLWarning;
 import java.sql.Statement;
@@ -644,36 +647,85 @@ public class QueryExecutorImpl extends QueryExecutorBase {
     pgStream.flush();
   }
 
+  // Just for API compatibility with previous versions.
   public synchronized void processNotifies() throws SQLException {
+	  processNotifies(-1);
+  }
+	  
+  /**
+   * @param timeoutMillis when >0, block for this time
+   *                      when =0, block forever
+   *                      when <0, don't block
+   */
+  public synchronized void processNotifies(int timeoutMillis) throws SQLException {
     waitOnLock();
     // Asynchronous notifies only arrive when we are not in a transaction
     if (getTransactionState() != TransactionState.IDLE) {
       return;
     }
 
+    boolean useTimeout = timeoutMillis > 0;
+    long startTime = 0;
+    if( useTimeout ) {
+		startTime = System.currentTimeMillis();
+    }
+
     try {
-      while (pgStream.hasMessagePending()) {
+      while (pgStream.hasMessagePending() || timeoutMillis >= 0 ) {
+    	if( useTimeout ) {
+        	setSocketTimeout(timeoutMillis);
+    	}
         int c = pgStream.receiveChar();
+        if( useTimeout ) {
+    		setSocketTimeout(0); // Don't timeout after first char
+        }
         switch (c) {
           case 'A': // Asynchronous Notify
             receiveAsyncNotify();
-            break;
+            timeoutMillis = -1;
+            continue;
           case 'E':
             // Error Response (response to pretty much everything; backend then skips until Sync)
             throw receiveErrorResponse();
           case 'N': // Notice Response (warnings / info)
             SQLWarning warning = receiveNoticeResponse();
             addWarning(warning);
+            if( useTimeout ) {
+                long newTimeMillis = System.currentTimeMillis();
+                timeoutMillis += startTime - newTimeMillis; // Overflows after 49 days, ignore that
+                startTime = newTimeMillis;
+                if( timeoutMillis == 0 ) {
+                	timeoutMillis = -1; // Don't accidentially wait forever
+                }
+            }
             break;
           default:
             throw new PSQLException(GT.tr("Unknown Response Type {0}.", (char) c),
                 PSQLState.CONNECTION_FAILURE);
         }
       }
+    } catch (SocketTimeoutException ioe) {
+    	// No notifications this time...
     } catch (IOException ioe) {
       throw new PSQLException(GT.tr("An I/O error occurred while sending to the backend."),
           PSQLState.CONNECTION_FAILURE, ioe);
+    } finally {
+    	if( useTimeout ) {
+    		setSocketTimeout(0);
+    	}
     }
+  }
+
+  private void setSocketTimeout(int millis) throws PSQLException {
+		try {
+			Socket s = pgStream.getSocket();
+			if( !s.isClosed() ) { // Is this check required?
+     			pgStream.getSocket().setSoTimeout(millis);
+			}
+		} catch (SocketException e) {
+		      throw new PSQLException(GT.tr("An error occured while trying to reset the socket timeout."),
+		              PSQLState.CONNECTION_FAILURE, e);
+		}
   }
 
   private byte[] receiveFastpathResult() throws IOException, SQLException {

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
@@ -970,16 +970,21 @@ public class PgConnection implements BaseConnection {
     checkClosed();
     queryExecutor.sendQueryCancel();
   }
-
+  
   @Override
   public PGNotification[] getNotifications() throws SQLException {
+    return getNotifications(-1);
+  }
+
+  @Override
+  public PGNotification[] getNotifications(int timeoutMillis) throws SQLException {
     checkClosed();
-    getQueryExecutor().processNotifies();
+    getQueryExecutor().processNotifies(timeoutMillis);
     // Backwards-compatibility hand-holding.
     PGNotification[] notifications = queryExecutor.getNotifications();
     return (notifications.length == 0 ? null : notifications);
   }
-
+  
   /**
    * Handler for transaction queries
    */

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
@@ -970,7 +970,7 @@ public class PgConnection implements BaseConnection {
     checkClosed();
     queryExecutor.sendQueryCancel();
   }
-  
+
   @Override
   public PGNotification[] getNotifications() throws SQLException {
     return getNotifications(-1);
@@ -984,7 +984,7 @@ public class PgConnection implements BaseConnection {
     PGNotification[] notifications = queryExecutor.getNotifications();
     return (notifications.length == 0 ? null : notifications);
   }
-  
+
   /**
    * Handler for transaction queries
    */

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/NotifyTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/NotifyTest.java
@@ -7,18 +7,19 @@ package org.postgresql.test.jdbc2;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-
-import org.postgresql.PGNotification;
-import org.postgresql.core.ServerVersion;
-import org.postgresql.test.TestUtil;
-
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import static org.junit.Assert.assertNull;
 
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.postgresql.PGNotification;
+import org.postgresql.core.ServerVersion;
+import org.postgresql.test.TestUtil;
 
 public class NotifyTest {
   private Connection conn;
@@ -73,22 +74,20 @@ public class NotifyTest {
     stmt.executeUpdate("LISTEN mynotification");
 
     // Notify on a separate connection to get an async notify on the first.
-    Connection conn2 = TestUtil.openDB();
-    try {
-      Statement stmt2 = conn2.createStatement();
-      stmt2.executeUpdate("NOTIFY mynotification");
-      stmt2.close();
-    } finally {
-      conn2.close();
-    }
+    connectAndNotify("mynotification");
 
-    // Wait a bit to let the notify come through..
+    // Wait a bit to let the notify come through... Changed this so the test takes ~2 seconds
+    // less to run and is still as effective.
+    PGNotification notifications[] = null;
     try {
-      Thread.sleep(2000);
+      int retries = 20;
+      while( retries --> 0 && // Special arrow operator decrements until retries is zero.
+    		 (notifications = ((org.postgresql.PGConnection) conn).getNotifications()) == null ) {
+          Thread.sleep(100);
+      }
     } catch (InterruptedException ie) {
     }
 
-    PGNotification notifications[] = ((org.postgresql.PGConnection) conn).getNotifications();
     assertNotNull(notifications);
     assertEquals(1, notifications.length);
     assertEquals("mynotification", notifications[0].getName());
@@ -96,4 +95,93 @@ public class NotifyTest {
 
     stmt.close();
   }
+
+  /**
+   * To test timeouts we have to send the notification from another thread, because we
+   * listener is blocking.
+   */
+  @Test(timeout=60000) // 120 seconds should be enough
+  public void testAsyncNotifyWithTimeout() throws Exception {
+    Statement stmt = conn.createStatement();
+    stmt.executeUpdate("LISTEN mynotification");
+
+    // Here we let the getNotifications() timeout.
+    long startMillis = System.currentTimeMillis();
+    PGNotification notifications[] = ((org.postgresql.PGConnection) conn).getNotifications(500);
+    long endMillis = System.currentTimeMillis();
+    long runtime = endMillis - startMillis;
+    assertNull("There have been notifications, althought none have been expected.",notifications);
+    Assert.assertTrue("We didn't wait long enough! runtime="+runtime, runtime > 450);
+
+    // Now we check the case where notifications are already available while we are starting to
+    // listen for notifications
+    connectAndNotify("mynotification");
+
+    notifications = ((org.postgresql.PGConnection) conn).getNotifications(10000);
+    assertNotNull(notifications);
+    assertEquals(1, notifications.length);
+    assertEquals("mynotification", notifications[0].getName());
+    assertEquals("", notifications[0].getParameter());
+
+    // Now we check the case where notifications are already available while we are waiting forever
+    connectAndNotify("mynotification");
+
+    notifications = ((org.postgresql.PGConnection) conn).getNotifications(0);
+    assertNotNull(notifications);
+    assertEquals(1, notifications.length);
+    assertEquals("mynotification", notifications[0].getName());
+    assertEquals("", notifications[0].getParameter());
+
+    // Now we check the case where notifications are send after we have started to listen for
+    // notifications
+    new Thread(()-> {
+      try {
+   	    Thread.sleep(200);
+   	  } catch (InterruptedException ie) {
+   	  }
+      connectAndNotify("mynotification");
+    }).start();
+
+    notifications = ((org.postgresql.PGConnection) conn).getNotifications(10000);
+    assertNotNull(notifications);
+    assertEquals(1, notifications.length);
+    assertEquals("mynotification", notifications[0].getName());
+    assertEquals("", notifications[0].getParameter());
+
+    // Now we check the case where notifications are send after we have started to listen for
+    // notifications forever
+    new Thread(()-> {
+      try {
+   	    Thread.sleep(200);
+   	  } catch (InterruptedException ie) {
+   	  }
+      connectAndNotify("mynotification");
+    }).start();
+
+    notifications = ((org.postgresql.PGConnection) conn).getNotifications(0);
+    assertNotNull(notifications);
+    assertEquals(1, notifications.length);
+    assertEquals("mynotification", notifications[0].getName());
+    assertEquals("", notifications[0].getParameter());
+
+    stmt.close();
+  }
+
+  private static void connectAndNotify(String channel) {
+	Connection conn2 = null;
+	try {
+      conn2 = TestUtil.openDB();
+      Statement stmt2 = conn2.createStatement();
+      stmt2.executeUpdate("NOTIFY "+channel);
+      stmt2.close();
+    } catch (Exception e) {
+      throw new RuntimeException("Couldn't notify '"+channel+"'.",e);
+	} finally {
+      try {
+		conn2.close();
+	  } catch (SQLException e) {
+	  }
+    }
+  }
+
 }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/NotifyTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/NotifyTest.java
@@ -135,12 +135,14 @@ public class NotifyTest {
 
     // Now we check the case where notifications are send after we have started to listen for
     // notifications
-    new Thread(() -> {
-      try {
-        Thread.sleep(200);
-      } catch (InterruptedException ie) {
+    new Thread( new Runnable() {
+      public void run() {
+        try {
+          Thread.sleep(200);
+        } catch (InterruptedException ie) {
+        }
+        connectAndNotify("mynotification");
       }
-      connectAndNotify("mynotification");
     }).start();
 
     notifications = ((org.postgresql.PGConnection) conn).getNotifications(10000);
@@ -151,12 +153,14 @@ public class NotifyTest {
 
     // Now we check the case where notifications are send after we have started to listen for
     // notifications forever
-    new Thread(() -> {
-      try {
-        Thread.sleep(200);
-      } catch (InterruptedException ie) {
+    new Thread( new Runnable() {
+      public void run() {
+        try {
+          Thread.sleep(200);
+        } catch (InterruptedException ie) {
+        }
+        connectAndNotify("mynotification");
       }
-      connectAndNotify("mynotification");
     }).start();
 
     notifications = ((org.postgresql.PGConnection) conn).getNotifications(0);

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/NotifyTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/NotifyTest.java
@@ -101,7 +101,6 @@ public class NotifyTest {
    * To test timeouts we have to send the notification from another thread, because we
    * listener is blocking.
    */
-  @Test(timeout = 60000) // 60 seconds should be enough
   public void testAsyncNotifyWithTimeout() throws Exception {
     Statement stmt = conn.createStatement();
     stmt.executeUpdate("LISTEN mynotification");
@@ -114,24 +113,47 @@ public class NotifyTest {
     assertNull("There have been notifications, althought none have been expected.",notifications);
     Assert.assertTrue("We didn't wait long enough! runtime=" + runtime, runtime > 450);
 
+    stmt.close();
+  }
+
+  public void testAsyncNotifyWithTimeout2() throws Exception {
+    Statement stmt = conn.createStatement();
+    stmt.executeUpdate("LISTEN mynotification");
+
     // Now we check the case where notifications are already available while we are starting to
     // listen for notifications
     connectAndNotify("mynotification");
 
-    notifications = ((org.postgresql.PGConnection) conn).getNotifications(10000);
+    PGNotification notifications[] = ((org.postgresql.PGConnection) conn).getNotifications(10000);
     assertNotNull(notifications);
     assertEquals(1, notifications.length);
     assertEquals("mynotification", notifications[0].getName());
     assertEquals("", notifications[0].getParameter());
+
+    stmt.close();
+  }
+
+  @Test(timeout = 60000) // 60 seconds should be enough
+  public void testAsyncNotifyWithTimeout3() throws Exception {
+    Statement stmt = conn.createStatement();
+    stmt.executeUpdate("LISTEN mynotification");
 
     // Now we check the case where notifications are already available while we are waiting forever
     connectAndNotify("mynotification");
 
-    notifications = ((org.postgresql.PGConnection) conn).getNotifications(0);
+    PGNotification notifications[] = ((org.postgresql.PGConnection) conn).getNotifications(0);
     assertNotNull(notifications);
     assertEquals(1, notifications.length);
     assertEquals("mynotification", notifications[0].getName());
     assertEquals("", notifications[0].getParameter());
+
+    stmt.close();
+  }
+
+  @Test(timeout = 60000) // 60 seconds should be enough
+  public void testAsyncNotifyWithTimeout4() throws Exception {
+    Statement stmt = conn.createStatement();
+    stmt.executeUpdate("LISTEN mynotification");
 
     // Now we check the case where notifications are send after we have started to listen for
     // notifications
@@ -145,11 +167,19 @@ public class NotifyTest {
       }
     }).start();
 
-    notifications = ((org.postgresql.PGConnection) conn).getNotifications(10000);
+    PGNotification notifications[] = ((org.postgresql.PGConnection) conn).getNotifications(10000);
     assertNotNull(notifications);
     assertEquals(1, notifications.length);
     assertEquals("mynotification", notifications[0].getName());
     assertEquals("", notifications[0].getParameter());
+
+    stmt.close();
+  }
+
+  @Test(timeout = 60000) // 60 seconds should be enough
+  public void testAsyncNotifyWithTimeout5() throws Exception {
+    Statement stmt = conn.createStatement();
+    stmt.executeUpdate("LISTEN mynotification");
 
     // Now we check the case where notifications are send after we have started to listen for
     // notifications forever
@@ -163,21 +193,18 @@ public class NotifyTest {
       }
     }).start();
 
-    notifications = ((org.postgresql.PGConnection) conn).getNotifications(0);
+    PGNotification notifications[] = ((org.postgresql.PGConnection) conn).getNotifications(0);
     assertNotNull(notifications);
     assertEquals(1, notifications.length);
     assertEquals("mynotification", notifications[0].getName());
     assertEquals("", notifications[0].getParameter());
 
-    // This checks if notifications are returned immediately when available also when a timeout
-    // has been given. The test will timeout when the notification goes unnoticed.
-    connectAndNotify("mynotification");
+    stmt.close();
+  }
 
-    notifications = ((org.postgresql.PGConnection) conn).getNotifications(120000);
-    assertNotNull(notifications);
-    assertEquals(1, notifications.length);
-    assertEquals("mynotification", notifications[0].getName());
-    assertEquals("", notifications[0].getParameter());
+  public void testAsyncNotifyWithTimeout6() throws Exception {
+    Statement stmt = conn.createStatement();
+    stmt.executeUpdate("LISTEN mynotification");
 
     // Here we check what happens when the connection gets closed from another thread. This
     // should be able, and this test ensures that no synchronized statements will stop the
@@ -196,7 +223,7 @@ public class NotifyTest {
     }).start();
 
     try {
-      notifications = ((org.postgresql.PGConnection) conn).getNotifications(40000);
+      ((org.postgresql.PGConnection) conn).getNotifications(40000);
       Assert.fail("The getNotifications(...) call didn't return when the socket closed.");
     } catch (SQLException e) {
       // We expected thta

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/NotifyTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/NotifyTest.java
@@ -35,7 +35,7 @@ public class NotifyTest {
     TestUtil.closeDB(conn);
   }
 
-  @Test
+  @Test(timeout = 60000)
   public void testNotify() throws SQLException {
     Statement stmt = conn.createStatement();
     stmt.executeUpdate("LISTEN mynotification");
@@ -50,7 +50,7 @@ public class NotifyTest {
     stmt.close();
   }
 
-  @Test
+  @Test(timeout = 60000)
   public void testNotifyArgument() throws Exception {
     if (!TestUtil.haveMinimumServerVersion(conn, ServerVersion.v9_0) || TestUtil.isProtocolVersion(conn, 2)) {
       return;
@@ -69,7 +69,7 @@ public class NotifyTest {
     stmt.close();
   }
 
-  @Test
+  @Test(timeout = 60000)
   public void testAsyncNotify() throws Exception {
     Statement stmt = conn.createStatement();
     stmt.executeUpdate("LISTEN mynotification");
@@ -101,6 +101,7 @@ public class NotifyTest {
    * To test timeouts we have to send the notification from another thread, because we
    * listener is blocking.
    */
+  @Test(timeout = 60000)
   public void testAsyncNotifyWithTimeout() throws Exception {
     Statement stmt = conn.createStatement();
     stmt.executeUpdate("LISTEN mynotification");
@@ -116,6 +117,7 @@ public class NotifyTest {
     stmt.close();
   }
 
+  @Test(timeout = 60000)
   public void testAsyncNotifyWithTimeout2() throws Exception {
     Statement stmt = conn.createStatement();
     stmt.executeUpdate("LISTEN mynotification");
@@ -133,7 +135,7 @@ public class NotifyTest {
     stmt.close();
   }
 
-  @Test(timeout = 60000) // 60 seconds should be enough
+  @Test(timeout = 60000)
   public void testAsyncNotifyWithTimeout3() throws Exception {
     Statement stmt = conn.createStatement();
     stmt.executeUpdate("LISTEN mynotification");
@@ -150,7 +152,7 @@ public class NotifyTest {
     stmt.close();
   }
 
-  @Test(timeout = 60000) // 60 seconds should be enough
+  @Test(timeout = 60000)
   public void testAsyncNotifyWithTimeout4() throws Exception {
     Statement stmt = conn.createStatement();
     stmt.executeUpdate("LISTEN mynotification");
@@ -176,7 +178,7 @@ public class NotifyTest {
     stmt.close();
   }
 
-  @Test(timeout = 60000) // 60 seconds should be enough
+  @Test(timeout = 60000)
   public void testAsyncNotifyWithTimeout5() throws Exception {
     Statement stmt = conn.createStatement();
     stmt.executeUpdate("LISTEN mynotification");
@@ -202,6 +204,7 @@ public class NotifyTest {
     stmt.close();
   }
 
+  @Test(timeout = 60000)
   public void testAsyncNotifyWithTimeout6() throws Exception {
     Statement stmt = conn.createStatement();
     stmt.executeUpdate("LISTEN mynotification");

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/NotifyTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/NotifyTest.java
@@ -100,7 +100,7 @@ public class NotifyTest {
    * To test timeouts we have to send the notification from another thread, because we
    * listener is blocking.
    */
-  @Test(timeout=60000) // 120 seconds should be enough
+  @Test(timeout=60000) // 60 seconds should be enough
   public void testAsyncNotifyWithTimeout() throws Exception {
     Statement stmt = conn.createStatement();
     stmt.executeUpdate("LISTEN mynotification");

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/NotifyTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/NotifyTest.java
@@ -9,17 +9,18 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
-import java.sql.Connection;
-import java.sql.SQLException;
-import java.sql.Statement;
+import org.postgresql.PGNotification;
+import org.postgresql.core.ServerVersion;
+import org.postgresql.test.TestUtil;
 
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.postgresql.PGNotification;
-import org.postgresql.core.ServerVersion;
-import org.postgresql.test.TestUtil;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
 
 public class NotifyTest {
   private Connection conn;
@@ -81,9 +82,9 @@ public class NotifyTest {
     PGNotification notifications[] = null;
     try {
       int retries = 20;
-      while( retries --> 0 && // Special arrow operator decrements until retries is zero.
-    		 (notifications = ((org.postgresql.PGConnection) conn).getNotifications()) == null ) {
-          Thread.sleep(100);
+      while (retries-- > 0
+        && (notifications = ((org.postgresql.PGConnection) conn).getNotifications()) == null ) {
+        Thread.sleep(100);
       }
     } catch (InterruptedException ie) {
     }
@@ -100,7 +101,7 @@ public class NotifyTest {
    * To test timeouts we have to send the notification from another thread, because we
    * listener is blocking.
    */
-  @Test(timeout=60000) // 60 seconds should be enough
+  @Test(timeout = 60000) // 60 seconds should be enough
   public void testAsyncNotifyWithTimeout() throws Exception {
     Statement stmt = conn.createStatement();
     stmt.executeUpdate("LISTEN mynotification");
@@ -111,7 +112,7 @@ public class NotifyTest {
     long endMillis = System.currentTimeMillis();
     long runtime = endMillis - startMillis;
     assertNull("There have been notifications, althought none have been expected.",notifications);
-    Assert.assertTrue("We didn't wait long enough! runtime="+runtime, runtime > 450);
+    Assert.assertTrue("We didn't wait long enough! runtime=" + runtime, runtime > 450);
 
     // Now we check the case where notifications are already available while we are starting to
     // listen for notifications
@@ -134,11 +135,11 @@ public class NotifyTest {
 
     // Now we check the case where notifications are send after we have started to listen for
     // notifications
-    new Thread(()-> {
+    new Thread(() -> {
       try {
-   	    Thread.sleep(200);
-   	  } catch (InterruptedException ie) {
-   	  }
+        Thread.sleep(200);
+      } catch (InterruptedException ie) {
+      }
       connectAndNotify("mynotification");
     }).start();
 
@@ -150,11 +151,11 @@ public class NotifyTest {
 
     // Now we check the case where notifications are send after we have started to listen for
     // notifications forever
-    new Thread(()-> {
+    new Thread(() -> {
       try {
-   	    Thread.sleep(200);
-   	  } catch (InterruptedException ie) {
-   	  }
+        Thread.sleep(200);
+      } catch (InterruptedException ie) {
+      }
       connectAndNotify("mynotification");
     }).start();
 
@@ -168,19 +169,19 @@ public class NotifyTest {
   }
 
   private static void connectAndNotify(String channel) {
-	Connection conn2 = null;
-	try {
+    Connection conn2 = null;
+    try {
       conn2 = TestUtil.openDB();
       Statement stmt2 = conn2.createStatement();
-      stmt2.executeUpdate("NOTIFY "+channel);
+      stmt2.executeUpdate("NOTIFY " + channel);
       stmt2.close();
     } catch (Exception e) {
-      throw new RuntimeException("Couldn't notify '"+channel+"'.",e);
-	} finally {
+      throw new RuntimeException("Couldn't notify '" + channel + "'.",e);
+    } finally {
       try {
-		conn2.close();
-	  } catch (SQLException e) {
-	  }
+        conn2.close();
+      } catch (SQLException e) {
+      }
     }
   }
 

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/NotifyTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/NotifyTest.java
@@ -118,7 +118,7 @@ public class NotifyTest {
   }
 
   @Test(timeout = 60000)
-  public void testAsyncNotifyWithTimeout2() throws Exception {
+  public void testAsyncNotifyWithTimeoutAndMessagesAvailableWhenStartingListening() throws Exception {
     Statement stmt = conn.createStatement();
     stmt.executeUpdate("LISTEN mynotification");
 
@@ -136,7 +136,7 @@ public class NotifyTest {
   }
 
   @Test(timeout = 60000)
-  public void testAsyncNotifyWithTimeout3() throws Exception {
+  public void testAsyncNotifyWithEndlessTimeoutAndMessagesAvailableWhenStartingListening() throws Exception {
     Statement stmt = conn.createStatement();
     stmt.executeUpdate("LISTEN mynotification");
 
@@ -153,7 +153,7 @@ public class NotifyTest {
   }
 
   @Test(timeout = 60000)
-  public void testAsyncNotifyWithTimeout4() throws Exception {
+  public void testAsyncNotifyWithTimeoutAndMessagesSendAfter() throws Exception {
     Statement stmt = conn.createStatement();
     stmt.executeUpdate("LISTEN mynotification");
 
@@ -179,7 +179,7 @@ public class NotifyTest {
   }
 
   @Test(timeout = 60000)
-  public void testAsyncNotifyWithTimeout5() throws Exception {
+  public void testAsyncNotifyWithEndlessTimeoutAndMessagesSendAfter() throws Exception {
     Statement stmt = conn.createStatement();
     stmt.executeUpdate("LISTEN mynotification");
 
@@ -205,7 +205,7 @@ public class NotifyTest {
   }
 
   @Test(timeout = 60000)
-  public void testAsyncNotifyWithTimeout6() throws Exception {
+  public void testAsyncNotifyWithTimeoutAndSocketThatBecomesClosed() throws Exception {
     Statement stmt = conn.createStatement();
     stmt.executeUpdate("LISTEN mynotification");
 


### PR DESCRIPTION
Improve waiting for notifications using the LISTEN/NOTIFY framework by adding an optional timeout to the PGConnection.getNotifications() method. The change does not have any effects for users that don't use this functionality and the API remain fully backwards compatible.

PS: Please squash commits when merging, the text of this pull request should give a nice commit message.