### PR TITLE
test: migrate BaseTest to JUnit 4

### DIFF
--- a/pgjdbc/src/test/java/org/postgresql/core/v3/V3ParameterListTests.java
+++ b/pgjdbc/src/test/java/org/postgresql/core/v3/V3ParameterListTests.java
@@ -5,9 +5,12 @@
 
 package org.postgresql.core.v3;
 
+import static org.junit.Assert.assertEquals;
+
 import org.postgresql.test.jdbc2.BaseTest;
 
 import org.junit.Before;
+import org.junit.Test;
 
 import java.sql.SQLException;
 
@@ -26,6 +29,7 @@ public class V3ParameterListTests extends BaseTest {
    * @throws SQLException
    *           raised exception if setting parameter fails.
    */
+  @Test
   public void testMergeOfParameterLists() throws SQLException {
     SimpleParameterList s1SPL = new SimpleParameterList(8, transferModeRegistry);
     s1SPL.setIntParameter(1, 1);
@@ -45,15 +49,11 @@ public class V3ParameterListTests extends BaseTest {
         "<[1 ,2 ,3 ,4 ,5 ,6 ,7 ,8]>", s1SPL.toString());
   }
 
-  public V3ParameterListTests(String test) {
-    super(test);
-  }
-
   private TypeTransferModeRegistry transferModeRegistry;
 
   @Override
   @Before
-  protected void setUp() throws Exception {
+  public void setUp() throws Exception {
     transferModeRegistry =
         new TypeTransferModeRegistry() {
           @Override

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/DeepBatchedInsertStatementTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/DeepBatchedInsertStatementTest.java
@@ -5,6 +5,8 @@
 
 package org.postgresql.jdbc;
 
+import static org.junit.Assert.assertEquals;
+
 import org.postgresql.PGProperty;
 import org.postgresql.core.ParameterList;
 import org.postgresql.core.Query;
@@ -12,6 +14,8 @@ import org.postgresql.core.v3.BatchedQuery;
 import org.postgresql.test.TestUtil;
 import org.postgresql.test.jdbc2.BaseTest;
 import org.postgresql.test.jdbc2.BatchExecuteTest;
+
+import org.junit.Test;
 
 import java.lang.reflect.Method;
 import java.sql.Date;
@@ -26,15 +30,12 @@ import java.util.Properties;
  * on.
  */
 public class DeepBatchedInsertStatementTest extends BaseTest {
-  public DeepBatchedInsertStatementTest(String name) {
-    super(name);
-  }
-
   /*
    * Set up the fixture for this testcase: a connection to a database with a
    * table for this test.
    */
-  protected void setUp() throws Exception {
+  @Override
+  public void setUp() throws Exception {
     super.setUp();
     Statement stmt = con.createStatement();
 
@@ -56,7 +57,8 @@ public class DeepBatchedInsertStatementTest extends BaseTest {
   }
 
   // Tear down the fixture for this test case.
-  protected void tearDown() throws SQLException {
+  @Override
+  public void tearDown() throws SQLException {
     TestUtil.dropTable(con, "testbatch");
     TestUtil.dropTable(con, "testunspecified");
     super.tearDown();
@@ -68,6 +70,7 @@ public class DeepBatchedInsertStatementTest extends BaseTest {
     forceBinary(props);
   }
 
+  @Test
   public void testDeepInternalsBatchedQueryDecorator() throws Exception {
     PgPreparedStatement pstmt = null;
     try {
@@ -200,6 +203,7 @@ public class DeepBatchedInsertStatementTest extends BaseTest {
   /**
    *
    */
+  @Test
   public void testUnspecifiedParameterType() throws Exception {
     PgPreparedStatement pstmt = null;
     try {
@@ -233,6 +237,7 @@ public class DeepBatchedInsertStatementTest extends BaseTest {
    * Test to check the statement can provide the necessary number of prepared
    * type fields. This is after running with a batch size of 1.
    */
+  @Test
   public void testVaryingTypeCounts() throws SQLException {
     PgPreparedStatement pstmt = null;
     try {

--- a/pgjdbc/src/test/java/org/postgresql/test/CursorFetchBinaryTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/CursorFetchBinaryTest.java
@@ -10,10 +10,6 @@ import org.postgresql.test.jdbc2.CursorFetchTest;
 import java.util.Properties;
 
 public class CursorFetchBinaryTest extends CursorFetchTest {
-  public CursorFetchBinaryTest(String name) {
-    super(name);
-  }
-
   @Override
   protected void updateProperties(Properties props) {
     forceBinary(props);

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BaseTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BaseTest.java
@@ -10,20 +10,19 @@ import org.postgresql.PGProperty;
 import org.postgresql.jdbc.PreferQueryMode;
 import org.postgresql.test.TestUtil;
 
-import junit.framework.TestCase;
+import org.junit.After;
 import org.junit.Assume;
+import org.junit.Before;
 
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Properties;
 
-public class BaseTest extends TestCase {
+public class BaseTest {
   protected Connection con;
   protected PreferQueryMode preferQueryMode;
 
-  public BaseTest(String name) {
-    super(name);
-
+  public BaseTest() {
     try {
       new org.postgresql.Driver();
     } catch (Exception ex) {
@@ -38,7 +37,8 @@ public class BaseTest extends TestCase {
     PGProperty.PREPARE_THRESHOLD.set(props, -1);
   }
 
-  protected void setUp() throws Exception {
+  @Before
+  public void setUp() throws Exception {
     Properties props = new Properties();
     updateProperties(props);
     con = TestUtil.openDB(props);
@@ -46,7 +46,8 @@ public class BaseTest extends TestCase {
     preferQueryMode = pg == null ? PreferQueryMode.EXTENDED : pg.getPreferQueryMode();
   }
 
-  protected void tearDown() throws SQLException {
+  @After
+  public void tearDown() throws SQLException {
     TestUtil.closeDB(con);
   }
 

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/CursorFetchTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/CursorFetchTest.java
@@ -5,7 +5,12 @@
 
 package org.postgresql.test.jdbc2;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import org.postgresql.test.TestUtil;
+
+import org.junit.Test;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -16,17 +21,15 @@ import java.sql.Statement;
  * Tests for using non-zero setFetchSize().
  */
 public class CursorFetchTest extends BaseTest {
-  public CursorFetchTest(String name) {
-    super(name);
-  }
-
-  protected void setUp() throws Exception {
+  @Override
+  public void setUp() throws Exception {
     super.setUp();
     TestUtil.createTable(con, "test_fetch", "value integer");
     con.setAutoCommit(false);
   }
 
-  protected void tearDown() throws SQLException {
+  @Override
+  public void tearDown() throws SQLException {
     if (!con.getAutoCommit()) {
       con.rollback();
     }
@@ -45,6 +48,7 @@ public class CursorFetchTest extends BaseTest {
   }
 
   // Test various fetchsizes.
+  @Test
   public void testBasicFetch() throws Exception {
     createRows(100);
 
@@ -69,6 +73,7 @@ public class CursorFetchTest extends BaseTest {
 
 
   // Similar, but for scrollable resultsets.
+  @Test
   public void testScrollableFetch() throws Exception {
     createRows(100);
 
@@ -111,6 +116,7 @@ public class CursorFetchTest extends BaseTest {
     }
   }
 
+  @Test
   public void testScrollableAbsoluteFetch() throws Exception {
     createRows(100);
 
@@ -153,6 +159,7 @@ public class CursorFetchTest extends BaseTest {
   // -run query (all rows should be fetched)
   // -set fetchsize = 50 (should have no effect)
   // -process results
+  @Test
   public void testResultSetFetchSizeOne() throws Exception {
     createRows(100);
 
@@ -178,6 +185,7 @@ public class CursorFetchTest extends BaseTest {
   // --process 25 rows
   // --should do a FETCH ALL to get more data
   // --process 75 rows
+  @Test
   public void testResultSetFetchSizeTwo() throws Exception {
     createRows(100);
 
@@ -205,6 +213,7 @@ public class CursorFetchTest extends BaseTest {
   // --process 50 rows
   // --do a FETCH FORWARD 50
   // --process 25 rows. end of results.
+  @Test
   public void testResultSetFetchSizeThree() throws Exception {
     createRows(100);
 
@@ -232,6 +241,7 @@ public class CursorFetchTest extends BaseTest {
   // --process 25 rows
   // --do a FETCH FORWARD 25
   // --process 25 rows. end of results.
+  @Test
   public void testResultSetFetchSizeFour() throws Exception {
     createRows(100);
 
@@ -249,6 +259,7 @@ public class CursorFetchTest extends BaseTest {
     assertEquals(100, count);
   }
 
+  @Test
   public void testSingleRowResultPositioning() throws Exception {
     String msg;
     createRows(1);
@@ -289,6 +300,7 @@ public class CursorFetchTest extends BaseTest {
     }
   }
 
+  @Test
   public void testMultiRowResultPositioning() throws Exception {
     String msg;
 
@@ -340,6 +352,7 @@ public class CursorFetchTest extends BaseTest {
   }
 
   // Test odd queries that should not be transformed into cursor-based fetches.
+  @Test
   public void testInsert() throws Exception {
     // INSERT should not be transformed.
     PreparedStatement stmt = con.prepareStatement("insert into test_fetch(value) values(1)");
@@ -347,6 +360,7 @@ public class CursorFetchTest extends BaseTest {
     stmt.executeUpdate();
   }
 
+  @Test
   public void testMultistatement() throws Exception {
     // Queries with multiple statements should not be transformed.
 
@@ -370,6 +384,7 @@ public class CursorFetchTest extends BaseTest {
   // if the driver tries to use a cursor with autocommit on
   // it will fail because the cursor will disappear partway
   // through execution
+  @Test
   public void testNoCursorWithAutoCommit() throws Exception {
     createRows(10); // 0 .. 9
     con.setAutoCommit(true);
@@ -384,6 +399,7 @@ public class CursorFetchTest extends BaseTest {
     assertEquals(10, count);
   }
 
+  @Test
   public void testGetRow() throws SQLException {
     Statement stmt = con.createStatement();
     stmt.setFetchSize(1);
@@ -400,6 +416,7 @@ public class CursorFetchTest extends BaseTest {
   // isLast() may change the results of other positioning methods as it has to
   // buffer some more results. This tests avoid using it so as to test robustness
   // other positioning methods
+  @Test
   public void testRowResultPositioningWithoutIsLast() throws Exception {
     String msg;
 
@@ -446,6 +463,7 @@ public class CursorFetchTest extends BaseTest {
 
 
   // Empty resultsets require all row positioning methods to return false
+  @Test
   public void testNoRowResultPositioning() throws Exception {
     String msg;
 
@@ -473,6 +491,7 @@ public class CursorFetchTest extends BaseTest {
   }
 
   // Empty resultsets require all row positioning methods to return false
+  @Test
   public void testScrollableNoRowResultPositioning() throws Exception {
     String msg;
 

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/Jdbc2TestSuite.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/Jdbc2TestSuite.java
@@ -24,6 +24,7 @@ import junit.framework.TestSuite;
 
 import java.sql.Connection;
 
+
 /*
  * Executes all known tests for JDBC2 and includes some utility methods.
  */
@@ -94,7 +95,7 @@ public class Jdbc2TestSuite extends TestSuite {
 
     suite.addTest(new JUnit4TestAdapter(BatchedInsertReWriteEnabledTest.class));
     suite.addTest(new JUnit4TestAdapter(NativeQueryBindLengthTest.class));
-    suite.addTestSuite(DeepBatchedInsertStatementTest.class);
+    suite.addTest(new JUnit4TestAdapter(DeepBatchedInsertStatementTest.class));
 
     // Other misc tests, based on previous problems users have had or specific
     // features some applications require.
@@ -110,8 +111,8 @@ public class Jdbc2TestSuite extends TestSuite {
     suite.addTest(new JUnit4TestAdapter(UpdateableResultTest.class));
 
     suite.addTest(new JUnit4TestAdapter(CallableStmtTest.class));
-    suite.addTestSuite(CursorFetchTest.class);
-    suite.addTestSuite(CursorFetchBinaryTest.class);
+    suite.addTest(new JUnit4TestAdapter(CursorFetchTest.class));
+    suite.addTest(new JUnit4TestAdapter(CursorFetchBinaryTest.class));
     suite.addTest(new JUnit4TestAdapter(ServerCursorTest.class));
 
     suite.addTest(new JUnit4TestAdapter(IntervalTest.class));
@@ -124,7 +125,7 @@ public class Jdbc2TestSuite extends TestSuite {
 
     suite.addTest(new JUnit4TestAdapter(PGPropertyTest.class));
 
-    suite.addTestSuite(V3ParameterListTests.class);
+    suite.addTest(new JUnit4TestAdapter(V3ParameterListTests.class));
 
     Connection conn = TestUtil.openDB();
     if (TestUtil.isProtocolVersion(conn, 3)) {
@@ -137,8 +138,8 @@ public class Jdbc2TestSuite extends TestSuite {
     }
 
     if (TestUtil.haveMinimumServerVersion(conn, ServerVersion.v9_5)) {
-      suite.addTestSuite(UpsertTest.class);
-      suite.addTestSuite(UpsertBinaryTest.class);
+      suite.addTest(new JUnit4TestAdapter(UpsertTest.class));
+      suite.addTest(new JUnit4TestAdapter(UpsertBinaryTest.class));
     }
 
     conn.close();

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/UpsertBinaryTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/UpsertBinaryTest.java
@@ -11,10 +11,6 @@ import java.util.Properties;
  * Tests {@code INSERT .. ON CONFLICT} in binary mode.
  */
 public class UpsertBinaryTest extends UpsertTest {
-  public UpsertBinaryTest(String name) {
-    super(name);
-  }
-
   @Override
   protected void updateProperties(Properties props) {
     forceBinary(props);

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/UpsertTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/UpsertTest.java
@@ -5,7 +5,11 @@
 
 package org.postgresql.test.jdbc2;
 
+import static org.junit.Assert.assertEquals;
+
 import org.postgresql.test.TestUtil;
+
+import org.junit.Test;
 
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
@@ -17,11 +21,8 @@ import java.sql.Statement;
 public class UpsertTest extends BaseTest {
   Statement stmt;
 
-  public UpsertTest(String name) {
-    super(name);
-  }
-
-  protected void setUp() throws Exception {
+  @Override
+  public void setUp() throws Exception {
     super.setUp();
 
     TestUtil.createTempTable(con, "test_statement", "i int primary key, t varchar(5)");
@@ -29,7 +30,8 @@ public class UpsertTest extends BaseTest {
     stmt.executeUpdate("INSERT INTO test_statement(i, t) VALUES (42, '42')");
   }
 
-  protected void tearDown() throws SQLException {
+  @Override
+  public void tearDown() throws SQLException {
     stmt.close();
     TestUtil.dropTable(con, "test_statement");
     super.tearDown();
@@ -42,6 +44,7 @@ public class UpsertTest extends BaseTest {
     return count;
   }
 
+  @Test
   public void testUpsertDoNothingConflict() throws SQLException {
     int count = executeUpdate(
         "INSERT INTO test_statement(i, t) VALUES (42, '42') ON CONFLICT DO NOTHING");
@@ -49,6 +52,7 @@ public class UpsertTest extends BaseTest {
         0, count);
   }
 
+  @Test
   public void testUpsertDoNothingNoConflict() throws SQLException {
     int count = executeUpdate(
         "INSERT INTO test_statement(i, t) VALUES (43, '43') ON CONFLICT DO NOTHING");
@@ -56,6 +60,7 @@ public class UpsertTest extends BaseTest {
         1, count);
   }
 
+  @Test
   public void testUpsertDoUpdateConflict() throws SQLException {
     int count = executeUpdate(
         "INSERT INTO test_statement(i, t) VALUES (42, '42') ON CONFLICT(i) DO UPDATE SET t='43'");
@@ -63,6 +68,7 @@ public class UpsertTest extends BaseTest {
         1, count);
   }
 
+  @Test
   public void testUpsertDoUpdateNoConflict() throws SQLException {
     int count = executeUpdate(
         "INSERT INTO test_statement(i, t) VALUES (43, '43') ON CONFLICT(i) DO UPDATE SET t='43'");

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc42/GetObject310BinaryTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc42/GetObject310BinaryTest.java
@@ -8,14 +8,8 @@ package org.postgresql.test.jdbc42;
 import java.util.Properties;
 
 public class GetObject310BinaryTest extends GetObject310Test {
-
-  public GetObject310BinaryTest(String name) {
-    super(name);
-  }
-
   @Override
   protected void updateProperties(Properties props) {
     forceBinary(props);
   }
-
 }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc42/GetObject310Test.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc42/GetObject310Test.java
@@ -5,10 +5,16 @@
 
 package org.postgresql.test.jdbc42;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import org.postgresql.test.TestUtil;
 import org.postgresql.test.jdbc2.BaseTest;
 import org.postgresql.util.PSQLException;
 import org.postgresql.util.PSQLState;
+
+import org.junit.Test;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -33,11 +39,8 @@ public class GetObject310Test extends BaseTest {
   private static final ZoneOffset GMT05 = ZoneOffset.of("-05:00"); // -0500 always
   private static final ZoneOffset GMT13 = ZoneOffset.of("+13:00"); // +1300 always
 
-  public GetObject310Test(String name) {
-    super(name);
-  }
-
-  protected void setUp() throws Exception {
+  @Override
+  public void setUp() throws Exception {
     super.setUp();
     TestUtil.createTable(con, "table1", "timestamp_without_time_zone_column timestamp without time zone,"
             + "timestamp_with_time_zone_column timestamp with time zone,"
@@ -47,7 +50,8 @@ public class GetObject310Test extends BaseTest {
     );
   }
 
-  protected void tearDown() throws SQLException {
+  @Override
+  public void tearDown() throws SQLException {
     TimeZone.setDefault(saveTZ);
     TestUtil.dropTable(con, "table1");
     super.tearDown();
@@ -56,6 +60,7 @@ public class GetObject310Test extends BaseTest {
   /**
    * Test the behavior getObject for date columns.
    */
+  @Test
   public void testGetLocalDate() throws SQLException {
     Statement stmt = con.createStatement();
     stmt.executeUpdate(TestUtil.insertSQL("table1","date_column","DATE '1999-01-08'"));
@@ -74,6 +79,7 @@ public class GetObject310Test extends BaseTest {
   /**
    * Test the behavior getObject for time columns.
    */
+  @Test
   public void testGetLocalTime() throws SQLException {
     Statement stmt = con.createStatement();
     stmt.executeUpdate(TestUtil.insertSQL("table1","time_without_time_zone_column","TIME '04:05:06.123456'"));
@@ -92,6 +98,7 @@ public class GetObject310Test extends BaseTest {
   /**
    * Test the behavior getObject for time columns with null.
    */
+  @Test
   public void testGetLocalTimeNull() throws SQLException {
     Statement stmt = con.createStatement();
     stmt.executeUpdate(TestUtil.insertSQL("table1","time_without_time_zone_column","NULL"));
@@ -109,6 +116,7 @@ public class GetObject310Test extends BaseTest {
   /**
    * Test the behavior getObject for time columns with null.
    */
+  @Test
   public void testGetLocalTimeInvalidType() throws SQLException {
     Statement stmt = con.createStatement();
     stmt.executeUpdate(TestUtil.insertSQL("table1","time_with_time_zone_column", "TIME '04:05:06.123456-08:00'"));
@@ -136,6 +144,7 @@ public class GetObject310Test extends BaseTest {
   /**
    * Test the behavior getObject for timestamp columns.
    */
+  @Test
   public void testGetLocalDateTime() throws SQLException {
     List<String> zoneIdsToTest = new ArrayList<String>();
     zoneIdsToTest.add("Africa/Casablanca"); // It is something like GMT+0..GMT+1
@@ -196,6 +205,7 @@ public class GetObject310Test extends BaseTest {
   /**
    * Test the behavior getObject for timestamp with time zone columns.
    */
+  @Test
   public void testGetTimestampWithTimeZone() throws SQLException {
     runGetOffsetDateTime(UTC);
     runGetOffsetDateTime(GMT03);

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc42/PreparedStatementTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc42/PreparedStatementTest.java
@@ -8,6 +8,8 @@ package org.postgresql.test.jdbc42;
 import org.postgresql.test.TestUtil;
 import org.postgresql.test.jdbc2.BaseTest;
 
+import org.junit.Test;
+
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Types;
@@ -15,22 +17,21 @@ import java.sql.Types;
 
 public class PreparedStatementTest extends BaseTest {
 
-  public PreparedStatementTest(String name) {
-    super(name);
-  }
-
-  protected void setUp() throws Exception {
+  @Override
+  public void setUp() throws Exception {
     super.setUp();
     TestUtil.createTable(con, "timestamptztable", "tstz timestamptz");
     TestUtil.createTable(con, "timetztable", "ttz timetz");
   }
 
-  protected void tearDown() throws SQLException {
+  @Override
+  public void tearDown() throws SQLException {
     TestUtil.dropTable(con, "timestamptztable");
     TestUtil.dropTable(con, "timetztable");
     super.tearDown();
   }
 
+  @Test
   public void testTimestampTzSetNull() throws SQLException {
     PreparedStatement pstmt = con.prepareStatement("INSERT INTO timestamptztable (tstz) VALUES (?)");
 
@@ -45,6 +46,7 @@ public class PreparedStatementTest extends BaseTest {
     pstmt.close();
   }
 
+  @Test
   public void testTimeTzSetNull() throws SQLException {
     PreparedStatement pstmt = con.prepareStatement("INSERT INTO timetztable (ttz) VALUES (?)");
 


### PR DESCRIPTION
This is motivated by wanting to use JUnit assumptions in GetObject310Test and SetObject310Test, which I'll submit in a separate PR. See https://github.com/pgjdbc/pgjdbc/pull/873 for details.
