### PR TITLE
chore: remove additional braces for LeftCurlyCheck checkstyle

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -1949,12 +1949,12 @@ public class QueryExecutorImpl extends QueryExecutorBase {
 
           break;
 
-        case 't': // ParameterDescription
+        case 't': { // ParameterDescription
           pgStream.receiveInteger4(); // len, discarded
 
           LOGGER.log(Level.FINEST, " <=BE ParameterDescription");
 
-        {
+
           DescribeRequest describeData = pendingDescribeStatementQueue.getFirst();
           SimpleQuery query = describeData.query;
           SimpleParameterList params = describeData.parameterList;
@@ -2022,14 +2022,14 @@ public class QueryExecutorImpl extends QueryExecutorBase {
           }
           break;
 
-        case 's': // Portal Suspended (end of Execute)
+        case 's': { // Portal Suspended (end of Execute)
           // nb: this appears *instead* of CommandStatus.
           // Must be a SELECT if we suspended, so don't worry about it.
 
           pgStream.receiveInteger4(); // len, discarded
           LOGGER.log(Level.FINEST, " <=BE PortalSuspended");
 
-        {
+
           ExecuteRequest executeData = pendingExecuteQueue.removeFirst();
           SimpleQuery currentQuery = executeData.query;
           Portal currentPortal = executeData.portal;
@@ -2046,7 +2046,7 @@ public class QueryExecutorImpl extends QueryExecutorBase {
           break;
         }
 
-        case 'C': // Command Status (end of Execute)
+        case 'C': { // Command Status (end of Execute)
           // Handle status.
           String status = receiveCommandStatus();
           if (isFlushCacheOnDeallocate()
@@ -2056,7 +2056,7 @@ public class QueryExecutorImpl extends QueryExecutorBase {
 
           doneAfterRowDescNoData = false;
 
-        {
+
           ExecuteRequest executeData = pendingExecuteQueue.peekFirst();
           SimpleQuery currentQuery = executeData.query;
           Portal currentPortal = executeData.portal;
@@ -2179,12 +2179,11 @@ public class QueryExecutorImpl extends QueryExecutorBase {
           // keep processing
           break;
 
-        case 'I': // Empty Query (end of Execute)
+        case 'I': { // Empty Query (end of Execute)
           pgStream.receiveInteger4();
 
           LOGGER.log(Level.FINEST, " <=BE EmptyQuery");
 
-        {
           ExecuteRequest executeData = pendingExecuteQueue.removeFirst();
           Portal currentPortal = executeData.portal;
           handler.handleCommandStatus("EMPTY", 0, 0);
@@ -2200,7 +2199,6 @@ public class QueryExecutorImpl extends QueryExecutorBase {
           break;
 
         case 'S': // Parameter Status
-        {
           try {
             receiveParameterStatus();
           } catch (SQLException e) {
@@ -2208,7 +2206,6 @@ public class QueryExecutorImpl extends QueryExecutorBase {
             endQuery = true;
           }
           break;
-        }
 
         case 'T': // Row Description (response to Describe)
           Field[] fields = receiveFields();

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -1197,7 +1197,6 @@ public class QueryExecutorImpl extends QueryExecutorBase {
           block = true;
           break;
         case 'S': // Parameter Status
-        {
           try {
             receiveParameterStatus();
           } catch (SQLException e) {
@@ -1205,7 +1204,6 @@ public class QueryExecutorImpl extends QueryExecutorBase {
             endReceiving = true;
           }
           break;
-        }
 
         case 'Z': // ReadyForQuery: After FE:CopyDone => BE:CommandComplete
 


### PR DESCRIPTION
By mistake I've corrected only one couple of braces. In this commit I tried to take into account all of them. 
I removed and replaced some additional braces in case scenarios that are also required for build to proceed. 
However, some braces were not removed and only displaced into other location otherwise it raises an exception of duplicated variable parameters: "Variable has been already defined in this scope"

Please refer to the following issue of the underlying problem : [LeftCurlyCheck](https://github.com/checkstyle/checkstyle/pull/5376)