### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,7 +144,7 @@ Git repository typically contains -SNAPSHOT versions, so you can use the followi
 
 Prerequisites:
 - JDK 6, JDK 7, and JDK8 configured in `~/.m2/toolchains.xml`
-- a PostgreSQL instance for running tests
+- a PostgreSQL instance for running tests; it must have a user named `test` as well as a database named `test`
 - ensure that the RPM packaging CI isn't failing at
   [copr web page](https://copr.fedorainfracloud.org/coprs/g/pgjdbc/pgjdbc-travis/builds/) -
   possibly bump `parent poms` or `pgjdbc` versions in RPM [spec file](packaging/rpm/postgresql-jdbc.spec).


### PR DESCRIPTION
Clarify that the build needs a database and a user called both `test` to run.