### PR TITLE
fix: first composite query not calling getNativeSql()

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/v3/CompositeQuery.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/CompositeQuery.java
@@ -44,7 +44,7 @@ class CompositeQuery implements Query {
 
   @Override
   public String getNativeSql() {
-    StringBuilder sbuf = new StringBuilder(subqueries[0].toString());
+    StringBuilder sbuf = new StringBuilder(subqueries[0].getNativeSql());
     for (int i = 1; i < subqueries.length; ++i) {
       sbuf.append(';');
       sbuf.append(subqueries[i].getNativeSql());


### PR DESCRIPTION
The Native SQL generation for the first composite query calls toString() instead of getNativeSql().