### PR TITLE
#800: fix last block of stream being ignored if size < 8k

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/util/ReaderInputStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/ReaderInputStream.java
@@ -142,7 +142,7 @@ public class ReaderInputStream extends InputStream {
         totalRead += remaining;
         off += remaining;
         len -= remaining;
-        if (len == 0) {
+        if (len >= 0) {
           return totalRead;
         }
       }

--- a/pgjdbc/src/main/java/org/postgresql/util/ReaderInputStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/ReaderInputStream.java
@@ -142,13 +142,13 @@ public class ReaderInputStream extends InputStream {
         totalRead += remaining;
         off += remaining;
         len -= remaining;
-        if (len >= 0) {
+        if (len == 0) {
           return totalRead;
         }
       }
       advance();
     }
-    if (endOfInput && !bbuf.hasRemaining()) {
+    if (endOfInput && !bbuf.hasRemaining() && totalRead == 0) {
       return -1;
     }
     return totalRead;

--- a/pgjdbc/src/test/java/org/postgresql/util/ReaderInputStreamTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/util/ReaderInputStreamTest.java
@@ -9,7 +9,13 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.CharArrayReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.io.StringReader;
 import java.nio.charset.MalformedInputException;
 import java.util.Arrays;
 
@@ -197,11 +203,7 @@ public class ReaderInputStreamTest {
     int total = 0;
 
     while ((read = r.read(buffer, 0, BLOCK)) > -1) {
-      // System.out.println(String.format("Read: %4d  Start: %3d  End: %3d", read, buffer[0], buffer[read - 1]));
       total += read;
-      if (read == BLOCK) {
-        assertEquals("Byte values are not correct", buffer[0], buffer[read % BLOCK]);
-      }
     }
 
     assertEquals("Data not read completely: missing " + (DATASIZE - total) + " bytes", total, DATASIZE);

--- a/pgjdbc/src/test/java/org/postgresql/util/ReaderInputStreamTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/util/ReaderInputStreamTest.java
@@ -187,19 +187,17 @@ public class ReaderInputStreamTest {
   @Test
   public void readsSmallerThanBlockSizeTest() throws Exception {
     final int BLOCK = 8 * 1024;
-    final int DATASIZE = BLOCK * 5 + 57;
+    final int DATASIZE = BLOCK + 57;
     final byte[] data = new byte[DATASIZE];
     final byte[] buffer = new byte[BLOCK];
 
     InputStreamReader isr = new InputStreamReader(new ByteArrayInputStream(data));
     ReaderInputStream r = new ReaderInputStream(isr);
 
-    int read;
     int total = 0;
 
-    while ((read = r.read(buffer, 0, BLOCK)) > -1) {
-      total += read;
-    }
+    total += r.read(buffer, 0, BLOCK);
+    total += r.read(buffer, 0, BLOCK);
 
     assertEquals("Data not read completely: missing " + (DATASIZE - total) + " bytes", total, DATASIZE);
   }

--- a/pgjdbc/src/test/java/org/postgresql/util/ReaderInputStreamTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/util/ReaderInputStreamTest.java
@@ -191,11 +191,6 @@ public class ReaderInputStreamTest {
     final byte[] data = new byte[DATASIZE];
     final byte[] buffer = new byte[BLOCK];
 
-    // initialize with values (0, 1, ... 127, 0, 1, ...)
-    for (int i = 0; i < data.length; i++) {
-      data[i] = (byte) (i & 0x7F);
-    }
-
     InputStreamReader isr = new InputStreamReader(new ByteArrayInputStream(data));
     ReaderInputStream r = new ReaderInputStream(isr);
 

--- a/pgjdbc/src/test/java/org/postgresql/util/ReaderInputStreamTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/util/ReaderInputStreamTest.java
@@ -185,21 +185,21 @@ public class ReaderInputStreamTest {
   }
 
   @Test
-  public void readsSmallerThanBlockSizeTest() throws Exception {
-    final int BLOCK = 8 * 1024;
-    final int DATASIZE = BLOCK + 57;
-    final byte[] data = new byte[DATASIZE];
-    final byte[] buffer = new byte[BLOCK];
+  public void readsEqualToBlockSizeTest() throws Exception {
+    final int blockSize = 8 * 1024;
+    final int dataSize = blockSize + 57;
+    final byte[] data = new byte[dataSize];
+    final byte[] buffer = new byte[blockSize];
 
-    InputStreamReader isr = new InputStreamReader(new ByteArrayInputStream(data));
-    ReaderInputStream r = new ReaderInputStream(isr);
+    InputStreamReader isr = new InputStreamReader(new ByteArrayInputStream(data), "UTF-8");
+    ReaderInputStream r = new ReaderInputStream(isr, blockSize);
 
     int total = 0;
 
-    total += r.read(buffer, 0, BLOCK);
-    total += r.read(buffer, 0, BLOCK);
+    total += r.read(buffer, 0, blockSize);
+    total += r.read(buffer, 0, blockSize);
 
-    assertEquals("Data not read completely: missing " + (DATASIZE - total) + " bytes", total, DATASIZE);
+    assertEquals("Data not read completely: missing " + (dataSize - total) + " bytes", dataSize, total);
   }
 
   private static class SingleCharPerReadReader extends Reader {


### PR DESCRIPTION
Fixes #800 (data truncated at the end of the stream, while using `setCharacterStream`)