### PR TITLE
use java.util.logging in the test suite

### DIFF
--- a/pgjdbc/src/test/java/org/postgresql/jdbc/InsertRewriteWithAlternatingTypesIssue584.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/InsertRewriteWithAlternatingTypesIssue584.java
@@ -27,6 +27,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Properties;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Prepared statements are, by nature, prepared. This test makes sure that new preparation sequences
@@ -37,6 +39,7 @@ import java.util.Properties;
  */
 @RunWith(Parameterized.class)
 public class InsertRewriteWithAlternatingTypesIssue584 extends BaseTest4 {
+  private static final Logger LOGGER = Logger.getLogger(InsertRewriteWithAlternatingTypesIssue584.class.getName());
 
   @Override
   public void setUp() throws Exception {
@@ -135,8 +138,7 @@ public class InsertRewriteWithAlternatingTypesIssue584 extends BaseTest4 {
       e.printStackTrace();
       SQLException nextException = e.getNextException();
       if (nextException != null) {
-        System.err.println("Next Exception:");
-        nextException.printStackTrace();
+        LOGGER.log(Level.INFO, "Next Exception", nextException);
       }
       throw e;
     }

--- a/pgjdbc/src/test/java/org/postgresql/test/TestUtil.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/TestUtil.java
@@ -25,11 +25,15 @@ import java.sql.Statement;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Utility class for JDBC tests
  */
 public class TestUtil {
+  private static final Logger LOGGER = Logger.getLogger(TestUtil.class.getName());
+
   /*
    * Returns the Test database JDBC URL
    */
@@ -206,8 +210,8 @@ public class TestUtil {
         }
         File f = getFile(name);
         if (!f.exists()) {
-          System.out.println("Configuration file " + f.getAbsolutePath()
-              + " does not exist. Consider adding it to specify test db host and login");
+          LOGGER.log(Level.INFO, "Configuration file {0} does not exist."
+              + " Consider adding it to specify test db host and login", f.getAbsolutePath());
           continue;
         }
         try {
@@ -674,25 +678,34 @@ public class TestUtil {
   }
 
   /**
-   * Print a ResultSet to System.out. This is useful for debugging tests.
+   * Log a ResultSet with Level.FINE. This is useful for debugging tests.
    */
-  public static void printResultSet(ResultSet rs) throws SQLException {
+  public static void logResultSet(Logger logger, ResultSet rs) throws SQLException {
+    logResultSet(logger, Level.FINE, rs);
+  }
+
+  /**
+   * Log a ResultSet. This is useful for debugging tests.
+   */
+  public static void logResultSet(Logger logger, Level level, ResultSet rs) throws SQLException {
     ResultSetMetaData rsmd = rs.getMetaData();
+    StringBuilder header = new StringBuilder();
     for (int i = 1; i <= rsmd.getColumnCount(); i++) {
       if (i != 1) {
-        System.out.print(", ");
+        header.append(", ");
       }
-      System.out.print(rsmd.getColumnName(i));
+      header.append(rsmd.getColumnName(i));
     }
-    System.out.println();
+    logger.log(level, header.toString());
     while (rs.next()) {
+      StringBuilder row = new StringBuilder();
       for (int i = 1; i <= rsmd.getColumnCount(); i++) {
         if (i != 1) {
-          System.out.print(", ");
+          row.append(", ");
         }
-        System.out.print(rs.getString(i));
+        row.append(rs.getString(i));
       }
-      System.out.println();
+      logger.log(level, row.toString());
     }
   }
 

--- a/pgjdbc/src/test/java/org/postgresql/test/TestUtilTestSuite.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/TestUtilTestSuite.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2017, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.test;
+
+import org.postgresql.test.jdbc2.BaseTest4;
+
+import org.junit.Test;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class TestUtilTestSuite extends BaseTest4 {
+  private static final Logger LOGGER = Logger.getLogger(TestUtilTestSuite.class.getName());
+
+  @Test
+  public void testLogResultSet() throws SQLException {
+    String sql = "SELECT * FROM pg_settings LIMIT 1";
+    Statement stmt = con.createStatement();
+    stmt.execute(sql);
+    ResultSet rs = stmt.getResultSet();
+    LOGGER.setLevel(Level.INFO);
+    TestUtil.logResultSet(LOGGER, Level.INFO, rs);
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseEncodingTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseEncodingTest.java
@@ -135,8 +135,6 @@ public class DatabaseEncodingTest {
         insert.setInt(1, i);
         insert.setString(2, testString);
 
-        // System.err.println("Inserting: " + dumpString(testString));
-
         assertEquals(1, insert.executeUpdate());
       }
     }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseEncodingTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseEncodingTest.java
@@ -22,6 +22,8 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.Statement;
 import java.util.Arrays;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /*
  * Test case for various encoding problems.
@@ -30,6 +32,7 @@ import java.util.Arrays;
  * and that bad encodings are detected.
  */
 public class DatabaseEncodingTest {
+  private static final Logger LOGGER = Logger.getLogger(DatabaseEncodingTest.class.getName());
   private static final int STEP = 100;
 
   private Connection con;
@@ -76,9 +79,8 @@ public class DatabaseEncodingTest {
 
     String dbEncoding = rs.getString(1);
     if (!dbEncoding.equals("UTF8")) {
-      System.err.println(
-          "DatabaseEncodingTest: Skipping UTF8 database tests as test database encoding is "
-              + dbEncoding);
+      LOGGER.log(Level.INFO,
+          "DatabaseEncodingTest: Skipping UTF8 database tests as test database encoding is {0}", dbEncoding);
       rs.close();
       return; // not a UTF8 database.
     }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/LoginTimeoutTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/LoginTimeoutTest.java
@@ -22,8 +22,11 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.Properties;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class LoginTimeoutTest {
+  private static final Logger LOGGER = Logger.getLogger(LoginTimeoutTest.class.getName());
 
   @Before
   public void setUp() throws Exception {
@@ -91,7 +94,7 @@ public class LoginTimeoutTest {
       try {
         localAddr = InetAddress.getLocalHost();
       } catch (UnknownHostException ex) {
-        System.err.println("WARNING: Could not resolve local host name, trying 'localhost'. " + ex);
+        LOGGER.log(Level.WARNING, "Could not resolve local host name, trying 'localhost'.", ex);
         localAddr = InetAddress.getByName("localhost");
       }
       this.listenSocket = new ServerSocket(0, 1, localAddr);

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PGTimeTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PGTimeTest.java
@@ -106,7 +106,6 @@ public class PGTimeTest extends BaseTest4 {
     assertTrue(rs.next());
 
     Time result1 = rs.getTime(1);
-    // System.out.println(stmt + " = " + sdf.format(result1));
     stmt.close();
 
     // Execute a query using with PGTime + PGInterval.
@@ -122,7 +121,6 @@ public class PGTimeTest extends BaseTest4 {
     assertTrue(rs.next());
 
     Time result2 = rs.getTime(1);
-    // System.out.println(stmt + " = " + sdf.format(result2));
     assertEquals(result1, result2);
     stmt.close();
   }
@@ -204,15 +202,11 @@ public class PGTimeTest extends BaseTest4 {
     Time tm1 = rs.getTime(1);
     Time tz1 = rs.getTime(2);
 
-    // System.out.println(pstmt1 + " -> " + tm1 + ", " + sdf.format(tz1));
-
     // Read the PGTime values.
     assertTrue(rs.next());
 
     Time tm2 = rs.getTime(1);
     Time tz2 = rs.getTime(2);
-
-    // System.out.println(pstmt2 + " -> " + tm2 + ", " + sdf.format(tz2));
 
     // Verify that the first and second versions match.
     assertEquals(tm1, tm2);

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PGTimestampTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PGTimestampTest.java
@@ -203,15 +203,11 @@ public class PGTimestampTest {
     Timestamp ts1 = rs.getTimestamp(1);
     Timestamp tz1 = rs.getTimestamp(2);
 
-    // System.out.println(pstmt1 + " -> " + ts1 + ", " + sdf.format(tz1));
-
     // Read the PGTimestamp values.
     assertTrue(rs.next());
 
     Timestamp ts2 = rs.getTimestamp(1);
     Timestamp tz2 = rs.getTimestamp(2);
-
-    // System.out.println(pstmt2 + " -> " + ts2 + ", " + sdf.format(tz2));
 
     // Verify that the first and second versions match.
     assertEquals(ts1, ts2);

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/TimezoneTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/TimezoneTest.java
@@ -97,7 +97,6 @@ public class TimezoneTest {
     // so will produce +03 timestamptz output
     con.createStatement().executeUpdate("set timezone = 'gmt-3'");
 
-    // System.err.println("++++++ TESTS START (" + getName() + ") ++++++");
   }
 
   private void connect() throws Exception {
@@ -108,7 +107,6 @@ public class TimezoneTest {
 
   @After
   public void tearDown() throws Exception {
-    // System.err.println("++++++ TESTS END (" + getName() + ") ++++++");
     TimeZone.setDefault(saveTZ);
 
     TestUtil.dropTable(con, "testtimezone");

--- a/pgjdbc/src/test/java/org/postgresql/test/ssl/SingleCertValidatingFactoryTestSuite.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/ssl/SingleCertValidatingFactoryTestSuite.java
@@ -27,9 +27,12 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Properties;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 @RunWith(Parameterized.class)
 public class SingleCertValidatingFactoryTestSuite {
+  private static final Logger LOGGER = Logger.getLogger(SingleCertValidatingFactoryTestSuite.class.getName());
   private static String IS_ENABLED_PROP_NAME = "testsinglecertfactory";
 
   /**
@@ -52,8 +55,8 @@ public class SingleCertValidatingFactoryTestSuite {
     String testSingleCertFactory = props.getProperty(IS_ENABLED_PROP_NAME);
     boolean skipTest = testSingleCertFactory == null || "".equals(testSingleCertFactory);
     if (skipTest) {
-      System.out.println("Skipping SingleCertSocketFactoryTests. To enable set the property "
-          + IS_ENABLED_PROP_NAME + "=true in the ssltest.properties file.");
+      LOGGER.log(Level.INFO, "Skipping SingleCertSocketFactoryTests. To enable set the property"
+          + " {0}=true in the ssltest.properties file.", IS_ENABLED_PROP_NAME);
       return Collections.emptyList();
     }
 
@@ -288,7 +291,7 @@ public class SingleCertValidatingFactoryTestSuite {
   public void connectSSLWithValidationProperCertEnvVar() throws SQLException, IOException {
     String envVarName = "DATASOURCE_SSL_CERT";
     if (System.getenv(envVarName) == null) {
-      System.out.println(
+      LOGGER.log(Level.INFO,
           "Skipping test connectSSLWithValidationProperCertEnvVar (env variable is not defined)");
       return;
     }
@@ -332,8 +335,8 @@ public class SingleCertValidatingFactoryTestSuite {
     // Use an environment variable that does *not* exist:
     String envVarName = "MISSING_DATASOURCE_SSL_CERT";
     if (System.getenv(envVarName) != null) {
-      System.out
-          .println("Skipping test connectSSLWithValidationMissingEnvVar (env variable is defined)");
+      LOGGER.log(Level.INFO,
+          "Skipping test connectSSLWithValidationMissingEnvVar (env variable is defined)");
       return;
     }
 

--- a/pgjdbc/src/test/java/org/postgresql/test/ssl/SslTestSuite.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/ssl/SslTestSuite.java
@@ -10,13 +10,16 @@ import org.postgresql.test.TestUtil;
 import junit.framework.TestSuite;
 
 import java.util.Properties;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class SslTestSuite extends TestSuite {
+  private static final Logger LOGGER = Logger.getLogger(SslTestSuite.class.getName());
   private static Properties prop;
 
   private static void add(TestSuite suite, String param) {
     if (prop.getProperty(param, "").equals("")) {
-      System.out.println("Skipping " + param + ".");
+      LOGGER.log(Level.INFO, "Skipping {0}.", param);
     } else {
       suite.addTest(SslTest.getSuite(prop, param));
     }

--- a/pgjdbc/src/test/java/org/postgresql/test/util/StrangeInputStream.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/util/StrangeInputStream.java
@@ -10,21 +10,23 @@ import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Random;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * {@link InputStream} implementation that reads less data than is provided in the destination
  * array. This allows to stress test {@link org.postgresql.copy.CopyManager} or other consumers.
  */
 public class StrangeInputStream extends FilterInputStream {
+  private static final Logger LOGGER = Logger.getLogger(FilterInputStream.class.getName());
   private Random rand; // generator of fun events
 
   public StrangeInputStream(InputStream is) throws FileNotFoundException {
     super(is);
     rand = new Random();
     long seed = Long.getLong("StrangeInputStream.seed", System.currentTimeMillis());
-    System.out
-        .println("Using seed = " + seed + " for StrangeInputStream. Set -DStrangeInputStream.seed="
-            + seed + " to reproduce the test");
+    LOGGER.log(Level.INFO, "Using seed = {0,number,#} for StrangeInputStream."
+        + " Set -DStrangeInputStream.seed={0,number,#} to reproduce the test", new Object[]{seed, seed});
     rand.setSeed(seed);
   }
 


### PR DESCRIPTION
This replaces the various `println` statements in the test suite with calls to `java.util.logging.Logger` instances. Current `loggerLevel` in `build.properties` is set to `OFF`, so most of the logging is silenced by default. Logging in a static context (for example, in constructors), respects the default logging level for `j.u.l`, which is `INFO`. An example of this is the seed values reported for `StrangeInputStream`. This is in effect until the driver sets `loggerLevel` from the properties. As with other properties, `loggerLevel` can be overridden in `build.local.properties`.

The added `logging.properties` file will be picked up if the surefire configuration in pgjdbc/pgjdbc-parent-poms, which makes the formatting of the log lines a bit more pleasant and similar to what it is replacing.

One issue I found when adding this logging is that `TestUtil.openDB` logs a NPE in `org.postgresql.Driver` due to a null `PARENT_LOGGER` log level (see below). I suspect this has something to do with how the driver is initialized in the test MultiHostTestSuite, but I haven't confirmed this. AFAICT, this is independent of the additional logging as I can observe it when debugging master.

```
SEVERE: Unexpected connection error: 
java.lang.NullPointerException
	at java.util.logging.Handler.setLevel(Handler.java:263)
	at org.postgresql.Driver.setupLoggerFromProperties(Driver.java:341)
	at org.postgresql.Driver.connect(Driver.java:239)
	at java.sql.DriverManager.getConnection(DriverManager.java:664)
	at java.sql.DriverManager.getConnection(DriverManager.java:208)
	at org.postgresql.test.hostchooser.MultiHostTestSuite.openSlaveDB(MultiHostTestSuite.java:31)
	at org.postgresql.test.hostchooser.MultiHostTestSuite.suite(MultiHostTestSuite.java:56)
```

I've submitted these as separate commits so they can be reviewed or picked à la carte.