### PR TITLE
Make GSS JAAS login optional

### DIFF
--- a/docs/documentation/head/connect.md
+++ b/docs/documentation/head/connect.md
@@ -309,10 +309,10 @@ Connection conn = DriverManager.getConnection(url);
 * **jaasLogin** = boolean
 
 	Specifies whether to perform a JAAS login before authenticating with GSSAPI.
-	If set to `true` (the default), it allows obtaining GSS credentials using a
-	JAAS login module (e.g. `Krb5LoginModule`) before authenticating. To skip the
-	JAAS login, for example if the native GSS implementation is being used to
-	obtain credentials, set this to `false`.
+	If set to `true` (the default), the driver will attempt to obtain GSS credentials
+	using the configured JAAS login module(s) (e.g. `Krb5LoginModule`) before
+	authenticating. To skip the JAAS login, for example if the native GSS
+	implementation is being used to obtain credentials, set this to `false`.
 
 * **ApplicationName** = String
 

--- a/docs/documentation/head/connect.md
+++ b/docs/documentation/head/connect.md
@@ -304,7 +304,15 @@ Connection conn = DriverManager.getConnection(url);
 
 * **jaasApplicationName** = String
 
-	Specifies the name of the JAAS system or application login configuration. 
+	Specifies the name of the JAAS system or application login configuration.
+
+* **jaasLogin** = boolean
+
+	Specifies whether to perform a JAAS login before authenticating with GSSAPI.
+	If set to `true` (the default), it allows obtaining GSS credentials using a
+	JAAS login module (e.g. `Krb5LoginModule`) before authenticating. To skip the
+	JAAS login, for example if the native GSS implementation is being used to
+	obtain credentials, set this to `false`.
 
 * **ApplicationName** = String
 

--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -305,6 +305,13 @@ public enum PGProperty {
   APPLICATION_NAME("ApplicationName", DriverInfo.DRIVER_NAME, "Name of the Application (backend >= 9.0)"),
 
   /**
+   * Flag to enable/disable obtaining a GSS credential via JAAS login before authenticating.
+   * Useful if setting system property javax.security.auth.useSubjectCredsOnly=false
+   * or using native GSS with system property sun.security.jgss.native=true
+   */
+  JAAS_LOGIN("jaasLogin", "true", "Login with JAAS before doing GSSAPI authentication"),
+
+  /**
    * Specifies the name of the JAAS system or application login configuration.
    */
   JAAS_APPLICATION_NAME("jaasApplicationName", null,

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java
@@ -593,7 +593,8 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
                   /* Use JGSS's GSSAPI for this request */
                   org.postgresql.gss.MakeGSS.authenticate(pgStream, host, user, password,
                       PGProperty.JAAS_APPLICATION_NAME.get(info),
-                      PGProperty.KERBEROS_SERVER_NAME.get(info), usespnego);
+                      PGProperty.KERBEROS_SERVER_NAME.get(info), usespnego,
+                      PGProperty.JAAS_LOGIN.getBoolean(info));
                 }
                 break;
 

--- a/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
+++ b/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
@@ -881,6 +881,22 @@ public abstract class BaseDataSource implements CommonDataSource, Referenceable 
   }
 
   /**
+   * @return true if perform JAAS login before GSS authentication
+   * @see PGProperty#JAAS_LOGIN
+   */
+  public boolean getJaasLogin() {
+    return PGProperty.JAAS_LOGIN.getBoolean(properties);
+  }
+
+  /**
+   * @param doLogin true if perform JAAS login before GSS authentication
+   * @see PGProperty#JAAS_LOGIN
+   */
+  public void setJaasLogin(boolean doLogin) {
+    PGProperty.JAAS_LOGIN.set(properties, doLogin);
+  }
+
+  /**
    * @return Kerberos server name
    * @see PGProperty#KERBEROS_SERVER_NAME
    */

--- a/pgjdbc/src/main/java/org/postgresql/gss/MakeGSS.java
+++ b/pgjdbc/src/main/java/org/postgresql/gss/MakeGSS.java
@@ -29,7 +29,7 @@ public class MakeGSS {
   private static final Logger LOGGER = Logger.getLogger(MakeGSS.class.getName());
 
   public static void authenticate(PGStream pgStream, String host, String user, String password,
-      String jaasApplicationName, String kerberosServerName, boolean useSpnego)
+      String jaasApplicationName, String kerberosServerName, boolean useSpnego, boolean jaasLogin)
           throws IOException, SQLException {
     LOGGER.log(Level.FINEST, " <=BE AuthenticationReqGSS");
 
@@ -42,7 +42,7 @@ public class MakeGSS {
 
     Exception result;
     try {
-      boolean performAuthentication = true;
+      boolean performAuthentication = jaasLogin;
       GSSCredential gssCredential = null;
       Subject sub = Subject.getSubject(AccessController.getContext());
       if (sub != null) {


### PR DESCRIPTION
The scenario where this is useful: we have users who use the OS-native Kerberos support to obtain a Kerberos ticket-granting ticket when they start using their workstation. The Kerberos TGT is stored in the OS-native credential cache (e.g. an API: cache on Mac OS X, or a FILE: or KEYRING: cache on Linux). They later want to use a SQL client application (e.g SQL Workbench/J) that uses this JDBC driver to talk to PostgreSQL, using GSS authentication with their existing Kerberos ticket.

Unfortunately there is no support in Oracle's Krb5LoginModule for reading Kerberos tickets out of API: or KEYRING: credential caches, it only supports file ccaches, so the usage of Krb5LoginModule to try and obtain Kerberos credentials throws an exception.

However, there is support in Oracle JDK 8 for using the native GSS-API implementation on Linux, Solaris and OS X by setting the system property “sun.security.jgss.native” to true. That allows JGSS to use existing tickets stored in native credential caches, so no JAAS login is required. If we skip trying to read the ticket using Krb5LoginModule, and rely on the native implementation, users can authenticate to PostgreSQL using their existing native ticket, without an extra prompt for a password.

The default for this new option is true, i.e. do attempt JAAS login (unless the Subject already has GSS credentials), which is the same as the current behaviour. The option must explicitly be set to false to disable JAAS login.