### PR TITLE
WIP: feat: PQsetErrorContextVisibility similar property.

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -394,6 +394,16 @@ public enum PGProperty {
       "Enable optimization to rewrite and collapse compatible INSERT statements that are batched."),
 
   /**
+   * Determines the handling of CONTEXT fields in messages returned by ServerErrorMessage. This mode
+   * controls whether the CONTEXT field is included in messages. The NEVER mode never includes
+   * CONTEXT, while ALWAYS always includes it if available. In ERRORS mode (the default), CONTEXT
+   * fields are included only for error messages, not for notices and warnings.
+   */
+  ERROR_CONTEXT_VISIBILITY("errorContextVisibility", "errors",
+      "Determines the handling of CONTEXT fields in messages returned by ServerErrorMessage.", false,
+      "never", "errors", "always"),
+
+  /**
    * <p>Connection parameter for startup message Available value(true, database). A Boolean value of
    * true tells the backend to go into walsender mode, wherein a small set of replication commands
    * can be issued instead of SQL statements. Only the simple query protocol can be used in

--- a/pgjdbc/src/main/java/org/postgresql/core/QueryExecutor.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/QueryExecutor.java
@@ -12,6 +12,7 @@ import org.postgresql.core.v3.TypeTransferModeRegistry;
 import org.postgresql.jdbc.AutoSave;
 import org.postgresql.jdbc.BatchResultHandler;
 import org.postgresql.jdbc.PreferQueryMode;
+import org.postgresql.util.ErrorContextVisibility;
 import org.postgresql.util.HostSpec;
 
 import java.sql.SQLException;
@@ -436,4 +437,6 @@ public interface QueryExecutor extends TypeTransferModeRegistry {
    * @return the ReplicationProtocol instance for this connection.
    */
   ReplicationProtocol getReplicationProtocol();
+
+  ErrorContextVisibility getErrorContextVisibility();
 }

--- a/pgjdbc/src/main/java/org/postgresql/core/QueryExecutorBase.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/QueryExecutorBase.java
@@ -9,6 +9,7 @@ import org.postgresql.PGNotification;
 import org.postgresql.PGProperty;
 import org.postgresql.jdbc.AutoSave;
 import org.postgresql.jdbc.PreferQueryMode;
+import org.postgresql.util.ErrorContextVisibility;
 import org.postgresql.util.HostSpec;
 import org.postgresql.util.LruCache;
 import org.postgresql.util.PSQLException;
@@ -41,6 +42,7 @@ public abstract class QueryExecutorBase implements QueryExecutor {
   private final boolean columnSanitiserDisabled;
   private final PreferQueryMode preferQueryMode;
   private AutoSave autoSave;
+  private final ErrorContextVisibility errorContextVisibility;
   private boolean flushCacheOnDeallocate = true;
 
   // default value for server versions that don't report standard_conforming_strings
@@ -75,6 +77,7 @@ public abstract class QueryExecutorBase implements QueryExecutor {
             cachedQuery.query.close();
           }
         });
+    this.errorContextVisibility = ErrorContextVisibility.of(PGProperty.ERROR_CONTEXT_VISIBILITY.get(info));
   }
 
   protected abstract void sendCloseMessage() throws IOException;
@@ -325,12 +328,19 @@ public abstract class QueryExecutorBase implements QueryExecutor {
     return preferQueryMode;
   }
 
+  @Override
   public AutoSave getAutoSave() {
     return autoSave;
   }
 
+  @Override
   public void setAutoSave(AutoSave autoSave) {
     this.autoSave = autoSave;
+  }
+
+  @Override
+  public ErrorContextVisibility getErrorContextVisibility() {
+    return errorContextVisibility;
   }
 
   protected boolean willHealViaReparse(SQLException e) {

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java
@@ -21,6 +21,7 @@ import org.postgresql.hostchooser.HostChooserFactory;
 import org.postgresql.hostchooser.HostRequirement;
 import org.postgresql.hostchooser.HostStatus;
 import org.postgresql.sspi.ISSPIClient;
+import org.postgresql.util.ErrorContextVisibility;
 import org.postgresql.util.GT;
 import org.postgresql.util.HostSpec;
 import org.postgresql.util.MD5Digest;
@@ -433,7 +434,7 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
             }
 
             ServerErrorMessage errorMsg =
-                new ServerErrorMessage(pgStream.receiveErrorString(l_elen - 4));
+                new ServerErrorMessage(pgStream.receiveErrorString(l_elen - 4), ErrorContextVisibility.of(PGProperty.ERROR_CONTEXT_VISIBILITY.get(info)));
             LOGGER.log(Level.FINEST, " <=BE ErrorMessage({0})", errorMsg);
             throw new PSQLException(errorMsg);
 

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -2467,7 +2467,7 @@ public class QueryExecutorImpl extends QueryExecutorBase {
 
     int elen = pgStream.receiveInteger4();
     EncodingPredictor.DecodeResult totalMessage = pgStream.receiveErrorString(elen - 4);
-    ServerErrorMessage errorMsg = new ServerErrorMessage(totalMessage);
+    ServerErrorMessage errorMsg = new ServerErrorMessage(totalMessage, getErrorContextVisibility());
 
     if (LOGGER.isLoggable(Level.FINEST)) {
       LOGGER.log(Level.FINEST, " <=BE ErrorMessage({0})", errorMsg.toString());
@@ -2484,7 +2484,7 @@ public class QueryExecutorImpl extends QueryExecutorBase {
 
   private SQLWarning receiveNoticeResponse() throws IOException {
     int nlen = pgStream.receiveInteger4();
-    ServerErrorMessage warnMsg = new ServerErrorMessage(pgStream.receiveString(nlen - 4));
+    ServerErrorMessage warnMsg = new ServerErrorMessage(pgStream.receiveString(nlen - 4), getErrorContextVisibility());
 
     if (LOGGER.isLoggable(Level.FINEST)) {
       LOGGER.log(Level.FINEST, " <=BE NoticeResponse({0})", warnMsg.toString());

--- a/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
+++ b/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
@@ -8,6 +8,7 @@ package org.postgresql.ds.common;
 import org.postgresql.PGProperty;
 import org.postgresql.jdbc.AutoSave;
 import org.postgresql.jdbc.PreferQueryMode;
+import org.postgresql.util.ErrorContextVisibility;
 import org.postgresql.util.ExpressionProperties;
 import org.postgresql.util.GT;
 import org.postgresql.util.PSQLException;
@@ -1256,6 +1257,22 @@ public abstract class BaseDataSource implements CommonDataSource, Referenceable 
    */
   public void setAutosave(AutoSave autoSave) {
     PGProperty.AUTOSAVE.set(properties, autoSave.value());
+  }
+
+  /**
+   * @see PGProperty#ERROR_CONTEXT_VISIBILITY
+   * @return ErrorContextVisibility setting for this connection
+   */
+  public ErrorContextVisibility getErrorContextVisibility() {
+    return ErrorContextVisibility.of(PGProperty.ERROR_CONTEXT_VISIBILITY.get(properties));
+  }
+
+  /**
+   * @see PGProperty#ERROR_CONTEXT_VISIBILITY
+   * @param errorContextVisibility property to set error context visibility
+   */
+  public void setErrorContextVisibility(ErrorContextVisibility errorContextVisibility) {
+    PGProperty.ERROR_CONTEXT_VISIBILITY.set(properties, errorContextVisibility.value());
   }
 
   /**

--- a/pgjdbc/src/main/java/org/postgresql/gss/GssAction.java
+++ b/pgjdbc/src/main/java/org/postgresql/gss/GssAction.java
@@ -6,6 +6,7 @@
 package org.postgresql.gss;
 
 import org.postgresql.core.PGStream;
+import org.postgresql.util.ErrorContextVisibility;
 import org.postgresql.util.GT;
 import org.postgresql.util.PSQLException;
 import org.postgresql.util.PSQLState;
@@ -110,7 +111,7 @@ class GssAction implements PrivilegedAction<Exception> {
             case 'E':
               int l_elen = pgStream.receiveInteger4();
               ServerErrorMessage l_errorMsg
-                  = new ServerErrorMessage(pgStream.receiveErrorString(l_elen - 4));
+                  = new ServerErrorMessage(pgStream.receiveErrorString(l_elen - 4), ErrorContextVisibility.ERRORS);
 
               LOGGER.log(Level.FINEST, " <=BE ErrorMessage({0})", l_errorMsg);
 

--- a/pgjdbc/src/main/java/org/postgresql/util/ErrorContextVisibility.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/ErrorContextVisibility.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2017, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.util;
+
+/**
+ * Property that handles {@link ServerErrorMessage} context display mode. This mode controls whether
+ * the CONTEXT field is included in messages. The NEVER mode never includes CONTEXT, while ALWAYS
+ * always includes it if available. In ERRORS mode (the default), CONTEXT fields are included only
+ * for error messages, not for notices and warnings.
+ *
+ * @see org.postgresql.PGProperty#ERROR_CONTEXT_VISIBILITY
+ *
+ * @author jsolorzano
+ */
+public enum ErrorContextVisibility {
+
+  NEVER("never"),
+  ERRORS("errors"),
+  ALWAYS("always");
+
+  private final String value;
+
+  ErrorContextVisibility(String value) {
+    this.value = value;
+  }
+
+  public static ErrorContextVisibility of(String visibility) {
+    for (ErrorContextVisibility errorContextVisibility : values()) {
+      if (errorContextVisibility.value.equals(visibility)) {
+        return errorContextVisibility;
+      }
+    }
+    return ERRORS;
+  }
+
+  public String value() {
+    return value;
+  }
+}


### PR DESCRIPTION
Introduce a feature in pgjdbc whereby the CONTEXT field of messages can be suppressed, either always or only for non-error messages.

This is similar to [PQsetErrorContextVisibility]( https://www.postgresql.org/docs/9.6/static/libpq-control.html#LIBPQ-PQSETERRORCONTEXTVISIBILITY) of libpq.