### PR TITLE
docs - change load.md to reflect current practice

### DIFF
--- a/docs/documentation/head/load.md
+++ b/docs/documentation/head/load.md
@@ -9,41 +9,22 @@ nexttitle: Connecting to the Database
 next: connect.html
 ---
 		
-Before you can connect to a database, you need to load the driver. There are two
-methods available, and it depends on your code which is the best one to use.
+Applications do not need to explicitly load the org.postgresql.Driver
+class because the pgjdbc driver jar supports the Java Service Provider
+mechanism. The driver will be loaded by the JVM when the application
+connects to PostgreSQL™ (as long as the driver's jar file is on the
+classpath).
 
-In the first method, your code implicitly loads the driver using the `Class.forName()`
-method. For PostgreSQL™, you would use:
+
+### Note
+
+Prior to Java 1.6, the driver had to be loaded by the application - either by calling
 
 ```java
 Class.forName("org.postgresql.Driver");
 ```
-
-This will load the driver, and while loading, the driver will automatically
-register itself with JDBC.
-
-### Note
-
-The `forName()` method can throw a `ClassNotFoundException` if the driver is not
-available.
-
-This is the most common method to use, but restricts your code to use just PostgreSQL™.
-If your code may access another database system in the future, and you do not
-use any PostgreSQL™-specific extensions, then the second method is advisable.
-
-The second method passes the driver as a parameter to the JVM as it starts, using
-the `-D` argument. Example:
+or by passing the driver class name as a JVM parameter.
 
 `java -Djdbc.drivers=org.postgresql.Driver example.ImageViewer`
 
-In this example, the JVM will attempt to load the driver as part of its initialization.
-Once done, the ImageViewer is started.
-
-Now, this method is the better one to use because it allows your code to be used
-with other database packages without recompiling the code. The only thing that
-would also change is the connection URL, which is covered next.
-
-One last thing: When your code then tries to open a `Connection`, and you get a
-No driver available `SQLException` being thrown, this is probably caused by the
-driver not being in the class path, or the value in the parameter not being
-correct.
+These older methods of loading the driver are still supported but they are no longer necessary.


### PR DESCRIPTION
The documentation in head should reflect current best practice while still providing the historical background needed by developers who are maintaining older code. I think this documentation change covers the significant points
1. you no longer need to explicitly load the driver
2. the driver jar file must be on the classpath in order for the driver to load
3. the old way still works but isn't needed