### PR TITLE
fix: wrong data from Blob/Clob when mark/reset is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Avoid failure for `insert ... on conflict...update` for `reWriteBatchedInserts=true` case [PR 1130](https://github.com/pgjdbc/pgjdbc/pull/1130)
 - fix: allowEncodingChanges should allow set client_encoding=... [PR 1125](https://github.com/pgjdbc/pgjdbc/pull/1125)
+- Wrong data from Blob/Clob when mark/reset is used [PR 971](https://github.com/pgjdbc/pgjdbc/pull/971)
 
 ## [42.2.1] (2018-01-25)
 ### Known issues

--- a/pgjdbc/src/main/java/org/postgresql/largeobject/BlobInputStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/largeobject/BlobInputStream.java
@@ -175,6 +175,7 @@ public class BlobInputStream extends InputStream {
         lo.seek64(mpos, LargeObject.SEEK_SET);
       }
       buffer = null;
+      apos = mpos;
     } catch (SQLException se) {
       throw new IOException(se.toString());
     }

--- a/pgjdbc/src/main/java/org/postgresql/largeobject/BlobInputStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/largeobject/BlobInputStream.java
@@ -41,7 +41,7 @@ public class BlobInputStream extends InputStream {
   /**
    * The mark position
    */
-  private int mpos = 0;
+  private long mpos = 0;
 
   /**
    * The limit
@@ -156,12 +156,7 @@ public class BlobInputStream extends InputStream {
    * @see java.io.InputStream#reset()
    */
   public synchronized void mark(int readlimit) {
-    try {
-      mpos = lo.tell();
-    } catch (SQLException se) {
-      // Can't throw this because mark API doesn't allow it.
-      // throw new IOException(se.toString());
-    }
+    mpos = apos;
   }
 
   /**
@@ -174,7 +169,11 @@ public class BlobInputStream extends InputStream {
   public synchronized void reset() throws IOException {
     checkClosed();
     try {
-      lo.seek(mpos);
+      if (mpos <= Integer.MAX_VALUE) {
+        lo.seek((int)mpos);
+      } else {
+        lo.seek64(mpos, LargeObject.SEEK_SET);
+      }
       buffer = null;
     } catch (SQLException se) {
       throw new IOException(se.toString());

--- a/pgjdbc/src/main/java/org/postgresql/largeobject/BlobInputStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/largeobject/BlobInputStream.java
@@ -175,6 +175,7 @@ public class BlobInputStream extends InputStream {
     checkClosed();
     try {
       lo.seek(mpos);
+      buffer = null;
     } catch (SQLException se) {
       throw new IOException(se.toString());
     }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BlobTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BlobTest.java
@@ -169,14 +169,14 @@ public class BlobTest {
     LargeObject blob = lom.open(oid);
     InputStream bis = blob.getInputStream();
 
-    assertEquals(bis.read(), '<');
+    assertEquals('<', bis.read());
     bis.mark(4);
-    assertEquals(bis.read(), '?');
-    assertEquals(bis.read(), 'x');
-    assertEquals(bis.read(), 'm');
-    assertEquals(bis.read(), 'l');
+    assertEquals('?', bis.read());
+    assertEquals('x', bis.read());
+    assertEquals('m', bis.read());
+    assertEquals('l', bis.read());
     bis.reset();
-    assertEquals(bis.read(), '?');
+    assertEquals('?', bis.read());
   }
 
 

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BlobTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BlobTest.java
@@ -156,6 +156,31 @@ public class BlobTest {
   }
 
   @Test
+  public void testMarkResetStream() throws Exception {
+    assertTrue(uploadFile("/test-file.xml", NATIVE_STREAM) > 0);
+
+    Statement stmt = con.createStatement();
+    ResultSet rs = stmt.executeQuery("SELECT lo FROM testblob");
+    assertTrue(rs.next());
+
+    LargeObjectManager lom = ((org.postgresql.PGConnection) con).getLargeObjectAPI();
+
+    long oid = rs.getLong(1);
+    LargeObject blob = lom.open(oid);
+    InputStream bis = blob.getInputStream();
+
+    assertEquals(bis.read(), '<');
+    bis.mark(4);
+    assertEquals(bis.read(), '?');
+    assertEquals(bis.read(), 'x');
+    assertEquals(bis.read(), 'm');
+    assertEquals(bis.read(), 'l');
+    bis.reset();
+    assertEquals(bis.read(), '?');
+  }
+
+
+  @Test
   public void testGetBytesOffset() throws Exception {
     assertTrue(uploadFile("/test-file.xml", NATIVE_STREAM) > 0);
 


### PR DESCRIPTION
Hi,

I spotted an incorrect behaviour using LargeObject BlobInputStream mark() and reset() methods.

Both methods do not take the internal buffer in account.

- mark() actually marks the position after the last byte in the buffer
- reset() changes the large object position, but does not clear the buffer. Buffered bytes from the old position are still returned after reset() until the buffer is depleted.

Here is a suggested fix. The reset() method could be more sophisticated by checking wheter parts of the buffer could be reused.