### PR TITLE
refactor: use TypeInfo getPGArrayType instead of munging type name

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
@@ -1096,10 +1096,8 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
     // literal from Array.toString(), such as the implementation we return
     // from ResultSet.getArray(). Eventually we need a proper implementation
     // here that works for any Array implementation.
-
-    // Add special suffix for array identification
-    String typename = x.getBaseTypeName() + "[]";
-    int oid = connection.getTypeInfo().getPGType(typename);
+    String typename = x.getBaseTypeName();
+    int oid = connection.getTypeInfo().getPGArrayType(typename);
     if (oid == Oid.UNSPECIFIED) {
       throw new PSQLException(GT.tr("Unknown type {0}.", typename),
           PSQLState.INVALID_PARAMETER_TYPE);

--- a/ubenchmark/src/main/java/org/postgresql/benchmark/statement/BindArray.java
+++ b/ubenchmark/src/main/java/org/postgresql/benchmark/statement/BindArray.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2017, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.benchmark.statement;
+
+import org.postgresql.benchmark.profilers.FlightRecorderProfiler;
+import org.postgresql.util.ConnectionUtil;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.sql.Array;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Types;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+@Fork(value = 1, jvmArgsPrepend = "-Xmx128m")
+@Measurement(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class BindArray {
+  private Connection connection;
+  private PreparedStatement ps;
+
+  @Setup(Level.Trial)
+  public void setUp() throws SQLException {
+    Properties props = ConnectionUtil.getProperties();
+
+    connection = DriverManager.getConnection(ConnectionUtil.getURL(), props);
+    ps = connection.prepareStatement("SELECT ?");
+  }
+
+  @TearDown(Level.Trial)
+  public void tearDown() throws SQLException {
+    ps.close();
+    connection.close();
+  }
+
+  @Benchmark
+  public Statement setObject() throws SQLException {
+    Integer[] ints = {1, 2, 3};
+    Array sqlInts = connection.createArrayOf("int", ints);
+    ps.setObject(1, sqlInts, Types.ARRAY);
+    return ps;
+  }
+
+  @Benchmark
+  public Statement setArray() throws SQLException {
+    Integer[] ints = {1, 2, 3};
+    Array sqlInts = connection.createArrayOf("int", ints);
+    ps.setArray(1, sqlInts);
+    return ps;
+  }
+
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder()
+        .include(BindArray.class.getSimpleName())
+        .addProfiler(GCProfiler.class)
+        .addProfiler(FlightRecorderProfiler.class)
+        .detectJvmArgs()
+        .build();
+
+    new Runner(opt).run();
+  }
+}

--- a/ubenchmark/src/main/java/org/postgresql/benchmark/statement/BindArray.java
+++ b/ubenchmark/src/main/java/org/postgresql/benchmark/statement/BindArray.java
@@ -15,6 +15,7 @@ import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
@@ -46,12 +47,21 @@ public class BindArray {
   private Connection connection;
   private PreparedStatement ps;
 
+  Integer[] ints;
+
+  @Param({"1", "5", "10", "50", "100", "1000"})
+  int arraySize;
+
   @Setup(Level.Trial)
   public void setUp() throws SQLException {
     Properties props = ConnectionUtil.getProperties();
 
     connection = DriverManager.getConnection(ConnectionUtil.getURL(), props);
     ps = connection.prepareStatement("SELECT ?");
+    ints = new Integer[arraySize];
+    for (int i = 0; i < arraySize; i++) {
+      ints[i] = i + 1;
+    }
   }
 
   @TearDown(Level.Trial)
@@ -62,7 +72,6 @@ public class BindArray {
 
   @Benchmark
   public Statement setObject() throws SQLException {
-    Integer[] ints = {1, 2, 3};
     Array sqlInts = connection.createArrayOf("int", ints);
     ps.setObject(1, sqlInts, Types.ARRAY);
     return ps;
@@ -70,7 +79,6 @@ public class BindArray {
 
   @Benchmark
   public Statement setArray() throws SQLException {
-    Integer[] ints = {1, 2, 3};
     Array sqlInts = connection.createArrayOf("int", ints);
     ps.setArray(1, sqlInts);
     return ps;


### PR DESCRIPTION
The purpose of the getPGArrayType method is to get the array type for
a given element type. Let the TypeInfo implementation figure out how
to do that rather than appending "[]" to the element type name in
PgPreparedStatement setArray.