### PR TITLE
test: check if url is not for PostgreSQL

### DIFF
--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DriverTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DriverTest.java
@@ -8,6 +8,7 @@ package org.postgresql.test.jdbc2;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -23,6 +24,7 @@ import java.io.PrintWriter;
 import java.lang.reflect.Method;
 import java.sql.Connection;
 import java.sql.DriverManager;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Properties;
@@ -34,6 +36,13 @@ import java.util.logging.Logger;
  *
  */
 public class DriverTest {
+
+  @Test
+  public void urlIsNotForPostgreSQL() throws SQLException {
+    Driver driver = new Driver();
+
+    assertNull(driver.connect("jdbc:otherdb:database", new Properties()));
+  }
 
   /*
    * This tests the acceptsURL() method with a couple of well and poorly formed jdbc urls.


### PR DESCRIPTION
java.sql.Driver's javadoc states " The driver should return "null" if it realizes it is the wrong kind of driver to connect to the given URL. This will be common, as when the JDBC driver manager is asked to connect to a given URL it passes the URL to each loaded driver in turn." (https://docs.oracle.com/javase/8/docs/api/java/sql/Driver.html#connect-java.lang.String-java.util.Properties-).

Add test for checking this behaviour.