### PR TITLE
fix: Avoid integer overflow for large arguments

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/Utils.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/Utils.java
@@ -68,7 +68,7 @@ public class Utils {
   public static StringBuilder escapeLiteral(StringBuilder sbuf, String value,
       boolean standardConformingStrings) throws SQLException {
     if (sbuf == null) {
-      sbuf = new StringBuilder(value.length() * 11 / 10); // Add 10% for escaping.
+      sbuf = new StringBuilder((value.length() + 10) / 10 * 11); // Add 10% for escaping.
     }
     doAppendEscapedLiteral(sbuf, value, standardConformingStrings);
     return sbuf;
@@ -136,7 +136,7 @@ public class Utils {
   public static StringBuilder escapeIdentifier(StringBuilder sbuf, String value)
       throws SQLException {
     if (sbuf == null) {
-      sbuf = new StringBuilder(2 + value.length() * 11 / 10); // Add 10% for escaping.
+      sbuf = new StringBuilder(2 + (value.length() + 10) / 10 * 11); // Add 10% for escaping.
     }
     doAppendEscapedIdentifier(sbuf, value);
     return sbuf;

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/SimpleParameterList.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/SimpleParameterList.java
@@ -214,7 +214,7 @@ class SimpleParameterList implements V3ParameterList {
       String param = paramValues[index].toString();
 
       // add room for quotes + potential escaping.
-      StringBuilder p = new StringBuilder(3 + param.length() * 11 / 10);
+      StringBuilder p = new StringBuilder(3 + (param.length() + 10) / 10 * 11);
 
       // No E'..' here since escapeLiteral escapes all things and it does not use \123 kind of
       // escape codes

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc4/LogTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc4/LogTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2007, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.test.jdbc4;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.postgresql.test.TestUtil;
+import org.postgresql.test.jdbc2.BaseTest4;
+
+import java.sql.Array;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collection;
+
+@RunWith(Parameterized.class)
+public class LogTest extends BaseTest4 {
+
+  private String oldLevel;
+
+  public LogTest(BinaryMode binaryMode) {
+    setBinaryMode(binaryMode);
+  }
+
+  @Parameterized.Parameters(name = "binary = {0}")
+  public static Iterable<Object[]> data() {
+    Collection<Object[]> ids = new ArrayList<Object[]>();
+    for (BinaryMode binaryMode : BinaryMode.values()) {
+      ids.add(new Object[]{binaryMode});
+    }
+    return ids;
+  }
+
+  public void setUp() throws Exception {
+    oldLevel = System.getProperties().getProperty("loglevel");
+    System.getProperties().setProperty("loglevel", "2");
+    super.setUp();
+  }
+
+  public void tearDown() throws SQLException {
+    super.tearDown();
+    if (oldLevel == null) {
+      System.getProperties().remove("loglevel");
+    } else {
+      System.getProperties().setProperty("loglevel", oldLevel);
+    }
+  }
+
+  @Test
+  public void reallyLargeArgumentsBreaksLogging() throws SQLException {
+    String[] largeInput = new String[220];
+    String largeString = String.format("%1048576s", " ");
+    for (int i = 0; i < largeInput.length; i++) {
+      largeInput[i] = largeString;
+    }
+    Array arr = con.createArrayOf("text", largeInput);
+    PreparedStatement ps = con.prepareStatement("select t from unnest(?::text[]) t");
+    ps.setArray(1, arr);
+    ResultSet rs = ps.executeQuery();
+    int x = 0;
+    while (rs.next()) {
+      x += 1;
+      String found = rs.getString(1);
+      Assert.assertEquals(largeString, found);
+    }
+    Assert.assertEquals(largeInput.length, x);
+    TestUtil.closeQuietly(rs);
+    TestUtil.closeQuietly(ps);
+  }
+}


### PR DESCRIPTION
If an argument is larger than 200MB it would overflow during escaping due to optimistic size estimation.
Change size estimation so it works for even larger arguments until StringBuilder crashes with negative size error.