### PR TITLE
feat: Parse command complete message via regex

### DIFF
--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/StatementTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/StatementTest.java
@@ -12,6 +12,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import org.postgresql.core.ServerVersion;
 import org.postgresql.jdbc.PgStatement;
 import org.postgresql.test.TestUtil;
 import org.postgresql.util.PSQLState;
@@ -125,6 +126,11 @@ public class StatementTest {
 
     count = stmt.executeUpdate("CREATE TEMP TABLE another_table (a int)");
     assertEquals(0, count);
+
+    if (TestUtil.haveMinimumServerVersion(con, ServerVersion.v9_0)) {
+      count = stmt.executeUpdate("CREATE TEMP TABLE yet_another_table AS SELECT x FROM generate_series(1,10) x");
+      assertEquals(10, count);
+    }
   }
 
   @Test


### PR DESCRIPTION
Regex based approach for #960. This should handle all the current cases as well as a couple other ones (ex: "COPY 123").

The new code only throws an exception if the response is out of range (ex: count of rows is greater than 2^31-1). I think there's a separate PR/Issue to address changing the count to a long so I haven't changed any of that behavior here.

If the pattern doesn't match then no parsing error is thrown, it's silently skipped. I think that's a saner default as any new feature added to the server with a possibly incompatible command complete message wouldn't break the driver. Plus any new server responses that matches the generic `COMMAND COUNT` or `COMMAND OID COUNT` format would be handled with no code additions.

I purposely left the commented out `String command = ...` on L2519 as it helps explain the parsing format. If we ever change the internals to store the parsed representation then we could use it.