### PR TITLE
chore: updates to CHANGELOG.md in release_notes.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,8 +43,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - Fix data being truncated in setCharacterStream (bug introduced in 42.0.0) [PR 802](https://github.com/pgjdbc/pgjdbc/pull/802)
-* Fix calculation of lastReceiveLSN for logical replication [PR 801](https://github.com/pgjdbc/pgjdbc/pull/801)
-* Make sure org.postgresql.Driver is loaded when accessing though DataSource interface [Issue 768](https://github.com/pgjdbc/pgjdbc/issues/768)
+- Fix calculation of lastReceiveLSN for logical replication [PR 801](https://github.com/pgjdbc/pgjdbc/pull/801)
+- Make sure org.postgresql.Driver is loaded when accessing though DataSource interface [Issue 768](https://github.com/pgjdbc/pgjdbc/issues/768)
 
 ### Regresions
 - There's no 42.1.0.jre6 version due to infinity handling bug. Fixed in 42.1.1.jre6
@@ -73,10 +73,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - No suitable driver found for jdbc:postgresql when using a DataSource implementation. Fixed in 42.1.0
 
 
-[Unreleased]: https://github.com/pgjdbc/pgjdbc/compare/REL42.1.4...HEAD
-[42.1.4]: https://github.com/pgjdbc/pgjdbc/compare/REL42.1.3...REL42.1.4
-[42.1.3]: https://github.com/pgjdbc/pgjdbc/compare/REL42.1.2...REL42.1.3
-[42.1.2]: https://github.com/pgjdbc/pgjdbc/compare/REL42.1.1...REL42.1.2
-[42.1.1]: https://github.com/pgjdbc/pgjdbc/compare/REL42.1.0...REL42.1.1
-[42.1.0]: https://github.com/pgjdbc/pgjdbc/compare/REL42.0.0...REL42.1.0
 [42.0.0]: https://github.com/pgjdbc/pgjdbc/compare/REL9.4.1212...REL42.0.0
+[42.1.0]: https://github.com/pgjdbc/pgjdbc/compare/REL42.0.0...REL42.1.0
+[42.1.1]: https://github.com/pgjdbc/pgjdbc/compare/REL42.1.0...REL42.1.1
+[42.1.2]: https://github.com/pgjdbc/pgjdbc/compare/REL42.1.1...REL42.1.2
+[42.1.3]: https://github.com/pgjdbc/pgjdbc/compare/REL42.1.2...REL42.1.3
+[42.1.4]: https://github.com/pgjdbc/pgjdbc/compare/REL42.1.3...REL42.1.4
+[Unreleased]: https://github.com/pgjdbc/pgjdbc/compare/REL42.1.4...HEAD

--- a/docs/_posts/2017-05-04-42.1.0-release.md
+++ b/docs/_posts/2017-05-04-42.1.0-release.md
@@ -12,8 +12,8 @@ version: 42.1.0
 
 ### Fixed
 - Fix data being truncated in setCharacterStream (bug introduced in 42.0.0) [PR 802](https://github.com/pgjdbc/pgjdbc/pull/802)
-* Fix calculation of lastReceiveLSN for logical replication [PR 801](https://github.com/pgjdbc/pgjdbc/pull/801)
-* Make sure org.postgresql.Driver is loaded when accessing though DataSource interface [Issue 768](https://github.com/pgjdbc/pgjdbc/issues/768)
+- Fix calculation of lastReceiveLSN for logical replication [PR 801](https://github.com/pgjdbc/pgjdbc/pull/801)
+- Make sure org.postgresql.Driver is loaded when accessing though DataSource interface [Issue 768](https://github.com/pgjdbc/pgjdbc/issues/768)
 
 ### Regresions
 - There's no 42.1.0.jre6 version due to infinity handling bug. Fixed in 42.1.1.jre6

--- a/release_notes.sh
+++ b/release_notes.sh
@@ -38,9 +38,18 @@ echo ---
 
 echo **Notable changes**
 echo
-echo '*'
+awk "/^## \[Unreleased\]/,/^## \[${PREV_VERSION:3}\]/ {print}" CHANGELOG.md | sed -e '1d' -e '$d'
 echo
 echo '<!--more-->'
 echo
+echo **Commits by author**
+echo
 
 git shortlog --format="%s@@@%H@@@%h@@@" --grep="maven-release-plugin|update versions in readme.md" --extended-regexp --invert-grep --no-merges $PREV_VERSION..HEAD | perl release_notes_filter.pl ${VERS}
+
+# Update CHANGELOG.md with the new version
+sed -i -e "s/^## \[Unreleased\]$/## \[${VERS}\] (${DATE_YMD})/" CHANGELOG.md
+sed -i -e "s/^\[Unreleased\]: /\[${VERS}\]: /" CHANGELOG.md
+sed -i -e "s/$PREV_VERSION\.\.\.HEAD/$PREV_VERSION\.\.\.REL${VERS}/" CHANGELOG.md
+sed -i -e "s/^## \[${VERS}\] (${DATE_YMD})$/## \[Unreleased\]\n\n&/g" CHANGELOG.md
+echo "[Unreleased]: https://github.com/pgjdbc/pgjdbc/compare/REL${VERS}...HEAD" >> CHANGELOG.md


### PR DESCRIPTION
This automates the generation of the _posts release file for the website using the CHANGELOG.md notes of Unreleased version, it also updates the CHANGELOG.md to stamp the new version there at the same time.

[skip ci]