### PR TITLE
fix: avoid NPE from getObject(..., Date.class) and getObject(..., Calendar.class) on null timestamps

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
@@ -3294,6 +3294,9 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
       //#endif
       ) {
         Timestamp timestampValue = getTimestamp(columnIndex);
+        if (wasNull()) {
+          return null;
+        }
         Calendar calendar = Calendar.getInstance(getDefaultCalendar().getTimeZone());
         calendar.setTimeInMillis(timestampValue.getTime());
         return type.cast(calendar);
@@ -3318,6 +3321,9 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
     } else if (type == java.util.Date.class) {
       if (sqlType == Types.TIMESTAMP) {
         Timestamp timestamp = getTimestamp(columnIndex);
+        if (wasNull()) {
+          return null;
+        }
         return type.cast(new java.util.Date(timestamp.getTime()));
       } else {
         throw new PSQLException(GT.tr("conversion to {0} from {1} not supported", type, sqlType),

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc4/jdbc41/GetObjectTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc4/jdbc41/GetObjectTest.java
@@ -220,9 +220,8 @@ public class GetObjectTest {
   @Test
   public void testGetJavaUtilDate() throws SQLException {
     Statement stmt = _conn.createStatement();
-    stmt.executeUpdate(TestUtil.insertSQL("table1","timestamp_without_time_zone_column","TIMESTAMP '2004-10-19 10:23:54'"));
-
-    ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("table1", "timestamp_without_time_zone_column"));
+    ResultSet rs = stmt.executeQuery("select TIMESTAMP '2004-10-19 10:23:54'::timestamp timestamp_without_time_zone_column"
+        + ", null::timestamp null_timestamp");
     try {
       assertTrue(rs.next());
       Calendar calendar = GregorianCalendar.getInstance();
@@ -236,6 +235,7 @@ public class GetObjectTest {
       java.util.Date expected = new java.util.Date(calendar.getTimeInMillis());
       assertEquals(expected, rs.getObject("timestamp_without_time_zone_column", java.util.Date.class));
       assertEquals(expected, rs.getObject(1, java.util.Date.class));
+      assertNull(rs.getObject(2, java.util.Date.class));
     } finally {
       rs.close();
     }
@@ -287,9 +287,9 @@ public class GetObjectTest {
   @Test
   public void testGetCalendar() throws SQLException {
     Statement stmt = _conn.createStatement();
-    stmt.executeUpdate(TestUtil.insertSQL("table1","timestamp_without_time_zone_column,timestamp_with_time_zone_column","TIMESTAMP '2004-10-19 10:23:54', TIMESTAMP '2004-10-19 10:23:54+02'"));
 
-    ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("table1", "timestamp_without_time_zone_column, timestamp_with_time_zone_column"));
+    ResultSet rs = stmt.executeQuery("select TIMESTAMP '2004-10-19 10:23:54'::timestamp timestamp_without_time_zone_column"
+        + ", TIMESTAMP '2004-10-19 10:23:54+02'::timestamp timestamp_with_time_zone_column, null::timestamp null_timestamp");
     try {
       assertTrue(rs.next());
       Calendar calendar = GregorianCalendar.getInstance();
@@ -303,10 +303,12 @@ public class GetObjectTest {
       long expected = calendar.getTimeInMillis();
       assertEquals(expected, rs.getObject("timestamp_without_time_zone_column", Calendar.class).getTimeInMillis());
       assertEquals(expected, rs.getObject(1, Calendar.class).getTimeInMillis());
+      assertNull(rs.getObject(3, Calendar.class));
       calendar.setTimeZone(TimeZone.getTimeZone("GMT+2:00"));
       expected = calendar.getTimeInMillis();
       assertEquals(expected, rs.getObject("timestamp_with_time_zone_column", Calendar.class).getTimeInMillis());
       assertEquals(expected, rs.getObject(2, Calendar.class).getTimeInMillis());
+      assertNull(rs.getObject(3, Calendar.class));
     } finally {
       rs.close();
     }


### PR DESCRIPTION
fixes #1071