### PR TITLE
 fix: Add fallback to setObject(int, Object) for Number

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
@@ -345,12 +345,7 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
   }
 
   public void setBigDecimal(int parameterIndex, BigDecimal x) throws SQLException {
-    checkClosed();
-    if (x == null) {
-      setNull(parameterIndex, Types.DECIMAL);
-    } else {
-      bindLiteral(parameterIndex, x.toString(), Oid.NUMERIC);
-    }
+    setNumber(parameterIndex, x);
   }
 
   public void setString(int parameterIndex, String x) throws SQLException {
@@ -512,6 +507,15 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
       bindBytes(parameterIndex, data, oid);
     } else {
       setString(parameterIndex, HStoreConverter.toString(x), oid);
+    }
+  }
+
+  private void setNumber(int parameterIndex, Number x) throws SQLException {
+    checkClosed();
+    if (x == null) {
+      setNull(parameterIndex, Types.DECIMAL);
+    } else {
+      bindLiteral(parameterIndex, x.toString(), Oid.NUMERIC);
     }
   }
 
@@ -962,6 +966,8 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
       //#endif
     } else if (x instanceof Map) {
       setMap(parameterIndex, (Map<?, ?>) x);
+    } else if (x instanceof Number) {
+      setNumber(parameterIndex, (Number) x);
     } else {
       // Can't infer a type.
       throw new PSQLException(GT.tr(

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PreparedStatementTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PreparedStatementTest.java
@@ -27,6 +27,7 @@ import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.math.RoundingMode;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -35,6 +36,7 @@ import java.sql.Statement;
 import java.sql.Types;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.concurrent.atomic.AtomicLong;
 
 
 @RunWith(Parameterized.class)
@@ -1090,6 +1092,66 @@ public class PreparedStatementTest extends BaseTest4 {
     psinsert.close();
     psselect.close();
     pstruncate.close();
+  }
+
+  @Test
+  public void testSetObjectWithBigDecimal() throws SQLException {
+    TestUtil.createTempTable(con, "number_fallback",
+            "n1 numeric");
+    PreparedStatement psinsert = con.prepareStatement("insert into number_fallback values(?)");
+    PreparedStatement psselect = con.prepareStatement("select n1 from number_fallback");
+
+    psinsert.setObject(1, new BigDecimal("733"));
+    psinsert.execute();
+
+    ResultSet rs = psselect.executeQuery();
+    assertTrue(rs.next());
+    assertTrue(
+        "expected 733, but received " + rs.getBigDecimal(1),
+        new BigDecimal("733").compareTo(rs.getBigDecimal(1)) == 0);
+
+    psinsert.close();
+    psselect.close();
+  }
+
+  @Test
+  public void testSetObjectNumberFallbackWithBigInteger() throws SQLException {
+    TestUtil.createTempTable(con, "number_fallback",
+            "n1 numeric");
+    PreparedStatement psinsert = con.prepareStatement("insert into number_fallback values(?)");
+    PreparedStatement psselect = con.prepareStatement("select n1 from number_fallback");
+
+    psinsert.setObject(1, new BigInteger("733"));
+    psinsert.execute();
+
+    ResultSet rs = psselect.executeQuery();
+    assertTrue(rs.next());
+    assertTrue(
+        "expected 733, but received " + rs.getBigDecimal(1),
+        new BigDecimal("733").compareTo(rs.getBigDecimal(1)) == 0);
+
+    psinsert.close();
+    psselect.close();
+  }
+
+  @Test
+  public void testSetObjectNumberFallbackWithAtomicLong() throws SQLException {
+    TestUtil.createTempTable(con, "number_fallback",
+            "n1 numeric");
+    PreparedStatement psinsert = con.prepareStatement("insert into number_fallback values(?)");
+    PreparedStatement psselect = con.prepareStatement("select n1 from number_fallback");
+
+    psinsert.setObject(1, new AtomicLong(733));
+    psinsert.execute();
+
+    ResultSet rs = psselect.executeQuery();
+    assertTrue(rs.next());
+    assertTrue(
+        "expected 733, but received " + rs.getBigDecimal(1),
+        new BigDecimal("733").compareTo(rs.getBigDecimal(1)) == 0);
+
+    psinsert.close();
+    psselect.close();
   }
 
   @Test


### PR DESCRIPTION
This pull request adds the fallback in question in #810.

It adds the following changes:

 * There is a new (private) `setNumber(int, Number)` method in `PgPreparedStatement` with the same functionality as `setBigDecimal(int, BigDecimal)`.
 * `setBigDecimal(int, BigDecimal)` does invoke `setNumber(int, Number)`.
 * A case has been added in `setObject(int, Object)` for when a `Number` of an unknown/unhandled type is given.
 * Unittests for this.

I've opted for the least intrusive way of adding this by simply adding another check "at the end" to see if the given `Object` is of the type `Number`. If yes, it is forwarded to `setNumber(int, Number)`.