### PR TITLE
doc: Added quotes to URL in '@see' tag over NTDSAPI#DsMakeSpnW

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/sspi/NTDSAPI.java
+++ b/pgjdbc/src/main/java/org/postgresql/sspi/NTDSAPI.java
@@ -36,7 +36,7 @@ interface NTDSAPI extends StdCallLibrary {
    *        terminator (out)
    * @param spn SPN buffer (in/out)
    * @return Error code ERROR_SUCCESS, ERROR_BUFFER_OVERFLOW or ERROR_INVALID_PARAMETER
-   * @see http://msdn.microsoft.com/en-us/library/ms676007(v=vs.85).aspx
+   * @see "http://msdn.microsoft.com/en-us/library/ms676007(v=vs.85).aspx"
    */
   int DsMakeSpnW(WString serviceClass, /* in */
       WString serviceName, /* in */


### PR DESCRIPTION
doc: Added quotes to URL in `'@see'` tag over org.postgresql.sspi.NTDSAPI#DsMakeSpnW for syntactic correctness

The javadoc syntax in [oracle docs](http://docs.oracle.com/javase/7/docs/technotes/tools/windows/javadoc.html#see) states that a string should be enclosed in quotes. Even javadoc tool itself gives an error if unquoted strings are used as `@see` tag's argument. On the other hand `references` in `@see` tag don't need any quotes which can also be concluded looking at the syntax.

[checkstyle](https://github.com/checkstyle/checkstyle/) has actually decided to lay down parse errors for such cases. `checkstyle` uses `pgjdbc` repo in `wercker` CI and this particular input case results in CI failure.

**See also:**  [checkstyle/pull/4550#issuecomment](https://github.com/checkstyle/checkstyle/pull/4550#issuecomment-312521474), [checkstyle/issues/4752](https://github.com/checkstyle/checkstyle/issues/4752), [checkstyle/pull/5011#issuecomment](https://github.com/checkstyle/checkstyle/pull/5011#issuecomment-325129446)