### PR TITLE
fix: ignore replication test until 11.1 to avoid random failures

### DIFF
--- a/pgjdbc/src/test/java/org/postgresql/replication/LogicalReplicationTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/replication/LogicalReplicationTest.java
@@ -262,7 +262,7 @@ public class LogicalReplicationTest {
    * wait new changes and until waiting messages from client ignores.
    */
   @Test(timeout = 1000)
-  @HaveMinimalServerVersion("10.1")
+  @HaveMinimalServerVersion("11.1")
   public void testAfterCloseReplicationStreamDBSlotStatusNotActive() throws Exception {
     PGConnection pgConnection = (PGConnection) replConnection;
 
@@ -333,7 +333,7 @@ public class LogicalReplicationTest {
    * wait new changes and until waiting messages from client ignores.
    */
   @Test(timeout = 10000)
-  @HaveMinimalServerVersion("10.1")
+  @HaveMinimalServerVersion("11.1")
   public void testDuringSendBigTransactionConnectionCloseSlotStatusNotActive() throws Exception {
     PGConnection pgConnection = (PGConnection) replConnection;
 
@@ -383,7 +383,7 @@ public class LogicalReplicationTest {
    * wait new changes and until waiting messages from client ignores.
    */
   @Test(timeout = 60000)
-  @HaveMinimalServerVersion("10.1")
+  @HaveMinimalServerVersion("11.1")
   public void testDuringSendBigTransactionReplicationStreamCloseNotActive() throws Exception {
     PGConnection pgConnection = (PGConnection) replConnection;
 


### PR DESCRIPTION
Some replication tests looks that suffer from race conditions for a feature
that is missing from the server "Stopping logical replication protocol".

Full discussion: https://www.postgresql.org/message-id/flat/CAFgjRd3hdYOa33m69TbeOfNNer2BZbwa8FFjt2V5VFzTBvUU3w@mail.gmail.com#CAFgjRd3hdYOa33m69TbeOfNNer2BZbwa8FFjt2V5VFzTBvUU3w@mail.gmail.com

Fixes #934 