### PR TITLE
feat: add caller push of binary data

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/FixedLengthOutputStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/FixedLengthOutputStream.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2017, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.core;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * A stream that refuses to write more than a maximum number of bytes.
+ */
+public class FixedLengthOutputStream extends OutputStream {
+
+  private final int size;
+  private final OutputStream target;
+  private int written;
+
+  public FixedLengthOutputStream(int size, OutputStream target) {
+    this.size = size;
+    this.target = target;
+  }
+
+  @Override
+  public void write(int b) throws IOException {
+    verifyAllowed(1);
+    written++;
+    target.write(b);
+  }
+
+  public void write(byte[] buf, int offset, int len) throws IOException {
+    if ((offset < 0) || (len < 0) || ((offset + len) > buf.length)) {
+      throw new IndexOutOfBoundsException();
+    } else if (len == 0) {
+      return;
+    }
+    verifyAllowed(len);
+    target.write(buf, offset, len);
+    written += len;
+  }
+
+  public int remaining() {
+    return size - written;
+  }
+
+  private void verifyAllowed(int wanted) throws IOException {
+    if (remaining() < wanted) {
+      throw new IOException("Attempt to write more than the specified " + size + " bytes");
+    }
+  }
+}

--- a/pgjdbc/src/main/java/org/postgresql/core/PGStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/PGStream.java
@@ -5,6 +5,7 @@
 
 package org.postgresql.core;
 
+import org.postgresql.util.ByteStreamWriter;
 import org.postgresql.util.GT;
 import org.postgresql.util.HostSpec;
 import org.postgresql.util.PSQLException;
@@ -277,6 +278,27 @@ public class PGStream implements Closeable, Flushable {
     int bufamt = buf.length - off;
     pg_output.write(buf, off, bufamt < siz ? bufamt : siz);
     for (int i = bufamt; i < siz; ++i) {
+      pg_output.write(0);
+    }
+  }
+
+  /**
+   * Send a fixed-size array of bytes to the backend. If {@code length < siz}, pad with zeros. If
+   * {@code length > siz}, truncate the array.
+   *
+   * @param writer the stream writer to invoke to send the bytes
+   * @throws IOException if an I/O error occurs
+   */
+  public void send(ByteStreamWriter writer) throws IOException {
+    FixedLengthOutputStream fixedLengthStream = new FixedLengthOutputStream(writer.getLength(), pg_output);
+    try {
+      writer.writeTo(fixedLengthStream);
+    } catch (IOException ioe) {
+      throw ioe;
+    } catch (Exception re) {
+      throw new IOException("Error writing bytes to stream", re);
+    }
+    for (int i = fixedLengthStream.remaining(); i > 0; i--) {
       pg_output.write(0);
     }
   }

--- a/pgjdbc/src/main/java/org/postgresql/core/PGStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/PGStream.java
@@ -5,26 +5,14 @@
 
 package org.postgresql.core;
 
-import org.postgresql.util.ByteStreamWriter;
-import org.postgresql.util.GT;
-import org.postgresql.util.HostSpec;
-import org.postgresql.util.PSQLException;
-import org.postgresql.util.PSQLState;
+import org.postgresql.util.*;
 
-import java.io.BufferedOutputStream;
-import java.io.Closeable;
-import java.io.EOFException;
-import java.io.FilterOutputStream;
-import java.io.Flushable;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.Writer;
+import javax.net.SocketFactory;
+import java.io.*;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.SocketTimeoutException;
 import java.sql.SQLException;
-import javax.net.SocketFactory;
 
 /**
  * <p>Wrapper around the raw connection to the server that implements some basic primitives
@@ -290,9 +278,14 @@ public class PGStream implements Closeable, Flushable {
    * @throws IOException if an I/O error occurs
    */
   public void send(ByteStreamWriter writer) throws IOException {
-    FixedLengthOutputStream fixedLengthStream = new FixedLengthOutputStream(writer.getLength(), pg_output);
+    final FixedLengthOutputStream fixedLengthStream = new FixedLengthOutputStream(writer.getLength(), pg_output);
     try {
-      writer.writeTo(fixedLengthStream);
+      writer.writeTo(new ByteStreamWriter.ByteStreamTarget() {
+        @Override
+        public OutputStream getOutputStream() {
+          return fixedLengthStream;
+        }
+      });
     } catch (IOException ioe) {
       throw ioe;
     } catch (Exception re) {

--- a/pgjdbc/src/main/java/org/postgresql/core/ParameterList.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/ParameterList.java
@@ -6,6 +6,8 @@
 
 package org.postgresql.core;
 
+import org.postgresql.util.ByteStreamWriter;
+
 import java.io.InputStream;
 import java.sql.SQLException;
 
@@ -123,6 +125,16 @@ public interface ParameterList {
    * @throws SQLException on error or if <code>index</code> is out of range
    */
   void setBytea(int index, InputStream stream) throws SQLException;
+
+  /**
+   * Binds a binary bytea value stored as a ByteStreamWriter. The parameter's type is implicitly set to
+   * 'bytea'. The stream should remain valid until query execution has completed.
+   *
+   * @param index the 1-based parameter index to bind.
+   * @param writer a writer that can write the bytes for the parameter
+   * @throws SQLException on error or if <code>index</code> is out of range
+   */
+  void setBytea(int index, ByteStreamWriter writer) throws SQLException;
 
   /**
    * Binds a text value stored as an InputStream that is a valid UTF-8 byte stream.

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/CompositeParameterList.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/CompositeParameterList.java
@@ -7,6 +7,7 @@
 package org.postgresql.core.v3;
 
 import org.postgresql.core.ParameterList;
+import org.postgresql.util.ByteStreamWriter;
 import org.postgresql.util.GT;
 import org.postgresql.util.PSQLException;
 import org.postgresql.util.PSQLState;
@@ -105,6 +106,11 @@ class CompositeParameterList implements V3ParameterList {
   public void setBytea(int index, InputStream stream) throws SQLException {
     int sub = findSubParam(index);
     subparams[sub].setBytea(index - offsets[sub], stream);
+  }
+
+  public void setBytea(int index, ByteStreamWriter writer) throws SQLException {
+    int sub = findSubParam(index);
+    subparams[sub].setBytea(index - offsets[sub], writer);
   }
 
   public void setText(int index, InputStream stream) throws SQLException {

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
@@ -18,6 +18,7 @@ import org.postgresql.core.v3.BatchedQuery;
 import org.postgresql.largeobject.LargeObject;
 import org.postgresql.largeobject.LargeObjectManager;
 import org.postgresql.util.ByteConverter;
+import org.postgresql.util.ByteStreamWriter;
 import org.postgresql.util.GT;
 import org.postgresql.util.HStoreConverter;
 import org.postgresql.util.PGBinaryObject;
@@ -339,6 +340,10 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
     byte[] copy = new byte[x.length];
     System.arraycopy(x, 0, copy, 0, x.length);
     preparedParameters.setBytea(parameterIndex, copy, 0, x.length);
+  }
+
+  private void setByteStreamWriter(int parameterIndex, ByteStreamWriter x) throws SQLException {
+    preparedParameters.setBytea(parameterIndex, x);
   }
 
   public void setDate(int parameterIndex, java.sql.Date x) throws SQLException {
@@ -908,6 +913,8 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
       setDouble(parameterIndex, (Double) x);
     } else if (x instanceof byte[]) {
       setBytes(parameterIndex, (byte[]) x);
+    } else if (x instanceof ByteStreamWriter) {
+      setByteStreamWriter(parameterIndex, (ByteStreamWriter) x);
     } else if (x instanceof java.sql.Date) {
       setDate(parameterIndex, (java.sql.Date) x);
     } else if (x instanceof Time) {

--- a/pgjdbc/src/main/java/org/postgresql/util/ByteBufferByteStreamWriter.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/ByteBufferByteStreamWriter.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2017, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.util;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
+import java.nio.channels.WritableByteChannel;
+
+/**
+ * A {@link ByteStreamWriter} that writes a {@link ByteBuffer java.nio.ByteBuffer} to a byte array
+ * parameter.
+ */
+public class ByteBufferByteStreamWriter implements ByteStreamWriter {
+
+  private final ByteBuffer buf;
+  private final int length;
+
+  /**
+   * Construct the writer with the given {@link ByteBuffer}
+   *
+   * @param buf the buffer to use.
+   */
+  public ByteBufferByteStreamWriter(ByteBuffer buf) {
+    this.buf = buf;
+    this.length = buf.remaining();
+  }
+
+  @Override
+  public int getLength() {
+    return length;
+  }
+
+  @Override
+  public void writeTo(OutputStream stream) throws IOException {
+    // this _does_ involve some copying to a temporary buffer, but that's unavoidable
+    // as OutputStream itself only accepts single bytes or heap allocated byte arrays
+    WritableByteChannel c = Channels.newChannel(stream);
+    try {
+      c.write(buf);
+    } finally {
+      c.close();
+    }
+  }
+}

--- a/pgjdbc/src/main/java/org/postgresql/util/ByteBufferByteStreamWriter.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/ByteBufferByteStreamWriter.java
@@ -6,7 +6,6 @@
 package org.postgresql.util;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
 import java.nio.channels.WritableByteChannel;
@@ -36,10 +35,10 @@ public class ByteBufferByteStreamWriter implements ByteStreamWriter {
   }
 
   @Override
-  public void writeTo(OutputStream stream) throws IOException {
+  public void writeTo(ByteStreamTarget target) throws IOException {
     // this _does_ involve some copying to a temporary buffer, but that's unavoidable
     // as OutputStream itself only accepts single bytes or heap allocated byte arrays
-    WritableByteChannel c = Channels.newChannel(stream);
+    WritableByteChannel c = Channels.newChannel(target.getOutputStream());
     try {
       c.write(buf);
     } finally {

--- a/pgjdbc/src/main/java/org/postgresql/util/ByteStreamWriter.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/ByteStreamWriter.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2017, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+/**
+ * A class that can be used to set a byte array parameter by writing to an OutputStream.
+ *
+ * <p>The intended use case is wanting to write data to a byte array parameter that is stored off
+ * heap in a direct memory pool or in some other form that is inconvenient to assemble into a single
+ * heap-allocated buffer.</p>
+ * <p> Users should write their own implementation depending on the
+ * original data source. The driver provides a built-in implementation supporting the {@link
+ * java.nio.ByteBuffer} class, see {@link ByteBufferByteStreamWriter}.</p>
+ * <p> Intended usage is to simply pass in an instance using
+ * {@link java.sql.PreparedStatement#setObject(int, Object)}:</p>
+ * <pre>
+ *     int bufLength = someBufferObject.length();
+ *     preparedStatement.setObject(1, new MyByteStreamWriter(bufLength, someBufferObject));
+ * </pre>
+ * <p>The length must be known ahead of the stream being written to. </p>
+ * <p>This provides the application more control over memory management than calling
+ * {@link java.sql.PreparedStatement#setBinaryStream(int, InputStream)} as with the latter the
+ * caller has no control over the buffering strategy. </p>
+ */
+public interface ByteStreamWriter {
+
+  /**
+   * Returns the length of the stream.
+   *
+   * <p> This must be known ahead of calling {@link #writeTo(OutputStream)}. </p>
+   *
+   * @return the number of bytes in the stream.
+   */
+  int getLength();
+
+  /**
+   * Write the data to the provided {@link OutputStream}.
+   *
+   * <p> Should not write more than {@link #getLength()} bytes. If attempted, the provided stream
+   * will throw an {@link java.io.IOException}. </p>
+   *
+   * @param stream the stream to write the data to
+   * @throws IOException if the underlying stream throws or there is some other error.
+   */
+  void writeTo(OutputStream stream) throws IOException;
+}

--- a/pgjdbc/src/main/java/org/postgresql/util/ByteStreamWriter.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/ByteStreamWriter.java
@@ -34,7 +34,7 @@ public interface ByteStreamWriter {
   /**
    * Returns the length of the stream.
    *
-   * <p> This must be known ahead of calling {@link #writeTo(OutputStream)}. </p>
+   * <p> This must be known ahead of calling {@link #writeTo(ByteStreamTarget)}. </p>
    *
    * @return the number of bytes in the stream.
    */
@@ -46,8 +46,19 @@ public interface ByteStreamWriter {
    * <p> Should not write more than {@link #getLength()} bytes. If attempted, the provided stream
    * will throw an {@link java.io.IOException}. </p>
    *
-   * @param stream the stream to write the data to
+   * @param target the stream to write the data to
    * @throws IOException if the underlying stream throws or there is some other error.
    */
-  void writeTo(OutputStream stream) throws IOException;
+  void writeTo(ByteStreamTarget target) throws IOException;
+
+  /**
+   * Provides a target to write bytes to.
+   */
+  interface ByteStreamTarget {
+
+    /**
+     * Provides an output stream to write bytes to.
+     */
+    OutputStream getOutputStream();
+  }
 }

--- a/pgjdbc/src/test/java/org/postgresql/test/core/FixedLengthOutputStreamTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/core/FixedLengthOutputStreamTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2017, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.test.core;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import org.postgresql.core.FixedLengthOutputStream;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.sql.SQLException;
+
+public class FixedLengthOutputStreamTest {
+
+  private ByteArrayOutputStream targetStream;
+  private FixedLengthOutputStream fixedLengthStream;
+
+  @Before
+  public void setUp() throws Exception {
+    targetStream = new ByteArrayOutputStream();
+    fixedLengthStream = new FixedLengthOutputStream(10, targetStream);
+  }
+
+  @After
+  public void tearDown() throws SQLException {
+  }
+
+  private void verifyExpectedOutput(byte[] expected) {
+    assertArrayEquals("Incorrect data written to target stream",
+        expected, targetStream.toByteArray());
+  }
+
+  @Test
+  public void testSingleByteWrites() throws IOException {
+    fixedLengthStream.write((byte) 1);
+    assertEquals("Incorrect remaining value", 9, fixedLengthStream.remaining());
+    fixedLengthStream.write((byte) 2);
+    assertEquals("Incorrect remaining value", 8, fixedLengthStream.remaining());
+    verifyExpectedOutput(new byte[]{1, 2});
+  }
+
+  @Test
+  public void testMultipleByteWrites() throws IOException {
+    fixedLengthStream.write(new byte[]{1, 2, 3, 4});
+    assertEquals("Incorrect remaining value", 6, fixedLengthStream.remaining());
+    fixedLengthStream.write(new byte[]{5, 6, 7, 8});
+    assertEquals("Incorrect remaining value", 2, fixedLengthStream.remaining());
+    verifyExpectedOutput(new byte[]{1, 2, 3, 4, 5, 6, 7, 8});
+  }
+
+  @Test
+  public void testSingleByteOverLimit() throws IOException {
+    byte[] data = new byte[]{1, 2, 3, 4, 5, 6, 7, 8, 9, 0};
+    fixedLengthStream.write(data);
+    assertEquals("Incorrect remaining value", 0, fixedLengthStream.remaining());
+    try {
+      fixedLengthStream.write((byte) 'a');
+      fail("Expected exception not thrown");
+    } catch (IOException e) {
+      assertEquals("Incorrect exception message",
+          "Attempt to write more than the specified 10 bytes", e.getMessage());
+    }
+    assertEquals("Incorrect remaining value after exception",
+        0, fixedLengthStream.remaining());
+    verifyExpectedOutput(data);
+  }
+
+  @Test
+  public void testMultipleBytesOverLimit() throws IOException {
+    byte[] data = new byte[]{1, 2, 3, 4, 5, 6, 7, 8};
+    fixedLengthStream.write(data);
+    assertEquals(2, fixedLengthStream.remaining());
+    try {
+      fixedLengthStream.write(new byte[]{'a', 'b', 'c', 'd'});
+      fail("Expected exception not thrown");
+    } catch (IOException e) {
+      assertEquals("Incorrect exception message",
+          "Attempt to write more than the specified 10 bytes", e.getMessage());
+    }
+    assertEquals("Incorrect remaining value after exception",
+        2, fixedLengthStream.remaining());
+    verifyExpectedOutput(data);
+  }
+
+
+}
+

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/Jdbc2TestSuite.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/Jdbc2TestSuite.java
@@ -15,7 +15,10 @@ import org.postgresql.core.v3.V3ParameterListTests;
 import org.postgresql.jdbc.DeepBatchedInsertStatementTest;
 import org.postgresql.jdbc.PrimitiveArraySupportTest;
 import org.postgresql.test.core.JavaVersionTest;
+import org.postgresql.test.core.FixedLengthOutputStreamTest;
 import org.postgresql.test.core.NativeQueryBindLengthTest;
+import org.postgresql.test.util.ByteBufferByteStreamWriterTest;
+import org.postgresql.test.util.ByteStreamWriterTest;
 import org.postgresql.test.util.ExpressionPropertiesTest;
 import org.postgresql.test.util.LruCacheTest;
 import org.postgresql.test.util.ServerVersionParseTest;
@@ -131,7 +134,11 @@ import org.junit.runners.Suite;
         CopyLargeFileTest.class,
         ServerErrorTest.class,
         UpsertTest.class,
-        OuterJoinSyntaxTest.class
+        OuterJoinSyntaxTest.class,
+
+        FixedLengthOutputStreamTest.class,
+        ByteStreamWriterTest.class,
+        ByteBufferByteStreamWriterTest.class
 })
 public class Jdbc2TestSuite {
 }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/Jdbc2TestSuite.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/Jdbc2TestSuite.java
@@ -5,28 +5,17 @@
 
 package org.postgresql.test.jdbc2;
 
-import org.postgresql.core.CommandCompleteParserNegativeTest;
-import org.postgresql.core.CommandCompleteParserTest;
-import org.postgresql.core.OidToStringTest;
-import org.postgresql.core.OidValueOfTest;
-import org.postgresql.core.ParserTest;
-import org.postgresql.core.ReturningParserTest;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.postgresql.core.*;
 import org.postgresql.core.v3.V3ParameterListTests;
 import org.postgresql.jdbc.DeepBatchedInsertStatementTest;
 import org.postgresql.jdbc.PrimitiveArraySupportTest;
-import org.postgresql.test.core.JavaVersionTest;
 import org.postgresql.test.core.FixedLengthOutputStreamTest;
+import org.postgresql.test.core.JavaVersionTest;
 import org.postgresql.test.core.NativeQueryBindLengthTest;
-import org.postgresql.test.util.ByteBufferByteStreamWriterTest;
-import org.postgresql.test.util.ByteStreamWriterTest;
-import org.postgresql.test.util.ExpressionPropertiesTest;
-import org.postgresql.test.util.LruCacheTest;
-import org.postgresql.test.util.ServerVersionParseTest;
-import org.postgresql.test.util.ServerVersionTest;
+import org.postgresql.test.util.*;
 import org.postgresql.util.ReaderInputStreamTest;
-
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
 
 /*
  * Executes all known tests for JDBC2 and includes some utility methods.

--- a/pgjdbc/src/test/java/org/postgresql/test/util/ByteBufferByteStreamWriterTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/util/ByteBufferByteStreamWriterTest.java
@@ -48,7 +48,7 @@ public class ByteBufferByteStreamWriterTest {
 
   @Test
   public void testPropagatesException() throws IOException {
-    IOException e = new IOException("oh no");
+    final IOException e = new IOException("oh no");
     OutputStream errorStream = new OutputStream() {
       @Override
       public void write(int b) throws IOException {

--- a/pgjdbc/src/test/java/org/postgresql/test/util/ByteBufferByteStreamWriterTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/util/ByteBufferByteStreamWriterTest.java
@@ -17,6 +17,7 @@ import java.nio.ByteBuffer;
 
 import static org.junit.Assert.*;
 
+
 public class ByteBufferByteStreamWriterTest {
 
   private ByteArrayOutputStream targetStream;

--- a/pgjdbc/src/test/java/org/postgresql/test/util/ByteBufferByteStreamWriterTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/util/ByteBufferByteStreamWriterTest.java
@@ -5,19 +5,17 @@
 
 package org.postgresql.test.util;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-
-import org.postgresql.util.ByteBufferByteStreamWriter;
-
 import org.junit.Before;
 import org.junit.Test;
+import org.postgresql.util.ByteBufferByteStreamWriter;
+import org.postgresql.util.ByteStreamWriter;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
+
+import static org.junit.Assert.*;
 
 public class ByteBufferByteStreamWriterTest {
 
@@ -41,7 +39,7 @@ public class ByteBufferByteStreamWriterTest {
 
   @Test
   public void testCopiesDataCorrectly() throws IOException {
-    writer.writeTo(targetStream);
+    writer.writeTo(target(targetStream));
     byte[] written = targetStream.toByteArray();
     assertArrayEquals("Incorrect data written to target stream", data, written);
   }
@@ -56,12 +54,20 @@ public class ByteBufferByteStreamWriterTest {
       }
     };
     try {
-      writer.writeTo(errorStream);
+      writer.writeTo(target(errorStream));
       fail("No exception thrown");
     } catch (IOException caught) {
       assertEquals("Exception was thrown that wasn't the expected one", caught, e);
     }
   }
 
+  private static ByteStreamWriter.ByteStreamTarget target(OutputStream stream) {
+    return new ByteStreamWriter.ByteStreamTarget() {
+      @Override
+      public OutputStream getOutputStream() {
+        return stream;
+      }
+    };
+  }
 }
 

--- a/pgjdbc/src/test/java/org/postgresql/test/util/ByteBufferByteStreamWriterTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/util/ByteBufferByteStreamWriterTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2017, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.test.util;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import org.postgresql.util.ByteBufferByteStreamWriter;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+
+public class ByteBufferByteStreamWriterTest {
+
+  private ByteArrayOutputStream targetStream;
+  private byte[] data;
+  private ByteBuffer buffer;
+  private ByteBufferByteStreamWriter writer;
+
+  @Before
+  public void setUp() throws Exception {
+    targetStream = new ByteArrayOutputStream();
+    data = new byte[] { 1, 2, 3, 4 };
+    buffer = ByteBuffer.wrap(data);
+    writer = new ByteBufferByteStreamWriter(buffer);
+  }
+
+  @Test
+  public void testReportsLengthCorrectly() {
+    assertEquals("Incorrect length reported", 4, writer.getLength());
+  }
+
+  @Test
+  public void testCopiesDataCorrectly() throws IOException {
+    writer.writeTo(targetStream);
+    byte[] written = targetStream.toByteArray();
+    assertArrayEquals("Incorrect data written to target stream", data, written);
+  }
+
+  @Test
+  public void testPropagatesException() throws IOException {
+    IOException e = new IOException("oh no");
+    OutputStream errorStream = new OutputStream() {
+      @Override
+      public void write(int b) throws IOException {
+        throw e;
+      }
+    };
+    try {
+      writer.writeTo(errorStream);
+      fail("No exception thrown");
+    } catch (IOException caught) {
+      assertEquals("Exception was thrown that wasn't the expected one", caught, e);
+    }
+  }
+
+}
+

--- a/pgjdbc/src/test/java/org/postgresql/test/util/ByteStreamWriterTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/util/ByteStreamWriterTest.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright (c) 2017, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.test.util;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.postgresql.test.TestUtil;
+import org.postgresql.test.jdbc2.BaseTest4;
+import org.postgresql.util.ByteBufferByteStreamWriter;
+import org.postgresql.util.ByteStreamWriter;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Random;
+
+public class ByteStreamWriterTest extends BaseTest4 {
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    assumeByteaSupported();
+    TestUtil.createTempTable(con, "images", "img bytea");
+  }
+
+  private ByteBuffer testData(int size) {
+    ByteBuffer data = ByteBuffer.allocate(size);
+    Random random = new Random(31459);
+    while (data.remaining() > 0) {
+      data.putLong(random.nextLong());
+    }
+    data.rewind();
+    return data;
+  }
+
+  private void insertStream(ByteBuffer testData) throws Exception {
+    insertStream(testData, null);
+  }
+
+  private void insertStream(ByteBuffer testData, Integer lengthOverride) throws Exception {
+    insertStream(new TestByteBufferByteStreamWriter(testData, lengthOverride));
+  }
+
+  private void insertStream(ByteStreamWriter writer) throws Exception {
+    PreparedStatement updatePS = con.prepareStatement(TestUtil.insertSQL("images", "img", "?"));
+    try {
+      updatePS.setObject(1, writer);
+      updatePS.executeUpdate();
+    } finally {
+      updatePS.close();
+    }
+  }
+
+  private void validateContent(ByteBuffer data) throws Exception {
+    validateContent(data.array());
+  }
+
+  private void validateContent(byte [] data) throws Exception {
+    PreparedStatement selectPS = con.prepareStatement(TestUtil.selectSQL("images", "img"));
+    try {
+      ResultSet rs = selectPS.executeQuery();
+      try {
+        rs.next();
+        byte[] actualData = rs.getBytes(1);
+        assertArrayEquals("Sent and received data are not the same", data, actualData);
+      } finally {
+        rs.close();
+      }
+    } finally {
+      selectPS.close();
+    }
+  }
+
+  @Test
+  public void testEmpty() throws Exception {
+    ByteBuffer testData = testData(0);
+    insertStream(testData);
+    validateContent(testData);
+  }
+
+  @Test
+  public void testLength2Kb() throws Exception {
+    ByteBuffer testData = testData(2 * 1024);
+    insertStream(testData);
+    validateContent(testData);
+  }
+
+  @Test
+  public void testLength10Kb() throws Exception {
+    ByteBuffer testData = testData(10 * 1024);
+    insertStream(testData);
+    validateContent(testData);
+  }
+
+  @Test
+  public void testLength100Kb() throws Exception {
+    ByteBuffer testData = testData(100 * 1024);
+    insertStream(testData);
+    validateContent(testData);
+  }
+
+  @Test
+  public void testLength200Kb() throws Exception {
+    ByteBuffer testData = testData(200 * 1024);
+    insertStream(testData);
+    validateContent(testData);
+  }
+
+  @Test
+  public void testLengthGreaterThanContent() throws Exception {
+    ByteBuffer testData = testData(8);
+    insertStream(testData, 10);
+    byte[] expectedData = new byte[10];
+    testData.rewind();
+    testData.get(expectedData, 0, 8);
+    // other two bytes are zeroed out, which the jvm does for us automatically
+    validateContent(expectedData);
+  }
+
+  @Test
+  public void testLengthLessThanContent() throws Exception {
+    ByteBuffer testData = testData(8);
+    try {
+      insertStream(testData, 4);
+      fail("did not throw exception when too much content");
+    } catch (SQLException e) {
+      Throwable cause = e.getCause();
+      assertTrue("cause wan't an IOException", cause instanceof IOException);
+      assertEquals("Incorrect exception message",
+          cause.getMessage(), "Attempt to write more than the specified 4 bytes");
+    }
+  }
+
+  @Test
+  public void testIOExceptionPassedThroughAsCause() throws Exception {
+    IOException e = new IOException("oh no");
+    try {
+      insertStream(new ExceptionThrowingByteStreamWriter(e));
+      fail("did not throw exception when IOException thrown");
+    } catch (SQLException sqle) {
+      Throwable cause = sqle.getCause();
+      assertEquals("Incorrect exception cause", e, cause);
+    }
+  }
+
+  @Test
+  public void testRuntimeExceptionPassedThroughAsIOException() throws Exception {
+    RuntimeException e = new RuntimeException("oh no");
+    try {
+      insertStream(new ExceptionThrowingByteStreamWriter(e));
+      fail("did not throw exception when RuntimeException thrown");
+    } catch (SQLException sqle) {
+      Throwable cause = sqle.getCause();
+      assertTrue("cause wan't an IOException", cause instanceof IOException);
+      assertEquals("Incorrect exception message",
+          cause.getMessage(), "Error writing bytes to stream");
+      Throwable nestedCause = cause.getCause();
+      assertEquals("Incorrect exception cause", e, nestedCause);
+    }
+  }
+
+  /**
+   * Allows testing where reported length doesn't match what the stream writer attempts
+   */
+  private static class TestByteBufferByteStreamWriter extends ByteBufferByteStreamWriter {
+
+    private final Integer lengthOverride;
+
+    private TestByteBufferByteStreamWriter(ByteBuffer buf, Integer lengthOverride) {
+      super(buf);
+      this.lengthOverride = lengthOverride;
+    }
+
+    @Override
+    public int getLength() {
+      return lengthOverride != null ? lengthOverride : super.getLength();
+    }
+  }
+
+  private static class ExceptionThrowingByteStreamWriter implements ByteStreamWriter {
+
+    private final Throwable cause;
+
+    private ExceptionThrowingByteStreamWriter(Throwable cause) {
+      assertTrue(cause instanceof RuntimeException || cause instanceof IOException);
+      this.cause = cause;
+    }
+
+    @Override
+    public int getLength() {
+      return 1;
+    }
+
+    @Override
+    public void writeTo(OutputStream stream) throws IOException {
+      if (cause instanceof RuntimeException) {
+        throw (RuntimeException) cause;
+      } else if (cause instanceof IOException) {
+        throw (IOException) cause;
+      }
+    }
+  }
+
+}

--- a/pgjdbc/src/test/java/org/postgresql/test/util/ByteStreamWriterTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/util/ByteStreamWriterTest.java
@@ -5,25 +5,20 @@
 
 package org.postgresql.test.util;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
+import org.junit.Test;
 import org.postgresql.test.TestUtil;
 import org.postgresql.test.jdbc2.BaseTest4;
 import org.postgresql.util.ByteBufferByteStreamWriter;
 import org.postgresql.util.ByteStreamWriter;
 
-import org.junit.Test;
-
 import java.io.IOException;
-import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Random;
+
+import static org.junit.Assert.*;
 
 public class ByteStreamWriterTest extends BaseTest4 {
 
@@ -203,7 +198,7 @@ public class ByteStreamWriterTest extends BaseTest4 {
     }
 
     @Override
-    public void writeTo(OutputStream stream) throws IOException {
+    public void writeTo(ByteStreamTarget target) throws IOException {
       if (cause instanceof RuntimeException) {
         throw (RuntimeException) cause;
       } else if (cause instanceof IOException) {


### PR DESCRIPTION
Allows a caller to push binary data to an output stream rather than
having to provide a byte array or input stream. This gives the caller
more control over buffering strategy and allows explicit cleanup of
off-heap buffers or other non-garbage-collected resources.

Originally discussed on-list [here](https://www.postgresql.org/message-id/C659D6A4-430F-4F55-BE06-BE1C960A5405%40tomd.cc).