### PR TITLE
chore: remove braces for LeftCurlyCheck issue checkstyle

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -1197,7 +1197,6 @@ public class QueryExecutorImpl extends QueryExecutorBase {
           block = true;
           break;
         case 'S': // Parameter Status
-        {
           try {
             receiveParameterStatus();
           } catch (SQLException e) {
@@ -1205,7 +1204,6 @@ public class QueryExecutorImpl extends QueryExecutorBase {
             endReceiving = true;
           }
           break;
-        }
 
         case 'Z': // ReadyForQuery: After FE:CopyDone => BE:CommandComplete
 


### PR DESCRIPTION
There is an issue in maven checkstyle project called [Issue #5207: add support for LITERAL_CASE and LITERAL_DEFAULT in LeftCurlyCheck](https://github.com/checkstyle/checkstyle/pull/5376) which fails to build wercker on pgjdbc project. 
I deleted unnecessary braces so the build could be stable.