### PR TITLE
feat: improve ResultSet#getObject(int, Class)

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
@@ -3166,13 +3166,15 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
       if (sqlType == Types.NUMERIC || sqlType == Types.DECIMAL) {
         return type.cast(getBigDecimal(columnIndex));
       } else {
-        throw new SQLException("conversion to " + type + " from " + sqlType + " not supported");
+        throw new PSQLException(GT.tr("conversion to {0} from {1} not supported", type, sqlType),
+                PSQLState.INVALID_PARAMETER_VALUE);
       }
     } else if (type == String.class) {
       if (sqlType == Types.CHAR || sqlType == Types.VARCHAR) {
         return type.cast(getString(columnIndex));
       } else {
-        throw new SQLException("conversion to " + type + " from " + sqlType + " not supported");
+        throw new PSQLException(GT.tr("conversion to {0} from {1} not supported", type, sqlType),
+                PSQLState.INVALID_PARAMETER_VALUE);
       }
     } else if (type == Boolean.class) {
       if (sqlType == Types.BOOLEAN || sqlType == Types.BIT) {
@@ -3182,17 +3184,30 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
         }
         return type.cast(booleanValue);
       } else {
-        throw new SQLException("conversion to " + type + " from " + sqlType + " not supported");
+        throw new PSQLException(GT.tr("conversion to {0} from {1} not supported", type, sqlType),
+                PSQLState.INVALID_PARAMETER_VALUE);
+      }
+    } else if (type == Short.class) {
+      if (sqlType == Types.SMALLINT) {
+        short shortValue = getShort(columnIndex);
+        if (wasNull()) {
+          return null;
+        }
+        return type.cast(shortValue);
+      } else {
+        throw new PSQLException(GT.tr("conversion to {0} from {1} not supported", type, sqlType),
+                PSQLState.INVALID_PARAMETER_VALUE);
       }
     } else if (type == Integer.class) {
-      if (sqlType == Types.SMALLINT || sqlType == Types.INTEGER) {
+      if (sqlType == Types.INTEGER || sqlType == Types.SMALLINT) {
         int intValue = getInt(columnIndex);
         if (wasNull()) {
           return null;
         }
         return type.cast(intValue);
       } else {
-        throw new SQLException("conversion to " + type + " from " + sqlType + " not supported");
+        throw new PSQLException(GT.tr("conversion to {0} from {1} not supported", type, sqlType),
+                PSQLState.INVALID_PARAMETER_VALUE);
       }
     } else if (type == Long.class) {
       if (sqlType == Types.BIGINT) {
@@ -3202,7 +3217,19 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
         }
         return type.cast(longValue);
       } else {
-        throw new SQLException("conversion to " + type + " from " + sqlType + " not supported");
+        throw new PSQLException(GT.tr("conversion to {0} from {1} not supported", type, sqlType),
+                PSQLState.INVALID_PARAMETER_VALUE);
+      }
+    } else if (type == BigInteger.class) {
+      if (sqlType == Types.BIGINT) {
+        long longValue = getLong(columnIndex);
+        if (wasNull()) {
+          return null;
+        }
+        return type.cast(BigInteger.valueOf(longValue));
+      } else {
+        throw new PSQLException(GT.tr("conversion to {0} from {1} not supported", type, sqlType),
+                PSQLState.INVALID_PARAMETER_VALUE);
       }
     } else if (type == Float.class) {
       if (sqlType == Types.REAL) {
@@ -3212,7 +3239,8 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
         }
         return type.cast(floatValue);
       } else {
-        throw new SQLException("conversion to " + type + " from " + sqlType + " not supported");
+        throw new PSQLException(GT.tr("conversion to {0} from {1} not supported", type, sqlType),
+                PSQLState.INVALID_PARAMETER_VALUE);
       }
     } else if (type == Double.class) {
       if (sqlType == Types.FLOAT || sqlType == Types.DOUBLE) {
@@ -3222,19 +3250,22 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
         }
         return type.cast(doubleValue);
       } else {
-        throw new SQLException("conversion to " + type + " from " + sqlType + " not supported");
+        throw new PSQLException(GT.tr("conversion to {0} from {1} not supported", type, sqlType),
+                PSQLState.INVALID_PARAMETER_VALUE);
       }
     } else if (type == Date.class) {
       if (sqlType == Types.DATE) {
         return type.cast(getDate(columnIndex));
       } else {
-        throw new SQLException("conversion to " + type + " from " + sqlType + " not supported");
+        throw new PSQLException(GT.tr("conversion to {0} from {1} not supported", type, sqlType),
+                PSQLState.INVALID_PARAMETER_VALUE);
       }
     } else if (type == Time.class) {
       if (sqlType == Types.TIME) {
         return type.cast(getTime(columnIndex));
       } else {
-        throw new SQLException("conversion to " + type + " from " + sqlType + " not supported");
+        throw new PSQLException(GT.tr("conversion to {0} from {1} not supported", type, sqlType),
+                PSQLState.INVALID_PARAMETER_VALUE);
       }
     } else if (type == Timestamp.class) {
       if (sqlType == Types.TIMESTAMP
@@ -3244,7 +3275,8 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
       ) {
         return type.cast(getTimestamp(columnIndex));
       } else {
-        throw new SQLException("conversion to " + type + " from " + sqlType + " not supported");
+        throw new PSQLException(GT.tr("conversion to {0} from {1} not supported", type, sqlType),
+                PSQLState.INVALID_PARAMETER_VALUE);
       }
     } else if (type == Calendar.class) {
       if (sqlType == Types.TIMESTAMP
@@ -3257,37 +3289,44 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
         calendar.setTimeInMillis(timestampValue.getTime());
         return type.cast(calendar);
       } else {
-        throw new SQLException("conversion to " + type + " from " + sqlType + " not supported");
+        throw new PSQLException(GT.tr("conversion to {0} from {1} not supported", type, sqlType),
+                PSQLState.INVALID_PARAMETER_VALUE);
       }
     } else if (type == Blob.class) {
       if (sqlType == Types.BLOB || sqlType == Types.BINARY || sqlType == Types.BIGINT) {
         return type.cast(getBlob(columnIndex));
       } else {
-        throw new SQLException("conversion to " + type + " from " + sqlType + " not supported");
+        throw new PSQLException(GT.tr("conversion to {0} from {1} not supported", type, sqlType),
+                PSQLState.INVALID_PARAMETER_VALUE);
       }
     } else if (type == Clob.class) {
       if (sqlType == Types.CLOB || sqlType == Types.BIGINT) {
         return type.cast(getClob(columnIndex));
       } else {
-        throw new SQLException("conversion to " + type + " from " + sqlType + " not supported");
+        throw new PSQLException(GT.tr("conversion to {0} from {1} not supported", type, sqlType),
+                PSQLState.INVALID_PARAMETER_VALUE);
       }
-    } else if (type == NClob.class) {
-      if (sqlType == Types.NCLOB) {
-        return type.cast(getNClob(columnIndex));
+    } else if (type == java.util.Date.class) {
+      if (sqlType == Types.TIMESTAMP) {
+        Timestamp timestamp = getTimestamp(columnIndex);
+        return type.cast(new java.util.Date(timestamp.getTime()));
       } else {
-        throw new SQLException("conversion to " + type + " from " + sqlType + " not supported");
+        throw new PSQLException(GT.tr("conversion to {0} from {1} not supported", type, sqlType),
+                PSQLState.INVALID_PARAMETER_VALUE);
       }
     } else if (type == Array.class) {
       if (sqlType == Types.ARRAY) {
         return type.cast(getArray(columnIndex));
       } else {
-        throw new SQLException("conversion to " + type + " from " + sqlType + " not supported");
+        throw new PSQLException(GT.tr("conversion to {0} from {1} not supported", type, sqlType),
+                PSQLState.INVALID_PARAMETER_VALUE);
       }
     } else if (type == SQLXML.class) {
       if (sqlType == Types.SQLXML) {
         return type.cast(getSQLXML(columnIndex));
       } else {
-        throw new SQLException("conversion to " + type + " from " + sqlType + " not supported");
+        throw new PSQLException(GT.tr("conversion to {0} from {1} not supported", type, sqlType),
+                PSQLState.INVALID_PARAMETER_VALUE);
       }
     } else if (type == UUID.class) {
       return type.cast(getObject(columnIndex));
@@ -3318,19 +3357,22 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
         }
         return type.cast(dateValue.toLocalDate());
       } else {
-        throw new SQLException("conversion to " + type + " from " + sqlType + " not supported");
+        throw new PSQLException(GT.tr("conversion to {0} from {1} not supported", type, sqlType),
+                PSQLState.INVALID_PARAMETER_VALUE);
       }
     } else if (type == LocalTime.class) {
       if (sqlType == Types.TIME) {
         return type.cast(getLocalTime(columnIndex));
       } else {
-        throw new SQLException("conversion to " + type + " from " + sqlType + " not supported");
+        throw new PSQLException(GT.tr("conversion to {0} from {1} not supported", type, sqlType),
+                PSQLState.INVALID_PARAMETER_VALUE);
       }
     } else if (type == LocalDateTime.class) {
       if (sqlType == Types.TIMESTAMP) {
         return type.cast(getLocalDateTime(columnIndex));
       } else {
-        throw new SQLException("conversion to " + type + " from " + sqlType + " not supported");
+        throw new PSQLException(GT.tr("conversion to {0} from {1} not supported", type, sqlType),
+                PSQLState.INVALID_PARAMETER_VALUE);
       }
     } else if (type == OffsetDateTime.class) {
       if (sqlType == Types.TIMESTAMP_WITH_TIMEZONE || sqlType == Types.TIMESTAMP) {
@@ -3349,7 +3391,8 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
         OffsetDateTime offsetDateTime = OffsetDateTime.ofInstant(timestampValue.toInstant(), ZoneOffset.UTC);
         return type.cast(offsetDateTime);
       } else {
-        throw new SQLException("conversion to " + type + " from " + sqlType + " not supported");
+        throw new PSQLException(GT.tr("conversion to {0} from {1} not supported", type, sqlType),
+                PSQLState.INVALID_PARAMETER_VALUE);
       }
       //#endif
     } else if (PGobject.class.isAssignableFrom(type)) {
@@ -3361,7 +3404,8 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
       }
       return type.cast(object);
     }
-    throw new SQLException("unsupported conversion to " + type);
+    throw new PSQLException(GT.tr("conversion to {0} from {1} not supported", type, sqlType),
+            PSQLState.INVALID_PARAMETER_VALUE);
   }
 
   public <T> T getObject(String columnLabel, Class<T> type) throws SQLException {

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc4/jdbc41/GetObjectTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc4/jdbc41/GetObjectTest.java
@@ -29,6 +29,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.sql.Array;
@@ -213,6 +214,34 @@ public class GetObjectTest {
   }
 
   /**
+   *
+   * Test the behavior getObject for timestamp columns.
+   */
+  @Test
+  public void testGetJavaUtilDate() throws SQLException {
+    Statement stmt = _conn.createStatement();
+    stmt.executeUpdate(TestUtil.insertSQL("table1","timestamp_without_time_zone_column","TIMESTAMP '2004-10-19 10:23:54'"));
+
+    ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("table1", "timestamp_without_time_zone_column"));
+    try {
+      assertTrue(rs.next());
+      Calendar calendar = GregorianCalendar.getInstance();
+      calendar.clear();
+      calendar.set(Calendar.YEAR, 2004);
+      calendar.set(Calendar.MONTH, Calendar.OCTOBER);
+      calendar.set(Calendar.DAY_OF_MONTH, 19);
+      calendar.set(Calendar.HOUR_OF_DAY, 10);
+      calendar.set(Calendar.MINUTE, 23);
+      calendar.set(Calendar.SECOND, 54);
+      java.util.Date expected = new java.util.Date(calendar.getTimeInMillis());
+      assertEquals(expected, rs.getObject("timestamp_without_time_zone_column", java.util.Date.class));
+      assertEquals(expected, rs.getObject(1, java.util.Date.class));
+    } finally {
+      rs.close();
+    }
+  }
+
+  /**
    * Test the behavior getObject for timestamp columns.
    */
   @Test
@@ -335,6 +364,42 @@ public class GetObjectTest {
   }
 
   /**
+   * Test the behavior getObject for small integer columns.
+   */
+  @Test
+  public void testGetShort() throws SQLException {
+    Statement stmt = _conn.createStatement();
+    stmt.executeUpdate(TestUtil.insertSQL("table1","smallint_column","1"));
+
+    ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("table1", "smallint_column"));
+    try {
+      assertTrue(rs.next());
+      assertEquals(Short.valueOf((short) 1), rs.getObject("smallint_column", Short.class));
+      assertEquals(Short.valueOf((short) 1), rs.getObject(1, Short.class));
+    } finally {
+      rs.close();
+    }
+  }
+
+  /**
+   * Test the behavior getObject for small integer columns.
+   */
+  @Test
+  public void testGetShortNull() throws SQLException {
+    Statement stmt = _conn.createStatement();
+    stmt.executeUpdate(TestUtil.insertSQL("table1","smallint_column","NULL"));
+
+    ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("table1", "smallint_column"));
+    try {
+      assertTrue(rs.next());
+      assertNull(rs.getObject("smallint_column", Short.class));
+      assertNull(rs.getObject(1, Short.class));
+    } finally {
+      rs.close();
+    }
+  }
+
+  /**
    * Test the behavior getObject for integer columns.
    */
   @Test
@@ -369,6 +434,24 @@ public class GetObjectTest {
       assertNull(rs.getObject(1, Integer.class));
       assertNull(rs.getObject("integer_column", Integer.class));
       assertNull(rs.getObject(2, Integer.class));
+    } finally {
+      rs.close();
+    }
+  }
+
+  /**
+   * Test the behavior getObject for long columns.
+   */
+  @Test
+  public void testGetBigInteger() throws SQLException {
+    Statement stmt = _conn.createStatement();
+    stmt.executeUpdate(TestUtil.insertSQL("table1","bigint_column","2147483648"));
+
+    ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("table1", "bigint_column"));
+    try {
+      assertTrue(rs.next());
+      assertEquals(BigInteger.valueOf(2147483648L), rs.getObject("bigint_column", BigInteger.class));
+      assertEquals(BigInteger.valueOf(2147483648L), rs.getObject(1, BigInteger.class));
     } finally {
       rs.close();
     }


### PR DESCRIPTION
In the review of #813 various issues with the initial implementation of
CallableStatement#getObject(int, Class) showed up that
ResultSet#getObject(int, Class) also has. This commit gives both
methods the same behavior.

This commit contains the following changes

- make errors localizable
- add support for SMALLINT <-> Short
- add support for BIGINT <-> BigInteger
- add support for TIMESTAMP <-> java.util.Date
- swap INTEGER and SMALLINT position