### PR TITLE
TypeInfoCache refactor

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
@@ -260,6 +260,14 @@ public class TypeInfoCache implements TypeInfo {
     return type;
   }
 
+  private static String onPathName(String typname) {
+    return typname;
+  }
+
+  private static String qualifiedName(String nspname, String typname) {
+    return "\"" + nspname + "\".\"" + typname + "\"";
+  }
+
   private PreparedStatement getOidStatement(String pgTypeName) throws SQLException {
     boolean isArray = pgTypeName.endsWith("[]");
     boolean hasQuote = pgTypeName.contains("\"");
@@ -435,11 +443,11 @@ public class TypeInfoCache implements TypeInfo {
       String schema = rs.getString(2);
       String name = rs.getString(3);
       if (onPath) {
-        pgTypeName = name;
+        pgTypeName = onPathName(name);
         _pgNameToOid.put(schema + "." + name, oid);
       } else {
         // TODO: escaping !?
-        pgTypeName = "\"" + schema + "\".\"" + name + "\"";
+        pgTypeName = qualifiedName(schema, name);
         // if all is lowercase add special type info
         // TODO: should probably check for all special chars
         if (schema.equals(schema.toLowerCase()) && schema.indexOf('.') == -1

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
@@ -776,8 +776,10 @@ public class TypeInfoCache implements TypeInfo {
 
     if (_getArrayDelimiterStatement == null) {
       String sql;
-      sql = "SELECT e.typdelim FROM pg_catalog.pg_type t, pg_catalog.pg_type e "
-          + "WHERE t.oid = ? and t.typelem = e.oid";
+      sql = "SELECT e.typdelim"
+          + " FROM pg_catalog.pg_type t"
+          + " JOIN pg_catalog.pg_type e ON (t.typelem, t.typinput) = (e.oid, 'array_in'::regproc)"
+          + " WHERE t.oid = ?";
       _getArrayDelimiterStatement = _conn.prepareStatement(sql);
     }
 

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
@@ -260,8 +260,17 @@ public class TypeInfoCache implements TypeInfo {
     return type;
   }
 
+  private static String quote(String ident) {
+    boolean hasDot = ident.indexOf('.') != -1;
+    boolean isQuoted = ident.startsWith("\"") && ident.endsWith("\"");
+    boolean isCaseSensitive = !ident.equals(ident.toLowerCase());
+    String arraySuffix = "[]";
+    boolean hasArraySuffix = ident.endsWith(arraySuffix);
+    return (hasDot || isQuoted || isCaseSensitive || hasArraySuffix) ? '"' + ident + '"' : ident;
+  }
+
   private static String onPathName(String typname) {
-    return typname;
+    return quote(typname);
   }
 
   private static String qualifiedName(String nspname, String typname) {

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
@@ -113,6 +113,8 @@ public class TypeInfoCache implements TypeInfo {
   }
 
   private static final String ARRAY_SUFFIX = "[]";
+  private static final String JAVA_SQL_ARRAY = "java.sql.Array";
+  private static final char DEFAULT_DELIMITER = ',';
 
   public TypeInfoCache(BaseConnection conn, int unknownLength) {
     _conn = conn;
@@ -157,24 +159,22 @@ public class TypeInfoCache implements TypeInfo {
     // to a comma. In a stock install the only exception is
     // the box datatype and it's not a JDBC core type.
     //
-    Character delim = ',';
-    _arrayOidToDelimiter.put(arrayOid, delim);
+    _arrayOidToDelimiter.put(arrayOid, DEFAULT_DELIMITER);
 
     String pgArrayTypeName = pgTypeName + ARRAY_SUFFIX;
-    _pgNameToJavaClass.put(pgArrayTypeName, "java.sql.Array");
-    _oidToJavaClass.put(arrayOid, "java.sql.Array");
+    _pgNameToJavaClass.put(pgArrayTypeName, JAVA_SQL_ARRAY);
+    _oidToJavaClass.put(arrayOid, JAVA_SQL_ARRAY);
     _pgNameToSQLType.put(pgArrayTypeName, Types.ARRAY);
     _oidToSQLType.put(arrayOid, Types.ARRAY);
     _pgNameToOid.put(pgArrayTypeName, arrayOid);
     pgArrayTypeName = "_" + pgTypeName;
     if (!_pgNameToJavaClass.containsKey(pgArrayTypeName)) {
-      _pgNameToJavaClass.put(pgArrayTypeName, "java.sql.Array");
+      _pgNameToJavaClass.put(pgArrayTypeName, JAVA_SQL_ARRAY);
       _pgNameToSQLType.put(pgArrayTypeName, Types.ARRAY);
       _pgNameToOid.put(pgArrayTypeName, arrayOid);
       _oidToPgName.put(arrayOid, pgArrayTypeName);
     }
   }
-
 
   public synchronized void addDataType(String type, Class<? extends PGobject> klass)
       throws SQLException {
@@ -339,11 +339,11 @@ public class TypeInfoCache implements TypeInfo {
     }
 
     if (pgType.isElement) {
-      _oidToJavaClass.put(arrayOid, "java.sql.Array");
+      _oidToJavaClass.put(arrayOid, JAVA_SQL_ARRAY);
     } else {
-      _oidToJavaClass.put(oid, "java.sql.Array");
+      _oidToJavaClass.put(oid, JAVA_SQL_ARRAY);
       if (!_pgNameToJavaClass.containsKey(cachedName)) {
-        _pgNameToJavaClass.put(cachedName, "java.sql.Array");
+        _pgNameToJavaClass.put(cachedName, JAVA_SQL_ARRAY);
       }
     }
 
@@ -357,7 +357,7 @@ public class TypeInfoCache implements TypeInfo {
       }
 
       if (!pgType.isElement() && !_pgNameToJavaClass.containsKey(cachedName)) {
-        _pgNameToJavaClass.put(cachedName, "java.sql.Array");
+        _pgNameToJavaClass.put(cachedName, JAVA_SQL_ARRAY);
       }
     }
 
@@ -376,7 +376,7 @@ public class TypeInfoCache implements TypeInfo {
     _pgNameToOid.put(nameString, pgType.oid());
     _pgNameToSQLType.put(nameString, pgType.sqlType());
     if (!pgType.isElement()) {
-      _pgNameToJavaClass.put(nameString, "java.sql.Array");
+      _pgNameToJavaClass.put(nameString, JAVA_SQL_ARRAY);
     }
   }
 
@@ -787,7 +787,7 @@ public class TypeInfoCache implements TypeInfo {
 
   public synchronized char getArrayDelimiter(int oid) throws SQLException {
     if (oid == Oid.UNSPECIFIED) {
-      return ',';
+      return DEFAULT_DELIMITER;
     }
 
     Character delim = _arrayOidToDelimiter.get(oid);
@@ -856,7 +856,7 @@ public class TypeInfoCache implements TypeInfo {
     }
 
     if (getSQLType(pgTypeName) == Types.ARRAY) {
-      javaClass = "java.sql.Array";
+      javaClass = JAVA_SQL_ARRAY;
       _pgNameToJavaClass.put(pgTypeName, javaClass);
       _oidToJavaClass.put(oid, javaClass);
     }

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
@@ -335,9 +335,15 @@ public class TypeInfoCache implements TypeInfo {
     } else {
       if (fullName.startsWith("\"")) {
         if (fullName.endsWith("\"")) {
-          String[] parts = fullName.split("\"\\.\"");
-          schema = parts.length == 2 ? parts[0] + "\"" : null;
-          name = parts.length == 2 ? "\"" + parts[1] : parts[0];
+          if (fullName.length() == 3) {
+            // type name string is dot-quote-dot (".")
+            schema = null;
+            name = fullName;
+          } else {
+            String[] parts = fullName.split("\"\\.\"");
+            schema = parts.length == 2 ? parts[0] + "\"" : null;
+            name = parts.length == 2 ? "\"" + parts[1] : parts[0];
+          }
         } else {
           int lastDotIndex = fullName.lastIndexOf('.');
           name = fullName.substring(lastDotIndex + 1);
@@ -349,12 +355,14 @@ public class TypeInfoCache implements TypeInfo {
       }
     }
     if (schema != null && schema.startsWith("\"") && schema.endsWith("\"")) {
-      schema = schema.substring(1, schema.length() - 1);
+      int schemaLength = schema.length();
+      schema = (schemaLength == 1) ? schema : schema.substring(1, schema.length() - 1);
     } else if (schema != null) {
       schema = schema.toLowerCase();
     }
     if (name.startsWith("\"") && name.endsWith("\"")) {
-      name = name.substring(1, name.length() - 1);
+      int nameLength = name.length();
+      name = (nameLength == 1) ? name : name.substring(1, name.length() - 1);
     } else {
       name = name.toLowerCase();
     }

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
@@ -202,18 +202,18 @@ public class TypeInfoCache implements TypeInfo {
       // (keeping old behaviour of finding types, that should not be found without correct search
       // path)
       sql = "SELECT typinput='array_in'::regproc, typtype "
-            + "  FROM pg_catalog.pg_type "
-            + "  LEFT "
-            + "  JOIN (select ns.oid as nspoid, ns.nspname, r.r "
-            + "          from pg_namespace as ns "
-            // -- go with older way of unnesting array to be compatible with 8.0
-            + "          join ( select s.r, (current_schemas(false))[s.r] as nspname "
-            + "                   from generate_series(1, array_upper(current_schemas(false), 1)) as s(r) ) as r "
-            + "         using ( nspname ) "
-            + "       ) as sp "
-            + "    ON sp.nspoid = typnamespace "
-            + " WHERE typname = ? "
-            + " ORDER BY sp.r, pg_type.oid DESC LIMIT 1;";
+          + "  FROM pg_catalog.pg_type "
+          + "  LEFT "
+          + "  JOIN (select ns.oid as nspoid, ns.nspname, r.r "
+          + "          from pg_namespace as ns "
+          // -- go with older way of unnesting array to be compatible with 8.0
+          + "          join ( select s.r, (current_schemas(false))[s.r] as nspname "
+          + "                   from generate_series(1, array_upper(current_schemas(false), 1)) as s(r) ) as r "
+          + "         using ( nspname ) "
+          + "       ) as sp "
+          + "    ON sp.nspoid = typnamespace "
+          + " WHERE typname = ? "
+          + " ORDER BY sp.r, pg_type.oid DESC LIMIT 1;";
 
       _getTypeInfoStatement = _conn.prepareStatement(sql);
     }
@@ -263,17 +263,17 @@ public class TypeInfoCache implements TypeInfo {
         // see comments in @getSQLType()
         // -- go with older way of unnesting array to be compatible with 8.0
         sql = "SELECT pg_type.oid, typname "
-              + "  FROM pg_catalog.pg_type "
-              + "  LEFT "
-              + "  JOIN (select ns.oid as nspoid, ns.nspname, r.r "
-              + "          from pg_namespace as ns "
-              + "          join ( select s.r, (current_schemas(false))[s.r] as nspname "
-              + "                   from generate_series(1, array_upper(current_schemas(false), 1)) as s(r) ) as r "
-              + "         using ( nspname ) "
-              + "       ) as sp "
-              + "    ON sp.nspoid = typnamespace "
-              + " WHERE typname = ? "
-              + " ORDER BY sp.r, pg_type.oid DESC LIMIT 1;";
+            + "  FROM pg_catalog.pg_type "
+            + "  LEFT "
+            + "  JOIN (select ns.oid as nspoid, ns.nspname, r.r "
+            + "          from pg_namespace as ns "
+            + "          join ( select s.r, (current_schemas(false))[s.r] as nspname "
+            + "                   from generate_series(1, array_upper(current_schemas(false), 1)) as s(r) ) as r "
+            + "         using ( nspname ) "
+            + "       ) as sp "
+            + "    ON sp.nspoid = typnamespace "
+            + " WHERE typname = ? "
+            + " ORDER BY sp.r, pg_type.oid DESC LIMIT 1;";
         _getOidStatementSimple = _conn.prepareStatement(sql);
       }
       // coerce to lower case to handle upper case type names
@@ -396,8 +396,8 @@ public class TypeInfoCache implements TypeInfo {
     if (_getNameStatement == null) {
       String sql;
       sql = "SELECT n.nspname = ANY(current_schemas(true)), n.nspname, t.typname "
-            + "FROM pg_catalog.pg_type t "
-            + "JOIN pg_catalog.pg_namespace n ON t.typnamespace = n.oid WHERE t.oid = ?";
+          + "FROM pg_catalog.pg_type t "
+          + "JOIN pg_catalog.pg_namespace n ON t.typnamespace = n.oid WHERE t.oid = ?";
 
       _getNameStatement = _conn.prepareStatement(sql);
     }
@@ -470,7 +470,7 @@ public class TypeInfoCache implements TypeInfo {
     if (_getArrayDelimiterStatement == null) {
       String sql;
       sql = "SELECT e.typdelim FROM pg_catalog.pg_type t, pg_catalog.pg_type e "
-            + "WHERE t.oid = ? and t.typelem = e.oid";
+          + "WHERE t.oid = ? and t.typelem = e.oid";
       _getArrayDelimiterStatement = _conn.prepareStatement(sql);
     }
 
@@ -511,8 +511,8 @@ public class TypeInfoCache implements TypeInfo {
     if (_getArrayElementOidStatement == null) {
       String sql;
       sql = "SELECT e.oid, n.nspname = ANY(current_schemas(true)), n.nspname, e.typname "
-            + "FROM pg_catalog.pg_type t JOIN pg_catalog.pg_type e ON t.typelem = e.oid "
-            + "JOIN pg_catalog.pg_namespace n ON t.typnamespace = n.oid WHERE t.oid = ?";
+          + "FROM pg_catalog.pg_type t JOIN pg_catalog.pg_type e ON t.typelem = e.oid "
+          + "JOIN pg_catalog.pg_namespace n ON t.typnamespace = n.oid WHERE t.oid = ?";
       _getArrayElementOidStatement = _conn.prepareStatement(sql);
     }
 
@@ -842,8 +842,8 @@ public class TypeInfoCache implements TypeInfo {
   }
 
   /**
-   * Returns true if particular sqlType requires quoting.
-   * This method is used internally by the driver, so it might disappear without notice.
+   * Returns true if particular sqlType requires quoting. This method is used internally by the
+   * driver, so it might disappear without notice.
    *
    * @param sqlType sql type as in java.sql.Types
    * @return true if the type requires quoting

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
@@ -306,9 +306,9 @@ public class TypeInfoCache implements TypeInfo {
           sql = "SELECT t.oid, t.typname "
               + "  FROM pg_catalog.pg_type t"
               + "  JOIN pg_catalog.pg_namespace n ON t.typnamespace = n.oid"
-              + " WHERE t.typelem = (SELECT oid FROM pg_catalog.pg_type WHERE typname = ?)"
-              + " AND substring(t.typname, 1, 1) = '_' AND t.typlen = -1"
-              + " AND (n.nspname = ? OR ? IS NULL AND n.nspname = ANY (current_schemas(true)))"
+              + "  JOIN pg_catalog.pg_type e"
+              + "    ON (e.oid, 'array_in'::regproc) = (t.typelem, t.typinput)"
+              + " WHERE e.typname = ? AND (n.nspname = ? OR ? IS NULL AND n.nspname = ANY (current_schemas(true)))"
               + " ORDER BY t.typelem DESC LIMIT 1";
         }
         _getOidStatementComplexArray = _conn.prepareStatement(sql);

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
@@ -408,6 +408,7 @@ public class TypeInfoCache implements TypeInfo {
     }
 
     oid = Oid.UNSPECIFIED;
+    String cachedName = pgTypeName;
     ResultSet rs = oidStatement.getResultSet();
     if (rs.next()) {
       oid = (int) rs.getLong(1);
@@ -415,14 +416,14 @@ public class TypeInfoCache implements TypeInfo {
       String schema = rs.getString(3);
       String name = rs.getString(4);
       if (onPath) {
-        pgTypeName = onPathName(name);
+        cachedName = onPathName(name);
         _pgNameToOid.put(schema + "." + name, oid);
       } else {
-        pgTypeName = qualifiedName(schema, name);
+        cachedName = qualifiedName(schema, name);
       }
     }
-    _pgNameToOid.put(pgTypeName, oid);
-    _oidToPgName.put(oid, pgTypeName);
+    _pgNameToOid.put(cachedName, oid);
+    _oidToPgName.put(oid, cachedName);
     rs.close();
 
     return oid;
@@ -485,8 +486,8 @@ public class TypeInfoCache implements TypeInfo {
       return Oid.UNSPECIFIED;
     }
 
-    elementTypeName = getTypeForAlias(elementTypeName);
-    return getPGType(elementTypeName + "[]");
+    String canonicalTypeName = getTypeForAlias(elementTypeName);
+    return getPGType(canonicalTypeName + "[]");
   }
 
   /**

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
@@ -850,18 +850,18 @@ public class TypeInfoCache implements TypeInfo {
 
     String pgTypeName = getPGType(oid);
 
-    String result = _pgNameToJavaClass.get(pgTypeName);
-    if (result != null) {
-      return result;
+    javaClass = _pgNameToJavaClass.get(pgTypeName);
+    if (javaClass != null) {
+      return javaClass;
     }
 
     if (getSQLType(pgTypeName) == Types.ARRAY) {
-      result = "java.sql.Array";
-      _pgNameToJavaClass.put(pgTypeName, result);
-      _oidToJavaClass.put(oid, result);
+      javaClass = "java.sql.Array";
+      _pgNameToJavaClass.put(pgTypeName, javaClass);
+      _oidToJavaClass.put(oid, javaClass);
     }
 
-    return result;
+    return javaClass;
   }
 
   public String getTypeForAlias(String alias) {

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
@@ -151,7 +151,7 @@ public class TypeInfoCache implements TypeInfo {
     // the box datatype and it's not a JDBC core type.
     //
     Character delim = ',';
-    _arrayOidToDelimiter.put(oid, delim);
+    _arrayOidToDelimiter.put(arrayOid, delim);
 
     String pgArrayTypeName = pgTypeName + ARRAY_SUFFIX;
     _pgNameToJavaClass.put(pgArrayTypeName, "java.sql.Array");

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
@@ -546,15 +546,15 @@ public class TypeInfoCache implements TypeInfo {
     return delim;
   }
 
-  public synchronized int getPGArrayElement(int oid) throws SQLException {
-    if (oid == Oid.UNSPECIFIED) {
+  public synchronized int getPGArrayElement(int arrayOid) throws SQLException {
+    if (arrayOid == Oid.UNSPECIFIED) {
       return Oid.UNSPECIFIED;
     }
 
-    Integer pgType = _pgArrayToPgType.get(oid);
+    Integer oid = _pgArrayToPgType.get(arrayOid);
 
-    if (pgType != null) {
-      return pgType;
+    if (oid != null) {
+      return oid;
     }
 
     if (_getArrayElementOidStatement == null) {
@@ -565,7 +565,7 @@ public class TypeInfoCache implements TypeInfo {
       _getArrayElementOidStatement = _conn.prepareStatement(sql);
     }
 
-    _getArrayElementOidStatement.setInt(1, oid);
+    _getArrayElementOidStatement.setInt(1, arrayOid);
 
     // Go through BaseStatement to avoid transaction start.
     if (!((BaseStatement) _getArrayElementOidStatement)
@@ -578,24 +578,24 @@ public class TypeInfoCache implements TypeInfo {
       return Oid.UNSPECIFIED;
     }
 
-    pgType = (int) rs.getLong(1);
+    oid = (int) rs.getLong(1);
     boolean onPath = rs.getBoolean(2);
     String schema = rs.getString(3);
     String name = rs.getString(4);
-    _pgArrayToPgType.put(oid, pgType);
-    _pgNameToOid.put(schema + "." + name, pgType);
+    _pgArrayToPgType.put(arrayOid, oid);
+    _pgNameToOid.put(schema + "." + name, oid);
     String fullName = "\"" + schema + "\".\"" + name + "\"";
-    _pgNameToOid.put(fullName, pgType);
+    _pgNameToOid.put(fullName, oid);
     if (onPath && name.equals(name.toLowerCase())) {
-      _oidToPgName.put(pgType, name);
-      _pgNameToOid.put(name, pgType);
+      _oidToPgName.put(oid, name);
+      _pgNameToOid.put(name, oid);
     } else {
-      _oidToPgName.put(pgType, fullName);
+      _oidToPgName.put(oid, fullName);
     }
 
     rs.close();
 
-    return pgType;
+    return oid;
   }
 
   public synchronized Class<? extends PGobject> getPGobject(String type) {

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
@@ -151,6 +151,7 @@ public class TypeInfoCache implements TypeInfo {
     _oidToPgName.put(oid, pgTypeName);
     _pgArrayToPgType.put(arrayOid, oid);
     _pgNameToSQLType.put(pgTypeName, sqlType);
+    _oidToSQLType.put(oid, sqlType);
 
     // Currently we hardcode all core types array delimiter
     // to a comma. In a stock install the only exception is
@@ -163,6 +164,7 @@ public class TypeInfoCache implements TypeInfo {
     _pgNameToJavaClass.put(pgArrayTypeName, "java.sql.Array");
     _oidToJavaClass.put(arrayOid, "java.sql.Array");
     _pgNameToSQLType.put(pgArrayTypeName, Types.ARRAY);
+    _oidToSQLType.put(arrayOid, Types.ARRAY);
     _pgNameToOid.put(pgArrayTypeName, arrayOid);
     pgArrayTypeName = "_" + pgTypeName;
     if (!_pgNameToJavaClass.containsKey(pgArrayTypeName)) {
@@ -324,6 +326,14 @@ public class TypeInfoCache implements TypeInfo {
 
     int sqlType = pgType.sqlType();
     // Take care not to overwrite core type entries loaded on instantiation.
+    if (!_oidToSQLType.containsKey(elementOid)) {
+      _oidToSQLType.put(elementOid, pgType.sqlType);
+    }
+
+    if (!_oidToSQLType.containsKey(arrayOid)) {
+      _oidToSQLType.put(arrayOid, Types.ARRAY);
+    }
+
     if (!_pgNameToSQLType.containsKey(cachedName)) {
       _pgNameToSQLType.put(cachedName, sqlType);
     }
@@ -469,18 +479,16 @@ public class TypeInfoCache implements TypeInfo {
       return Types.OTHER;
     }
 
+    Integer sqlType = _oidToSQLType.get(oid);
+    if (sqlType != null) {
+      return sqlType;
+    }
+
     PgType pgType = fetchPgType(oid);
     if (pgType == null) {
       return Types.OTHER;
     }
 
-    // If we had a map of oids to SQLType, we wouldn't have to do this conversion
-    String cachedName = pgType.cacheName();
-
-    Integer sqlType = _pgNameToSQLType.get(cachedName);
-    if (sqlType != null) {
-      return sqlType;
-    }
     return pgType.sqlType();
   }
 

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
@@ -178,10 +178,18 @@ public class TypeInfoCache implements TypeInfo {
   }
 
   public int getSQLType(int oid) throws SQLException {
+    if (oid == Oid.UNSPECIFIED) {
+      return Types.OTHER;
+    }
+
     return getSQLType(getPGType(oid));
   }
 
   public synchronized int getSQLType(String pgTypeName) throws SQLException {
+    if (pgTypeName == null) {
+      return Types.OTHER;
+    }
+
     if (pgTypeName.endsWith("[]")) {
       return Types.ARRAY;
     }
@@ -357,6 +365,10 @@ public class TypeInfoCache implements TypeInfo {
   }
 
   public synchronized int getPGType(String pgTypeName) throws SQLException {
+    if (pgTypeName == null) {
+      return Oid.UNSPECIFIED;
+    }
+
     Integer oid = _pgNameToOid.get(pgTypeName);
     if (oid != null) {
       return oid;
@@ -436,6 +448,10 @@ public class TypeInfoCache implements TypeInfo {
   }
 
   public int getPGArrayType(String elementTypeName) throws SQLException {
+    if (elementTypeName == null) {
+      return Oid.UNSPECIFIED;
+    }
+
     elementTypeName = getTypeForAlias(elementTypeName);
     return getPGType(elementTypeName + "[]");
   }
@@ -526,7 +542,7 @@ public class TypeInfoCache implements TypeInfo {
 
     ResultSet rs = _getArrayElementOidStatement.getResultSet();
     if (!rs.next()) {
-      throw new PSQLException(GT.tr("No results were returned by the query."), PSQLState.NO_DATA);
+      return Oid.UNSPECIFIED;
     }
 
     pgType = (int) rs.getLong(1);
@@ -554,6 +570,10 @@ public class TypeInfoCache implements TypeInfo {
   }
 
   public synchronized String getJavaClass(int oid) throws SQLException {
+    if (oid == Oid.UNSPECIFIED) {
+      return null;
+    }
+
     String pgTypeName = getPGType(oid);
 
     String result = _pgNameToJavaClass.get(pgTypeName);
@@ -570,6 +590,10 @@ public class TypeInfoCache implements TypeInfo {
   }
 
   public String getTypeForAlias(String alias) {
+    if (alias == null) {
+      return null;
+    }
+
     String type = typeAliases.get(alias);
     if (type != null) {
       return type;

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
@@ -362,17 +362,12 @@ public class TypeInfoCache implements TypeInfo {
     }
 
     if (_getTypeInfoStatement == null) {
-      // There's no great way of telling what's an array type.
-      // People can name their own types starting with _.
-      // Other types use typelem that aren't actually arrays, like box.
-      //
-      String sql;
       // in case of multiple records (in different schemas) choose the one from the current
       // schema,
       // otherwise take the last version of a type that is at least more deterministic then before
       // (keeping old behaviour of finding types, that should not be found without correct search
       // path)
-      sql = "SELECT typinput='array_in'::regproc, typtype "
+      String sql = "SELECT typinput='array_in'::regproc, typtype "
           + "  FROM pg_catalog.pg_type "
           + "  JOIN pg_catalog.pg_namespace n ON n.oid = typnamespace"
           + "  LEFT "

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
@@ -474,7 +474,7 @@ public class TypeInfoCache implements TypeInfo {
     }
   }
 
-  public int getSQLType(int oid) throws SQLException {
+  public synchronized int getSQLType(int oid) throws SQLException {
     if (oid == Oid.UNSPECIFIED) {
       return Types.OTHER;
     }

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
@@ -548,6 +548,10 @@ public class TypeInfoCache implements TypeInfo {
   comparison to time spent over the wire and the overhead in maintaining a separate code path for 8.2.
    */
 
+  /*
+    getOidStatement(ParsedTypeName) is private and only called from fetchPgType(String), which
+    is synchronized. As such, we forgo marking getOidStatement as synchronized.
+   */
   private PreparedStatement getOidStatement(ParsedTypeName typeName) throws SQLException {
     if (typeName.isSimple()) {
       if (_getOidStatementSimple == null) {
@@ -602,6 +606,10 @@ public class TypeInfoCache implements TypeInfo {
     return oidStatementComplex;
   }
 
+  /*
+    getArrayOidStatement(ParsedTypeName) is private and only called from fetchPgType(String), which
+    is synchronized. As such, we forgo marking getArrayOidStatement as synchronized.
+   */
   private PreparedStatement getArrayOidStatement(ParsedTypeName typeName) throws SQLException {
     PreparedStatement oidStatementComplex;
     if (_getOidStatementComplexArray == null) {

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/TypeInfoCacheEdgeCaseTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/TypeInfoCacheEdgeCaseTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2017, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.jdbc;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.postgresql.PGProperty;
+import org.postgresql.core.Oid;
+import org.postgresql.core.TypeInfo;
+import org.postgresql.test.jdbc2.BaseTest4;
+import org.postgresql.util.PSQLException;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.Properties;
+
+public class TypeInfoCacheEdgeCaseTest extends BaseTest4 {
+  @Rule
+  public final ExpectedException exception = ExpectedException.none();
+
+  private TypeInfo typeInfo;
+
+  @Override
+  protected void updateProperties(Properties props) {
+    super.updateProperties(props);
+    PGProperty.UNKNOWN_LENGTH.set(props, UNKNOWN_LENGTH);
+  }
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    typeInfo = ((PgConnection) con).getTypeInfo();
+  }
+
+  private static final String NO_SUCH_TYPE_NAME = "none.such";
+  private static final int NO_SUCH_TYPE_OID = -100;
+  private static final int UNKNOWN_LENGTH = 100000;
+
+  @Test
+  public void testGetArrayTypeDelimiter() throws SQLException {
+    assertEquals("Oid.UNSPECIFIED", ",",
+        String.valueOf(typeInfo.getArrayDelimiter(Oid.UNSPECIFIED)));
+  }
+
+  @Test
+  public void testGetArrayTypeDelimiterThrowsOnNonExistentOid() throws SQLException {
+    exception.expect(PSQLException.class);
+    typeInfo.getArrayDelimiter(NO_SUCH_TYPE_OID);
+  }
+
+  @Test
+  public void testDisplaySize() {
+    assertEquals("Oid.UNSPECIFIED", UNKNOWN_LENGTH, typeInfo.getDisplaySize(Oid.UNSPECIFIED, 0));
+    assertEquals("non-existent type", UNKNOWN_LENGTH, typeInfo.getDisplaySize(NO_SUCH_TYPE_OID, 0));
+  }
+
+  @Test
+  public void testGetJavaClass() throws SQLException {
+    assertNull("Oid.UNSPECIFIED", typeInfo.getJavaClass(Oid.UNSPECIFIED));
+    assertNull("non-existent type", typeInfo.getJavaClass(NO_SUCH_TYPE_OID));
+  }
+
+  @Test
+  public void testGetPGArrayElement() throws SQLException {
+    assertEquals("Oid.UNSPECIFIED", Oid.UNSPECIFIED, typeInfo.getPGArrayElement(Oid.UNSPECIFIED));
+    assertEquals("non-existent type", Oid.UNSPECIFIED,
+        typeInfo.getPGArrayElement(NO_SUCH_TYPE_OID));
+    assertEquals("element type argument", Oid.UNSPECIFIED, typeInfo.getPGArrayElement(Oid.INT4));
+  }
+
+  @Test
+  public void testGetPGArrayType() throws SQLException {
+    assertEquals("null", Oid.UNSPECIFIED, typeInfo.getPGArrayType(null));
+    assertEquals("non-existent type", Oid.UNSPECIFIED, typeInfo.getPGArrayType(NO_SUCH_TYPE_NAME));
+    assertEquals("array type argument", Oid.UNSPECIFIED, typeInfo.getPGArrayType("_int4"));
+  }
+
+
+  @Test
+  public void testGetPGobject() {
+    assertNull("null", typeInfo.getPGobject(null));
+    assertNull("non-existent type", typeInfo.getPGobject(NO_SUCH_TYPE_NAME));
+  }
+
+  @Test
+  public void testGetPGTypeByOid() throws SQLException {
+    assertNull("Oid.UNSPECIFIED", typeInfo.getPGType(Oid.UNSPECIFIED));
+    assertNull("non-existent type", typeInfo.getPGType(NO_SUCH_TYPE_OID));
+  }
+
+  @Test
+  public void testGetPGTypeByName() throws SQLException {
+    assertEquals("null", Oid.UNSPECIFIED, typeInfo.getPGType(null));
+    assertEquals("non-existent type", Oid.UNSPECIFIED, typeInfo.getPGType(NO_SUCH_TYPE_NAME));
+  }
+
+  @Test
+  public void testGetPrecision() {
+    assertEquals("Oid.UNSPECIFIED", UNKNOWN_LENGTH, typeInfo.getPrecision(Oid.UNSPECIFIED, 0));
+    assertEquals("non-existent type", UNKNOWN_LENGTH, typeInfo.getPrecision(NO_SUCH_TYPE_OID, 0));
+  }
+
+  @Test
+  public void testGetMaximumPrecision() {
+    assertEquals("Oid.UNSPECIFIED", 0, typeInfo.getMaximumPrecision(Oid.UNSPECIFIED));
+    assertEquals("non-existent type", 0, typeInfo.getMaximumPrecision(NO_SUCH_TYPE_OID));
+  }
+
+  @Test
+  public void testIsCaseSensitive() {
+    assertTrue("Oid.UNSPECIFIED", typeInfo.isCaseSensitive(Oid.UNSPECIFIED));
+    assertTrue("non-existent type", typeInfo.isCaseSensitive(NO_SUCH_TYPE_OID));
+  }
+
+  @Test
+  public void testIsSigned() {
+    assertFalse("Oid.UNSPECIFIED", typeInfo.isSigned(Oid.UNSPECIFIED));
+    assertFalse("non-existent type", typeInfo.isSigned(NO_SUCH_TYPE_OID));
+  }
+
+
+  @Test
+  public void testGetScale() throws SQLException {
+    assertEquals("Oid.UNSPECIFIED", 0, typeInfo.getScale(Oid.UNSPECIFIED, 0));
+    assertEquals("non-existent type", 0, typeInfo.getScale(NO_SUCH_TYPE_OID, 0));
+  }
+
+  @Test
+  public void testGetSQLTypeByName() throws SQLException {
+    assertEquals("null", Types.OTHER, typeInfo.getSQLType(null));
+    assertEquals("non-existent type", Types.OTHER, typeInfo.getSQLType(NO_SUCH_TYPE_NAME));
+  }
+
+  @Test
+  public void testGetSQLTypeByOid() throws SQLException {
+    assertEquals("Oid.UNSPECIFIED", Types.OTHER, typeInfo.getSQLType(Oid.UNSPECIFIED));
+    assertEquals("non-existent type", Types.OTHER, typeInfo.getSQLType(NO_SUCH_TYPE_OID));
+  }
+
+  @Test
+  public void testGetTypeForAlias() throws SQLException {
+    assertNull("null", typeInfo.getTypeForAlias(null));
+  }
+
+  @Test
+  public void testRequiresQuoting() throws SQLException {
+    assertTrue("Oid.UNSPECIFIED", typeInfo.requiresQuoting(Oid.UNSPECIFIED));
+    assertTrue("non-existent type", typeInfo.requiresQuoting(NO_SUCH_TYPE_OID));
+  }
+
+  @Test
+  public void testRequiresQuotingSQLType() throws SQLException {
+    assertTrue(typeInfo.requiresQuotingSqlType(Types.OTHER));
+  }
+
+}

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/TypeInfoCacheGetArrayDelimiterTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/TypeInfoCacheGetArrayDelimiterTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2017, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.jdbc;
+
+import static org.junit.Assert.assertEquals;
+
+import org.postgresql.core.TypeInfo;
+import org.postgresql.jdbc.TypeInfoCacheTestUtil.PgTypeSet;
+import org.postgresql.jdbc.TypeInfoCacheTestUtil.PgTypeStruct;
+import org.postgresql.test.TestUtil;
+import org.postgresql.util.PSQLException;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.List;
+
+@RunWith(Parameterized.class)
+public class TypeInfoCacheGetArrayDelimiterTest {
+  @Rule
+  public final ExpectedException exception = ExpectedException.none();
+
+  private static PgTypeSet typeSet;
+
+  private Connection conn;
+  private TypeInfo typeInfo;
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    Connection conn = TestUtil.openDB();
+    typeSet = PgTypeSet.createAndInstall(types, conn);
+  }
+
+  @AfterClass
+  public static void afterClass() throws Exception {
+    Connection conn = TestUtil.openDB();
+    typeSet.uninstall(conn);
+    TestUtil.closeDB(conn);
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    conn = TestUtil.openDB();
+    typeInfo = ((PgConnection) conn).getTypeInfo();
+  }
+
+  @After
+  public void tearDown() throws SQLException {
+    TestUtil.closeDB(conn);
+  }
+
+  private final PgTypeStruct type;
+  private final PgTypeStruct arrayType;
+  private final Character delimiter;
+
+  private static final Character DEFAULT_DELIMITER = ',';
+
+  private static final List<PgTypeStruct> types = Arrays.asList(
+      new PgTypeStruct("ns", "type"),
+      new PgTypeStruct("public", "type"),
+      new PgTypeStruct("pg_catalog", "box"),
+      new PgTypeStruct("pg_catalog", "int2"),
+      new PgTypeStruct("pg_catalog", "int4"),
+      new PgTypeStruct("pg_catalog", "text"));
+
+  @Parameterized.Parameters(name = "{0} → {1}")
+  public static Iterable<Object[]> data() {
+    return Arrays.asList(
+        new Object[]{new PgTypeStruct("pg_catalog", "int2"), DEFAULT_DELIMITER},
+        new Object[]{new PgTypeStruct("pg_catalog", "text"), DEFAULT_DELIMITER},
+        new Object[]{new PgTypeStruct("pg_catalog", "box"), ';'},
+        new Object[]{new PgTypeStruct("ns", "type"), DEFAULT_DELIMITER},
+        new Object[]{new PgTypeStruct("public", "type"), DEFAULT_DELIMITER});
+  }
+
+  public TypeInfoCacheGetArrayDelimiterTest(PgTypeStruct type, Character delimiter) {
+    this.type = type;
+    this.arrayType = PgTypeStruct.createArrayType(type);
+    this.delimiter = delimiter;
+  }
+
+  @Test
+  public void testGetArrayDelimiterByElementOidThrows() throws SQLException {
+    int oid = typeSet.oid(type);
+    exception.expect(PSQLException.class);
+    typeInfo.getArrayDelimiter(oid);
+  }
+
+  @Test
+  public void testGetArrayDelimiterByArrayOid() throws SQLException {
+    typeSet.assumeSupportedType(conn, arrayType);
+    int oid = typeSet.oid(arrayType);
+    assertEquals(String.valueOf(delimiter), String.valueOf(typeInfo.getArrayDelimiter(oid)));
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/TypeInfoCacheGetJavaClassTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/TypeInfoCacheGetJavaClassTest.java
@@ -26,6 +26,10 @@ import java.sql.SQLException;
 import java.sql.Types;
 import java.util.Arrays;
 
+/*
+ This extends BaseTest4 instead of TypeInfoCachePGTypeBaseTest as it uses more than one custom type.
+ PgTypeSet (used in TypeInfoCachePGTypeBaseTest) only creates a single type of custom type.
+ */
 @RunWith(Parameterized.class)
 public class TypeInfoCacheGetJavaClassTest extends BaseTest4 {
   private TypeInfo typeInfo;

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/TypeInfoCacheGetJavaClassTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/TypeInfoCacheGetJavaClassTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2017, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.jdbc;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeTrue;
+import static org.postgresql.jdbc.TypeInfoCacheTestUtil.PgTypeStruct;
+import static org.postgresql.jdbc.TypeInfoCacheTestUtil.assumeUserDefinedArrays;
+
+import org.postgresql.core.Oid;
+import org.postgresql.core.ServerVersion;
+import org.postgresql.core.TypeInfo;
+import org.postgresql.test.TestUtil;
+import org.postgresql.test.jdbc2.BaseTest4;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.Arrays;
+
+@RunWith(Parameterized.class)
+public class TypeInfoCacheGetJavaClassTest extends BaseTest4 {
+  private TypeInfo typeInfo;
+
+  private final PgTypeStruct pgType;
+  private final int expectedSQLType;
+  private final String expectedClassName;
+  private int oid;
+  private int arrayOid;
+
+  private static final String CUSTOM_SCHEMA = "ns";
+  private static final String DISTINCT_TYPE = "d";
+  private static final String STRUCT_TYPE = "s";
+  private static final String VARCHAR_TYPE = "v";
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    typeInfo = ((PgConnection) con).getTypeInfo();
+
+    if (CUSTOM_SCHEMA.equals(pgType.nspname)) {
+      TestUtil.createSchema(con, pgType.nspname);
+      if (DISTINCT_TYPE.equals(pgType.typname)) {
+        TestUtil.createDomain(con, pgType.name(), "int");
+      } else if (STRUCT_TYPE.equals(pgType.typname)) {
+        TestUtil.createCompositeType(con, pgType.name(), "v timestamptz");
+      } else if (VARCHAR_TYPE.equals(pgType.typname)) {
+        assumeTrue("enum requires PostgreSQL 8.3 or later",
+            expectedSQLType != Types.VARCHAR || TestUtil.haveMinimumServerVersion(con,
+                ServerVersion.v8_3));
+        TestUtil.createEnumType(con, pgType.name(), "'black'");
+      }
+    }
+
+    oid = Oid.UNSPECIFIED;
+    arrayOid = Oid.UNSPECIFIED;
+
+    PreparedStatement stmt = con.prepareStatement(
+        "SELECT t.oid, COALESCE(arr.oid, 0) "
+            + " FROM pg_catalog.pg_type AS t"
+            + " JOIN pg_catalog.pg_namespace AS n ON n.oid = t.typnamespace"
+            + " LEFT JOIN pg_catalog.pg_type AS arr"
+            + " ON (t.oid, 'array_in'::regproc) = (arr.typelem, arr.typinput)"
+            + " WHERE (nspname, t.typname) = (?, ?)");
+    stmt.setString(1, pgType.nspname);
+    stmt.setString(2, pgType.typname);
+    ResultSet rs = stmt.executeQuery();
+    if (rs.next()) {
+      oid = (int) rs.getLong(1);
+      arrayOid = (int) rs.getLong(2);
+    }
+  }
+
+  @Parameterized.Parameters(name = "{0} → {2}")
+  public static Iterable<Object[]> data() {
+    return Arrays.asList(
+        new Object[]{new PgTypeStruct("pg_catalog", "int2"), Types.SMALLINT, "java.lang.Integer"},
+        new Object[]{new PgTypeStruct("pg_catalog", "int4"), Types.INTEGER, "java.lang.Integer"},
+        new Object[]{new PgTypeStruct("pg_catalog", "numeric"), Types.NUMERIC, "java.math.BigDecimal"},
+        new Object[]{new PgTypeStruct(CUSTOM_SCHEMA, DISTINCT_TYPE), Types.DISTINCT, null},
+        new Object[]{new PgTypeStruct(CUSTOM_SCHEMA, STRUCT_TYPE), Types.STRUCT, null},
+        new Object[]{new PgTypeStruct(CUSTOM_SCHEMA, VARCHAR_TYPE), Types.VARCHAR, null});
+  }
+
+  public TypeInfoCacheGetJavaClassTest(PgTypeStruct pgType, int expectedSQLType,
+      String expectedClassName) {
+    this.pgType = pgType;
+    this.expectedSQLType = expectedSQLType;
+    this.expectedClassName = expectedClassName;
+  }
+
+  @Test
+  public void testGetJavaClass() throws SQLException {
+    assertEquals("class name", expectedClassName, typeInfo.getJavaClass(oid));
+    assertEquals("cached class name", expectedClassName, typeInfo.getJavaClass(oid));
+  }
+
+  @Test
+  public void testGetJavaClassForArrays() throws SQLException {
+    assumeUserDefinedArrays(con);
+    assumeTrue("arrays of domains (represented by Types.DISTINCT) aren't supported by PostgreSQL",
+        expectedSQLType != Types.DISTINCT);
+    assertEquals("array class name", "java.sql.Array", typeInfo.getJavaClass(arrayOid));
+    assertEquals("cached array class name", "java.sql.Array", typeInfo.getJavaClass(arrayOid));
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/TypeInfoCacheGetPGArrayElementTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/TypeInfoCacheGetPGArrayElementTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2017, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.jdbc;
+
+import static org.junit.Assert.assertEquals;
+import static org.postgresql.jdbc.TypeInfoCacheTestParameters.installedTypes;
+import static org.postgresql.jdbc.TypeInfoCacheTestUtil.PgTypeStruct;
+
+import org.junit.Test;
+import org.junit.runners.Parameterized;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class TypeInfoCacheGetPGArrayElementTest extends TypeInfoCacheGetPGTypeBaseTest {
+  @Parameterized.Parameters(name = "{0}")
+  public static Iterable<Object[]> data() {
+    Collection<Object[]> params = new ArrayList<Object[]>();
+    for (PgTypeStruct elementType : installedTypes) {
+      PgTypeStruct arrayType = PgTypeStruct.createArrayType(elementType);
+      params.add(new Object[]{arrayType, elementType});
+    }
+    return params;
+  }
+
+  private final PgTypeStruct arrayType;
+  private final int arrayOid;
+  private final PgTypeStruct elementType;
+
+  public TypeInfoCacheGetPGArrayElementTest(PgTypeStruct arrayType, PgTypeStruct elementType)
+      throws SQLException {
+    this.arrayType = arrayType;
+    this.arrayOid = oid(arrayType);
+    this.elementType = elementType;
+  }
+
+  @Test
+  public void testGetPGArrayElementType() throws SQLException {
+    assumeSupportedType(conn, arrayType);
+    int elementOid = typeInfo.getPGArrayElement(arrayOid);
+    assertEquals("type cached by getPGArrayElement matches element type of given array",
+        elementType, type(elementOid));
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/TypeInfoCacheGetPGArrayTypeCachedNameTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/TypeInfoCacheGetPGArrayTypeCachedNameTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2017, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.jdbc;
+
+import static org.junit.Assert.assertEquals;
+import static org.postgresql.jdbc.TypeInfoCacheTestParameters.badRoundTripTypes;
+import static org.postgresql.jdbc.TypeInfoCacheTestParameters.installedTypes;
+import static org.postgresql.jdbc.TypeInfoCacheTestUtil.PgTypeStruct;
+
+import org.junit.Test;
+import org.junit.runners.Parameterized;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class TypeInfoCacheGetPGArrayTypeCachedNameTest extends TypeInfoCacheGetPGTypeBaseTest {
+
+  private int oid;
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    oid = oid(type);
+  }
+
+  @Parameterized.Parameters(name = "{0} → {1} (oid)")
+  public static Iterable<Object[]> data() {
+    Collection<Object[]> params = new ArrayList<Object[]>();
+    for (PgTypeStruct type : installedTypes) {
+      params.add(new Object[]{type, PgTypeStruct.createArrayType(type)});
+    }
+    return params;
+  }
+
+  private final PgTypeStruct type;
+  private final PgTypeStruct arrayType;
+
+  public TypeInfoCacheGetPGArrayTypeCachedNameTest(PgTypeStruct type, PgTypeStruct arrayType) {
+    this.type = type;
+    this.arrayType = arrayType;
+  }
+
+  @Test
+  public void testGetPGTypeByCachedArrayName() throws SQLException {
+    assumeSupportedType(conn, arrayType);
+    String nameString = typeInfo.getPGType(oid);
+    int arrayOid = typeInfo.getPGArrayType(nameString);
+    PgTypeStruct expectedArrayType = (badRoundTripTypes.keySet().contains(type))
+        ? PgTypeStruct.createArrayType(badRoundTripTypes.get(type)) : arrayType;
+    assertEquals("type cached by getPGArrayType matches the array type of the given element type",
+        expectedArrayType, type(arrayOid));
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/TypeInfoCacheGetPGArrayTypeTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/TypeInfoCacheGetPGArrayTypeTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2017, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.jdbc;
+
+import static org.junit.Assert.assertEquals;
+import static org.postgresql.jdbc.TypeInfoCacheTestParameters.getPGArrayTypeParseableTestParams;
+import static org.postgresql.jdbc.TypeInfoCacheTestUtil.PgTypeStruct;
+
+import org.junit.Test;
+import org.junit.runners.Parameterized;
+
+import java.sql.SQLException;
+
+public class TypeInfoCacheGetPGArrayTypeTest extends TypeInfoCacheGetPGTypeBaseTest {
+
+  @Parameterized.Parameters(name = "{0} → {1} (oid)")
+  public static Iterable<Object[]> data() {
+    return getPGArrayTypeParseableTestParams();
+  }
+
+  private final String nameString;
+  private final PgTypeStruct type;
+
+  public TypeInfoCacheGetPGArrayTypeTest(String nameString, PgTypeStruct type) {
+    this.nameString = nameString;
+    this.type = type;
+  }
+
+  @Test
+  public void testGetPGArrayType() throws SQLException {
+    assumeSupportedType(conn, type);
+    int oid = typeInfo.getPGArrayType(nameString);
+    assertEquals(type, type(oid));
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/TypeInfoCacheGetPGArrayTypeUnparseableNameTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/TypeInfoCacheGetPGArrayTypeUnparseableNameTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2017, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.jdbc;
+
+import static org.postgresql.jdbc.TypeInfoCacheTestParameters.getPGArrayTypeUnparseableTestParams;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runners.Parameterized;
+
+import java.sql.SQLException;
+
+public class TypeInfoCacheGetPGArrayTypeUnparseableNameTest extends TypeInfoCacheGetPGTypeBaseTest {
+  @Rule
+  public final ExpectedException exception = ExpectedException.none();
+
+  @Parameterized.Parameters(name = "{0}")
+  public static Iterable<Object[]> data() {
+    return getPGArrayTypeUnparseableTestParams();
+  }
+
+  private final String nameString;
+
+  public TypeInfoCacheGetPGArrayTypeUnparseableNameTest(String nameString) {
+    this.nameString = nameString;
+  }
+
+  @Test
+  public void testGetPGArrayTypeThrowsOnUnparseableNames() throws SQLException {
+    exception.expect(Exception.class);
+    typeInfo.getPGArrayType(nameString);
+  }
+
+}

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/TypeInfoCacheGetPGTypeBaseTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/TypeInfoCacheGetPGTypeBaseTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2017, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.jdbc;
+
+import static org.postgresql.jdbc.TypeInfoCacheTestParameters.installedTypes;
+import static org.postgresql.jdbc.TypeInfoCacheTestUtil.PgTypeStruct;
+
+import org.postgresql.core.TypeInfo;
+import org.postgresql.jdbc.TypeInfoCacheTestUtil.PgTypeSet;
+import org.postgresql.test.TestUtil;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+/**
+ * Many TypeInfoCache tests rely on knowledge of a set of user-defined and pg_catalog types.
+ * This class creates an instance of TypeInfoCacheTestUtil.PgTypeSet with the list of
+ * TypeInfoCacheTestParameters.installedTypes and makes those types easily available via oid() and
+ * type() methods which wrap the PgTypeSet instance. It also uses beforeClass and afterClass to set
+ * up and tear down these types once per class rather than per test.
+ */
+@RunWith(Parameterized.class)
+public class TypeInfoCacheGetPGTypeBaseTest {
+  private static PgTypeSet typeSet;
+
+  @Rule
+  public final ExpectedException exception = ExpectedException.none();
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    Connection conn = TestUtil.openDB();
+    typeSet = PgTypeSet.createAndInstall(installedTypes, conn);
+    TestUtil.closeDB(conn);
+  }
+
+  @AfterClass
+  public static void afterClass() throws Exception {
+    Connection conn = TestUtil.openDB();
+    typeSet.uninstall(conn);
+    TestUtil.closeDB(conn);
+  }
+
+  Connection conn;
+  TypeInfo typeInfo;
+
+  @Before
+  public void setUp() throws Exception {
+    conn = TestUtil.openDB();
+    typeInfo = ((PgConnection) conn).getTypeInfo();
+  }
+
+  @After
+  public void tearDown() throws SQLException {
+    TestUtil.closeDB(conn);
+  }
+
+  public TypeInfoCacheGetPGTypeBaseTest() {
+  }
+
+  static void assumeSupportedType(Connection conn, PgTypeStruct type) throws SQLException {
+    typeSet.assumeSupportedType(conn, type);
+  }
+
+  static int oid(PgTypeStruct type) {
+    return typeSet.oid(type);
+  }
+
+  static PgTypeStruct type(int oid) {
+    return typeSet.type(oid);
+  }
+
+}

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/TypeInfoCacheGetPGTypeByNameTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/TypeInfoCacheGetPGTypeByNameTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2017, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.jdbc;
+
+import static org.junit.Assert.assertEquals;
+import static org.postgresql.jdbc.TypeInfoCacheTestParameters.getPGTypeParseableNameParams;
+import static org.postgresql.jdbc.TypeInfoCacheTestUtil.PgTypeStruct;
+
+import org.postgresql.core.Oid;
+
+import org.junit.Test;
+import org.junit.runners.Parameterized;
+
+import java.sql.SQLException;
+
+public class TypeInfoCacheGetPGTypeByNameTest extends TypeInfoCacheGetPGTypeBaseTest {
+
+  @Parameterized.Parameters(name = "{0} → {1} (oid)")
+  public static Iterable<Object[]> data() {
+    return getPGTypeParseableNameParams();
+  }
+
+  private final String nameString;
+  private final PgTypeStruct type;
+
+  public TypeInfoCacheGetPGTypeByNameTest(String nameString, PgTypeStruct getPGTypeType) {
+    this.nameString = nameString;
+    this.type = getPGTypeType;
+  }
+
+  @Test
+  public void testGetPGTypeByName() throws SQLException {
+    assumeSupportedType(conn, type);
+    int oid = typeInfo.getPGType(nameString);
+    PgTypeStruct expectedType = type.hasSearchPathException() ? type.searchPathException : type;
+    assertEquals(expectedType, type(oid));
+    String roundTripNameString = (oid == Oid.UNSPECIFIED) ? null : typeInfo.getPGType(oid);
+    int roundTripOid = typeInfo.getPGType(roundTripNameString);
+    assertEquals("round trip (oid)", expectedType, type(roundTripOid));
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/TypeInfoCacheGetPGTypeByOidCachedNameTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/TypeInfoCacheGetPGTypeByOidCachedNameTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2017, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.jdbc;
+
+import static org.junit.Assert.assertEquals;
+import static org.postgresql.jdbc.TypeInfoCacheTestParameters.getPGTypeByOidCachedNameParams;
+import static org.postgresql.jdbc.TypeInfoCacheTestUtil.PgTypeStruct;
+
+import org.postgresql.core.TypeInfo;
+import org.postgresql.test.TestUtil;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+@RunWith(Parameterized.class)
+public class TypeInfoCacheGetPGTypeByOidCachedNameTest extends TypeInfoCacheGetPGTypeBaseTest {
+
+  private final PgTypeStruct type;
+  private final String nameString;
+  private final PgTypeStruct arrayType;
+  private final String arrayNameString;
+  private int oid;
+  private String uncachedNameString;
+  private int arrayOid;
+  private String uncachedArrayNameString;
+
+  private Connection myConn;
+  private TypeInfo myTypeInfo;
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    oid = oid(type);
+    uncachedNameString = typeInfo.getPGType(oid);
+    arrayOid = oid(arrayType);
+    uncachedArrayNameString = typeInfo.getPGType(arrayOid);
+
+    myConn = TestUtil.openDB();
+    myTypeInfo = ((PgConnection) myConn).getTypeInfo();
+  }
+
+  @Override
+  public void tearDown() throws SQLException {
+    TestUtil.closeDB(myConn);
+    super.tearDown();
+  }
+
+  @Parameterized.Parameters(name = "{0}")
+  public static Iterable<Object[]> data() {
+    return getPGTypeByOidCachedNameParams();
+  }
+
+  public TypeInfoCacheGetPGTypeByOidCachedNameTest(PgTypeStruct type, String nameString,
+      String arrayNameString) {
+    this.type = type;
+    this.nameString = nameString;
+    this.arrayType = PgTypeStruct.createArrayType(type);
+    this.arrayNameString = arrayNameString;
+  }
+
+  @Test
+  public void testGetPGTypeByNameCached() throws Exception {
+    myTypeInfo.getPGType(uncachedNameString);
+    String cachedNameString = myTypeInfo.getPGType(oid);
+    assertEquals("type name cached by getPGType(name) matches cached by getPGType(oid)",
+        nameString, cachedNameString);
+  }
+
+  @Test
+  public void testGetPGTypeByArrayNameCached() throws Exception {
+    assumeSupportedType(conn, arrayType);
+    myTypeInfo.getPGType(uncachedArrayNameString);
+    String cachedNameString = myTypeInfo.getPGType(arrayOid);
+    assertEquals("array type name cached by getPGType(name) matches that cached by getPGType(oid)",
+        arrayNameString, cachedNameString);
+  }
+
+}

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/TypeInfoCacheGetPGTypeByOidTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/TypeInfoCacheGetPGTypeByOidTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2017, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.jdbc;
+
+import static org.junit.Assert.assertEquals;
+import static org.postgresql.jdbc.TypeInfoCacheTestParameters.getPGTypeByOidParams;
+import static org.postgresql.jdbc.TypeInfoCacheTestUtil.PgTypeStruct;
+
+import org.junit.Test;
+import org.junit.runners.Parameterized;
+
+import java.sql.SQLException;
+
+public class TypeInfoCacheGetPGTypeByOidTest extends TypeInfoCacheGetPGTypeBaseTest {
+  @Parameterized.Parameters(name = "{0} (oid) → {1}")
+  public static Iterable<Object[]> data() {
+    return getPGTypeByOidParams();
+  }
+
+  private final PgTypeStruct type;
+  private final String expectedNameString;
+  private final PgTypeStruct arrayType;
+  private final String expectedArrayNameString;
+
+  public TypeInfoCacheGetPGTypeByOidTest(PgTypeStruct type, String expectedNameString,
+      PgTypeStruct arrayType, String expectedArrayNameString) {
+    this.type = type;
+    this.expectedNameString = expectedNameString;
+    this.arrayType = arrayType;
+    this.expectedArrayNameString = expectedArrayNameString;
+  }
+
+  @Test
+  public void testGetPGTypeByOid() throws SQLException {
+    int oid = oid(type);
+    String nameString = typeInfo.getPGType(oid);
+    assertEquals(expectedNameString, nameString);
+    int roundTripOid = typeInfo.getPGType(nameString);
+    assertEquals("name returned by getPGType(oid) round-trips through getPGType(name)",
+        type, type(roundTripOid));
+  }
+
+  @Test
+  public void testGetPGTypeByArrayOid() throws SQLException {
+    assumeSupportedType(conn, arrayType);
+    int oid = oid(arrayType);
+    String nameString = typeInfo.getPGType(oid);
+    assertEquals(expectedArrayNameString, nameString);
+    int roundTripOid = typeInfo.getPGType(nameString);
+    assertEquals("name of array type returned by getPGType(oid) round-trips through getPGType(name)",
+        arrayType, type(roundTripOid));
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/TypeInfoCacheGetPGTypeNamesWithSQLTypesTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/TypeInfoCacheGetPGTypeNamesWithSQLTypesTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2017, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.jdbc;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.postgresql.jdbc.TypeInfoCacheTestUtil.assertSQLType;
+
+import org.postgresql.core.TypeInfo;
+import org.postgresql.jdbc.TypeInfoCacheTestUtil.PgTypeSet;
+import org.postgresql.jdbc.TypeInfoCacheTestUtil.PgTypeStruct;
+import org.postgresql.test.jdbc2.BaseTest4;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+
+@RunWith(Parameterized.class)
+public class TypeInfoCacheGetPGTypeNamesWithSQLTypesTest extends BaseTest4 {
+
+  private TypeInfo typeInfo;
+  private PgTypeSet typeSet;
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    typeInfo = ((PgConnection) con).getTypeInfo();
+    typeSet = PgTypeSet.createAndInstall(types, con);
+    sqlType = typeSet.userDefinedTypeSqlType(con);
+  }
+
+  @Override
+  public void tearDown() throws SQLException {
+    typeSet.uninstall(con);
+    super.tearDown();
+  }
+
+  @Parameterized.Parameters(name = "{0} ; Types: {1}")
+  public static Iterable<Object[]> data() {
+    Collection<Object[]> cases = new ArrayList<Object[]>();
+    //noinspection ArraysAsListWithZeroOrOneArgument
+    List<PgTypeStruct> types = Arrays.asList(new PgTypeStruct("ns", "type"));
+    cases.add(new Object[]{"ns.type", types});
+    return cases;
+  }
+
+  private final List<PgTypeStruct> types;
+  private final String nameString;
+  private int sqlType;
+
+  public TypeInfoCacheGetPGTypeNamesWithSQLTypesTest(String nameString,
+      List<PgTypeStruct> types) throws SQLException {
+    this.nameString = nameString;
+    this.types = types;
+  }
+
+  @Test
+  /*
+  This is not an expansive test. It only confirms that the iterator contains expected data,
+  not that the iterator is implemented correctly.
+   */
+  public void testGetPGTypeNamesForUserDefinedType() throws SQLException {
+    boolean isFound = false;
+
+    for (Iterator<String> i = typeInfo.getPGTypeNamesWithSQLTypes(); i.hasNext(); ) {
+      String fetchedNameString = i.next();
+      if (fetchedNameString.equals(nameString)) {
+        isFound = true;
+        break;
+      }
+    }
+
+    assertFalse("not found before loaded into cache", isFound);
+
+    // The getSQLType call will load the type into cache.
+    assertSQLType("have expected SQL Type", sqlType, typeInfo.getSQLType(nameString));
+
+    for (Iterator<String> i = typeInfo.getPGTypeNamesWithSQLTypes(); i.hasNext(); ) {
+      String fetchedNameString = i.next();
+      if (fetchedNameString.equals(nameString)) {
+        isFound = true;
+        break;
+      }
+    }
+    assertTrue("found after loaded into cache", isFound);
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/TypeInfoCacheGetPGTypeSearchPathTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/TypeInfoCacheGetPGTypeSearchPathTest.java
@@ -6,6 +6,7 @@
 package org.postgresql.jdbc;
 
 import static org.junit.Assert.assertEquals;
+import static org.postgresql.jdbc.TypeInfoCacheTestUtil.join;
 import static org.postgresql.jdbc.TypeInfoCacheTestUtil.quotify;
 
 import org.postgresql.core.TypeInfo;
@@ -53,24 +54,6 @@ public class TypeInfoCacheGetPGTypeSearchPathTest extends BaseTest4 {
   public void tearDown() throws SQLException {
     typeSet.uninstall(con);
     super.tearDown();
-  }
-
-  private static String join(
-      @SuppressWarnings("SameParameterValue") String separator,
-      String[] coll) {
-    if (coll == null) {
-      return null;
-    }
-    int length = coll.length;
-    if (length == 0) {
-      return null;
-    }
-    StringBuilder out = new StringBuilder();
-    out.append(coll[0]);
-    for (int i = 1; i < length; ++i) {
-      out.append(separator).append(coll[i]);
-    }
-    return out.toString();
   }
 
   @Parameterized.Parameters(name = "{0} Path: {4}; Types: {3}")

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/TypeInfoCacheGetPGTypeSearchPathTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/TypeInfoCacheGetPGTypeSearchPathTest.java
@@ -1,0 +1,287 @@
+/*
+ * Copyright (c) 2017, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.jdbc;
+
+import static org.junit.Assert.assertEquals;
+import static org.postgresql.jdbc.TypeInfoCacheTestUtil.quotify;
+
+import org.postgresql.core.TypeInfo;
+import org.postgresql.jdbc.TypeInfoCacheTestUtil.PgTypeSet;
+import org.postgresql.jdbc.TypeInfoCacheTestUtil.PgTypeStruct;
+import org.postgresql.test.jdbc2.BaseTest4;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+
+@RunWith(Parameterized.class)
+public class TypeInfoCacheGetPGTypeSearchPathTest extends BaseTest4 {
+
+  private static final String[] DEFAULT_SEARCH_PATH = new String[0];
+
+  private final String nameString;
+  private final PgTypeStruct type;
+  private final PgTypeStruct arrayType;
+  private final ArrayList<PgTypeStruct> types;
+  private final String searchPath;
+
+  private TypeInfo typeInfo;
+  private PgTypeSet typeSet;
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    typeSet = PgTypeSet.createAndInstall(types, con);
+    typeInfo = ((PgConnection) con).getTypeInfo();
+    if (searchPath != null) {
+      String searchPathSql = "SET search_path TO " + searchPath;
+      con.createStatement().execute(searchPathSql);
+    }
+  }
+
+  @Override
+  public void tearDown() throws SQLException {
+    typeSet.uninstall(con);
+    super.tearDown();
+  }
+
+  private static String join(
+      @SuppressWarnings("SameParameterValue") String separator,
+      String[] coll) {
+    if (coll == null) {
+      return null;
+    }
+    int length = coll.length;
+    if (length == 0) {
+      return null;
+    }
+    StringBuilder out = new StringBuilder();
+    out.append(coll[0]);
+    for (int i = 1; i < length; ++i) {
+      out.append(separator).append(coll[i]);
+    }
+    return out.toString();
+  }
+
+  @Parameterized.Parameters(name = "{0} Path: {4}; Types: {3}")
+  public static Iterable<Object[]> data() {
+    Collection<Object[]> cases = new ArrayList<Object[]>();
+
+    /*
+    Each case is: types, search path schemas, and a map of type name strings to the
+    PgTypeStruct instance it should match, with PgTypeStruct.UNSPECIFIED for no match.
+
+    Notes:
+    1. ParsedTypeName.fromString lowers unquoted type names, so type name string "NS.TYPE" will be
+       parsed as (nspname, typname) = ('ns', 'type'), and type name string "TYPE" will be parsed as
+       the unqualified type (typname) = ('type'). This accounts for matching the lowered type names.
+
+    2. getPGType special-cases unqualified, unquoted type names. If these two conditions are met,
+       the type name will be looked up *without regard to the search_path*, matching the most recently
+       created type with that name. This is *not* how the type would normally be found if used in a
+       query. getPGArrayType does not exhibit this behavior.
+
+    3. There's a bug regarding search-path precedence for *non*-simple type names, i.e.,
+       unqualified, but quoted or an array. The most recently created will be returned regardless
+       of search path precedence. For example, with types a.type and b.type, both a and b on the
+       search path, "type" will return whichever was created last regardless of search path order.
+     */
+
+    // baseline
+    cases.add(new Object[]{
+        new PgTypeStruct[]{new PgTypeStruct("pg_catalog", "text")},
+        DEFAULT_SEARCH_PATH,
+        new HashMap<String, PgTypeStruct>() {
+          {
+            put("text", new PgTypeStruct("pg_catalog", "text"));
+            put("%text%", new PgTypeStruct("pg_catalog", "text"));
+            put("TEXT", new PgTypeStruct("pg_catalog", "text"));
+            put("%TEXT%", PgTypeStruct.UNSPECIFIED);
+          }
+        },
+    });
+
+    /*
+     "text" and TEXT match public.text
+     "text" and "text"[] match because they're non-simple and the quotes are removed
+     TEXT matches because it's simple and lowered on search.
+     TEXT[] matches because it's non-simple, and is case-folded because it's not quoted.
+    */
+    cases.add(new Object[]{
+        new PgTypeStruct[]{new PgTypeStruct("pg_catalog", "text"),
+            new PgTypeStruct("public", "text")},
+        DEFAULT_SEARCH_PATH,
+        new HashMap<String, PgTypeStruct>() {
+          {
+            put("text", new PgTypeStruct("pg_catalog", "text"));
+            put("%text%", new PgTypeStruct("public", "text"));
+            put("TEXT", new PgTypeStruct("public", "text"));
+            put("%TEXT%", PgTypeStruct.UNSPECIFIED);
+          }
+        },
+    });
+
+
+    // only quoted %TEXT% matches public.TEXT
+    cases.add(new Object[]{
+        new PgTypeStruct[]{
+            new PgTypeStruct("pg_catalog", "text"),
+            new PgTypeStruct("public", "TEXT")},
+        DEFAULT_SEARCH_PATH,
+        new HashMap<String, PgTypeStruct>() {
+          {
+            put("TEXT", new PgTypeStruct("pg_catalog", "text"));
+            put("%TEXT%", new PgTypeStruct("public", "TEXT"));
+          }
+        },
+    });
+
+    /*
+     With schema a on the search path, a.type is selected instead of x.type.
+     */
+    cases.add(new Object[]{
+        new PgTypeStruct[]{
+            new PgTypeStruct("a", "type"),
+            new PgTypeStruct("x", "type")
+        },
+        new String[]{"a"},
+        new HashMap<String, PgTypeStruct>() {
+          {
+            put("type", new PgTypeStruct("a", "type"));
+            put("%type%", new PgTypeStruct("a", "type"));
+          }
+        },
+    });
+
+    /*
+    Even though x is not on the path, it's matched anyway. This is a legacy bug.
+     */
+    cases.add(new Object[]{
+        new PgTypeStruct[]{
+            new PgTypeStruct("x", "type")
+        },
+        DEFAULT_SEARCH_PATH,
+        new HashMap<String, Object>() {
+          {
+            // "type" matches (x, type), "type[]" matches UNSPECIFIED
+            put("type", Arrays.asList(new PgTypeStruct("x", "type"), PgTypeStruct.UNSPECIFIED));
+            put("%type%", PgTypeStruct.UNSPECIFIED);
+          }
+        },
+    });
+    /*
+    Even though neither a.type nor x.type are on the path, x.type is matched as it has a higher oid
+    (it was created after a.type).
+     */
+    cases.add(new Object[]{
+        new PgTypeStruct[]{
+            new PgTypeStruct("a", "type"),
+            new PgTypeStruct("x", "type")
+        },
+        DEFAULT_SEARCH_PATH,
+        new HashMap<String, Object>() {
+          {
+            // "type" matches (x, type), "type[]" matches UNSPECIFIED
+            put("type", Arrays.asList(new PgTypeStruct("x", "type"), PgTypeStruct.UNSPECIFIED));
+          }
+        },
+    });
+
+    /*
+    Note how creation order affects which one is selected between the following two cases.
+    In the first, a.type is created first, then b.type.
+    In the second, b.type is created first.
+     */
+    cases.add(new Object[]{
+        new PgTypeStruct[]{
+            new PgTypeStruct("a", "type"),
+            new PgTypeStruct("b", "type")
+        },
+        new String[]{"a", "b"},
+        new HashMap<String, Object>() {
+          {
+            // "type" matches (a, type), "type[]" matches (b, type)
+            put("type",
+                Arrays.asList(new PgTypeStruct("a", "type"), new PgTypeStruct("b", "type")));
+            put("%type%", new PgTypeStruct("b", "type"));
+          }
+        },
+    });
+
+    cases.add(new Object[]{
+        new PgTypeStruct[]{
+            new PgTypeStruct("b", "type"),
+            new PgTypeStruct("a", "type")
+        },
+        new String[]{"a", "b"},
+        new HashMap<String, PgTypeStruct>() {
+          {
+            put("type", new PgTypeStruct("a", "type"));
+            put("%type%", new PgTypeStruct("a", "type"));
+          }
+        },
+    });
+
+    Collection<Object[]> params = new ArrayList<Object[]>();
+    for (Object[] c : cases) {
+      @SuppressWarnings("unchecked")
+      ArrayList<PgTypeStruct> types = new ArrayList<PgTypeStruct>();
+      types.addAll(Arrays.asList((PgTypeStruct[]) c[0]));
+      @SuppressWarnings("unchecked")
+      HashMap<String, Object> nameStrings = (HashMap<String, Object>) c[2];
+      String searchPath = join(",", (String[]) c[1]);
+      for (String nameString : nameStrings.keySet()) {
+        Object obj = nameStrings.get(nameString);
+        PgTypeStruct type;
+        PgTypeStruct elementType;
+        if (obj instanceof List) {
+          @SuppressWarnings("unchecked")
+          List<PgTypeStruct> expectedTypes = (List<PgTypeStruct>) obj;
+          type = expectedTypes.get(0);
+          elementType = PgTypeStruct.createArrayType(expectedTypes.get(1));
+        } else {
+          type = (PgTypeStruct) obj;
+          elementType = PgTypeStruct.createArrayType(type);
+        }
+        params.add(
+            new Object[]{quotify(nameString), type, elementType, types, searchPath});
+      }
+    }
+    return params;
+  }
+
+  public TypeInfoCacheGetPGTypeSearchPathTest(String nameString, PgTypeStruct type,
+      PgTypeStruct arrayType,
+      ArrayList<PgTypeStruct> types, String searchPath) {
+    this.nameString = nameString;
+    this.type = type;
+    this.arrayType = arrayType;
+    this.types = types;
+    this.searchPath = searchPath;
+  }
+
+  @Test
+  public void testMatchesSearchPath() throws SQLException {
+    int oid = typeInfo.getPGType(nameString);
+    PgTypeStruct actualType = typeSet.type(oid);
+    assertEquals(type, actualType);
+  }
+
+  @Test
+  public void testArrayMatchesSearchPath() throws SQLException {
+    typeSet.assumeSupportedType(con, arrayType);
+    int arrayOid = typeInfo.getPGArrayType(nameString);
+    PgTypeStruct actualArrayType = typeSet.type(arrayOid);
+    assertEquals(arrayType, actualArrayType);
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/TypeInfoCacheGetPGTypeUnparseableNameTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/TypeInfoCacheGetPGTypeUnparseableNameTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2017, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.jdbc;
+
+import static org.postgresql.jdbc.TypeInfoCacheTestParameters.getPGTypeUnParseableNameParams;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runners.Parameterized;
+
+import java.sql.SQLException;
+
+public class TypeInfoCacheGetPGTypeUnparseableNameTest extends TypeInfoCacheGetPGTypeBaseTest {
+  @Rule
+  public final ExpectedException exception = ExpectedException.none();
+
+  @Parameterized.Parameters(name = "{0}")
+  public static Iterable<Object[]> data() {
+    return getPGTypeUnParseableNameParams();
+  }
+
+  private final String nameString;
+
+  public TypeInfoCacheGetPGTypeUnparseableNameTest(String nameString) {
+    this.nameString = nameString;
+  }
+
+  @Test
+  public void testGetPgTypeThrowsOnUnparseableNames() throws SQLException {
+    exception.expect(Exception.class);
+    typeInfo.getPGType(nameString);
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/TypeInfoCacheGetSQLTypeSearchPathTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/TypeInfoCacheGetSQLTypeSearchPathTest.java
@@ -24,6 +24,10 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 
+/*
+ This extends BaseTest4 instead of TypeInfoCachePGTypeBaseTest as it uses more than one custom type.
+ PgTypeSet (used in TypeInfoCachePGTypeBaseTest) only creates a single type of custom type.
+ */
 @RunWith(Parameterized.class)
 public class TypeInfoCacheGetSQLTypeSearchPathTest extends BaseTest4 {
   public static class Schema {
@@ -92,8 +96,8 @@ public class TypeInfoCacheGetSQLTypeSearchPathTest extends BaseTest4 {
 
     /*
     getSQLType doesn't return the PostgreSQL type it's matching, so trying to determine which
-    underlying type is being selected. Here we're creating different custom type with the same name,
-    each in its own schema.
+    underlying type is being selected requires a bit of work. Here we're creating different user-defined
+    types with the same name, each in its own schema.
 
      java.sql.Types |    type     | definition
     ----------------|-------------|-------------------------------------------
@@ -103,8 +107,8 @@ public class TypeInfoCacheGetSQLTypeSearchPathTest extends BaseTest4 {
 
     So, search_path will determine which java.sql.Types value is returned for unqualified type names.
 
-    Each case is: schemas, types, search path schemas,
-    and a map of type name strings to the schema the type name string is expected to match; null is no match
+    Each case is: schemas, types, search path schemas, and a map of type name strings to the schema
+    the type name string is expected to match; null is no match.
      */
 
     cases.add(new Object[]{

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/TypeInfoCacheGetSQLTypeSearchPathTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/TypeInfoCacheGetSQLTypeSearchPathTest.java
@@ -1,0 +1,267 @@
+/*
+ * Copyright (c) 2017, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.jdbc;
+
+import static org.postgresql.jdbc.TypeInfoCacheTestUtil.SQLType;
+import static org.postgresql.jdbc.TypeInfoCacheTestUtil.assertSQLType;
+import static org.postgresql.jdbc.TypeInfoCacheTestUtil.join;
+
+import org.postgresql.core.TypeInfo;
+import org.postgresql.test.TestUtil;
+import org.postgresql.test.jdbc2.BaseTest4;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+
+@RunWith(Parameterized.class)
+public class TypeInfoCacheGetSQLTypeSearchPathTest extends BaseTest4 {
+  public static class Schema {
+    static final Schema PUBLIC = new Schema("public");
+    static final Schema PG_CATALOG = new Schema("pg_catalog");
+
+    public final String name;
+
+    Schema(String name) {
+      this.name = name;
+    }
+
+    static String[] names(Schema[] schemas) {
+      if (schemas == null) {
+        return null;
+      }
+      Collection<String> coll = new ArrayList<String>();
+      for (Schema s : schemas) {
+        coll.add(s.name);
+      }
+      String[] names = new String[coll.size()];
+      coll.toArray(names);
+      return names;
+    }
+
+    @Override
+    public String toString() {
+      return name;
+    }
+
+    static Schema[] noSchemas() {
+      return new Schema[0];
+    }
+
+    @SuppressWarnings("SameReturnValue")
+    static Schema[] defaultSearchPath() {
+      return null;
+    }
+
+  }
+
+  private static final Schema V = new Schema("v");
+  private static final Schema S = new Schema("s");
+
+  private static final HashMap<Integer, Schema> SqlTypeSchemas = new HashMap<Integer, Schema>() {
+    {
+      put(Types.DISTINCT, Schema.PUBLIC);
+      put(Types.STRUCT, S);
+      put(Types.VARCHAR, V);
+      put(Types.INTEGER, Schema.PG_CATALOG);
+    }
+  };
+
+  private static final HashMap<Schema, SQLType> SchemaSqlTypes = new HashMap<Schema, SQLType>() {
+    {
+      put(V, SQLType.VARCHAR);
+      put(S, SQLType.STRUCT);
+      put(Schema.PUBLIC, SQLType.DISTINCT);
+      put(Schema.PG_CATALOG, SQLType.INTEGER);
+    }
+  };
+
+  @Parameterized.Parameters(name = "{0} → {1} ({2}); schemas {3}; path: {4}")
+  public static Iterable<Object[]> data() {
+    Collection<Object[]> cases = new ArrayList<Object[]>();
+
+    /*
+    getSQLType doesn't return the PostgreSQL type it's matching, so trying to determine which
+    underlying type is being selected. Here we're creating different custom type with the same name,
+    each in its own schema.
+
+     java.sql.Types |    type     | definition
+    ----------------|-------------|-------------------------------------------
+     Types.VARCHAR  | v.type      | CREATE TYPE v.type AS ENUM ('black')
+     Types.STRUCT   | s.type      | CREATE TYPE s.type AS (v timestamptz)
+     Types.DISTINCT | public.type | CREATE DOMAIN public.type AS int
+
+    So, search_path will determine which java.sql.Types value is returned for unqualified type names.
+
+    Each case is: schemas, types, search path schemas,
+    and a map of type name strings to the schema the type name string is expected to match; null is no match
+     */
+
+    cases.add(new Object[]{
+        Schema.noSchemas(),
+        Schema.defaultSearchPath(),
+        new HashMap<String, Schema>() {
+          {
+            put("type", null);
+            put("TYPE", null);
+            put("\"TYPE\"", null);
+          }
+        }
+    });
+
+    cases.add(new Object[]{
+        new Schema[]{
+            Schema.PUBLIC},
+        Schema.defaultSearchPath(),
+        new HashMap<String, Schema>() {
+          {
+            put("type", Schema.PUBLIC);
+            put("public.type", Schema.PUBLIC);
+          }
+        }
+    });
+
+    cases.add(new Object[]{
+        new Schema[]{
+            S, Schema.PUBLIC},
+        Schema.defaultSearchPath(),
+        new HashMap<String, Schema>() {
+          {
+            put("type", Schema.PUBLIC);
+            put("public.type", Schema.PUBLIC);
+            put("s.type", S);
+          }
+        }
+    });
+
+    cases.add(new Object[]{
+        new Schema[]{
+            Schema.PUBLIC, S},
+        Schema.defaultSearchPath(),
+        new HashMap<String, Schema>() {
+          {
+            put("type", Schema.PUBLIC);
+            put("public.type", Schema.PUBLIC);
+            put("s.type", S);
+          }
+        }
+    });
+
+    cases.add(new Object[]{
+        new Schema[]{
+            S, Schema.PUBLIC},
+        new Schema[]{
+            S},
+        new HashMap<String, Schema>() {
+          {
+            put("type", S);
+            put("s.type", S);
+            put("public.type", Schema.PUBLIC);
+          }
+        }
+    });
+
+    Collection<Object[]> params = new ArrayList<Object[]>();
+    for (Object[] c : cases) {
+      Schema[] schemas = (Schema[]) c[0];
+      Schema[] searchPathSchemas = (Schema[]) c[1];
+      @SuppressWarnings("unchecked")
+      HashMap<String, Schema> nameStrings = (HashMap<String, Schema>) c[2];
+      String searchPath = join(",", Schema.names(searchPathSchemas));
+
+      for (String nameString : nameStrings.keySet()) {
+        Schema expectedSchema = nameStrings.get(nameString);
+        SQLType expectedSQLType = SQLType.OTHER;
+        if (expectedSchema != null) {
+          expectedSQLType = SchemaSqlTypes.get(expectedSchema);
+        }
+        params.add(new Object[]{nameString, expectedSchema, expectedSQLType,
+            new ArrayList<Schema>(Arrays.asList(schemas)), searchPath});
+      }
+    }
+    return params;
+  }
+
+  private final String typeName;
+  private final SQLType expectedSQLType;
+  private final ArrayList<Schema> schemas;
+  private final String searchPath;
+
+  private TypeInfo typeInfo;
+
+  public TypeInfoCacheGetSQLTypeSearchPathTest(
+      String typeName, @SuppressWarnings("unused") Schema expectedSchema, SQLType expectedSQLType,
+      ArrayList<Schema> schemas, String searchPath) {
+    this.typeName = typeName;
+    this.expectedSQLType = expectedSQLType;
+    this.schemas = schemas;
+    this.searchPath = searchPath;
+  }
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    typeInfo = ((PgConnection) con).getTypeInfo();
+
+    for (Schema schema : schemas) {
+      if (schema == Schema.PG_CATALOG) {
+        continue;
+      }
+      if (schema != Schema.PUBLIC) {
+        TestUtil.createSchema(con, schema.name);
+      }
+      String typeName = schema.name + "." + "type";
+      SQLType sqlType = SchemaSqlTypes.get(schema);
+      switch (sqlType.type) {
+        case Types.DISTINCT:
+          TestUtil.createDomain(con, typeName, "int");
+          break;
+        case Types.STRUCT:
+          TestUtil.createCompositeType(con, typeName, "v timestamptz");
+          break;
+        case Types.VARCHAR:
+          TestUtil.createEnumType(con, typeName, "'black'");
+          break;
+        default:
+          throw new IllegalArgumentException("Unknown type " + sqlType + " for schema " + schema);
+      }
+    }
+
+    if (searchPath != null) {
+      String searchPathSql = "SET search_path TO " + searchPath;
+      con.createStatement().execute(searchPathSql);
+    }
+  }
+
+  @Override
+  public void tearDown() throws SQLException {
+    for (Schema schema : schemas) {
+      if (schema == Schema.PG_CATALOG) {
+        return;
+      }
+      if (schema != Schema.PUBLIC) {
+        TestUtil.dropSchema(con, schema.name);
+      }
+      String typeName = schema.name + "." + "type";
+      TestUtil.dropType(con, typeName);
+    }
+    super.tearDown();
+  }
+
+  @Test
+  public void testSearchPath() throws SQLException {
+    int sqlType = typeInfo.getSQLType(typeName);
+    Schema actualSchema = SqlTypeSchemas.get(sqlType);
+    assertSQLType("got " + actualSchema, expectedSQLType.type, sqlType);
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/TypeInfoCacheGetSQLTypeTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/TypeInfoCacheGetSQLTypeTest.java
@@ -27,6 +27,10 @@ import java.sql.SQLException;
 import java.sql.Types;
 import java.util.Arrays;
 
+/*
+ This extends BaseTest4 instead of TypeInfoCachePGTypeBaseTest as it uses more than one custom type.
+ PgTypeSet (used in TypeInfoCachePGTypeBaseTest) only creates a single type of custom type.
+ */
 @RunWith(Parameterized.class)
 public class TypeInfoCacheGetSQLTypeTest extends BaseTest4 {
   private TypeInfo typeInfo;

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/TypeInfoCacheGetSQLTypeTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/TypeInfoCacheGetSQLTypeTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2017, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.jdbc;
+
+import static org.junit.Assume.assumeTrue;
+import static org.postgresql.jdbc.TypeInfoCacheTestUtil.PgTypeStruct;
+import static org.postgresql.jdbc.TypeInfoCacheTestUtil.assertSQLType;
+import static org.postgresql.jdbc.TypeInfoCacheTestUtil.assumeUserDefinedArrays;
+
+import org.postgresql.core.Oid;
+import org.postgresql.core.ServerVersion;
+import org.postgresql.core.TypeInfo;
+import org.postgresql.jdbc.TypeInfoCacheTestUtil.SQLType;
+import org.postgresql.test.TestUtil;
+import org.postgresql.test.jdbc2.BaseTest4;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.Arrays;
+
+@RunWith(Parameterized.class)
+public class TypeInfoCacheGetSQLTypeTest extends BaseTest4 {
+  private TypeInfo typeInfo;
+
+  private final PgTypeStruct type;
+  private final SQLType expectedSQLType;
+  private int oid;
+  private int arrayOid;
+
+  private static final String CUSTOM_SCHEMA = "ns";
+  private static final String DISTINCT_TYPE = "d";
+  private static final String STRUCT_TYPE = "s";
+  private static final String VARCHAR_TYPE = "v";
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    typeInfo = ((PgConnection) con).getTypeInfo();
+    oid = Oid.UNSPECIFIED;
+    arrayOid = Oid.UNSPECIFIED;
+
+    if (CUSTOM_SCHEMA.equals(type.nspname)) {
+      TestUtil.createSchema(con, type.nspname);
+      if (DISTINCT_TYPE.equals(type.typname)) {
+        TestUtil.createDomain(con, type.name(), "int");
+      } else if (STRUCT_TYPE.equals(type.typname)) {
+        TestUtil.createCompositeType(con, type.name(), "v timestamptz");
+      } else if (VARCHAR_TYPE.equals(type.typname)) {
+        assumeTrue("enum requires PostgreSQL 8.3 or later",
+            expectedSQLType.type != Types.VARCHAR || TestUtil.haveMinimumServerVersion(con,
+                ServerVersion.v8_3));
+        TestUtil.createEnumType(con, type.name(), "'black'");
+      }
+    }
+
+    PreparedStatement stmt = con.prepareStatement(
+        "SELECT t.oid, COALESCE(arr.oid, 0) "
+            + " FROM pg_catalog.pg_type AS t"
+            + " JOIN pg_catalog.pg_namespace AS n ON n.oid = t.typnamespace"
+            + " LEFT JOIN pg_catalog.pg_type AS arr"
+            + " ON (t.oid, 'array_in'::regproc) = (arr.typelem, arr.typinput)"
+            + " WHERE (nspname, t.typname) = (?, ?)");
+    stmt.setString(1, type.nspname);
+    stmt.setString(2, type.typname);
+    ResultSet rs = stmt.executeQuery();
+    if (rs.next()) {
+      oid = (int) rs.getLong(1);
+      arrayOid = (int) rs.getLong(2);
+    }
+  }
+
+  @Parameterized.Parameters(name = "{0} → {1}")
+  public static Iterable<Object[]> data() {
+    return Arrays.asList(
+        new Object[]{new PgTypeStruct("pg_catalog", "int2"), SQLType.SMALLINT},
+        new Object[]{new PgTypeStruct("pg_catalog", "int4"), SQLType.INTEGER},
+        new Object[]{new PgTypeStruct("pg_catalog", "numeric"), SQLType.NUMERIC},
+        new Object[]{new PgTypeStruct(CUSTOM_SCHEMA, DISTINCT_TYPE), SQLType.DISTINCT},
+        new Object[]{new PgTypeStruct(CUSTOM_SCHEMA, STRUCT_TYPE), SQLType.STRUCT},
+        new Object[]{new PgTypeStruct(CUSTOM_SCHEMA, VARCHAR_TYPE), SQLType.VARCHAR});
+  }
+
+  public TypeInfoCacheGetSQLTypeTest(PgTypeStruct type, SQLType expectedSQLType) {
+    this.type = type;
+    this.expectedSQLType = expectedSQLType;
+  }
+
+  @Test
+  public void testGetSQLType() throws SQLException {
+    assertSQLType("oid", expectedSQLType.type, typeInfo.getSQLType(oid));
+    assertSQLType("cached oid", expectedSQLType.type, typeInfo.getSQLType(oid));
+    assertSQLType("nameString", expectedSQLType.type, typeInfo.getSQLType(type.name()));
+    assertSQLType("cached nameString", expectedSQLType.type,
+        typeInfo.getSQLType(type.name()));
+  }
+
+  @Test
+  public void testGetSQLTypeForArrays() throws SQLException {
+    assumeUserDefinedArrays(con);
+    assumeTrue("arrays of domains (represented by Types.DISTINCT) aren't supported by PostgreSQL",
+        expectedSQLType.type != Types.DISTINCT);
+    assertSQLType("array oid", Types.ARRAY, typeInfo.getSQLType(arrayOid));
+    assertSQLType("cached array oid", Types.ARRAY, typeInfo.getSQLType(arrayOid));
+    String arrayTypeName = type.name() + "[]";
+    assertSQLType("nameString", Types.ARRAY, typeInfo.getSQLType(arrayTypeName));
+    assertSQLType("cached nameString", Types.ARRAY, typeInfo.getSQLType(arrayTypeName));
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/TypeInfoCacheGetTypeForAliasTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/TypeInfoCacheGetTypeForAliasTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2017, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.jdbc;
+
+import static org.junit.Assert.assertEquals;
+
+import org.postgresql.core.TypeInfo;
+import org.postgresql.test.jdbc2.BaseTest4;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+
+@RunWith(Parameterized.class)
+public class TypeInfoCacheGetTypeForAliasTest extends BaseTest4 {
+
+  private TypeInfo typeInfo;
+
+  private final String expectedType;
+  private final String alias;
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    typeInfo = ((PgConnection) con).getTypeInfo();
+  }
+
+  @Parameterized.Parameters(name = "{0} → {1}")
+  public static Iterable<Object[]> data() {
+    Collection<Object[]> aliasing = Arrays.asList(
+        new Object[]{"int2", new String[]{"smallint"}},
+        new Object[]{"int4", new String[]{"integer", "int"}},
+        new Object[]{"float8", new String[]{"float"}},
+        new Object[]{"bool", new String[]{"boolean"}},
+        new Object[]{"numeric", new String[]{"decimal"}});
+
+    Collection<Object[]> params = new ArrayList<Object[]>();
+    for (Object[] a : aliasing) {
+      String base = (String) a[0];
+      String[] aliases = (String[]) a[1];
+      for (String alias : aliases) {
+        params.add(new Object[]{alias.toUpperCase(), base});
+        params.add(new Object[]{alias, base});
+      }
+    }
+    return params;
+  }
+
+
+  public TypeInfoCacheGetTypeForAliasTest(String alias, String expectedType) {
+    this.alias = alias;
+    this.expectedType = expectedType;
+  }
+
+  @Test
+  public void testGetTypeForAlias() {
+    assertEquals(expectedType, typeInfo.getTypeForAlias(alias));
+  }
+
+}

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/TypeInfoCacheTestParameters.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/TypeInfoCacheTestParameters.java
@@ -471,50 +471,12 @@ class TypeInfoCacheTestParameters {
 
   /*
    This is similar to getPGTypeByOidParams, though it's used when testing names that have been cached
-   by getPGType(name), which has different behavior than getPGType(oid). Before refactoring, you need
-   to have a baseline to know if you're making any undesired behavioral changes. Once it's confirmed
-   that the behavior is consistent, this separate parameter set can be removed.
+   by getPGType(name).
    */
   static Iterable<Object[]> getPGTypeByOidCachedNameParams() {
-    Collection<Object[]> cases = new ArrayList<Object[]>();
-    cases.add(new Object[]{new PgTypeStruct("pg_catalog", "text"), "text", "_text"});
-
-    cases.add(new Object[]{PgTypeStruct.createQuotified("public", " "), " ", "_ "});
-    cases.add(new Object[]{PgTypeStruct.createQuotified("public", "%"), "%", "_%"});
-    cases.add(new Object[]{PgTypeStruct.createQuotified("public", "%%"), "%%", "_%%"});
-    cases.add(new Object[]{PgTypeStruct.createQuotified("public", "%%%"), "%%%", "_%%%"});
-    cases.add(new Object[]{PgTypeStruct.createQuotified("public", "%%%%"), "%%%%", "_%%%%"});
-    cases.add(new Object[]{PgTypeStruct.createQuotified("public", "."), ".", "_."});
-
-    cases.add(new Object[]{PgTypeStruct.createQuotified("public", "%TYPE[]%"), "%TYPE[]%", "_%TYPE[]%"});
-    cases.add(new Object[]{PgTypeStruct.createQuotified("public", "%type[]%"), "%type[]%", "_%type[]%"});
-    cases.add(new Object[]{PgTypeStruct.createQuotified("public", "TYPE"), "TYPE", "_TYPE"});
-    cases.add(new Object[]{PgTypeStruct.createQuotified("public", "TYPE[]"), "TYPE[]", "_TYPE[]"});
-    cases.add(new Object[]{PgTypeStruct.createQuotified("public", "type"), "type", "_type"});
-    cases.add(new Object[]{PgTypeStruct.createQuotified("public", "type[]"), "type[]", "_type[]"});
-
-    // Drops namespace
-    cases.add(new Object[]{PgTypeStruct.createQuotified("ns", " "), " ", "_ "});
-    cases.add(new Object[]{PgTypeStruct.createQuotified("ns", "%"), "%", "_%"});
-    cases.add(new Object[]{PgTypeStruct.createQuotified("ns", "."), ".", "_."});
-
-    cases.add(new Object[]{PgTypeStruct.createQuotified("%NS%", "%TYPE%"), "%TYPE%", "_%TYPE%"});
-    cases.add(new Object[]{PgTypeStruct.createQuotified("%NS%", "%TYPE[]%"), "%TYPE[]%", "_%TYPE[]%"});
-    cases.add(new Object[]{PgTypeStruct.createQuotified("NS", "TYPE"), "TYPE", "_TYPE"});
-    cases.add(new Object[]{PgTypeStruct.createQuotified("NS", "TYPE[]"), "TYPE[]", "_TYPE[]"});
-    cases.add(new Object[]{PgTypeStruct.createQuotified("ns", "type"), "type", "_type"});
-    cases.add(new Object[]{PgTypeStruct.createQuotified("ns", "type[]"), "type[]", "_type[]"});
-
-    cases.add(new Object[]{PgTypeStruct.createQuotified("ns", "ty.pe"), "ty.pe", "_ty.pe"});
-    cases.add(new Object[]{PgTypeStruct.createQuotified("n%%.%%s%%", "%%ty%%.%%pe%%"), "%n%%.%%s%%%.%%%ty%%.%%pe%%%", "%n%%.%%s%%%.%_%%ty%%.%%pe%%%"});
-    cases.add(new Object[]{PgTypeStruct.createQuotified("n%%s", "%%type%%"), "%%type%%", "_%%type%%"});
-    cases.add(new Object[]{PgTypeStruct.createQuotified("n%.%s%", "%ty%.%pe%"), "%n%.%s%%.%%ty%.%pe%%", "%n%.%s%%.%_%ty%.%pe%%"});
-    cases.add(new Object[]{PgTypeStruct.createQuotified("n%s", "%type%"), "%type%", "_%type%"});
-    cases.add(new Object[]{PgTypeStruct.createQuotified("n%s", "type"), "type", "_type"});
-
     Collection<Object[]> params = new ArrayList<Object[]>();
-    for (Object[] c : cases) {
-      params.add(new Object[]{c[0], quotify((String) c[1]), quotify((String) c[2])});
+    for (Object[] c : getPGTypeByOidParams()) {
+      params.add(new Object[]{c[0], quotify((String) c[1]), quotify((String) c[3])});
     }
     return params;
   }

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/TypeInfoCacheTestParameters.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/TypeInfoCacheTestParameters.java
@@ -1,0 +1,512 @@
+/*
+ * Copyright (c) 2017, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.jdbc;
+
+import static org.postgresql.jdbc.TypeInfoCacheTestUtil.PgTypeStruct;
+import static org.postgresql.jdbc.TypeInfoCacheTestUtil.PgTypeStructType;
+import static org.postgresql.jdbc.TypeInfoCacheTestUtil.quotify;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+
+/**
+ * Many of the TypeInfoCache tests are parameterized, and rely on a common set of data. Some of that
+ * requires modification depending on the particular test. All of them are included here rather than
+ * in their particular test classes for easy reference to the core set of types.
+ */
+class TypeInfoCacheTestParameters {
+
+  enum PGTypeParam {
+    NAME_STRING(0), TYPE(1), GET_PG_ARRAY_TYPE(2);
+    final int idx;
+
+    PGTypeParam(int idx) {
+      this.idx = idx;
+    }
+  }
+
+  /*
+   Used by TypeInfoCacheBaseTest to load custom types. Select pg_catalog types are included to
+   populate maps of oid to PgTypeStruct instance and vice versa.
+
+   Due to legacy issues with TypeInfoCache, the order of these types matters for some of the tests
+   to be deterministic.
+   */
+  static final ArrayList<PgTypeStruct> installedTypes = new ArrayList<PgTypeStruct>() {
+    {
+      add(new PgTypeStruct("pg_catalog", "text"));
+      add(new PgTypeStruct("pg_catalog", "int2"));
+      add(new PgTypeStruct("pg_catalog", "int4"));
+
+      add(PgTypeStruct.createQuotified("%", "%"));
+      add(PgTypeStruct.createQuotified("%", "."));
+      add(PgTypeStruct.createQuotified("%", "%."));
+      add(PgTypeStruct.createQuotified("%", ".%%"));
+      add(PgTypeStruct.createQuotified(".", "%"));
+      add(PgTypeStruct.createQuotified(".", "."));
+
+      add(PgTypeStruct.createQuotified("ns", "element"));
+      add(PgTypeStruct.createQuotified("public", "element"));
+
+      add(PgTypeStruct.createQuotified("public", " "));
+      add(PgTypeStruct.createQuotified("public", "% %"));
+      add(PgTypeStruct.createQuotified("public", "%"));
+      add(PgTypeStruct.createQuotified("public", "%%"));
+      add(PgTypeStruct.createQuotified("public", "%%%"));
+      add(PgTypeStruct.createQuotified("public", "%%%%"));
+      add(PgTypeStruct.createQuotified("public", "%.%"));
+
+      add(PgTypeStruct.createQuotified("public", "%TYPE%"));
+      add(PgTypeStruct.createQuotified("public", "%TYPE[]%"));
+      add(PgTypeStruct.createQuotified("public", "%n"));
+      add(PgTypeStruct.createQuotified("public", "%ns"));
+      add(PgTypeStruct.createQuotified("public", "%type%"));
+      add(PgTypeStruct.createQuotified("public", "."));
+      add(PgTypeStruct.createQuotified("public", "TYPE"));
+      add(PgTypeStruct.createQuotified("public", "TYPE[]"));
+      add(PgTypeStruct.createQuotified("public", "type"));
+      add(PgTypeStruct.createQuotified("public", "type[]"));
+      add(PgTypeStruct.createQuotified("public", "%type[]%"));
+
+      add(PgTypeStruct.createQuotified("public", "n"));
+      add(PgTypeStruct.createQuotified("public", "NS.%TYPE"));
+
+      add(PgTypeStruct.createQuotified("ns", " "));
+      add(PgTypeStruct.createQuotified("ns", "%"));
+      add(PgTypeStruct.createQuotified("ns", "."));
+      add(PgTypeStruct.createQuotified("n%%.%%s%%", "%%ty%%.%%pe%%"));
+      add(PgTypeStruct.createQuotified("n%%s", "%%type%%"));
+      add(PgTypeStruct.createQuotified("n%.%s%", "%ty%.%pe%"));
+      add(PgTypeStruct.createQuotified("n%s", "%type%"));
+      add(PgTypeStruct.createQuotified("n%s", "type"));
+      add(PgTypeStruct.createQuotified("N%S", "type"));
+      add(PgTypeStruct.createQuotified("N%S", "%type%"));
+      add(PgTypeStruct.createQuotified("ns", "ty.pe"));
+      add(PgTypeStruct.createQuotified("ns.ty", "pe"));
+
+      add(PgTypeStruct.createQuotified("%NS%", "%TYPE%"));
+      add(PgTypeStruct.createQuotified("%%NS%%", "%%TYPE%%"));
+      add(PgTypeStruct.createQuotified("%NS%", "%TYPE[]%"));
+      add(PgTypeStruct.createQuotified("%%NS%%", "%%TYPE[]%%"));
+      add(PgTypeStruct.createQuotified("%ns%", "%type%"));
+      add(PgTypeStruct.createQuotified("%ns%", "%type[]%"));
+      add(PgTypeStruct.createQuotified("NS", "%TYPE%"));
+      add(PgTypeStruct.createQuotified("NS", "%TYPE[]%"));
+      add(PgTypeStruct.createQuotified("NS", "%%TYPE[]%%"));
+      add(PgTypeStruct.createQuotified("NS", "%type%"));
+      add(PgTypeStruct.createQuotified("NS", "%type[]%"));
+      add(PgTypeStruct.createQuotified("NS", "TYPE"));
+      add(PgTypeStruct.createQuotified("NS", "TYPE[]"));
+      add(PgTypeStruct.createQuotified("NS", "type"));
+      add(PgTypeStruct.createQuotified("NS", "type[]"));
+      add(PgTypeStruct.createQuotified("ns", "%TYPE[]%"));
+      add(PgTypeStruct.createQuotified("ns", "%type%"));
+      add(PgTypeStruct.createQuotified("ns", "TYPE[]"));
+      add(PgTypeStruct.createQuotified("ns", "type"));
+      add(PgTypeStruct.createQuotified("ns", "type[]"));
+
+      // shadows pg_catalog.text
+      add(PgTypeStruct.createQuotified("sp", "text"));
+    }
+  };
+
+  private static void assertTypeIsInstalled(PgTypeStruct type) {
+    if (!installedTypes.contains(type)) {
+      throw new AssertionError("Add type " + type + " to installed types");
+    }
+  }
+
+  static final HashMap<PgTypeStruct, PgTypeStruct> badRoundTripTypes =
+      new HashMap<PgTypeStruct, PgTypeStruct>() {
+        {
+          put(PgTypeStruct.createQuotified("%", "%."), PgTypeStruct.UNSPECIFIED);
+
+          put(PgTypeStruct.createQuotified("public", "%%"), PgTypeStruct.UNSPECIFIED);
+
+          put(PgTypeStruct.createQuotified("public", "%%%"),
+              PgTypeStruct.createQuotified("public", "%"));
+
+          put(PgTypeStruct.createQuotified("public", "%%%%"),
+              PgTypeStruct.createQuotified("public", "%%"));
+
+          put(PgTypeStruct.createQuotified("public", "."), PgTypeStruct.UNSPECIFIED);
+
+          put(PgTypeStruct.createQuotified("public", "% %"),
+              PgTypeStruct.createQuotified("public", " "));
+
+          put(PgTypeStruct.createQuotified("n%%.%%s%%", "%%ty%%.%%pe%%"),
+              PgTypeStruct.createQuotified("public", "n"));
+
+          put(PgTypeStruct.createQuotified("n%.%s%", "%ty%.%pe%"),
+              PgTypeStruct.createQuotified("public", "%n"));
+
+          put(PgTypeStruct.createQuotified("public", "NS.%TYPE"), PgTypeStruct.UNSPECIFIED);
+
+          put(PgTypeStruct.createQuotified("public", "%TYPE%"),
+              PgTypeStruct.createQuotified("public", "TYPE"));
+
+          put(PgTypeStruct.createQuotified("public", "%TYPE[]%"),
+              PgTypeStruct.createQuotified("public", "TYPE[]"));
+
+          put(PgTypeStruct.createQuotified("public", "%type%"),
+              PgTypeStruct.createQuotified("public", "type"));
+
+          put(PgTypeStruct.createQuotified("public", "%type[]%"),
+              PgTypeStruct.createQuotified("public", "type[]"));
+
+          put(PgTypeStruct.createQuotified("public", "TYPE"),
+              PgTypeStruct.createQuotified("public", "type"));
+
+          put(PgTypeStruct.createQuotified("public", "TYPE[]"),
+              PgTypeStruct.createQuotified("public", "type[]"));
+        }
+      };
+
+  private static Iterable<Object[]> getPGTypeByNameParams() {
+    Collection<Object[]> cases = new ArrayList<Object[]>();
+    /*
+     Each case has two or three elements:
+
+     1. The type name string to be fed to TypeInfoCache getPGType(String) or getPGArrayType(String).
+        Internal quotes can be represented as % for easier reading.
+          For example                    "\"ns\".\"type\""
+          can be written as              "%ns%.%type%"
+          to mean the (unquoted) string  |"ns"."type"|
+
+     2. A PgTypeStruct instance representing the type the string should match. If you want % to be
+        replaced with quotes as above, use the PgTypeStruct.createQuotified factory method.
+
+     3. A PgTypeStruct instance representing the element type of the type returned by getPGArrayType
+        if different from the one returned by getPGType. These are used to note differences in
+        behavior between the two functions.
+
+     Array cases are added by default, so both "ns.type" and "ns.type[]" will be tested.
+     If the given name string represents an array, such as "_int4", the second argument should be a
+     PgTypeStruct for an array, and there should be no third argument.
+     */
+
+    // matching core types
+    cases.add(new Object[]{"text", new PgTypeStruct("pg_catalog", "text")});
+    cases.add(new Object[]{"int2", new PgTypeStruct("pg_catalog", "int2")});
+    cases.add(
+        new Object[]{"_text", new PgTypeStruct("pg_catalog", "text", PgTypeStructType.ARRAY)});
+    cases.add(
+        new Object[]{"_int2", new PgTypeStruct("pg_catalog", "int2", PgTypeStructType.ARRAY)});
+    cases.add(
+        new Object[]{"_int4", new PgTypeStruct("pg_catalog", "int4", PgTypeStructType.ARRAY)});
+
+    /*
+     The naming of pg_type.typname for arrays of user-defined types is determined by the order in
+     which they're created. For example:
+
+     CREATE SCHEMA case1;
+     CREATE TYPE case1.color AS (color text);
+     CREATE TYPE case1._color AS (color text);
+
+     CREATE SCHEMA case2;
+     CREATE TYPE case2._color AS (color text);
+     CREATE TYPE case2.color AS (color text);
+
+     SELECT e.oid::regtype, e.typname, a.typname AS a_typname
+       FROM pg_type e
+       JOIN pg_namespace n ON e.typnamespace = n.oid
+       JOIN pg_type a ON (e.oid, 'array_in'::regproc) = (a.typelem, a.typinput)
+       WHERE nspname ~ '^case'
+       ORDER BY nspname, e.oid;
+
+          oid      | typname | a_typname
+     --------------+---------+-----------
+      case1.color  | color   | __color
+      case1._color | _color  | ___color
+      case2._color | _color  | __color
+      case2.color  | color   | ___color
+    */
+    cases.add(new Object[]{"element", new PgTypeStruct("public", "element")});
+    cases.add(new Object[]{"ns.element", new PgTypeStruct("ns", "element")});
+    cases.add(
+        new Object[]{"_element", new PgTypeStruct("public", "element", PgTypeStructType.ARRAY)});
+    cases.add(
+        new Object[]{"ns._element", new PgTypeStruct("ns", "element", PgTypeStructType.ARRAY)});
+
+    // matching aliases
+    cases.add(
+        new Object[]{"%smallint%", PgTypeStruct.UNSPECIFIED});
+    cases.add(
+        new Object[]{"smallint", PgTypeStruct.UNSPECIFIED, new PgTypeStruct("pg_catalog", "int2")});
+    cases.add(new Object[]{"%int4%", new PgTypeStruct("pg_catalog", "int4")});
+    cases.add(new Object[]{"int4", new PgTypeStruct("pg_catalog", "int4")});
+    cases.add(
+        new Object[]{"int", PgTypeStruct.UNSPECIFIED, new PgTypeStruct("pg_catalog", "int4")});
+    cases.add(
+        new Object[]{"integer", PgTypeStruct.UNSPECIFIED, new PgTypeStruct("pg_catalog", "int4")});
+    cases.add(
+        new Object[]{"INT", PgTypeStruct.UNSPECIFIED, new PgTypeStruct("pg_catalog", "int4")});
+
+    /*
+     sp.text is shadowing pg_catalog.text. Lower-case "text" matches pg_catalog.text because
+     it's cached when TypeInfoCache is instantiated via addCoreType
+     */
+    cases.add(new Object[]{"TEXT",
+        PgTypeStruct.createWithSearchPathException("pg_catalog", "text", "sp")});
+
+    // edge cases
+    cases.add(new Object[]{" ", PgTypeStruct.createQuotified("public", " ")});
+    cases.add(new Object[]{"", PgTypeStruct.UNSPECIFIED}); // empty string
+    cases.add(new Object[]{"% %", PgTypeStruct.createQuotified("public", " ")});
+    cases.add(new Object[]{"%", PgTypeStruct.UNPARSEABLE});
+    cases.add(new Object[]{"%%", PgTypeStruct.UNSPECIFIED}); // "%%" parses as (null, "")
+    cases.add(new Object[]{"%%%", PgTypeStruct.createQuotified("public", "%")});
+    cases.add(new Object[]{"%%%%", PgTypeStruct.createQuotified("public", "%%")});
+    cases.add(new Object[]{"%.%", PgTypeStruct.UNPARSEABLE});
+    cases.add(new Object[]{"%.%.", PgTypeStruct.UNSPECIFIED}); // "%.%." parses as ("", "..")
+    cases.add(new Object[]{"%.%.%.%", PgTypeStruct.UNPARSEABLE});
+    cases.add(new Object[]{".", PgTypeStruct.UNSPECIFIED});    // "." parses as ("", "")
+    cases.add(new Object[]{".%.%", PgTypeStruct.UNSPECIFIED}); // ".%.%" parses as ("", "%.%")
+    cases.add(new Object[]{"..", PgTypeStruct.UNSPECIFIED});   // ".." parses as ("", ".")
+    cases.add(new Object[]{"...", PgTypeStruct.UNSPECIFIED});  // "..." parses as ("", "..")
+
+    // unqualified (default search path, so public is an available schema for users)
+    // quotes are stripped
+    cases.add(new Object[]{"%TYPE%", PgTypeStruct.createQuotified("public", "TYPE")});
+    cases.add(new Object[]{"%TYPE[]%", PgTypeStruct.createQuotified("public", "TYPE[]")});
+    cases.add(new Object[]{"%%TYPE[]%%", PgTypeStruct.createQuotified("public", "%TYPE[]%")});
+    cases.add(new Object[]{"%type%", PgTypeStruct.createQuotified("public", "type")});
+
+    cases.add(new Object[]{"type", PgTypeStruct.createQuotified("public", "type")});
+    // unquoted type names are case-folded
+    cases.add(new Object[]{"TYPE", PgTypeStruct.createQuotified("public", "type")});
+    cases.add(new Object[]{"%NS.%TYPE%", PgTypeStruct.createQuotified("public", "NS.%TYPE")});
+
+    // qualified
+    cases.add(new Object[]{"%NS%.%TYPE%", PgTypeStruct.createQuotified("NS", "TYPE")});
+    cases.add(new Object[]{"%%NS%%.%%TYPE%%", PgTypeStruct.createQuotified("%NS%", "%TYPE%")});
+    cases.add(new Object[]{"%%%NS%%%.%%%TYPE%%%", PgTypeStruct.createQuotified("%%NS%%", "%%TYPE%%")});
+    cases.add(new Object[]{"%NS%.%TYPE[]%", PgTypeStruct.createQuotified("NS", "TYPE[]")});
+    cases.add(new Object[]{"%NS%.%%TYPE[]%%", PgTypeStruct.createQuotified("NS", "%TYPE[]%")});
+    cases.add(new Object[]{"%NS%.%%%TYPE[]%%%", PgTypeStruct.createQuotified("NS", "%%TYPE[]%%")});
+    cases.add(new Object[]{"%ns%.%type%", PgTypeStruct.createQuotified("ns", "type")});
+
+    // unquoted type names are is case-folded
+    cases.add(new Object[]{"NS.TYPE", PgTypeStruct.createQuotified("ns", "type")});
+    cases.add(new Object[]{"ns.%type[]%", PgTypeStruct.createQuotified("ns", "type[]")});
+    cases.add(new Object[]{"ns.type", PgTypeStruct.createQuotified("ns", "type")});
+
+    cases.add(new Object[]{"ns.ty.pe", PgTypeStruct.createQuotified("ns", "ty.pe")});
+    cases.add(new Object[]{"n%s.%type%", PgTypeStruct.createQuotified("n%s", "type")});
+    cases.add(new Object[]{"N%S.type", PgTypeStruct.createQuotified("n%s", "type")});
+    cases.add(new Object[]{"%n%s%.%%type%%", PgTypeStruct.createQuotified("n%s", "%type%")});
+    cases.add(new Object[]{"%n%%s%.%%%type%%%", PgTypeStruct.createQuotified("n%%s", "%%type%%")});
+
+    // bad parsing
+    cases.add(
+        new Object[]{"%n%%.%%s%%%.%%%ty%%.%%pe%%%", PgTypeStruct.createQuotified("public", "n")});
+    cases.add(new Object[]{"%ns%.%ty%.%pe%", PgTypeStruct.createQuotified("public", "%ns")});
+
+    Collection<Object[]> params = new ArrayList<Object[]>();
+    for (Object[] c : cases) {
+      String nameString = quotify((String) c[0]);
+      PgTypeStruct type = (PgTypeStruct) c[1];
+      boolean haveArrayTypeOverride = c.length > 2;
+      PgTypeStruct getPGArrayTypeType =
+          PgTypeStruct.createArrayType(haveArrayTypeOverride ? (PgTypeStruct) c[2] : type);
+      if (type.type.isElement || haveArrayTypeOverride) {
+        params.add(new Object[]{nameString, type, getPGArrayTypeType});
+      } else {
+        params.add(new Object[]{nameString, type, PgTypeStruct.UNSPECIFIED});
+      }
+      if (type.equals(PgTypeStruct.UNPARSEABLE) || type.equals(PgTypeStruct.UNSPECIFIED)) {
+        continue;
+      }
+      if (type.type.isElement) {
+        assertTypeIsInstalled(type);
+      }
+      if (type.type.isElement) {
+        String arrayNameString = nameString + PgTypeStruct.ARRAY_SUFFIX;
+        PgTypeStruct arrayType = PgTypeStruct.createArrayType(type);
+        params.add(new Object[]{arrayNameString, arrayType});
+      }
+    }
+    return params;
+  }
+
+  static Iterable<Object[]> getPGTypeParseableNameParams() {
+    Collection<Object[]> params = new ArrayList<Object[]>();
+    for (Object[] p : getPGTypeByNameParams()) {
+      PgTypeStruct type = (PgTypeStruct) p[PGTypeParam.TYPE.idx];
+      if (type == PgTypeStruct.UNPARSEABLE) {
+        continue;
+      }
+      if (type.type.isElement && !type.equals(PgTypeStruct.UNSPECIFIED)) {
+        assertTypeIsInstalled(type);
+      }
+      params.add(new Object[]{p[PGTypeParam.NAME_STRING.idx], p[PGTypeParam.TYPE.idx]});
+    }
+    return params;
+  }
+
+  static Iterable<Object[]> getPGTypeUnParseableNameParams() {
+    Collection<Object[]> params = new ArrayList<Object[]>();
+    for (Object[] p : getPGTypeByNameParams()) {
+      PgTypeStruct type = (PgTypeStruct) p[PGTypeParam.TYPE.idx];
+      if (type == PgTypeStruct.UNPARSEABLE) {
+        params.add(new Object[]{p[PGTypeParam.NAME_STRING.idx]});
+      }
+    }
+    return params;
+  }
+
+  private static Iterable<Object[]> getPGArrayTypeTestParams() {
+    Collection<Object[]> params = new ArrayList<Object[]>();
+    for (Object[] p : getPGTypeByNameParams()) {
+      if (p.length > 2) {
+        PgTypeStruct type = (PgTypeStruct) p[PGTypeParam.GET_PG_ARRAY_TYPE.idx];
+        params.add(new Object[]{p[PGTypeParam.NAME_STRING.idx], type});
+      }
+    }
+    return params;
+  }
+
+  static Iterable<Object[]> getPGArrayTypeParseableTestParams() {
+    Collection<Object[]> params = new ArrayList<Object[]>();
+    for (Object[] p : getPGArrayTypeTestParams()) {
+      PgTypeStruct type = (PgTypeStruct) p[1];
+      if (type.equals(PgTypeStruct.UNPARSEABLE)) {
+        continue;
+      }
+      params.add(new Object[]{p[PGTypeParam.NAME_STRING.idx], type});
+    }
+    return params;
+  }
+
+  static Iterable<Object[]> getPGArrayTypeUnparseableTestParams() {
+    Collection<Object[]> params = new ArrayList<Object[]>();
+    for (Object[] p : getPGArrayTypeTestParams()) {
+      PgTypeStruct type = (PgTypeStruct) p[1];
+      if (type.equals(PgTypeStruct.UNPARSEABLE)) {
+        params.add(new Object[]{p[0]});
+      }
+    }
+    return params;
+  }
+
+  static Iterable<Object[]> getPGTypeByOidParams() {
+    Collection<Object[]> cases = new ArrayList<Object[]>();
+    cases.add(new Object[]{new PgTypeStruct("pg_catalog", "text"), "text", "_text"});
+    cases.add(new Object[]{new PgTypeStruct("pg_catalog", "int2"), "int2", "_int2"});
+    cases.add(new Object[]{new PgTypeStruct("pg_catalog", "int4"), "int4", "_int4"});
+
+    cases.add(new Object[]{PgTypeStruct.createQuotified("public", " "), " ", "_ "});
+    cases.add(new Object[]{PgTypeStruct.createQuotified("public", "% %"), "% %", "_% %"});
+    cases.add(new Object[]{PgTypeStruct.createQuotified("public", "%"), "%", "_%"});
+    cases.add(new Object[]{PgTypeStruct.createQuotified("public", "%%"), "%%", "_%%"});
+    cases.add(new Object[]{PgTypeStruct.createQuotified("public", "%%%"), "%%%", "_%%%"});
+    cases.add(new Object[]{PgTypeStruct.createQuotified("public", "%%%%"), "%%%%", "_%%%%"});
+    cases.add(new Object[]{PgTypeStruct.createQuotified("public", "."), ".", "_."});
+    cases.add(new Object[]{PgTypeStruct.createQuotified("public", "%.%"), "%.%", "_%.%"});
+    cases.add(new Object[]{PgTypeStruct.createQuotified("public", "%TYPE%"), "%TYPE%", "_%TYPE%"});
+    cases.add(new Object[]{PgTypeStruct.createQuotified("public", "%TYPE[]%"), "%TYPE[]%", "_%TYPE[]%"});
+    cases.add(new Object[]{PgTypeStruct.createQuotified("public", "%type%"), "%type%", "_%type%"});
+    cases.add(new Object[]{PgTypeStruct.createQuotified("public", "%type[]%"), "%type[]%", "_%type[]%"});
+    cases.add(new Object[]{PgTypeStruct.createQuotified("public", "TYPE"), "TYPE", "_TYPE"});
+    cases.add(new Object[]{PgTypeStruct.createQuotified("public", "TYPE[]"), "TYPE[]", "_TYPE[]"});
+    cases.add(new Object[]{PgTypeStruct.createQuotified("public", "type"), "type", "_type"});
+    cases.add(new Object[]{PgTypeStruct.createQuotified("public", "type[]"), "type[]", "_type[]"});
+    cases.add(new Object[]{PgTypeStruct.createQuotified("public", "%ns"), "%ns", "_%ns"});
+    cases.add(new Object[]{PgTypeStruct.createQuotified("public", "NS.%TYPE"), "NS.%TYPE", "_NS.%TYPE"});
+
+    cases.add(new Object[]{PgTypeStruct.createQuotified("%", "%"), "%%%.%%%", "%%%.%_%%"});
+    cases.add(new Object[]{PgTypeStruct.createQuotified("%", "."), "%%%.%.%", "%%%.%_.%"});
+    cases.add(new Object[]{PgTypeStruct.createQuotified(".", "%"), "%.%.%%%", "%.%.%_%%"});
+    cases.add(new Object[]{PgTypeStruct.createQuotified(".", "."), "%.%.%.%", "%.%.%_.%"});
+
+    cases.add(new Object[]{PgTypeStruct.createQuotified("ns", " "), "%ns%.% %", "%ns%.%_ %"});
+    cases.add(new Object[]{PgTypeStruct.createQuotified("ns", "%"), "%ns%.%%%", "%ns%.%_%%"});
+    cases.add(new Object[]{PgTypeStruct.createQuotified("ns", "."), "%ns%.%.%", "%ns%.%_.%"});
+
+    cases.add(new Object[]{PgTypeStruct.createQuotified("%NS%", "%TYPE%"), "%%NS%%.%%TYPE%%", "%%NS%%.%_%TYPE%%"});
+    cases.add(new Object[]{PgTypeStruct.createQuotified("%NS%", "%TYPE[]%"), "%%NS%%.%%TYPE[]%%", "%%NS%%.%_%TYPE[]%%"});
+    cases.add(new Object[]{PgTypeStruct.createQuotified("NS", "%TYPE[]%"), "%NS%.%%TYPE[]%%", "%NS%.%_%TYPE[]%%"});
+    cases.add(new Object[]{PgTypeStruct.createQuotified("NS", "%%TYPE[]%%"), "%NS%.%%%TYPE[]%%%", "%NS%.%_%%TYPE[]%%%"});
+    cases.add(new Object[]{PgTypeStruct.createQuotified("NS", "TYPE"), "%NS%.%TYPE%", "%NS%.%_TYPE%"});
+    cases.add(new Object[]{PgTypeStruct.createQuotified("NS", "TYPE[]"), "%NS%.%TYPE[]%", "%NS%.%_TYPE[]%"});
+    cases.add(new Object[]{PgTypeStruct.createQuotified("%ns%", "%type%"), "%%ns%%.%%type%%", "%%ns%%.%_%type%%"});
+    cases.add(new Object[]{PgTypeStruct.createQuotified("%ns%", "%type[]%"), "%%ns%%.%%type[]%%", "%%ns%%.%_%type[]%%"});
+    cases.add(new Object[]{PgTypeStruct.createQuotified("ns", "type"), "%ns%.%type%", "%ns%.%_type%"});
+    cases.add(new Object[]{PgTypeStruct.createQuotified("ns", "type[]"), "%ns%.%type[]%", "%ns%.%_type[]%"});
+
+    cases.add(new Object[]{PgTypeStruct.createQuotified("ns", "ty.pe"), "%ns%.%ty.pe%", "%ns%.%_ty.pe%"});
+
+    cases.add(new Object[]{PgTypeStruct.createQuotified("n%%.%%s%%", "%%ty%%.%%pe%%"), "%n%%.%%s%%%.%%%ty%%.%%pe%%%", "%n%%.%%s%%%.%_%%ty%%.%%pe%%%"});
+    cases.add(new Object[]{PgTypeStruct.createQuotified("n%%s", "%%type%%"), "%n%%s%.%%%type%%%","%n%%s%.%_%%type%%%"});
+    cases.add(new Object[]{PgTypeStruct.createQuotified("n%.%s%", "%ty%.%pe%"), "%n%.%s%%.%%ty%.%pe%%", "%n%.%s%%.%_%ty%.%pe%%"});
+    cases.add(new Object[]{PgTypeStruct.createQuotified("n%s", "%type%"), "%n%s%.%%type%%", "%n%s%.%_%type%%"});
+    cases.add(new Object[]{PgTypeStruct.createQuotified("n%s", "type"), "%n%s%.%type%", "%n%s%.%_type%"});
+
+    Collection<Object[]> params = new ArrayList<Object[]>();
+    for (Object[] c : cases) {
+      PgTypeStruct type = (PgTypeStruct) c[0];
+      assertTypeIsInstalled(type);
+      PgTypeStruct arrayType = PgTypeStruct.createArrayType(type);
+
+      String nameString = quotify((String) c[1]);
+      String arrayNameString =
+          (c.length > 2 ? quotify((String) c[2]) : nameString + PgTypeStruct.ARRAY_SUFFIX);
+      params.add(new Object[]{type, nameString, arrayType, arrayNameString});
+    }
+    return params;
+  }
+
+  /*
+   This is similar to getPGTypeByOidParams, though it's used when testing names that have been cached
+   by getPGType(name), which has different behavior than getPGType(oid). Before refactoring, you need
+   to have a baseline to know if you're making any undesired behavioral changes. Once it's confirmed
+   that the behavior is consistent, this separate parameter set can be removed.
+   */
+  static Iterable<Object[]> getPGTypeByOidCachedNameParams() {
+    Collection<Object[]> cases = new ArrayList<Object[]>();
+    cases.add(new Object[]{new PgTypeStruct("pg_catalog", "text"), "text", "_text"});
+
+    cases.add(new Object[]{PgTypeStruct.createQuotified("public", " "), " ", "_ "});
+    cases.add(new Object[]{PgTypeStruct.createQuotified("public", "%"), "%", "_%"});
+    cases.add(new Object[]{PgTypeStruct.createQuotified("public", "%%"), "%%", "_%%"});
+    cases.add(new Object[]{PgTypeStruct.createQuotified("public", "%%%"), "%%%", "_%%%"});
+    cases.add(new Object[]{PgTypeStruct.createQuotified("public", "%%%%"), "%%%%", "_%%%%"});
+    cases.add(new Object[]{PgTypeStruct.createQuotified("public", "."), ".", "_."});
+
+    cases.add(new Object[]{PgTypeStruct.createQuotified("public", "%TYPE[]%"), "%TYPE[]%", "_%TYPE[]%"});
+    cases.add(new Object[]{PgTypeStruct.createQuotified("public", "%type[]%"), "%type[]%", "_%type[]%"});
+    cases.add(new Object[]{PgTypeStruct.createQuotified("public", "TYPE"), "TYPE", "_TYPE"});
+    cases.add(new Object[]{PgTypeStruct.createQuotified("public", "TYPE[]"), "TYPE[]", "_TYPE[]"});
+    cases.add(new Object[]{PgTypeStruct.createQuotified("public", "type"), "type", "_type"});
+    cases.add(new Object[]{PgTypeStruct.createQuotified("public", "type[]"), "type[]", "_type[]"});
+
+    // Drops namespace
+    cases.add(new Object[]{PgTypeStruct.createQuotified("ns", " "), " ", "_ "});
+    cases.add(new Object[]{PgTypeStruct.createQuotified("ns", "%"), "%", "_%"});
+    cases.add(new Object[]{PgTypeStruct.createQuotified("ns", "."), ".", "_."});
+
+    cases.add(new Object[]{PgTypeStruct.createQuotified("%NS%", "%TYPE%"), "%TYPE%", "_%TYPE%"});
+    cases.add(new Object[]{PgTypeStruct.createQuotified("%NS%", "%TYPE[]%"), "%TYPE[]%", "_%TYPE[]%"});
+    cases.add(new Object[]{PgTypeStruct.createQuotified("NS", "TYPE"), "TYPE", "_TYPE"});
+    cases.add(new Object[]{PgTypeStruct.createQuotified("NS", "TYPE[]"), "TYPE[]", "_TYPE[]"});
+    cases.add(new Object[]{PgTypeStruct.createQuotified("ns", "type"), "type", "_type"});
+    cases.add(new Object[]{PgTypeStruct.createQuotified("ns", "type[]"), "type[]", "_type[]"});
+
+    cases.add(new Object[]{PgTypeStruct.createQuotified("ns", "ty.pe"), "ty.pe", "_ty.pe"});
+    cases.add(new Object[]{PgTypeStruct.createQuotified("n%%.%%s%%", "%%ty%%.%%pe%%"), "%n%%.%%s%%%.%%%ty%%.%%pe%%%", "%n%%.%%s%%%.%_%%ty%%.%%pe%%%"});
+    cases.add(new Object[]{PgTypeStruct.createQuotified("n%%s", "%%type%%"), "%%type%%", "_%%type%%"});
+    cases.add(new Object[]{PgTypeStruct.createQuotified("n%.%s%", "%ty%.%pe%"), "%n%.%s%%.%%ty%.%pe%%", "%n%.%s%%.%_%ty%.%pe%%"});
+    cases.add(new Object[]{PgTypeStruct.createQuotified("n%s", "%type%"), "%type%", "_%type%"});
+    cases.add(new Object[]{PgTypeStruct.createQuotified("n%s", "type"), "type", "_type"});
+
+    Collection<Object[]> params = new ArrayList<Object[]>();
+    for (Object[] c : cases) {
+      params.add(new Object[]{c[0], quotify((String) c[1]), quotify((String) c[2])});
+    }
+    return params;
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/TypeInfoCacheTestParameters.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/TypeInfoCacheTestParameters.java
@@ -125,6 +125,12 @@ class TypeInfoCacheTestParameters {
         {
           put(PgTypeStruct.createQuotified("%", "%."), PgTypeStruct.UNSPECIFIED);
 
+          put(PgTypeStruct.createQuotified(".", "%"),
+              PgTypeStruct.createQuotified("%", ".%%"));
+
+          put(PgTypeStruct.createQuotified(".", "."),
+              PgTypeStruct.createQuotified("%", "%."));
+
           put(PgTypeStruct.createQuotified("public", "%%"), PgTypeStruct.UNSPECIFIED);
 
           put(PgTypeStruct.createQuotified("public", "%%%"),
@@ -132,6 +138,9 @@ class TypeInfoCacheTestParameters {
 
           put(PgTypeStruct.createQuotified("public", "%%%%"),
               PgTypeStruct.createQuotified("public", "%%"));
+
+          put(PgTypeStruct.createQuotified("public", "%.%"),
+              PgTypeStruct.createQuotified("public", "."));
 
           put(PgTypeStruct.createQuotified("public", "."), PgTypeStruct.UNSPECIFIED);
 
@@ -257,13 +266,13 @@ class TypeInfoCacheTestParameters {
     cases.add(new Object[]{" ", PgTypeStruct.createQuotified("public", " ")});
     cases.add(new Object[]{"", PgTypeStruct.UNSPECIFIED}); // empty string
     cases.add(new Object[]{"% %", PgTypeStruct.createQuotified("public", " ")});
-    cases.add(new Object[]{"%", PgTypeStruct.UNPARSEABLE});
+    cases.add(new Object[]{"%", PgTypeStruct.createQuotified("public", "%")});
     cases.add(new Object[]{"%%", PgTypeStruct.UNSPECIFIED}); // "%%" parses as (null, "")
     cases.add(new Object[]{"%%%", PgTypeStruct.createQuotified("public", "%")});
     cases.add(new Object[]{"%%%%", PgTypeStruct.createQuotified("public", "%%")});
-    cases.add(new Object[]{"%.%", PgTypeStruct.UNPARSEABLE});
+    cases.add(new Object[]{"%.%", PgTypeStruct.createQuotified("public", ".")});
     cases.add(new Object[]{"%.%.", PgTypeStruct.UNSPECIFIED}); // "%.%." parses as ("", "..")
-    cases.add(new Object[]{"%.%.%.%", PgTypeStruct.UNPARSEABLE});
+    cases.add(new Object[]{"%.%.%.%", PgTypeStruct.createQuotified("%", "%.")});
     cases.add(new Object[]{".", PgTypeStruct.UNSPECIFIED});    // "." parses as ("", "")
     cases.add(new Object[]{".%.%", PgTypeStruct.UNSPECIFIED}); // ".%.%" parses as ("", "%.%")
     cases.add(new Object[]{"..", PgTypeStruct.UNSPECIFIED});   // ".." parses as ("", ".")

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/TypeInfoCacheTestParameters.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/TypeInfoCacheTestParameters.java
@@ -131,47 +131,13 @@ class TypeInfoCacheTestParameters {
           put(PgTypeStruct.createQuotified(".", "."),
               PgTypeStruct.createQuotified("%", "%."));
 
-          put(PgTypeStruct.createQuotified("public", "%%"), PgTypeStruct.UNSPECIFIED);
-
-          put(PgTypeStruct.createQuotified("public", "%%%"),
-              PgTypeStruct.createQuotified("public", "%"));
-
-          put(PgTypeStruct.createQuotified("public", "%%%%"),
-              PgTypeStruct.createQuotified("public", "%%"));
-
-          put(PgTypeStruct.createQuotified("public", "%.%"),
-              PgTypeStruct.createQuotified("public", "."));
-
-          put(PgTypeStruct.createQuotified("public", "."), PgTypeStruct.UNSPECIFIED);
-
-          put(PgTypeStruct.createQuotified("public", "% %"),
-              PgTypeStruct.createQuotified("public", " "));
+          put(PgTypeStruct.createQuotified("public", "%.%"), PgTypeStruct.UNSPECIFIED);
 
           put(PgTypeStruct.createQuotified("n%%.%%s%%", "%%ty%%.%%pe%%"),
               PgTypeStruct.createQuotified("public", "n"));
 
           put(PgTypeStruct.createQuotified("n%.%s%", "%ty%.%pe%"),
               PgTypeStruct.createQuotified("public", "%n"));
-
-          put(PgTypeStruct.createQuotified("public", "NS.%TYPE"), PgTypeStruct.UNSPECIFIED);
-
-          put(PgTypeStruct.createQuotified("public", "%TYPE%"),
-              PgTypeStruct.createQuotified("public", "TYPE"));
-
-          put(PgTypeStruct.createQuotified("public", "%TYPE[]%"),
-              PgTypeStruct.createQuotified("public", "TYPE[]"));
-
-          put(PgTypeStruct.createQuotified("public", "%type%"),
-              PgTypeStruct.createQuotified("public", "type"));
-
-          put(PgTypeStruct.createQuotified("public", "%type[]%"),
-              PgTypeStruct.createQuotified("public", "type[]"));
-
-          put(PgTypeStruct.createQuotified("public", "TYPE"),
-              PgTypeStruct.createQuotified("public", "type"));
-
-          put(PgTypeStruct.createQuotified("public", "TYPE[]"),
-              PgTypeStruct.createQuotified("public", "type[]"));
         }
       };
 
@@ -409,23 +375,23 @@ class TypeInfoCacheTestParameters {
     cases.add(new Object[]{new PgTypeStruct("pg_catalog", "int4"), "int4", "_int4"});
 
     cases.add(new Object[]{PgTypeStruct.createQuotified("public", " "), " ", "_ "});
-    cases.add(new Object[]{PgTypeStruct.createQuotified("public", "% %"), "% %", "_% %"});
-    cases.add(new Object[]{PgTypeStruct.createQuotified("public", "%"), "%", "_%"});
-    cases.add(new Object[]{PgTypeStruct.createQuotified("public", "%%"), "%%", "_%%"});
-    cases.add(new Object[]{PgTypeStruct.createQuotified("public", "%%%"), "%%%", "_%%%"});
-    cases.add(new Object[]{PgTypeStruct.createQuotified("public", "%%%%"), "%%%%", "_%%%%"});
-    cases.add(new Object[]{PgTypeStruct.createQuotified("public", "."), ".", "_."});
-    cases.add(new Object[]{PgTypeStruct.createQuotified("public", "%.%"), "%.%", "_%.%"});
-    cases.add(new Object[]{PgTypeStruct.createQuotified("public", "%TYPE%"), "%TYPE%", "_%TYPE%"});
-    cases.add(new Object[]{PgTypeStruct.createQuotified("public", "%TYPE[]%"), "%TYPE[]%", "_%TYPE[]%"});
-    cases.add(new Object[]{PgTypeStruct.createQuotified("public", "%type%"), "%type%", "_%type%"});
-    cases.add(new Object[]{PgTypeStruct.createQuotified("public", "%type[]%"), "%type[]%", "_%type[]%"});
-    cases.add(new Object[]{PgTypeStruct.createQuotified("public", "TYPE"), "TYPE", "_TYPE"});
-    cases.add(new Object[]{PgTypeStruct.createQuotified("public", "TYPE[]"), "TYPE[]", "_TYPE[]"});
+    cases.add(new Object[]{PgTypeStruct.createQuotified("public", "% %"), "%% %%", "_% %"});
+    cases.add(new Object[]{PgTypeStruct.createQuotified("public", "%"), "%%%", "_%"});
+    cases.add(new Object[]{PgTypeStruct.createQuotified("public", "%%"), "%%%%", "_%%"});
+    cases.add(new Object[]{PgTypeStruct.createQuotified("public", "%%%"), "%%%%%", "_%%%"});
+    cases.add(new Object[]{PgTypeStruct.createQuotified("public", "%%%%"), "%%%%%%", "_%%%%"});
+    cases.add(new Object[]{PgTypeStruct.createQuotified("public", "."), "%.%", "%_.%"});
+    cases.add(new Object[]{PgTypeStruct.createQuotified("public", "%.%"), "%%.%%", "%_%.%%"});
+    cases.add(new Object[]{PgTypeStruct.createQuotified("public", "%TYPE%"), "%%TYPE%%", "%_%TYPE%%"});
+    cases.add(new Object[]{PgTypeStruct.createQuotified("public", "%TYPE[]%"), "%%TYPE[]%%", "%_%TYPE[]%%"});
+    cases.add(new Object[]{PgTypeStruct.createQuotified("public", "%type%"), "%%type%%", "_%type%"});
+    cases.add(new Object[]{PgTypeStruct.createQuotified("public", "%type[]%"), "%%type[]%%", "_%type[]%"});
+    cases.add(new Object[]{PgTypeStruct.createQuotified("public", "TYPE"), "%TYPE%", "%_TYPE%"});
+    cases.add(new Object[]{PgTypeStruct.createQuotified("public", "TYPE[]"), "%TYPE[]%", "%_TYPE[]%"});
     cases.add(new Object[]{PgTypeStruct.createQuotified("public", "type"), "type", "_type"});
-    cases.add(new Object[]{PgTypeStruct.createQuotified("public", "type[]"), "type[]", "_type[]"});
+    cases.add(new Object[]{PgTypeStruct.createQuotified("public", "type[]"), "%type[]%", "%_type[]%"});
     cases.add(new Object[]{PgTypeStruct.createQuotified("public", "%ns"), "%ns", "_%ns"});
-    cases.add(new Object[]{PgTypeStruct.createQuotified("public", "NS.%TYPE"), "NS.%TYPE", "_NS.%TYPE"});
+    cases.add(new Object[]{PgTypeStruct.createQuotified("public", "NS.%TYPE"), "%NS.%TYPE%", "%_NS.%TYPE%"});
 
     cases.add(new Object[]{PgTypeStruct.createQuotified("%", "%"), "%%%.%%%", "%%%.%_%%"});
     cases.add(new Object[]{PgTypeStruct.createQuotified("%", "."), "%%%.%.%", "%%%.%_.%"});

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/TypeInfoCacheTestSuite.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/TypeInfoCacheTestSuite.java
@@ -11,7 +11,8 @@ import org.junit.runners.Suite.SuiteClasses;
 
 @RunWith(Suite.class)
 @SuiteClasses({
-    TypeInfoCacheEdgeCaseTest.class
+    TypeInfoCacheEdgeCaseTest.class,
+    TypeInfoCacheGetTypeForAliasTest.class
 })
 
 public class TypeInfoCacheTestSuite {

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/TypeInfoCacheTestSuite.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/TypeInfoCacheTestSuite.java
@@ -20,6 +20,7 @@ import org.junit.runners.Suite.SuiteClasses;
     TypeInfoCacheGetPGTypeByNameTest.class,
     TypeInfoCacheGetPGTypeByOidCachedNameTest.class,
     TypeInfoCacheGetPGTypeByOidTest.class,
+    TypeInfoCacheGetPGTypeNamesWithSQLTypesTest.class,
     TypeInfoCacheGetPGTypeSearchPathTest.class,
     TypeInfoCacheGetPGTypeUnparseableNameTest.class,
     TypeInfoCacheGetSQLTypeSearchPathTest.class,

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/TypeInfoCacheTestSuite.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/TypeInfoCacheTestSuite.java
@@ -21,6 +21,8 @@ import org.junit.runners.Suite.SuiteClasses;
     TypeInfoCacheGetPGTypeByOidTest.class,
     TypeInfoCacheGetPGTypeSearchPathTest.class,
     TypeInfoCacheGetPGTypeUnparseableNameTest.class,
+    TypeInfoCacheGetSQLTypeSearchPathTest.class,
+    TypeInfoCacheGetSQLTypeTest.class,
     TypeInfoCacheGetTypeForAliasTest.class
 })
 

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/TypeInfoCacheTestSuite.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/TypeInfoCacheTestSuite.java
@@ -12,6 +12,15 @@ import org.junit.runners.Suite.SuiteClasses;
 @RunWith(Suite.class)
 @SuiteClasses({
     TypeInfoCacheEdgeCaseTest.class,
+    TypeInfoCacheGetPGArrayTypeCachedNameTest.class,
+    TypeInfoCacheGetPGArrayTypeTest.class,
+    TypeInfoCacheGetPGArrayTypeUnparseableNameTest.class,
+    TypeInfoCacheGetPGArrayElementTest.class,
+    TypeInfoCacheGetPGTypeByNameTest.class,
+    TypeInfoCacheGetPGTypeByOidCachedNameTest.class,
+    TypeInfoCacheGetPGTypeByOidTest.class,
+    TypeInfoCacheGetPGTypeSearchPathTest.class,
+    TypeInfoCacheGetPGTypeUnparseableNameTest.class,
     TypeInfoCacheGetTypeForAliasTest.class
 })
 

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/TypeInfoCacheTestSuite.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/TypeInfoCacheTestSuite.java
@@ -12,6 +12,7 @@ import org.junit.runners.Suite.SuiteClasses;
 @RunWith(Suite.class)
 @SuiteClasses({
     TypeInfoCacheEdgeCaseTest.class,
+    TypeInfoCacheGetArrayDelimiterTest.class,
     TypeInfoCacheGetJavaClassTest.class,
     TypeInfoCacheGetPGArrayTypeCachedNameTest.class,
     TypeInfoCacheGetPGArrayTypeTest.class,

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/TypeInfoCacheTestSuite.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/TypeInfoCacheTestSuite.java
@@ -12,6 +12,7 @@ import org.junit.runners.Suite.SuiteClasses;
 @RunWith(Suite.class)
 @SuiteClasses({
     TypeInfoCacheEdgeCaseTest.class,
+    TypeInfoCacheGetJavaClassTest.class,
     TypeInfoCacheGetPGArrayTypeCachedNameTest.class,
     TypeInfoCacheGetPGArrayTypeTest.class,
     TypeInfoCacheGetPGArrayTypeUnparseableNameTest.class,

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/TypeInfoCacheTestSuite.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/TypeInfoCacheTestSuite.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2017, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.jdbc;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+@RunWith(Suite.class)
+@SuiteClasses({
+    TypeInfoCacheEdgeCaseTest.class
+})
+
+public class TypeInfoCacheTestSuite {
+}

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/TypeInfoCacheTestUtil.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/TypeInfoCacheTestUtil.java
@@ -142,7 +142,6 @@ class TypeInfoCacheTestUtil {
       result = 31 * result + (type != null ? type.hashCode() : 0);
       return result;
     }
-
   }
 
   /**
@@ -280,6 +279,5 @@ class TypeInfoCacheTestUtil {
       assumeTrue("arrays of user-defined types require version PostgreSQL 8.3 or later",
           isSupportedType(conn, type));
     }
-
   }
 }

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/TypeInfoCacheTestUtil.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/TypeInfoCacheTestUtil.java
@@ -1,0 +1,285 @@
+/*
+ * Copyright (c) 2017, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.jdbc;
+
+import static org.junit.Assume.assumeTrue;
+
+import org.postgresql.core.Oid;
+import org.postgresql.core.ServerVersion;
+import org.postgresql.test.TestUtil;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+
+class TypeInfoCacheTestUtil {
+
+  /**
+   * Helper function to make writing strings with internal quotes easier. Rather than escape all of
+   * the quotes, use % instead and replace them all before use.
+   */
+  static String quotify(String s) {
+    return s.replaceAll("%", "\"");
+  }
+
+  enum PgTypeStructType {
+    ELEMENT(true), ARRAY(false);
+    final boolean isElement;
+
+    PgTypeStructType(boolean isElement) {
+      this.isElement = isElement;
+    }
+  }
+
+  /**
+   * A container for type information independent of TypeInfoCache implementation.
+   * As it's used to test TypeInfoCache, it can't really be dependent on it.
+   */
+  public static class PgTypeStruct {
+    static final String ARRAY_SUFFIX = "[]";
+    final String nspname;
+    final String typname;
+    final PgTypeStructType type;
+    final PgTypeStruct searchPathException;
+
+    PgTypeStruct(String nspname, String typname) {
+      this(nspname, typname, PgTypeStructType.ELEMENT);
+    }
+
+    PgTypeStruct(String nspname, String typname, PgTypeStructType type) {
+      this.nspname = nspname;
+      this.typname = typname;
+      this.type = type;
+      this.searchPathException = null;
+
+    }
+
+    static PgTypeStruct createQuotified(String nspname, String typname) {
+      return new PgTypeStruct(quotify(nspname), quotify(typname));
+    }
+
+    static PgTypeStruct createArrayType(PgTypeStruct type) {
+      if (type.equals(UNSPECIFIED)) {
+        return UNSPECIFIED;
+      } else if (type.equals(UNPARSEABLE)) {
+        return UNPARSEABLE;
+      }
+
+      return new PgTypeStruct(type.nspname, type.typname, PgTypeStructType.ARRAY);
+    }
+
+    /**
+     * For testing cases where TypeInfoCache's legacy search path behavior is important. See
+     * getPGType(String) for details
+     */
+    @SuppressWarnings("SameParameterValue")
+    static PgTypeStruct createWithSearchPathException(String nspname, String typname,
+        String exceptionNspname) {
+      return new PgTypeStruct(nspname, typname, exceptionNspname);
+    }
+
+    private PgTypeStruct(String nspname, String typname, String searchPathException) {
+      this.nspname = nspname;
+      this.typname = typname;
+      this.type = PgTypeStructType.ELEMENT;
+      this.searchPathException = new PgTypeStruct(searchPathException, this.typname, this.type);
+    }
+
+    boolean hasSearchPathException() {
+      return this.searchPathException != null;
+    }
+
+    @Override
+    public String toString() {
+      if (this.equals(UNPARSEABLE)) {
+        return "-UNPARSEABLE-";
+      }
+      if (this.equals(UNSPECIFIED)) {
+        return "-UNSPECIFIED-";
+      }
+      return "(" + nspname + "," + typname + ")" + (type.isElement ? "" : "[]");
+    }
+
+    String name() {
+      //noinspection ConstantConditions
+      return (nspname.equals("pg_catalog") ? typname :
+          (nspname == null ? "" : '"' + nspname + "\".") + '"'
+              + typname + '"') + (type.isElement ? "" : "[]");
+    }
+
+    static final PgTypeStruct UNPARSEABLE =
+        new PgTypeStruct((String) "*unparseable*", "*unparseable*");
+    static final PgTypeStruct UNSPECIFIED = new PgTypeStruct((String) null, null);
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+
+      PgTypeStruct that = (PgTypeStruct) o;
+
+      return (nspname != null ? nspname.equals(that.nspname) : that.nspname == null) && (
+          typname != null ? typname.equals(that.typname) : that.typname == null)
+          && type == that.type;
+    }
+
+    @Override
+    public int hashCode() {
+      int result = nspname != null ? nspname.hashCode() : 0;
+      result = 31 * result + (typname != null ? typname.hashCode() : 0);
+      result = 31 * result + (type != null ? type.hashCode() : 0);
+      return result;
+    }
+
+  }
+
+  /**
+   * Testing TypeInfoCache often relies on creating a bunch of types and referencing them and others
+   * that are part of core PostgreSQL implementation. In some ways it's a limited TypeInfoCache.
+   *
+   * Given a list of PgTypeStruct instances, a PgTypeset instance creates those that are user defined
+   * (as well as any necessary schema). It also stores their oids and those of any core PostgreSQL
+   * types included in the list so the types and oids can be used to reference each other in tests.
+   *
+   * The intended pattern of use:
+   *<pre>
+   *{@code
+   * // setUp
+   * PgTypeSet typeSet = PgTypeSet.createAndInstall(conn, types);
+   *
+   * // do work
+   * int myOid = typeSet.oid(type);
+   * PgTypeStruct myType = typeSet.type(myOid);
+   * assertEquals(type, myType);
+   *
+   * // tearDown
+   * typeSet.uninstall(conn);
+   * }
+   *</pre>
+   */
+  static class PgTypeSet {
+    private final HashMap<Integer, PgTypeStruct> oidToType = new HashMap<Integer, PgTypeStruct>();
+    private final HashMap<PgTypeStruct, Integer> typeToOid = new HashMap<PgTypeStruct, Integer>();
+    private final List<String> quotedTypeNames = new ArrayList<String>();
+    private final HashSet<String> quotedSchemaNames = new HashSet<String>();
+    private final HashSet<PgTypeStruct> userDefinedTypeArrayTypes = new HashSet<PgTypeStruct>();
+
+    private static final String quoteSql = "SELECT quote_ident(?), quote_ident(?)";
+    private static final String oidSql = "SELECT t.oid, COALESCE(arr.oid, 0)"
+        + " FROM pg_catalog.pg_type t"
+        + " JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace"
+        + " LEFT JOIN pg_catalog.pg_type arr"
+        + " ON (arr.typelem, arr.typinput) = (t.oid, 'array_in'::regproc)"
+        + " WHERE (n.nspname, t.typname) = (?, ?)";
+
+    private final List<PgTypeStruct> types;
+
+    PgTypeSet(List<PgTypeStruct> types) {
+      this.types = types;
+    }
+
+    void install(Connection conn) throws SQLException {
+      oidToType.put(Oid.UNSPECIFIED, PgTypeStruct.UNSPECIFIED);
+
+      PreparedStatement quoteStatement = conn.prepareStatement(quoteSql);
+      PreparedStatement oidStatement = conn.prepareStatement(oidSql);
+      ResultSet rs;
+      int oid;
+      int arrayOid;
+      PgTypeStruct arrayType;
+
+      for (PgTypeStruct type : types) {
+        quoteStatement.setString(1, type.nspname);
+        quoteStatement.setString(2, type.typname);
+        rs = quoteStatement.executeQuery();
+        rs.next();
+        String quotedSchema = rs.getString(1);
+        String quotedType = rs.getString(2);
+        String quotedName = quotedSchema + "." + quotedType;
+        arrayType = new PgTypeStruct(type.nspname, type.typname, PgTypeStructType.ARRAY);
+
+        if (!quotedSchemaNames.contains(quotedSchema)
+            && !type.nspname.equals("public")
+            && !type.nspname.equals("pg_catalog")) {
+          TestUtil.createSchema(conn, quotedSchema);
+          quotedSchemaNames.add(quotedSchema);
+        }
+
+        if (!"pg_catalog".equals(type.nspname)) {
+          if (TestUtil.haveMinimumServerVersion(conn, ServerVersion.v8_3)) {
+            TestUtil.createEnumType(conn, quotedName, "'black'");
+          } else {
+            TestUtil.createCompositeType(conn, quotedName, "color text");
+          }
+          userDefinedTypeArrayTypes.add(arrayType);
+        }
+        oidStatement.setString(1, type.nspname);
+        oidStatement.setString(2, type.typname);
+        rs = oidStatement.executeQuery();
+        rs.next();
+        oid = (int) rs.getLong(1);
+        arrayOid = (int) rs.getLong(2);
+        oidToType.put(oid, type);
+        typeToOid.put(type, oid);
+
+        /*
+        Arrays for user-defined types were introduced in 8.3. Prior to that, there will be no
+        pg_type row for the array type. We don't want to overwrite UNSPECIFIED with some other type.
+        */
+        if (isSupportedType(conn, arrayType)) {
+          oidToType.put(arrayOid, arrayType);
+        }
+        typeToOid.put(arrayType, arrayOid);
+
+        quotedTypeNames.add(quotedName);
+      }
+    }
+
+    static PgTypeSet createAndInstall(List<PgTypeStruct> types, Connection conn)
+        throws SQLException {
+      PgTypeSet typeSet = new PgTypeSet(types);
+      typeSet.install(conn);
+      return typeSet;
+    }
+
+    PgTypeStruct type(int oid) {
+      return oidToType.get(oid);
+    }
+
+    int oid(PgTypeStruct type) {
+      return typeToOid.get(type);
+    }
+
+    void uninstall(Connection conn) throws SQLException {
+      for (String quotedName : quotedTypeNames) {
+        TestUtil.dropType(conn, quotedName);
+      }
+      for (String quotedName : quotedSchemaNames) {
+        TestUtil.dropSchema(conn, quotedName);
+      }
+    }
+
+    private boolean isSupportedType(Connection conn, PgTypeStruct type) throws SQLException {
+      return TestUtil.haveMinimumServerVersion(conn, ServerVersion.v8_3)
+          || !userDefinedTypeArrayTypes.contains(type);
+    }
+
+    void assumeSupportedType(Connection conn, PgTypeStruct type) throws SQLException {
+      assumeTrue("arrays of user-defined types require version PostgreSQL 8.3 or later",
+          isSupportedType(conn, type));
+    }
+
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/TypeInfoCacheTestUtil.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/TypeInfoCacheTestUtil.java
@@ -34,6 +34,11 @@ class TypeInfoCacheTestUtil {
     return s.replaceAll("%", "\"");
   }
 
+  /**
+   * Convenience function (which was finally added in Java 8). However, we support back to JDK 1.2,
+   * and test back to OpenJDK6.
+   * https://docs.oracle.com/javase/8/docs/api/java/util/StringJoiner.html
+   */
   static String join(
       @SuppressWarnings("SameParameterValue") String separator,
       String[] coll) {
@@ -307,6 +312,10 @@ class TypeInfoCacheTestUtil {
     }
   }
 
+  /**
+   * Convenience wrapper for java.sql.Types to make it easier to read test output. Used primarily
+   * via the custom assertSQLType assertion (below).
+   */
   public static class SQLType {
     private static final HashMap<Integer, SQLType> sqlTypes = new HashMap<Integer, SQLType>();
 

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/TypeInfoCacheTestUtil.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/TypeInfoCacheTestUtil.java
@@ -283,6 +283,10 @@ class TypeInfoCacheTestUtil {
       return typeToOid.get(type);
     }
 
+    int userDefinedTypeSqlType(Connection conn) throws SQLException {
+      return (TestUtil.haveMinimumServerVersion(conn, ServerVersion.v8_3)) ? Types.VARCHAR : Types.STRUCT;
+    }
+
     void uninstall(Connection conn) throws SQLException {
       for (String quotedName : quotedTypeNames) {
         TestUtil.dropType(conn, quotedName);


### PR DESCRIPTION
This started out when I was looking to fix inconsistencies between type names cached by `getPGType(oid)` and `getPGType(name)` and expanded into quite a bit more. This adds more dedicated test coverage to `TypeInfoCache` and along the way teased out quite a few bugs that have been squashed. The number of database fetches in typical use cases has been reduced and caching has been centralized. There should be no regression with any existing tests.