### PR TITLE
fix: avoid connection failure when DateStyle is set to ISO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+- Avoid connection failure when `DateStyle` is set to `ISO` [Issue 1080](https://github.com/pgjdbc/pgjdbc/issues/1080)
+
 ## [42.2.0] (2018-01-17)
 ### Added
 - Support SCRAM-SHA-256 for PostgreSQL 10 in the JDBC 4.2 version (Java 8+) using the Ongres SCRAM library. [PR 842](https://github.com/pgjdbc/pgjdbc/pull/842)

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -2593,7 +2593,8 @@ public class QueryExecutorImpl extends QueryExecutorBase {
           value), PSQLState.CONNECTION_FAILURE);
     }
 
-    if (name.equals("DateStyle") && !value.startsWith("ISO,")) {
+    if (name.equals("DateStyle") && !value.startsWith("ISO")
+        && !value.toUpperCase().startsWith("ISO")) {
       close(); // we're screwed now; we can't trust any subsequent date.
       throw new PSQLException(GT.tr(
           "The server''s DateStyle parameter was changed to {0}. The JDBC driver requires DateStyle to begin with ISO for correct operation.",

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DateStyleTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DateStyleTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2018, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.test.jdbc2;
+
+import org.postgresql.test.TestUtil;
+import org.postgresql.util.PSQLState;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Arrays;
+
+@RunWith(Parameterized.class)
+public class DateStyleTest extends BaseTest4 {
+
+  @Parameterized.Parameter(0)
+  public String dateStyle;
+
+  @Parameterized.Parameter(1)
+  public boolean shouldPass;
+
+
+  @Parameterized.Parameters(name = "dateStyle={0}, shouldPass={1}")
+  public static Iterable<Object[]> data() {
+    return Arrays.asList(new Object[][]{
+        {"iso, mdy", true},
+        {"ISO", true},
+        {"ISO,ymd", true},
+        {"PostgreSQL", false}
+    });
+  }
+
+  @Test
+  public void conenct() throws SQLException {
+    Statement st = con.createStatement();
+    try {
+      st.execute("set DateStyle='" + dateStyle + "'");
+      if (!shouldPass) {
+        Assert.fail("Set DateStyle=" + dateStyle + " should not be allowed");
+      }
+    } catch (SQLException e) {
+      if (shouldPass) {
+        throw new IllegalStateException("Set DateStyle=" + dateStyle
+            + " should be fine, however received " + e.getMessage(), e);
+      }
+      if (PSQLState.CONNECTION_FAILURE.getState().equals(e.getSQLState())) {
+        return;
+      }
+      throw new IllegalStateException("Set DateStyle=" + dateStyle
+          + " should result in CONNECTION_FAILURE error, however received " + e.getMessage(), e);
+    } finally {
+      TestUtil.closeQuietly(st);
+    }
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/Jdbc2TestSuite.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/Jdbc2TestSuite.java
@@ -31,6 +31,7 @@ import org.junit.runners.Suite;
 
         DriverTest.class,
         ConnectionTest.class,
+        DateStyleTest.class,
         DatabaseMetaDataTest.class,
         DatabaseMetaDataPropertiesTest.class,
         SearchPathLookupTest.class,


### PR DESCRIPTION
Default PostgreSQL configuration is DateStyle='iso, dmy',
however just iso would be fine.

Note: PostgreSQL prints DateStyle value in upper case, and toUpperCase
was added just in case.

fixes #1080