### PR TITLE
test: assume integer datetimes for timestamp tests

### DIFF
--- a/pgjdbc/src/test/java/org/postgresql/test/TestUtil.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/TestUtil.java
@@ -664,6 +664,16 @@ public class TestUtil {
     return (jvm.compareTo(version) >= 0);
   }
 
+  public static boolean haveIntegerDateTimes(Connection con) {
+    if (con == null) {
+      throw new NullPointerException("Connection is null");
+    }
+    if (con instanceof PgConnection) {
+      return ((PgConnection) con).getQueryExecutor().getIntegerDateTimes();
+    }
+    return false;
+  }
+
   /**
    * Print a ResultSet to System.out. This is useful for debugging tests.
    */

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PGTimeTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PGTimeTest.java
@@ -8,6 +8,7 @@ package org.postgresql.test.jdbc2;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 import org.postgresql.test.TestUtil;
 import org.postgresql.util.PGInterval;
@@ -54,6 +55,8 @@ public class PGTimeTest extends BaseTest4 {
    */
   @Test
   public void testTimeWithInterval() throws SQLException {
+    assumeTrue(TestUtil.haveIntegerDateTimes(con));
+
     Calendar cal = Calendar.getInstance();
     cal.set(1970, 0, 1);
 

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PGTimestampTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PGTimestampTest.java
@@ -8,6 +8,7 @@ package org.postgresql.test.jdbc2;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 import org.postgresql.test.TestUtil;
 import org.postgresql.util.PGInterval;
@@ -58,6 +59,7 @@ public class PGTimestampTest {
    */
   @Test
   public void testTimestampWithInterval() throws SQLException {
+    assumeTrue(TestUtil.haveIntegerDateTimes(con));
     PGTimestamp timestamp = new PGTimestamp(System.currentTimeMillis());
     PGInterval interval = new PGInterval(0, 0, 0, 1, 2, 3.14);
     verifyTimestampWithInterval(timestamp, interval, true);

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/TimestampTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/TimestampTest.java
@@ -9,6 +9,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeTrue;
 
 import org.postgresql.PGStatement;
 import org.postgresql.core.BaseConnection;
@@ -174,6 +175,8 @@ public class TimestampTest extends BaseTest4 {
    */
   @Test
   public void testGetTimestampWTZ() throws SQLException {
+    assumeTrue(TestUtil.haveIntegerDateTimes(con));
+
     Statement stmt = con.createStatement();
     TimestampUtils tsu = ((BaseConnection) con).getTimestampUtils();
 
@@ -235,6 +238,8 @@ public class TimestampTest extends BaseTest4 {
    */
   @Test
   public void testSetTimestampWTZ() throws SQLException {
+    assumeTrue(TestUtil.haveIntegerDateTimes(con));
+
     Statement stmt = con.createStatement();
     PreparedStatement pstmt = con.prepareStatement(TestUtil.insertSQL(TSWTZ_TABLE, "?"));
 
@@ -305,6 +310,8 @@ public class TimestampTest extends BaseTest4 {
    */
   @Test
   public void testGetTimestampWOTZ() throws SQLException {
+    assumeTrue(TestUtil.haveIntegerDateTimes(con));
+
     Statement stmt = con.createStatement();
     TimestampUtils tsu = ((BaseConnection) con).getTimestampUtils();
 
@@ -385,6 +392,8 @@ public class TimestampTest extends BaseTest4 {
    */
   @Test
   public void testSetTimestampWOTZ() throws SQLException {
+    assumeTrue(TestUtil.haveIntegerDateTimes(con));
+
     Statement stmt = con.createStatement();
     PreparedStatement pstmt = con.prepareStatement(TestUtil.insertSQL(TSWOTZ_TABLE, "?"));
 

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc42/GetObject310Test.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc42/GetObject310Test.java
@@ -8,6 +8,7 @@ package org.postgresql.test.jdbc42;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 import org.postgresql.test.TestUtil;
 import org.postgresql.test.jdbc2.BaseTest4;
@@ -164,6 +165,8 @@ public class GetObject310Test extends BaseTest4 {
    */
   @Test
   public void testGetLocalDateTime() throws SQLException {
+    assumeTrue(TestUtil.haveIntegerDateTimes(con));
+
     List<String> zoneIdsToTest = new ArrayList<String>();
     zoneIdsToTest.add("Africa/Casablanca"); // It is something like GMT+0..GMT+1
     zoneIdsToTest.add("America/Adak"); // It is something like GMT-10..GMT-9

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc42/SetObject310Test.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc42/SetObject310Test.java
@@ -8,6 +8,7 @@ package org.postgresql.test.jdbc42;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 import org.postgresql.test.TestUtil;
 
@@ -279,6 +280,8 @@ public class SetObject310Test {
    */
   @Test
   public void testSetLocalDateTimeBc() throws SQLException {
+    assumeTrue(TestUtil.haveIntegerDateTimes(con));
+
     // use BC for funsies
     List<LocalDateTime> bcDates = new ArrayList<LocalDateTime>();
     bcDates.add(LocalDateTime.parse("1997-06-30T23:59:59.999999").with(ChronoField.ERA, IsoEra.BCE.getValue()));


### PR DESCRIPTION
Float timestamp equality comparisons like comparisons with any float
are problematic if they don't take into account their imprecise
nature. Some timestamp tests produce false negative failures for
servers compiled with float timestamps. Use JUnit assumptions to skip
these tests if the server doesn't have integer datetimes.

GetObject310Test and SetObject310Test still produce these false
negative failures. Failing assumptions in these tests throw
AssumptionViolationException rather than skipping the tests. This
may be due to these tests extending BaseTest which extends
junit.framework.TestCase rather than being treated as JUnit 4
tests. Leave these failing tests as-is for now as it's the existing
behavior, and throwing these exceptions exposes an issue with the test
setup rather than testing JDBC behavior.

This addresses https://github.com/pgjdbc/pgjdbc/issues/12 in part in
that it omits (most of) the failing tests, though it leaves these
timestamp behaviors untested under float timestamps, which was the
default prior to PostgreSQL 8.4.