### PR TITLE
bug: floating logical replcation test

### DIFF
--- a/pgjdbc/src/test/java/org/postgresql/replication/LogicalReplicationTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/replication/LogicalReplicationTest.java
@@ -443,6 +443,8 @@ public class LogicalReplicationTest {
     result.addAll(receiveMessage(stream, 3));
 
     replConnection.close();
+    waitStopReplicationSlot();
+
     replConnection = openReplicationConnection();
     pgConnection = (PGConnection) replConnection;
 


### PR DESCRIPTION
```
ERROR: replication slot "pgjdbc_logical_replication_slot" is active for PID 19978
```

After close replication slot, postgresql require some times to kill
previous session before start new, that why need wait when previous session
die before restart replication replication via replication slot.

More correct way, it's use
org.postgresql.replication.PGReplicationStream#close, in that case not
necessary wait when previous session die, but current version postgresql still
have a bug that not allow stop replication fast enough[1].

1. http://www.postgresql.org/message-id/CAFgjRd3hdYOa33m69TbeOfNNer2BZbwa8FFjt2V5VFzTBvUU3w@mail.gmail.com