### PR TITLE
feat: fetch size for ref cursor

### DIFF
--- a/docs/documentation/head/callproc.md
+++ b/docs/documentation/head/callproc.md
@@ -69,12 +69,8 @@ When calling a function that returns a refcursor you must cast the return type o
 
 ### Note
 	  
-> One notable limitation of the current support for a `ResultSet` created from
-a refcursor is that even though it is a cursor backed `ResultSet`, all data will
-be retrieved and cached on the client. The `Statement` fetch size parameter
-described in the section called [“Getting results based on a cursor”](query.html#query-with-cursor)
-is ignored. This limitation is a deficiency of the JDBC driver, not the server,
-and it is technically possible to remove it, we just haven't found the time.
+> The `Statement` fetch size parameter described in the section called [“Getting results based on a cursor”](query.html#query-with-cursor) 
+can be used to improve memory usage and performance on large data sets.
 
 <a name="get-refcursor-from-function-call"></a>
 **Example 6.3. Getting refcursor Value From a Function**

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
@@ -13,6 +13,7 @@ import org.postgresql.core.Encoding;
 import org.postgresql.core.Field;
 import org.postgresql.core.Oid;
 import org.postgresql.core.Query;
+import org.postgresql.core.QueryExecutor;
 import org.postgresql.core.ResultCursor;
 import org.postgresql.core.ResultHandlerBase;
 import org.postgresql.core.TypeInfo;
@@ -230,36 +231,7 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
 
         // Specialized support for ref cursors is neater.
         if (type.equals("refcursor")) {
-          // Fetch all results.
-          String cursorName = getString(columnIndex);
-
-          StringBuilder sb = new StringBuilder("FETCH ALL IN ");
-          Utils.escapeIdentifier(sb, cursorName);
-
-          // nb: no BEGIN triggered here. This is fine. If someone
-          // committed, and the cursor was not holdable (closing the
-          // cursor), we avoid starting a new xact and promptly causing
-          // it to fail. If the cursor *was* holdable, we don't want a
-          // new xact anyway since holdable cursor state isn't affected
-          // by xact boundaries. If our caller didn't commit at all, or
-          // autocommit was on, then we wouldn't issue a BEGIN anyway.
-          //
-          // We take the scrollability from the statement, but until
-          // we have updatable cursors it must be readonly.
-          ResultSet rs =
-              connection.execSQLQuery(sb.toString(), resultsettype, ResultSet.CONCUR_READ_ONLY);
-          //
-          // In long running transactions these backend cursors take up memory space
-          // we could close in rs.close(), but if the transaction is closed before the result set,
-          // then
-          // the cursor no longer exists
-
-          sb.setLength(0);
-          sb.append("CLOSE ");
-          Utils.escapeIdentifier(sb, cursorName);
-          connection.execSQLUpdate(sb.toString());
-          ((PgResultSet) rs).setRefCursor(cursorName);
-          return rs;
+          return getRefCursor(columnIndex);
         }
         if ("hstore".equals(type)) {
           if (isBinary(columnIndex)) {
@@ -271,6 +243,46 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
         // Caller determines what to do (JDBC3 overrides in this case)
         return null;
     }
+  }
+
+  private Object getRefCursor(int columnIndex) throws SQLException {
+    // Fetch all results.
+    String cursorName = getString(columnIndex);
+
+    StringBuilder sb = new StringBuilder("FETCH ");
+    if (fetchSize > 0) {
+      sb.append("FORWARD ");
+      sb.append(fetchSize);
+      sb.append(" IN ");
+    } else {
+      sb.append("ALL IN ");
+    }
+    Utils.escapeIdentifier(sb, cursorName);
+
+    // nb: no BEGIN triggered here. This is fine. If someone
+    // committed, and the cursor was not holdable (closing the
+    // cursor), we avoid starting a new xact and promptly causing
+    // it to fail. If the cursor *was* holdable, we don't want a
+    // new xact anyway since holdable cursor state isn't affected
+    // by xact boundaries. If our caller didn't commit at all, or
+    // autocommit was on, then we wouldn't issue a BEGIN anyway.
+    //
+    // We take the scrollability from the statement, but until
+    // we have updatable cursors it must be readonly.
+    ResultSet rs =
+        connection.execSQLQuery(sb.toString(), resultsettype, ResultSet.CONCUR_READ_ONLY);
+    //
+    // In long running transactions these backend cursors take up memory space
+    // we could close in rs.close(), but if the transaction is closed before the result set,
+    // then
+    // the cursor no longer exists
+    if (fetchSize == 0) {
+      closeRefCursor(cursorName);
+    }
+
+    rs.setFetchSize(fetchSize);
+    ((PgResultSet) rs).setRefCursor(cursorName);
+    return rs;
   }
 
   private void checkScrollable() throws SQLException {
@@ -1834,7 +1846,7 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
     }
 
     if (current_row + 1 >= rows.size()) {
-      if (cursor == null || (maxRows > 0 && row_offset + rows.size() >= maxRows)) {
+      if (checkEndOfResult()) {
         current_row = rows.size();
         this_row = null;
         rowBuffer = null;
@@ -1853,7 +1865,17 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
       }
 
       // Execute the fetch and update this resultset.
-      connection.getQueryExecutor().fetch(cursor, new CursorResultHandler(), fetchRows);
+      if (refCursorName == null || refCursorName.isEmpty()) {
+        connection.getQueryExecutor().fetch(cursor, new CursorResultHandler(), fetchRows);
+      } else {
+        StringBuilder sb = new StringBuilder("FETCH FORWARD ");
+        sb.append(fetchRows);
+        sb.append(" IN ");
+        Utils.escapeIdentifier(sb, refCursorName);
+        final Query cursorForward = connection.getQueryExecutor().createSimpleQuery(sb.toString());
+        connection.getQueryExecutor().execute(cursorForward, null, new CursorResultHandler(), maxRows, fetchSize, QueryExecutor.QUERY_ONESHOT | QueryExecutor.QUERY_SUPPRESS_BEGIN
+                | QueryExecutor.QUERY_EXECUTE_AS_SIMPLE );
+      }
 
       current_row = 0;
 
@@ -1871,6 +1893,10 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
     return true;
   }
 
+  private boolean checkEndOfResult() {
+    return cursor == null && refCursorName == null || (refCursorName != null && fetchSize == 0) || (maxRows > 0 && row_offset + rows.size() >= maxRows);
+  }
+
   public void close() throws SQLException {
     try {
       // release resources held (memory for tuples)
@@ -1879,9 +1905,18 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
         cursor.close();
         cursor = null;
       }
+      if (refCursorName != null && fetchSize > 0) {
+        closeRefCursor(refCursorName);
+      }
     } finally {
       ((PgStatement) statement).checkCompletion();
     }
+  }
+
+  private void closeRefCursor(String refCursorName) throws SQLException {
+    StringBuilder sb = new StringBuilder("CLOSE ");
+    Utils.escapeIdentifier(sb, refCursorName);
+    connection.execSQLUpdate(sb.toString());
   }
 
   public boolean wasNull() throws SQLException {

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/RefCursorTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/RefCursorTest.java
@@ -90,49 +90,48 @@ public class RefCursorTest extends BaseTest4 {
 
   @Test
   public void testResult() throws SQLException {
-    assumeCallableStatementsSupported();
-    CallableStatement call = con.prepareCall("{ ? = call testspg__getRefcursor () }");
-    call.registerOutParameter(1, cursorType);
-    call.execute();
-    ResultSet rs = (ResultSet) call.getObject(1);
-
-    assertTrue(rs.next());
-    assertEquals(1, rs.getInt(1));
-
-    assertTrue(rs.next());
-    assertEquals(2, rs.getInt(1));
-
-    assertTrue(rs.next());
-    assertEquals(3, rs.getInt(1));
-
-    assertTrue(rs.next());
-    assertEquals(4, rs.getInt(1));
-
-    assertTrue(rs.next());
-    assertEquals(6, rs.getInt(1));
-
-    assertTrue(rs.next());
-    assertEquals(9, rs.getInt(1));
-
-    assertFalse(rs.next());
-    rs.close();
-
-    call.close();
+    checkAndRunResult(null);
+    return;
   }
 
+  @Test
+  public void testFetchSizeZero() throws SQLException {
+    checkAndRunResult(0);
+  }
+
+  @Test
+  public void testFetchSizeOne() throws SQLException {
+    checkAndRunResult(1);
+  }
+
+  @Test
+  public void testFetchSize() throws SQLException {
+    checkAndRunResult(3);
+  }
+
+  @Test
+  public void testFetchHighBoundDecrease1() throws SQLException {
+    checkAndRunResult(5);
+  }
+
+  @Test
+  public void testFetchHighBound() throws SQLException {
+    checkAndRunResult(6);
+  }
+
+  @Test
+  public void testFetchHighBoundIncrease1() throws SQLException {
+    checkAndRunResult(7);
+  }
 
   @Test
   public void testEmptyResult() throws SQLException {
-    assumeCallableStatementsSupported();
-    CallableStatement call = con.prepareCall("{ ? = call testspg__getEmptyRefcursor () }");
-    call.registerOutParameter(1, cursorType);
-    call.execute();
+    checkAndRunEmptyResult(null);
+  }
 
-    ResultSet rs = (ResultSet) call.getObject(1);
-    assertTrue(!rs.next());
-    rs.close();
-
-    call.close();
+  @Test
+  public void testFetchEmptyResult() throws SQLException {
+    checkAndRunEmptyResult(3);
   }
 
   @Test
@@ -169,6 +168,56 @@ public class RefCursorTest extends BaseTest4 {
     assertTrue(rs.last());
     assertEquals(6, rs.getRow());
     rs.close();
+    call.close();
+  }
+
+  private void checkAndRunResult(Integer fetchSize) throws SQLException {
+    assumeCallableStatementsSupported();
+    CallableStatement call = con.prepareCall("{ ? = call testspg__getRefcursor () }");
+    call.registerOutParameter(1, cursorType);
+    if (fetchSize != null) {
+      call.setFetchSize(fetchSize);
+    }
+    call.execute();
+    ResultSet rs = (ResultSet) call.getObject(1);
+
+    assertTrue(rs.next());
+    assertEquals(1, rs.getInt(1));
+
+    assertTrue(rs.next());
+    assertEquals(2, rs.getInt(1));
+
+    assertTrue(rs.next());
+    assertEquals(3, rs.getInt(1));
+
+    assertTrue(rs.next());
+    assertEquals(4, rs.getInt(1));
+
+    assertTrue(rs.next());
+    assertEquals(6, rs.getInt(1));
+
+    assertTrue(rs.next());
+    assertEquals(9, rs.getInt(1));
+
+    assertFalse(rs.next());
+    rs.close();
+
+    call.close();
+  }
+
+  private void checkAndRunEmptyResult(Integer fetchSize) throws SQLException {
+    assumeCallableStatementsSupported();
+    CallableStatement call = con.prepareCall("{ ? = call testspg__getEmptyRefcursor () }");
+    call.registerOutParameter(1, cursorType);
+    if (fetchSize != null) {
+      call.setFetchSize(fetchSize);
+    }
+    call.execute();
+
+    ResultSet rs = (ResultSet) call.getObject(1);
+    assertTrue(!rs.next());
+    rs.close();
+
     call.close();
   }
 


### PR DESCRIPTION
feat: implement fetchSize for refCursor

big cursors take up less memory and have improved performance after the change when using fetchSize

closes #924