### PR TITLE
prefer secondary over slave referring to standby or secondary servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ In addition to the standard connection parameters the driver supports a number o
 | disableColumnSanitiser        | Boolean | false   | Enable optimization that disables column name sanitiser |
 | assumeMinServerVersion        | String  | null    | Assume the server is at least that version |
 | currentSchema                 | String  | null    | Specify the schema to be set in the search-path |
-| targetServerType              | String  | any     | Specifies what kind of server to connect, possible values: any, master, slave, preferSlave |
+| targetServerType              | String  | any     | Specifies what kind of server to connect, possible values: any, master, slave, secondary, preferSlave, preferSecondary |
 | hostRecheckSeconds            | Integer | 10      | Specifies period (seconds) after which the host status is checked again in case it has changed |
 | loadBalanceHosts              | Boolean | false   | If disabled hosts are connected in the given order. If enabled hosts are chosen randomly from the set of suitable candidates |
 | socketFactory                 | String  | null    | Specify a socket factory for socket creation |

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ In addition to the standard connection parameters the driver supports a number o
 | disableColumnSanitiser        | Boolean | false   | Enable optimization that disables column name sanitiser |
 | assumeMinServerVersion        | String  | null    | Assume the server is at least that version |
 | currentSchema                 | String  | null    | Specify the schema to be set in the search-path |
-| targetServerType              | String  | any     | Specifies what kind of server to connect, possible values: any, master, slave, secondary, preferSlave, preferSecondary |
+| targetServerType              | String  | any     | Specifies what kind of server to connect, possible values: any, master, slave (deprecated), secondary, preferSlave (deprecated), preferSecondary |
 | hostRecheckSeconds            | Integer | 10      | Specifies period (seconds) after which the host status is checked again in case it has changed |
 | loadBalanceHosts              | Boolean | false   | If disabled hosts are connected in the given order. If enabled hosts are chosen randomly from the set of suitable candidates |
 | socketFactory                 | String  | null    | Specify a socket factory for socket creation |

--- a/build.properties
+++ b/build.properties
@@ -6,13 +6,9 @@
 server=localhost
 port=5432
 secondaryServer=localhost
-slaveServer=localhost
 secondaryPort=5433
-slavePort=5433
 secondaryServer2=localhost
-slaveServer2=localhost
 secondaryServerPort2=5434
-slavePort2=5434
 database=test
 username=test
 password=test

--- a/build.properties
+++ b/build.properties
@@ -5,9 +5,13 @@
 
 server=localhost
 port=5432
+secondaryServer=localhost
 slaveServer=localhost
+secondaryPort=5433
 slavePort=5433
+secondaryServer2=localhost
 slaveServer2=localhost
+secondaryServerPort2=5434
 slavePort2=5434
 database=test
 username=test

--- a/docs/documentation/head/connect.md
+++ b/docs/documentation/head/connect.md
@@ -385,9 +385,9 @@ Connection conn = DriverManager.getConnection(url);
 * **targetServerType** = String
 
 	Allows opening connections to only servers with required state, 
-	the allowed values are any, master, slave and preferSlave. 
+	the allowed values are any, master, slave, secondary, preferSlave and preferSecondary. 
 	The master/slave distinction is currently done by observing if the server allows writes. 
-	The value preferSlave tries to connect to slaves if any are available, 
+	The value preferSecondary tries to connect to secondary if any are available, 
 	otherwise allows falls back to connecting also to master.
 
 * **hostRecheckSeconds** = int

--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -361,7 +361,7 @@ public enum PGProperty {
   CURRENT_SCHEMA("currentSchema", null, "Specify the schema to be set in the search-path"),
 
   TARGET_SERVER_TYPE("targetServerType", "any", "Specifies what kind of server to connect", false,
-      "any", "master", "slave", "preferSlave"),
+      "any", "master", "slave", "secondary",  "preferSlave", "preferSecondary"),
 
   LOAD_BALANCE_HOSTS("loadBalanceHosts", "false",
       "If disabled hosts are connected in the given order. If enabled hosts are chosen randomly from the set of suitable candidates"),

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java
@@ -212,10 +212,10 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
         QueryExecutor queryExecutor = new QueryExecutorImpl(newStream, user, database,
             cancelSignalTimeout, info);
 
-        // Check Master or Slave
+        // Check Master or Secondary
         HostStatus hostStatus = HostStatus.ConnectOK;
         if (candidateHost.targetServerType != HostRequirement.any) {
-          hostStatus = isMaster(queryExecutor) ? HostStatus.Master : HostStatus.Slave;
+          hostStatus = isMaster(queryExecutor) ? HostStatus.Master : HostStatus.Secondary;
         }
         GlobalHostStatusTracker.reportHostStatus(hostSpec, hostStatus);
         knownStates.put(hostSpec, hostStatus);

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java
@@ -118,7 +118,7 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
     HostRequirement targetServerType;
     String targetServerTypeStr = PGProperty.TARGET_SERVER_TYPE.get(info);
     try {
-      targetServerType = HostRequirement.valueOf(targetServerTypeStr);
+      targetServerType = HostRequirement.getTargetServerType(targetServerTypeStr);
     } catch (IllegalArgumentException ex) {
       throw new PSQLException(
           GT.tr("Invalid targetServerType value: {0}", targetServerTypeStr),

--- a/pgjdbc/src/main/java/org/postgresql/hostchooser/HostRequirement.java
+++ b/pgjdbc/src/main/java/org/postgresql/hostchooser/HostRequirement.java
@@ -31,4 +31,16 @@ public enum HostRequirement {
   };
 
   public abstract boolean allowConnectingTo(HostStatus status);
+
+  /**
+   *
+   * @param targetServerType
+   * @return
+   */
+
+  public static HostRequirement getTargetServerType(String targetServerType) {
+    String allowSlave = targetServerType.replaceFirst("slave", targetServerType);
+    return valueOf(allowSlave);
+  }
+
 }

--- a/pgjdbc/src/main/java/org/postgresql/hostchooser/HostRequirement.java
+++ b/pgjdbc/src/main/java/org/postgresql/hostchooser/HostRequirement.java
@@ -19,12 +19,12 @@ public enum HostRequirement {
       return status == HostStatus.Master || status == HostStatus.ConnectOK;
     }
   },
-  slave {
+  secondary {
     public boolean allowConnectingTo(HostStatus status) {
-      return status == HostStatus.Slave || status == HostStatus.ConnectOK;
+      return status == HostStatus.Secondary || status == HostStatus.ConnectOK;
     }
   },
-  preferSlave {
+  preferSecondary {
     public boolean allowConnectingTo(HostStatus status) {
       return status != HostStatus.ConnectFail;
     }

--- a/pgjdbc/src/main/java/org/postgresql/hostchooser/HostRequirement.java
+++ b/pgjdbc/src/main/java/org/postgresql/hostchooser/HostRequirement.java
@@ -34,8 +34,15 @@ public enum HostRequirement {
 
   /**
    *
+   * The postgreSQL project has decided not to use the term slave to refer to alternate servers.
+   * secondary or standby is preferred. We have arbitrarily chosen secondary.
+   * As of Jan 2018 in order not to break existint code we are going to accept both slave or
+   * secondary for names of alternate servers.
+   * 
+   * The current policy is to keep accepting this silently but not document slave, or slave preferSlave
+   *
    * @param targetServerType
-   * @return
+   * @return HostRequirement
    */
 
   public static HostRequirement getTargetServerType(String targetServerType) {

--- a/pgjdbc/src/main/java/org/postgresql/hostchooser/HostRequirement.java
+++ b/pgjdbc/src/main/java/org/postgresql/hostchooser/HostRequirement.java
@@ -38,10 +38,10 @@ public enum HostRequirement {
    * secondary or standby is preferred. We have arbitrarily chosen secondary.
    * As of Jan 2018 in order not to break existint code we are going to accept both slave or
    * secondary for names of alternate servers.
-   * 
+   *
    * The current policy is to keep accepting this silently but not document slave, or slave preferSlave
    *
-   * @param targetServerType
+   * @param targetServerType the value of {@code targetServerType} connection property
    * @return HostRequirement
    */
 

--- a/pgjdbc/src/main/java/org/postgresql/hostchooser/HostRequirement.java
+++ b/pgjdbc/src/main/java/org/postgresql/hostchooser/HostRequirement.java
@@ -39,7 +39,7 @@ public enum HostRequirement {
    */
 
   public static HostRequirement getTargetServerType(String targetServerType) {
-    String allowSlave = targetServerType.replaceFirst("slave", targetServerType);
+    String allowSlave = targetServerType.replace("lave", "econdary");
     return valueOf(allowSlave);
   }
 

--- a/pgjdbc/src/main/java/org/postgresql/hostchooser/HostStatus.java
+++ b/pgjdbc/src/main/java/org/postgresql/hostchooser/HostStatus.java
@@ -12,5 +12,5 @@ public enum HostStatus {
   ConnectFail,
   ConnectOK,
   Master,
-  Slave
+  Secondary
 }

--- a/pgjdbc/src/main/java/org/postgresql/hostchooser/MultiHostChooser.java
+++ b/pgjdbc/src/main/java/org/postgresql/hostchooser/MultiHostChooser.java
@@ -56,32 +56,32 @@ class MultiHostChooser implements HostChooser {
   }
 
   private Iterator<CandidateHost> candidateIterator() {
-    if (targetServerType != HostRequirement.preferSlave) {
+    if (targetServerType != HostRequirement.preferSecondary) {
       return getCandidateHosts(targetServerType).iterator();
     }
 
-    // preferSlave tries to find slave hosts first
+    // preferSecondary tries to find secondary hosts first
     // Note: sort does not work here since there are "unknown" hosts,
-    // and that "unkown" might turn out to be master, so we should discard that
-    // if other slaves exist
-    List<CandidateHost> slaves = getCandidateHosts(HostRequirement.slave);
+    // and that "unknown" might turn out to be master, so we should discard that
+    // if other secondaries exist
+    List<CandidateHost> secondaries = getCandidateHosts(HostRequirement.secondary);
     List<CandidateHost> any = getCandidateHosts(HostRequirement.any);
 
-    if (slaves.isEmpty()) {
+    if (secondaries.isEmpty()) {
       return any.iterator();
     }
 
     if (any.isEmpty()) {
-      return slaves.iterator();
+      return secondaries.iterator();
     }
 
-    if (slaves.get(slaves.size() - 1).equals(any.get(0))) {
-      // When the last slave's hostspec is the same as the first in "any" list, there's no need
-      // to attempt to connect it as "slave"
+    if (secondaries.get(secondaries.size() - 1).equals(any.get(0))) {
+      // When the last secondary's hostspec is the same as the first in "any" list, there's no need
+      // to attempt to connect it as "secondary"
       // Note: this is only an optimization
-      slaves = rtrim(1, slaves);
+      secondaries = rtrim(1, secondaries);
     }
-    return append(slaves, any).iterator();
+    return append(secondaries, any).iterator();
   }
 
   private List<CandidateHost> getCandidateHosts(HostRequirement hostRequirement) {

--- a/pgjdbc/src/test/java/org/postgresql/test/hostchooser/MultiHostTestSuite.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/hostchooser/MultiHostTestSuite.java
@@ -20,7 +20,7 @@ import java.util.Properties;
  */
 public class MultiHostTestSuite extends TestSuite {
 
-  public static java.sql.Connection openSlaveDB() throws Exception {
+  public static java.sql.Connection openSecondaryDB() throws Exception {
     TestUtil.initDriver();
 
     Properties props = new Properties();
@@ -28,10 +28,10 @@ public class MultiHostTestSuite extends TestSuite {
     props.setProperty("user", TestUtil.getUser());
     props.setProperty("password", TestUtil.getPassword());
 
-    return DriverManager.getConnection(TestUtil.getURL(getSlaveServer(), getSlavePort()), props);
+    return DriverManager.getConnection(TestUtil.getURL(getSecondaryServer(), getSecondaryPort()), props);
   }
 
-  public static java.sql.Connection openSlaveDB2() throws Exception {
+  public static java.sql.Connection openSecondaryDB2() throws Exception {
     TestUtil.initDriver();
 
     Properties props = new Properties();
@@ -39,37 +39,37 @@ public class MultiHostTestSuite extends TestSuite {
     props.setProperty("user", TestUtil.getUser());
     props.setProperty("password", TestUtil.getPassword());
 
-    return DriverManager.getConnection(TestUtil.getURL(getSlaveServer2(), getSlavePort2()), props);
+    return DriverManager.getConnection(TestUtil.getURL(getSecondaryServer2(), getSecondaryPort2()), props);
   }
 
   /*
    * Returns the Test server
    */
-  public static String getSlaveServer() {
-    return System.getProperty("slaveServer", TestUtil.getServer());
+  public static String getSecondaryServer() {
+    return System.getProperty("secondaryServer", TestUtil.getServer());
   }
 
   /*
    * Returns the Test port
    */
-  public static int getSlavePort() {
+  public static int getSecondaryPort() {
     return Integer
-        .parseInt(System.getProperty("slavePort", String.valueOf(TestUtil.getPort() + 1)));
+        .parseInt(System.getProperty("secondaryPort", String.valueOf(TestUtil.getPort() + 1)));
   }
 
   /*
    * Returns the Test server
    */
-  public static String getSlaveServer2() {
-    return System.getProperty("slaveServer2", TestUtil.getServer());
+  public static String getSecondaryServer2() {
+    return System.getProperty("secondaryServer2", TestUtil.getServer());
   }
 
   /*
    * Returns the Test port
    */
-  public static int getSlavePort2() {
+  public static int getSecondaryPort2() {
     return Integer
-        .parseInt(System.getProperty("slavePort2", String.valueOf(TestUtil.getPort() + 2)));
+        .parseInt(System.getProperty("secondaryPort2", String.valueOf(TestUtil.getPort() + 2)));
   }
 
   /*
@@ -79,10 +79,10 @@ public class MultiHostTestSuite extends TestSuite {
     TestSuite suite = new TestSuite();
 
     try {
-      Connection connection = openSlaveDB();
+      Connection connection = openSecondaryDB();
       TestUtil.closeDB(connection);
 
-      connection = openSlaveDB2();
+      connection = openSecondaryDB2();
       TestUtil.closeDB(connection);
     } catch (PSQLException ex) {
       // replication instance is not available, but suite must have at lest one test case

--- a/pgjdbc/src/test/java/org/postgresql/test/hostchooser/MultiHostsConnectionTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/hostchooser/MultiHostsConnectionTest.java
@@ -10,10 +10,10 @@ import static java.util.Arrays.asList;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.postgresql.hostchooser.HostRequirement.any;
 import static org.postgresql.hostchooser.HostRequirement.master;
-import static org.postgresql.hostchooser.HostRequirement.preferSlave;
-import static org.postgresql.hostchooser.HostRequirement.slave;
+import static org.postgresql.hostchooser.HostRequirement.preferSecondary;
+import static org.postgresql.hostchooser.HostRequirement.secondary;
 import static org.postgresql.hostchooser.HostStatus.Master;
-import static org.postgresql.hostchooser.HostStatus.Slave;
+import static org.postgresql.hostchooser.HostStatus.Secondary;
 import static org.postgresql.test.TestUtil.closeDB;
 
 import org.postgresql.hostchooser.GlobalHostStatusTracker;
@@ -39,14 +39,14 @@ public class MultiHostsConnectionTest extends TestCase {
   static final String user = TestUtil.getUser();
   static final String password = TestUtil.getPassword();
   static final String master1 = TestUtil.getServer() + ":" + TestUtil.getPort();
-  static final String slave1 =
-      MultiHostTestSuite.getSlaveServer() + ":" + MultiHostTestSuite.getSlavePort();
-  static final String slave2 =
-      MultiHostTestSuite.getSlaveServer2() + ":" + MultiHostTestSuite.getSlavePort2();
+  static final String secondary1 =
+      MultiHostTestSuite.getSecondaryServer() + ":" + MultiHostTestSuite.getSecondaryPort();
+  static final String secondary2 =
+      MultiHostTestSuite.getSecondaryServer2() + ":" + MultiHostTestSuite.getSecondaryPort2();
   static final String fake1 = "127.127.217.217:1";
   static String masterIp;
-  static String slaveIp;
-  static String slaveIp2;
+  static String secondaryIP;
+  static String secondaryIP2;
   static String fakeIp = fake1;
 
   static Connection con;
@@ -62,12 +62,12 @@ public class MultiHostsConnectionTest extends TestCase {
       masterIp = getRemoteHostSpec();
       closeDB(con);
 
-      con = MultiHostTestSuite.openSlaveDB();
-      slaveIp = getRemoteHostSpec();
+      con = MultiHostTestSuite.openSecondaryDB();
+      secondaryIP = getRemoteHostSpec();
       closeDB(con);
 
-      con = MultiHostTestSuite.openSlaveDB2();
-      slaveIp2 = getRemoteHostSpec();
+      con = MultiHostTestSuite.openSecondaryDB2();
+      secondaryIP2 = getRemoteHostSpec();
       closeDB(con);
 
     } catch (Exception e) {
@@ -155,9 +155,9 @@ public class MultiHostsConnectionTest extends TestCase {
     assertGlobalState(master1, "ConnectOK");
     assertGlobalState(fake1, "ConnectFail");
 
-    getConnection(any, fake1, slave1);
-    assertRemote(slaveIp);
-    assertGlobalState(slave1, "ConnectOK");
+    getConnection(any, fake1, secondary1);
+    assertRemote(secondaryIP);
+    assertGlobalState(secondary1, "ConnectOK");
 
     getConnection(any, fake1, master1);
     assertRemote(masterIp);
@@ -166,50 +166,50 @@ public class MultiHostsConnectionTest extends TestCase {
   }
 
   public static void testConnectToMaster() throws SQLException {
-    getConnection(master, true, fake1, master1, slave1);
+    getConnection(master, true, fake1, master1, secondary1);
     assertRemote(masterIp);
     assertGlobalState(fake1, "ConnectFail");
     assertGlobalState(master1, "Master");
-    assertGlobalState(slave1, null);
+    assertGlobalState(secondary1, null);
 
-    getConnection(master, false, fake1, slave1, master1);
+    getConnection(master, false, fake1, secondary1, master1);
     assertRemote(masterIp);
     assertGlobalState(fake1, "ConnectFail"); // cached
     assertGlobalState(master1, "Master"); // connected to master
-    assertGlobalState(slave1, "Slave"); // was unknown, so tried to connect in order
+    assertGlobalState(secondary1, "Secondary"); // was unknown, so tried to connect in order
   }
 
   public static void testConnectToSlave() throws SQLException {
-    getConnection(slave, true, fake1, slave1, master1);
-    assertRemote(slaveIp);
+    getConnection(secondary, true, fake1, secondary1, master1);
+    assertRemote(secondaryIP);
     assertGlobalState(fake1, "ConnectFail");
-    assertGlobalState(slave1, "Slave");
+    assertGlobalState(secondary1, "Secondary");
     assertGlobalState(master1, null);
 
-    getConnection(slave, false, fake1, master1, slave1);
-    assertRemote(slaveIp);
+    getConnection(secondary, false, fake1, master1, secondary1);
+    assertRemote(secondaryIP);
     assertGlobalState(fake1, "ConnectFail"); // cached
-    assertGlobalState(slave1, "Slave"); // connected
+    assertGlobalState(secondary1, "Secondary"); // connected
     assertGlobalState(master1, "Master"); // tried as it was unknown
   }
 
   public static void testConnectToSlaveFirst() throws SQLException {
-    getConnection(preferSlave, true, fake1, slave1, master1);
-    assertRemote(slaveIp);
+    getConnection(preferSecondary, true, fake1, secondary1, master1);
+    assertRemote(secondaryIP);
     assertGlobalState(fake1, "ConnectFail");
-    assertGlobalState(slave1, "Slave");
+    assertGlobalState(secondary1, "Secondary");
     assertGlobalState(master1, null);
 
-    getConnection(slave, false, fake1, master1, slave1);
-    assertRemote(slaveIp);
+    getConnection(secondary, false, fake1, master1, secondary1);
+    assertRemote(secondaryIP);
     assertGlobalState(fake1, "ConnectFail");
-    assertGlobalState(slave1, "Slave");
+    assertGlobalState(secondary1, "Secondary");
     assertGlobalState(master1, "Master"); // tried as it was unknown
 
-    getConnection(preferSlave, true, fake1, master1, slave1);
-    assertRemote(slaveIp);
+    getConnection(preferSecondary, true, fake1, master1, secondary1);
+    assertRemote(secondaryIP);
     assertGlobalState(fake1, "ConnectFail");
-    assertGlobalState(slave1, "Slave");
+    assertGlobalState(secondary1, "Secondary");
     assertGlobalState(master1, "Master");
   }
 
@@ -225,51 +225,53 @@ public class MultiHostsConnectionTest extends TestCase {
     Set<String> connectedHosts = new HashSet<String>();
     boolean fake1FoundTried = false;
     for (int i = 0; i < 20; ++i) {
-      getConnection(any, true, true, fake1, master1, slave1);
+      getConnection(any, true, true, fake1, master1, secondary1);
       connectedHosts.add(getRemoteHostSpec());
       fake1FoundTried |= hostStatusMap.containsKey(hostSpec(fake1));
       if (connectedHosts.size() == 2 && fake1FoundTried) {
         break;
       }
     }
-    assertEquals("Never connected to all hosts", new HashSet<String>(asList(masterIp, slaveIp)),
+    assertEquals("Never connected to all hosts", new HashSet<String>(asList(masterIp, secondaryIP)),
         connectedHosts);
     assertTrue("Never tried to connect to fake node", fake1FoundTried);
   }
 
-  public static void testLoadBalancing_preferSlave() throws SQLException {
+  public static void testLoadBalancing_preferSecondary() throws SQLException {
     Set<String> connectedHosts = new HashSet<String>();
     Set<HostSpec> tryConnectedHosts = new HashSet<HostSpec>();
     for (int i = 0; i < 20; ++i) {
-      getConnection(preferSlave, true, true, fake1, master1, slave1, slave2);
+      getConnection(preferSecondary, true, true, fake1, master1, secondary1, secondary2);
       connectedHosts.add(getRemoteHostSpec());
       tryConnectedHosts.addAll(hostStatusMap.keySet());
       if (tryConnectedHosts.size() == 4) {
         break;
       }
     }
-    assertEquals("Never connected to all slave hosts", new HashSet<String>(asList(slaveIp, slaveIp2)),
+    assertEquals("Never connected to all secondary hosts", new HashSet<String>(asList(secondaryIP,
+        secondaryIP2)),
         connectedHosts);
     assertEquals("Never tried to connect to fake node",4, tryConnectedHosts.size());
 
-    getConnection(preferSlave, false, true, fake1, master1, slave1);
-    assertRemote(slaveIp);
+    getConnection(preferSecondary, false, true, fake1, master1, secondary1);
+    assertRemote(secondaryIP);
     connectedHosts.clear();
     for (int i = 0; i < 20; ++i) {
-      getConnection(preferSlave, false, true, fake1, master1, slave1, slave2);
+      getConnection(preferSecondary, false, true, fake1, master1, secondary1, secondary2);
       connectedHosts.add(getRemoteHostSpec());
       if (connectedHosts.size() == 2) {
         break;
       }
     }
-    assertEquals("Never connected to all slave hosts", new HashSet<String>(asList(slaveIp, slaveIp2)),
+    assertEquals("Never connected to all secondary hosts", new HashSet<String>(asList(secondaryIP,
+        secondaryIP2)),
         connectedHosts);
 
-    // connect to master when there's no slave
-    getConnection(preferSlave, true, true, fake1, master1);
+    // connect to master when there's no secondary
+    getConnection(preferSecondary, true, true, fake1, master1);
     assertRemote(masterIp);
 
-    getConnection(preferSlave, false, true, fake1, master1);
+    getConnection(preferSecondary, false, true, fake1, master1);
     assertRemote(masterIp);
   }
 
@@ -277,58 +279,60 @@ public class MultiHostsConnectionTest extends TestCase {
     Set<String> connectedHosts = new HashSet<String>();
     Set<HostSpec> tryConnectedHosts = new HashSet<HostSpec>();
     for (int i = 0; i < 20; ++i) {
-      getConnection(slave, true, true, fake1, master1, slave1, slave2);
+      getConnection(secondary, true, true, fake1, master1, secondary1, secondary2);
       connectedHosts.add(getRemoteHostSpec());
       tryConnectedHosts.addAll(hostStatusMap.keySet());
       if (tryConnectedHosts.size() == 4) {
         break;
       }
     }
-    assertEquals("Never connected to all salve hosts", new HashSet<String>(asList(slaveIp, slaveIp2)),
+    assertEquals("Never connected to all salve hosts", new HashSet<String>(asList(secondaryIP,
+        secondaryIP2)),
         connectedHosts);
     assertEquals("Never tried to connect to maste and fake node", 4, tryConnectedHosts.size());
 
-    getConnection(preferSlave, false, true, fake1, master1, slave1);
-    assertRemote(slaveIp);
+    getConnection(preferSecondary, false, true, fake1, master1, secondary1);
+    assertRemote(secondaryIP);
     connectedHosts.clear();
     for (int i = 0; i < 20; ++i) {
-      getConnection(slave, false, true, fake1, master1, slave1, slave2);
+      getConnection(secondary, false, true, fake1, master1, secondary1, secondary2);
       connectedHosts.add(getRemoteHostSpec());
       if (connectedHosts.size() == 2) {
         break;
       }
     }
-    assertEquals("Never connected to all slave hosts", new HashSet<String>(asList(slaveIp, slaveIp2)),
+    assertEquals("Never connected to all secondary hosts", new HashSet<String>(asList(secondaryIP,
+        secondaryIP2)),
         connectedHosts);
   }
 
   public static void testHostRechecks() throws SQLException, InterruptedException {
-    GlobalHostStatusTracker.reportHostStatus(hostSpec(master1), Slave);
-    GlobalHostStatusTracker.reportHostStatus(hostSpec(slave1), Master);
-    GlobalHostStatusTracker.reportHostStatus(hostSpec(fake1), Slave);
+    GlobalHostStatusTracker.reportHostStatus(hostSpec(master1), Secondary);
+    GlobalHostStatusTracker.reportHostStatus(hostSpec(secondary1), Master);
+    GlobalHostStatusTracker.reportHostStatus(hostSpec(fake1), Secondary);
 
     try {
-      getConnection(master, false, fake1, slave1, master1);
+      getConnection(master, false, fake1, secondary1, master1);
       fail();
     } catch (SQLException ex) {
     }
 
-    GlobalHostStatusTracker.reportHostStatus(hostSpec(master1), Slave);
-    GlobalHostStatusTracker.reportHostStatus(hostSpec(slave1), Master);
-    GlobalHostStatusTracker.reportHostStatus(hostSpec(fake1), Slave);
+    GlobalHostStatusTracker.reportHostStatus(hostSpec(master1), Secondary);
+    GlobalHostStatusTracker.reportHostStatus(hostSpec(secondary1), Master);
+    GlobalHostStatusTracker.reportHostStatus(hostSpec(fake1), Secondary);
 
     SECONDS.sleep(3);
 
-    getConnection(master, false, slave1, fake1, master1);
+    getConnection(master, false, secondary1, fake1, master1);
     assertRemote(masterIp);
   }
 
   public static void testNoGoodHostsRechecksEverything() throws SQLException, InterruptedException {
-    GlobalHostStatusTracker.reportHostStatus(hostSpec(master1), Slave);
-    GlobalHostStatusTracker.reportHostStatus(hostSpec(slave1), Slave);
-    GlobalHostStatusTracker.reportHostStatus(hostSpec(fake1), Slave);
+    GlobalHostStatusTracker.reportHostStatus(hostSpec(master1), Secondary);
+    GlobalHostStatusTracker.reportHostStatus(hostSpec(secondary1), Secondary);
+    GlobalHostStatusTracker.reportHostStatus(hostSpec(fake1), Secondary);
 
-    getConnection(master, false, slave1, fake1, master1);
+    getConnection(master, false, secondary1, fake1, master1);
     assertRemote(masterIp);
   }
 }

--- a/pgjdbc/src/test/java/org/postgresql/test/hostchooser/MultiHostsConnectionTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/hostchooser/MultiHostsConnectionTest.java
@@ -286,10 +286,10 @@ public class MultiHostsConnectionTest extends TestCase {
         break;
       }
     }
-    assertEquals("Never connected to all salve hosts", new HashSet<String>(asList(secondaryIP,
+    assertEquals("Did not connect to all secondary hosts", new HashSet<String>(asList(secondaryIP,
         secondaryIP2)),
         connectedHosts);
-    assertEquals("Never tried to connect to maste and fake node", 4, tryConnectedHosts.size());
+    assertEquals("Did not attempt to connect to master and fake node", 4, tryConnectedHosts.size());
 
     getConnection(preferSecondary, false, true, fake1, master1, secondary1);
     assertRemote(secondaryIP);
@@ -301,7 +301,7 @@ public class MultiHostsConnectionTest extends TestCase {
         break;
       }
     }
-    assertEquals("Never connected to all secondary hosts", new HashSet<String>(asList(secondaryIP,
+    assertEquals("Did not connect to all secondary hosts", new HashSet<String>(asList(secondaryIP,
         secondaryIP2)),
         connectedHosts);
   }


### PR DESCRIPTION
The community has decided that the naming of replicas in any form
should be referred to as secondary or standby.
We have chosen to use the word secondary
This PR renames (hopefully) all of the uses of slave to secondary