### PR TITLE
fix: always return Short[] for java.sql.Array.getArray() on smallint[]

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgArray.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgArray.java
@@ -583,7 +583,31 @@ public class PgArray implements java.sql.Array {
           pa[length++] = o == null ? false : BooleanTypeUtil.castToBoolean((String) o);
         }
       }
-    } else if (type == Types.SMALLINT || type == Types.INTEGER) {
+    } else if (type == Types.SMALLINT) {
+      short[] pa = null;
+      Object[] oa = null;
+
+      if (dims > 1 || useObjects) {
+        ret =
+            oa = (dims > 1
+                ? (Object[]) java.lang.reflect.Array
+                    .newInstance(useObjects ? Short.class : short.class, dimsLength)
+                : new Short[count]);
+      } else {
+        ret = pa = new short[count];
+      }
+
+      for (; count > 0; count--) {
+        Object o = input.get(index++);
+
+        if (dims > 1 || useObjects) {
+          oa[length++] = o == null ? null
+              : (dims > 1 ? buildArray((PgArrayList) o, 0, -1) : PgResultSet.toShort((String) o));
+        } else {
+          pa[length++] = o == null ? 0 : PgResultSet.toShort((String) o);
+        }
+      }
+    } else if (type == Types.INTEGER) {
       int[] pa = null;
       Object[] oa = null;
 

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
@@ -2020,9 +2020,6 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
     return 0; // SQL NULL
   }
 
-  private static final BigInteger SHORTMAX = new BigInteger(Short.toString(Short.MAX_VALUE));
-  private static final BigInteger SHORTMIN = new BigInteger(Short.toString(Short.MIN_VALUE));
-
   @Override
   public short getShort(int columnIndex) throws SQLException {
     connection.getLogger().log(Level.FINEST, "  getShort columnIndex: {0}", columnIndex);
@@ -2040,32 +2037,7 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
       return (short) readLongValue(this_row[col], oid, Short.MIN_VALUE, Short.MAX_VALUE, "short");
     }
 
-    String s = getFixedString(columnIndex);
-
-    if (s != null) {
-      s = s.trim();
-      try {
-        return Short.parseShort(s);
-      } catch (NumberFormatException e) {
-        try {
-          BigDecimal n = new BigDecimal(s);
-          BigInteger i = n.toBigInteger();
-          int gt = i.compareTo(SHORTMAX);
-          int lt = i.compareTo(SHORTMIN);
-
-          if (gt > 0 || lt < 0) {
-            throw new PSQLException(GT.tr("Bad value for type {0} : {1}", "short", s),
-                PSQLState.NUMERIC_VALUE_OUT_OF_RANGE);
-          }
-          return i.shortValue();
-
-        } catch (NumberFormatException ne) {
-          throw new PSQLException(GT.tr("Bad value for type {0} : {1}", "short", s),
-              PSQLState.NUMERIC_VALUE_OUT_OF_RANGE);
-        }
-      }
-    }
-    return 0; // SQL NULL
+    return toShort(getFixedString(columnIndex));
   }
 
   public int getInt(int columnIndex) throws SQLException {
@@ -2810,6 +2782,36 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
   }
 
   // ----------------- Formatting Methods -------------------
+
+  private static final BigInteger SHORTMAX = new BigInteger(Short.toString(Short.MAX_VALUE));
+  private static final BigInteger SHORTMIN = new BigInteger(Short.toString(Short.MIN_VALUE));
+
+  public static short toShort(String s) throws SQLException {
+    if (s != null) {
+      try {
+        s = s.trim();
+        return Short.parseShort(s);
+      } catch (NumberFormatException e) {
+        try {
+          BigDecimal n = new BigDecimal(s);
+          BigInteger i = n.toBigInteger();
+          int gt = i.compareTo(SHORTMAX);
+          int lt = i.compareTo(SHORTMIN);
+
+          if (gt > 0 || lt < 0) {
+            throw new PSQLException(GT.tr("Bad value for type {0} : {1}", "short", s),
+                PSQLState.NUMERIC_VALUE_OUT_OF_RANGE);
+          }
+          return i.shortValue();
+
+        } catch (NumberFormatException ne) {
+          throw new PSQLException(GT.tr("Bad value for type {0} : {1}", "short", s),
+              PSQLState.NUMERIC_VALUE_OUT_OF_RANGE);
+        }
+      }
+    }
+    return 0; // SQL NULL
+  }
 
   private static final BigInteger INTMAX = new BigInteger(Integer.toString(Integer.MAX_VALUE));
   private static final BigInteger INTMIN = new BigInteger(Integer.toString(Integer.MIN_VALUE));

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc4/ArrayTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc4/ArrayTest.java
@@ -95,6 +95,26 @@ public class ArrayTest extends BaseTest4 {
   }
 
   @Test
+  public void testCreateArrayOfSmallInt() throws SQLException {
+    PreparedStatement pstmt = _conn.prepareStatement("SELECT ?::smallint[]");
+    Short[] in = new Short[3];
+    in[0] = 0;
+    in[1] = -1;
+    in[2] = 2;
+    pstmt.setArray(1, _conn.createArrayOf("int2", in));
+
+    ResultSet rs = pstmt.executeQuery();
+    Assert.assertTrue(rs.next());
+    Array arr = rs.getArray(1);
+    Short[] out = (Short[]) arr.getArray();
+
+    Assert.assertEquals(3, out.length);
+    Assert.assertEquals(0, out[0].shortValue());
+    Assert.assertEquals(-1, out[1].shortValue());
+    Assert.assertEquals(2, out[2].shortValue());
+  }
+
+  @Test
   public void testCreateArrayOfMultiString() throws SQLException {
     PreparedStatement pstmt = _conn.prepareStatement("SELECT ?::text[]");
     String[][] in = new String[2][2];


### PR DESCRIPTION
Fix #420.

Without the changes to PgArray, the new test fails for BinaryMode.REGULAR and passes for BinaryMode.FORCE.