### PR TITLE
add support for fetching 'TIMESTAMP(6) WITHOUT TIME ZONE' as LocalDate

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
@@ -3371,6 +3371,12 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
           return type.cast(LocalDate.MIN);
         }
         return type.cast(dateValue.toLocalDate());
+      } else if (sqlType == Types.TIMESTAMP) {
+        LocalDateTime localDateTimeValue = getLocalDateTime(columnIndex);
+        if (wasNull()) {
+          return null;
+        }
+        return type.cast(localDateTimeValue.toLocalDate());
       } else {
         throw new PSQLException(GT.tr("conversion to {0} from {1} not supported", type, sqlType),
                 PSQLState.INVALID_PARAMETER_VALUE);

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc42/GetObject310Test.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc42/GetObject310Test.java
@@ -214,6 +214,10 @@ public class GetObject310Test extends BaseTest4 {
         LocalDateTime localDateTime = LocalDateTime.parse(timestamp);
         assertEquals(localDateTime, rs.getObject("timestamp_without_time_zone_column", LocalDateTime.class));
         assertEquals(localDateTime, rs.getObject(1, LocalDateTime.class));
+
+        //Also test that we get the correct values when retrieving the data as LocalDate objects
+        assertEquals(localDateTime.toLocalDate(), rs.getObject("timestamp_without_time_zone_column", LocalDate.class));
+        assertEquals(localDateTime.toLocalDate(), rs.getObject(1, LocalDate.class));
       } finally {
         rs.close();
       }


### PR DESCRIPTION
When fetching objects from an ResultSet, it would be convenient to be able to fetch timestamp columns as both LocalDateTime and LocalDate.

That enables me to write code like this:
```
        user.setToDate(rs.getObject("ToDate", LocalDate.class));
```
instead of having to check for null everywhere:
```
        LocalDateTime ldt = rs.getObject("ToDate", LocalDateTime.class);
        user.setToDate(ltd == null ? null : ltd);

```