### PR TITLE
perf: cache isolation level

### DIFF
--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ConnectionTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ConnectionTest.java
@@ -226,6 +226,12 @@ public class ConnectionTest {
     con.setTransactionIsolation(Connection.TRANSACTION_READ_COMMITTED);
     assertEquals(Connection.TRANSACTION_READ_COMMITTED, con.getTransactionIsolation());
 
+    con.setTransactionIsolation(Connection.TRANSACTION_REPEATABLE_READ);
+    assertEquals(Connection.TRANSACTION_REPEATABLE_READ, con.getTransactionIsolation());
+
+    con.setTransactionIsolation(Connection.TRANSACTION_READ_UNCOMMITTED);
+    assertEquals(Connection.TRANSACTION_READ_UNCOMMITTED, con.getTransactionIsolation());
+
     // Test if a change of isolation level before beginning the
     // transaction affects the isolation level inside the transaction.
     con.setTransactionIsolation(Connection.TRANSACTION_SERIALIZABLE);
@@ -247,6 +253,8 @@ public class ConnectionTest {
     con.setTransactionIsolation(Connection.TRANSACTION_SERIALIZABLE);
     // Should still be ok.
     con.setTransactionIsolation(Connection.TRANSACTION_READ_COMMITTED);
+    // Double set the same isolation level is a no-op.
+    con.setTransactionIsolation(Connection.TRANSACTION_READ_COMMITTED);
 
     // Test that we can't change isolation mid-transaction
     Statement stmt = con.createStatement();
@@ -256,6 +264,20 @@ public class ConnectionTest {
     try {
       con.setTransactionIsolation(Connection.TRANSACTION_SERIALIZABLE);
       fail("Expected an exception when changing transaction isolation mid-transaction");
+    } catch (SQLException e) {
+      // Ok.
+    }
+
+    try {
+      con.setTransactionIsolation(Connection.TRANSACTION_NONE);
+      fail("TRANSACTION_NONE cannot be used because it specifies that transactions are not supported.");
+    } catch (SQLException e) {
+      // Ok.
+    }
+
+    try {
+      con.setTransactionIsolation(Integer.MIN_VALUE);
+      fail("The given parameter is not one of the allowed Connection constants");
     } catch (SQLException e) {
       // Ok.
     }


### PR DESCRIPTION
I have seen many, many calls to 'SHOW TRANSACTION ISOLATION LEVEL' in the logs of postgresql.

The pg_stat_statements shows me that it was executed many times in a production database, in fact is the most executed query of all, some application calls getTransactionIsolation() many times. This in turn, creates many calls to the database which are not needed.

This change cache the value for the isolation level, so multiple calls to getTransactionIsolation() return the cached value.

They are questions about this in StackOverflow:
https://stackoverflow.com/questions/35146741/lot-of-show-transaction-isolation-level-queries-in-postgres
https://dba.stackexchange.com/questions/49585/getting-multiple-queries-with-show-transaction-isolation-level-in-pg-activity