### PR TITLE
feat: support creating binary varchar[]

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PrimitiveArraySupport.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PrimitiveArraySupport.java
@@ -5,12 +5,20 @@
 
 package org.postgresql.jdbc;
 
+import org.postgresql.core.BaseConnection;
+import org.postgresql.core.Encoding;
 import org.postgresql.core.Oid;
 import org.postgresql.core.TypeInfo;
 import org.postgresql.util.ByteConverter;
+import org.postgresql.util.GT;
+import org.postgresql.util.PSQLException;
+import org.postgresql.util.PSQLState;
 
-import java.sql.Connection;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -26,7 +34,7 @@ abstract class PrimitiveArraySupport<A> {
     return true;
   }
 
-  public abstract byte[] toBinaryRepresentation(Connection connection, A array) throws SQLFeatureNotSupportedException;
+  public abstract byte[] toBinaryRepresentation(BaseConnection connection, A array) throws SQLException, SQLFeatureNotSupportedException;
 
   private static final PrimitiveArraySupport<long[]> LONG_ARRAY = new PrimitiveArraySupport<long[]>() {
 
@@ -64,7 +72,7 @@ abstract class PrimitiveArraySupport<A> {
      * {@inheritDoc}
      */
     @Override
-    public byte[] toBinaryRepresentation(Connection connection, long[] array) {
+    public byte[] toBinaryRepresentation(BaseConnection connection, long[] array) {
 
       int length = 20 + (12 * array.length);
       final byte[] bytes = new byte[length];
@@ -125,7 +133,7 @@ abstract class PrimitiveArraySupport<A> {
      * {@inheritDoc}
      */
     @Override
-    public byte[] toBinaryRepresentation(Connection connection, int[] array) {
+    public byte[] toBinaryRepresentation(BaseConnection connection, int[] array) {
 
       int length = 20 + (8 * array.length);
       final byte[] bytes = new byte[length];
@@ -186,7 +194,7 @@ abstract class PrimitiveArraySupport<A> {
      * {@inheritDoc}
      */
     @Override
-    public byte[] toBinaryRepresentation(Connection connection, short[] array) {
+    public byte[] toBinaryRepresentation(BaseConnection connection, short[] array) {
 
       int length = 20 + (6 * array.length);
       final byte[] bytes = new byte[length];
@@ -251,7 +259,7 @@ abstract class PrimitiveArraySupport<A> {
      * {@inheritDoc}
      */
     @Override
-    public byte[] toBinaryRepresentation(Connection connection, double[] array) {
+    public byte[] toBinaryRepresentation(BaseConnection connection, double[] array) {
 
       int length = 20 + (12 * array.length);
       final byte[] bytes = new byte[length];
@@ -316,7 +324,7 @@ abstract class PrimitiveArraySupport<A> {
      * {@inheritDoc}
      */
     @Override
-    public byte[] toBinaryRepresentation(Connection connection, float[] array) {
+    public byte[] toBinaryRepresentation(BaseConnection connection, float[] array) {
 
       int length = 20 + (8 * array.length);
       final byte[] bytes = new byte[length];
@@ -381,7 +389,7 @@ abstract class PrimitiveArraySupport<A> {
      *           Because this feature is not supported.
      */
     @Override
-    public byte[] toBinaryRepresentation(Connection connection, boolean[] array) throws SQLFeatureNotSupportedException {
+    public byte[] toBinaryRepresentation(BaseConnection connection, boolean[] array) throws SQLFeatureNotSupportedException {
       int length = 20 + (5 * array.length);
       final byte[] bytes = new byte[length];
 
@@ -450,20 +458,62 @@ abstract class PrimitiveArraySupport<A> {
      */
     @Override
     public boolean supportBinaryRepresentation() {
-      return false;
+      return true;
     }
 
     /**
      * {@inheritDoc}
-     *
-     * @throws SQLFeatureNotSupportedException
-     *           Because this feature is not supported.
      */
     @Override
-    public byte[] toBinaryRepresentation(Connection connection, String[] array) throws SQLFeatureNotSupportedException {
-      throw new SQLFeatureNotSupportedException();
-    }
+    public byte[] toBinaryRepresentation(BaseConnection connection, String[] array) throws SQLException{
+      final ByteArrayOutputStream baos = new ByteArrayOutputStream(Math.min(1024, (array.length * 32) + 20));
 
+      final byte[] buffer = new byte[4];
+
+      try {
+        //1 dimension
+        ByteConverter.int4(buffer, 0, 1);
+        baos.write(buffer);
+        // no null
+        Arrays.fill(buffer, (byte) 0);
+        baos.write(buffer);
+        // oid
+        ByteConverter.int4(buffer, 0, Oid.VARCHAR);
+        baos.write(buffer);
+        // length
+        ByteConverter.int4(buffer, 0, array.length);
+        baos.write(buffer);
+
+        //write 4 empty bytes
+        Arrays.fill(buffer, (byte) 0);
+        baos.write(buffer);
+  
+        final Encoding encoding = connection.getEncoding();
+        for (int i=0; i<array.length; ++i) {
+          final String string = array[i];
+          if (string != null) {
+            final byte[] encoded;
+            try {
+              encoded = encoding.encode(string);
+            } catch (IOException e) {
+              throw new PSQLException(GT.tr("Unable to translate data into the desired encoding."),
+                  PSQLState.DATA_ERROR, e);
+            }
+            ByteConverter.int4(buffer, 0, encoded.length);
+            baos.write(buffer);
+            baos.write(encoded);
+          } else {
+            ByteConverter.int4(buffer, 0, -1);
+            baos.write(buffer);
+          }
+        }
+  
+        return baos.toByteArray();
+      } catch (IOException e) {
+        //this IO exception is from writing to baos, which will never throw an IOException
+        throw new java.lang.AssertionError(e);
+      }
+    }
   };
 
   private static final Map<Class, PrimitiveArraySupport> ARRAY_CLASS_TO_SUPPORT = new HashMap<Class, PrimitiveArraySupport>((int) (7 / .75) + 1);

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PrimitiveArraySupport.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PrimitiveArraySupport.java
@@ -465,7 +465,7 @@ abstract class PrimitiveArraySupport<A> {
      * {@inheritDoc}
      */
     @Override
-    public byte[] toBinaryRepresentation(BaseConnection connection, String[] array) throws SQLException{
+    public byte[] toBinaryRepresentation(BaseConnection connection, String[] array) throws SQLException {
       final ByteArrayOutputStream baos = new ByteArrayOutputStream(Math.min(1024, (array.length * 32) + 20));
 
       final byte[] buffer = new byte[4];
@@ -487,9 +487,9 @@ abstract class PrimitiveArraySupport<A> {
         //write 4 empty bytes
         Arrays.fill(buffer, (byte) 0);
         baos.write(buffer);
-  
+
         final Encoding encoding = connection.getEncoding();
-        for (int i=0; i<array.length; ++i) {
+        for (int i = 0; i < array.length; ++i) {
           final String string = array[i];
           if (string != null) {
             final byte[] encoded;
@@ -507,7 +507,7 @@ abstract class PrimitiveArraySupport<A> {
             baos.write(buffer);
           }
         }
-  
+
         return baos.toByteArray();
       } catch (IOException e) {
         //this IO exception is from writing to baos, which will never throw an IOException

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/PrimitiveArraySupportTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/PrimitiveArraySupportTest.java
@@ -273,9 +273,8 @@ public class PrimitiveArraySupportTest {
   @Test
   public void testStringBinary() throws Exception {
     final PrimitiveArraySupport<String[]> stringArrays = PrimitiveArraySupport.getArraySupport(new String[] {});
-    //unicode escape for pi character
-    final String[] strings = new String[] {"1.235", null, "", "have some \u03C0"};
-    final BaseConnection conn = new UTFConnection();
+    final String[] strings = new String[] {"1.235", null, "", "have some \u03C0"}; //unicode escape for pi character
+    final BaseConnection conn = new EncodingConnection(Encoding.getJVMEncoding("UTF-8"));
     final PgArray pgArray = new PgArray(conn, Oid.VARCHAR, stringArrays.toBinaryRepresentation(conn, strings));
 
     Object arrayObj = pgArray.getArray();
@@ -292,34 +291,51 @@ public class PrimitiveArraySupportTest {
   }
 
   @Test
+  public void testStringBinary_unsupportedCharacter() throws Exception {
+    final PrimitiveArraySupport<String[]> stringArrays = PrimitiveArraySupport.getArraySupport(new String[] {});
+    final String[] strings = new String[] {"1.235", null, "", "have some \u03C0"}; //unicode escape for pi character
+    final BaseConnection conn = new EncodingConnection(Encoding.getJVMEncoding("ASCII"));
+
+    final PgArray pgArray = new PgArray(conn, Oid.VARCHAR, stringArrays.toBinaryRepresentation(conn, strings));
+
+    Object arrayObj = pgArray.getArray();
+
+    assertThat(arrayObj, instanceOf(String[].class));
+
+    final String[] actual = (String[]) arrayObj;
+
+    assertEquals(strings.length, actual.length);
+
+    assertEquals("have some ?", actual[3]);
+  }
+
+  @Test
   public void testStringToString() throws Exception {
     final PrimitiveArraySupport<String[]> stringArrays = PrimitiveArraySupport.getArraySupport(new String[] {});
-    //unicode escape for pi character
-    final String[] strings = new String[] {"1.235", null, "", "have some \u03C0"};
+    final String[] strings = new String[] {"1.235", null, "", "have some \u03C0"}; //unicode escape for pi character
 
     final String arrayString = stringArrays.toArrayString(',', strings);
 
     assertEquals("{\"1.235\",NULL,\"\",\"have some \u03C0\"}", arrayString);
   }
 
-  private static final class UTFConnection implements BaseConnection
-  {
-    UTFConnection()
-    {
+  private static final class EncodingConnection implements BaseConnection {
+    private final Encoding encoding;
+
+    EncodingConnection(Encoding encoding) {
+      this.encoding = encoding;
     }
 
     /**
      * {@inheritDoc}
      */
-    @Override
     public Encoding getEncoding() throws SQLException {
-      return Encoding.getJVMEncoding("UTF-8");
+      return encoding;
     }
 
     /**
      * {@inheritDoc}
      */
-    @Override
     public void cancelQuery() throws SQLException {
       throw new UnsupportedOperationException();
     }
@@ -327,7 +343,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public ResultSet execSQLQuery(String s) throws SQLException {
       throw new UnsupportedOperationException();
     }
@@ -335,7 +350,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public ResultSet execSQLQuery(String s, int resultSetType, int resultSetConcurrency)
         throws SQLException {
       throw new UnsupportedOperationException();
@@ -344,7 +358,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public void execSQLUpdate(String s) throws SQLException {
       throw new UnsupportedOperationException();
     }
@@ -352,7 +365,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public QueryExecutor getQueryExecutor() {
       throw new UnsupportedOperationException();
     }
@@ -360,7 +372,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public ReplicationProtocol getReplicationProtocol() {
       throw new UnsupportedOperationException();
     }
@@ -368,7 +379,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public Object getObject(String type, String value, byte[] byteValue) throws SQLException {
       throw new UnsupportedOperationException();
     }
@@ -376,7 +386,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public TypeInfo getTypeInfo() {
       throw new UnsupportedOperationException();
     }
@@ -384,7 +393,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public boolean haveMinimumServerVersion(int ver) {
       throw new UnsupportedOperationException();
     }
@@ -392,7 +400,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public boolean haveMinimumServerVersion(Version ver) {
       throw new UnsupportedOperationException();
     }
@@ -400,7 +407,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public byte[] encodeString(String str) throws SQLException {
       throw new UnsupportedOperationException();
     }
@@ -408,7 +414,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public String escapeString(String str) throws SQLException {
       throw new UnsupportedOperationException();
     }
@@ -416,7 +421,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public boolean getStandardConformingStrings() {
       throw new UnsupportedOperationException();
     }
@@ -424,7 +428,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public TimestampUtils getTimestampUtils() {
       throw new UnsupportedOperationException();
     }
@@ -432,7 +435,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public Logger getLogger() {
       throw new UnsupportedOperationException();
     }
@@ -440,7 +442,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public boolean getStringVarcharFlag() {
       throw new UnsupportedOperationException();
     }
@@ -448,7 +449,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public TransactionState getTransactionState() {
       throw new UnsupportedOperationException();
     }
@@ -456,7 +456,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public boolean binaryTransferSend(int oid) {
       throw new UnsupportedOperationException();
     }
@@ -464,7 +463,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public boolean isColumnSanitiserDisabled() {
       throw new UnsupportedOperationException();
     }
@@ -472,7 +470,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public void addTimerTask(TimerTask timerTask, long milliSeconds) {
       throw new UnsupportedOperationException();
     }
@@ -480,7 +477,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public void purgeTimerTasks() {
       throw new UnsupportedOperationException();
     }
@@ -488,7 +484,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public LruCache<Key, FieldMetadata> getFieldMetadataCache() {
       throw new UnsupportedOperationException();
     }
@@ -496,7 +491,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public CachedQuery createQuery(String sql, boolean escapeProcessing, boolean isParameterized,
         String... columnNames) throws SQLException {
       throw new UnsupportedOperationException();
@@ -505,7 +499,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public void setFlushCacheOnDeallocate(boolean flushCacheOnDeallocate) {
       throw new UnsupportedOperationException();
     }
@@ -513,7 +506,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public Statement createStatement() throws SQLException {
       throw new UnsupportedOperationException();
     }
@@ -521,7 +513,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public PreparedStatement prepareStatement(String sql) throws SQLException {
       throw new UnsupportedOperationException();
     }
@@ -529,7 +520,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public CallableStatement prepareCall(String sql) throws SQLException {
       throw new UnsupportedOperationException();
     }
@@ -537,7 +527,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public String nativeSQL(String sql) throws SQLException {
       throw new UnsupportedOperationException();
     }
@@ -545,7 +534,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public void setAutoCommit(boolean autoCommit) throws SQLException {
       throw new UnsupportedOperationException();
     }
@@ -553,7 +541,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public boolean getAutoCommit() throws SQLException {
       throw new UnsupportedOperationException();
     }
@@ -561,7 +548,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public void commit() throws SQLException {
       throw new UnsupportedOperationException();
     }
@@ -569,7 +555,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public void rollback() throws SQLException {
       throw new UnsupportedOperationException();
     }
@@ -577,7 +562,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public void close() throws SQLException {
       throw new UnsupportedOperationException();
     }
@@ -585,7 +569,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public boolean isClosed() throws SQLException {
       throw new UnsupportedOperationException();
     }
@@ -593,7 +576,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public DatabaseMetaData getMetaData() throws SQLException {
       throw new UnsupportedOperationException();
     }
@@ -601,7 +583,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public void setReadOnly(boolean readOnly) throws SQLException {
       throw new UnsupportedOperationException();
     }
@@ -609,7 +590,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public boolean isReadOnly() throws SQLException {
       throw new UnsupportedOperationException();
     }
@@ -617,7 +597,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public void setCatalog(String catalog) throws SQLException {
       throw new UnsupportedOperationException();
     }
@@ -625,7 +604,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public String getCatalog() throws SQLException {
       throw new UnsupportedOperationException();
     }
@@ -633,7 +611,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public void setTransactionIsolation(int level) throws SQLException {
       throw new UnsupportedOperationException();
     }
@@ -641,7 +618,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public int getTransactionIsolation() throws SQLException {
       throw new UnsupportedOperationException();
     }
@@ -649,7 +625,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public SQLWarning getWarnings() throws SQLException {
       throw new UnsupportedOperationException();
     }
@@ -657,7 +632,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public void clearWarnings() throws SQLException {
       throw new UnsupportedOperationException();
     }
@@ -665,7 +639,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public Statement createStatement(int resultSetType, int resultSetConcurrency)
         throws SQLException {
       throw new UnsupportedOperationException();
@@ -674,7 +647,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public PreparedStatement prepareStatement(String sql, int resultSetType,
         int resultSetConcurrency) throws SQLException {
       throw new UnsupportedOperationException();
@@ -683,7 +655,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public CallableStatement prepareCall(String sql, int resultSetType, int resultSetConcurrency)
         throws SQLException {
       throw new UnsupportedOperationException();
@@ -692,7 +663,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public Map<String, Class<?>> getTypeMap() throws SQLException {
       throw new UnsupportedOperationException();
     }
@@ -700,7 +670,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public void setTypeMap(Map<String, Class<?>> map) throws SQLException {
       throw new UnsupportedOperationException();
     }
@@ -708,7 +677,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public void setHoldability(int holdability) throws SQLException {
       throw new UnsupportedOperationException();
     }
@@ -716,7 +684,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public int getHoldability() throws SQLException {
       throw new UnsupportedOperationException();
     }
@@ -724,7 +691,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public Savepoint setSavepoint() throws SQLException {
       throw new UnsupportedOperationException();
     }
@@ -732,7 +698,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public Savepoint setSavepoint(String name) throws SQLException {
       throw new UnsupportedOperationException();
     }
@@ -740,7 +705,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public void rollback(Savepoint savepoint) throws SQLException {
       throw new UnsupportedOperationException();
     }
@@ -748,7 +712,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public void releaseSavepoint(Savepoint savepoint) throws SQLException {
       throw new UnsupportedOperationException();
     }
@@ -756,7 +719,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public Statement createStatement(int resultSetType, int resultSetConcurrency,
         int resultSetHoldability) throws SQLException {
       throw new UnsupportedOperationException();
@@ -765,7 +727,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public PreparedStatement prepareStatement(String sql, int resultSetType,
         int resultSetConcurrency, int resultSetHoldability) throws SQLException {
       throw new UnsupportedOperationException();
@@ -774,7 +735,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public CallableStatement prepareCall(String sql, int resultSetType, int resultSetConcurrency,
         int resultSetHoldability) throws SQLException {
       throw new UnsupportedOperationException();
@@ -783,7 +743,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public PreparedStatement prepareStatement(String sql, int autoGeneratedKeys)
         throws SQLException {
       throw new UnsupportedOperationException();
@@ -792,7 +751,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public PreparedStatement prepareStatement(String sql, int[] columnIndexes) throws SQLException {
       throw new UnsupportedOperationException();
     }
@@ -800,7 +758,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public PreparedStatement prepareStatement(String sql, String[] columnNames)
         throws SQLException {
       throw new UnsupportedOperationException();
@@ -809,7 +766,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public Clob createClob() throws SQLException {
       throw new UnsupportedOperationException();
     }
@@ -817,7 +773,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public Blob createBlob() throws SQLException {
       throw new UnsupportedOperationException();
     }
@@ -825,7 +780,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public NClob createNClob() throws SQLException {
       throw new UnsupportedOperationException();
     }
@@ -833,7 +787,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public SQLXML createSQLXML() throws SQLException {
       throw new UnsupportedOperationException();
     }
@@ -841,7 +794,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public boolean isValid(int timeout) throws SQLException {
       throw new UnsupportedOperationException();
     }
@@ -849,7 +801,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public void setClientInfo(String name, String value) throws SQLClientInfoException {
       throw new UnsupportedOperationException();
     }
@@ -857,7 +808,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public void setClientInfo(Properties properties) throws SQLClientInfoException {
       throw new UnsupportedOperationException();
     }
@@ -865,7 +815,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public String getClientInfo(String name) throws SQLException {
       throw new UnsupportedOperationException();
     }
@@ -873,7 +822,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public Properties getClientInfo() throws SQLException {
       throw new UnsupportedOperationException();
     }
@@ -881,7 +829,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public Array createArrayOf(String typeName, Object[] elements) throws SQLException {
       throw new UnsupportedOperationException();
     }
@@ -889,7 +836,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public Struct createStruct(String typeName, Object[] attributes) throws SQLException {
       throw new UnsupportedOperationException();
     }
@@ -897,7 +843,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public void setSchema(String schema) throws SQLException {
       throw new UnsupportedOperationException();
     }
@@ -905,7 +850,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public String getSchema() throws SQLException {
       throw new UnsupportedOperationException();
     }
@@ -913,7 +857,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public void abort(Executor executor) throws SQLException {
       throw new UnsupportedOperationException();
     }
@@ -921,7 +864,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public void setNetworkTimeout(Executor executor, int milliseconds) throws SQLException {
       throw new UnsupportedOperationException();
     }
@@ -929,7 +871,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public int getNetworkTimeout() throws SQLException {
       throw new UnsupportedOperationException();
     }
@@ -937,7 +878,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public <T> T unwrap(Class<T> iface) throws SQLException {
       throw new UnsupportedOperationException();
     }
@@ -945,7 +885,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public boolean isWrapperFor(Class<?> iface) throws SQLException {
       throw new UnsupportedOperationException();
     }
@@ -953,7 +892,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public Array createArrayOf(String typeName, Object elements) throws SQLException {
       throw new UnsupportedOperationException();
     }
@@ -961,7 +899,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public PGNotification[] getNotifications() throws SQLException {
       throw new UnsupportedOperationException();
     }
@@ -969,7 +906,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public PGNotification[] getNotifications(int timeoutMillis) throws SQLException {
       throw new UnsupportedOperationException();
     }
@@ -977,7 +913,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public CopyManager getCopyAPI() throws SQLException {
       throw new UnsupportedOperationException();
     }
@@ -985,7 +920,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public LargeObjectManager getLargeObjectAPI() throws SQLException {
       throw new UnsupportedOperationException();
     }
@@ -993,7 +927,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public Fastpath getFastpathAPI() throws SQLException {
       throw new UnsupportedOperationException();
     }
@@ -1001,7 +934,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public void addDataType(String type, String className) {
       throw new UnsupportedOperationException();
     }
@@ -1009,7 +941,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public void addDataType(String type, Class<? extends PGobject> klass) throws SQLException {
       throw new UnsupportedOperationException();
     }
@@ -1017,7 +948,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public void setPrepareThreshold(int threshold) {
       throw new UnsupportedOperationException();
     }
@@ -1025,7 +955,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public int getPrepareThreshold() {
       throw new UnsupportedOperationException();
     }
@@ -1033,7 +962,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public void setDefaultFetchSize(int fetchSize) throws SQLException {
       throw new UnsupportedOperationException();
     }
@@ -1041,7 +969,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public int getDefaultFetchSize() {
       throw new UnsupportedOperationException();
     }
@@ -1049,7 +976,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public int getBackendPID() {
       throw new UnsupportedOperationException();
     }
@@ -1057,7 +983,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public String escapeIdentifier(String identifier) throws SQLException {
       throw new UnsupportedOperationException();
     }
@@ -1065,7 +990,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public String escapeLiteral(String literal) throws SQLException {
       throw new UnsupportedOperationException();
     }
@@ -1073,7 +997,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public PreferQueryMode getPreferQueryMode() {
       throw new UnsupportedOperationException();
     }
@@ -1081,7 +1004,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public AutoSave getAutosave() {
       throw new UnsupportedOperationException();
     }
@@ -1089,7 +1011,6 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public void setAutosave(AutoSave autoSave) {
       throw new UnsupportedOperationException();
     }
@@ -1097,10 +1018,8 @@ public class PrimitiveArraySupportTest {
     /**
      * {@inheritDoc}
      */
-    @Override
     public PGReplicationConnection getReplicationAPI() {
       throw new UnsupportedOperationException();
     }
-    
   }
 }

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/PrimitiveArraySupportTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/PrimitiveArraySupportTest.java
@@ -7,16 +7,48 @@ package org.postgresql.jdbc;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
 
+import org.postgresql.PGNotification;
+import org.postgresql.copy.CopyManager;
+import org.postgresql.core.BaseConnection;
+import org.postgresql.core.CachedQuery;
+import org.postgresql.core.Encoding;
 import org.postgresql.core.Oid;
+import org.postgresql.core.QueryExecutor;
+import org.postgresql.core.ReplicationProtocol;
+import org.postgresql.core.TransactionState;
+import org.postgresql.core.TypeInfo;
+import org.postgresql.core.Version;
+import org.postgresql.fastpath.Fastpath;
+import org.postgresql.jdbc.FieldMetadata.Key;
+import org.postgresql.largeobject.LargeObjectManager;
+import org.postgresql.replication.PGReplicationConnection;
+import org.postgresql.util.LruCache;
+import org.postgresql.util.PGobject;
 
 import org.junit.Test;
 
-import java.sql.SQLFeatureNotSupportedException;
+import java.sql.Array;
+import java.sql.Blob;
+import java.sql.CallableStatement;
+import java.sql.Clob;
+import java.sql.DatabaseMetaData;
+import java.sql.NClob;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLClientInfoException;
+import java.sql.SQLException;
+import java.sql.SQLWarning;
+import java.sql.SQLXML;
+import java.sql.Savepoint;
+import java.sql.Statement;
+import java.sql.Struct;
+import java.util.Map;
+import java.util.Properties;
+import java.util.TimerTask;
+import java.util.concurrent.Executor;
+import java.util.logging.Logger;
 
 public class PrimitiveArraySupportTest {
 
@@ -239,15 +271,836 @@ public class PrimitiveArraySupportTest {
   }
 
   @Test
-  public void testStringNotSupportBinary() {
-    PrimitiveArraySupport<String[]> stringArrays = PrimitiveArraySupport.getArraySupport(new String[] {});
-    assertNotNull(stringArrays);
-    assertFalse(stringArrays.supportBinaryRepresentation());
-    try {
-      stringArrays.toBinaryRepresentation(null, new String[] { "1.2" });
-      fail("no sql exception thrown");
-    } catch (SQLFeatureNotSupportedException e) {
+  public void testStringBinary() throws Exception {
+    final PrimitiveArraySupport<String[]> stringArrays = PrimitiveArraySupport.getArraySupport(new String[] {});
+    //unicode escape for pi character
+    final String[] strings = new String[] {"1.235", null, "", "have some \u03C0"};
+    final BaseConnection conn = new UTFConnection();
+    final PgArray pgArray = new PgArray(conn, Oid.VARCHAR, stringArrays.toBinaryRepresentation(conn, strings));
 
+    Object arrayObj = pgArray.getArray();
+
+    assertThat(arrayObj, instanceOf(String[].class));
+
+    final String[] actual = (String[]) arrayObj;
+
+    assertEquals(strings.length, actual.length);
+
+    for (int i = 0; i < strings.length; ++i) {
+      assertEquals(strings[i], actual[i]);
     }
+  }
+
+  @Test
+  public void testStringToString() throws Exception {
+    final PrimitiveArraySupport<String[]> stringArrays = PrimitiveArraySupport.getArraySupport(new String[] {});
+    //unicode escape for pi character
+    final String[] strings = new String[] {"1.235", null, "", "have some \u03C0"};
+
+    final String arrayString = stringArrays.toArrayString(',', strings);
+
+    assertEquals("{\"1.235\",NULL,\"\",\"have some \u03C0\"}", arrayString);
+  }
+
+  private static final class UTFConnection implements BaseConnection
+  {
+    UTFConnection()
+    {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Encoding getEncoding() throws SQLException {
+      return Encoding.getJVMEncoding("UTF-8");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void cancelQuery() throws SQLException {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ResultSet execSQLQuery(String s) throws SQLException {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ResultSet execSQLQuery(String s, int resultSetType, int resultSetConcurrency)
+        throws SQLException {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void execSQLUpdate(String s) throws SQLException {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public QueryExecutor getQueryExecutor() {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ReplicationProtocol getReplicationProtocol() {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Object getObject(String type, String value, byte[] byteValue) throws SQLException {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public TypeInfo getTypeInfo() {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean haveMinimumServerVersion(int ver) {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean haveMinimumServerVersion(Version ver) {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public byte[] encodeString(String str) throws SQLException {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String escapeString(String str) throws SQLException {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean getStandardConformingStrings() {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public TimestampUtils getTimestampUtils() {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Logger getLogger() {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean getStringVarcharFlag() {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public TransactionState getTransactionState() {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean binaryTransferSend(int oid) {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isColumnSanitiserDisabled() {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void addTimerTask(TimerTask timerTask, long milliSeconds) {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void purgeTimerTasks() {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public LruCache<Key, FieldMetadata> getFieldMetadataCache() {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CachedQuery createQuery(String sql, boolean escapeProcessing, boolean isParameterized,
+        String... columnNames) throws SQLException {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setFlushCacheOnDeallocate(boolean flushCacheOnDeallocate) {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Statement createStatement() throws SQLException {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public PreparedStatement prepareStatement(String sql) throws SQLException {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CallableStatement prepareCall(String sql) throws SQLException {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String nativeSQL(String sql) throws SQLException {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setAutoCommit(boolean autoCommit) throws SQLException {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean getAutoCommit() throws SQLException {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void commit() throws SQLException {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void rollback() throws SQLException {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void close() throws SQLException {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isClosed() throws SQLException {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public DatabaseMetaData getMetaData() throws SQLException {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setReadOnly(boolean readOnly) throws SQLException {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isReadOnly() throws SQLException {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setCatalog(String catalog) throws SQLException {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getCatalog() throws SQLException {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setTransactionIsolation(int level) throws SQLException {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getTransactionIsolation() throws SQLException {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public SQLWarning getWarnings() throws SQLException {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void clearWarnings() throws SQLException {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Statement createStatement(int resultSetType, int resultSetConcurrency)
+        throws SQLException {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public PreparedStatement prepareStatement(String sql, int resultSetType,
+        int resultSetConcurrency) throws SQLException {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CallableStatement prepareCall(String sql, int resultSetType, int resultSetConcurrency)
+        throws SQLException {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Map<String, Class<?>> getTypeMap() throws SQLException {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setTypeMap(Map<String, Class<?>> map) throws SQLException {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setHoldability(int holdability) throws SQLException {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getHoldability() throws SQLException {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Savepoint setSavepoint() throws SQLException {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Savepoint setSavepoint(String name) throws SQLException {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void rollback(Savepoint savepoint) throws SQLException {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void releaseSavepoint(Savepoint savepoint) throws SQLException {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Statement createStatement(int resultSetType, int resultSetConcurrency,
+        int resultSetHoldability) throws SQLException {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public PreparedStatement prepareStatement(String sql, int resultSetType,
+        int resultSetConcurrency, int resultSetHoldability) throws SQLException {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CallableStatement prepareCall(String sql, int resultSetType, int resultSetConcurrency,
+        int resultSetHoldability) throws SQLException {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public PreparedStatement prepareStatement(String sql, int autoGeneratedKeys)
+        throws SQLException {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public PreparedStatement prepareStatement(String sql, int[] columnIndexes) throws SQLException {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public PreparedStatement prepareStatement(String sql, String[] columnNames)
+        throws SQLException {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Clob createClob() throws SQLException {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Blob createBlob() throws SQLException {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public NClob createNClob() throws SQLException {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public SQLXML createSQLXML() throws SQLException {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isValid(int timeout) throws SQLException {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setClientInfo(String name, String value) throws SQLClientInfoException {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setClientInfo(Properties properties) throws SQLClientInfoException {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getClientInfo(String name) throws SQLException {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Properties getClientInfo() throws SQLException {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Array createArrayOf(String typeName, Object[] elements) throws SQLException {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Struct createStruct(String typeName, Object[] attributes) throws SQLException {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setSchema(String schema) throws SQLException {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getSchema() throws SQLException {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void abort(Executor executor) throws SQLException {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setNetworkTimeout(Executor executor, int milliseconds) throws SQLException {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getNetworkTimeout() throws SQLException {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <T> T unwrap(Class<T> iface) throws SQLException {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isWrapperFor(Class<?> iface) throws SQLException {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Array createArrayOf(String typeName, Object elements) throws SQLException {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public PGNotification[] getNotifications() throws SQLException {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public PGNotification[] getNotifications(int timeoutMillis) throws SQLException {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CopyManager getCopyAPI() throws SQLException {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public LargeObjectManager getLargeObjectAPI() throws SQLException {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Fastpath getFastpathAPI() throws SQLException {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void addDataType(String type, String className) {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void addDataType(String type, Class<? extends PGobject> klass) throws SQLException {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setPrepareThreshold(int threshold) {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getPrepareThreshold() {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setDefaultFetchSize(int fetchSize) throws SQLException {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getDefaultFetchSize() {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getBackendPID() {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String escapeIdentifier(String identifier) throws SQLException {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String escapeLiteral(String literal) throws SQLException {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public PreferQueryMode getPreferQueryMode() {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public AutoSave getAutosave() {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setAutosave(AutoSave autoSave) {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public PGReplicationConnection getReplicationAPI() {
+      throw new UnsupportedOperationException();
+    }
+    
   }
 }

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/PrimitiveArraySupportTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/PrimitiveArraySupportTest.java
@@ -316,7 +316,7 @@ public class PrimitiveArraySupportTest {
 
     final String arrayString = stringArrays.toArrayString(',', strings);
 
-    assertEquals("{\"1.235\",NULL,\"\",\"have some \u03C0\"}", arrayString);
+    assertEquals("{\"1.235\",NULL,\"\",\"have some \u03C0\"}", arrayString); //unicode escape for pi character
   }
 
   private static final class EncodingConnection implements BaseConnection {


### PR DESCRIPTION
The original support for primitive arrays supported creating binary representation for everything except `String[]`. This will now create binary `String[]` also.