### PR TITLE
refactor: type safe query flags using enumset

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/BaseStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/BaseStatement.java
@@ -10,6 +10,7 @@ import org.postgresql.PGStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.EnumSet;
 import java.util.List;
 
 /**
@@ -45,31 +46,28 @@ public interface BaseStatement extends PGStatement, Statement {
    * Execute a query, passing additional query flags.
    *
    * @param p_sql the query to execute (JDBC-style query)
-   * @param flags additional {@link QueryExecutor} flags for execution; these are bitwise-ORed into
-   *        the default flags.
+   * @param flags additional EnumSet of QueryFlag for execution
    * @return true if there is a result set
    * @throws SQLException if something goes wrong.
    */
-  boolean executeWithFlags(String p_sql, int flags) throws SQLException;
+  boolean executeWithFlags(String p_sql, EnumSet<QueryFlag> flags) throws SQLException;
 
   /**
    * Execute a query, passing additional query flags.
    *
    * @param cachedQuery the query to execute (native to PostgreSQL)
-   * @param flags additional {@link QueryExecutor} flags for execution; these are bitwise-ORed into
-   *        the default flags.
+   * @param flags additional EnumSet of QueryFlag for execution
    * @return true if there is a result set
    * @throws SQLException if something goes wrong.
    */
-  boolean executeWithFlags(CachedQuery cachedQuery, int flags) throws SQLException;
+  boolean executeWithFlags(CachedQuery cachedQuery, EnumSet<QueryFlag> flags) throws SQLException;
 
   /**
    * Execute a prepared query, passing additional query flags.
    *
-   * @param flags additional {@link QueryExecutor} flags for execution; these are bitwise-ORed into
-   *        the default flags.
+   * @param flags additional EnumSet of QueryFlag for execution
    * @return true if there is a result set
    * @throws SQLException if something goes wrong.
    */
-  boolean executeWithFlags(int flags) throws SQLException;
+  boolean executeWithFlags(EnumSet<QueryFlag> flags) throws SQLException;
 }

--- a/pgjdbc/src/main/java/org/postgresql/core/QueryExecutor.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/QueryExecutor.java
@@ -16,6 +16,7 @@ import org.postgresql.util.HostSpec;
 
 import java.sql.SQLException;
 import java.sql.SQLWarning;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
 import java.util.TimeZone;
@@ -30,8 +31,8 @@ import java.util.TimeZone;
  * <li>factory methods for Query objects ({@link #createSimpleQuery(String)} and
  * {@link #createQuery(String, boolean, boolean, String...)})
  * <li>execution methods for created Query objects (
- * {@link #execute(Query, ParameterList, ResultHandler, int, int, int)} for single queries and
- * {@link #execute(Query[], ParameterList[], BatchResultHandler, int, int, int)} for batches of queries)
+ * {@link #execute(Query, ParameterList, ResultHandler, int, int, EnumSet)} for single queries and
+ * {@link #execute(Query[], ParameterList[], BatchResultHandler, int, int, EnumSet)} for batches of queries)
  * <li>a fastpath call interface ({@link #createFastpathParameters} and {@link #fastpathCall}).
  * </ul>
  *
@@ -51,73 +52,6 @@ import java.util.TimeZone;
  * @author Oliver Jowett (oliver@opencloud.com)
  */
 public interface QueryExecutor extends TypeTransferModeRegistry {
-  /**
-   * Flag for query execution that indicates the given Query object is unlikely to be reused.
-   */
-  int QUERY_ONESHOT = 1;
-
-  /**
-   * Flag for query execution that indicates that resultset metadata isn't needed and can be safely
-   * omitted.
-   */
-  int QUERY_NO_METADATA = 2;
-
-  /**
-   * Flag for query execution that indicates that a resultset isn't expected and the query executor
-   * can safely discard any rows (although the resultset should still appear to be from a
-   * resultset-returning query).
-   */
-  int QUERY_NO_RESULTS = 4;
-
-  /**
-   * Flag for query execution that indicates a forward-fetch-capable cursor should be used if
-   * possible.
-   */
-  int QUERY_FORWARD_CURSOR = 8;
-
-  /**
-   * Flag for query execution that indicates the automatic BEGIN on the first statement when outside
-   * a transaction should not be done.
-   */
-  int QUERY_SUPPRESS_BEGIN = 16;
-
-  /**
-   * Flag for query execution when we don't really want to execute, we just want to get the
-   * parameter metadata for the statement.
-   */
-  int QUERY_DESCRIBE_ONLY = 32;
-
-  /**
-   * Flag for query execution used by generated keys where we want to receive both the ResultSet and
-   * associated update count from the command status.
-   */
-  int QUERY_BOTH_ROWS_AND_STATUS = 64;
-
-  /**
-   * Force this query to be described at each execution. This is done in pipelined batches where we
-   * might need to detect mismatched result types.
-   */
-  int QUERY_FORCE_DESCRIBE_PORTAL = 512;
-
-  /**
-   * Flag to disable batch execution when we expect results (generated keys) from a statement.
-   *
-   * @deprecated in PgJDBC 9.4 as we now auto-size batches.
-   */
-  @Deprecated
-  int QUERY_DISALLOW_BATCHING = 128;
-
-  /**
-   * Flag for query execution to avoid using binary transfer.
-   */
-  int QUERY_NO_BINARY_TRANSFER = 256;
-
-  /**
-   * Execute the query via simple 'Q' command (not parse, bind, exec, but simple execute).
-   * This sends query text on each execution, however it supports sending multiple queries
-   * separated with ';' as a single command.
-   */
-  int QUERY_EXECUTE_AS_SIMPLE = 1024;
 
   /**
    * Execute a Query, passing results to a provided ResultHandler.
@@ -131,11 +65,11 @@ public interface QueryExecutor extends TypeTransferModeRegistry {
    * @param maxRows the maximum number of rows to retrieve
    * @param fetchSize if QUERY_FORWARD_CURSOR is set, the preferred number of rows to retrieve
    *        before suspending
-   * @param flags a combination of QUERY_* flags indicating how to handle the query.
+   * @param flags a EnumSet of QueryFlag indicating how to handle the query.
    * @throws SQLException if query execution fails
    */
   void execute(Query query, ParameterList parameters, ResultHandler handler, int maxRows,
-      int fetchSize, int flags) throws SQLException;
+      int fetchSize, EnumSet<QueryFlag> flags) throws SQLException;
 
   /**
    * Execute several Query, passing results to a provided ResultHandler.
@@ -151,11 +85,11 @@ public interface QueryExecutor extends TypeTransferModeRegistry {
    * @param maxRows the maximum number of rows to retrieve
    * @param fetchSize if QUERY_FORWARD_CURSOR is set, the preferred number of rows to retrieve
    *        before suspending
-   * @param flags a combination of QUERY_* flags indicating how to handle the query.
+   * @param flags a EnumSet of QueryFlag indicating how to handle the query.
    * @throws SQLException if query execution fails
    */
   void execute(Query[] queries, ParameterList[] parameterLists, BatchResultHandler handler, int maxRows,
-      int fetchSize, int flags) throws SQLException;
+      int fetchSize, EnumSet<QueryFlag> flags) throws SQLException;
 
   /**
    * Fetch additional rows from a cursor.

--- a/pgjdbc/src/main/java/org/postgresql/core/QueryFlag.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/QueryFlag.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2017, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.core;
+
+/**
+ * Type safe QueryExecutor flags, for use with <code>EnumSet&lt;QueryFlag&gt;</code>. Enum sets are
+ * represented internally as bit vectors. This representation is extremely compact and efficient.
+ */
+public enum QueryFlag {
+
+  /**
+   * Flag for query execution that indicates the given Query object is unlikely to be reused.
+   */
+  ONESHOT,
+  /**
+   * Flag for query execution that indicates that resultset metadata isn't needed and can be safely
+   * omitted.
+   */
+  NO_METADATA,
+  /**
+   * Flag for query execution that indicates that a resultset isn't expected and the query executor
+   * can safely discard any rows (although the resultset should still appear to be from a
+   * resultset-returning query).
+   */
+  NO_RESULTS,
+  /**
+   * Flag for query execution that indicates a forward-fetch-capable cursor should be used if
+   * possible.
+   */
+  FORWARD_CURSOR,
+  /**
+   * Flag for query execution that indicates the automatic BEGIN on the first statement when outside
+   * a transaction should not be done.
+   */
+  SUPPRESS_BEGIN,
+  /**
+   * Flag for query execution when we don't really want to execute, we just want to get the
+   * parameter metadata for the statement.
+   */
+  DESCRIBE_ONLY,
+  /**
+   * Flag for query execution used by generated keys where we want to receive both the ResultSet and
+   * associated update count from the command status.
+   */
+  BOTH_ROWS_AND_STATUS,
+  /**
+   * Force this query to be described at each execution. This is done in pipelined batches where we
+   * might need to detect mismatched result types.
+   */
+  FORCE_DESCRIBE_PORTAL,
+  /**
+   * Flag to disable batch execution when we expect results (generated keys) from a statement.
+   *
+   * @deprecated in PgJDBC 9.4 as we now auto-size batches.
+   */
+  @Deprecated
+  DISALLOW_BATCHING,
+  /**
+   * Flag for query execution to avoid using binary transfer.
+   */
+  NO_BINARY_TRANSFER,
+  /**
+   * Execute the query via simple 'Q' command (not parse, bind, exec, but simple execute). This
+   * sends query text on each execution, however it supports sending multiple queries separated with
+   * ';' as a single command.
+   */
+  EXECUTE_AS_SIMPLE
+
+}

--- a/pgjdbc/src/main/java/org/postgresql/core/SetupQueryRunner.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/SetupQueryRunner.java
@@ -12,6 +12,7 @@ import org.postgresql.util.PSQLState;
 
 import java.sql.SQLException;
 import java.sql.SQLWarning;
+import java.util.EnumSet;
 import java.util.List;
 
 /**
@@ -43,10 +44,11 @@ public class SetupQueryRunner {
     Query query = executor.createSimpleQuery(queryString);
     SimpleResultHandler handler = new SimpleResultHandler();
 
-    int flags = QueryExecutor.QUERY_ONESHOT | QueryExecutor.QUERY_SUPPRESS_BEGIN
-        | QueryExecutor.QUERY_EXECUTE_AS_SIMPLE;
+    EnumSet<QueryFlag> flags = EnumSet.of(QueryFlag.ONESHOT, QueryFlag.SUPPRESS_BEGIN,
+        QueryFlag.EXECUTE_AS_SIMPLE);
     if (!wantResults) {
-      flags |= QueryExecutor.QUERY_NO_RESULTS | QueryExecutor.QUERY_NO_METADATA;
+      flags.add(QueryFlag.NO_RESULTS);
+      flags.add(QueryFlag.NO_METADATA);
     }
 
     try {

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgCallableStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgCallableStatement.java
@@ -8,6 +8,7 @@ package org.postgresql.jdbc;
 import org.postgresql.Driver;
 import org.postgresql.core.ParameterList;
 import org.postgresql.core.Query;
+import org.postgresql.core.QueryFlag;
 import org.postgresql.util.GT;
 import org.postgresql.util.PSQLException;
 import org.postgresql.util.PSQLState;
@@ -29,6 +30,7 @@ import java.sql.Time;
 import java.sql.Timestamp;
 import java.sql.Types;
 import java.util.Calendar;
+import java.util.EnumSet;
 import java.util.Map;
 
 class PgCallableStatement extends PgPreparedStatement implements CallableStatement {
@@ -59,7 +61,7 @@ class PgCallableStatement extends PgPreparedStatement implements CallableStateme
 
   public int executeUpdate() throws SQLException {
     if (isFunction) {
-      executeWithFlags(0);
+      executeWithFlags(EnumSet.noneOf(QueryFlag.class));
       return 0;
     }
     return super.executeUpdate();
@@ -74,7 +76,7 @@ class PgCallableStatement extends PgPreparedStatement implements CallableStateme
   }
 
   @Override
-  public boolean executeWithFlags(int flags) throws SQLException {
+  public boolean executeWithFlags(EnumSet<QueryFlag> flags) throws SQLException {
     boolean hasResultSet = super.executeWithFlags(flags);
     if (!isFunction || !returnTypeSet) {
       return hasResultSet;

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
@@ -18,6 +18,7 @@ import org.postgresql.core.Oid;
 import org.postgresql.core.Provider;
 import org.postgresql.core.Query;
 import org.postgresql.core.QueryExecutor;
+import org.postgresql.core.QueryFlag;
 import org.postgresql.core.ReplicationProtocol;
 import org.postgresql.core.ResultHandlerBase;
 import org.postgresql.core.ServerVersion;
@@ -58,6 +59,7 @@ import java.sql.Savepoint;
 import java.sql.Statement;
 import java.sql.Struct;
 import java.sql.Types;
+import java.util.EnumSet;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -413,7 +415,7 @@ public class PgConnection implements BaseConnection {
   public ResultSet execSQLQuery(String s, int resultSetType, int resultSetConcurrency)
       throws SQLException {
     BaseStatement stat = (BaseStatement) createStatement(resultSetType, resultSetConcurrency);
-    boolean hasResultSet = stat.executeWithFlags(s, QueryExecutor.QUERY_SUPPRESS_BEGIN);
+    boolean hasResultSet = stat.executeWithFlags(s, EnumSet.of(QueryFlag.SUPPRESS_BEGIN));
 
     while (!hasResultSet && stat.getUpdateCount() != -1) {
       hasResultSet = stat.getMoreResults();
@@ -435,8 +437,8 @@ public class PgConnection implements BaseConnection {
 
   public void execSQLUpdate(String s) throws SQLException {
     BaseStatement stmt = (BaseStatement) createStatement();
-    if (stmt.executeWithFlags(s, QueryExecutor.QUERY_NO_METADATA | QueryExecutor.QUERY_NO_RESULTS
-        | QueryExecutor.QUERY_SUPPRESS_BEGIN)) {
+    if (stmt.executeWithFlags(s, EnumSet.of(QueryFlag.NO_METADATA, QueryFlag.NO_RESULTS,
+         QueryFlag.SUPPRESS_BEGIN))) {
       throw new PSQLException(GT.tr("A result was returned when none was expected."),
           PSQLState.TOO_MANY_RESULTS);
     }
@@ -729,10 +731,10 @@ public class PgConnection implements BaseConnection {
   }
 
   private void executeTransactionCommand(Query query) throws SQLException {
-    int flags = QueryExecutor.QUERY_NO_METADATA | QueryExecutor.QUERY_NO_RESULTS
-        | QueryExecutor.QUERY_SUPPRESS_BEGIN;
+    EnumSet<QueryFlag> flags = EnumSet.of(QueryFlag.NO_METADATA, QueryFlag.NO_RESULTS,
+         QueryFlag.SUPPRESS_BEGIN);
     if (prepareThreshold == 0) {
-      flags |= QueryExecutor.QUERY_ONESHOT;
+      flags.add(QueryFlag.ONESHOT);
     }
 
     try {

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
@@ -8,7 +8,7 @@ package org.postgresql.jdbc;
 import org.postgresql.core.BaseConnection;
 import org.postgresql.core.BaseStatement;
 import org.postgresql.core.Oid;
-import org.postgresql.core.QueryExecutor;
+import org.postgresql.core.QueryFlag;
 import org.postgresql.core.ServerVersion;
 import org.postgresql.core.TypeInfo;
 import org.postgresql.util.GT;
@@ -21,6 +21,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -222,7 +223,7 @@ public class TypeInfoCache implements TypeInfo {
 
     // Go through BaseStatement to avoid transaction start.
     if (!((BaseStatement) _getTypeInfoStatement)
-        .executeWithFlags(QueryExecutor.QUERY_SUPPRESS_BEGIN)) {
+        .executeWithFlags(EnumSet.of(QueryFlag.SUPPRESS_BEGIN))) {
       throw new PSQLException(GT.tr("No results were returned by the query."), PSQLState.NO_DATA);
     }
 
@@ -365,7 +366,7 @@ public class TypeInfoCache implements TypeInfo {
     PreparedStatement oidStatement = getOidStatement(pgTypeName);
 
     // Go through BaseStatement to avoid transaction start.
-    if (!((BaseStatement) oidStatement).executeWithFlags(QueryExecutor.QUERY_SUPPRESS_BEGIN)) {
+    if (!((BaseStatement) oidStatement).executeWithFlags(EnumSet.of(QueryFlag.SUPPRESS_BEGIN))) {
       throw new PSQLException(GT.tr("No results were returned by the query."), PSQLState.NO_DATA);
     }
 
@@ -405,7 +406,7 @@ public class TypeInfoCache implements TypeInfo {
     _getNameStatement.setInt(1, oid);
 
     // Go through BaseStatement to avoid transaction start.
-    if (!((BaseStatement) _getNameStatement).executeWithFlags(QueryExecutor.QUERY_SUPPRESS_BEGIN)) {
+    if (!((BaseStatement) _getNameStatement).executeWithFlags(EnumSet.of(QueryFlag.SUPPRESS_BEGIN))) {
       throw new PSQLException(GT.tr("No results were returned by the query."), PSQLState.NO_DATA);
     }
 
@@ -478,7 +479,7 @@ public class TypeInfoCache implements TypeInfo {
 
     // Go through BaseStatement to avoid transaction start.
     if (!((BaseStatement) _getArrayDelimiterStatement)
-        .executeWithFlags(QueryExecutor.QUERY_SUPPRESS_BEGIN)) {
+        .executeWithFlags(EnumSet.of(QueryFlag.SUPPRESS_BEGIN))) {
       throw new PSQLException(GT.tr("No results were returned by the query."), PSQLState.NO_DATA);
     }
 
@@ -520,7 +521,7 @@ public class TypeInfoCache implements TypeInfo {
 
     // Go through BaseStatement to avoid transaction start.
     if (!((BaseStatement) _getArrayElementOidStatement)
-        .executeWithFlags(QueryExecutor.QUERY_SUPPRESS_BEGIN)) {
+        .executeWithFlags(EnumSet.of(QueryFlag.SUPPRESS_BEGIN))) {
       throw new PSQLException(GT.tr("No results were returned by the query."), PSQLState.NO_DATA);
     }
 


### PR DESCRIPTION
Refactor the `QueryExecutor.QUERY_*` int-based flags to use a type safe alternative with EnumSet.

This improve code readability and maintenance, and helps to debug more easily.