### PR TITLE
fix: remove type name from cast exception of getBoolean and setObject

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
@@ -1935,8 +1935,8 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
    * @param columnIndex the first column is 1, the second is 2, ...
    * @return the column value; if the value is SQL <code>NULL</code>, the value returned is
    * <code>false</code>
-   * @exception SQLException if the columnIndex is not valid; if a database access error occurs or
-   * this method is called on a closed result set
+   * @exception SQLException if the columnIndex is not valid; if a database access error occurs; if
+   * this method is called on a closed result set or is an invalid cast to boolean type.
    * @see <a href="https://www.postgresql.org/docs/current/static/datatype-boolean.html">PostgreSQL
    * Boolean Type</a>
    */

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PreparedStatementTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PreparedStatementTest.java
@@ -613,68 +613,79 @@ public class PreparedStatementTest extends BaseTest4 {
       pstmt.setObject(1, "this is not boolean", Types.BOOLEAN);
       fail();
     } catch (SQLException e) {
-      assertEquals(e.getSQLState(), org.postgresql.util.PSQLState.CANNOT_COERCE.getState());
+      assertEquals(org.postgresql.util.PSQLState.CANNOT_COERCE.getState(), e.getSQLState());
+      assertEquals("Cannot cast to boolean: \"this is not boolean\"", e.getMessage());
     }
     try {
       pstmt.setObject(1, 'X', Types.BOOLEAN);
       fail();
     } catch (SQLException e) {
-      assertEquals(e.getSQLState(), org.postgresql.util.PSQLState.CANNOT_COERCE.getState());
+      assertEquals(org.postgresql.util.PSQLState.CANNOT_COERCE.getState(), e.getSQLState());
+      assertEquals("Cannot cast to boolean: \"X\"", e.getMessage());
     }
     try {
       java.io.File obj = new java.io.File("");
       pstmt.setObject(1, obj, Types.BOOLEAN);
       fail();
     } catch (SQLException e) {
-      assertEquals(e.getSQLState(), org.postgresql.util.PSQLState.CANNOT_COERCE.getState());
+      assertEquals(org.postgresql.util.PSQLState.CANNOT_COERCE.getState(), e.getSQLState());
+      assertEquals("Cannot cast to boolean", e.getMessage());
     }
     try {
       pstmt.setObject(1, "1.0", Types.BOOLEAN);
       fail();
     } catch (SQLException e) {
-      assertEquals(e.getSQLState(), org.postgresql.util.PSQLState.CANNOT_COERCE.getState());
+      assertEquals(org.postgresql.util.PSQLState.CANNOT_COERCE.getState(), e.getSQLState());
+      assertEquals("Cannot cast to boolean: \"1.0\"", e.getMessage());
     }
     try {
       pstmt.setObject(1, "-1", Types.BOOLEAN);
       fail();
     } catch (SQLException e) {
-      assertEquals(e.getSQLState(), org.postgresql.util.PSQLState.CANNOT_COERCE.getState());
+      assertEquals(org.postgresql.util.PSQLState.CANNOT_COERCE.getState(), e.getSQLState());
+      assertEquals("Cannot cast to boolean: \"-1\"", e.getMessage());
     }
     try {
       pstmt.setObject(1, "ok", Types.BOOLEAN);
       fail();
     } catch (SQLException e) {
-      assertEquals(e.getSQLState(), org.postgresql.util.PSQLState.CANNOT_COERCE.getState());
+      assertEquals(org.postgresql.util.PSQLState.CANNOT_COERCE.getState(), e.getSQLState());
+      assertEquals("Cannot cast to boolean: \"ok\"", e.getMessage());
     }
     try {
       pstmt.setObject(1, 0.99f, Types.BOOLEAN);
       fail();
     } catch (SQLException e) {
-      assertEquals(e.getSQLState(), org.postgresql.util.PSQLState.CANNOT_COERCE.getState());
+      assertEquals(org.postgresql.util.PSQLState.CANNOT_COERCE.getState(), e.getSQLState());
+      assertEquals("Cannot cast to boolean: \"0.99\"", e.getMessage());
     }
     try {
       pstmt.setObject(1, -0.01d, Types.BOOLEAN);
       fail();
     } catch (SQLException e) {
-      assertEquals(e.getSQLState(), org.postgresql.util.PSQLState.CANNOT_COERCE.getState());
+      assertEquals(org.postgresql.util.PSQLState.CANNOT_COERCE.getState(), e.getSQLState());
+      assertEquals("Cannot cast to boolean: \"-0.01\"", e.getMessage());
     }
     try {
       pstmt.setObject(1, new java.sql.Date(0), Types.BOOLEAN);
       fail();
     } catch (SQLException e) {
-      assertEquals(e.getSQLState(), org.postgresql.util.PSQLState.CANNOT_COERCE.getState());
+      assertEquals(org.postgresql.util.PSQLState.CANNOT_COERCE.getState(), e.getSQLState());
+      assertEquals("Cannot cast to boolean", e.getMessage());
     }
     try {
       pstmt.setObject(1, new java.math.BigInteger("1000"), Types.BOOLEAN);
       fail();
     } catch (SQLException e) {
-      assertEquals(e.getSQLState(), org.postgresql.util.PSQLState.CANNOT_COERCE.getState());
+      assertEquals(org.postgresql.util.PSQLState.CANNOT_COERCE.getState(), e.getSQLState());
+      assertEquals("Cannot cast to boolean: \"1000\"", e.getMessage());
     }
     try {
       pstmt.setObject(1, Math.PI, Types.BOOLEAN);
       fail();
     } catch (SQLException e) {
-      assertEquals(e.getSQLState(), org.postgresql.util.PSQLState.CANNOT_COERCE.getState());
+      assertEquals(org.postgresql.util.PSQLState.CANNOT_COERCE.getState(), e.getSQLState());
+      assertEquals("Cannot cast to boolean: \"3.141592653589793\"", e.getMessage());
     }
     pstmt.close();
   }


### PR DESCRIPTION
Fix PSQLException messages in getBoolean and setObject removing the type name of the column to avoid confusion.

closes #776