### PR TITLE
fix: allow disabling field metadata cache

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -108,7 +108,7 @@ public enum PGProperty {
           "Specifies the maximum number of fields to be cached per connection. A value of {@code 0} disables the cache."),
 
   /**
-   * Specifies the maximum number of fields to be cached per connection. A value of {@code 0} disables the cache.
+   * Specifies the maximum size (in megabytes) of fields to be cached per connection. A value of {@code 0} disables the cache.
    */
   DATABASE_METADATA_CACHE_FIELDS_MIB("databaseMetadataCacheFieldsMiB", "5",
           "Specifies the maximum size (in megabytes) of fields to be cached per connection. A value of {@code 0} disables the cache."),

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSetMetaData.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSetMetaData.java
@@ -10,8 +10,9 @@ import org.postgresql.core.BaseConnection;
 import org.postgresql.core.Field;
 import org.postgresql.core.ServerVersion;
 import org.postgresql.util.GT;
+import org.postgresql.util.Gettable;
+import org.postgresql.util.GettableHashMap;
 import org.postgresql.util.JdbcBlackHole;
-import org.postgresql.util.LruCache;
 import org.postgresql.util.PSQLException;
 import org.postgresql.util.PSQLState;
 
@@ -202,9 +203,8 @@ public class PgResultSetMetaData implements ResultSetMetaData, PGResultSetMetaDa
     return "";
   }
 
-  private boolean populateFieldsWithCachedMetadata() {
+  private boolean populateFieldsWithMetadata(Gettable<FieldMetadata.Key, FieldMetadata> metadata) {
     boolean allOk = true;
-    LruCache<FieldMetadata.Key, FieldMetadata> metadata = connection.getFieldMetadataCache();
     for (Field field : fields) {
       if (field.getMetadata() != null) {
         // No need to update metadata
@@ -227,7 +227,7 @@ public class PgResultSetMetaData implements ResultSetMetaData, PGResultSetMetaDa
       return;
     }
 
-    if (populateFieldsWithCachedMetadata()) {
+    if (populateFieldsWithMetadata(connection.getFieldMetadataCache())) {
       fieldInfoFetched = true;
       return;
     }
@@ -285,8 +285,8 @@ public class PgResultSetMetaData implements ResultSetMetaData, PGResultSetMetaDa
 
     Statement stmt = connection.createStatement();
     ResultSet rs = null;
+    GettableHashMap<FieldMetadata.Key, FieldMetadata> md = new GettableHashMap<FieldMetadata.Key, FieldMetadata>();
     try {
-      LruCache<FieldMetadata.Key, FieldMetadata> metadataCache = connection.getFieldMetadataCache();
       rs = stmt.executeQuery(sql.toString());
       while (rs.next()) {
         int table = (int) rs.getLong(1);
@@ -300,13 +300,14 @@ public class PgResultSetMetaData implements ResultSetMetaData, PGResultSetMetaDa
         FieldMetadata fieldMetadata =
             new FieldMetadata(columnName, tableName, schemaName, nullable, autoIncrement);
         FieldMetadata.Key key = new FieldMetadata.Key(table, column);
-        metadataCache.put(key, fieldMetadata);
+        md.put(key, fieldMetadata);
       }
     } finally {
       JdbcBlackHole.close(rs);
       JdbcBlackHole.close(stmt);
     }
-    populateFieldsWithCachedMetadata();
+    populateFieldsWithMetadata(md);
+    connection.getFieldMetadataCache().putAll(md);
   }
 
   public String getBaseSchemaName(int column) throws SQLException {

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSetMetaData.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSetMetaData.java
@@ -219,6 +219,7 @@ public class PgResultSetMetaData implements ResultSetMetaData, PGResultSetMetaDa
         field.setMetadata(fieldMetadata);
       }
     }
+    fieldInfoFetched |= allOk;
     return allOk;
   }
 
@@ -228,7 +229,6 @@ public class PgResultSetMetaData implements ResultSetMetaData, PGResultSetMetaDa
     }
 
     if (populateFieldsWithMetadata(connection.getFieldMetadataCache())) {
-      fieldInfoFetched = true;
       return;
     }
 

--- a/pgjdbc/src/main/java/org/postgresql/util/Gettable.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/Gettable.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2018, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.util;
+
+public interface Gettable<K,V> {
+  V get(K key);
+}

--- a/pgjdbc/src/main/java/org/postgresql/util/GettableHashMap.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/GettableHashMap.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2018, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.util;
+
+import java.util.HashMap;
+
+public class GettableHashMap<K,V> extends HashMap<K,V> implements Gettable<K,V> {
+
+}

--- a/pgjdbc/src/main/java/org/postgresql/util/LruCache.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/LruCache.java
@@ -13,7 +13,7 @@ import java.util.Map;
 /**
  * Caches values in simple least-recently-accessed order.
  */
-public class LruCache<Key, Value extends CanEstimateSize> {
+public class LruCache<Key, Value extends CanEstimateSize> implements Gettable<Key, Value> {
   /**
    * Action that is invoked when the entry is removed from the cache.
    *
@@ -141,6 +141,15 @@ public class LruCache<Key, Value extends CanEstimateSize> {
     currentSize -= prev.getSize();
     if (prev != value) {
       evictValue(prev);
+    }
+  }
+
+  /**
+   * Puts all the values from the given map into the cache.
+   */
+  public synchronized void putAll(Map<Key, Value> m) {
+    for (Map.Entry<Key, Value> entry : m.entrySet()) {
+      this.put(entry.getKey(), entry.getValue());
     }
   }
 

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ResultSetMetaDataTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ResultSetMetaDataTest.java
@@ -9,6 +9,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import org.postgresql.PGProperty;
 import org.postgresql.PGResultSetMetaData;
 import org.postgresql.core.ServerVersion;
 import org.postgresql.jdbc.PreferQueryMode;
@@ -17,6 +18,8 @@ import org.postgresql.test.TestUtil;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
@@ -26,15 +29,49 @@ import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Types;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Properties;
 
+@RunWith(Parameterized.class)
 public class ResultSetMetaDataTest extends BaseTest4 {
   Connection conn;
+  private final Integer databaseMetadataCacheFields;
+  private final Integer databaseMetadataCacheFieldsMib;
+
+  public ResultSetMetaDataTest(Integer databaseMetadataCacheFields, Integer databaseMetadataCacheFieldsMib) {
+    this.databaseMetadataCacheFields = databaseMetadataCacheFields;
+    this.databaseMetadataCacheFieldsMib = databaseMetadataCacheFieldsMib;
+  }
+
+  @Parameterized.Parameters(name = "databaseMetadataCacheFields = {0}, databaseMetadataCacheFieldsMib = {1}")
+  public static Iterable<Object[]> data() {
+    Collection<Object[]> ids = new ArrayList<Object[]>();
+    for (Integer fields : new Integer[]{null, 0}) {
+      for (Integer fieldsMib : new Integer[]{null, 0}) {
+        ids.add(new Object[]{fields, fieldsMib});
+      }
+    }
+    return ids;
+  }
+
+  @Override
+  protected void updateProperties(Properties props) {
+    super.updateProperties(props);
+    if (databaseMetadataCacheFields != null) {
+      PGProperty.DATABASE_METADATA_CACHE_FIELDS.set(props, databaseMetadataCacheFields);
+    }
+    if (databaseMetadataCacheFieldsMib != null) {
+      PGProperty.DATABASE_METADATA_CACHE_FIELDS_MIB.set(props, databaseMetadataCacheFieldsMib);
+    }
+  }
 
   @Override
   public void setUp() throws Exception {
     super.setUp();
     conn = con;
     TestUtil.createTable(conn, "rsmd1", "a int primary key, b text, c decimal(10,2)", true);
+    TestUtil.createTable(conn, "rsmd_cache", "a int primary key");
     TestUtil.createTable(conn, "timetest",
         "tm time(3), tmtz timetz, ts timestamp without time zone, tstz timestamp(6) with time zone");
 
@@ -57,6 +94,7 @@ public class ResultSetMetaDataTest extends BaseTest4 {
   public void tearDown() throws SQLException {
     TestUtil.dropTable(conn, "compositetest");
     TestUtil.dropTable(conn, "rsmd1");
+    TestUtil.dropTable(conn, "rsmd_cache");
     TestUtil.dropTable(conn, "timetest");
     TestUtil.dropTable(conn, "serialtest");
     if (TestUtil.haveMinimumServerVersion(conn, ServerVersion.v10)) {
@@ -266,6 +304,35 @@ public class ResultSetMetaDataTest extends BaseTest4 {
     ResultSet rs = pstmt.executeQuery();
     ResultSetMetaData rsmd = pstmt.getMetaData();
     Assert.assertTrue(rsmd.isAutoIncrement(1));
+  }
+
+  // Verifies that the field metadatacache will cache when enabled and also functions properly
+  // when disabled.
+  @Test
+  public void testCache() throws Exception {
+    boolean isCacheDisabled = new Integer(0).equals(databaseMetadataCacheFields)
+                           || new Integer(0).equals(databaseMetadataCacheFieldsMib);
+
+    {
+      PreparedStatement pstmt = conn.prepareStatement("SELECT a FROM rsmd_cache");
+      ResultSet rs = pstmt.executeQuery();
+      PGResultSetMetaData pgrsmd = (PGResultSetMetaData) rs.getMetaData();
+      assertEquals("a", pgrsmd.getBaseColumnName(1));
+      rs.close();
+    }
+
+    Statement stmt = conn.createStatement();
+    stmt.execute("ALTER TABLE rsmd_cache RENAME COLUMN a TO b");
+    stmt.close();
+
+    {
+      PreparedStatement pstmt = conn.prepareStatement("SELECT b FROM rsmd_cache");
+      ResultSet rs = pstmt.executeQuery();
+      PGResultSetMetaData pgrsmd = (PGResultSetMetaData) rs.getMetaData();
+      // Unless the cache is disabled, we expect to see stale results.
+      assertEquals(isCacheDisabled ? "b" : "a", pgrsmd.getBaseColumnName(1));
+      rs.close();
+    }
   }
 
   private void assumePreparedStatementMetadataSupported() {

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ResultSetMetaDataTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ResultSetMetaDataTest.java
@@ -318,12 +318,13 @@ public class ResultSetMetaDataTest extends BaseTest4 {
       ResultSet rs = pstmt.executeQuery();
       PGResultSetMetaData pgrsmd = (PGResultSetMetaData) rs.getMetaData();
       assertEquals("a", pgrsmd.getBaseColumnName(1));
-      rs.close();
+      TestUtil.closeQuietly(rs);
+      TestUtil.closeQuietly(pstmt);
     }
 
     Statement stmt = conn.createStatement();
     stmt.execute("ALTER TABLE rsmd_cache RENAME COLUMN a TO b");
-    stmt.close();
+    TestUtil.closeQuietly(stmt);
 
     {
       PreparedStatement pstmt = conn.prepareStatement("SELECT b FROM rsmd_cache");
@@ -331,7 +332,8 @@ public class ResultSetMetaDataTest extends BaseTest4 {
       PGResultSetMetaData pgrsmd = (PGResultSetMetaData) rs.getMetaData();
       // Unless the cache is disabled, we expect to see stale results.
       assertEquals(isCacheDisabled ? "b" : "a", pgrsmd.getBaseColumnName(1));
-      rs.close();
+      TestUtil.closeQuietly(rs);
+      TestUtil.closeQuietly(pstmt);
     }
   }
 


### PR DESCRIPTION
Clients accessing very dynamic schemas can have issues with the
field metadata cache getting stale.  This change allows configuring the
databaseMetadataCacheFields property to 0 to disable the cache and
avoid these issues where necessary.  This behaviour was already
documented, however did not actually work as the codepath assumed
it could retrieve the fields from the cache.