### PR TITLE
perf:  introduce properties to cache session characteristics state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 ### Added
 - Make SELECT INTO and CREATE TABLE AS return row counts to the client in their command tags. [Issue 958](https://github.com/pgjdbc/pgjdbc/issues/958) [PR 962](https://github.com/pgjdbc/pgjdbc/pull/962)
+- Introduce properties to cache session characteristics state for read-only (cacheReadOnlyState) and transaction-isolation (cacheIsolationState), by default the read-only cache is enabled and the transaction-isolation is disabled to preserve current behavior. [PR 998](https://github.com/pgjdbc/pgjdbc/pull/958)
 
 ### Changed
 - Improve behavior of ResultSet.getObject(int, Class). [PR 932](https://github.com/pgjdbc/pgjdbc/pull/932)

--- a/README.md
+++ b/README.md
@@ -136,7 +136,9 @@ In addition to the standard connection parameters the driver supports a number o
 | socketTimeout                 | Integer | 0       | The timeout value used for socket read operations. |
 | tcpKeepAlive                  | Boolean | false   | Enable or disable TCP keep-alive. |
 | ApplicationName               | String  | null    | The application name (require server version >= 9.0) |
-| readOnly                      | Boolean | true    | Puts this connection in read-only mode |
+| readOnly                      | Boolean | false   | Puts this connection in read-only mode |
+| cacheReadOnlyState            | Boolean | true    | Cache value for read-only state. |
+| cacheIsolationState           | Boolean | false   | Cache value for isolation-level state. |
 | disableColumnSanitiser        | Boolean | false   | Enable optimization that disables column name sanitiser |
 | assumeMinServerVersion        | String  | null    | Assume the server is at least that version |
 | currentSchema                 | String  | null    | Specify the schema to be set in the search-path |

--- a/docs/documentation/head/connect.md
+++ b/docs/documentation/head/connect.md
@@ -355,6 +355,16 @@ Connection conn = DriverManager.getConnection(url);
 
 	Put the connection in read-only mode
 
+* **cacheReadOnlyState** = boolean
+
+	Cache value for read-only state. If your application uses the jdbc methods isReadOnly()/setReadOnly()
+	this can avoid unnecesary calls to the database.
+
+* **cacheIsolationState** = boolean
+
+	Cache value for isolation-level state. If your application uses the jdbc methods
+	setTransactionIsolation()/getTransactionIsolation() this can avoid unnecesary calls to the database.
+
 * **disableColumnSanitiser** = boolean
 
 	Setting this to true disables column name sanitiser. 

--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -132,6 +132,19 @@ public enum PGProperty {
   READ_ONLY("readOnly", "false", "Puts this connection in read-only mode"),
 
   /**
+   * Cache value for read-only state. If your application uses the jdbc methods
+   * isReadOnly/setReadOnly this can avoid unnecesary calls to the database.
+   */
+  CACHE_READ_ONLY_STATE("cacheReadOnlyState", "true", "Cache value for read-only state."),
+
+  /**
+   * Cache value for isolation-level state. If your application uses the jdbc methods
+   * setTransactionIsolation/getTransactionIsolation this can avoid unnecesary calls to the
+   * database.
+   */
+  CACHE_ISOLATION_STATE("cacheIsolationState", "false", "Cache value for isolation-level state."),
+
+  /**
    * Comma separated list of types to enable binary transfer. Either OID numbers or names
    */
   BINARY_TRANSFER_ENABLE("binaryTransferEnable", "",

--- a/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
+++ b/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
@@ -833,6 +833,38 @@ public abstract class BaseDataSource implements CommonDataSource, Referenceable 
   }
 
   /**
+   * @return true if the cache of the read only state is enabled
+   * @see PGProperty#CACHE_READ_ONLY_STATE
+   */
+  public boolean getCacheReadOnlyState() {
+    return PGProperty.CACHE_READ_ONLY_STATE.getBoolean(properties);
+  }
+
+  /**
+   * @param cacheReadOnlyState enable the cache of the read only state
+   * @see PGProperty#CACHE_READ_ONLY_STATE
+   */
+  public void setCacheReadOnlyState(boolean cacheReadOnlyState) {
+    PGProperty.CACHE_READ_ONLY_STATE.set(properties, cacheReadOnlyState);
+  }
+
+  /**
+   * @return true if the cache of the isolation state is enabled
+   * @see PGProperty#CACHE_ISOLATION_STATE
+   */
+  public boolean getCacheIsolationState() {
+    return PGProperty.CACHE_ISOLATION_STATE.getBoolean(properties);
+  }
+
+  /**
+   * @param cacheIsolationState enable the cache of the isolation state
+   * @see PGProperty#CACHE_ISOLATION_STATE
+   */
+  public void setCacheIsolationState(boolean cacheIsolationState) {
+    PGProperty.CACHE_ISOLATION_STATE.set(properties, cacheIsolationState);
+  }
+
+  /**
    * @return true if driver should log unclosed connections
    * @see PGProperty#LOG_UNCLOSED_CONNECTIONS
    */

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
@@ -61,7 +61,6 @@ import java.sql.Types;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Locale;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Properties;
@@ -121,6 +120,11 @@ public class PgConnection implements BaseConnection {
   private boolean autoCommit = true;
   // Connection's readonly state.
   private boolean readOnly = false;
+  // Connection's isolation level state.
+  private int isolationLevel = -1;
+  // Cache Session Characteristics to avoid calls to database.
+  private final boolean cacheReadOnlyState;
+  private final boolean cacheIsolationState;
 
   // Bind String to UNSPECIFIED or VARCHAR?
   private final boolean bindStringAsVarchar;
@@ -197,6 +201,10 @@ public class PgConnection implements BaseConnection {
     if (LOGGER.isLoggable(Level.WARNING) && !haveMinimumServerVersion(ServerVersion.v8_2)) {
       LOGGER.log(Level.WARNING, "Unsupported Server Version: {0}", queryExecutor.getServerVersion());
     }
+
+    // Cache transaction state (read only/isolation level)
+    this.cacheReadOnlyState = PGProperty.CACHE_READ_ONLY_STATE.getBoolean(info);
+    this.cacheIsolationState = PGProperty.CACHE_ISOLATION_STATE.getBoolean(info);
 
     // Set read-only early if requested
     if (PGProperty.READ_ONLY.getBoolean(info)) {
@@ -684,28 +692,49 @@ public class PgConnection implements BaseConnection {
     firstWarning = null;
   }
 
-
+  @Override
   public void setReadOnly(boolean readOnly) throws SQLException {
     checkClosed();
+
     if (queryExecutor.getTransactionState() != TransactionState.IDLE) {
       throw new PSQLException(
           GT.tr("Cannot change transaction read-only property in the middle of a transaction."),
           PSQLState.ACTIVE_SQL_TRANSACTION);
     }
 
-    if (readOnly != this.readOnly) {
-      String readOnlySql
-             = "SET SESSION CHARACTERISTICS AS TRANSACTION " + (readOnly ? "READ ONLY" : "READ WRITE");
-      execSQLUpdate(readOnlySql); // nb: no BEGIN triggered.
+    if (this.readOnly == readOnly && cacheReadOnlyState) {
+      return; //Same read only state, not set it again.
     }
 
+    String readOnlySql
+        = "SET SESSION CHARACTERISTICS AS TRANSACTION " + (readOnly ? "READ ONLY" : "READ WRITE");
+    execSQLUpdate(readOnlySql); // nb: no BEGIN triggered.
+
     this.readOnly = readOnly;
-    LOGGER.log(Level.FINE, "  setReadOnly = {0}", readOnly);
+    LOGGER.log(Level.FINE, "  setReadOnly = {0}", this.readOnly);
   }
 
+  @Override
   public boolean isReadOnly() throws SQLException {
     checkClosed();
-    return readOnly;
+
+    if (!cacheReadOnlyState) {
+      ResultSet rs = null;
+      try {
+        rs = execSQLQuery("show transaction_read_only"); // nb: no BEGIN triggered
+        if (rs.next()) {
+          String transaction_read_only = rs.getString(1);
+          this.readOnly = "on".equals(transaction_read_only);
+        }
+      } finally {
+        if (rs != null) {
+          rs.close();
+        }
+      }
+    }
+
+    LOGGER.log(Level.FINE, "  isReadOnly = {0}", this.readOnly);
+    return this.readOnly;
   }
 
   public void setAutoCommit(boolean autoCommit) throws SQLException {
@@ -786,38 +815,38 @@ public class PgConnection implements BaseConnection {
     return queryExecutor.getTransactionState();
   }
 
+  @Override
   public int getTransactionIsolation() throws SQLException {
     checkClosed();
 
-    String level = null;
-    final ResultSet rs = execSQLQuery("SHOW TRANSACTION ISOLATION LEVEL"); // nb: no BEGIN triggered
-    if (rs.next()) {
-      level = rs.getString(1);
-    }
-    rs.close();
-
-    // TODO revisit: throw exception instead of silently eating the error in unknown cases?
-    if (level == null) {
-      return Connection.TRANSACTION_READ_COMMITTED; // Best guess.
-    }
-
-    level = level.toUpperCase(Locale.US);
-    if (level.equals("READ COMMITTED")) {
-      return Connection.TRANSACTION_READ_COMMITTED;
-    }
-    if (level.equals("READ UNCOMMITTED")) {
-      return Connection.TRANSACTION_READ_UNCOMMITTED;
-    }
-    if (level.equals("REPEATABLE READ")) {
-      return Connection.TRANSACTION_REPEATABLE_READ;
-    }
-    if (level.equals("SERIALIZABLE")) {
-      return Connection.TRANSACTION_SERIALIZABLE;
+    if (!cacheIsolationState || this.isolationLevel == -1) {
+      ResultSet rs = null;
+      try {
+        rs = execSQLQuery("show transaction_isolation"); // nb: no BEGIN triggered
+        if (rs.next()) {
+          String transaction_isolation = rs.getString(1);
+          if ("read committed".equals(transaction_isolation)) {
+            this.isolationLevel = Connection.TRANSACTION_READ_COMMITTED;
+          } else if ("serializable".equals(transaction_isolation)) {
+            this.isolationLevel = Connection.TRANSACTION_SERIALIZABLE;
+          } else if ("repeatable read".equals(transaction_isolation)) {
+            this.isolationLevel = Connection.TRANSACTION_REPEATABLE_READ;
+          } else if ("read uncommitted".equals(transaction_isolation)) {
+            this.isolationLevel = Connection.TRANSACTION_READ_UNCOMMITTED;
+          }
+        }
+      } finally {
+        if (rs != null) {
+          rs.close();
+        }
+      }
     }
 
-    return Connection.TRANSACTION_READ_COMMITTED; // Best guess.
+    LOGGER.log(Level.FINE, "  getTransactionIsolation = {0}", this.isolationLevel);
+    return this.isolationLevel;
   }
 
+  @Override
   public void setTransactionIsolation(int level) throws SQLException {
     checkClosed();
 
@@ -827,7 +856,31 @@ public class PgConnection implements BaseConnection {
           PSQLState.ACTIVE_SQL_TRANSACTION);
     }
 
-    String isolationLevelName = getIsolationLevelName(level);
+    if (level == Connection.TRANSACTION_NONE) {
+      throw new PSQLException(GT.tr("Transaction isolation level {0} not supported.",
+          "TRANSACTION_NONE"), PSQLState.INVALID_PARAMETER_VALUE);
+    } else if (this.isolationLevel == level && cacheIsolationState) {
+      return; // Same isolation level, not set it again.
+    }
+
+    String isolationLevelName;
+    switch (level) {
+      case Connection.TRANSACTION_READ_COMMITTED:
+        isolationLevelName = "READ COMMITTED";
+        break;
+      case Connection.TRANSACTION_SERIALIZABLE:
+        isolationLevelName = "SERIALIZABLE";
+        break;
+      case Connection.TRANSACTION_REPEATABLE_READ:
+        isolationLevelName = "REPEATABLE READ";
+        break;
+      case Connection.TRANSACTION_READ_UNCOMMITTED:
+        isolationLevelName = "READ UNCOMMITTED";
+        break;
+      default:
+        isolationLevelName = null;
+    }
+
     if (isolationLevelName == null) {
       throw new PSQLException(GT.tr("Transaction isolation level {0} not supported.", level),
           PSQLState.NOT_IMPLEMENTED);
@@ -836,22 +889,9 @@ public class PgConnection implements BaseConnection {
     String isolationLevelSQL =
         "SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL " + isolationLevelName;
     execSQLUpdate(isolationLevelSQL); // nb: no BEGIN triggered
-    LOGGER.log(Level.FINE, "  setTransactionIsolation = {0}", isolationLevelName);
-  }
 
-  protected String getIsolationLevelName(int level) {
-    switch (level) {
-      case Connection.TRANSACTION_READ_COMMITTED:
-        return "READ COMMITTED";
-      case Connection.TRANSACTION_SERIALIZABLE:
-        return "SERIALIZABLE";
-      case Connection.TRANSACTION_READ_UNCOMMITTED:
-        return "READ UNCOMMITTED";
-      case Connection.TRANSACTION_REPEATABLE_READ:
-        return "REPEATABLE READ";
-      default:
-        return null;
-    }
+    this.isolationLevel = level; // cache the value for later use.
+    LOGGER.log(Level.FINE, "  setTransactionIsolation = {0}", this.isolationLevel);
   }
 
   public void setCatalog(String catalog) throws SQLException {

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
@@ -883,8 +883,8 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
   /**
    * {@inheritDoc}
    * <p>
-   * We only support TRANSACTION_SERIALIZABLE and TRANSACTION_READ_COMMITTED before 8.0; from 8.0
-   * READ_UNCOMMITTED and REPEATABLE_READ are accepted aliases for READ_COMMITTED.
+   * In PostgreSQL READ UNCOMMITTED is treated as READ COMMITTED, while REPEATABLE READ is treated
+   * as SERIALIZABLE before PostgreSQL 9.1.
    */
   public boolean supportsTransactionIsolationLevel(int level) throws SQLException {
     switch (level) {

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/Jdbc2TestSuite.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/Jdbc2TestSuite.java
@@ -113,7 +113,9 @@ import org.junit.runners.Suite;
         CopyTest.class,
         CopyLargeFileTest.class,
         ServerErrorTest.class,
-        UpsertTest.class
+        UpsertTest.class,
+
+        TransactionModeCacheStateTest.class
 })
 public class Jdbc2TestSuite {
 }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/TransactionModeCacheStateTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/TransactionModeCacheStateTest.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright (c) 2017, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.test.jdbc2;
+
+import org.postgresql.PGProperty;
+import org.postgresql.test.TestUtil;
+import org.postgresql.util.PSQLState;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Arrays;
+import java.util.Properties;
+
+/**
+ * Test the functionality of the transaction mode state cache.
+ */
+@RunWith(Parameterized.class)
+public class TransactionModeCacheStateTest {
+
+  @Parameters(name = "{index}: cacheReadOnly={0}, cacheIsolation={1}, readOnlyMode={2}, autoCommitMode={3}")
+  public static Iterable<Object[]> data() {
+    return Arrays.asList(new Object[][]{
+      {true, true, true, true}, {true, true, true, false},
+      {true, true, false, false}, {true, true, false, true},
+      {true, false, false, false}, {true, false, true, false},
+      {true, false, false, true}, {true, false, true, true},
+      {false, false, false, false}, {false, false, false, true},
+      {false, false, true, true}, {false, false, true, false},
+      {false, true, true, true}, {false, true, false, true},
+      {false, true, true, false}, {false, true, false, false}
+    });
+  }
+
+  private final boolean cacheReadOnly;
+  private final boolean cacheIsolation;
+  private final boolean readOnlyMode;
+  private final boolean autoCommitMode;
+
+  public TransactionModeCacheStateTest(boolean cacheReadOnly, boolean cacheIsolation, boolean readOnlyMode, boolean autoCommitMode) {
+    this.cacheReadOnly = cacheReadOnly;
+    this.cacheIsolation = cacheIsolation;
+    this.readOnlyMode = readOnlyMode;
+    this.autoCommitMode = autoCommitMode;
+  }
+
+  @Test
+  public void testReadOnlyCache() throws Exception {
+    Properties prop = new Properties();
+    prop.setProperty(PGProperty.CACHE_ISOLATION_STATE.getName(), String.valueOf(cacheIsolation));
+    prop.setProperty(PGProperty.CACHE_READ_ONLY_STATE.getName(), String.valueOf(cacheReadOnly));
+    prop.setProperty(PGProperty.READ_ONLY.getName(), String.valueOf(readOnlyMode));
+
+    Connection con = TestUtil.openDB(prop);
+    Statement stmt;
+    ResultSet rs;
+
+    Assert.assertEquals("Connection started as read-only: " + readOnlyMode, readOnlyMode, con.isReadOnly());
+
+    // Set and Get
+    con.setReadOnly(false);
+    Assert.assertFalse(con.isReadOnly());
+    con.setReadOnly(true);
+    Assert.assertTrue(con.isReadOnly());
+
+    con.setReadOnly(false);
+    stmt = con.createStatement();
+    Assert.assertFalse("Check between createStatement", con.isReadOnly());
+    rs = stmt.executeQuery("SELECT 1");
+    con.setReadOnly(true);
+    rs.close();
+    Assert.assertTrue("Check between close ResultSet", con.isReadOnly());
+    stmt.close();
+
+    // Test double set of read-only, it's generally a no-op.
+    con.setReadOnly(false);
+    con.setReadOnly(false);
+    Assert.assertFalse("Double set false", con.isReadOnly());
+    con.setReadOnly(true);
+    con.setReadOnly(true);
+    Assert.assertTrue("Double set true", con.isReadOnly());
+
+    rs.close();
+    stmt.close();
+    TestUtil.closeDB(con);
+  }
+
+  @Test
+  public void testReadOnlyCacheAutoCommit() throws Exception {
+    Properties prop = new Properties();
+    prop.setProperty(PGProperty.CACHE_ISOLATION_STATE.getName(), String.valueOf(cacheIsolation));
+    prop.setProperty(PGProperty.CACHE_READ_ONLY_STATE.getName(), String.valueOf(cacheReadOnly));
+    prop.setProperty(PGProperty.READ_ONLY.getName(), String.valueOf(readOnlyMode));
+
+    Connection con = TestUtil.openDB(prop);
+    Statement stmt;
+    ResultSet rs;
+
+    // Test with autocommit on/off and between transactions
+    con.setAutoCommit(autoCommitMode);
+    con.setReadOnly(true);
+    stmt = con.createStatement();
+    Assert.assertTrue("No transaction started", con.isReadOnly());
+    rs = stmt.executeQuery("SELECT 1"); // Start of transaction
+    try {
+      if (!con.getAutoCommit()) {
+        con.setReadOnly(false);
+        Assert.fail("Cannot change transaction read-only property in the middle of a transaction.");
+      }
+    } catch (SQLException ex) {
+      Assert.assertEquals(PSQLState.ACTIVE_SQL_TRANSACTION.getState(), ex.getSQLState());
+    }
+    if (!con.getAutoCommit()) {
+      con.commit(); // End transaction
+      con.setReadOnly(false);
+      Assert.assertFalse("Allow change after end of transaction", con.isReadOnly());
+    }
+
+    rs.close();
+    stmt.close();
+    TestUtil.closeDB(con);
+  }
+
+  @Test
+  public void testTransactionIsolationCache() throws Exception {
+    Properties prop = new Properties();
+    prop.setProperty(PGProperty.CACHE_ISOLATION_STATE.getName(), String.valueOf(cacheIsolation));
+    prop.setProperty(PGProperty.CACHE_READ_ONLY_STATE.getName(), String.valueOf(cacheReadOnly));
+    prop.setProperty(PGProperty.READ_ONLY.getName(), String.valueOf(readOnlyMode));
+
+    Connection con = TestUtil.openDB(prop);
+    DatabaseMetaData dbmd = con.getMetaData();
+    Statement stmt;
+    ResultSet rs;
+
+    // Check support of transaction isolation level
+    Assert.assertTrue(dbmd.supportsTransactionIsolationLevel(Connection.TRANSACTION_READ_COMMITTED));
+    Assert.assertTrue(dbmd.supportsTransactionIsolationLevel(Connection.TRANSACTION_READ_UNCOMMITTED));
+    Assert.assertTrue(dbmd.supportsTransactionIsolationLevel(Connection.TRANSACTION_REPEATABLE_READ));
+    Assert.assertTrue(dbmd.supportsTransactionIsolationLevel(Connection.TRANSACTION_SERIALIZABLE));
+    Assert.assertFalse(dbmd.supportsTransactionIsolationLevel(Connection.TRANSACTION_NONE));
+    Assert.assertFalse(dbmd.supportsTransactionIsolationLevel(-1));
+    Assert.assertFalse(dbmd.supportsTransactionIsolationLevel(Integer.MAX_VALUE));
+
+    Assert.assertNotEquals("Connection isolation never -1", -1, con.getTransactionIsolation());
+    Assert.assertTrue("Connection must be a supported isolation",
+        dbmd.supportsTransactionIsolationLevel(con.getTransactionIsolation()));
+
+    // Set and Get
+    con.setTransactionIsolation(Connection.TRANSACTION_REPEATABLE_READ);
+    Assert.assertEquals(Connection.TRANSACTION_REPEATABLE_READ, con.getTransactionIsolation());
+
+    stmt = con.createStatement();
+    Assert.assertEquals("Check between createStatement",
+        Connection.TRANSACTION_REPEATABLE_READ, con.getTransactionIsolation());
+    rs = stmt.executeQuery("SELECT 1");
+    con.setTransactionIsolation(Connection.TRANSACTION_READ_UNCOMMITTED);
+    rs.close();
+    Assert.assertEquals("Check between close ResultSet",
+        Connection.TRANSACTION_READ_UNCOMMITTED, con.getTransactionIsolation());
+    stmt.close();
+
+    // Test double set of isolation level, it's generally a no-op.
+    con.setTransactionIsolation(Connection.TRANSACTION_READ_UNCOMMITTED);
+    con.setTransactionIsolation(Connection.TRANSACTION_READ_UNCOMMITTED);
+    Assert.assertEquals("Double set TRANSACTION_READ_UNCOMMITTED",
+        Connection.TRANSACTION_READ_UNCOMMITTED, con.getTransactionIsolation());
+    con.setTransactionIsolation(Connection.TRANSACTION_READ_COMMITTED);
+    con.setTransactionIsolation(Connection.TRANSACTION_READ_COMMITTED);
+    Assert.assertEquals("Double set TRANSACTION_READ_COMMITTED",
+        Connection.TRANSACTION_READ_COMMITTED, con.getTransactionIsolation());
+    con.setTransactionIsolation(Connection.TRANSACTION_REPEATABLE_READ);
+    con.setTransactionIsolation(Connection.TRANSACTION_REPEATABLE_READ);
+    Assert.assertEquals("Double set TRANSACTION_REPEATABLE_READ",
+        Connection.TRANSACTION_REPEATABLE_READ, con.getTransactionIsolation());
+    con.setTransactionIsolation(Connection.TRANSACTION_SERIALIZABLE);
+    con.setTransactionIsolation(Connection.TRANSACTION_SERIALIZABLE);
+    Assert.assertEquals("Double set TRANSACTION_SERIALIZABLE",
+        Connection.TRANSACTION_SERIALIZABLE, con.getTransactionIsolation());
+
+    rs.close();
+    stmt.close();
+    TestUtil.closeDB(con);
+  }
+
+  @Test
+  public void testTransactionIsolationCacheAutoCommit() throws Exception {
+    Properties prop = new Properties();
+    prop.setProperty(PGProperty.CACHE_ISOLATION_STATE.getName(), String.valueOf(cacheIsolation));
+    prop.setProperty(PGProperty.CACHE_READ_ONLY_STATE.getName(), String.valueOf(cacheReadOnly));
+    prop.setProperty(PGProperty.READ_ONLY.getName(), String.valueOf(readOnlyMode));
+
+    Connection con = TestUtil.openDB(prop);
+    Statement stmt;
+    ResultSet rs;
+
+    // Test with autocommit on/off and between transactions
+    con.setAutoCommit(autoCommitMode);
+    con.setTransactionIsolation(Connection.TRANSACTION_READ_UNCOMMITTED);
+    stmt = con.createStatement();
+    Assert.assertEquals("No transaction started",
+        Connection.TRANSACTION_READ_UNCOMMITTED, con.getTransactionIsolation());
+    rs = stmt.executeQuery("SELECT 1"); // Start of transaction
+    try {
+      if (!con.getAutoCommit()) {
+        con.setTransactionIsolation(Connection.TRANSACTION_REPEATABLE_READ);
+        Assert.fail("Cannot change transaction isolation level in the middle of a transaction.");
+      }
+    } catch (SQLException ex) {
+      Assert.assertEquals(PSQLState.ACTIVE_SQL_TRANSACTION.getState(), ex.getSQLState());
+    }
+    if (!con.getAutoCommit()) {
+      con.commit(); // End transaction
+      con.setTransactionIsolation(Connection.TRANSACTION_SERIALIZABLE);
+      Assert.assertEquals("Allow change after end of transaction",
+          Connection.TRANSACTION_SERIALIZABLE, con.getTransactionIsolation());
+    }
+
+    // Invalid isolation levels
+    try {
+      con.setTransactionIsolation(Connection.TRANSACTION_NONE);
+      Assert.fail("Transaction isolation level TRANSACTION_NONE not supported.");
+    } catch (SQLException ex) {
+      Assert.assertEquals(PSQLState.INVALID_PARAMETER_VALUE.getState(), ex.getSQLState());
+    }
+    try {
+      con.setTransactionIsolation(Integer.MIN_VALUE);
+      Assert.fail("Invalid Transaction isolation level (not supported)");
+    } catch (SQLException ex) {
+      Assert.assertEquals(PSQLState.NOT_IMPLEMENTED.getState(), ex.getSQLState());
+    }
+
+    rs.close();
+    stmt.close();
+    TestUtil.closeDB(con);
+  }
+
+}

--- a/ubenchmark/src/main/java/org/postgresql/benchmark/connection/TransactionModeCache.java
+++ b/ubenchmark/src/main/java/org/postgresql/benchmark/connection/TransactionModeCache.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2017, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.benchmark.connection;
+
+import org.postgresql.PGProperty;
+import org.postgresql.util.ConnectionUtil;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+@Fork(value = 1, jvmArgsPrepend = "-Xmx64m")
+@Measurement(iterations = 50, time = 1, timeUnit = TimeUnit.SECONDS)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@State(Scope.Thread)
+@Threads(1)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class TransactionModeCache {
+
+  private Connection connection;
+
+  @Param({"false", "true"})
+  public String enableCache;
+
+  @Setup(Level.Trial)
+  public void setUp() throws SQLException {
+    Properties props = ConnectionUtil.getProperties();
+    props.setProperty(PGProperty.CACHE_READ_ONLY_STATE.getName(), enableCache);
+    props.setProperty(PGProperty.CACHE_ISOLATION_STATE.getName(), enableCache);
+
+    connection = DriverManager.getConnection(ConnectionUtil.getURL(), props);
+  }
+
+  @TearDown(Level.Trial)
+  public void tearDown() throws SQLException {
+    connection.close();
+  }
+
+  @Benchmark
+  public void testReadOnly(Blackhole b) throws SQLException {
+    b.consume(connection.isReadOnly());
+  }
+
+  @Benchmark
+  public void testTransactionIsolation(Blackhole b) throws SQLException {
+    b.consume(connection.getTransactionIsolation());
+  }
+
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder()
+        .include(TransactionModeCache.class.getSimpleName())
+        .detectJvmArgs()
+        .build();
+
+    new Runner(opt).run();
+  }
+
+}


### PR DESCRIPTION
This PR adds a property to enable cache the transaction state (read_only/isolation_level) and also improves the handing of the set/get methods for TransactionIsolation and ReadOnly.

The isReadOnly method is also standardized to get the state from the database connection.