### PR TITLE
don't attempt to read a SQLXML more than once (#964)

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
@@ -1525,10 +1525,11 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
 
   public void setSQLXML(int parameterIndex, SQLXML xmlObject) throws SQLException {
     checkClosed();
-    if (xmlObject == null || xmlObject.getString() == null) {
+    String stringValue = xmlObject == null ? null : xmlObject.getString(); 
+    if (stringValue==null) {
       setNull(parameterIndex, Types.SQLXML);
     } else {
-      setString(parameterIndex, xmlObject.getString(), Oid.XML);
+      setString(parameterIndex, stringValue, Oid.XML);
     }
   }
 

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
@@ -1525,8 +1525,8 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
 
   public void setSQLXML(int parameterIndex, SQLXML xmlObject) throws SQLException {
     checkClosed();
-    String stringValue = xmlObject == null ? null : xmlObject.getString(); 
-    if (stringValue==null) {
+    String stringValue = xmlObject == null ? null : xmlObject.getString();
+    if (stringValue == null) {
       setNull(parameterIndex, Types.SQLXML);
     } else {
       setString(parameterIndex, stringValue, Oid.XML);

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc4/XmlTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc4/XmlTest.java
@@ -262,7 +262,7 @@ public class XmlTest extends BaseTest4 {
   }
 
   private SQLXML newConsumableSQLXML(String content) throws Exception {
-    SQLXML xml=(SQLXML) Proxy.newProxyInstance(getClass().getClassLoader(), new Class[] { SQLXML.class }, new InvocationHandler() {
+    SQLXML xml = (SQLXML) Proxy.newProxyInstance(getClass().getClassLoader(), new Class[] { SQLXML.class }, new InvocationHandler() {
       SQLXML xml = con.createSQLXML();
       boolean consumed = false;
       Set<Method> consumingMethods = new HashSet<>(Arrays.asList(
@@ -309,7 +309,7 @@ public class XmlTest extends BaseTest4 {
     assertEquals(_xmlDocument, rs.getSQLXML(1).getString());
     assertTrue(!rs.next());
   }
-  
+
   @Test
   public void testSetNull() throws SQLException {
     Statement stmt = con.createStatement();

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc4/XmlTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc4/XmlTest.java
@@ -21,6 +21,9 @@ import org.w3c.dom.Node;
 import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -28,6 +31,9 @@ import java.sql.SQLException;
 import java.sql.SQLXML;
 import java.sql.Statement;
 import java.sql.Types;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 
 import javax.xml.transform.ErrorListener;
 import javax.xml.transform.Result;
@@ -255,6 +261,55 @@ public class XmlTest extends BaseTest4 {
     SQLXML xml = (SQLXML) rs.getObject(1);
   }
 
+  private SQLXML newConsumableSQLXML(String content) throws Exception {
+    SQLXML xml=(SQLXML) Proxy.newProxyInstance(getClass().getClassLoader(), new Class[] { SQLXML.class }, new InvocationHandler() {
+      SQLXML xml = con.createSQLXML();
+      boolean consumed = false;
+      Set<Method> consumingMethods = new HashSet<>(Arrays.asList(
+          SQLXML.class.getMethod("getBinaryStream"),
+          SQLXML.class.getMethod("getCharacterStream"),
+          SQLXML.class.getMethod("getString")
+      ));
+
+      @Override
+      public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+        if (consumingMethods.contains(method)) {
+          if (consumed) {
+            fail("SQLXML-object already consumed");
+          } else {
+            consumed = true;
+          }
+        }
+        return method.invoke(xml, args);
+      }
+    });
+    xml.setString(content);
+    return xml;
+  }
+
+  @Test
+  public void testSet() throws Exception {
+    Statement stmt = con.createStatement();
+    stmt.execute("DELETE FROM xmltest");
+    stmt.close();
+
+    PreparedStatement ps = con.prepareStatement("INSERT INTO xmltest VALUES (?,?)");
+    ps.setInt(1, 1);
+    ps.setSQLXML(2, newConsumableSQLXML(_xmlDocument));
+    assertEquals(1, ps.executeUpdate());
+    ps.setInt(1, 2);
+    ps.setObject(2, newConsumableSQLXML(_xmlDocument));
+    assertEquals(1, ps.executeUpdate());
+    ResultSet rs = getRS();
+    assertTrue(rs.next());
+    Object o = rs.getObject(1);
+    assertTrue(o instanceof SQLXML);
+    assertEquals(_xmlDocument, ((SQLXML) o).getString());
+    assertTrue(rs.next());
+    assertEquals(_xmlDocument, rs.getSQLXML(1).getString());
+    assertTrue(!rs.next());
+  }
+  
   @Test
   public void testSetNull() throws SQLException {
     Statement stmt = con.createStatement();

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc4/XmlTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc4/XmlTest.java
@@ -265,7 +265,7 @@ public class XmlTest extends BaseTest4 {
     SQLXML xml = (SQLXML) Proxy.newProxyInstance(getClass().getClassLoader(), new Class[] { SQLXML.class }, new InvocationHandler() {
       SQLXML xml = con.createSQLXML();
       boolean consumed = false;
-      Set<Method> consumingMethods = new HashSet<>(Arrays.asList(
+      Set<Method> consumingMethods = new HashSet<Method>(Arrays.asList(
           SQLXML.class.getMethod("getBinaryStream"),
           SQLXML.class.getMethod("getCharacterStream"),
           SQLXML.class.getMethod("getString")


### PR DESCRIPTION
The case is clear: the [specification](http://download.java.net/java/jdk9/docs/api/java/sql/SQLXML.html#getString--) says, calling getString() "consumes" the data and cannot be done multiple times on the same object. 

Here a simple fix.