### PR TITLE
test: make StringTypeParameterTest 8.3+ since 8.2 misses enum types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,13 +54,6 @@ cache:
 
 matrix:
   fast_finish: true
-  allow_failures:
-    - env: # this has to match the environment for 8.2 below
-        - PG_VERSION=8.2
-        - XA=true
-        - COVERAGE=Y
-        - NO_HSTORE=Y
-        - CREATE_PLPGSQL=Y
   include:
     - jdk: oraclejdk8
       env: RUN_CHECKSTYLE=true

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc3/StringTypeParameterTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc3/StringTypeParameterTest.java
@@ -9,6 +9,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import org.postgresql.core.ServerVersion;
 import org.postgresql.jdbc.PreferQueryMode;
 import org.postgresql.test.TestUtil;
 import org.postgresql.test.jdbc2.BaseTest4;
@@ -40,6 +41,8 @@ public class StringTypeParameterTest extends BaseTest4 {
   @Override
   public void setUp() throws Exception {
     super.setUp();
+    // Assume enum supported
+    Assume.assumeTrue(TestUtil.haveMinimumServerVersion(con, ServerVersion.v8_3));
     TestUtil.createEnumType(con, "mood", "'happy', 'sad'");
     TestUtil.createTable(con, "stringtypetest", "m mood");
   }


### PR DESCRIPTION
PostgreSQL 8.2 tests at Travis should be green now, so removing allow_failures configuration