### PR TITLE
refactor: SQL type not used in registerOutParameter

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/ParameterList.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/ParameterList.java
@@ -25,7 +25,7 @@ import java.sql.SQLException;
 public interface ParameterList {
 
 
-  void registerOutParameter(int index, int sqlType) throws SQLException;
+  void registerOutParameter(int index) throws SQLException;
 
   /**
    * Get the number of parameters in this list. This value never changes for a particular instance,

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/CompositeParameterList.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/CompositeParameterList.java
@@ -43,7 +43,7 @@ class CompositeParameterList implements V3ParameterList {
     throw new IllegalArgumentException("I am confused; can't find a subparam for index " + index);
   }
 
-  public void registerOutParameter(int index, int sqlType) {
+  public void registerOutParameter(int index) {
 
   }
 

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/SimpleParameterList.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/SimpleParameterList.java
@@ -48,7 +48,7 @@ class SimpleParameterList implements V3ParameterList {
   }
 
   @Override
-  public void registerOutParameter(int index, int sqlType) throws SQLException {
+  public void registerOutParameter(int index) throws SQLException {
     if (index < 1 || index > paramValues.length) {
       throw new PSQLException(
           GT.tr("The column index is out of range: {0}, number of columns: {1}.",

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgCallableStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgCallableStatement.java
@@ -199,7 +199,7 @@ class PgCallableStatement extends PgPreparedStatement implements CallableStateme
     checkIndex(parameterIndex, false);
 
     if (setPreparedParameters) {
-      preparedParameters.registerOutParameter(parameterIndex, sqlType);
+      preparedParameters.registerOutParameter(parameterIndex);
     }
     // functionReturnType contains the user supplied value to check
     // testReturn contains a modified version to make it easier to


### PR DESCRIPTION
ParameterList#registerOutParameter takes a SQL type int which is never
used.