### PR TITLE
test: skip ConcurrentStatementFetch for PostgreSQL < 8.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ There are also available (snapshot) binary RPMs in [Fedora's Copr repository](ht
 ## Changelog
 Notable changes for:
 
+**NEXT**:
+* Statements with non-zero fetchSize no longer require server-side named handle. This might cause issues when using old PostgreSQL versions (pre-8.4)+fetchSize+interleaved ResultSet processing combo. see [issue 869](https://github.com/pgjdbc/pgjdbc/issues/869)
+
 **[42.1.3]** (2017-07-14):
 * fixed NPE in PreparedStatement.executeBatch in case of empty batch (regression since 42.1.2) PR#867
 

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ConcurrentStatementFetch.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ConcurrentStatementFetch.java
@@ -5,9 +5,11 @@
 
 package org.postgresql.test.jdbc2;
 
+import org.postgresql.core.ServerVersion;
 import org.postgresql.test.TestUtil;
 
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -50,6 +52,9 @@ public class ConcurrentStatementFetch extends BaseTest4 {
 
   @Test
   public void testFetchTwoStatements() throws Exception {
+    // This test definitely fails at 8.2 in autocommit=false, and works with 8.4+
+    Assume.assumeTrue(autoCommit == AutoCommit.YES
+        || TestUtil.haveMinimumServerVersion(con, ServerVersion.v8_4));
     PreparedStatement ps1 = null;
     PreparedStatement ps2 = null;
     try {


### PR DESCRIPTION
PostgreSQL 8.2 is known to close named portals unexpectedly, so we just ignore the test.
The following scenario might be affected: old backend version + setFetchSize + interleaved ResultSet processing

This is a follow-up for #870 and #869 for PostgreSQL < 8.4
