### PR TITLE
chore: install PostgreSQL 9.1 to Trusty builds via apt, and use Precise for Java 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -156,6 +156,7 @@ matrix:
         - PG_VERSION=9.4
         - MCENTRAL=Y
     - jdk: openjdk6
+      dist: precise # Trusty does not have Java 6, and installers no longer work
       addons:
         postgresql: "9.4"
       env:
@@ -195,12 +196,14 @@ matrix:
         - PG_VERSION=9.3
         - COVERAGE=Y
     - jdk: openjdk6
+      dist: precise # Trusty does not have Java 6, and installers no longer work
       addons:
         postgresql: "9.2"
       env:
         - PG_VERSION=9.2
         - COVERAGE=Y
     - jdk: oraclejdk8
+      sudo: required # to install PostgreSQL 9.1
       addons:
         postgresql: "9.1"
       env:

--- a/.travis/travis_install_postgres.sh
+++ b/.travis/travis_install_postgres.sh
@@ -10,7 +10,6 @@ then
     ./.travis/travis_install_head_postgres.sh
 elif [ ! -d "${PG_DATADIR}" ]
 then
-    sudo cp /etc/postgresql/9.1/main/pg_hba.conf ./
     sudo apt-get remove postgresql libpq-dev libpq5 postgresql-client-common postgresql-common -qq --purge
     source /etc/lsb-release
     echo "deb http://apt.postgresql.org/pub/repos/apt/ $DISTRIB_CODENAME-pgdg main ${PG_VERSION}" > pgdg.list
@@ -19,7 +18,10 @@ then
     sudo apt-get update
     sudo apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confnew" install postgresql-${PG_VERSION} postgresql-contrib-${PG_VERSION} -qq
 
-    sudo cp ./pg_hba.conf /etc/postgresql/${PG_VERSION}/main
+    sudo sh -c "echo 'local all postgres trust' > /etc/postgresql/${PG_VERSION}/main/pg_hba.conf"
+    sudo sh -c "echo 'local all all trust' >> /etc/postgresql/${PG_VERSION}/main/pg_hba.conf"
+    sudo sh -c "echo -n 'host all all 127.0.0.1/32 trust' >> /etc/postgresql/${PG_VERSION}/main/pg_hba.conf"
+
     if [ ${PG_VERSION} = '8.4' ]
     then
       sudo sed -i -e 's/port = 5433/port = 5432/g' /etc/postgresql/8.4/main/postgresql.conf


### PR DESCRIPTION
Travis deprecates Precise. See https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming

sudo: required for dist: precise will still be supported for a while, however no updates to that image is planned

Java 6 is not included into Trusty image, and installers no longer work (see http://www.webupd8.org/2017/06/why-oracle-java-7-and-6-installers-no.html) since Oracle removed the installer files from public access.
