### PR TITLE
Support configuring proxy per connection.

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/Driver.java
+++ b/pgjdbc/src/main/java/org/postgresql/Driver.java
@@ -103,6 +103,9 @@ public class Driver implements java.sql.Driver {
   private Properties loadDefaultProperties() throws IOException {
     Properties merged = new Properties();
 
+    // resolve DNS by default if not using socks proxy
+    PGProperty.RESOLVE_DNS.set(merged, System.getProperty("socksProxyHost") == null);
+    
     try {
       PGProperty.USER.set(merged, System.getProperty("user.name"));
     } catch (java.lang.SecurityException se) {
@@ -228,6 +231,7 @@ public class Driver implements java.sql.Driver {
         props.setProperty(propName, propValue);
       }
     }
+    
     // parse URL and add more properties
     if ((props = parseURL(url, props)) == null) {
       LOGGER.log(Level.SEVERE, "Error in url: {0}", url);

--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -282,6 +282,13 @@ public enum PGProperty {
       "Argument forwarded to constructor of SocketFactory class."),
 
   /**
+   * Resolve DNS address to ip.  Should be false if you want a socks proxy to resolve the
+   * DNS address
+   */
+  RESOLVE_DNS("resolveDNS", null, 
+		  "Wether to resolve dns addresses,  set to false if using a socks proxy"),
+  
+  /**
    * Socket read buffer size (SO_RECVBUF). A value of {@code -1}, which is the default, means system
    * default.
    */

--- a/pgjdbc/src/main/java/org/postgresql/core/PGStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/PGStream.java
@@ -53,7 +53,7 @@ public class PGStream {
    * @param timeout timeout in milliseconds, or 0 if no timeout set
    * @throws IOException if an IOException occurs below it.
    */
-  public PGStream(SocketFactory socketFactory, HostSpec hostSpec, int timeout) throws IOException {
+  public PGStream(SocketFactory socketFactory, HostSpec hostSpec, boolean resolveDNS, int timeout) throws IOException {
     this.socketFactory = socketFactory;
     this.hostSpec = hostSpec;
 
@@ -62,9 +62,10 @@ public class PGStream {
       // When using a SOCKS proxy, the host might not be resolvable locally,
       // thus we defer resolution until the traffic reaches the proxy. If there
       // is no proxy, we must resolve the host to an IP to connect the socket.
-      InetSocketAddress address = System.getProperty("socksProxyHost") == null
-          ? new InetSocketAddress(hostSpec.getHost(), hostSpec.getPort())
-          : InetSocketAddress.createUnresolved(hostSpec.getHost(), hostSpec.getPort());
+    	InetSocketAddress address = resolveDNS ? 
+			new InetSocketAddress(hostSpec.getHost(), hostSpec.getPort()) :
+				InetSocketAddress.createUnresolved(hostSpec.getHost(), hostSpec.getPort());
+
       socket.connect(address, timeout);
     }
     changeSocket(socket);
@@ -82,8 +83,8 @@ public class PGStream {
    * @throws IOException if an IOException occurs below it.
    * @deprecated use {@link #PGStream(SocketFactory, org.postgresql.util.HostSpec, int)}
    */
-  public PGStream(SocketFactory socketFactory, HostSpec hostSpec) throws IOException {
-    this(socketFactory, hostSpec, 0);
+  public PGStream(SocketFactory socketFactory, HostSpec hostSpec, boolean resolve) throws IOException {
+    this(socketFactory, hostSpec, resolve, 0);
   }
 
   public HostSpec getHostSpec() {

--- a/pgjdbc/src/main/java/org/postgresql/core/QueryExecutorBase.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/QueryExecutorBase.java
@@ -42,6 +42,7 @@ public abstract class QueryExecutorBase implements QueryExecutor {
   private final PreferQueryMode preferQueryMode;
   private AutoSave autoSave;
   private boolean flushCacheOnDeallocate = true;
+  private boolean resolveDNS = true;
 
   // default value for server versions that don't report standard_conforming_strings
   private boolean standardConformingStrings = false;
@@ -64,6 +65,8 @@ public abstract class QueryExecutorBase implements QueryExecutor {
     this.preferQueryMode = PreferQueryMode.of(preferMode);
     this.autoSave = AutoSave.of(PGProperty.AUTOSAVE.get(info));
     this.cachedQueryCreateAction = new CachedQueryCreateAction(this);
+    this.resolveDNS = PGProperty.RESOLVE_DNS.getBoolean(info);
+    
     statementCache = new LruCache<Object, CachedQuery>(
         Math.max(0, PGProperty.PREPARED_STATEMENT_CACHE_QUERIES.getInt(info)),
         Math.max(0, PGProperty.PREPARED_STATEMENT_CACHE_SIZE_MIB.getInt(info) * 1024 * 1024),
@@ -152,7 +155,7 @@ public abstract class QueryExecutorBase implements QueryExecutor {
       }
 
       cancelStream =
-          new PGStream(pgStream.getSocketFactory(), pgStream.getHostSpec(), cancelSignalTimeout);
+          new PGStream(pgStream.getSocketFactory(), pgStream.getHostSpec(), this.resolveDNS, cancelSignalTimeout);
       if (cancelSignalTimeout > 0) {
         cancelStream.getSocket().setSoTimeout(cancelSignalTimeout);
       }

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java
@@ -126,6 +126,8 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
           PSQLState.CONNECTION_UNABLE_TO_CONNECT);
     }
 
+    boolean resolveDNS = PGProperty.RESOLVE_DNS.getBoolean(info);
+    
     SocketFactory socketFactory = SocketFactoryFactory.getSocketFactory(info);
 
     HostChooser hostChooser =
@@ -141,11 +143,11 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
 
       PGStream newStream = null;
       try {
-        newStream = new PGStream(socketFactory, hostSpec, connectTimeout);
+        newStream = new PGStream(socketFactory, hostSpec, resolveDNS, connectTimeout);
 
         // Construct and send an ssl startup packet if requested.
         if (trySSL) {
-          newStream = enableSSL(newStream, requireSSL, info, connectTimeout);
+          newStream = enableSSL(newStream, requireSSL, info, resolveDNS, connectTimeout);
         }
 
         // Set the socket timeout if the "socketTimeout" property has been set.
@@ -315,7 +317,7 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
     return start + tz.substring(4);
   }
 
-  private PGStream enableSSL(PGStream pgStream, boolean requireSSL, Properties info, int connectTimeout)
+  private PGStream enableSSL(PGStream pgStream, boolean requireSSL, Properties info, boolean resolveDNS, int connectTimeout)
       throws IOException, SQLException {
     LOGGER.log(Level.FINEST, " FE=> SSLRequest");
 
@@ -324,7 +326,7 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
     pgStream.sendInteger2(1234);
     pgStream.sendInteger2(5679);
     pgStream.flush();
-
+    
     // Now get the response from the backend, one of N, E, S.
     int beresp = pgStream.receiveChar();
     switch (beresp) {
@@ -339,7 +341,7 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
 
         // We have to reconnect to continue.
         pgStream.close();
-        return new PGStream(pgStream.getSocketFactory(), pgStream.getHostSpec(), connectTimeout);
+        return new PGStream(pgStream.getSocketFactory(), pgStream.getHostSpec(), resolveDNS, connectTimeout);
 
       case 'N':
         LOGGER.log(Level.FINEST, " <=BE SSLRefused");

--- a/pgjdbc/src/main/java/org/postgresql/util/ProxySocketFactory.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/ProxySocketFactory.java
@@ -1,0 +1,110 @@
+package org.postgresql.util;
+
+import java.io.IOException;
+import java.net.Authenticator;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.PasswordAuthentication;
+import java.net.Proxy;
+import java.net.Socket;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.UnknownHostException;
+
+public class ProxySocketFactory extends javax.net.SocketFactory{
+
+	private Proxy proxy;
+	
+	public ProxySocketFactory(Proxy proxy) {
+		this.proxy = proxy;
+	}
+
+
+	public ProxySocketFactory(String urlString) throws URISyntaxException
+	{
+		URI url = new URI(urlString);
+		
+		Proxy.Type proxyType = Proxy.Type.DIRECT;
+		
+		if (url.getScheme().equalsIgnoreCase("http")) {
+			proxyType = Proxy.Type.HTTP;
+		}
+		else if (url.getScheme().equalsIgnoreCase("socks")) {
+			proxyType = Proxy.Type.SOCKS;
+		}
+		
+		final String proxyHost = url.getHost();
+		final int proxyPort = url.getPort();
+		
+		String userInfo = url.getUserInfo();
+		
+		if (userInfo != null ) {
+		
+			final String username = userInfo.split(":")[0];
+			final String password = userInfo.split(":")[1];
+			
+			// Java ignores http.proxyUser. Here come's the workaround.
+			Authenticator.setDefault(new Authenticator() {
+			    @Override
+			    protected PasswordAuthentication getPasswordAuthentication() {
+			        if (getRequestorType() == RequestorType.PROXY) {
+	
+			            if (getRequestingHost().equalsIgnoreCase(proxyHost)) {
+			                if (proxyPort == getRequestingPort()) {
+			                    // Seems to be OK.
+			                    return new PasswordAuthentication(username, password.toCharArray());  
+			                }
+			            }
+			        }
+			        return null;
+			    }  
+			});
+		}
+		
+		this.proxy = new Proxy(proxyType, new InetSocketAddress(proxyHost, proxyPort));
+
+	}
+	
+	public Proxy getProxy() {
+		return this.proxy;
+	}	
+
+	@Override
+	public Socket createSocket() throws IOException {
+		return new Socket(proxy);
+	}
+	
+	@Override
+	public Socket createSocket(String host, int port) throws IOException, UnknownHostException {
+		Socket socket = createSocket();
+		socket.connect(InetSocketAddress.createUnresolved(host, port));
+		return socket;
+		
+	}
+
+	@Override
+	public Socket createSocket(InetAddress host, int port) throws IOException {
+		Socket socket = createSocket();
+		socket.connect(new InetSocketAddress(host, port));
+		return socket;
+	}
+
+	@Override
+	public Socket createSocket(String host, int port, InetAddress localhost, int localport)
+			throws IOException, UnknownHostException {
+		Socket socket = createSocket();
+		socket.bind(new InetSocketAddress(localhost, localport));
+		socket.connect(InetSocketAddress.createUnresolved(host, port));
+		return socket;
+	}
+
+	@Override
+	public Socket createSocket(InetAddress host, int port, InetAddress localhost, int localport) throws IOException {
+		// TODO Auto-generated method stub
+		Socket socket = createSocket();
+		socket.bind(new InetSocketAddress(localhost, localport));
+		socket.connect(new InetSocketAddress(host, port));
+		return socket;
+	}
+
+}


### PR DESCRIPTION
Support configuring a proxy for each individual database connection
To support a socks proxy,  add the following properties to your connection:

resolveDNS=false
socketFactory=org.postgresql.util.ProxySocketFactory
socketFactoryArg=socks://host:port

We need this because we have one cognos server that connects to databases on prem (direct access)  as well as on the cloud (through proxy).    So some connections need a proxy and some don't.   Using -DsocksProxyHost and -DsocksProxyPort  is not good because it is an all or nothing solution.