### PR TITLE
Improve finalizer guard mechanism n PgConnection to avoid GC overhead

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -159,11 +159,24 @@ public enum PGProperty {
       "Specifies the length to return for types of unknown length"),
 
   /**
+   * When connections that are not explicitly closed are garbage collected, close them during finalization
+   * in garbage collection.
+   *
+   * <b>IMPORTANT:</b> may have severe performance implications as it slows down garbage collection
+   * considerably. Best used in development and testing, or for systems that are not tested not to
+   * leak connections.
+   */
+  RESOURCE_FINALIZER_GUARD("resourceFinalizerGuard", "true",
+      "Close connections that are not explicitly closed over finalization in the garbage collection"),
+
+  /**
    * When connections that are not explicitly closed are garbage collected, log the stacktrace from
    * the opening of the connection to trace the leak source.
+   *
+   * This flag is ignored unless 'resourceFinalizerGuard' is set to true.
    */
   LOG_UNCLOSED_CONNECTIONS("logUnclosedConnections", "false",
-      "When connections that are not explicitly closed are garbage collected, log the stacktrace from the opening of the connection to trace the leak source"),
+      "When connections that are not explicitly closed are garbage collected, log the stacktrace from the opening of the connection to trace the leak source; requires the 'resourceFinalizerGuard' property to be set to 'true'"),
 
   /**
    * Enable optimization that disables column name sanitiser.

--- a/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
+++ b/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
@@ -833,6 +833,22 @@ public abstract class BaseDataSource implements CommonDataSource, Referenceable 
   }
 
   /**
+   * @return true if driver should guard with finalizers against leaking unclosed resources (connections, statements, etc.)
+   * @see PGProperty#RESOURCE_FINALIZER_GUARD
+   */
+  public boolean getResourceFinalizerGuard() {
+    return PGProperty.RESOURCE_FINALIZER_GUARD.getBoolean(properties);
+  }
+
+  /**
+   * @param enabled true if driver should guard with finalizers against leaking unclosed resources (connections, statements, etc.)
+   * @see PGProperty#RESOURCE_FINALIZER_GUARD
+   */
+  public void setResourceFinalizerGuard(boolean enabled) {
+    PGProperty.RESOURCE_FINALIZER_GUARD.set(properties, enabled);
+  }
+
+  /**
    * @return true if driver should log unclosed connections
    * @see PGProperty#LOG_UNCLOSED_CONNECTIONS
    */


### PR DESCRIPTION
The PgConnection class override finalize to guard against leaked connections
and be able to log them if they are leaked by the code.

While the goal is worthy, the implementation causes *large* overhead in Garbage
collection because, no matter if the leak guard is needed or not, the finalizer
will be executed.

This change introduces a finalizer guard following the pattern explained in the
"Effective Java" book, which uses a dedicated object with "just" the finalize
method overridden, and that it is instantiated only if the leak guard is needed.
If the leak guard is *not* needed, no finalizer will cause overhead during
Garbage Collection.