### PR TITLE
Bug: Not valid calculate lastReceiveLSN for logical replication 

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/replication/ReplicationType.java
+++ b/pgjdbc/src/main/java/org/postgresql/replication/ReplicationType.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2017, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.replication;
+
+public enum ReplicationType {
+  LOGICAL,
+  PHYSICAL
+}

--- a/pgjdbc/src/test/java/org/postgresql/replication/LogicalReplicationStatusTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/replication/LogicalReplicationStatusTest.java
@@ -87,18 +87,11 @@ public class LogicalReplicationStatusTest {
     LogSequenceNumber lastReceivedLSN = stream.getLastReceiveLSN();
     stream.forceUpdateStatus();
 
-    int lastPayloadSize =
-        received
-            .get(countMessage - 1)
-            .getBytes()
-            .length;
-
-    LogSequenceNumber waitLsn = LogSequenceNumber.valueOf(lastReceivedLSN.asLong() - lastPayloadSize);
     LogSequenceNumber sentByServer = getSentLocationOnView();
 
     assertThat("When changes absent on server last receive by stream LSN "
             + "should be equal to last sent by server LSN",
-        sentByServer, equalTo(waitLsn)
+        sentByServer, equalTo(lastReceivedLSN)
     );
   }
 

--- a/pgjdbc/src/test/java/org/postgresql/replication/LogicalReplicationTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/replication/LogicalReplicationTest.java
@@ -746,6 +746,91 @@ public class LogicalReplicationTest {
         result, equalTo(wait));
   }
 
+  @Test
+  public void testReplicationRestartFromLastFeedbackPositionParallelTransaction() throws Exception {
+    PGConnection pgConnection = (PGConnection) replConnection;
+
+    LogSequenceNumber startLSN = getCurrentLSN();
+
+    PGReplicationStream stream =
+        pgConnection
+            .getReplicationAPI()
+            .replicationStream()
+            .logical()
+            .withSlotName(SLOT_NAME)
+            .withStartPosition(startLSN)
+            .withSlotOption("include-xids", false)
+            .withSlotOption("skip-empty-xacts", true)
+            .start();
+
+    Connection tx1Connection = TestUtil.openDB();
+    tx1Connection.setAutoCommit(false);
+
+    Connection tx2Connection = TestUtil.openDB();
+    tx2Connection.setAutoCommit(false);
+
+    Statement stTx1 = tx1Connection.createStatement();
+    Statement stTx2 = tx2Connection.createStatement();
+
+    stTx1.execute("BEGIN");
+    stTx2.execute("BEGIN");
+
+    stTx1.execute("insert into test_logic_table(name) values('first tx changes')");
+    stTx2.execute("insert into test_logic_table(name) values('second tx changes')");
+
+    tx1Connection.commit();
+    tx2Connection.commit();
+
+    tx1Connection.close();
+    tx2Connection.close();
+
+    List<String> consumedData = new ArrayList<String>();
+    consumedData.addAll(receiveMessageWithoutBlock(stream, 3));
+    stream.setFlushedLSN(stream.getLastReceiveLSN());
+    stream.setAppliedLSN(stream.getLastReceiveLSN());
+
+    stream.forceUpdateStatus();
+
+    //emulate replication break
+    replConnection.close();
+    waitStopReplicationSlot();
+
+    replConnection = openReplicationConnection();
+    pgConnection = (PGConnection) replConnection;
+    stream =
+        pgConnection
+            .getReplicationAPI()
+            .replicationStream()
+            .logical()
+            .withSlotName(SLOT_NAME)
+            .withStartPosition(LogSequenceNumber.INVALID_LSN) /* Invalid LSN indicate for start from restart lsn */
+            .withSlotOption("include-xids", false)
+            .withSlotOption("skip-empty-xacts", true)
+            .start();
+
+    Statement st = sqlConnection.createStatement();
+    st.execute("insert into test_logic_table(name) values('third tx changes')");
+    st.close();
+
+    consumedData.addAll(receiveMessageWithoutBlock(stream, 3));
+    String result = group(consumedData);
+
+    String wait = group(Arrays.asList(
+        "BEGIN",
+        "table public.test_logic_table: INSERT: pk[integer]:1 name[character varying]:'first tx changes'",
+        "COMMIT",
+        "BEGIN",
+        "table public.test_logic_table: INSERT: pk[integer]:2 name[character varying]:'second tx changes'",
+        "COMMIT"
+    ));
+
+    assertThat(
+        "When we add feedback about applied lsn to replication stream(in this case it's force update status)"
+            + "after restart consume changes via this slot should be started from last success lsn that "
+            + "we send before via force status update, that why we wait consume both transaction without duplicates",
+        result, equalTo(wait));
+  }
+
   private void waitStopReplicationSlot() throws SQLException, InterruptedException {
     while (true) {
       PreparedStatement statement =


### PR DESCRIPTION
lastReceiveLSN calculates not valid for logical replication. Right now it calculates like
`startLSN + payloadSize` from XLogData it's correct statement for physical replication 
where payload it's raw data from WAL, and we can easily estimate position of next message [1]. 
But it's does't work for logical replication, because raw data from WAL changes in output plugin
as a result size of output payload not equal to size of payload from WAL. For deal with this problem
logical replication for commit message include to startLSN transaction end lsn + 1 [2]. So we can use 
startLSN as is for lastReceiveLSN.

Thanks Stefan Smith for report this problem [3]. 

[1] https://github.com/pgjdbc/pgjdbc/pull/550#issuecomment-254427102
[2] https://github.com/postgres/postgres/blob/master/src/backend/replication/logical/logical.c#L643
[3] https://www.postgresql.org/message-id/CAHHbV7V4XvdHGw_jpR9Xyq3fz%3Df%2BO4oa%2B73sbizGTv_AvmDXhQ%40mail.gmail.com