### PR TITLE
bug: fix false alarm on check coredump

### DIFF
--- a/.travis/travis_check_postgres_health.sh
+++ b/.travis/travis_check_postgres_health.sh
@@ -1,22 +1,36 @@
 #!/usr/bin/env bash
 
 check_core_dump() {
+    local command_to_find="find ${PG_DATADIR} -type f -iname core*"
+    if [ ! -r "${PG_DATADIR}" ]
+    then
+        command_to_find="sudo ${command_to_find}"
+    fi
+
     local status=0
     while IFS= read -r core_dump_file
     do
         status=1
         echo "Detected core dump: ${core_dump_file}"
         echo bt full | sudo gdb --quiet /usr/local/pgsql/bin/postgres "${core_dump_file}"
-    done < <(sudo find "${PG_DATADIR}" -type f -iname "core*")
+    done < <(${command_to_find})
     return ${status}
 }
 
 print_logs() {
+    local log_file
     if [[ "${PG_VERSION}" = "HEAD" ]]
     then
-      sudo cat /tmp/postgres.log
+      log_file="/tmp/postgres.log"
     else
-      cat "/var/log/postgresql/postgresql-${PG_VERSION}-main.log"
+      log_file="/var/log/postgresql/postgresql-${PG_VERSION}-main.log"
+    fi
+
+    if [ -r "${log_file}" ]
+    then
+        cat "${log_file}"
+    else
+        sudo cat "${log_file}"
     fi
 }
 


### PR DESCRIPTION
Find coredump without sudo if it's available. It fix problem that travis
print to stdout not stderr message

```
This job is running on container-based infrastructure, which does not allow use of 'sudo', setuid, and setgid executables.
If you require sudo, add 'sudo: required' to your .travis.yml
```

that affect command that find corredumps.