### PR TITLE
refactor: remove useless checks in the tests

### DIFF
--- a/pgjdbc/src/test/java/org/postgresql/test/TestUtil.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/TestUtil.java
@@ -664,18 +664,6 @@ public class TestUtil {
     return (jvm.compareTo(version) >= 0);
   }
 
-  @Deprecated
-  public static boolean isProtocolVersion(Connection con, int version) {
-    if (con == null) {
-      throw new NullPointerException("Connection is null");
-    }
-    if (con instanceof PgConnection) {
-      return (version == ((PgConnection) con).getProtocolVersion());
-
-    }
-    return false;
-  }
-
   /**
    * Print a ResultSet to System.out. This is useful for debugging tests.
    */

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/CallableStmtTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/CallableStmtTest.java
@@ -159,13 +159,11 @@ public class CallableStmtTest extends BaseTest4 {
   @Test
   public void testGetShort() throws Throwable {
     assumeCallableStatementsSupported();
-    if (TestUtil.isProtocolVersion(con, 3)) {
-      CallableStatement call = con.prepareCall(func + pkgName + "getShort (?) }");
-      call.setShort(2, (short) 4);
-      call.registerOutParameter(1, Types.SMALLINT);
-      call.execute();
-      assertEquals(42, call.getShort(1));
-    }
+    CallableStatement call = con.prepareCall(func + pkgName + "getShort (?) }");
+    call.setShort(2, (short) 4);
+    call.registerOutParameter(1, Types.SMALLINT);
+    call.execute();
+    assertEquals(42, call.getShort(1));
   }
 
   @Test

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/Jdbc2TestSuite.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/Jdbc2TestSuite.java
@@ -125,10 +125,8 @@ public class Jdbc2TestSuite extends TestSuite {
     suite.addTest(new JUnit4TestAdapter(V3ParameterListTests.class));
 
     Connection conn = TestUtil.openDB();
-    if (TestUtil.isProtocolVersion(conn, 3)) {
-      suite.addTest(new JUnit4TestAdapter(CopyTest.class));
-      suite.addTest(new JUnit4TestAdapter(CopyLargeFileTest.class));
-    }
+    suite.addTest(new JUnit4TestAdapter(CopyTest.class));
+    suite.addTest(new JUnit4TestAdapter(CopyLargeFileTest.class));
 
     if (TestUtil.haveMinimumServerVersion(conn, ServerVersion.v9_3)) {
       suite.addTest(new JUnit4TestAdapter(ServerErrorTest.class));

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/NotifyTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/NotifyTest.java
@@ -52,7 +52,7 @@ public class NotifyTest {
 
   @Test(timeout = 60000)
   public void testNotifyArgument() throws Exception {
-    if (!TestUtil.haveMinimumServerVersion(conn, ServerVersion.v9_0) || TestUtil.isProtocolVersion(conn, 2)) {
+    if (!TestUtil.haveMinimumServerVersion(conn, ServerVersion.v9_0)) {
       return;
     }
 

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PreparedStatementTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PreparedStatementTest.java
@@ -143,15 +143,6 @@ public class PreparedStatementTest extends BaseTest4 {
 
   @Test
   public void testBinaryStreamErrorsRestartable() throws SQLException {
-    // The V2 protocol does not have the ability to recover when
-    // streaming data to the server. We could potentially try
-    // introducing a syntax error to force the query to fail, but
-    // that seems dangerous.
-    //
-    if (!TestUtil.isProtocolVersion(con, 3)) {
-      return;
-    }
-
     byte buf[] = new byte[10];
     for (int i = 0; i < buf.length; i++) {
       buf[i] = (byte) i;
@@ -1169,15 +1160,13 @@ public class PreparedStatementTest extends BaseTest4 {
   public void testUnknownSetObject() throws SQLException {
     PreparedStatement pstmt = con.prepareStatement("INSERT INTO intervaltable(i) VALUES (?)");
 
-    if (TestUtil.isProtocolVersion(con, 3)) {
-      pstmt.setString(1, "1 week");
-      try {
-        pstmt.executeUpdate();
-        assertTrue("When using extended protocol, interval vs character varying type mismatch error is expected",
-            preferQueryMode == PreferQueryMode.SIMPLE);
-      } catch (SQLException sqle) {
-        // ERROR: column "i" is of type interval but expression is of type character varying
-      }
+    pstmt.setString(1, "1 week");
+    try {
+      pstmt.executeUpdate();
+      assertTrue("When using extended protocol, interval vs character varying type mismatch error is expected",
+          preferQueryMode == PreferQueryMode.SIMPLE);
+    } catch (SQLException sqle) {
+      // ERROR: column "i" is of type interval but expression is of type character varying
     }
 
     pstmt.setObject(1, "1 week", Types.OTHER);

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ResultSetMetaDataTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ResultSetMetaDataTest.java
@@ -88,10 +88,8 @@ public class ResultSetMetaDataTest extends BaseTest4 {
 
     assertEquals("a", rsmd.getColumnName(1));
     assertEquals("oid", rsmd.getColumnName(5));
-    if (TestUtil.isProtocolVersion(conn, 3)) {
-      assertEquals("", pgrsmd.getBaseColumnName(4));
-      assertEquals("b", pgrsmd.getBaseColumnName(6));
-    }
+    assertEquals("", pgrsmd.getBaseColumnName(4));
+    assertEquals("b", pgrsmd.getBaseColumnName(6));
 
     assertEquals(Types.INTEGER, rsmd.getColumnType(1));
     assertEquals(Types.VARCHAR, rsmd.getColumnType(2));
@@ -105,25 +103,17 @@ public class ResultSetMetaDataTest extends BaseTest4 {
 
     assertEquals("", rsmd.getSchemaName(1));
     assertEquals("", rsmd.getSchemaName(4));
-    if (TestUtil.isProtocolVersion(conn, 3)) {
-      assertEquals("public", pgrsmd.getBaseSchemaName(1));
-      assertEquals("", pgrsmd.getBaseSchemaName(4));
-    }
+    assertEquals("public", pgrsmd.getBaseSchemaName(1));
+    assertEquals("", pgrsmd.getBaseSchemaName(4));
 
     assertEquals("rsmd1", rsmd.getTableName(1));
     assertEquals("", rsmd.getTableName(4));
-    if (TestUtil.isProtocolVersion(conn, 3)) {
-      assertEquals("rsmd1", pgrsmd.getBaseTableName(1));
-      assertEquals("", pgrsmd.getBaseTableName(4));
-    }
+    assertEquals("rsmd1", pgrsmd.getBaseTableName(1));
+    assertEquals("", pgrsmd.getBaseTableName(4));
 
-    if (TestUtil.isProtocolVersion(conn, 3)) {
-      assertEquals(ResultSetMetaData.columnNoNulls, rsmd.isNullable(1));
-      assertEquals(ResultSetMetaData.columnNullable, rsmd.isNullable(2));
-      assertEquals(ResultSetMetaData.columnNullableUnknown, rsmd.isNullable(4));
-    } else {
-      assertEquals(ResultSetMetaData.columnNullableUnknown, rsmd.isNullable(1));
-    }
+    assertEquals(ResultSetMetaData.columnNoNulls, rsmd.isNullable(1));
+    assertEquals(ResultSetMetaData.columnNullable, rsmd.isNullable(2));
+    assertEquals(ResultSetMetaData.columnNullableUnknown, rsmd.isNullable(4));
   }
 
   // verify that a prepared update statement returns no metadata and doesn't execute.
@@ -205,12 +195,10 @@ public class ResultSetMetaDataTest extends BaseTest4 {
     ResultSetMetaData rsmd = rs.getMetaData();
 
     assertTrue(!rsmd.isAutoIncrement(1));
-    if (TestUtil.isProtocolVersion(conn, 3)) {
-      assertTrue(rsmd.isAutoIncrement(2));
-      assertTrue(rsmd.isAutoIncrement(3));
-      assertEquals("bigserial", rsmd.getColumnTypeName(2));
-      assertEquals("serial", rsmd.getColumnTypeName(3));
-    }
+    assertTrue(rsmd.isAutoIncrement(2));
+    assertTrue(rsmd.isAutoIncrement(3));
+    assertEquals("bigserial", rsmd.getColumnTypeName(2));
+    assertEquals("serial", rsmd.getColumnTypeName(3));
 
     rs.close();
     stmt.close();

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc3/ParameterMetaDataTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc3/ParameterMetaDataTest.java
@@ -41,10 +41,6 @@ public class ParameterMetaDataTest extends BaseTest4 {
 
   @Test
   public void testParameterMD() throws SQLException {
-    if (!TestUtil.isProtocolVersion(con, 3)) {
-      return;
-    }
-
     PreparedStatement pstmt =
         con.prepareStatement("SELECT a FROM parametertest WHERE b = ? AND c = ? AND d >^ ? ");
     ParameterMetaData pmd = pstmt.getParameterMetaData();
@@ -65,10 +61,6 @@ public class ParameterMetaDataTest extends BaseTest4 {
 
   @Test
   public void testFailsOnBadIndex() throws SQLException {
-    if (!TestUtil.isProtocolVersion(con, 3)) {
-      return;
-    }
-
     PreparedStatement pstmt =
         con.prepareStatement("SELECT a FROM parametertest WHERE b = ? AND c = ?");
     ParameterMetaData pmd = pstmt.getParameterMetaData();
@@ -87,10 +79,6 @@ public class ParameterMetaDataTest extends BaseTest4 {
   // Make sure we work when mashing two queries into a single statement.
   @Test
   public void testMultiStatement() throws SQLException {
-    if (!TestUtil.isProtocolVersion(con, 3)) {
-      return;
-    }
-
     PreparedStatement pstmt = con.prepareStatement(
         "SELECT a FROM parametertest WHERE b = ? AND c = ? ; SELECT b FROM parametertest WHERE a = ?");
     ParameterMetaData pmd = pstmt.getParameterMetaData();
@@ -113,10 +101,6 @@ public class ParameterMetaDataTest extends BaseTest4 {
   //
   @Test
   public void testTypeChangeWithUnknown() throws SQLException {
-    if (!TestUtil.isProtocolVersion(con, 3)) {
-      return;
-    }
-
     PreparedStatement pstmt =
         con.prepareStatement("SELECT a FROM parametertest WHERE c = ? AND e = ?");
     ParameterMetaData pmd = pstmt.getParameterMetaData();


### PR DESCRIPTION
remove useless checks for protocol version in the tests.
Driver is compatible with PostgreSQL 8.2 and higher using the version 3.0 of the protocol.