### PR TITLE
Support Subject Alternative Names for SSL connections

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/ssl/jdbc4/LibPQFactory.java
+++ b/pgjdbc/src/main/java/org/postgresql/ssl/jdbc4/LibPQFactory.java
@@ -261,18 +261,17 @@ public class LibPQFactory extends WrappedFactory implements HostnameVerifier {
 
     try {
       // Check for Subject Alternative Names (see RFC 6125)
-      Collection subjectAltNames = serverCert.getSubjectAlternativeNames();
+      Collection <List<?>>subjectAltNames = serverCert.getSubjectAlternativeNames();
 
       if (subjectAltNames != null) {
 
-        for (Iterator<List> sanit = subjectAltNames.iterator(); sanit.hasNext();) {
+        for (List<?> sanit : subjectAltNames ) {
 
-          List list = sanit.next();
-          Integer type = (Integer) list.get(0);
-          String san = (String) list.get(1);
+          Integer type = (Integer) sanit.get(0);
+          String san = (String) sanit.get(1);
 
           // this mimics libpq check for ALT_DNS_NAME
-          if (type != null && san != null && type == ALT_DNS_NAME && san.equals(hostname)) {
+          if (type != null && san != null && type == ALT_DNS_NAME && san.equalsIgnoreCase(hostname)) {
             return true;
           }
         }

--- a/pgjdbc/src/main/java/org/postgresql/ssl/jdbc4/LibPQFactory.java
+++ b/pgjdbc/src/main/java/org/postgresql/ssl/jdbc4/LibPQFactory.java
@@ -262,15 +262,21 @@ public class LibPQFactory extends WrappedFactory implements HostnameVerifier {
     try {
       // Check for Subject Alternative Names (see RFC 6125)
       Collection subjectAltNames = serverCert.getSubjectAlternativeNames();
-      Iterator sanIt = subjectAltNames.iterator();
-      while (sanIt.hasNext()) {
-        List list = (List) sanIt.next();
-        String san = ((String) list.get(1));
-        Integer type = (Integer) list.get(0);
 
-        // this mimics libpq check for ALT_DNS_NAME
-        if (type == ALT_DNS_NAME && san.equals(hostname)) {
-          return true;
+      if (subjectAltNames != null) {
+
+        Iterator sanIt = subjectAltNames.iterator();
+
+        while (sanIt.hasNext()) {
+
+          List list = (List) sanIt.next();
+          String san = ((String) list.get(1));
+          Integer type = (Integer) list.get(0);
+
+          // this mimics libpq check for ALT_DNS_NAME
+          if (type == ALT_DNS_NAME && san.equals(hostname)) {
+            return true;
+          }
         }
       }
     } catch (CertificateParsingException e) {

--- a/pgjdbc/src/main/java/org/postgresql/ssl/jdbc4/LibPQFactory.java
+++ b/pgjdbc/src/main/java/org/postgresql/ssl/jdbc4/LibPQFactory.java
@@ -265,16 +265,14 @@ public class LibPQFactory extends WrappedFactory implements HostnameVerifier {
 
       if (subjectAltNames != null) {
 
-        Iterator sanIt = subjectAltNames.iterator();
+        for (Iterator<List> sanit = subjectAltNames.iterator(); sanit.hasNext();) {
 
-        while (sanIt.hasNext()) {
-
-          List list = (List) sanIt.next();
-          String san = ((String) list.get(1));
+          List list = sanit.next();
           Integer type = (Integer) list.get(0);
+          String san = (String) list.get(1);
 
           // this mimics libpq check for ALT_DNS_NAME
-          if (type == ALT_DNS_NAME && san.equals(hostname)) {
+          if (type != null && san != null && type == ALT_DNS_NAME && san.equals(hostname)) {
             return true;
           }
         }

--- a/pgjdbc/src/main/java/org/postgresql/ssl/jdbc4/LibPQFactory.java
+++ b/pgjdbc/src/main/java/org/postgresql/ssl/jdbc4/LibPQFactory.java
@@ -246,7 +246,7 @@ public class LibPQFactory extends WrappedFactory implements HostnameVerifier {
     if (hostname.length() < pattern.length() - 1) {
       return false;
     }
-    // Compare ingore case
+    // Compare ignore case
     final boolean ignoreCase = true;
     // Below code is "hostname.endsWithIgnoreCase(pattern.withoutFirstStar())"
 
@@ -257,7 +257,7 @@ public class LibPQFactory extends WrappedFactory implements HostnameVerifier {
     int toffset = hostname.length() - pattern.length() + 1;
 
     // Wildcard covers just one domain level
-    // a.b.c.com sould not be covered by *.c.com
+    // a.b.c.com should not be covered by *.c.com
     if (hostname.lastIndexOf('.', toffset - 1) >= 0) {
       // If there's a dot in between 0..toffset
       return false;

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc4/Jdbc4TestSuite.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc4/Jdbc4TestSuite.java
@@ -24,6 +24,7 @@ import org.junit.runners.Suite;
         BinaryStreamTest.class,
         CharacterStreamTest.class,
         UUIDTest.class,
+        LibPQFactoryHostNameTest.class,
         XmlTest.class
 })
 public class Jdbc4TestSuite {

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc4/LibPQFactoryHostNameTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc4/LibPQFactoryHostNameTest.java
@@ -1,0 +1,52 @@
+package org.postgresql.test.jdbc4;
+
+import org.postgresql.ssl.jdbc4.LibPQFactory;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+
+@RunWith(Parameterized.class)
+public class LibPQFactoryHostNameTest {
+
+  private final String hostname;
+  private final String pattern;
+  private final boolean expected;
+
+  public LibPQFactoryHostNameTest(String hostname, String pattern, boolean expected) {
+    this.hostname = hostname;
+    this.pattern = pattern;
+    this.expected = expected;
+  }
+
+  @Parameterized.Parameters(name = "host={0}, pattern={1}")
+  public static Iterable<Object[]> data() {
+    return Arrays.asList(new Object[][]{
+        {"host.com", "pattern.com", false},
+        {"host.com", ".pattern.com", false},
+        {"host.com", "*.pattern.com", false},
+        {"host.com", "*.host.com", false},
+        {"a.com", "*.host.com", false},
+        {".a.com", "*.host.com", false},
+        {"longhostname.com", "*.com", true},
+        {"longhostname.ru", "*.com", false},
+        {"host.com", "host.com", true},
+        {"sub.host.com", "host.com", false},
+        {"sub.host.com", "sub.host.com", true},
+        {"sub.host.com", "*.host.com", true},
+        {"Sub.host.com", "sub.host.com", true},
+        {"sub.host.com", "Sub.host.com", true},
+        {"sub.host.com", "*.hoSt.com", true},
+        {"*.host.com", "host.com", false},
+        {"sub.sub.host.com", "*.host.com", false}, // Wildcard should cover just one level
+    });
+  }
+
+  @Test
+  public void checkPattern() throws Exception {
+    Assert.assertEquals(expected, LibPQFactory.verifyHostName(hostname, pattern));
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc4/LibPQFactoryHostNameTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc4/LibPQFactoryHostNameTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2017, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
 package org.postgresql.test.jdbc4;
 
 import org.postgresql.ssl.jdbc4.LibPQFactory;


### PR DESCRIPTION
Qualify the type of the alternative name with ALT_DNS_NAME  to match libpq.

Previous implementation: https://github.com/pgjdbc/pgjdbc/pull/743