### PR TITLE
style: remove deprecated maxLineLength from LeftCurlyCheck

### DIFF
--- a/pgjdbc/src/main/checkstyle/checks.xml
+++ b/pgjdbc/src/main/checkstyle/checks.xml
@@ -71,9 +71,7 @@
                 value="LITERAL_TRY, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_SWITCH"/>
     </module>
     <module name="NeedBraces"/>
-    <module name="LeftCurly">
-      <property name="maxLineLength" value="100"/>
-    </module>
+    <module name="LeftCurly"/>
     <module name="RightCurly">
       <property name="tokens" value="LITERAL_TRY, LITERAL_CATCH, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_DO"/>
     </module>


### PR DESCRIPTION
This PR is being created because of a backward breaking change being made in CheckStyle.
PR: https://github.com/checkstyle/checkstyle/pull/4893
Issue: https://github.com/checkstyle/checkstyle/issues/3671

We are breaking multiple APIs in Checkstyle 8 to clean up deprecated methods and such. This removed the deprecated property `maxLineLength` in `LeftCurly` as it wasn't doing anything and it's functionality was removed some time ago.

You can either accept this PR and not have an issue when you upgrade CS with this fix in the future,
or make your own change/fix later when you do upgrade CS.
Please let us know which way you intend to go.

Feel free to ask any questions.
Thanks.