### PR TITLE
test: standardize benchmark parameters to fork with 10 iterations

### DIFF
--- a/ubenchmark/src/main/java/org/postgresql/benchmark/statement/BindBoolean.java
+++ b/ubenchmark/src/main/java/org/postgresql/benchmark/statement/BindBoolean.java
@@ -35,9 +35,9 @@ import java.sql.Types;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
-@Fork(value = 0, jvmArgsPrepend = "-Xmx128m")
-@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
-@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 1, jvmArgsPrepend = "-Xmx128m")
+@Measurement(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
 @State(Scope.Thread)
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)

--- a/ubenchmark/src/main/java/org/postgresql/benchmark/statement/BindTimestamp.java
+++ b/ubenchmark/src/main/java/org/postgresql/benchmark/statement/BindTimestamp.java
@@ -38,8 +38,8 @@ import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 
 @Fork(value = 1, jvmArgsPrepend = "-Xmx128m")
-@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
-@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
 @State(Scope.Thread)
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)

--- a/ubenchmark/src/main/java/org/postgresql/benchmark/statement/ProcessBoolean.java
+++ b/ubenchmark/src/main/java/org/postgresql/benchmark/statement/ProcessBoolean.java
@@ -42,7 +42,7 @@ import java.util.concurrent.TimeUnit;
  */
 @Fork(value = 1, jvmArgsPrepend = "-Xmx128m")
 @Measurement(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
-@Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
 @State(Scope.Thread)
 @Threads(1)
 @BenchmarkMode(Mode.AverageTime)

--- a/ubenchmark/src/main/java/org/postgresql/benchmark/time/AddPaddingZeros.java
+++ b/ubenchmark/src/main/java/org/postgresql/benchmark/time/AddPaddingZeros.java
@@ -25,9 +25,9 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 import java.sql.Timestamp;
 import java.util.concurrent.TimeUnit;
 
-@Fork(value = 0, jvmArgsPrepend = "-Xmx128m")
-@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
-@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 1, jvmArgsPrepend = "-Xmx128m")
+@Measurement(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
 @State(Scope.Thread)
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)

--- a/ubenchmark/src/main/java/org/postgresql/benchmark/time/TimestampToDate.java
+++ b/ubenchmark/src/main/java/org/postgresql/benchmark/time/TimestampToDate.java
@@ -28,8 +28,8 @@ import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 
 @Fork(value = 1, jvmArgsPrepend = "-Xmx128m")
-@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
-@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
 @State(Scope.Thread)
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)

--- a/ubenchmark/src/main/java/org/postgresql/benchmark/time/TimestampToTime.java
+++ b/ubenchmark/src/main/java/org/postgresql/benchmark/time/TimestampToTime.java
@@ -28,8 +28,8 @@ import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 
 @Fork(value = 1, jvmArgsPrepend = "-Xmx128m")
-@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
-@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
 @State(Scope.Thread)
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)


### PR DESCRIPTION
This PR is motivated by a comment by @jorsol that the benchmarks should fork and have 10 iterations for both warm-up and during the test run. This appears to be consistent with the intention of the comment in FinalizeConnection:

https://github.com/pgjdbc/pgjdbc/blob/master/ubenchmark/src/main/java/org/postgresql/benchmark/connection/FinalizeConnection.java