### PR TITLE
Fix documentation spelling of sslpasswordcallback

### DIFF
--- a/docs/documentation/head/connect.md
+++ b/docs/documentation/head/connect.md
@@ -116,7 +116,7 @@ Connection conn = DriverManager.getConnection(url);
 
 	Class name of hostname verifier. Defaults to using `org.postgresql.ssl.jdbc4.LibPQFactory.verify()`
 
-* **sslpaswordcallback** = String
+* **sslpasswordcallback** = String
 
 	Class name of the SSL password provider. Defaults to `org.postgresql.ssl.jdbc4.LibPQFactory.ConsoleCallbackHandler`
 


### PR DESCRIPTION
Fix a tiny but important spelling error