### PR TITLE
test: querymode extendedCacheEverything

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,11 @@ cache:
 
 matrix:
   fast_finish: true
+  allow_failures:
+    - env: # REMOVE FAILURE extendedCacheEverything
+        - PG_VERSION=9.4
+        - QUERY_MODE=extendedCacheEverything
+        - COVERAGE=Y
   include:
     - jdk: oraclejdk8
       env: RUN_CHECKSTYLE=true
@@ -110,13 +115,11 @@ matrix:
         - XA=true
         - REPLICATION=Y
     - jdk: oraclejdk8
-      sudo: required
       addons:
         postgresql: "9.4"
       env:
         - PG_VERSION=9.4
-        - XA=true
-        - REPLICATION=Y
+        - QUERY_MODE=extendedCacheEverything
         - COVERAGE=Y
     - jdk: openjdk7
       sudo: required


### PR DESCRIPTION
Add test for extendedCacheEverything to track issue #955.

The replication is tested on other jobs, so is safe to remove it for 9.4 and use that to test extendedCacheEverything.