### PR TITLE
refactor: introduce tuple abstraction

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/BaseStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/BaseStatement.java
@@ -24,7 +24,7 @@ public interface BaseStatement extends PGStatement, Statement {
    * @return the new ResultSet
    * @throws SQLException if something goes wrong
    */
-  ResultSet createDriverResultSet(Field[] fields, List<byte[][]> tuples) throws SQLException;
+  ResultSet createDriverResultSet(Field[] fields, List<Tuple> tuples) throws SQLException;
 
   /**
    * Create a resultset from data retrieved from the server.
@@ -38,7 +38,7 @@ public interface BaseStatement extends PGStatement, Statement {
    * @return the new ResultSet
    * @throws SQLException if something goes wrong
    */
-  ResultSet createResultSet(Query originalQuery, Field[] fields, List<byte[][]> tuples,
+  ResultSet createResultSet(Query originalQuery, Field[] fields, List<Tuple> tuples,
       ResultCursor cursor) throws SQLException;
 
   /**

--- a/pgjdbc/src/main/java/org/postgresql/core/PGStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/PGStream.java
@@ -391,7 +391,7 @@ public class PGStream implements Closeable {
    * @return tuple from the back end
    * @throws IOException if a data I/O error occurs
    */
-  public byte[][] receiveTupleV3() throws IOException, OutOfMemoryError {
+  public Tuple receiveTupleV3() throws IOException, OutOfMemoryError {
     // TODO: use l_msgSize
     int l_msgSize = receiveInteger4();
     int l_nf = receiveInteger2();
@@ -415,7 +415,7 @@ public class PGStream implements Closeable {
       throw oom;
     }
 
-    return answer;
+    return new Tuple(answer);
   }
 
   /**

--- a/pgjdbc/src/main/java/org/postgresql/core/ResultHandler.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/ResultHandler.java
@@ -36,8 +36,7 @@ public interface ResultHandler {
    * @param cursor a cursor to use to fetch additional data; <code>null</code> if no further results
    *        are present.
    */
-  void handleResultRows(Query fromQuery, Field[] fields, List<byte[][]> tuples,
-      ResultCursor cursor);
+  void handleResultRows(Query fromQuery, Field[] fields, List<Tuple> tuples, ResultCursor cursor);
 
   /**
    * Called when a query that did not return a resultset completes.

--- a/pgjdbc/src/main/java/org/postgresql/core/ResultHandlerBase.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/ResultHandlerBase.java
@@ -25,7 +25,7 @@ public class ResultHandlerBase implements ResultHandler {
   private SQLWarning lastWarning;
 
   @Override
-  public void handleResultRows(Query fromQuery, Field[] fields, List<byte[][]> tuples,
+  public void handleResultRows(Query fromQuery, Field[] fields, List<Tuple> tuples,
       ResultCursor cursor) {
   }
 

--- a/pgjdbc/src/main/java/org/postgresql/core/ResultHandlerDelegate.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/ResultHandlerDelegate.java
@@ -23,7 +23,7 @@ public class ResultHandlerDelegate implements ResultHandler {
   }
 
   @Override
-  public void handleResultRows(Query fromQuery, Field[] fields, List<byte[][]> tuples,
+  public void handleResultRows(Query fromQuery, Field[] fields, List<Tuple> tuples,
       ResultCursor cursor) {
     if (delegate != null) {
       delegate.handleResultRows(fromQuery, fields, tuples, cursor);

--- a/pgjdbc/src/main/java/org/postgresql/core/SetupQueryRunner.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/SetupQueryRunner.java
@@ -21,13 +21,13 @@ import java.util.List;
 public class SetupQueryRunner {
 
   private static class SimpleResultHandler extends ResultHandlerBase {
-    private List<byte[][]> tuples;
+    private List<Tuple> tuples;
 
-    List<byte[][]> getResults() {
+    List<Tuple> getResults() {
       return tuples;
     }
 
-    public void handleResultRows(Query fromQuery, Field[] fields, List<byte[][]> tuples,
+    public void handleResultRows(Query fromQuery, Field[] fields, List<Tuple> tuples,
         ResultCursor cursor) {
       this.tuples = tuples;
     }
@@ -38,7 +38,7 @@ public class SetupQueryRunner {
     }
   }
 
-  public static byte[][] run(QueryExecutor executor, String queryString,
+  public static Tuple run(QueryExecutor executor, String queryString,
       boolean wantResults) throws SQLException {
     Query query = executor.createSimpleQuery(queryString);
     SimpleResultHandler handler = new SimpleResultHandler();
@@ -59,7 +59,7 @@ public class SetupQueryRunner {
       return null;
     }
 
-    List<byte[][]> tuples = handler.getResults();
+    List<Tuple> tuples = handler.getResults();
     if (tuples == null || tuples.size() != 1) {
       throw new PSQLException(GT.tr("An unexpected result was returned by a query."),
           PSQLState.CONNECTION_UNABLE_TO_CONNECT);

--- a/pgjdbc/src/main/java/org/postgresql/core/Tuple.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/Tuple.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2008, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.core;
+
+public class Tuple {
+  private final boolean forUpdate;
+  final byte[][] data;
+
+  public Tuple(int length) {
+    this(new byte[length][], true);
+  }
+
+  public Tuple(byte[][] data) {
+    this(data, false);
+  }
+
+  private Tuple(byte[][] data, boolean forUpdate) {
+    this.data = data;
+    this.forUpdate = forUpdate;
+  }
+
+  public int columnCount() {
+    return data.length;
+  }
+
+  public int length() {
+    int length = 0;
+    for (byte[] aTuple : data) {
+      if (aTuple != null) {
+        length += aTuple.length;
+      }
+    }
+    return length;
+  }
+
+  public byte[] get(int index) {
+    return data[index];
+  }
+
+  public Tuple updateableCopy() {
+    return copy(true);
+  }
+
+  public Tuple readOnlyCopy() {
+    return copy(false);
+  }
+
+  private Tuple copy(boolean forUpdate) {
+    byte[][] dataCopy = new byte[data.length][];
+    System.arraycopy(data, 0, dataCopy, 0, data.length);
+    return new Tuple(dataCopy, forUpdate);
+  }
+
+  public void set(int column, byte[] fieldData) {
+    if (!forUpdate) {
+      throw new IllegalArgumentException("Attempted to write to readonly tuple");
+    }
+    data[column] = fieldData;
+  }
+}

--- a/pgjdbc/src/main/java/org/postgresql/core/Tuple.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/Tuple.java
@@ -1,18 +1,29 @@
 /*
- * Copyright (c) 2008, PostgreSQL Global Development Group
+ * Copyright (c) 2017, PostgreSQL Global Development Group
  * See the LICENSE file in the project root for more information.
  */
 
 package org.postgresql.core;
 
+/**
+ * Class representing a row in a {@link java.sql.ResultSet}.
+ */
 public class Tuple {
   private final boolean forUpdate;
   final byte[][] data;
 
+  /**
+   * Construct an empty tuple. Used in updatable result sets.
+   * @param length the number of fields in the tuple.
+   */
   public Tuple(int length) {
     this(new byte[length][], true);
   }
 
+  /**
+   * Construct a populated tuple. Used when returning results.
+   * @param data the tuple data
+   */
   public Tuple(byte[][] data) {
     this(data, false);
   }
@@ -22,28 +33,49 @@ public class Tuple {
     this.forUpdate = forUpdate;
   }
 
-  public int columnCount() {
+  /**
+   * Number of fields in the tuple
+   * @return number of fields
+   */
+  public int fieldCount() {
     return data.length;
   }
 
+  /**
+   * Total length in bytes of the tuple data.
+   * @return the number of bytes in this tuple
+   */
   public int length() {
     int length = 0;
-    for (byte[] aTuple : data) {
-      if (aTuple != null) {
-        length += aTuple.length;
+    for (byte[] field : data) {
+      if (field != null) {
+        length += field.length;
       }
     }
     return length;
   }
 
+  /**
+   * Get the data for the given field
+   * @param index 0-based field position in the tuple
+   * @return byte array of the data
+   */
   public byte[] get(int index) {
     return data[index];
   }
 
+  /**
+   * Create a copy of the tuple for updating.
+   * @return a copy of the tuple that allows updates
+   */
   public Tuple updateableCopy() {
     return copy(true);
   }
 
+  /**
+   * Create a read-only copy of the tuple
+   * @return a copy of the tuple that does not allow updates
+   */
   public Tuple readOnlyCopy() {
     return copy(false);
   }
@@ -54,10 +86,15 @@ public class Tuple {
     return new Tuple(dataCopy, forUpdate);
   }
 
-  public void set(int column, byte[] fieldData) {
+  /**
+   * Set the given field to the given data.
+   * @param index 0-based field position
+   * @param fieldData the data to set
+   */
+  public void set(int index, byte[] fieldData) {
     if (!forUpdate) {
       throw new IllegalArgumentException("Attempted to write to readonly tuple");
     }
-    data[column] = fieldData;
+    data[index] = fieldData;
   }
 }

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java
@@ -13,6 +13,7 @@ import org.postgresql.core.QueryExecutor;
 import org.postgresql.core.ServerVersion;
 import org.postgresql.core.SetupQueryRunner;
 import org.postgresql.core.SocketFactoryFactory;
+import org.postgresql.core.Tuple;
 import org.postgresql.core.Utils;
 import org.postgresql.core.Version;
 import org.postgresql.hostchooser.GlobalHostStatusTracker;
@@ -663,8 +664,8 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
   }
 
   private boolean isMaster(QueryExecutor queryExecutor) throws SQLException, IOException {
-    byte[][] results = SetupQueryRunner.run(queryExecutor, "show transaction_read_only", true);
-    String value = queryExecutor.getEncoding().decode(results[0]);
+    Tuple results = SetupQueryRunner.run(queryExecutor, "show transaction_read_only", true);
+    String value = queryExecutor.getEncoding().decode(results.get(0));
     return value.equalsIgnoreCase("off");
   }
 }

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/CallableBatchResultHandler.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/CallableBatchResultHandler.java
@@ -9,6 +9,7 @@ import org.postgresql.core.Field;
 import org.postgresql.core.ParameterList;
 import org.postgresql.core.Query;
 import org.postgresql.core.ResultCursor;
+import org.postgresql.core.Tuple;
 
 import java.util.List;
 
@@ -17,7 +18,7 @@ class CallableBatchResultHandler extends BatchResultHandler {
     super(statement, queries, parameterLists, false);
   }
 
-  public void handleResultRows(Query fromQuery, Field[] fields, List<byte[][]> tuples, ResultCursor cursor) {
+  public void handleResultRows(Query fromQuery, Field[] fields, List<Tuple> tuples, ResultCursor cursor) {
     /* ignore */
   }
 }

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgArray.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgArray.java
@@ -10,6 +10,7 @@ import org.postgresql.core.BaseStatement;
 import org.postgresql.core.Encoding;
 import org.postgresql.core.Field;
 import org.postgresql.core.Oid;
+import org.postgresql.core.Tuple;
 import org.postgresql.jdbc2.ArrayAssistant;
 import org.postgresql.jdbc2.ArrayAssistantRegistry;
 import org.postgresql.util.ByteConverter;
@@ -282,7 +283,7 @@ public class PgArray implements java.sql.Array {
     if (count > 0 && dimensions > 0) {
       dims[0] = Math.min(count, dims[0]);
     }
-    List<byte[][]> rows = new ArrayList<byte[][]>();
+    List<Tuple> rows = new ArrayList<Tuple>();
     Field[] fields = new Field[2];
 
     storeValues(rows, fields, elementOid, dims, pos, 0, index);
@@ -292,7 +293,7 @@ public class PgArray implements java.sql.Array {
     return stat.createDriverResultSet(fields, rows);
   }
 
-  private int storeValues(List<byte[][]> rows, Field[] fields, int elementOid, final int[] dims,
+  private int storeValues(List<Tuple> rows, Field[] fields, int elementOid, final int[] dims,
       int pos, final int thisDimension, int index) throws SQLException {
     // handle an empty array
     if (dims.length == 0) {
@@ -323,7 +324,7 @@ public class PgArray implements java.sql.Array {
         byte[][] rowData = new byte[2][];
         rowData[0] = new byte[4];
         ByteConverter.int4(rowData[0], 0, i + index);
-        rows.add(rowData);
+        rows.add(new Tuple(rowData));
         int len = ByteConverter.int4(fieldBytes, pos);
         pos += 4;
         if (len == -1) {
@@ -347,7 +348,7 @@ public class PgArray implements java.sql.Array {
         byte[][] rowData = new byte[2][];
         rowData[0] = new byte[4];
         ByteConverter.int4(rowData[0], 0, i + index);
-        rows.add(rowData);
+        rows.add(new Tuple(rowData));
         int dataEndPos = calcRemainingDataLength(dims, pos, elementOid, nextDimension);
         int dataLength = dataEndPos - pos;
         rowData[1] = new byte[12 + 8 * dimensionsLeft + dataLength];
@@ -834,7 +835,7 @@ public class PgArray implements java.sql.Array {
           PSQLState.DATA_ERROR);
     }
 
-    List<byte[][]> rows = new ArrayList<byte[][]>();
+    List<Tuple> rows = new ArrayList<Tuple>();
 
     Field[] fields = new Field[2];
 
@@ -851,7 +852,7 @@ public class PgArray implements java.sql.Array {
         String v = (String) arrayList.get(offset);
         t[0] = connection.encodeString(Integer.toString(offset + 1));
         t[1] = v == null ? null : connection.encodeString(v);
-        rows.add(t);
+        rows.add(new Tuple(t));
       }
     } else {
       // when multi-dimensional
@@ -864,7 +865,7 @@ public class PgArray implements java.sql.Array {
 
         t[0] = connection.encodeString(Integer.toString(offset + 1));
         t[1] = v == null ? null : connection.encodeString(toString((PgArrayList) v));
-        rows.add(t);
+        rows.add(new Tuple(t));
       }
     }
 

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
@@ -9,6 +9,7 @@ import org.postgresql.core.BaseStatement;
 import org.postgresql.core.Field;
 import org.postgresql.core.Oid;
 import org.postgresql.core.ServerVersion;
+import org.postgresql.core.Tuple;
 import org.postgresql.util.GT;
 import org.postgresql.util.JdbcBlackHole;
 import org.postgresql.util.PSQLException;
@@ -981,7 +982,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
     int columns = 20;
 
     Field[] f = new Field[columns];
-    List<byte[][]> v = new ArrayList<byte[][]>(); // The new ResultSet tuple stuff
+    List<Tuple> v = new ArrayList<Tuple>(); // The new ResultSet tuple stuff
 
     f[0] = new Field("PROCEDURE_CAT", Oid.VARCHAR);
     f[1] = new Field("PROCEDURE_SCHEM", Oid.VARCHAR);
@@ -1082,7 +1083,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
         tuple[18] = isnullableUnknown;
         tuple[19] = specificName;
 
-        v.add(tuple);
+        v.add(new Tuple(tuple));
       }
 
       // Add a row for each argument.
@@ -1130,7 +1131,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
         tuple[18] = isnullableUnknown;
         tuple[19] = specificName;
 
-        v.add(tuple);
+        v.add(new Tuple(tuple));
       }
 
       // if we are returning a multi-column result.
@@ -1163,7 +1164,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
           tuple[18] = isnullableUnknown;
           tuple[19] = specificName;
 
-          v.add(tuple);
+          v.add(new Tuple(tuple));
         }
         columnrs.close();
         columnstmt.close();
@@ -1355,11 +1356,11 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
   @Override
   public ResultSet getCatalogs() throws SQLException {
     Field[] f = new Field[1];
-    List<byte[][]> v = new ArrayList<byte[][]>();
+    List<Tuple> v = new ArrayList<Tuple>();
     f[0] = new Field("TABLE_CAT", Oid.VARCHAR);
     byte[][] tuple = new byte[1][];
     tuple[0] = connection.encodeString(connection.getCatalog());
-    v.add(tuple);
+    v.add(new Tuple(tuple));
 
     return ((BaseStatement) createMetaDataStatement()).createDriverResultSet(f, v);
   }
@@ -1370,12 +1371,12 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
     Arrays.sort(types);
 
     Field[] f = new Field[1];
-    List<byte[][]> v = new ArrayList<byte[][]>();
+    List<Tuple> v = new ArrayList<Tuple>();
     f[0] = new Field("TABLE_TYPE", Oid.VARCHAR);
     for (String type : types) {
       byte[][] tuple = new byte[1][];
       tuple[0] = connection.encodeString(type);
-      v.add(tuple);
+      v.add(new Tuple(tuple));
     }
 
     return ((BaseStatement) createMetaDataStatement()).createDriverResultSet(f, v);
@@ -1385,7 +1386,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
                               String columnNamePattern) throws SQLException {
 
     int numberOfFields = 23; // JDBC4
-    List<byte[][]> v = new ArrayList<byte[][]>(); // The new ResultSet tuple stuff
+    List<Tuple> v = new ArrayList<Tuple>(); // The new ResultSet tuple stuff
     Field[] f = new Field[numberOfFields]; // The field descriptors for the new ResultSet
 
     f[0] = new Field("TABLE_CAT", Oid.VARCHAR);
@@ -1553,7 +1554,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
       }
       tuple[22] = connection.encodeString(autoinc);
 
-      v.add(tuple);
+      v.add(new Tuple(tuple));
     }
     rs.close();
     stmt.close();
@@ -1565,7 +1566,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
   public ResultSet getColumnPrivileges(String catalog, String schema, String table,
       String columnNamePattern) throws SQLException {
     Field[] f = new Field[8];
-    List<byte[][]> v = new ArrayList<byte[][]>();
+    List<Tuple> v = new ArrayList<Tuple>();
 
     f[0] = new Field("TABLE_CAT", Oid.VARCHAR);
     f[1] = new Field("TABLE_SCHEM", Oid.VARCHAR);
@@ -1635,7 +1636,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
             tuple[5] = connection.encodeString(grantee);
             tuple[6] = privilege;
             tuple[7] = connection.encodeString(grantable);
-            v.add(tuple);
+            v.add(new Tuple(tuple));
           }
         }
       }
@@ -1650,7 +1651,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
   public ResultSet getTablePrivileges(String catalog, String schemaPattern,
       String tableNamePattern) throws SQLException {
     Field[] f = new Field[7];
-    List<byte[][]> v = new ArrayList<byte[][]>();
+    List<Tuple> v = new ArrayList<Tuple>();
 
     f[0] = new Field("TABLE_CAT", Oid.VARCHAR);
     f[1] = new Field("TABLE_SCHEM", Oid.VARCHAR);
@@ -1705,7 +1706,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
             tuple[4] = connection.encodeString(granteeUser);
             tuple[5] = privilege;
             tuple[6] = connection.encodeString(grantable);
-            v.add(tuple);
+            v.add(new Tuple(tuple));
           }
         }
       }
@@ -1884,7 +1885,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
   public ResultSet getBestRowIdentifier(String catalog, String schema, String table,
       int scope, boolean nullable) throws SQLException {
     Field[] f = new Field[8];
-    List<byte[][]> v = new ArrayList<byte[][]>(); // The new ResultSet tuple stuff
+    List<Tuple> v = new ArrayList<Tuple>(); // The new ResultSet tuple stuff
 
     f[0] = new Field("SCOPE", Oid.INT2);
     f[1] = new Field("COLUMN_NAME", Oid.VARCHAR);
@@ -1940,7 +1941,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
       tuple[6] = connection.encodeString(Integer.toString(decimalDigits));
       tuple[7] =
           connection.encodeString(Integer.toString(java.sql.DatabaseMetaData.bestRowNotPseudo));
-      v.add(tuple);
+      v.add(new Tuple(tuple));
     }
     rs.close();
     stmt.close();
@@ -1951,7 +1952,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
   public ResultSet getVersionColumns(String catalog, String schema, String table)
       throws SQLException {
     Field[] f = new Field[8];
-    List<byte[][]> v = new ArrayList<byte[][]>(); // The new ResultSet tuple stuff
+    List<Tuple> v = new ArrayList<Tuple>(); // The new ResultSet tuple stuff
 
     f[0] = new Field("SCOPE", Oid.INT2);
     f[1] = new Field("COLUMN_NAME", Oid.VARCHAR);
@@ -1982,7 +1983,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
     tuple[6] = null;
     tuple[7] =
         connection.encodeString(Integer.toString(java.sql.DatabaseMetaData.versionColumnPseudo));
-    v.add(tuple);
+    v.add(new Tuple(tuple));
 
     /*
      * Perhaps we should check that the given catalog.schema.table actually exists. -KJ
@@ -2133,7 +2134,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
   public ResultSet getTypeInfo() throws SQLException {
 
     Field[] f = new Field[18];
-    List<byte[][]> v = new ArrayList<byte[][]>(); // The new ResultSet tuple stuff
+    List<Tuple> v = new ArrayList<Tuple>(); // The new ResultSet tuple stuff
 
     f[0] = new Field("TYPE_NAME", Oid.VARCHAR);
     f[1] = new Field("DATA_TYPE", Oid.INT2);
@@ -2206,7 +2207,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
       // 12 - LOCAL_TYPE_NAME is null
       // 15 & 16 are unused so we return null
       tuple[17] = b10; // everything is base 10
-      v.add(tuple);
+      v.add(new Tuple(tuple));
 
       // add pseudo-type serial, bigserial
       if (typname.equals("int4")) {
@@ -2214,13 +2215,13 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
 
         tuple1[0] = connection.encodeString("serial");
         tuple1[11] = bt;
-        v.add(tuple1);
+        v.add(new Tuple(tuple1));
       } else if (typname.equals("int8")) {
         byte[][] tuple1 = tuple.clone();
 
         tuple1[0] = connection.encodeString("bigserial");
         tuple1[11] = bt;
-        v.add(tuple1);
+        v.add(new Tuple(tuple1));
       }
 
     }
@@ -2513,7 +2514,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
     f[2] = new Field("DEFAULT_VALUE", Oid.VARCHAR);
     f[3] = new Field("DESCRIPTION", Oid.VARCHAR);
 
-    List<byte[][]> v = new ArrayList<byte[][]>();
+    List<Tuple> v = new ArrayList<Tuple>();
 
     if (connection.haveMinimumServerVersion(ServerVersion.v9_0)) {
       byte[][] tuple = new byte[4][];
@@ -2522,7 +2523,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
       tuple[2] = connection.encodeString("");
       tuple[3] = connection
           .encodeString("The name of the application currently utilizing the connection.");
-      v.add(tuple);
+      v.add(new Tuple(tuple));
     }
 
     return ((BaseStatement) createMetaDataStatement()).createDriverResultSet(f, v);

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgStatement.java
@@ -16,6 +16,7 @@ import org.postgresql.core.QueryExecutor;
 import org.postgresql.core.ResultCursor;
 import org.postgresql.core.ResultHandlerBase;
 import org.postgresql.core.SqlCommand;
+import org.postgresql.core.Tuple;
 import org.postgresql.util.GT;
 import org.postgresql.util.PSQLException;
 import org.postgresql.util.PSQLState;
@@ -151,7 +152,7 @@ public class PgStatement implements Statement, BaseStatement {
     this.rsHoldability = rsHoldability;
   }
 
-  public ResultSet createResultSet(Query originalQuery, Field[] fields, List<byte[][]> tuples,
+  public ResultSet createResultSet(Query originalQuery, Field[] fields, List<Tuple> tuples,
       ResultCursor cursor) throws SQLException {
     PgResultSet newResult = new PgResultSet(originalQuery, this, fields, tuples, cursor,
         getMaxRows(), getMaxFieldSize(), getResultSetType(), getResultSetConcurrency(),
@@ -202,7 +203,7 @@ public class PgStatement implements Statement, BaseStatement {
     }
 
     @Override
-    public void handleResultRows(Query fromQuery, Field[] fields, List<byte[][]> tuples,
+    public void handleResultRows(Query fromQuery, Field[] fields, List<Tuple> tuples,
         ResultCursor cursor) {
       try {
         ResultSet rs = PgStatement.this.createResultSet(fromQuery, fields, tuples, cursor);
@@ -1065,7 +1066,7 @@ public class PgStatement implements Statement, BaseStatement {
   public ResultSet getGeneratedKeys() throws SQLException {
     checkClosed();
     if (generatedKeys == null || generatedKeys.getResultSet() == null) {
-      return createDriverResultSet(new Field[0], new ArrayList<byte[][]>());
+      return createDriverResultSet(new Field[0], new ArrayList<Tuple>());
     }
 
     return generatedKeys.getResultSet();
@@ -1129,7 +1130,7 @@ public class PgStatement implements Statement, BaseStatement {
     return rsHoldability;
   }
 
-  public ResultSet createDriverResultSet(Field[] fields, List<byte[][]> tuples)
+  public ResultSet createDriverResultSet(Field[] fields, List<Tuple> tuples)
       throws SQLException {
     return createResultSet(null, fields, tuples, null);
   }


### PR DESCRIPTION
This replaces the use of byte[][] in a number of places with a Tuple class that wraps it. This is a necessary change to support doing anything other than blindly reading incoming data into a heap-allocated byte array.

The intended use-case is the flip side of https://github.com/pgjdbc/pgjdbc/pull/953. The actual functionality will follow in a subsequent PR if there's support for the refactor and feature.