### PR TITLE
Fixes #638 Implement support for get/setNetworkTimeout().

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/PGStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/PGStream.java
@@ -540,4 +540,12 @@ public class PGStream implements Closeable {
     pg_input.close();
     connection.close();
   }
+
+  public void setNetworkTimeout(int milliseconds) throws IOException {
+    connection.setSoTimeout(milliseconds);
+  }
+
+  public int getNetworkTimeout() throws IOException {
+    return connection.getSoTimeout();
+  }
 }

--- a/pgjdbc/src/main/java/org/postgresql/core/QueryExecutor.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/QueryExecutor.java
@@ -14,6 +14,7 @@ import org.postgresql.jdbc.BatchResultHandler;
 import org.postgresql.jdbc.PreferQueryMode;
 import org.postgresql.util.HostSpec;
 
+import java.io.IOException;
 import java.sql.SQLException;
 import java.sql.SQLWarning;
 import java.util.List;
@@ -437,4 +438,8 @@ public interface QueryExecutor extends TypeTransferModeRegistry {
    * @return the ReplicationProtocol instance for this connection.
    */
   ReplicationProtocol getReplicationProtocol();
+
+  void setNetworkTimeout(int milliseconds) throws IOException;
+
+  int getNetworkTimeout() throws IOException;
 }

--- a/pgjdbc/src/main/java/org/postgresql/core/QueryExecutorBase.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/QueryExecutorBase.java
@@ -80,6 +80,16 @@ public abstract class QueryExecutorBase implements QueryExecutor {
   protected abstract void sendCloseMessage() throws IOException;
 
   @Override
+  public void setNetworkTimeout(int milliseconds) throws IOException {
+    pgStream.setNetworkTimeout(milliseconds);
+  }
+
+  @Override
+  public int getNetworkTimeout() throws IOException {
+    return pgStream.getNetworkTimeout();
+  }
+
+  @Override
   public HostSpec getHostSpec() {
     return pgStream.getHostSpec();
   }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc4/jdbc41/Jdbc41TestSuite.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc4/jdbc41/Jdbc41TestSuite.java
@@ -17,6 +17,7 @@ import org.junit.runners.Suite;
         AbortTest.class,
         CloseOnCompletionTest.class,
         SharedTimerClassLoaderLeakTest.class,
+        NetworkTimeoutTest.class,
         GetObjectTest.class}
     )
 public class Jdbc41TestSuite {

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc4/jdbc41/NetworkTimeoutTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc4/jdbc41/NetworkTimeoutTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2007, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.test.jdbc4.jdbc41;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.postgresql.test.TestUtil;
+
+import org.junit.Test;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.concurrent.TimeUnit;
+
+public class NetworkTimeoutTest {
+  @Test
+  public void testSetNetworkTimeout() throws Exception {
+    Connection _conn = TestUtil.openDB();
+    try {
+      _conn.setNetworkTimeout(null, 0);
+    } catch (SQLException e) {
+      fail("Connection.setNetworkTimeout() throw exception");
+    } finally {
+      TestUtil.closeDB(_conn);
+    }
+  }
+
+  @Test
+  public void testSetNetworkTimeoutInvalid() throws Exception {
+    Connection _conn = TestUtil.openDB();
+    try {
+      _conn.setNetworkTimeout(null, -1);
+      fail("Connection.setNetworkTimeout() did not throw expected exception");
+    } catch (SQLException e) {
+      // Passed
+    } finally {
+      TestUtil.closeDB(_conn);
+    }
+  }
+
+  @Test
+  public void testSetNetworkTimeoutValid() throws Exception {
+    Connection _conn = TestUtil.openDB();
+    try {
+      _conn.setNetworkTimeout(null, (int) TimeUnit.SECONDS.toMillis(5));
+      assertEquals(TimeUnit.SECONDS.toMillis(5), _conn.getNetworkTimeout());
+    } catch (SQLException e) {
+      fail("Connection.setNetworkTimeout() throw exception");
+    } finally {
+      TestUtil.closeDB(_conn);
+    }
+  }
+
+  @Test
+  public void testSetNetworkTimeoutEnforcement() throws Exception {
+    Connection _conn = TestUtil.openDB();
+    Statement stmt = null;
+    try {
+      _conn.setNetworkTimeout(null, (int) TimeUnit.SECONDS.toMillis(1));
+      stmt = _conn.createStatement();
+      stmt.execute("SELECT pg_sleep(2)");
+      fail("Connection.setNetworkTimeout() did not throw expected exception");
+    } catch (SQLException e) {
+      // assertTrue(stmt.isClosed());
+      assertTrue(_conn.isClosed());
+    } finally {
+      TestUtil.closeQuietly(stmt);
+      TestUtil.closeDB(_conn);
+    }
+  }
+}


### PR DESCRIPTION
HikariCP logs a warning at connection pool startup when a driver is found to not support get/setNetworkTimeout() -- due to vulnerability to getting stuck during a network disruption or partition event.

Given our user-base of several hundred thousand users, the warning message has turned into a support burden, with users concerned about its meaning.  One solution would be to do away with the warning, but that doesn't really serve the user.

So, here is the implementation of said feature -- I should have done this a year ago out of self-preservation.
