### PR TITLE
in check for returning word, make sure it is a whole word and not par…

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/Parser.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/Parser.java
@@ -71,14 +71,14 @@ public class Parser {
     int numberOfStatements = 0;
 
     boolean whitespaceOnly = true;
-    boolean prevCharWhitespace = false;
+    boolean isKeyWordChar = false;
 
     int keyWordCount = 0;
     int keywordStart = -1;
     for (int i = 0; i < aChars.length; ++i) {
+
       char aChar = aChars[i];
-      boolean isKeyWordChar = false;
-      prevCharWhitespace = whitespaceOnly;
+      isKeyWordChar = false;
       // ';' is ignored as it splits the queries
       whitespaceOnly &= aChar == ';' || Character.isWhitespace(aChar);
       switch (aChar) {
@@ -176,8 +176,7 @@ public class Parser {
           break;
 
         default:
-          isKeyWordChar =
-              aChars[i] >= 'a' && aChars[i] <= 'z' || aChars[i] >= 'A' && aChars[i] <= 'Z';
+          isKeyWordChar = isKeyWordChar(aChars[i]);
           if (isKeyWordChar && keywordStart < 0) {
             keywordStart = i;
           }
@@ -208,7 +207,9 @@ public class Parser {
             }
           }
         }
-        if (prevCharWhitespace && wordLength == 9 && parseReturningKeyword(aChars, keywordStart)) {
+
+        if ( keywordStart > 0 && !isKeyWordChar(aChars[keywordStart - 1])
+            && wordLength == 9 && parseReturningKeyword(aChars, keywordStart)) {
           isReturningPresent = true;
         } else if (wordLength == 6 && parseValuesKeyword(aChars, keywordStart)) {
           isValuesFound = true;
@@ -265,6 +266,10 @@ public class Parser {
       nativeQueries.add(lastQuery);
     }
     return nativeQueries;
+  }
+
+  private static boolean isKeyWordChar(char ch) {
+    return   ch >= 'a' && ch <= 'z' || ch >= 'A' && ch <= 'Z';
   }
 
   private static boolean addReturning(StringBuilder nativeSql, SqlCommandType currentCommandType,

--- a/pgjdbc/src/main/java/org/postgresql/core/Parser.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/Parser.java
@@ -547,7 +547,11 @@ public class Parser {
       return false;
     }
 
-    return (query[offset] | 32) == 'r'
+    /* test to make sure the word returning is not in the statement
+        we have to test for a space in front and in the end
+    */
+    return (query[offset - 1] == ' ')
+        && (query[offset] | 32) == 'r'
         && (query[offset + 1] | 32) == 'e'
         && (query[offset + 2] | 32) == 't'
         && (query[offset + 3] | 32) == 'u'
@@ -555,7 +559,9 @@ public class Parser {
         && (query[offset + 5] | 32) == 'n'
         && (query[offset + 6] | 32) == 'i'
         && (query[offset + 7] | 32) == 'n'
-        && (query[offset + 8] | 32) == 'g';
+        && (query[offset + 8] | 32) == 'g'
+        /* ensure that returning is not part of another column name */
+        && (query[offset + 9] == ' ');
   }
 
   /**

--- a/pgjdbc/src/main/java/org/postgresql/core/Parser.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/Parser.java
@@ -71,11 +71,14 @@ public class Parser {
     int numberOfStatements = 0;
 
     boolean whitespaceOnly = true;
+    boolean prevCharWhitespace = false;
+
     int keyWordCount = 0;
     int keywordStart = -1;
     for (int i = 0; i < aChars.length; ++i) {
       char aChar = aChars[i];
       boolean isKeyWordChar = false;
+      prevCharWhitespace = whitespaceOnly;
       // ';' is ignored as it splits the queries
       whitespaceOnly &= aChar == ';' || Character.isWhitespace(aChar);
       switch (aChar) {
@@ -205,7 +208,7 @@ public class Parser {
             }
           }
         }
-        if (wordLength == 9 && parseReturningKeyword(aChars, keywordStart)) {
+        if (prevCharWhitespace && wordLength == 9 && parseReturningKeyword(aChars, keywordStart)) {
           isReturningPresent = true;
         } else if (wordLength == 6 && parseValuesKeyword(aChars, keywordStart)) {
           isValuesFound = true;
@@ -550,8 +553,7 @@ public class Parser {
     /* test to make sure the word returning is not in the statement
         we have to test for a space in front and in the end
     */
-    return (query[offset - 1] == ' ')
-        && (query[offset] | 32) == 'r'
+    return (query[offset] | 32) == 'r'
         && (query[offset + 1] | 32) == 'e'
         && (query[offset + 2] | 32) == 't'
         && (query[offset + 3] | 32) == 'u'
@@ -559,9 +561,7 @@ public class Parser {
         && (query[offset + 5] | 32) == 'n'
         && (query[offset + 6] | 32) == 'i'
         && (query[offset + 7] | 32) == 'n'
-        && (query[offset + 8] | 32) == 'g'
-        /* ensure that returning is not part of another column name */
-        && (query[offset + 9] == ' ');
+        && (query[offset + 8] | 32) == 'g';
   }
 
   /**

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ParseReturningTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ParseReturningTest.java
@@ -32,7 +32,7 @@ public class ParseReturningTest extends BaseTest {
   }
 
   protected void tearDown() throws SQLException {
-    TestUtil.dropTable(con, "test_returning");
+    TestUtil.dropTable(con, "testreturning");
     super.tearDown();
   }
 
@@ -41,7 +41,8 @@ public class ParseReturningTest extends BaseTest {
    */
   @Test
   public void testColumnReturning() throws SQLException {
-    PreparedStatement pstmt = con.prepareStatement("insert into test_returning (address, returning_allowed) values (?,?)", Statement.RETURN_GENERATED_KEYS);
+    PreparedStatement pstmt = con.prepareStatement("insert into test_returning (address,"
+        + "\nreturning_allowed) values (?,?)", Statement.RETURN_GENERATED_KEYS);
     pstmt.setString(1, "a");
     pstmt.setBoolean(2, true);
     assertEquals(1,pstmt.executeUpdate());

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ParseReturningTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ParseReturningTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2004, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.test.jdbc2;
+
+/**
+ * Created by davec on 2017-05-16.
+ */
+
+import org.postgresql.test.TestUtil;
+
+import org.junit.Test;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+public class ParseReturningTest extends BaseTest {
+  Statement stmt;
+
+  public ParseReturningTest(String name) {
+    super(name);
+  }
+
+  protected void setUp() throws Exception {
+    super.setUp();
+
+    TestUtil.createTempTable(con, "test_returning", "id serial primary key, address text, returning_allowed bool");
+  }
+
+  protected void tearDown() throws SQLException {
+    TestUtil.dropTable(con, "test_returning");
+    super.tearDown();
+  }
+
+  /*
+  This actually tests for tables with the word returning and columns with the word returning in them
+   */
+  @Test
+  public void testColumnReturning() throws SQLException {
+    PreparedStatement pstmt = con.prepareStatement("insert into test_returning (address, returning_allowed) values (?,?)", Statement.RETURN_GENERATED_KEYS);
+    pstmt.setString(1, "a");
+    pstmt.setBoolean(2, true);
+    assertEquals(1,pstmt.executeUpdate());
+    ResultSet generatedKeys = pstmt.getGeneratedKeys();
+    assertTrue("There should be at least one result", generatedKeys.next());
+
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ParseReturningTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ParseReturningTest.java
@@ -13,7 +13,6 @@ import org.postgresql.test.TestUtil;
 
 import org.junit.Test;
 
-import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -41,13 +40,21 @@ public class ParseReturningTest extends BaseTest {
    */
   @Test
   public void testColumnReturning() throws SQLException {
-    PreparedStatement pstmt = con.prepareStatement("insert into test_returning (address,"
-        + "\nreturning_allowed) values (?,?)", Statement.RETURN_GENERATED_KEYS);
-    pstmt.setString(1, "a");
-    pstmt.setBoolean(2, true);
-    assertEquals(1,pstmt.executeUpdate());
-    ResultSet generatedKeys = pstmt.getGeneratedKeys();
+    Statement stmt = con.createStatement();
+    stmt.execute("insert into test_returning (address,"
+        + "\nreturning_allowed) values ('a','t')", Statement.RETURN_GENERATED_KEYS);
+    ResultSet generatedKeys = stmt.getGeneratedKeys();
     assertTrue("There should be at least one result", generatedKeys.next());
+    generatedKeys.close();
+    generatedKeys.close();
+
+    try {
+      stmt.execute("insert into \"test_returning\"(address,returning_allowed)values('a','t')returning*", Statement.RETURN_GENERATED_KEYS);
+    } catch (SQLException ex) {
+      assertEquals("42601", ex.getSQLState());
+    } finally {
+      stmt.close();
+    }
 
   }
 }


### PR DESCRIPTION
…t of a column or part of a table name fixes #824 