### PR TITLE
fix:the login timeout in DriverManager never be used.

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/Driver.java
+++ b/pgjdbc/src/main/java/org/postgresql/Driver.java
@@ -630,7 +630,7 @@ public class Driver implements java.sql.Driver {
    * @return the timeout from the URL, in milliseconds
    */
   private static long timeout(Properties props) {
-    String timeout = PGProperty.LOGIN_TIMEOUT.get(props);
+    String timeout = props.getProperty(PGProperty.LOGIN_TIMEOUT.getName(), null);
     if (timeout != null) {
       try {
         return (long) (Float.parseFloat(timeout) * 1000);


### PR DESCRIPTION
Why is it needed?
In actual use cases, the login will use 0s as the value for login timeout by default if we don't set the value in the connect properties.
That is, it will never use the value set in the java.sql.DriverManager.
But in fact, we will usually set the value in java.sql.DriverManager instead of the connect properties.
How to fix?
Actually, it is very easy. Why the bug appears is the PGProperty.LOGIN_TIMEOUT provides a default value 0, and the old code will always use the default 0 instead of the value in java.sql.DriverManager. We can just prevent it from getting the default value of LOGIN_TIMEOUT.
How about the result?
As result, we will prefer to use the value in connect properties if it is set rather than the value in DriverManager. And we will use the value in DriverManager if connect properties doesn't contain the value.
This can cover the case that we want to set the value in connect properties without the effect of the value in DriverManager because the latter is static, this will be problem sometimes if the user uses multi jdbc at the same time.