### PR TITLE
fix: synchronize modification of shared calendar (#921)

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/TimestampUtils.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/TimestampUtils.java
@@ -1066,7 +1066,7 @@ public class TimestampUtils {
    * @param tz desired time zone
    * @return timestamp that would be rendered in {@code tz} like {@code millis} in UTC
    */
-  private long guessTimestamp(long millis, TimeZone tz) {
+  private synchronized long guessTimestamp(long millis, TimeZone tz) {
     if (tz == null) {
       // If client did not provide us with time zone, we use system default time zone
       tz = getDefaultTz();
@@ -1133,7 +1133,7 @@ public class TimestampUtils {
    * @param tz The time zone of the date.
    * @return The extracted date.
    */
-  public Date convertToDate(long millis, TimeZone tz) {
+  public synchronized Date convertToDate(long millis, TimeZone tz) {
 
     // no adjustments for the inifity hack values
     if (millis <= PGStatement.DATE_NEGATIVE_INFINITY
@@ -1177,7 +1177,7 @@ public class TimestampUtils {
    * @param tz timezone to use.
    * @return The extracted time.
    */
-  public Time convertToTime(long millis, TimeZone tz) {
+  public synchronized Time convertToTime(long millis, TimeZone tz) {
     if (tz == null) {
       tz = getDefaultTz();
     }


### PR DESCRIPTION
Calendar is not thread-safe, so ensuring all entry points that modify shared instances of `org.postgresql.jdbc.TimestampUtils.calendarWithUserTz` are properly synchronized.

fixes #921

---

Simply ensuring the following methods:

- `TimestampUtils.convertToDate(long,TimeZone)`
- `TimestampUtils.convertToTime(long,TimeZone)`
- `TimestampUtils.guessTimestamp(long,TimeZone)`

are synchronized, as they may modify the shared calendar `calendarWithUserTz` via `java.util.Calendar.set()` methods.

I have added a failing unit test to `org.postgresql.test.jdbc2.DateTest`, which outputs something like

```
   testDateThreadSafety(org.postgresql.test.jdbc2.DateTest)  Time elapsed: 0.301 sec  <<< FAILURE!
   java.lang.AssertionError: expected:<2017> but was:<7777>
   	at org.junit.Assert.fail(Assert.java:88)
   	at org.junit.Assert.failNotEquals(Assert.java:834)
   	at org.junit.Assert.assertEquals(Assert.java:645)
   	at org.junit.Assert.assertEquals(Assert.java:631)
   	at org.postgresql.test.jdbc2.DateTest.testDateThreadSafety(DateTest.java:216)
```

and confirmed it passes under JDK 8, 7, and 6 ("BEFORE", "AFTER", "JDK7", and "JDK6", respectively, below).

```
--- [BEFORE: mvn clean package] ---

johnsontm@dellxps139360:~/pgjdbc/git/pgjdbc$ mvn clean package
[INFO] Scanning for projects...
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Build Order:
[INFO] 
[INFO] PostgreSQL JDBC Driver - JDBC 4.2
[INFO] PostgreSQL JDBC Driver - benchmarks
[INFO] PostgreSQL JDBC Driver aggregate
[INFO]                                                                         
[INFO] ------------------------------------------------------------------------
[INFO] Building PostgreSQL JDBC Driver - JDBC 4.2 42.1.5-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[INFO] 
[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ postgresql ---
[INFO] 
[INFO] --- maven-enforcer-plugin:1.3.1:enforce (enforce-java) @ postgresql ---
[INFO] 
[INFO] --- build-helper-maven-plugin:1.5:parse-version (parse-version) @ postgresql ---
[INFO] 
[INFO] --- properties-maven-plugin:1.0-alpha-2:read-project-properties (default) @ postgresql ---
[INFO] 
[INFO] --- jcp:6.0.1:preprocess (preprocessSources) @ postgresql ---
[INFO] Added MAVEN property mvn.project.name=PostgreSQL JDBC Driver - JDBC 4.2
[INFO] Added MAVEN property mvn.project.version=42.1.5-SNAPSHOT
[INFO] Added MAVEN property mvn.project.url=https://github.com/pgjdbc/pgjdbc
[INFO] Added MAVEN property mvn.project.packaging=bundle
[INFO] Added MAVEN property mvn.project.modelversion=4.0.0
[INFO] Added MAVEN property mvn.project.inceptionyear=
[INFO] Added MAVEN property mvn.project.id=org.postgresql:postgresql:bundle:42.1.5-SNAPSHOT
[INFO] Added MAVEN property mvn.project.groupid=org.postgresql
[INFO] Added MAVEN property mvn.project.description=Java JDBC 4.2 (JRE 8+) driver for PostgreSQL database
[INFO] Added MAVEN property mvn.project.artifact.id=org.postgresql:postgresql:bundle:42.1.5-SNAPSHOT
[INFO] Added MAVEN property mvn.project.artifact.artifactid=postgresql
[INFO] Added MAVEN property mvn.project.artifact.baseversion=42.1.5-SNAPSHOT
[INFO] Added MAVEN property mvn.project.artifact.dependencyconflictid=org.postgresql:postgresql:bundle
[INFO] Added MAVEN property mvn.project.artifact.downloadurl=
[INFO] Added MAVEN property mvn.project.artifact.groupid=org.postgresql
[INFO] Added MAVEN property mvn.project.artifact.scope=
[INFO] Added MAVEN property mvn.project.artifact.type=bundle
[INFO] Added MAVEN property mvn.project.artifact.version=42.1.5-SNAPSHOT
[INFO] Added MAVEN property mvn.project.build.directory=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/target
[INFO] Added MAVEN property mvn.project.build.defaultgoal=
[INFO] Added MAVEN property mvn.project.build.outputdirectory=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/target/classes
[INFO] Added MAVEN property mvn.project.build.scriptsourcedirectory=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/src/main/scripts
[INFO] Added MAVEN property mvn.project.build.sourcedirectory=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/src/main/java
[INFO] Added MAVEN property mvn.project.build.testoutputdirectory=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/target/test-classes
[INFO] Added MAVEN property mvn.project.build.testsourcedirectory=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/src/test/java
[INFO] Added MAVEN property mvn.project.organization.name=PostgreSQL Global Development Group
[INFO] Added MAVEN property mvn.project.organization.url=https://jdbc.postgresql.org/
[INFO] Added MAVEN property mvn.project.activeprofiles=
[INFO] Added MAVEN property mvn.project.property.postgresql.enforce.jdk.version=1.8
[INFO] Added MAVEN property mvn.project.property.postgresql.preprocessed.test.sources.directory=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/target/gen-test-src
[INFO] Added MAVEN property mvn.project.property.loggerlevel=OFF
[INFO] Added MAVEN property mvn.project.property.javac.target=1.8
[INFO] Added MAVEN property mvn.project.property.postgresql.driver.fullversion=PostgreSQL JDBC4.2
[INFO] Added MAVEN property mvn.project.property.jdbc.specification.version=4.2
[INFO] Added MAVEN property mvn.project.property.unzip.jdk.ant.build.xml=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/target/unzip-jdk-ant.xml
[INFO] Added MAVEN property mvn.project.property.loggerfile=target/pgjdbc-tests.log
[INFO] Added MAVEN property mvn.project.property.parsedversion.minorversion=1
[INFO] Added MAVEN property mvn.project.property.project.build.sourceencoding=UTF-8
[INFO] Added MAVEN property mvn.project.property.build.properties.relative.path=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/..
[INFO] Added MAVEN property mvn.project.property.privilegedpassword=***** [hidden because may contain private info]
[INFO] Added MAVEN property mvn.project.property.waffleenabled=true
[INFO] Added MAVEN property mvn.project.property.skip.assembly=false
[INFO] Added MAVEN property mvn.project.property.protocolversion=0
[INFO] Added MAVEN property mvn.project.property.postgresql.preprocessed.sources.directory=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/target/gen-src
[INFO] Added MAVEN property mvn.project.property.osgienabled=true
[INFO] Added MAVEN property mvn.project.property.preparethreshold=5
[INFO] Added MAVEN property mvn.project.property.password=***** [hidden because may contain private info]
[INFO] Added MAVEN property mvn.project.property.jdbc.specification.version.nodot=42
[INFO] Added MAVEN property mvn.project.property.username=test
[INFO] Added MAVEN property mvn.project.property.parsedversion.buildnumber=0
[INFO] Added MAVEN property mvn.project.property.server=localhost
[INFO] Added MAVEN property mvn.project.property.port=5432
[INFO] Added MAVEN property mvn.project.property.template.default.pg.port=5432
[INFO] Added MAVEN property mvn.project.property.parsedversion.qualifier=SNAPSHOT
[INFO] Added MAVEN property mvn.project.property.waffle-jna.version=1.7.5
[INFO] Added MAVEN property mvn.project.property.skip.unzip-jdk-src=true
[INFO] Added MAVEN property mvn.project.property.database=test
[INFO] Added MAVEN property mvn.project.property.parsedversion.incrementalversion=5
[INFO] Added MAVEN property mvn.project.property.sspiusername=testsspi
[INFO] Added MAVEN property mvn.project.property.privilegeduser=postgres
[INFO] Added MAVEN property mvn.project.property.checkstyle.version=7.8.2
[INFO] Added MAVEN property mvn.project.property.parsedversion.majorversion=42
[INFO] Added MAVEN property mvn.project.property.parsedversion.osgiversion=42.1.5.SNAPSHOT
[INFO] Added MAVEN property mvn.project.property.postgresql.jdbc.spec=JDBC4.2
[INFO] Added MAVEN property mvn.project.property.argline=-Xmx512m
[INFO] Preprocess sources : /home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/src/main/java
[INFO] Preprocess destination : /home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/target/gen-src
[INFO] -----------------------------------------------------------------
[INFO] Completed, preprocessed 208 files, copied 16 files, elapsed time 355ms
[INFO] A Compile source root has been removed from the root list [/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/src/main/java]
[INFO] The New compile source root has been added into the list [/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/target/gen-src]
[INFO] 
[INFO] --- maven-resources-plugin:2.6:resources (default-resources) @ postgresql ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] Copying 17 resources
[INFO] 
[INFO] --- maven-compiler-plugin:3.3:compile (default-compile) @ postgresql ---
[INFO] Changes detected - recompiling the module!
[INFO] Compiling 208 source files to /home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/target/classes
[INFO] /home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/target/gen-src/org/postgresql/jdbc3/Jdbc3PoolingDataSource.java: Some input files use or override a deprecated API.
[INFO] /home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/target/gen-src/org/postgresql/jdbc3/Jdbc3PoolingDataSource.java: Recompile with -Xlint:deprecation for details.
[INFO] /home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/target/gen-src/org/postgresql/util/LruCache.java: Some input files use unchecked or unsafe operations.
[INFO] /home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/target/gen-src/org/postgresql/util/LruCache.java: Recompile with -Xlint:unchecked for details.
[INFO] 
[INFO] --- jcp:6.0.1:preprocess (preprocessTestSources) @ postgresql ---
[INFO] Added MAVEN property mvn.project.name=PostgreSQL JDBC Driver - JDBC 4.2
[INFO] Added MAVEN property mvn.project.version=42.1.5-SNAPSHOT
[INFO] Added MAVEN property mvn.project.url=https://github.com/pgjdbc/pgjdbc
[INFO] Added MAVEN property mvn.project.packaging=bundle
[INFO] Added MAVEN property mvn.project.modelversion=4.0.0
[INFO] Added MAVEN property mvn.project.inceptionyear=
[INFO] Added MAVEN property mvn.project.id=org.postgresql:postgresql:bundle:42.1.5-SNAPSHOT
[INFO] Added MAVEN property mvn.project.groupid=org.postgresql
[INFO] Added MAVEN property mvn.project.description=Java JDBC 4.2 (JRE 8+) driver for PostgreSQL database
[INFO] Added MAVEN property mvn.project.artifact.id=org.postgresql:postgresql:bundle:42.1.5-SNAPSHOT
[INFO] Added MAVEN property mvn.project.artifact.artifactid=postgresql
[INFO] Added MAVEN property mvn.project.artifact.baseversion=42.1.5-SNAPSHOT
[INFO] Added MAVEN property mvn.project.artifact.dependencyconflictid=org.postgresql:postgresql:bundle
[INFO] Added MAVEN property mvn.project.artifact.downloadurl=
[INFO] Added MAVEN property mvn.project.artifact.groupid=org.postgresql
[INFO] Added MAVEN property mvn.project.artifact.scope=
[INFO] Added MAVEN property mvn.project.artifact.type=bundle
[INFO] Added MAVEN property mvn.project.artifact.version=42.1.5-SNAPSHOT
[INFO] Added MAVEN property mvn.project.build.directory=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/target
[INFO] Added MAVEN property mvn.project.build.defaultgoal=
[INFO] Added MAVEN property mvn.project.build.outputdirectory=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/target/classes
[INFO] Added MAVEN property mvn.project.build.scriptsourcedirectory=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/src/main/scripts
[INFO] Added MAVEN property mvn.project.build.sourcedirectory=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/src/main/java
[INFO] Added MAVEN property mvn.project.build.testoutputdirectory=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/target/test-classes
[INFO] Added MAVEN property mvn.project.build.testsourcedirectory=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/src/test/java
[INFO] Added MAVEN property mvn.project.organization.name=PostgreSQL Global Development Group
[INFO] Added MAVEN property mvn.project.organization.url=https://jdbc.postgresql.org/
[INFO] Added MAVEN property mvn.project.activeprofiles=
[INFO] Added MAVEN property mvn.project.property.postgresql.enforce.jdk.version=1.8
[INFO] Added MAVEN property mvn.project.property.postgresql.preprocessed.test.sources.directory=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/target/gen-test-src
[INFO] Added MAVEN property mvn.project.property.loggerlevel=OFF
[INFO] Added MAVEN property mvn.project.property.javac.target=1.8
[INFO] Added MAVEN property mvn.project.property.postgresql.driver.fullversion=PostgreSQL JDBC4.2
[INFO] Added MAVEN property mvn.project.property.jdbc.specification.version=4.2
[INFO] Added MAVEN property mvn.project.property.unzip.jdk.ant.build.xml=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/target/unzip-jdk-ant.xml
[INFO] Added MAVEN property mvn.project.property.loggerfile=target/pgjdbc-tests.log
[INFO] Added MAVEN property mvn.project.property.parsedversion.minorversion=1
[INFO] Added MAVEN property mvn.project.property.project.build.sourceencoding=UTF-8
[INFO] Added MAVEN property mvn.project.property.build.properties.relative.path=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/..
[INFO] Added MAVEN property mvn.project.property.privilegedpassword=***** [hidden because may contain private info]
[INFO] Added MAVEN property mvn.project.property.waffleenabled=true
[INFO] Added MAVEN property mvn.project.property.skip.assembly=false
[INFO] Added MAVEN property mvn.project.property.protocolversion=0
[INFO] Added MAVEN property mvn.project.property.postgresql.preprocessed.sources.directory=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/target/gen-src
[INFO] Added MAVEN property mvn.project.property.osgienabled=true
[INFO] Added MAVEN property mvn.project.property.preparethreshold=5
[INFO] Added MAVEN property mvn.project.property.password=***** [hidden because may contain private info]
[INFO] Added MAVEN property mvn.project.property.jdbc.specification.version.nodot=42
[INFO] Added MAVEN property mvn.project.property.username=test
[INFO] Added MAVEN property mvn.project.property.parsedversion.buildnumber=0
[INFO] Added MAVEN property mvn.project.property.server=localhost
[INFO] Added MAVEN property mvn.project.property.port=5432
[INFO] Added MAVEN property mvn.project.property.template.default.pg.port=5432
[INFO] Added MAVEN property mvn.project.property.parsedversion.qualifier=SNAPSHOT
[INFO] Added MAVEN property mvn.project.property.waffle-jna.version=1.7.5
[INFO] Added MAVEN property mvn.project.property.skip.unzip-jdk-src=true
[INFO] Added MAVEN property mvn.project.property.database=test
[INFO] Added MAVEN property mvn.project.property.parsedversion.incrementalversion=5
[INFO] Added MAVEN property mvn.project.property.sspiusername=testsspi
[INFO] Added MAVEN property mvn.project.property.privilegeduser=postgres
[INFO] Added MAVEN property mvn.project.property.checkstyle.version=7.8.2
[INFO] Added MAVEN property mvn.project.property.parsedversion.majorversion=42
[INFO] Added MAVEN property mvn.project.property.parsedversion.osgiversion=42.1.5.SNAPSHOT
[INFO] Added MAVEN property mvn.project.property.postgresql.jdbc.spec=JDBC4.2
[INFO] Added MAVEN property mvn.project.property.argline=-Xmx512m
[INFO] Preprocess sources : /home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/src/test/java
[INFO] Preprocess destination : /home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/target/gen-test-src
[INFO] -----------------------------------------------------------------
[INFO] Completed, preprocessed 145 files, copied 2 files, elapsed time 93ms
[INFO] A Compile source root has been removed from the root list [/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/src/test/java]
[INFO] The New compile source root has been added into the list [/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/target/gen-test-src]
[INFO] 
[INFO] --- maven-resources-plugin:2.6:testResources (default-testResources) @ postgresql ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] Copying 1 resource
[INFO] 
[INFO] --- maven-compiler-plugin:3.3:testCompile (default-testCompile) @ postgresql ---
[INFO] Changes detected - recompiling the module!
[INFO] Compiling 145 source files to /home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/target/test-classes
[INFO] /home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/target/gen-test-src/org/postgresql/test/jdbc2/optional/CaseOptimiserDataSourceTest.java: Some input files use or override a deprecated API.
[INFO] /home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/target/gen-test-src/org/postgresql/test/jdbc2/optional/CaseOptimiserDataSourceTest.java: Recompile with -Xlint:deprecation for details.
[INFO] /home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/target/gen-test-src/org/postgresql/test/hostchooser/MultiHostsConnectionTest.java: Some input files use unchecked or unsafe operations.
[INFO] /home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/target/gen-test-src/org/postgresql/test/hostchooser/MultiHostsConnectionTest.java: Recompile with -Xlint:unchecked for details.
[INFO] 
[INFO] --- maven-surefire-plugin:2.18.1:test (default-test) @ postgresql ---
[INFO] Surefire report directory: /home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/target/surefire-reports

-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Skipping SingleCertSocketFactoryTests. To enable set the property testsinglecertfactory=true in the ssltest.properties file.
Skipping ssloff8.
Skipping sslhostnossl8.
Skipping ssloff9.
Skipping sslhostnossl9.
Skipping sslhostgh8.
Skipping sslhostgh9.
Skipping sslhostbh8.
Skipping sslhostbh9.
Skipping sslhostsslgh8.
Skipping sslhostsslgh9.
Skipping sslhostsslbh8.
Skipping sslhostsslbh9.
Skipping sslhostsslcertgh8.
Skipping sslhostsslcertgh9.
Skipping sslhostsslcertbh8.
Skipping sslhostsslcertbh9.
Skipping sslcertgh8.
Skipping sslcertgh9.
Skipping sslcertbh8.
Skipping sslcertbh9.
Running org.postgresql.test.extensions.ExtensionsTestSuite
Tests run: 5, Failures: 0, Errors: 0, Skipped: 5, Time elapsed: 0.079 sec - in org.postgresql.test.extensions.ExtensionsTestSuite
Running org.postgresql.test.osgi.OsgiTestSuite
Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 sec - in org.postgresql.test.osgi.OsgiTestSuite
Running org.postgresql.test.ssl.SingleCertValidatingFactoryTestSuite
Skipping SingleCertSocketFactoryTests. To enable set the property testsinglecertfactory=true in the ssltest.properties file.
Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 sec - in org.postgresql.test.ssl.SingleCertValidatingFactoryTestSuite
Running org.postgresql.test.ssl.SslTestSuite
Skipping ssloff8.
Skipping sslhostnossl8.
Skipping ssloff9.
Skipping sslhostnossl9.
Skipping sslhostgh8.
Skipping sslhostgh9.
Skipping sslhostbh8.
Skipping sslhostbh9.
Skipping sslhostsslgh8.
Skipping sslhostsslgh9.
Skipping sslhostsslbh8.
Skipping sslhostsslbh9.
Skipping sslhostsslcertgh8.
Skipping sslhostsslcertgh9.
Skipping sslhostsslcertbh8.
Skipping sslhostsslcertbh9.
Skipping sslcertgh8.
Skipping sslcertgh9.
Skipping sslcertbh8.
Skipping sslcertbh9.
Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.postgresql.test.ssl.SslTestSuite
Running org.postgresql.test.jdbc2.Jdbc2TestSuite
Using seed = 1505089562717 for StrangeInputStream. Set -DStrangeInputStream.seed=1505089562717 to reproduce the test
Using seed = 1505089562949 for StrangeInputStream. Set -DStrangeInputStream.seed=1505089562949 to reproduce the test
Using seed = 1505089563195 for StrangeInputStream. Set -DStrangeInputStream.seed=1505089563195 to reproduce the test
Using seed = 1505089563457 for StrangeInputStream. Set -DStrangeInputStream.seed=1505089563457 to reproduce the test
Using seed = 1505089563678 for StrangeInputStream. Set -DStrangeInputStream.seed=1505089563678 to reproduce the test
Using seed = 1505089563915 for StrangeInputStream. Set -DStrangeInputStream.seed=1505089563915 to reproduce the test
Using seed = 1505089564124 for StrangeInputStream. Set -DStrangeInputStream.seed=1505089564124 to reproduce the test
Using seed = 1505089564330 for StrangeInputStream. Set -DStrangeInputStream.seed=1505089564330 to reproduce the test
Using seed = 1505089564555 for StrangeInputStream. Set -DStrangeInputStream.seed=1505089564555 to reproduce the test
Using seed = 1505089564777 for StrangeInputStream. Set -DStrangeInputStream.seed=1505089564777 to reproduce the test
Tests run: 4117, Failures: 1, Errors: 0, Skipped: 9, Time elapsed: 108.045 sec <<< FAILURE! - in org.postgresql.test.jdbc2.Jdbc2TestSuite
testDateThreadSafety(org.postgresql.test.jdbc2.DateTest)  Time elapsed: 0.265 sec  <<< FAILURE!
java.lang.AssertionError: expected:<2017> but was:<7777>
	at org.junit.Assert.fail(Assert.java:88)
	at org.junit.Assert.failNotEquals(Assert.java:834)
	at org.junit.Assert.assertEquals(Assert.java:645)
	at org.junit.Assert.assertEquals(Assert.java:631)
	at org.postgresql.test.jdbc2.DateTest.testDateThreadSafety(DateTest.java:240)

Running org.postgresql.test.jdbc2.optional.OptionalTestSuite
Tests run: 49, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 0.989 sec - in org.postgresql.test.jdbc2.optional.OptionalTestSuite
Running org.postgresql.test.jdbc2.AutoRollbackTestSuite
Tests run: 96, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.748 sec - in org.postgresql.test.jdbc2.AutoRollbackTestSuite
Running org.postgresql.test.socketfactory.SocketFactoryTestSuite
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 sec - in org.postgresql.test.socketfactory.SocketFactoryTestSuite
Running org.postgresql.test.hostchooser.MultiHostTestSuite
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 sec - in org.postgresql.test.hostchooser.MultiHostTestSuite
Running org.postgresql.test.jdbc4.Jdbc4TestSuite
Tests run: 117, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.528 sec - in org.postgresql.test.jdbc4.Jdbc4TestSuite
Running org.postgresql.test.jdbc4.jdbc41.Jdbc41TestSuite
JUnit used sun.misc.Launcher$AppClassLoader@4aa298b7
SeparateClassLoaderInvokeMethod used sun.misc.Launcher$AppClassLoader@4aa298b7
se.jiderhamn.classloader.RedefiningClassLoader[org.postgresql.test.jdbc4.jdbc41.SharedTimerClassLoaderLeakTest.sharedTimerDoesNotCauseLeak]@554dfb98 is being finalized
Tests run: 50, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 1.278 sec - in org.postgresql.test.jdbc4.jdbc41.Jdbc41TestSuite
Running org.postgresql.test.xa.XATestSuite
Tests run: 12, Failures: 0, Errors: 0, Skipped: 12, Time elapsed: 0.053 sec - in org.postgresql.test.xa.XATestSuite
Running org.postgresql.test.jdbc3.Jdbc3TestSuite
Tests run: 159, Failures: 0, Errors: 0, Skipped: 4, Time elapsed: 2.087 sec - in org.postgresql.test.jdbc3.Jdbc3TestSuite
Running org.postgresql.test.jdbc42.Jdbc42TestSuite
Tests run: 44, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 613.623 sec - in org.postgresql.test.jdbc42.Jdbc42TestSuite
Running org.postgresql.replication.ReplicationTestSuite
Tests run: 1, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 0.007 sec - in org.postgresql.replication.ReplicationTestSuite

Results :

Failed tests: 
  DateTest.testDateThreadSafety:240 expected:<2017> but was:<7777>

Tests run: 4660, Failures: 1, Errors: 0, Skipped: 33

[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO] 
[INFO] PostgreSQL JDBC Driver - JDBC 4.2 .................. FAILURE [12:17 min]
[INFO] PostgreSQL JDBC Driver - benchmarks ................ SKIPPED
[INFO] PostgreSQL JDBC Driver aggregate ................... SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 12:18 min
[INFO] Finished at: 2017-09-10T20:36:27-04:00
[INFO] Final Memory: 28M/478M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:2.18.1:test (default-test) on project postgresql: There are test failures.
[ERROR] 
[ERROR] Please refer to /home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/target/surefire-reports for the individual test results.
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
johnsontm@dellxps139360:~/pgjdbc/git/pgjdbc$ 

--- [AFTER: mvn clean package] ---

johnsontm@dellxps139360:~/pgjdbc/git/pgjdbc$ mvn clean package
[INFO] Scanning for projects...
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Build Order:
[INFO] 
[INFO] PostgreSQL JDBC Driver - JDBC 4.2
[INFO] PostgreSQL JDBC Driver - benchmarks
[INFO] PostgreSQL JDBC Driver aggregate
[INFO]                                                                         
[INFO] ------------------------------------------------------------------------
[INFO] Building PostgreSQL JDBC Driver - JDBC 4.2 42.1.5-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[INFO] 
[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ postgresql ---
[INFO] Deleting /home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/target
[INFO] 
[INFO] --- maven-enforcer-plugin:1.3.1:enforce (enforce-java) @ postgresql ---
[INFO] 
[INFO] --- build-helper-maven-plugin:1.5:parse-version (parse-version) @ postgresql ---
[INFO] 
[INFO] --- properties-maven-plugin:1.0-alpha-2:read-project-properties (default) @ postgresql ---
[INFO] 
[INFO] --- jcp:6.0.1:preprocess (preprocessSources) @ postgresql ---
[INFO] Added MAVEN property mvn.project.name=PostgreSQL JDBC Driver - JDBC 4.2
[INFO] Added MAVEN property mvn.project.version=42.1.5-SNAPSHOT
[INFO] Added MAVEN property mvn.project.url=https://github.com/pgjdbc/pgjdbc
[INFO] Added MAVEN property mvn.project.packaging=bundle
[INFO] Added MAVEN property mvn.project.modelversion=4.0.0
[INFO] Added MAVEN property mvn.project.inceptionyear=
[INFO] Added MAVEN property mvn.project.id=org.postgresql:postgresql:bundle:42.1.5-SNAPSHOT
[INFO] Added MAVEN property mvn.project.groupid=org.postgresql
[INFO] Added MAVEN property mvn.project.description=Java JDBC 4.2 (JRE 8+) driver for PostgreSQL database
[INFO] Added MAVEN property mvn.project.artifact.id=org.postgresql:postgresql:bundle:42.1.5-SNAPSHOT
[INFO] Added MAVEN property mvn.project.artifact.artifactid=postgresql
[INFO] Added MAVEN property mvn.project.artifact.baseversion=42.1.5-SNAPSHOT
[INFO] Added MAVEN property mvn.project.artifact.dependencyconflictid=org.postgresql:postgresql:bundle
[INFO] Added MAVEN property mvn.project.artifact.downloadurl=
[INFO] Added MAVEN property mvn.project.artifact.groupid=org.postgresql
[INFO] Added MAVEN property mvn.project.artifact.scope=
[INFO] Added MAVEN property mvn.project.artifact.type=bundle
[INFO] Added MAVEN property mvn.project.artifact.version=42.1.5-SNAPSHOT
[INFO] Added MAVEN property mvn.project.build.directory=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/target
[INFO] Added MAVEN property mvn.project.build.defaultgoal=
[INFO] Added MAVEN property mvn.project.build.outputdirectory=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/target/classes
[INFO] Added MAVEN property mvn.project.build.scriptsourcedirectory=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/src/main/scripts
[INFO] Added MAVEN property mvn.project.build.sourcedirectory=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/src/main/java
[INFO] Added MAVEN property mvn.project.build.testoutputdirectory=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/target/test-classes
[INFO] Added MAVEN property mvn.project.build.testsourcedirectory=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/src/test/java
[INFO] Added MAVEN property mvn.project.organization.name=PostgreSQL Global Development Group
[INFO] Added MAVEN property mvn.project.organization.url=https://jdbc.postgresql.org/
[INFO] Added MAVEN property mvn.project.activeprofiles=
[INFO] Added MAVEN property mvn.project.property.postgresql.enforce.jdk.version=1.8
[INFO] Added MAVEN property mvn.project.property.postgresql.preprocessed.test.sources.directory=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/target/gen-test-src
[INFO] Added MAVEN property mvn.project.property.loggerlevel=OFF
[INFO] Added MAVEN property mvn.project.property.javac.target=1.8
[INFO] Added MAVEN property mvn.project.property.postgresql.driver.fullversion=PostgreSQL JDBC4.2
[INFO] Added MAVEN property mvn.project.property.jdbc.specification.version=4.2
[INFO] Added MAVEN property mvn.project.property.unzip.jdk.ant.build.xml=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/target/unzip-jdk-ant.xml
[INFO] Added MAVEN property mvn.project.property.loggerfile=target/pgjdbc-tests.log
[INFO] Added MAVEN property mvn.project.property.parsedversion.minorversion=1
[INFO] Added MAVEN property mvn.project.property.project.build.sourceencoding=UTF-8
[INFO] Added MAVEN property mvn.project.property.build.properties.relative.path=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/..
[INFO] Added MAVEN property mvn.project.property.privilegedpassword=***** [hidden because may contain private info]
[INFO] Added MAVEN property mvn.project.property.waffleenabled=true
[INFO] Added MAVEN property mvn.project.property.skip.assembly=false
[INFO] Added MAVEN property mvn.project.property.protocolversion=0
[INFO] Added MAVEN property mvn.project.property.postgresql.preprocessed.sources.directory=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/target/gen-src
[INFO] Added MAVEN property mvn.project.property.osgienabled=true
[INFO] Added MAVEN property mvn.project.property.preparethreshold=5
[INFO] Added MAVEN property mvn.project.property.password=***** [hidden because may contain private info]
[INFO] Added MAVEN property mvn.project.property.jdbc.specification.version.nodot=42
[INFO] Added MAVEN property mvn.project.property.username=test
[INFO] Added MAVEN property mvn.project.property.parsedversion.buildnumber=0
[INFO] Added MAVEN property mvn.project.property.server=localhost
[INFO] Added MAVEN property mvn.project.property.port=5432
[INFO] Added MAVEN property mvn.project.property.template.default.pg.port=5432
[INFO] Added MAVEN property mvn.project.property.parsedversion.qualifier=SNAPSHOT
[INFO] Added MAVEN property mvn.project.property.waffle-jna.version=1.7.5
[INFO] Added MAVEN property mvn.project.property.skip.unzip-jdk-src=true
[INFO] Added MAVEN property mvn.project.property.database=test
[INFO] Added MAVEN property mvn.project.property.parsedversion.incrementalversion=5
[INFO] Added MAVEN property mvn.project.property.sspiusername=testsspi
[INFO] Added MAVEN property mvn.project.property.privilegeduser=postgres
[INFO] Added MAVEN property mvn.project.property.checkstyle.version=7.8.2
[INFO] Added MAVEN property mvn.project.property.parsedversion.majorversion=42
[INFO] Added MAVEN property mvn.project.property.parsedversion.osgiversion=42.1.5.SNAPSHOT
[INFO] Added MAVEN property mvn.project.property.postgresql.jdbc.spec=JDBC4.2
[INFO] Added MAVEN property mvn.project.property.argline=-Xmx512m
[INFO] Preprocess sources : /home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/src/main/java
[INFO] Preprocess destination : /home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/target/gen-src
[INFO] -----------------------------------------------------------------
[INFO] Completed, preprocessed 208 files, copied 16 files, elapsed time 312ms
[INFO] A Compile source root has been removed from the root list [/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/src/main/java]
[INFO] The New compile source root has been added into the list [/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/target/gen-src]
[INFO] 
[INFO] --- maven-resources-plugin:2.6:resources (default-resources) @ postgresql ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] Copying 17 resources
[INFO] 
[INFO] --- maven-compiler-plugin:3.3:compile (default-compile) @ postgresql ---
[INFO] Changes detected - recompiling the module!
[INFO] Compiling 208 source files to /home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/target/classes
[INFO] /home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/target/gen-src/org/postgresql/jdbc3/Jdbc3PoolingDataSource.java: Some input files use or override a deprecated API.
[INFO] /home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/target/gen-src/org/postgresql/jdbc3/Jdbc3PoolingDataSource.java: Recompile with -Xlint:deprecation for details.
[INFO] /home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/target/gen-src/org/postgresql/util/LruCache.java: Some input files use unchecked or unsafe operations.
[INFO] /home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/target/gen-src/org/postgresql/util/LruCache.java: Recompile with -Xlint:unchecked for details.
[INFO] 
[INFO] --- jcp:6.0.1:preprocess (preprocessTestSources) @ postgresql ---
[INFO] Added MAVEN property mvn.project.name=PostgreSQL JDBC Driver - JDBC 4.2
[INFO] Added MAVEN property mvn.project.version=42.1.5-SNAPSHOT
[INFO] Added MAVEN property mvn.project.url=https://github.com/pgjdbc/pgjdbc
[INFO] Added MAVEN property mvn.project.packaging=bundle
[INFO] Added MAVEN property mvn.project.modelversion=4.0.0
[INFO] Added MAVEN property mvn.project.inceptionyear=
[INFO] Added MAVEN property mvn.project.id=org.postgresql:postgresql:bundle:42.1.5-SNAPSHOT
[INFO] Added MAVEN property mvn.project.groupid=org.postgresql
[INFO] Added MAVEN property mvn.project.description=Java JDBC 4.2 (JRE 8+) driver for PostgreSQL database
[INFO] Added MAVEN property mvn.project.artifact.id=org.postgresql:postgresql:bundle:42.1.5-SNAPSHOT
[INFO] Added MAVEN property mvn.project.artifact.artifactid=postgresql
[INFO] Added MAVEN property mvn.project.artifact.baseversion=42.1.5-SNAPSHOT
[INFO] Added MAVEN property mvn.project.artifact.dependencyconflictid=org.postgresql:postgresql:bundle
[INFO] Added MAVEN property mvn.project.artifact.downloadurl=
[INFO] Added MAVEN property mvn.project.artifact.groupid=org.postgresql
[INFO] Added MAVEN property mvn.project.artifact.scope=
[INFO] Added MAVEN property mvn.project.artifact.type=bundle
[INFO] Added MAVEN property mvn.project.artifact.version=42.1.5-SNAPSHOT
[INFO] Added MAVEN property mvn.project.build.directory=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/target
[INFO] Added MAVEN property mvn.project.build.defaultgoal=
[INFO] Added MAVEN property mvn.project.build.outputdirectory=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/target/classes
[INFO] Added MAVEN property mvn.project.build.scriptsourcedirectory=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/src/main/scripts
[INFO] Added MAVEN property mvn.project.build.sourcedirectory=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/src/main/java
[INFO] Added MAVEN property mvn.project.build.testoutputdirectory=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/target/test-classes
[INFO] Added MAVEN property mvn.project.build.testsourcedirectory=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/src/test/java
[INFO] Added MAVEN property mvn.project.organization.name=PostgreSQL Global Development Group
[INFO] Added MAVEN property mvn.project.organization.url=https://jdbc.postgresql.org/
[INFO] Added MAVEN property mvn.project.activeprofiles=
[INFO] Added MAVEN property mvn.project.property.postgresql.enforce.jdk.version=1.8
[INFO] Added MAVEN property mvn.project.property.postgresql.preprocessed.test.sources.directory=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/target/gen-test-src
[INFO] Added MAVEN property mvn.project.property.loggerlevel=OFF
[INFO] Added MAVEN property mvn.project.property.javac.target=1.8
[INFO] Added MAVEN property mvn.project.property.postgresql.driver.fullversion=PostgreSQL JDBC4.2
[INFO] Added MAVEN property mvn.project.property.jdbc.specification.version=4.2
[INFO] Added MAVEN property mvn.project.property.unzip.jdk.ant.build.xml=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/target/unzip-jdk-ant.xml
[INFO] Added MAVEN property mvn.project.property.loggerfile=target/pgjdbc-tests.log
[INFO] Added MAVEN property mvn.project.property.parsedversion.minorversion=1
[INFO] Added MAVEN property mvn.project.property.project.build.sourceencoding=UTF-8
[INFO] Added MAVEN property mvn.project.property.build.properties.relative.path=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/..
[INFO] Added MAVEN property mvn.project.property.privilegedpassword=***** [hidden because may contain private info]
[INFO] Added MAVEN property mvn.project.property.waffleenabled=true
[INFO] Added MAVEN property mvn.project.property.skip.assembly=false
[INFO] Added MAVEN property mvn.project.property.protocolversion=0
[INFO] Added MAVEN property mvn.project.property.postgresql.preprocessed.sources.directory=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/target/gen-src
[INFO] Added MAVEN property mvn.project.property.osgienabled=true
[INFO] Added MAVEN property mvn.project.property.preparethreshold=5
[INFO] Added MAVEN property mvn.project.property.password=***** [hidden because may contain private info]
[INFO] Added MAVEN property mvn.project.property.jdbc.specification.version.nodot=42
[INFO] Added MAVEN property mvn.project.property.username=test
[INFO] Added MAVEN property mvn.project.property.parsedversion.buildnumber=0
[INFO] Added MAVEN property mvn.project.property.server=localhost
[INFO] Added MAVEN property mvn.project.property.port=5432
[INFO] Added MAVEN property mvn.project.property.template.default.pg.port=5432
[INFO] Added MAVEN property mvn.project.property.parsedversion.qualifier=SNAPSHOT
[INFO] Added MAVEN property mvn.project.property.waffle-jna.version=1.7.5
[INFO] Added MAVEN property mvn.project.property.skip.unzip-jdk-src=true
[INFO] Added MAVEN property mvn.project.property.database=test
[INFO] Added MAVEN property mvn.project.property.parsedversion.incrementalversion=5
[INFO] Added MAVEN property mvn.project.property.sspiusername=testsspi
[INFO] Added MAVEN property mvn.project.property.privilegeduser=postgres
[INFO] Added MAVEN property mvn.project.property.checkstyle.version=7.8.2
[INFO] Added MAVEN property mvn.project.property.parsedversion.majorversion=42
[INFO] Added MAVEN property mvn.project.property.parsedversion.osgiversion=42.1.5.SNAPSHOT
[INFO] Added MAVEN property mvn.project.property.postgresql.jdbc.spec=JDBC4.2
[INFO] Added MAVEN property mvn.project.property.argline=-Xmx512m
[INFO] Preprocess sources : /home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/src/test/java
[INFO] Preprocess destination : /home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/target/gen-test-src
[INFO] -----------------------------------------------------------------
[INFO] Completed, preprocessed 145 files, copied 2 files, elapsed time 98ms
[INFO] A Compile source root has been removed from the root list [/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/src/test/java]
[INFO] The New compile source root has been added into the list [/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/target/gen-test-src]
[INFO] 
[INFO] --- maven-resources-plugin:2.6:testResources (default-testResources) @ postgresql ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] Copying 1 resource
[INFO] 
[INFO] --- maven-compiler-plugin:3.3:testCompile (default-testCompile) @ postgresql ---
[INFO] Changes detected - recompiling the module!
[INFO] Compiling 145 source files to /home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/target/test-classes
[INFO] /home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/target/gen-test-src/org/postgresql/test/jdbc2/optional/CaseOptimiserDataSourceTest.java: Some input files use or override a deprecated API.
[INFO] /home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/target/gen-test-src/org/postgresql/test/jdbc2/optional/CaseOptimiserDataSourceTest.java: Recompile with -Xlint:deprecation for details.
[INFO] /home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/target/gen-test-src/org/postgresql/test/hostchooser/MultiHostsConnectionTest.java: Some input files use unchecked or unsafe operations.
[INFO] /home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/target/gen-test-src/org/postgresql/test/hostchooser/MultiHostsConnectionTest.java: Recompile with -Xlint:unchecked for details.
[INFO] 
[INFO] --- maven-surefire-plugin:2.18.1:test (default-test) @ postgresql ---
[INFO] Surefire report directory: /home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/target/surefire-reports

-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Skipping SingleCertSocketFactoryTests. To enable set the property testsinglecertfactory=true in the ssltest.properties file.
Skipping ssloff8.
Skipping sslhostnossl8.
Skipping ssloff9.
Skipping sslhostnossl9.
Skipping sslhostgh8.
Skipping sslhostgh9.
Skipping sslhostbh8.
Skipping sslhostbh9.
Skipping sslhostsslgh8.
Skipping sslhostsslgh9.
Skipping sslhostsslbh8.
Skipping sslhostsslbh9.
Skipping sslhostsslcertgh8.
Skipping sslhostsslcertgh9.
Skipping sslhostsslcertbh8.
Skipping sslhostsslcertbh9.
Skipping sslcertgh8.
Skipping sslcertgh9.
Skipping sslcertbh8.
Skipping sslcertbh9.
Running org.postgresql.test.extensions.ExtensionsTestSuite
Tests run: 5, Failures: 0, Errors: 0, Skipped: 5, Time elapsed: 0.075 sec - in org.postgresql.test.extensions.ExtensionsTestSuite
Running org.postgresql.test.osgi.OsgiTestSuite
Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 sec - in org.postgresql.test.osgi.OsgiTestSuite
Running org.postgresql.test.ssl.SingleCertValidatingFactoryTestSuite
Skipping SingleCertSocketFactoryTests. To enable set the property testsinglecertfactory=true in the ssltest.properties file.
Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.postgresql.test.ssl.SingleCertValidatingFactoryTestSuite
Running org.postgresql.test.ssl.SslTestSuite
Skipping ssloff8.
Skipping sslhostnossl8.
Skipping ssloff9.
Skipping sslhostnossl9.
Skipping sslhostgh8.
Skipping sslhostgh9.
Skipping sslhostbh8.
Skipping sslhostbh9.
Skipping sslhostsslgh8.
Skipping sslhostsslgh9.
Skipping sslhostsslbh8.
Skipping sslhostsslbh9.
Skipping sslhostsslcertgh8.
Skipping sslhostsslcertgh9.
Skipping sslhostsslcertbh8.
Skipping sslhostsslcertbh9.
Skipping sslcertgh8.
Skipping sslcertgh9.
Skipping sslcertbh8.
Skipping sslcertbh9.
Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 sec - in org.postgresql.test.ssl.SslTestSuite
Running org.postgresql.test.jdbc2.Jdbc2TestSuite
Using seed = 1505090813965 for StrangeInputStream. Set -DStrangeInputStream.seed=1505090813965 to reproduce the test
Using seed = 1505090814211 for StrangeInputStream. Set -DStrangeInputStream.seed=1505090814211 to reproduce the test
Using seed = 1505090814446 for StrangeInputStream. Set -DStrangeInputStream.seed=1505090814446 to reproduce the test
Using seed = 1505090814676 for StrangeInputStream. Set -DStrangeInputStream.seed=1505090814676 to reproduce the test
Using seed = 1505090814891 for StrangeInputStream. Set -DStrangeInputStream.seed=1505090814891 to reproduce the test
Using seed = 1505090815118 for StrangeInputStream. Set -DStrangeInputStream.seed=1505090815118 to reproduce the test
Using seed = 1505090815352 for StrangeInputStream. Set -DStrangeInputStream.seed=1505090815352 to reproduce the test
Using seed = 1505090815582 for StrangeInputStream. Set -DStrangeInputStream.seed=1505090815582 to reproduce the test
Using seed = 1505090816429 for StrangeInputStream. Set -DStrangeInputStream.seed=1505090816429 to reproduce the test
Using seed = 1505090817198 for StrangeInputStream. Set -DStrangeInputStream.seed=1505090817198 to reproduce the test
Tests run: 4117, Failures: 0, Errors: 0, Skipped: 9, Time elapsed: 199.618 sec - in org.postgresql.test.jdbc2.Jdbc2TestSuite
Running org.postgresql.test.jdbc2.optional.OptionalTestSuite
Tests run: 49, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 1.096 sec - in org.postgresql.test.jdbc2.optional.OptionalTestSuite
Running org.postgresql.test.jdbc2.AutoRollbackTestSuite
Tests run: 96, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.507 sec - in org.postgresql.test.jdbc2.AutoRollbackTestSuite
Running org.postgresql.test.socketfactory.SocketFactoryTestSuite
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.007 sec - in org.postgresql.test.socketfactory.SocketFactoryTestSuite
Running org.postgresql.test.hostchooser.MultiHostTestSuite
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 sec - in org.postgresql.test.hostchooser.MultiHostTestSuite
Running org.postgresql.test.jdbc4.Jdbc4TestSuite
Tests run: 117, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.207 sec - in org.postgresql.test.jdbc4.Jdbc4TestSuite
Running org.postgresql.test.jdbc4.jdbc41.Jdbc41TestSuite
JUnit used sun.misc.Launcher$AppClassLoader@4aa298b7
SeparateClassLoaderInvokeMethod used sun.misc.Launcher$AppClassLoader@4aa298b7
se.jiderhamn.classloader.RedefiningClassLoader[org.postgresql.test.jdbc4.jdbc41.SharedTimerClassLoaderLeakTest.sharedTimerDoesNotCauseLeak]@554dfb98 is being finalized
Tests run: 50, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 1.133 sec - in org.postgresql.test.jdbc4.jdbc41.Jdbc41TestSuite
Running org.postgresql.test.xa.XATestSuite
Tests run: 12, Failures: 0, Errors: 0, Skipped: 12, Time elapsed: 0.056 sec - in org.postgresql.test.xa.XATestSuite
Running org.postgresql.test.jdbc3.Jdbc3TestSuite
Tests run: 159, Failures: 0, Errors: 0, Skipped: 4, Time elapsed: 2.224 sec - in org.postgresql.test.jdbc3.Jdbc3TestSuite
Running org.postgresql.test.jdbc42.Jdbc42TestSuite
Tests run: 44, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1,877.701 sec - in org.postgresql.test.jdbc42.Jdbc42TestSuite
Running org.postgresql.replication.ReplicationTestSuite
Tests run: 1, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 0.015 sec - in org.postgresql.replication.ReplicationTestSuite

Results :

Tests run: 4660, Failures: 0, Errors: 0, Skipped: 33

[INFO] 
[INFO] --- maven-bundle-plugin:2.5.3:bundle (default-bundle) @ postgresql ---
[INFO]                                                                         
[INFO] ------------------------------------------------------------------------
[INFO] Building PostgreSQL JDBC Driver - benchmarks 42.1.5-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[INFO] 
[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ pgjdbc-benchmark ---
[INFO] 
[INFO] --- jcp:6.0.1:preprocess (preprocessSources) @ pgjdbc-benchmark ---
[INFO] Added MAVEN property mvn.project.name=PostgreSQL JDBC Driver - benchmarks
[INFO] Added MAVEN property mvn.project.version=42.1.5-SNAPSHOT
[INFO] Added MAVEN property mvn.project.url=https://github.com/pgjdbc/pgjdbc
[INFO] Added MAVEN property mvn.project.packaging=jar
[INFO] Added MAVEN property mvn.project.modelversion=4.0.0
[INFO] Added MAVEN property mvn.project.inceptionyear=
[INFO] Added MAVEN property mvn.project.id=org.postgresql:pgjdbc-benchmark:jar:42.1.5-SNAPSHOT
[INFO] Added MAVEN property mvn.project.groupid=org.postgresql
[INFO] Added MAVEN property mvn.project.description=PostgreSQL JDBC Driver - benchmarks
[INFO] Added MAVEN property mvn.project.artifact.id=org.postgresql:pgjdbc-benchmark:jar:42.1.5-SNAPSHOT
[INFO] Added MAVEN property mvn.project.artifact.artifactid=pgjdbc-benchmark
[INFO] Added MAVEN property mvn.project.artifact.baseversion=42.1.5-SNAPSHOT
[INFO] Added MAVEN property mvn.project.artifact.dependencyconflictid=org.postgresql:pgjdbc-benchmark:jar
[INFO] Added MAVEN property mvn.project.artifact.downloadurl=
[INFO] Added MAVEN property mvn.project.artifact.groupid=org.postgresql
[INFO] Added MAVEN property mvn.project.artifact.scope=
[INFO] Added MAVEN property mvn.project.artifact.type=jar
[INFO] Added MAVEN property mvn.project.artifact.version=42.1.5-SNAPSHOT
[INFO] Added MAVEN property mvn.project.build.directory=/home/johnsontm/pgjdbc/git/pgjdbc/ubenchmark/target
[INFO] Added MAVEN property mvn.project.build.defaultgoal=
[INFO] Added MAVEN property mvn.project.build.outputdirectory=/home/johnsontm/pgjdbc/git/pgjdbc/ubenchmark/target/classes
[INFO] Added MAVEN property mvn.project.build.scriptsourcedirectory=/home/johnsontm/pgjdbc/git/pgjdbc/ubenchmark/src/main/scripts
[INFO] Added MAVEN property mvn.project.build.sourcedirectory=/home/johnsontm/pgjdbc/git/pgjdbc/ubenchmark/src/main/java
[INFO] Added MAVEN property mvn.project.build.testoutputdirectory=/home/johnsontm/pgjdbc/git/pgjdbc/ubenchmark/target/test-classes
[INFO] Added MAVEN property mvn.project.build.testsourcedirectory=/home/johnsontm/pgjdbc/git/pgjdbc/ubenchmark/src/test/java
[INFO] Added MAVEN property mvn.project.organization.name=PostgreSQL Global Development Group
[INFO] Added MAVEN property mvn.project.organization.url=http://jdbc.postgresql.org/
[INFO] Added MAVEN property mvn.project.activeprofiles=
[INFO] Added MAVEN property mvn.project.property.current.jdk=1.8
[INFO] Added MAVEN property mvn.project.property.postgresql.driver.fullversion=PostgreSQL JDBC${jdbc.specification.version}
[INFO] Added MAVEN property mvn.project.property.waffle-jna.version=1.7.5
[INFO] Added MAVEN property mvn.project.property.template.default.pg.port=5432
[INFO] Added MAVEN property mvn.project.property.skip.unzip-jdk-src=true
[INFO] Added MAVEN property mvn.project.property.jmh.version=1.17.4
[INFO] Added MAVEN property mvn.project.property.uberjar.name=benchmarks
[INFO] Added MAVEN property mvn.project.property.postgresql.jdbc.spec=JDBC${jdbc.specification.version}
[INFO] Added MAVEN property mvn.project.property.postgresql.preprocessed.test.sources.directory=/home/johnsontm/pgjdbc/git/pgjdbc/ubenchmark/target/gen-test-src
[INFO] Added MAVEN property mvn.project.property.javac.target=1.8
[INFO] Added MAVEN property mvn.project.property.project.build.sourceencoding=UTF-8
[INFO] Added MAVEN property mvn.project.property.postgresql.preprocessed.sources.directory=/home/johnsontm/pgjdbc/git/pgjdbc/ubenchmark/target/gen-src
[INFO] Added MAVEN property mvn.project.property.unzip.jdk.ant.build.xml=/home/johnsontm/pgjdbc/git/pgjdbc/ubenchmark/target/unzip-jdk-ant.xml
[INFO] Added MAVEN property mvn.project.property.argline=-Xmx512m
[INFO] Preprocess sources : /home/johnsontm/pgjdbc/git/pgjdbc/ubenchmark/src/main/java
[INFO] Preprocess destination : /home/johnsontm/pgjdbc/git/pgjdbc/ubenchmark/target/gen-src
[INFO] -----------------------------------------------------------------
[INFO] Completed, preprocessed 15 files, copied 0 files, elapsed time 57ms
[INFO] A Compile source root has been removed from the root list [/home/johnsontm/pgjdbc/git/pgjdbc/ubenchmark/src/main/java]
[INFO] The New compile source root has been added into the list [/home/johnsontm/pgjdbc/git/pgjdbc/ubenchmark/target/gen-src]
[INFO] 
[INFO] --- maven-resources-plugin:2.6:resources (default-resources) @ pgjdbc-benchmark ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] skip non existing resourceDirectory /home/johnsontm/pgjdbc/git/pgjdbc/ubenchmark/src/main/resources
[INFO] 
[INFO] --- maven-compiler-plugin:3.3:compile (default-compile) @ pgjdbc-benchmark ---
[INFO] Compiling 15 source files to /home/johnsontm/pgjdbc/git/pgjdbc/ubenchmark/target/classes
[INFO] 
[INFO] --- jcp:6.0.1:preprocess (preprocessTestSources) @ pgjdbc-benchmark ---
[INFO] Added MAVEN property mvn.project.name=PostgreSQL JDBC Driver - benchmarks
[INFO] Added MAVEN property mvn.project.version=42.1.5-SNAPSHOT
[INFO] Added MAVEN property mvn.project.url=https://github.com/pgjdbc/pgjdbc
[INFO] Added MAVEN property mvn.project.packaging=jar
[INFO] Added MAVEN property mvn.project.modelversion=4.0.0
[INFO] Added MAVEN property mvn.project.inceptionyear=
[INFO] Added MAVEN property mvn.project.id=org.postgresql:pgjdbc-benchmark:jar:42.1.5-SNAPSHOT
[INFO] Added MAVEN property mvn.project.groupid=org.postgresql
[INFO] Added MAVEN property mvn.project.description=PostgreSQL JDBC Driver - benchmarks
[INFO] Added MAVEN property mvn.project.artifact.id=org.postgresql:pgjdbc-benchmark:jar:42.1.5-SNAPSHOT
[INFO] Added MAVEN property mvn.project.artifact.artifactid=pgjdbc-benchmark
[INFO] Added MAVEN property mvn.project.artifact.baseversion=42.1.5-SNAPSHOT
[INFO] Added MAVEN property mvn.project.artifact.dependencyconflictid=org.postgresql:pgjdbc-benchmark:jar
[INFO] Added MAVEN property mvn.project.artifact.downloadurl=
[INFO] Added MAVEN property mvn.project.artifact.groupid=org.postgresql
[INFO] Added MAVEN property mvn.project.artifact.scope=
[INFO] Added MAVEN property mvn.project.artifact.type=jar
[INFO] Added MAVEN property mvn.project.artifact.version=42.1.5-SNAPSHOT
[INFO] Added MAVEN property mvn.project.build.directory=/home/johnsontm/pgjdbc/git/pgjdbc/ubenchmark/target
[INFO] Added MAVEN property mvn.project.build.defaultgoal=
[INFO] Added MAVEN property mvn.project.build.outputdirectory=/home/johnsontm/pgjdbc/git/pgjdbc/ubenchmark/target/classes
[INFO] Added MAVEN property mvn.project.build.scriptsourcedirectory=/home/johnsontm/pgjdbc/git/pgjdbc/ubenchmark/src/main/scripts
[INFO] Added MAVEN property mvn.project.build.sourcedirectory=/home/johnsontm/pgjdbc/git/pgjdbc/ubenchmark/src/main/java
[INFO] Added MAVEN property mvn.project.build.testoutputdirectory=/home/johnsontm/pgjdbc/git/pgjdbc/ubenchmark/target/test-classes
[INFO] Added MAVEN property mvn.project.build.testsourcedirectory=/home/johnsontm/pgjdbc/git/pgjdbc/ubenchmark/src/test/java
[INFO] Added MAVEN property mvn.project.organization.name=PostgreSQL Global Development Group
[INFO] Added MAVEN property mvn.project.organization.url=http://jdbc.postgresql.org/
[INFO] Added MAVEN property mvn.project.activeprofiles=
[INFO] Added MAVEN property mvn.project.property.current.jdk=1.8
[INFO] Added MAVEN property mvn.project.property.postgresql.driver.fullversion=PostgreSQL JDBC${jdbc.specification.version}
[INFO] Added MAVEN property mvn.project.property.waffle-jna.version=1.7.5
[INFO] Added MAVEN property mvn.project.property.template.default.pg.port=5432
[INFO] Added MAVEN property mvn.project.property.skip.unzip-jdk-src=true
[INFO] Added MAVEN property mvn.project.property.jmh.version=1.17.4
[INFO] Added MAVEN property mvn.project.property.uberjar.name=benchmarks
[INFO] Added MAVEN property mvn.project.property.postgresql.jdbc.spec=JDBC${jdbc.specification.version}
[INFO] Added MAVEN property mvn.project.property.postgresql.preprocessed.test.sources.directory=/home/johnsontm/pgjdbc/git/pgjdbc/ubenchmark/target/gen-test-src
[INFO] Added MAVEN property mvn.project.property.javac.target=1.8
[INFO] Added MAVEN property mvn.project.property.project.build.sourceencoding=UTF-8
[INFO] Added MAVEN property mvn.project.property.postgresql.preprocessed.sources.directory=/home/johnsontm/pgjdbc/git/pgjdbc/ubenchmark/target/gen-src
[INFO] Added MAVEN property mvn.project.property.unzip.jdk.ant.build.xml=/home/johnsontm/pgjdbc/git/pgjdbc/ubenchmark/target/unzip-jdk-ant.xml
[INFO] Added MAVEN property mvn.project.property.argline=-Xmx512m
[INFO] Preprocess sources : /home/johnsontm/pgjdbc/git/pgjdbc/ubenchmark/src/test/java
[INFO] Preprocess destination : /home/johnsontm/pgjdbc/git/pgjdbc/ubenchmark/target/gen-test-src
[INFO] -----------------------------------------------------------------
[INFO] Completed, preprocessed 1 files, copied 0 files, elapsed time 0ms
[INFO] A Compile source root has been removed from the root list [/home/johnsontm/pgjdbc/git/pgjdbc/ubenchmark/src/test/java]
[INFO] The New compile source root has been added into the list [/home/johnsontm/pgjdbc/git/pgjdbc/ubenchmark/target/gen-test-src]
[INFO] 
[INFO] --- maven-resources-plugin:2.6:testResources (default-testResources) @ pgjdbc-benchmark ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] skip non existing resourceDirectory /home/johnsontm/pgjdbc/git/pgjdbc/ubenchmark/src/test/resources
[INFO] 
[INFO] --- maven-compiler-plugin:3.3:testCompile (default-testCompile) @ pgjdbc-benchmark ---
[INFO] Nothing to compile - all classes are up to date
[INFO] 
[INFO] --- maven-surefire-plugin:2.18.1:test (default-test) @ pgjdbc-benchmark ---
[INFO] No tests to run.
[INFO] 
[INFO] --- maven-jar-plugin:2.6:jar (default-jar) @ pgjdbc-benchmark ---
[INFO] Building jar: /home/johnsontm/pgjdbc/git/pgjdbc/ubenchmark/target/pgjdbc-benchmark-42.1.5-SNAPSHOT.jar
[INFO] 
[INFO] --- maven-shade-plugin:2.2:shade (default) @ pgjdbc-benchmark ---
[INFO] Including org.openjdk.jmh:jmh-core:jar:1.17.4 in the shaded jar.
[INFO] Including net.sf.jopt-simple:jopt-simple:jar:4.6 in the shaded jar.
[INFO] Including org.apache.commons:commons-math3:jar:3.2 in the shaded jar.
[INFO] Including org.postgresql:postgresql:jar:42.1.5-SNAPSHOT in the shaded jar.
[INFO] Replacing /home/johnsontm/pgjdbc/git/pgjdbc/ubenchmark/target/benchmarks.jar with /home/johnsontm/pgjdbc/git/pgjdbc/ubenchmark/target/pgjdbc-benchmark-42.1.5-SNAPSHOT-shaded.jar
[INFO]                                                                         
[INFO] ------------------------------------------------------------------------
[INFO] Building PostgreSQL JDBC Driver aggregate 42.1.5-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[INFO] 
[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ pgjdbc-aggregate ---
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO] 
[INFO] PostgreSQL JDBC Driver - JDBC 4.2 .................. SUCCESS [34:53 min]
[INFO] PostgreSQL JDBC Driver - benchmarks ................ SUCCESS [  1.844 s]
[INFO] PostgreSQL JDBC Driver aggregate ................... SUCCESS [  0.000 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 34:55 min
[INFO] Finished at: 2017-09-10T21:18:27-04:00
[INFO] Final Memory: 37M/454M
[INFO] ------------------------------------------------------------------------
johnsontm@dellxps139360:~/pgjdbc/git/pgjdbc$ 

--- [JDK7: pgjdbc-jre7> mvn test] ---

johnsontm@dellxps139360:~/pgjdbc/git/pgjdbc/pgjdbc-jre7$ mvn test
[INFO] Scanning for projects...
[INFO]                                                                         
[INFO] ------------------------------------------------------------------------
[INFO] Building PostgreSQL JDBC Driver - JDBC 4.1 42.1.5.jre7-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[INFO] 
[INFO] --- maven-enforcer-plugin:1.3.1:enforce (enforce-java) @ postgresql ---
[INFO] Skipping Rule Enforcement.
[INFO] 
[INFO] --- maven-toolchains-plugin:1.1:toolchain (default) @ postgresql ---
[INFO] Required toolchain: jdk [ version='1.7' ]
[INFO] Found matching toolchain for type jdk: JDK[/usr/lib/jvm/jdk1.7.0_80]
[INFO] 
[INFO] --- build-helper-maven-plugin:1.5:parse-version (parse-version) @ postgresql ---
[INFO] 
[INFO] --- properties-maven-plugin:1.0-alpha-2:read-project-properties (default) @ postgresql ---
[INFO] 
[INFO] --- jcp:6.0.1:preprocess (preprocessSources) @ postgresql ---
[INFO] Added MAVEN property mvn.project.name=PostgreSQL JDBC Driver - JDBC 4.1
[INFO] Added MAVEN property mvn.project.version=42.1.5.jre7-SNAPSHOT
[INFO] Added MAVEN property mvn.project.url=https://github.com/pgjdbc/pgjdbc-parent-poms/pgjdbc-core-parent/pgjdbc-core-prevjre/postgresql
[INFO] Added MAVEN property mvn.project.packaging=bundle
[INFO] Added MAVEN property mvn.project.modelversion=4.0.0
[INFO] Added MAVEN property mvn.project.inceptionyear=
[INFO] Added MAVEN property mvn.project.id=org.postgresql:postgresql:bundle:42.1.5.jre7-SNAPSHOT
[INFO] Added MAVEN property mvn.project.groupid=org.postgresql
[INFO] Added MAVEN property mvn.project.description=Java JDBC 4.1 (JRE 7+) driver for PostgreSQL database
[INFO] Added MAVEN property mvn.project.artifact.id=org.postgresql:postgresql:bundle:42.1.5.jre7-SNAPSHOT
[INFO] Added MAVEN property mvn.project.artifact.artifactid=postgresql
[INFO] Added MAVEN property mvn.project.artifact.baseversion=42.1.5.jre7-SNAPSHOT
[INFO] Added MAVEN property mvn.project.artifact.dependencyconflictid=org.postgresql:postgresql:bundle
[INFO] Added MAVEN property mvn.project.artifact.downloadurl=
[INFO] Added MAVEN property mvn.project.artifact.groupid=org.postgresql
[INFO] Added MAVEN property mvn.project.artifact.scope=
[INFO] Added MAVEN property mvn.project.artifact.type=bundle
[INFO] Added MAVEN property mvn.project.artifact.version=42.1.5.jre7-SNAPSHOT
[INFO] Added MAVEN property mvn.project.build.directory=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc-jre7/target
[INFO] Added MAVEN property mvn.project.build.defaultgoal=
[INFO] Added MAVEN property mvn.project.build.outputdirectory=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc-jre7/target/classes
[INFO] Added MAVEN property mvn.project.build.scriptsourcedirectory=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc-jre7/src/main/scripts
[INFO] Added MAVEN property mvn.project.build.sourcedirectory=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/src/main/java
[INFO] Added MAVEN property mvn.project.build.testoutputdirectory=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc-jre7/target/test-classes
[INFO] Added MAVEN property mvn.project.build.testsourcedirectory=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/src/test/java
[INFO] Added MAVEN property mvn.project.organization.name=PostgreSQL Global Development Group
[INFO] Added MAVEN property mvn.project.organization.url=http://jdbc.postgresql.org/
[INFO] Added MAVEN property mvn.project.activeprofiles=
[INFO] Added MAVEN property mvn.project.property.postgresql.enforce.jdk.version=[1.7,1.8)
[INFO] Added MAVEN property mvn.project.property.postgresql.preprocessed.test.sources.directory=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc-jre7/target/gen-test-src
[INFO] Added MAVEN property mvn.project.property.loggerlevel=OFF
[INFO] Added MAVEN property mvn.project.property.javac.target=1.7
[INFO] Added MAVEN property mvn.project.property.postgresql.driver.fullversion=PostgreSQL JDBC4.1
[INFO] Added MAVEN property mvn.project.property.jdbc.specification.version=4.1
[INFO] Added MAVEN property mvn.project.property.unzip.jdk.ant.build.xml=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc-jre7/target/unzip-jdk-ant.xml
[INFO] Added MAVEN property mvn.project.property.loggerfile=target/pgjdbc-tests.log
[INFO] Added MAVEN property mvn.project.property.parsedversion.minorversion=1
[INFO] Added MAVEN property mvn.project.property.project.build.sourceencoding=UTF-8
[INFO] Added MAVEN property mvn.project.property.build.properties.relative.path=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc-jre7/..
[INFO] Added MAVEN property mvn.project.property.pgjdbc.clone.location=..
[INFO] Added MAVEN property mvn.project.property.privilegedpassword=***** [hidden because may contain private info]
[INFO] Added MAVEN property mvn.project.property.waffleenabled=true
[INFO] Added MAVEN property mvn.project.property.skip.assembly=false
[INFO] Added MAVEN property mvn.project.property.protocolversion=0
[INFO] Added MAVEN property mvn.project.property.postgresql.preprocessed.sources.directory=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc-jre7/target/gen-src
[INFO] Added MAVEN property mvn.project.property.osgienabled=true
[INFO] Added MAVEN property mvn.project.property.preparethreshold=5
[INFO] Added MAVEN property mvn.project.property.password=***** [hidden because may contain private info]
[INFO] Added MAVEN property mvn.project.property.jdbc.specification.version.nodot=41
[INFO] Added MAVEN property mvn.project.property.username=test
[INFO] Added MAVEN property mvn.project.property.parsedversion.buildnumber=0
[INFO] Added MAVEN property mvn.project.property.server=localhost
[INFO] Added MAVEN property mvn.project.property.port=5432
[INFO] Added MAVEN property mvn.project.property.template.default.pg.port=5432
[INFO] Added MAVEN property mvn.project.property.parsedversion.qualifier=jre7
[INFO] Added MAVEN property mvn.project.property.waffle-jna.version=1.7.5
[INFO] Added MAVEN property mvn.project.property.skip.unzip-jdk-src=false
[INFO] Added MAVEN property mvn.project.property.database=test
[INFO] Added MAVEN property mvn.project.property.parsedversion.incrementalversion=5
[INFO] Added MAVEN property mvn.project.property.sspiusername=testsspi
[INFO] Added MAVEN property mvn.project.property.privilegeduser=postgres
[INFO] Added MAVEN property mvn.project.property.parsedversion.majorversion=42
[INFO] Added MAVEN property mvn.project.property.parsedversion.osgiversion=42.1.5.jre7
[INFO] Added MAVEN property mvn.project.property.postgresql.jdbc.spec=JDBC4.1
[INFO] Added MAVEN property mvn.project.property.argline=-Xmx512m
[INFO] Preprocess sources : /home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/src/main/java
[INFO] Preprocess destination : /home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc-jre7/target/gen-src
[INFO] -----------------------------------------------------------------
[INFO] Completed, preprocessed 208 files, copied 0 files, elapsed time 361ms
[INFO] A Compile source root has been removed from the root list [/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/src/main/java]
[INFO] The New compile source root has been added into the list [/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc-jre7/target/gen-src]
[INFO] 
[INFO] --- maven-resources-plugin:2.6:resources (default-resources) @ postgresql ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] Copying 17 resources
[INFO] 
[INFO] --- maven-compiler-plugin:3.3:compile (default-compile) @ postgresql ---
[INFO] Toolchain in maven-compiler-plugin: JDK[/usr/lib/jvm/jdk1.7.0_80]
[INFO] Nothing to compile - all classes are up to date
[INFO] 
[INFO] --- jcp:6.0.1:preprocess (preprocessTestSources) @ postgresql ---
[INFO] Added MAVEN property mvn.project.name=PostgreSQL JDBC Driver - JDBC 4.1
[INFO] Added MAVEN property mvn.project.version=42.1.5.jre7-SNAPSHOT
[INFO] Added MAVEN property mvn.project.url=https://github.com/pgjdbc/pgjdbc-parent-poms/pgjdbc-core-parent/pgjdbc-core-prevjre/postgresql
[INFO] Added MAVEN property mvn.project.packaging=bundle
[INFO] Added MAVEN property mvn.project.modelversion=4.0.0
[INFO] Added MAVEN property mvn.project.inceptionyear=
[INFO] Added MAVEN property mvn.project.id=org.postgresql:postgresql:bundle:42.1.5.jre7-SNAPSHOT
[INFO] Added MAVEN property mvn.project.groupid=org.postgresql
[INFO] Added MAVEN property mvn.project.description=Java JDBC 4.1 (JRE 7+) driver for PostgreSQL database
[INFO] Added MAVEN property mvn.project.artifact.id=org.postgresql:postgresql:bundle:42.1.5.jre7-SNAPSHOT
[INFO] Added MAVEN property mvn.project.artifact.artifactid=postgresql
[INFO] Added MAVEN property mvn.project.artifact.baseversion=42.1.5.jre7-SNAPSHOT
[INFO] Added MAVEN property mvn.project.artifact.dependencyconflictid=org.postgresql:postgresql:bundle
[INFO] Added MAVEN property mvn.project.artifact.downloadurl=
[INFO] Added MAVEN property mvn.project.artifact.groupid=org.postgresql
[INFO] Added MAVEN property mvn.project.artifact.scope=
[INFO] Added MAVEN property mvn.project.artifact.type=bundle
[INFO] Added MAVEN property mvn.project.artifact.version=42.1.5.jre7-SNAPSHOT
[INFO] Added MAVEN property mvn.project.build.directory=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc-jre7/target
[INFO] Added MAVEN property mvn.project.build.defaultgoal=
[INFO] Added MAVEN property mvn.project.build.outputdirectory=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc-jre7/target/classes
[INFO] Added MAVEN property mvn.project.build.scriptsourcedirectory=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc-jre7/src/main/scripts
[INFO] Added MAVEN property mvn.project.build.sourcedirectory=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/src/main/java
[INFO] Added MAVEN property mvn.project.build.testoutputdirectory=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc-jre7/target/test-classes
[INFO] Added MAVEN property mvn.project.build.testsourcedirectory=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/src/test/java
[INFO] Added MAVEN property mvn.project.organization.name=PostgreSQL Global Development Group
[INFO] Added MAVEN property mvn.project.organization.url=http://jdbc.postgresql.org/
[INFO] Added MAVEN property mvn.project.activeprofiles=
[INFO] Added MAVEN property mvn.project.property.postgresql.enforce.jdk.version=[1.7,1.8)
[INFO] Added MAVEN property mvn.project.property.postgresql.preprocessed.test.sources.directory=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc-jre7/target/gen-test-src
[INFO] Added MAVEN property mvn.project.property.loggerlevel=OFF
[INFO] Added MAVEN property mvn.project.property.javac.target=1.7
[INFO] Added MAVEN property mvn.project.property.postgresql.driver.fullversion=PostgreSQL JDBC4.1
[INFO] Added MAVEN property mvn.project.property.jdbc.specification.version=4.1
[INFO] Added MAVEN property mvn.project.property.unzip.jdk.ant.build.xml=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc-jre7/target/unzip-jdk-ant.xml
[INFO] Added MAVEN property mvn.project.property.loggerfile=target/pgjdbc-tests.log
[INFO] Added MAVEN property mvn.project.property.parsedversion.minorversion=1
[INFO] Added MAVEN property mvn.project.property.project.build.sourceencoding=UTF-8
[INFO] Added MAVEN property mvn.project.property.build.properties.relative.path=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc-jre7/..
[INFO] Added MAVEN property mvn.project.property.pgjdbc.clone.location=..
[INFO] Added MAVEN property mvn.project.property.privilegedpassword=***** [hidden because may contain private info]
[INFO] Added MAVEN property mvn.project.property.waffleenabled=true
[INFO] Added MAVEN property mvn.project.property.skip.assembly=false
[INFO] Added MAVEN property mvn.project.property.protocolversion=0
[INFO] Added MAVEN property mvn.project.property.postgresql.preprocessed.sources.directory=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc-jre7/target/gen-src
[INFO] Added MAVEN property mvn.project.property.osgienabled=true
[INFO] Added MAVEN property mvn.project.property.preparethreshold=5
[INFO] Added MAVEN property mvn.project.property.password=***** [hidden because may contain private info]
[INFO] Added MAVEN property mvn.project.property.jdbc.specification.version.nodot=41
[INFO] Added MAVEN property mvn.project.property.username=test
[INFO] Added MAVEN property mvn.project.property.parsedversion.buildnumber=0
[INFO] Added MAVEN property mvn.project.property.server=localhost
[INFO] Added MAVEN property mvn.project.property.port=5432
[INFO] Added MAVEN property mvn.project.property.template.default.pg.port=5432
[INFO] Added MAVEN property mvn.project.property.parsedversion.qualifier=jre7
[INFO] Added MAVEN property mvn.project.property.waffle-jna.version=1.7.5
[INFO] Added MAVEN property mvn.project.property.skip.unzip-jdk-src=false
[INFO] Added MAVEN property mvn.project.property.database=test
[INFO] Added MAVEN property mvn.project.property.parsedversion.incrementalversion=5
[INFO] Added MAVEN property mvn.project.property.sspiusername=testsspi
[INFO] Added MAVEN property mvn.project.property.privilegeduser=postgres
[INFO] Added MAVEN property mvn.project.property.parsedversion.majorversion=42
[INFO] Added MAVEN property mvn.project.property.parsedversion.osgiversion=42.1.5.jre7
[INFO] Added MAVEN property mvn.project.property.postgresql.jdbc.spec=JDBC4.1
[INFO] Added MAVEN property mvn.project.property.argline=-Xmx512m
[INFO] Preprocess sources : /home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/src/test/java
[INFO] Preprocess destination : /home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc-jre7/target/gen-test-src
[INFO] -----------------------------------------------------------------
[INFO] Completed, preprocessed 145 files, copied 0 files, elapsed time 162ms
[INFO] A Compile source root has been removed from the root list [/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/src/test/java]
[INFO] The New compile source root has been added into the list [/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc-jre7/target/gen-test-src]
[INFO] 
[INFO] --- maven-resources-plugin:2.6:testResources (default-testResources) @ postgresql ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] Copying 1 resource
[INFO] 
[INFO] --- maven-compiler-plugin:3.3:testCompile (default-testCompile) @ postgresql ---
[INFO] Toolchain in maven-compiler-plugin: JDK[/usr/lib/jvm/jdk1.7.0_80]
[INFO] Nothing to compile - all classes are up to date
[INFO] 
[INFO] --- maven-surefire-plugin:2.18.1:test (default-test) @ postgresql ---
[INFO] Toolchain in maven-surefire-plugin: JDK[/usr/lib/jvm/jdk1.7.0_80]
[INFO] Surefire report directory: /home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc-jre7/target/surefire-reports

-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Skipping SingleCertSocketFactoryTests. To enable set the property testsinglecertfactory=true in the ssltest.properties file.
Skipping ssloff8.
Skipping sslhostnossl8.
Skipping ssloff9.
Skipping sslhostnossl9.
Skipping sslhostgh8.
Skipping sslhostgh9.
Skipping sslhostbh8.
Skipping sslhostbh9.
Skipping sslhostsslgh8.
Skipping sslhostsslgh9.
Skipping sslhostsslbh8.
Skipping sslhostsslbh9.
Skipping sslhostsslcertgh8.
Skipping sslhostsslcertgh9.
Skipping sslhostsslcertbh8.
Skipping sslhostsslcertbh9.
Skipping sslcertgh8.
Skipping sslcertgh9.
Skipping sslcertbh8.
Skipping sslcertbh9.
Running org.postgresql.test.extensions.ExtensionsTestSuite
Tests run: 5, Failures: 0, Errors: 0, Skipped: 5, Time elapsed: 0.079 sec - in org.postgresql.test.extensions.ExtensionsTestSuite
Running org.postgresql.test.osgi.OsgiTestSuite
Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 sec - in org.postgresql.test.osgi.OsgiTestSuite
Running org.postgresql.test.ssl.SingleCertValidatingFactoryTestSuite
Skipping SingleCertSocketFactoryTests. To enable set the property testsinglecertfactory=true in the ssltest.properties file.
Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.postgresql.test.ssl.SingleCertValidatingFactoryTestSuite
Running org.postgresql.test.ssl.SslTestSuite
Skipping ssloff8.
Skipping sslhostnossl8.
Skipping ssloff9.
Skipping sslhostnossl9.
Skipping sslhostgh8.
Skipping sslhostgh9.
Skipping sslhostbh8.
Skipping sslhostbh9.
Skipping sslhostsslgh8.
Skipping sslhostsslgh9.
Skipping sslhostsslbh8.
Skipping sslhostsslbh9.
Skipping sslhostsslcertgh8.
Skipping sslhostsslcertgh9.
Skipping sslhostsslcertbh8.
Skipping sslhostsslcertbh9.
Skipping sslcertgh8.
Skipping sslcertgh9.
Skipping sslcertbh8.
Skipping sslcertbh9.
Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.postgresql.test.ssl.SslTestSuite
Running org.postgresql.test.jdbc2.Jdbc2TestSuite
Using seed = 1505093069256 for StrangeInputStream. Set -DStrangeInputStream.seed=1505093069256 to reproduce the test
Using seed = 1505093069477 for StrangeInputStream. Set -DStrangeInputStream.seed=1505093069477 to reproduce the test
Using seed = 1505093069713 for StrangeInputStream. Set -DStrangeInputStream.seed=1505093069713 to reproduce the test
Using seed = 1505093069956 for StrangeInputStream. Set -DStrangeInputStream.seed=1505093069956 to reproduce the test
Using seed = 1505093070170 for StrangeInputStream. Set -DStrangeInputStream.seed=1505093070170 to reproduce the test
Using seed = 1505093070386 for StrangeInputStream. Set -DStrangeInputStream.seed=1505093070386 to reproduce the test
Using seed = 1505093070595 for StrangeInputStream. Set -DStrangeInputStream.seed=1505093070595 to reproduce the test
Using seed = 1505093070812 for StrangeInputStream. Set -DStrangeInputStream.seed=1505093070812 to reproduce the test
Using seed = 1505093071043 for StrangeInputStream. Set -DStrangeInputStream.seed=1505093071043 to reproduce the test
Using seed = 1505093071247 for StrangeInputStream. Set -DStrangeInputStream.seed=1505093071247 to reproduce the test
Tests run: 4113, Failures: 0, Errors: 0, Skipped: 9, Time elapsed: 112.985 sec - in org.postgresql.test.jdbc2.Jdbc2TestSuite
Running org.postgresql.test.jdbc2.optional.OptionalTestSuite
Tests run: 49, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 0.966 sec - in org.postgresql.test.jdbc2.optional.OptionalTestSuite
Running org.postgresql.test.jdbc2.AutoRollbackTestSuite
Tests run: 96, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.555 sec - in org.postgresql.test.jdbc2.AutoRollbackTestSuite
Running org.postgresql.test.socketfactory.SocketFactoryTestSuite
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 sec - in org.postgresql.test.socketfactory.SocketFactoryTestSuite
Running org.postgresql.test.hostchooser.MultiHostTestSuite
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 sec - in org.postgresql.test.hostchooser.MultiHostTestSuite
Running org.postgresql.test.jdbc4.Jdbc4TestSuite
Tests run: 117, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.407 sec - in org.postgresql.test.jdbc4.Jdbc4TestSuite
Running org.postgresql.test.jdbc4.jdbc41.Jdbc41TestSuite
JUnit used sun.misc.Launcher$AppClassLoader@5ce345c2
SeparateClassLoaderInvokeMethod used sun.misc.Launcher$AppClassLoader@5ce345c2
se.jiderhamn.classloader.RedefiningClassLoader[org.postgresql.test.jdbc4.jdbc41.SharedTimerClassLoaderLeakTest.sharedTimerDoesNotCauseLeak]@496246a9 is being finalized
Tests run: 50, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 1.141 sec - in org.postgresql.test.jdbc4.jdbc41.Jdbc41TestSuite
Running org.postgresql.test.xa.XATestSuite
Tests run: 12, Failures: 0, Errors: 0, Skipped: 12, Time elapsed: 0.062 sec - in org.postgresql.test.xa.XATestSuite
Running org.postgresql.test.jdbc3.Jdbc3TestSuite
Tests run: 159, Failures: 0, Errors: 0, Skipped: 4, Time elapsed: 2.451 sec - in org.postgresql.test.jdbc3.Jdbc3TestSuite
Running org.postgresql.replication.ReplicationTestSuite
Tests run: 1, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 0.005 sec - in org.postgresql.replication.ReplicationTestSuite

Results :

Tests run: 4612, Failures: 0, Errors: 0, Skipped: 33

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 02:06 min
[INFO] Finished at: 2017-09-10T21:24:40-04:00
[INFO] Final Memory: 18M/411M
[INFO] ------------------------------------------------------------------------
johnsontm@dellxps139360:~/pgjdbc/git/pgjdbc/pgjdbc-jre7$ 

--- [JDK6: pgjdbc-jre6> mvn test] ---

johnsontm@dellxps139360:~/pgjdbc/git/pgjdbc/pgjdbc-jre6$ mvn test
[INFO] Scanning for projects...
[INFO]                                                                         
[INFO] ------------------------------------------------------------------------
[INFO] Building PostgreSQL JDBC Driver - JDBC 4.0 42.1.5.jre6-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[INFO] 
[INFO] --- maven-enforcer-plugin:1.3.1:enforce (enforce-java) @ postgresql ---
[INFO] Skipping Rule Enforcement.
[INFO] 
[INFO] --- maven-toolchains-plugin:1.1:toolchain (default) @ postgresql ---
[INFO] Required toolchain: jdk [ version='1.6' ]
[INFO] Found matching toolchain for type jdk: JDK[/usr/lib/jvm/jdk1.6.0_45]
[INFO] 
[INFO] --- build-helper-maven-plugin:1.5:parse-version (parse-version) @ postgresql ---
[INFO] 
[INFO] --- properties-maven-plugin:1.0-alpha-2:read-project-properties (default) @ postgresql ---
[INFO] 
[INFO] --- jcp:6.0.1:preprocess (preprocessSources) @ postgresql ---
[INFO] Added MAVEN property mvn.project.name=PostgreSQL JDBC Driver - JDBC 4.0
[INFO] Added MAVEN property mvn.project.version=42.1.5.jre6-SNAPSHOT
[INFO] Added MAVEN property mvn.project.url=https://github.com/pgjdbc/pgjdbc-parent-poms/pgjdbc-core-parent/pgjdbc-core-prevjre/postgresql
[INFO] Added MAVEN property mvn.project.packaging=bundle
[INFO] Added MAVEN property mvn.project.modelversion=4.0.0
[INFO] Added MAVEN property mvn.project.inceptionyear=
[INFO] Added MAVEN property mvn.project.id=org.postgresql:postgresql:bundle:42.1.5.jre6-SNAPSHOT
[INFO] Added MAVEN property mvn.project.groupid=org.postgresql
[INFO] Added MAVEN property mvn.project.description=Java JDBC 4.0 (JRE 6+) driver for PostgreSQL database
[INFO] Added MAVEN property mvn.project.artifact.id=org.postgresql:postgresql:bundle:42.1.5.jre6-SNAPSHOT
[INFO] Added MAVEN property mvn.project.artifact.artifactid=postgresql
[INFO] Added MAVEN property mvn.project.artifact.baseversion=42.1.5.jre6-SNAPSHOT
[INFO] Added MAVEN property mvn.project.artifact.dependencyconflictid=org.postgresql:postgresql:bundle
[INFO] Added MAVEN property mvn.project.artifact.downloadurl=
[INFO] Added MAVEN property mvn.project.artifact.groupid=org.postgresql
[INFO] Added MAVEN property mvn.project.artifact.scope=
[INFO] Added MAVEN property mvn.project.artifact.type=bundle
[INFO] Added MAVEN property mvn.project.artifact.version=42.1.5.jre6-SNAPSHOT
[INFO] Added MAVEN property mvn.project.build.directory=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc-jre6/target
[INFO] Added MAVEN property mvn.project.build.defaultgoal=
[INFO] Added MAVEN property mvn.project.build.outputdirectory=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc-jre6/target/classes
[INFO] Added MAVEN property mvn.project.build.scriptsourcedirectory=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc-jre6/src/main/scripts
[INFO] Added MAVEN property mvn.project.build.sourcedirectory=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/src/main/java
[INFO] Added MAVEN property mvn.project.build.testoutputdirectory=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc-jre6/target/test-classes
[INFO] Added MAVEN property mvn.project.build.testsourcedirectory=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/src/test/java
[INFO] Added MAVEN property mvn.project.organization.name=PostgreSQL Global Development Group
[INFO] Added MAVEN property mvn.project.organization.url=http://jdbc.postgresql.org/
[INFO] Added MAVEN property mvn.project.activeprofiles=
[INFO] Added MAVEN property mvn.project.property.postgresql.enforce.jdk.version=[1.6,1.7)
[INFO] Added MAVEN property mvn.project.property.postgresql.preprocessed.test.sources.directory=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc-jre6/target/gen-test-src
[INFO] Added MAVEN property mvn.project.property.loggerlevel=OFF
[INFO] Added MAVEN property mvn.project.property.javac.target=1.6
[INFO] Added MAVEN property mvn.project.property.postgresql.driver.fullversion=PostgreSQL JDBC4.0
[INFO] Added MAVEN property mvn.project.property.jdbc.specification.version=4.0
[INFO] Added MAVEN property mvn.project.property.unzip.jdk.ant.build.xml=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc-jre6/target/unzip-jdk-ant.xml
[INFO] Added MAVEN property mvn.project.property.loggerfile=target/pgjdbc-tests.log
[INFO] Added MAVEN property mvn.project.property.parsedversion.minorversion=1
[INFO] Added MAVEN property mvn.project.property.project.build.sourceencoding=UTF-8
[INFO] Added MAVEN property mvn.project.property.build.properties.relative.path=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc-jre6/..
[INFO] Added MAVEN property mvn.project.property.pgjdbc.clone.location=..
[INFO] Added MAVEN property mvn.project.property.privilegedpassword=***** [hidden because may contain private info]
[INFO] Added MAVEN property mvn.project.property.waffleenabled=true
[INFO] Added MAVEN property mvn.project.property.skip.assembly=false
[INFO] Added MAVEN property mvn.project.property.protocolversion=0
[INFO] Added MAVEN property mvn.project.property.postgresql.preprocessed.sources.directory=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc-jre6/target/gen-src
[INFO] Added MAVEN property mvn.project.property.osgienabled=true
[INFO] Added MAVEN property mvn.project.property.preparethreshold=5
[INFO] Added MAVEN property mvn.project.property.password=***** [hidden because may contain private info]
[INFO] Added MAVEN property mvn.project.property.jdbc.specification.version.nodot=40
[INFO] Added MAVEN property mvn.project.property.username=test
[INFO] Added MAVEN property mvn.project.property.parsedversion.buildnumber=0
[INFO] Added MAVEN property mvn.project.property.server=localhost
[INFO] Added MAVEN property mvn.project.property.port=5432
[INFO] Added MAVEN property mvn.project.property.template.default.pg.port=5432
[INFO] Added MAVEN property mvn.project.property.parsedversion.qualifier=jre6
[INFO] Added MAVEN property mvn.project.property.waffle-jna.version=1.7.5
[INFO] Added MAVEN property mvn.project.property.skip.unzip-jdk-src=false
[INFO] Added MAVEN property mvn.project.property.database=test
[INFO] Added MAVEN property mvn.project.property.parsedversion.incrementalversion=5
[INFO] Added MAVEN property mvn.project.property.sspiusername=testsspi
[INFO] Added MAVEN property mvn.project.property.privilegeduser=postgres
[INFO] Added MAVEN property mvn.project.property.parsedversion.majorversion=42
[INFO] Added MAVEN property mvn.project.property.parsedversion.osgiversion=42.1.5.jre6
[INFO] Added MAVEN property mvn.project.property.postgresql.jdbc.spec=JDBC4.0
[INFO] Added MAVEN property mvn.project.property.argline=-Xmx512m
[INFO] Preprocess sources : /home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/src/main/java
[INFO] Preprocess destination : /home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc-jre6/target/gen-src
[INFO] -----------------------------------------------------------------
[INFO] Completed, preprocessed 208 files, copied 0 files, elapsed time 344ms
[INFO] A Compile source root has been removed from the root list [/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/src/main/java]
[INFO] The New compile source root has been added into the list [/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc-jre6/target/gen-src]
[INFO] 
[INFO] --- maven-resources-plugin:2.6:resources (default-resources) @ postgresql ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] Copying 17 resources
[INFO] 
[INFO] --- maven-compiler-plugin:3.3:compile (default-compile) @ postgresql ---
[INFO] Toolchain in maven-compiler-plugin: JDK[/usr/lib/jvm/jdk1.6.0_45]
[INFO] Nothing to compile - all classes are up to date
[INFO] 
[INFO] --- jcp:6.0.1:preprocess (preprocessTestSources) @ postgresql ---
[INFO] Added MAVEN property mvn.project.name=PostgreSQL JDBC Driver - JDBC 4.0
[INFO] Added MAVEN property mvn.project.version=42.1.5.jre6-SNAPSHOT
[INFO] Added MAVEN property mvn.project.url=https://github.com/pgjdbc/pgjdbc-parent-poms/pgjdbc-core-parent/pgjdbc-core-prevjre/postgresql
[INFO] Added MAVEN property mvn.project.packaging=bundle
[INFO] Added MAVEN property mvn.project.modelversion=4.0.0
[INFO] Added MAVEN property mvn.project.inceptionyear=
[INFO] Added MAVEN property mvn.project.id=org.postgresql:postgresql:bundle:42.1.5.jre6-SNAPSHOT
[INFO] Added MAVEN property mvn.project.groupid=org.postgresql
[INFO] Added MAVEN property mvn.project.description=Java JDBC 4.0 (JRE 6+) driver for PostgreSQL database
[INFO] Added MAVEN property mvn.project.artifact.id=org.postgresql:postgresql:bundle:42.1.5.jre6-SNAPSHOT
[INFO] Added MAVEN property mvn.project.artifact.artifactid=postgresql
[INFO] Added MAVEN property mvn.project.artifact.baseversion=42.1.5.jre6-SNAPSHOT
[INFO] Added MAVEN property mvn.project.artifact.dependencyconflictid=org.postgresql:postgresql:bundle
[INFO] Added MAVEN property mvn.project.artifact.downloadurl=
[INFO] Added MAVEN property mvn.project.artifact.groupid=org.postgresql
[INFO] Added MAVEN property mvn.project.artifact.scope=
[INFO] Added MAVEN property mvn.project.artifact.type=bundle
[INFO] Added MAVEN property mvn.project.artifact.version=42.1.5.jre6-SNAPSHOT
[INFO] Added MAVEN property mvn.project.build.directory=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc-jre6/target
[INFO] Added MAVEN property mvn.project.build.defaultgoal=
[INFO] Added MAVEN property mvn.project.build.outputdirectory=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc-jre6/target/classes
[INFO] Added MAVEN property mvn.project.build.scriptsourcedirectory=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc-jre6/src/main/scripts
[INFO] Added MAVEN property mvn.project.build.sourcedirectory=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/src/main/java
[INFO] Added MAVEN property mvn.project.build.testoutputdirectory=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc-jre6/target/test-classes
[INFO] Added MAVEN property mvn.project.build.testsourcedirectory=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/src/test/java
[INFO] Added MAVEN property mvn.project.organization.name=PostgreSQL Global Development Group
[INFO] Added MAVEN property mvn.project.organization.url=http://jdbc.postgresql.org/
[INFO] Added MAVEN property mvn.project.activeprofiles=
[INFO] Added MAVEN property mvn.project.property.postgresql.enforce.jdk.version=[1.6,1.7)
[INFO] Added MAVEN property mvn.project.property.postgresql.preprocessed.test.sources.directory=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc-jre6/target/gen-test-src
[INFO] Added MAVEN property mvn.project.property.loggerlevel=OFF
[INFO] Added MAVEN property mvn.project.property.javac.target=1.6
[INFO] Added MAVEN property mvn.project.property.postgresql.driver.fullversion=PostgreSQL JDBC4.0
[INFO] Added MAVEN property mvn.project.property.jdbc.specification.version=4.0
[INFO] Added MAVEN property mvn.project.property.unzip.jdk.ant.build.xml=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc-jre6/target/unzip-jdk-ant.xml
[INFO] Added MAVEN property mvn.project.property.loggerfile=target/pgjdbc-tests.log
[INFO] Added MAVEN property mvn.project.property.parsedversion.minorversion=1
[INFO] Added MAVEN property mvn.project.property.project.build.sourceencoding=UTF-8
[INFO] Added MAVEN property mvn.project.property.build.properties.relative.path=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc-jre6/..
[INFO] Added MAVEN property mvn.project.property.pgjdbc.clone.location=..
[INFO] Added MAVEN property mvn.project.property.privilegedpassword=***** [hidden because may contain private info]
[INFO] Added MAVEN property mvn.project.property.waffleenabled=true
[INFO] Added MAVEN property mvn.project.property.skip.assembly=false
[INFO] Added MAVEN property mvn.project.property.protocolversion=0
[INFO] Added MAVEN property mvn.project.property.postgresql.preprocessed.sources.directory=/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc-jre6/target/gen-src
[INFO] Added MAVEN property mvn.project.property.osgienabled=true
[INFO] Added MAVEN property mvn.project.property.preparethreshold=5
[INFO] Added MAVEN property mvn.project.property.password=***** [hidden because may contain private info]
[INFO] Added MAVEN property mvn.project.property.jdbc.specification.version.nodot=40
[INFO] Added MAVEN property mvn.project.property.username=test
[INFO] Added MAVEN property mvn.project.property.parsedversion.buildnumber=0
[INFO] Added MAVEN property mvn.project.property.server=localhost
[INFO] Added MAVEN property mvn.project.property.port=5432
[INFO] Added MAVEN property mvn.project.property.template.default.pg.port=5432
[INFO] Added MAVEN property mvn.project.property.parsedversion.qualifier=jre6
[INFO] Added MAVEN property mvn.project.property.waffle-jna.version=1.7.5
[INFO] Added MAVEN property mvn.project.property.skip.unzip-jdk-src=false
[INFO] Added MAVEN property mvn.project.property.database=test
[INFO] Added MAVEN property mvn.project.property.parsedversion.incrementalversion=5
[INFO] Added MAVEN property mvn.project.property.sspiusername=testsspi
[INFO] Added MAVEN property mvn.project.property.privilegeduser=postgres
[INFO] Added MAVEN property mvn.project.property.parsedversion.majorversion=42
[INFO] Added MAVEN property mvn.project.property.parsedversion.osgiversion=42.1.5.jre6
[INFO] Added MAVEN property mvn.project.property.postgresql.jdbc.spec=JDBC4.0
[INFO] Added MAVEN property mvn.project.property.argline=-Xmx512m
[INFO] Preprocess sources : /home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/src/test/java
[INFO] Preprocess destination : /home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc-jre6/target/gen-test-src
[INFO] -----------------------------------------------------------------
[INFO] Completed, preprocessed 145 files, copied 0 files, elapsed time 175ms
[INFO] A Compile source root has been removed from the root list [/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc/src/test/java]
[INFO] The New compile source root has been added into the list [/home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc-jre6/target/gen-test-src]
[INFO] 
[INFO] --- maven-resources-plugin:2.6:testResources (default-testResources) @ postgresql ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] Copying 1 resource
[INFO] 
[INFO] --- maven-compiler-plugin:3.3:testCompile (default-testCompile) @ postgresql ---
[INFO] Toolchain in maven-compiler-plugin: JDK[/usr/lib/jvm/jdk1.6.0_45]
[INFO] Nothing to compile - all classes are up to date
[INFO] 
[INFO] --- maven-surefire-plugin:2.18.1:test (default-test) @ postgresql ---
[INFO] Toolchain in maven-surefire-plugin: JDK[/usr/lib/jvm/jdk1.6.0_45]
[INFO] Surefire report directory: /home/johnsontm/pgjdbc/git/pgjdbc/pgjdbc-jre6/target/surefire-reports

-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Skipping SingleCertSocketFactoryTests. To enable set the property testsinglecertfactory=true in the ssltest.properties file.
Skipping ssloff8.
Skipping sslhostnossl8.
Skipping ssloff9.
Skipping sslhostnossl9.
Skipping sslhostgh8.
Skipping sslhostgh9.
Skipping sslhostbh8.
Skipping sslhostbh9.
Skipping sslhostsslgh8.
Skipping sslhostsslgh9.
Skipping sslhostsslbh8.
Skipping sslhostsslbh9.
Skipping sslhostsslcertgh8.
Skipping sslhostsslcertgh9.
Skipping sslhostsslcertbh8.
Skipping sslhostsslcertbh9.
Skipping sslcertgh8.
Skipping sslcertgh9.
Skipping sslcertbh8.
Skipping sslcertbh9.
Running org.postgresql.test.extensions.ExtensionsTestSuite
Tests run: 5, Failures: 0, Errors: 0, Skipped: 5, Time elapsed: 0.063 sec - in org.postgresql.test.extensions.ExtensionsTestSuite
Running org.postgresql.test.osgi.OsgiTestSuite
Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 sec - in org.postgresql.test.osgi.OsgiTestSuite
Running org.postgresql.test.ssl.SingleCertValidatingFactoryTestSuite
Skipping SingleCertSocketFactoryTests. To enable set the property testsinglecertfactory=true in the ssltest.properties file.
Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.postgresql.test.ssl.SingleCertValidatingFactoryTestSuite
Running org.postgresql.test.ssl.SslTestSuite
Skipping ssloff8.
Skipping sslhostnossl8.
Skipping ssloff9.
Skipping sslhostnossl9.
Skipping sslhostgh8.
Skipping sslhostgh9.
Skipping sslhostbh8.
Skipping sslhostbh9.
Skipping sslhostsslgh8.
Skipping sslhostsslgh9.
Skipping sslhostsslbh8.
Skipping sslhostsslbh9.
Skipping sslhostsslcertgh8.
Skipping sslhostsslcertgh9.
Skipping sslhostsslcertbh8.
Skipping sslhostsslcertbh9.
Skipping sslcertgh8.
Skipping sslcertgh9.
Skipping sslcertbh8.
Skipping sslcertbh9.
Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 sec - in org.postgresql.test.ssl.SslTestSuite
Running org.postgresql.test.jdbc2.Jdbc2TestSuite
Using seed = 1505093537468 for StrangeInputStream. Set -DStrangeInputStream.seed=1505093537468 to reproduce the test
Using seed = 1505093537692 for StrangeInputStream. Set -DStrangeInputStream.seed=1505093537692 to reproduce the test
Using seed = 1505093537940 for StrangeInputStream. Set -DStrangeInputStream.seed=1505093537940 to reproduce the test
Using seed = 1505093538168 for StrangeInputStream. Set -DStrangeInputStream.seed=1505093538168 to reproduce the test
Using seed = 1505093538389 for StrangeInputStream. Set -DStrangeInputStream.seed=1505093538389 to reproduce the test
Using seed = 1505093538623 for StrangeInputStream. Set -DStrangeInputStream.seed=1505093538623 to reproduce the test
Using seed = 1505093538839 for StrangeInputStream. Set -DStrangeInputStream.seed=1505093538839 to reproduce the test
Using seed = 1505093539075 for StrangeInputStream. Set -DStrangeInputStream.seed=1505093539075 to reproduce the test
Using seed = 1505093539294 for StrangeInputStream. Set -DStrangeInputStream.seed=1505093539294 to reproduce the test
Using seed = 1505093539501 for StrangeInputStream. Set -DStrangeInputStream.seed=1505093539501 to reproduce the test
Tests run: 4113, Failures: 0, Errors: 0, Skipped: 9, Time elapsed: 114.691 sec - in org.postgresql.test.jdbc2.Jdbc2TestSuite
Running org.postgresql.test.jdbc2.optional.OptionalTestSuite
Tests run: 49, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 0.941 sec - in org.postgresql.test.jdbc2.optional.OptionalTestSuite
Running org.postgresql.test.jdbc2.AutoRollbackTestSuite
Tests run: 96, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.653 sec - in org.postgresql.test.jdbc2.AutoRollbackTestSuite
Running org.postgresql.test.socketfactory.SocketFactoryTestSuite
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 sec - in org.postgresql.test.socketfactory.SocketFactoryTestSuite
Running org.postgresql.test.hostchooser.MultiHostTestSuite
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 sec - in org.postgresql.test.hostchooser.MultiHostTestSuite
Running org.postgresql.test.jdbc4.Jdbc4TestSuite
Tests run: 117, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.138 sec - in org.postgresql.test.jdbc4.Jdbc4TestSuite
Running org.postgresql.test.xa.XATestSuite
Tests run: 12, Failures: 0, Errors: 0, Skipped: 12, Time elapsed: 0.05 sec - in org.postgresql.test.xa.XATestSuite
Running org.postgresql.test.jdbc3.Jdbc3TestSuite
Tests run: 159, Failures: 0, Errors: 0, Skipped: 4, Time elapsed: 2.579 sec - in org.postgresql.test.jdbc3.Jdbc3TestSuite
Running org.postgresql.replication.ReplicationTestSuite
Tests run: 1, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 0.005 sec - in org.postgresql.replication.ReplicationTestSuite

Results :

Tests run: 4562, Failures: 0, Errors: 0, Skipped: 32

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 02:07 min
[INFO] Finished at: 2017-09-10T21:32:27-04:00
[INFO] Final Memory: 18M/417M
[INFO] ------------------------------------------------------------------------
johnsontm@dellxps139360:~/pgjdbc/git/pgjdbc/pgjdbc-jre6$ 
```

Thanks for your consideration of this patch.