### PR TITLE
fix: advance lastReceiveLSN on keepalive messages

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/v3/replication/V3PGReplicationStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/replication/V3PGReplicationStream.java
@@ -222,6 +222,9 @@ public class V3PGReplicationStream implements PGReplicationStream {
 
   private boolean processKeepAliveMessage(ByteBuffer buffer) {
     lastServerLSN = LogSequenceNumber.valueOf(buffer.getLong());
+    if (lastServerLSN.asLong() > lastReceiveLSN.asLong()) {
+      lastReceiveLSN = lastServerLSN;
+    }
 
     long lastServerClock = buffer.getLong();
 


### PR DESCRIPTION
Fix a bug with V3PGReplicationStream where the server may never
be able to send a CommandComplete message to the client because
the client's status update messages do not advance the received LSN.
This behavior can be reliably reproduced on a server where no
data changes are happening, so the only messages being sent from
the client are status updates and the only messages coming from
the server are keepalives. The LSN reported from the server keepalives
continues to advance, but the client reports a static
lastReceiveLSN, so the server never considers the client caught
up and never sends CommandComplete to trigger the client to shut down.
By updating lastReceiveLSN on keepalive messages, the expected
server CommandComplete and client Terminate messages are exchanged,
allowing the server to gracefully shut down.