### PR TITLE
chore: remove unstable updates to java

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,9 +72,6 @@ matrix:
         - docker
     - jdk: oraclejdk9
       addons:
-        apt:
-          packages:
-            - oracle-java9-installer # Test with latest update
         postgresql: "9.6"
       env:
         - PG_VERSION=9.6
@@ -115,13 +112,9 @@ matrix:
     - jdk: oraclejdk8
       sudo: required
       addons:
-        apt:
-          packages:
-            - oracle-java8-installer # Test with latest update
         postgresql: "9.4"
       env:
         - PG_VERSION=9.4
-        - LATEST_JAVA_UPDATE=Y # Use Travis last Java update
         - XA=true
         - REPLICATION=Y
         - COVERAGE=Y


### PR DESCRIPTION
Travis use "[Oracle Java (JDK) 8 / 9 Installer PPA](https://launchpad.net/~webupd8team/+archive/ubuntu/java)" which pulls binaries directly from Oracle site, that PPA is sometimes slow updating the packages when Oracle release new versions of Java and that cause unstable (error) builds when Oracle release a new version and the former release is archived and requires login to download.

This removes the use of updated java versions since Travis release new images from time to time and we don't actually require using the very latest version.