### PR TITLE
fix: function calls without parameters do not require parentheses

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/Parser.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/Parser.java
@@ -921,14 +921,16 @@ public class Parser {
     }
     String s = jdbcSql.substring(startIndex, endIndex);
     StringBuilder sb = new StringBuilder(s);
-    if (outParmBeforeFunc) {
+
+    int opening = s.indexOf('(') + 1;
+    if (opening == 0) {
+      sb.append(outParmBeforeFunc ? "(?)" : "()");
+    } else if (outParmBeforeFunc) {
       // move the single out parameter into the function call
       // so that it can be treated like all other parameters
       boolean needComma = false;
 
-      // have to use String.indexOf for java 2
-      int opening = s.indexOf('(') + 1;
-      int closing = s.indexOf(')');
+      int closing = s.indexOf(')', opening);
       for (int j = opening; j < closing; j++) {
         if (!Character.isWhitespace(sb.charAt(j))) {
           needComma = true;


### PR DESCRIPTION
Fixes that function calls without parameters must have had parentheses, see #767 for further details.

I'm unsure about the tests I have added, are those in the correct class? Should there be others or are those sufficient?
