### PR TITLE
honour PGPORT, PGHOST, PGDBNAME in connection properties

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/Driver.java
+++ b/pgjdbc/src/main/java/org/postgresql/Driver.java
@@ -577,13 +577,13 @@ public class Driver implements java.sql.Driver {
       urlProps.setProperty("PGPORT", ports.toString());
       urlProps.setProperty("PGHOST", hosts.toString());
     } else {
-      if (!defaults.containsKey("PGPORT")) {
+      if (defaults != null && !defaults.containsKey("PGPORT")) {
         urlProps.setProperty("PGPORT", "/*$mvn.project.property.template.default.pg.port$*/");
       }
-      if (!defaults.containsKey("PGHOST")) {
+      if (defaults != null && !defaults.containsKey("PGHOST")) {
         urlProps.setProperty("PGHOST", "localhost");
       }
-      if (!defaults.containsKey("PGDBNAME")) {
+      if (defaults != null && !defaults.containsKey("PGDBNAME")) {
         urlProps.setProperty("PGDBNAME", URLDecoder.decode(l_urlServer));
       }
     }

--- a/pgjdbc/src/main/java/org/postgresql/Driver.java
+++ b/pgjdbc/src/main/java/org/postgresql/Driver.java
@@ -577,9 +577,15 @@ public class Driver implements java.sql.Driver {
       urlProps.setProperty("PGPORT", ports.toString());
       urlProps.setProperty("PGHOST", hosts.toString());
     } else {
-      urlProps.setProperty("PGPORT", "/*$mvn.project.property.template.default.pg.port$*/");
-      urlProps.setProperty("PGHOST", "localhost");
-      urlProps.setProperty("PGDBNAME", URLDecoder.decode(l_urlServer));
+      if (!defaults.containsKey("PGPORT")) {
+        urlProps.setProperty("PGPORT", "/*$mvn.project.property.template.default.pg.port$*/");
+      }
+      if (!defaults.containsKey("PGHOST")) {
+        urlProps.setProperty("PGHOST", "localhost");
+      }
+      if (!defaults.containsKey("PGDBNAME")) {
+        urlProps.setProperty("PGDBNAME", URLDecoder.decode(l_urlServer));
+      }
     }
 
     // parse the args part of the url

--- a/pgjdbc/src/main/java/org/postgresql/Driver.java
+++ b/pgjdbc/src/main/java/org/postgresql/Driver.java
@@ -577,25 +577,19 @@ public class Driver implements java.sql.Driver {
       urlProps.setProperty("PGPORT", ports.toString());
       urlProps.setProperty("PGHOST", hosts.toString());
     } else {
-
-      if (defaults != null && !defaults.containsKey("PGPORT")) {
-        urlProps.setProperty("PGPORT", "/*$mvn.project.property.template.default.pg.port$*/");
-      } else {
+      /*
+       if there are no defaults set or any one of PORT, HOST, DBNAME not set
+       then set it to default
+      */
+      if (defaults == null || !defaults.containsKey("PGPORT")) {
         urlProps.setProperty("PGPORT", "/*$mvn.project.property.template.default.pg.port$*/");
       }
-
-      if (defaults != null && !defaults.containsKey("PGHOST")) {
-        urlProps.setProperty("PGHOST", "localhost");
-      } else {
+      if (defaults == null || !defaults.containsKey("PGHOST")) {
         urlProps.setProperty("PGHOST", "localhost");
       }
-
-      if (defaults != null && !defaults.containsKey("PGDBNAME")) {
-        urlProps.setProperty("PGDBNAME", URLDecoder.decode(l_urlServer));
-      } else {
+      if (defaults == null || !defaults.containsKey("PGDBNAME")) {
         urlProps.setProperty("PGDBNAME", URLDecoder.decode(l_urlServer));
       }
-
     }
 
     // parse the args part of the url

--- a/pgjdbc/src/main/java/org/postgresql/Driver.java
+++ b/pgjdbc/src/main/java/org/postgresql/Driver.java
@@ -577,15 +577,25 @@ public class Driver implements java.sql.Driver {
       urlProps.setProperty("PGPORT", ports.toString());
       urlProps.setProperty("PGHOST", hosts.toString());
     } else {
+
       if (defaults != null && !defaults.containsKey("PGPORT")) {
         urlProps.setProperty("PGPORT", "/*$mvn.project.property.template.default.pg.port$*/");
+      } else {
+        urlProps.setProperty("PGPORT", "/*$mvn.project.property.template.default.pg.port$*/");
       }
+
       if (defaults != null && !defaults.containsKey("PGHOST")) {
         urlProps.setProperty("PGHOST", "localhost");
+      } else {
+        urlProps.setProperty("PGHOST", "localhost");
       }
+
       if (defaults != null && !defaults.containsKey("PGDBNAME")) {
         urlProps.setProperty("PGDBNAME", URLDecoder.decode(l_urlServer));
+      } else {
+        urlProps.setProperty("PGDBNAME", URLDecoder.decode(l_urlServer));
       }
+
     }
 
     // parse the args part of the url

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DriverTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DriverTest.java
@@ -12,6 +12,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import org.postgresql.Driver;
+import org.postgresql.PGProperty;
 import org.postgresql.test.TestUtil;
 import org.postgresql.util.NullOutputStream;
 import org.postgresql.util.WriterHandler;
@@ -76,9 +77,9 @@ public class DriverTest {
         drv.getClass().getDeclaredMethod("parseURL", String.class, Properties.class);
     parseMethod.setAccessible(true);
     Properties p = (Properties) parseMethod.invoke(drv, url, null);
-    assertEquals(url, dbName, p.getProperty("PGDBNAME"));
-    assertEquals(url, hosts, p.getProperty("PGHOST"));
-    assertEquals(url, ports, p.getProperty("PGPORT"));
+    assertEquals(url, dbName, p.getProperty(PGProperty.PG_DBNAME.getName()));
+    assertEquals(url, hosts, p.getProperty(PGProperty.PG_HOST.getName()));
+    assertEquals(url, ports, p.getProperty(PGProperty.PG_PORT.getName()));
   }
 
   /**


### PR DESCRIPTION
Previously setting these in properties passed to DriverManager.getConnection(url, props) were ignored