### PR TITLE
test: assume minimum server version 8.3 testing autosave with ALTER

### DIFF
--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/AutoRollbackTestSuite.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/AutoRollbackTestSuite.java
@@ -104,6 +104,8 @@ public class AutoRollbackTestSuite extends BaseTest4 {
         failMode != FailMode.DEALLOCATE || TestUtil.haveMinimumServerVersion(con, ServerVersion.v8_3));
     Assume.assumeTrue("DISCARD ALL requires PostgreSQL 8.3+",
         failMode != FailMode.DISCARD || TestUtil.haveMinimumServerVersion(con, ServerVersion.v8_3));
+    Assume.assumeTrue("Plan invalidation on table redefinition requires PostgreSQL 8.3+",
+        failMode != FailMode.ALTER || TestUtil.haveMinimumServerVersion(con, ServerVersion.v8_3));
   }
 
   @Override


### PR DESCRIPTION
Prior to 8.3, PostgreSQL didn't invalidate cached plans following DDL
changes. This is mentioned in the 8.3 release notes as

    Automatically re-plan cached queries when table definitions change
    or statistics are updated

https://www.postgresql.org/docs/8.3/static/release-8-3.html

For details, see PostgreSQL commit b9527e9840 and friends.

https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=b9527e984092e838790b543b014c0c2720ea4f11