### PR TITLE
fix: use 'time with time zone' and 'timestamp with time zone' values as is and avoid computation with user-provided/default Calendars

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
@@ -71,6 +71,7 @@ import java.util.Map;
 import java.util.StringTokenizer;
 import java.util.TimeZone;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 
 
@@ -518,8 +519,14 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
         // If backend provides just TIMESTAMP, we use "cal" timezone
         // If backend provides TIMESTAMPTZ, we ignore "cal" as we know true instant value
         Timestamp timestamp = getTimestamp(i, cal);
+        long timeMillis = timestamp.getTime();
+        if (oid == Oid.TIMESTAMPTZ) {
+          // time zone == UTC since BINARY "timestamp with time zone" is always sent in UTC
+          // So we truncate days
+          return new Time(timeMillis % TimeUnit.DAYS.toMillis(1));
+        }
         // Here we just truncate date part
-        return connection.getTimestampUtils().convertToTime(timestamp.getTime(), tz);
+        return connection.getTimestampUtils().convertToTime(timeMillis, tz);
       } else {
         throw new PSQLException(
             GT.tr("Cannot convert the column of type {0} to requested type {1}.",
@@ -529,13 +536,7 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
     }
 
     String string = getString(i);
-    if (string.equals("24:00:00")) {
-      return Time.valueOf(string);
-    } else if (string.equals("00:00:00")) {
-      return new Time(0);
-    } else {
-      return connection.getTimestampUtils().toTime(cal, string);
-    }
+    return connection.getTimestampUtils().toTime(cal, string);
   }
 
   //#if mvn.project.property.postgresql.jdbc.spec >= "JDBC4.2"

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/TimestampUtils.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/TimestampUtils.java
@@ -25,6 +25,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.time.chrono.IsoEra;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoField;
@@ -761,6 +762,10 @@ public class TimestampUtils {
     return sbuf.toString();
   }
 
+  /**
+   * Formats {@link LocalDateTime} to be sent to the backend, thus it adds time zone.
+   * Do not use this method in {@link java.sql.ResultSet#getString(int)}
+   */
   public synchronized String toString(LocalDateTime localDateTime) {
     if (LocalDateTime.MAX.equals(localDateTime)) {
       return "infinity";
@@ -768,15 +773,9 @@ public class TimestampUtils {
       return "-infinity";
     }
 
-    sbuf.setLength(0);
-
-    LocalDate localDate = localDateTime.toLocalDate();
-    appendDate(sbuf, localDate);
-    sbuf.append(' ');
-    appendTime(sbuf, localDateTime.toLocalTime());
-    appendEra(sbuf, localDate);
-
-    return sbuf.toString();
+    // LocalDateTime is always passed with time zone so backend can decide between timestamp and timestamptz
+    ZonedDateTime zonedDateTime = localDateTime.atZone(getDefaultTz().toZoneId());
+    return toString(zonedDateTime.toOffsetDateTime());
   }
 
   private static void appendDate(StringBuilder sb, LocalDate localDate) {

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/TimezoneTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/TimezoneTest.java
@@ -189,8 +189,8 @@ public class TimezoneTest {
       // 1970-01-01 15:00:00 +0300 -> 1970-01-01 07:00:00 -0500
       assertEquals(43200000L, ts.getTime());
       ts = rs.getTimestamp(4, cGMT13);
-      // 1970-01-01 15:00:00 +0300 -> 1970-01-02 01:00:00 +1300 (CHECK ME)
-      assertEquals(-43200000L, ts.getTime());
+      // 1970-01-01 15:00:00 +0300 -> 1970-01-02 01:00:00 +1300
+      assertEquals(43200000L, ts.getTime());
       str = rs.getString(4);
       assertEquals("timetz -> getString" + format, "15:00:00+03", str);
 
@@ -299,7 +299,7 @@ public class TimezoneTest {
       assertEquals(43200000L, t.getTime());
       t = rs.getTime(1, cGMT13);
       // 2005-01-02 01:00:00 +1300 -> 1970-01-01 01:00:00 +1300
-      assertEquals(-43200000L, t.getTime());
+      assertEquals(43200000L, t.getTime());
 
       // timestamp: 2005-01-01 15:00:00
       t = rs.getTime(2);
@@ -335,7 +335,7 @@ public class TimezoneTest {
       t = rs.getTime(4, cGMT05);
       assertEquals(43200000L, t.getTime()); // 1970-01-01 07:00:00 -0500
       t = rs.getTime(4, cGMT13);
-      assertEquals(-43200000L, t.getTime()); // 1970-01-01 01:00:00 +1300
+      assertEquals(43200000L, t.getTime()); // 1970-01-01 01:00:00 +1300
       rs.close();
     }
   }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc42/SetObject310Test.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc42/SetObject310Test.java
@@ -30,6 +30,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.chrono.IsoEra;
+import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoField;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -103,10 +104,6 @@ public class SetObject310Test {
     insert(data, columnName, null);
   }
 
-  private void insertWithType(OffsetDateTime data, String columnName) throws SQLException {
-    insert(data, columnName, Types.TIMESTAMP_WITH_TIMEZONE);
-  }
-
   private <T> T insertThenReadWithoutType(Object data, String columnName, Class<T> expectedType) throws SQLException {
     PreparedStatement ps = con.prepareStatement(TestUtil.insertSQL("table1", columnName, "?"));
     try {
@@ -178,7 +175,9 @@ public class SetObject310Test {
       ZoneId zone = ZoneId.of(zoneId);
       for (String date : datesToTest) {
         LocalDateTime localDateTime = LocalDateTime.parse(date);
-        String expected = date.replace('T', ' ');
+        String expected = localDateTime.atZone(zone)
+            .format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+            .replace('T', ' ');
         localTimestamps(zone, localDateTime, expected);
       }
     }
@@ -241,37 +240,42 @@ public class SetObject310Test {
   private void localTimestamps(ZoneId zoneId, LocalDateTime localDateTime, String expected) throws SQLException {
     TimeZone.setDefault(TimeZone.getTimeZone(zoneId));
     String readBack = insertThenReadStringWithoutType(localDateTime, "timestamp_without_time_zone_column");
-    assertEquals(expected, readBack);
+    assertEquals(
+        "LocalDateTime=" + localDateTime + ", with TimeZone.default=" + zoneId + ", setObject(int, Object)",
+        expected, readBack);
     deleteRows();
 
     readBack = insertThenReadStringWithType(localDateTime, "timestamp_without_time_zone_column");
-    assertEquals(expected, readBack);
+    assertEquals(
+        "LocalDateTime=" + localDateTime + ", with TimeZone.default=" + zoneId + ", setObject(int, Object, TIMESTAMP)",
+        expected, readBack);
     deleteRows();
   }
 
   private void offsetTimestamps(ZoneId dataZone, LocalDateTime localDateTime, String expected, List<TimeZone> storeZones) throws SQLException {
     OffsetDateTime data = localDateTime.atZone(dataZone).toOffsetDateTime();
-    for (TimeZone storeZone : storeZones) {
-      TimeZone.setDefault(storeZone);
-      insertWithoutType(data, "timestamp_with_time_zone_column");
-
-      String readBack = readString("timestamp_with_time_zone_column");
-      OffsetDateTime o = OffsetDateTime.parse(readBack.replace(' ', 'T') + ":00");
-      assertEquals(data.toInstant(), o.toInstant());
-
-      deleteRows();
-    }
-
-    for (TimeZone storeZone : storeZones) {
-      TimeZone.setDefault(storeZone);
-      insertWithType(data, "timestamp_with_time_zone_column");
-
-      String readBack = readString("timestamp_with_time_zone_column");
-      OffsetDateTime o = OffsetDateTime.parse(readBack.replace(' ', 'T') + ":00");
-
-      assertEquals(data.toInstant(), o.toInstant());
-
-      deleteRows();
+    try (PreparedStatement ps = con.prepareStatement(
+        "select ?::timestamp with time zone, ?::timestamp with time zone")) {
+      for (TimeZone storeZone : storeZones) {
+        TimeZone.setDefault(storeZone);
+        ps.setObject(1, data);
+        ps.setObject(2, data, Types.TIMESTAMP_WITH_TIMEZONE);
+        try (ResultSet rs = ps.executeQuery()) {
+          rs.next();
+          String noType = rs.getString(1);
+          OffsetDateTime noTypeRes = OffsetDateTime.parse(noType.replace(' ', 'T') + ":00");
+          assertEquals(
+              "OffsetDateTime=" + data + " (with ZoneId=" + dataZone + "), with TimeZone.default="
+                  + storeZone + ", setObject(int, Object)", data.toInstant(),
+              noTypeRes.toInstant());
+          String withType = rs.getString(1);
+          OffsetDateTime withTypeRes = OffsetDateTime.parse(withType.replace(' ', 'T') + ":00");
+          assertEquals(
+              "OffsetDateTime=" + data + " (with ZoneId=" + dataZone + "), with TimeZone.default="
+                  + storeZone + ", setObject(int, Object, TIMESTAMP_WITH_TIMEZONE)",
+              data.toInstant(), withTypeRes.toInstant());
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Previous behavior:
getTime(int), getTime(int, Calendar) kind of methods ensured that the resulting java.sql.Time
would render as 1970-01-01 ... in the given time zone (e.g. given Calendar and/or default TimeZone)
Note: the resulting Time object

E.g. if server was sending `1970-01-01 15:00:00 +0300` and `getTime(int, GMT+13)` was used by the client, then pgjdbc subtracted a day since otherwise the timestamp is equal to `1970-01-02 01:00:00 +1300` (note the date is 2).

New behavior:
for 'time with time zone' and 'timestamp with time zone' the value from the server is assumed to be
"instant" (i.e. absolute point in time), and no further adjustments is made to make the date part to be 1970-01-01.
For instance, `1970-01-01 15:00:00 +0300` is parsed as is (no matter which Calendar is provided to `getTime(...)`).

'time' and 'timestamp' work as earlier except "00:00:00" and "24:00:00" times in text format.
Previously, text times "00:00:00" and "24:00:00" were mapped to Time(0) and Time.valueOf("24:00:00"):
1) Time(0) is 1970-01-01 00:00:00 UTC (it does not account neither user-provided nor default Calendar)
2) Time.valueOf("24:00:00") uses system-provided calendar, and it does not account user-provided one