### PR TITLE
feat: make SELECT INTO and CREATE TABLE AS return row counts to the client in their command tags

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -2512,7 +2512,7 @@ public class QueryExecutorImpl extends QueryExecutorBase {
     long insert_oid = 0;
 
     if (status.startsWith("INSERT") || status.startsWith("UPDATE") || status.startsWith("DELETE")
-        || status.startsWith("MOVE")) {
+        || status.startsWith("SELECT ") || status.startsWith("MOVE")) {
       try {
         long updates = Long.parseLong(status.substring(1 + status.lastIndexOf(' ')));
 

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -2512,7 +2512,8 @@ public class QueryExecutorImpl extends QueryExecutorBase {
     long insert_oid = 0;
 
     if (status.startsWith("INSERT ") || status.startsWith("UPDATE ") || status.startsWith("DELETE ")
-        || status.startsWith("SELECT ") || status.startsWith("MOVE ")) {
+        || status.startsWith("SELECT ") || status.startsWith("COPY ")
+        || status.startsWith("MOVE ") || status.startsWith("FETCH ")) {
       try {
         long updates = Long.parseLong(status.substring(1 + status.lastIndexOf(' ')));
 

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -2511,8 +2511,8 @@ public class QueryExecutorImpl extends QueryExecutorBase {
     int update_count = 0;
     long insert_oid = 0;
 
-    if (status.startsWith("INSERT") || status.startsWith("UPDATE") || status.startsWith("DELETE")
-        || status.startsWith("SELECT ") || status.startsWith("MOVE")) {
+    if (status.startsWith("INSERT ") || status.startsWith("UPDATE ") || status.startsWith("DELETE ")
+        || status.startsWith("SELECT ") || status.startsWith("MOVE ")) {
       try {
         long updates = Long.parseLong(status.substring(1 + status.lastIndexOf(' ')));
 

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/StatementTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/StatementTest.java
@@ -12,7 +12,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import org.postgresql.core.BaseConnection;
 import org.postgresql.core.ServerVersion;
 import org.postgresql.jdbc.PgStatement;
 import org.postgresql.test.TestUtil;
@@ -130,7 +129,7 @@ public class StatementTest {
 
     count = stmt.executeUpdate("CREATE TEMP TABLE another_tablecount AS "
         + "select true as test from generate_series(1,25);");
-    if (((BaseConnection) con).haveMinimumServerVersion(ServerVersion.v9_0)) {
+    if (TestUtil.haveMinimumServerVersion(con, ServerVersion.v9_0)) {
       assertEquals("Pg9.0+ returns count for select commands", 25, count);
     } else {
       assertEquals("Pg8.2 to 8.4 return nothing", 0, count);

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/StatementTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/StatementTest.java
@@ -12,6 +12,8 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import org.postgresql.core.BaseConnection;
+import org.postgresql.core.ServerVersion;
 import org.postgresql.jdbc.PgStatement;
 import org.postgresql.test.TestUtil;
 import org.postgresql.util.PSQLState;
@@ -125,6 +127,16 @@ public class StatementTest {
 
     count = stmt.executeUpdate("CREATE TEMP TABLE another_table (a int)");
     assertEquals(0, count);
+
+    count = stmt.executeUpdate("CREATE TEMP TABLE another_tablecount AS "
+        + "select true as test from generate_series(1,25);");
+    if (((BaseConnection) con).haveMinimumServerVersion(ServerVersion.v9_0)) {
+      assertEquals("Pg9.0+ returns count for select commands", 25, count);
+    } else {
+      assertEquals("Pg8.2 to 8.4 return nothing", 0, count);
+    }
+
+    stmt.close();
   }
 
   @Test

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/StatementTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/StatementTest.java
@@ -139,6 +139,19 @@ public class StatementTest {
   }
 
   @Test
+  public void testCopyCount() throws Exception {
+    Connection pcon = TestUtil.openPrivilegedDB();
+    Statement stmt = pcon.createStatement();
+    try {
+      int count = stmt.executeUpdate("COPY (SELECT x FROM generate_series(1,10) x) TO '/tmp/foo.txt';");
+      assertEquals(10, count);
+    } finally {
+      TestUtil.closeQuietly(stmt);
+      TestUtil.closeQuietly(pcon);
+    }
+  }
+
+  @Test
   public void testEscapeProcessing() throws SQLException {
     Statement stmt = con.createStatement();
     int count;


### PR DESCRIPTION
For a SELECT INTO or CREATE TABLE AS command, return the row counts to the client.

This can save an entire round-trip to the client, allowing result counts and pagination to be calculated without an additional COUNT query.

Fixes #958 