### PR TITLE
fix: sort result set by sql type value in metadata typeinfo

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
@@ -2237,7 +2237,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
         try {
           int i1 = Integer.parseInt(connection.getEncoding().decode(o1[1]));
           int i2 = Integer.parseInt(connection.getEncoding().decode(o2[1]));
-          return Integer.compare(i1, i2);
+          return (i1 < i2) ? -1 : ((i1 == i2) ? 0 : 1);
         } catch (IOException e) {
           return -1; // Should not happen, but if we do, we should avoid breaking the operation.
         }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc4/DatabaseMetaDataTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc4/DatabaseMetaDataTest.java
@@ -87,7 +87,7 @@ public class DatabaseMetaDataTest {
     DatabaseMetaData dbmd = _conn.getMetaData();
     ResultSet rs = dbmd.getTypeInfo();
     int lastType = Integer.MIN_VALUE;
-    while(rs.next()) {
+    while (rs.next()) {
       int type = rs.getInt("DATA_TYPE");
       assertTrue(lastType <= type);
       lastType = type;

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc4/DatabaseMetaDataTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc4/DatabaseMetaDataTest.java
@@ -80,4 +80,18 @@ public class DatabaseMetaDataTest {
     assertNull(rs.getString("TABLE_CATALOG"));
     assertTrue(!rs.next());
   }
+
+  @Test
+  public void testSortedDataTypes() throws SQLException {
+    // https://github.com/pgjdbc/pgjdbc/issues/716
+    DatabaseMetaData dbmd = _conn.getMetaData();
+    ResultSet rs = dbmd.getTypeInfo();
+    int lastType = Integer.MIN_VALUE;
+    while(rs.next()) {
+      int type = rs.getInt("DATA_TYPE");
+      assertTrue(lastType <= type);
+      lastType = type;
+    }
+    rs.close();
+  }
 }


### PR DESCRIPTION
fixes #716 

I don't see a good way to sort the type from backend query, so I provide a solution that sort the result after the query. Let me know if this is good for you or not.