### PR TITLE
Add support for LocalDateTime, LocalDate and LocalTime to updateObject()

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
@@ -71,6 +71,8 @@ import java.sql.Types;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.HashMap;
@@ -1904,6 +1906,11 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
             rowBuffer.set(columnIndex, connection.encodeString(
                 connection.getTimestampUtils().toString(
                     getDefaultCalendar(), Timestamp.valueOf((LocalDateTime) valueObject))));
+          } else if (valueObject instanceof OffsetDateTime) {
+            rowBuffer.set(columnIndex, connection.encodeString(
+                connection.getTimestampUtils().toString(
+                    getDefaultCalendar(), Timestamp.valueOf(((OffsetDateTime) valueObject)
+                        .atZoneSameInstant(ZoneOffset.UTC).toLocalDateTime()))));
           } else {
             throw new PSQLException(GT.tr("conversion to {0} from {1} not supported",
                 Types.TIMESTAMP, valueObject.getClass().getName()),

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
@@ -1862,8 +1862,12 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
             rowBuffer.set(columnIndex, connection
                 .encodeString(
                     connection.getTimestampUtils().toString(
+                        getDefaultCalendar(), (Timestamp) valueObject)));
+          } else if (valueObject instanceof Date) {
+            rowBuffer.set(columnIndex, connection
+                .encodeString(
+                    connection.getTimestampUtils().toString(
                         getDefaultCalendar(), (Date) valueObject)));
-
           } else if (valueObject instanceof LocalDate) {
             rowBuffer.set(columnIndex, connection
                 .encodeString(connection.getTimestampUtils().toString((LocalDate) valueObject)));
@@ -1897,7 +1901,6 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
             rowBuffer.set(columnIndex, connection.encodeString(
                 connection.getTimestampUtils().toString(
                     getDefaultCalendar(), (Timestamp) valueObject)));
-
           } else if (valueObject instanceof LocalDateTime) {
             rowBuffer.set(columnIndex, connection.encodeString(
                 connection.getTimestampUtils().toString((LocalDateTime) valueObject)));

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
@@ -72,7 +72,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.HashMap;
@@ -1867,9 +1866,7 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
 
           } else if (valueObject instanceof LocalDate) {
             rowBuffer.set(columnIndex, connection
-                .encodeString(
-                    connection.getTimestampUtils().toString(
-                        getDefaultCalendar(), Date.valueOf((LocalDate) valueObject))));
+                .encodeString(connection.getTimestampUtils().toString((LocalDate) valueObject)));
           } else {
             throw new PSQLException(GT.tr("conversion to {0} from {1} not supported",
                 Types.DATE, valueObject.getClass().getName()),
@@ -1887,8 +1884,7 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
           } else if (valueObject instanceof LocalTime) {
             rowBuffer.set(columnIndex, connection
                 .encodeString(
-                    connection.getTimestampUtils().toString(
-                        getDefaultCalendar(), Time.valueOf((LocalTime) valueObject))));
+                    connection.getTimestampUtils().toString((LocalTime) valueObject)));
           } else {
             throw new PSQLException(GT.tr("conversion to {0} from {1} not supported",
                 Types.TIME, valueObject.getClass().getName()),
@@ -1904,13 +1900,10 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
 
           } else if (valueObject instanceof LocalDateTime) {
             rowBuffer.set(columnIndex, connection.encodeString(
-                connection.getTimestampUtils().toString(
-                    getDefaultCalendar(), Timestamp.valueOf((LocalDateTime) valueObject))));
+                connection.getTimestampUtils().toString((LocalDateTime) valueObject)));
           } else if (valueObject instanceof OffsetDateTime) {
             rowBuffer.set(columnIndex, connection.encodeString(
-                connection.getTimestampUtils().toString(
-                    getDefaultCalendar(), Timestamp.valueOf(((OffsetDateTime) valueObject)
-                        .atZoneSameInstant(ZoneOffset.UTC).toLocalDateTime()))));
+                connection.getTimestampUtils().toString((OffsetDateTime) valueObject)));
           } else {
             throw new PSQLException(GT.tr("conversion to {0} from {1} not supported",
                 Types.TIMESTAMP, valueObject.getClass().getName()),

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
@@ -1861,7 +1861,7 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
             rowBuffer.set(columnIndex, connection
                 .encodeString(
                     connection.getTimestampUtils().toString(
-                        getDefaultCalendar(), (java.sql.Date) valueObject)));
+                        getDefaultCalendar(), (Date) valueObject)));
 
           } else if (valueObject instanceof LocalDate) {
             rowBuffer.set(columnIndex, connection

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
@@ -68,6 +68,9 @@ import java.sql.Statement;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.sql.Types;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.HashMap;
@@ -1854,23 +1857,58 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
         // or we won't be able to re-parse it.
         //
         case Types.DATE:
-          rowBuffer.set(columnIndex, connection
-              .encodeString(
-                  connection.getTimestampUtils().toString(
-                      getDefaultCalendar(), (Date) valueObject)));
+          if (valueObject instanceof Timestamp) {
+            rowBuffer.set(columnIndex, connection
+                .encodeString(
+                    connection.getTimestampUtils().toString(
+                        getDefaultCalendar(), (java.sql.Date) valueObject)));
+
+          } else if (valueObject instanceof LocalDate) {
+            rowBuffer.set(columnIndex, connection
+                .encodeString(
+                    connection.getTimestampUtils().toString(
+                        getDefaultCalendar(), Date.valueOf((LocalDate) valueObject))));
+          } else {
+            throw new PSQLException(GT.tr("conversion to {0} from {1} not supported",
+                Types.DATE, valueObject.getClass().getName()),
+                PSQLState.INVALID_PARAMETER_VALUE);
+          }
           break;
 
         case Types.TIME:
-          rowBuffer.set(columnIndex, connection
-              .encodeString(
-                  connection.getTimestampUtils().toString(
-                      getDefaultCalendar(), (Time) valueObject)));
+          if (valueObject instanceof Time) {
+            rowBuffer.set(columnIndex, connection
+                .encodeString(
+                    connection.getTimestampUtils().toString(
+                        getDefaultCalendar(), (Time) valueObject)));
+
+          } else if (valueObject instanceof LocalTime) {
+            rowBuffer.set(columnIndex, connection
+                .encodeString(
+                    connection.getTimestampUtils().toString(
+                        getDefaultCalendar(), Time.valueOf((LocalTime) valueObject))));
+          } else {
+            throw new PSQLException(GT.tr("conversion to {0} from {1} not supported",
+                Types.TIME, valueObject.getClass().getName()),
+                PSQLState.INVALID_PARAMETER_VALUE);
+          }
           break;
 
         case Types.TIMESTAMP:
-          rowBuffer.set(columnIndex, connection.encodeString(
-              connection.getTimestampUtils().toString(
-                  getDefaultCalendar(), (Timestamp) valueObject)));
+          if (valueObject instanceof Timestamp) {
+            rowBuffer.set(columnIndex, connection.encodeString(
+                connection.getTimestampUtils().toString(
+                    getDefaultCalendar(), (Timestamp) valueObject)));
+
+          } else if (valueObject instanceof LocalDateTime) {
+            rowBuffer.set(columnIndex, connection.encodeString(
+                connection.getTimestampUtils().toString(
+                    getDefaultCalendar(), Timestamp.valueOf((LocalDateTime) valueObject))));
+          } else {
+            throw new PSQLException(GT.tr("conversion to {0} from {1} not supported",
+                Types.TIMESTAMP, valueObject.getClass().getName()),
+                PSQLState.INVALID_PARAMETER_VALUE);
+          }
           break;
 
         case Types.NULL:

--- a/pgjdbc/src/test/java/org/postgresql/test/TestUtil.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/TestUtil.java
@@ -427,6 +427,25 @@ public class TestUtil {
     }
   }
 
+  /*
+   * Helper - creates a test table for use by a test with a primary key
+   */
+  public static void createTableWithPrimaryKey(Connection con, String table, String columns)
+      throws SQLException {
+    Statement st = con.createStatement();
+    try {
+      // Drop the table
+      dropTable(con, table);
+
+      // Now create the table
+      String sql = "CREATE TABLE " + table + " (" + table + "_id SERIAL PRIMARY KEY, " + columns + ")";
+
+      st.executeUpdate(sql);
+    } finally {
+      closeQuietly(st);
+    }
+  }
+
   /**
    * Helper creates a temporary table.
    *

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc42/Jdbc42TestSuite.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc42/Jdbc42TestSuite.java
@@ -20,6 +20,7 @@ import org.junit.runners.Suite.SuiteClasses;
     PreparedStatementTest.class,
     SetObject310Test.class,
     SimpleJdbc42Test.class,
+    UpdateObject310Test.class,
 })
 public class Jdbc42TestSuite {
 

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc42/UpdateObject310Test.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc42/UpdateObject310Test.java
@@ -89,7 +89,7 @@ public class UpdateObject310Test {
 
       rs = s.executeQuery(TestUtil.selectSQL("table1", columnName));
       rs.next();
-      assertEquals(newValue, rs.getObject(1, newValue.getClass()));
+      assertEquals("Object wasn't identical when it got read back from the database", newValue, rs.getObject(1, newValue.getClass()));
     } finally {
       TestUtil.closeQuietly(rs);
       TestUtil.closeQuietly(s);
@@ -114,7 +114,7 @@ public class UpdateObject310Test {
 
       fail("should have thrown an PSQLException because integers can't represent the date");
     } catch (PSQLException e) {
-      assertEquals(PSQLState.DATATYPE_MISMATCH.getState(), e.getSQLState());
+      assertEquals("Should have thrown an DATATYPE_MISMATCH error, since integers can't represent the date", PSQLState.DATATYPE_MISMATCH.getState(), e.getSQLState());
     } finally {
       TestUtil.closeQuietly(rs);
       TestUtil.closeQuietly(s);

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc42/UpdateObject310Test.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc42/UpdateObject310Test.java
@@ -5,12 +5,15 @@
 
 package org.postgresql.test.jdbc42;
 
+import static org.junit.Assert.assertEquals;
+
+import org.postgresql.test.TestUtil;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import org.postgresql.test.TestUtil;
 
 import java.sql.Connection;
 import java.sql.ResultSet;
@@ -23,8 +26,6 @@ import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.TimeZone;
-
-import static org.junit.Assert.assertEquals;
 
 @RunWith(Parameterized.class)
 public class UpdateObject310Test {

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc42/UpdateObject310Test.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc42/UpdateObject310Test.java
@@ -28,12 +28,9 @@ import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.TimeZone;
 
 @RunWith(Parameterized.class)
 public class UpdateObject310Test {
-  private static final TimeZone saveTZ = TimeZone.getDefault();
-
   private Connection con;
 
   @Parameterized.Parameters
@@ -56,7 +53,6 @@ public class UpdateObject310Test {
 
   @After
   public void tearDown() throws SQLException {
-    TimeZone.setDefault(saveTZ);
     TestUtil.dropTable(con, "table1");
     TestUtil.closeDB(con);
   }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc42/UpdateObject310Test.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc42/UpdateObject310Test.java
@@ -38,10 +38,10 @@ public class UpdateObject310Test {
   @Parameterized.Parameters
   public static Collection<Object[]> data() {
     return Arrays.asList(new Object[][]{
-        {LocalDateTime.now().truncatedTo(ChronoUnit.MICROS), "timestamp_without_time_zone_column", "'2003-01-01'::TIMESTAMP"},
-        {OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).truncatedTo(ChronoUnit.MICROS), "timestamp_with_time_zone_column", "'2007-06-03'::TIMESTAMP"},
-        {LocalDate.now(), "date_column", "'2003-01-01'::DATE"},
-        {LocalTime.now().truncatedTo(ChronoUnit.MICROS), "time_without_time_zone_column", "'07:23'::TIME WITHOUT TIME ZONE"}
+        {LocalDateTime.of(2017, 1, 2, 3, 4, 5, 6000).truncatedTo(ChronoUnit.MICROS), "timestamp_without_time_zone_column", "'2003-01-01'::TIMESTAMP"},
+        {OffsetDateTime.of(2017, 1, 2, 3, 4, 5, 6000, ZoneOffset.UTC).truncatedTo(ChronoUnit.MICROS), "timestamp_with_time_zone_column", "'2007-06-03'::TIMESTAMP"},
+        {LocalDate.of(2017, 1, 2), "date_column", "'2003-01-01'::DATE"},
+        {LocalTime.of(11, 12, 13).truncatedTo(ChronoUnit.MICROS), "time_without_time_zone_column", "'07:23'::TIME WITHOUT TIME ZONE"}
     });
   }
 
@@ -91,10 +91,8 @@ public class UpdateObject310Test {
       rs.next();
       assertEquals(newValue, rs.getObject(1, newValue.getClass()));
     } finally {
-      if (rs != null) {
-        rs.close();
-      }
-      s.close();
+      TestUtil.closeQuietly(rs);
+      TestUtil.closeQuietly(s);
     }
   }
 
@@ -114,14 +112,12 @@ public class UpdateObject310Test {
       rs.updateRow();
       rs.close();
 
-      fail("should have thrown an Exception");
+      fail("should have thrown an PSQLException because integers can't represent the date");
     } catch (PSQLException e) {
       assertEquals(PSQLState.DATATYPE_MISMATCH.getState(), e.getSQLState());
     } finally {
-      if (rs != null) {
-        rs.close();
-      }
-      s.close();
+      TestUtil.closeQuietly(rs);
+      TestUtil.closeQuietly(s);
     }
   }
 }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc42/UpdateObject310Test.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc42/UpdateObject310Test.java
@@ -5,15 +5,12 @@
 
 package org.postgresql.test.jdbc42;
 
-import static org.junit.Assert.assertEquals;
-
-import org.postgresql.test.TestUtil;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.postgresql.test.TestUtil;
 
 import java.sql.Connection;
 import java.sql.ResultSet;
@@ -22,9 +19,12 @@ import java.sql.Statement;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.TimeZone;
+
+import static org.junit.Assert.assertEquals;
 
 @RunWith(Parameterized.class)
 public class UpdateObject310Test {
@@ -35,9 +35,9 @@ public class UpdateObject310Test {
   @Parameterized.Parameters
   public static Collection<Object[]> data() {
     return Arrays.asList(new Object[][]{
-        {LocalDateTime.now(), "timestamp_without_time_zone_column", "'2003-01-01'::TIMESTAMP"},
+        {LocalDateTime.now().truncatedTo(ChronoUnit.MICROS), "timestamp_without_time_zone_column", "'2003-01-01'::TIMESTAMP"},
         {LocalDate.now(), "date_column", "'2003-01-01'::DATE"},
-        {LocalTime.now(), "time_without_time_zone_column", "'07:23'::TIME WITHOUT TIME ZONE"}
+        {LocalTime.now().truncatedTo(ChronoUnit.MICROS), "time_without_time_zone_column", "'07:23'::TIME WITHOUT TIME ZONE"}
     });
   }
 

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc42/UpdateObject310Test.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc42/UpdateObject310Test.java
@@ -6,11 +6,11 @@
 package org.postgresql.test.jdbc42;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import org.postgresql.test.TestUtil;
 import org.postgresql.util.PSQLException;
+import org.postgresql.util.PSQLState;
 
 import org.junit.After;
 import org.junit.Before;
@@ -39,20 +39,9 @@ public class UpdateObject310Test {
   @Parameterized.Parameters
   public static Collection<Object[]> data() {
     return Arrays.asList(new Object[][]{
-        {LocalDateTime.now().truncatedTo(ChronoUnit.MICROS), "timestamp_without_time_zone_column",
-            "'2003-01-01'::TIMESTAMP",
-            "ERROR: column \"timestamp_without_time_zone_column\" is of type timestamp without time zone but expression is of type integer\n"
-                + "  Hint: You will need to rewrite or cast the expression.\n"
-                + "  Position:"},
-        {LocalDate.now(), "date_column", "'2003-01-01'::DATE",
-            "ERROR: column \"date_column\" is of type date but expression is of type integer\n"
-                + "  Hint: You will need to rewrite or cast the expression.\n"
-                + "  Position:"},
-        {LocalTime.now().truncatedTo(ChronoUnit.MICROS), "time_without_time_zone_column",
-            "'07:23'::TIME WITHOUT TIME ZONE",
-            "ERROR: column \"time_without_time_zone_column\" is of type time without time zone but expression is of type integer\n"
-                + "  Hint: You will need to rewrite or cast the expression.\n"
-                + "  Position:"}
+        {LocalDateTime.now().truncatedTo(ChronoUnit.MICROS), "timestamp_without_time_zone_column", "'2003-01-01'::TIMESTAMP"},
+        {LocalDate.now(), "date_column", "'2003-01-01'::DATE"},
+        {LocalTime.now().truncatedTo(ChronoUnit.MICROS), "time_without_time_zone_column", "'07:23'::TIME WITHOUT TIME ZONE"}
     });
   }
 
@@ -75,13 +64,11 @@ public class UpdateObject310Test {
   private Object updateDate;
   private String columnName;
   private String originalValue;
-  private String errorMessage;
 
-  public UpdateObject310Test(Object updateDate, String columnName, String originalValue, String errorMessage) {
+  public UpdateObject310Test(Object updateDate, String columnName, String originalValue) {
     this.updateDate = updateDate;
     this.columnName = columnName;
     this.originalValue = originalValue;
-    this.errorMessage = errorMessage;
   }
 
   /**
@@ -129,7 +116,7 @@ public class UpdateObject310Test {
 
       fail("should have thrown an Exception");
     } catch (PSQLException e) {
-      assertTrue(e.getMessage().contains(errorMessage));
+      assertEquals(PSQLState.DATATYPE_MISMATCH.getState(), e.getSQLState());
     } finally {
       if (rs != null) {
         rs.close();

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc42/UpdateObject310Test.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc42/UpdateObject310Test.java
@@ -25,6 +25,8 @@ import java.sql.Statement;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.Collection;
@@ -37,6 +39,7 @@ public class UpdateObject310Test {
   public static Collection<Object[]> data() {
     return Arrays.asList(new Object[][]{
         {LocalDateTime.now().truncatedTo(ChronoUnit.MICROS), "timestamp_without_time_zone_column", "'2003-01-01'::TIMESTAMP"},
+        {OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).truncatedTo(ChronoUnit.MICROS), "timestamp_with_time_zone_column", "'2007-06-03'::TIMESTAMP"},
         {LocalDate.now(), "date_column", "'2003-01-01'::DATE"},
         {LocalTime.now().truncatedTo(ChronoUnit.MICROS), "time_without_time_zone_column", "'07:23'::TIME WITHOUT TIME ZONE"}
     });
@@ -46,6 +49,7 @@ public class UpdateObject310Test {
   public void setUp() throws Exception {
     con = TestUtil.openDB();
     TestUtil.createTableWithPrimaryKey(con, "table1", "timestamp_without_time_zone_column timestamp without time zone,"
+        + "timestamp_with_time_zone_column timestamp with time zone,"
         + "date_column date,"
         + "time_without_time_zone_column time without time zone"
     );

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc42/UpdateObject310Test.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc42/UpdateObject310Test.java
@@ -6,6 +6,7 @@
 package org.postgresql.test.jdbc42;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import org.postgresql.test.TestUtil;
@@ -42,16 +43,16 @@ public class UpdateObject310Test {
             "'2003-01-01'::TIMESTAMP",
             "ERROR: column \"timestamp_without_time_zone_column\" is of type timestamp without time zone but expression is of type integer\n"
                 + "  Hint: You will need to rewrite or cast the expression.\n"
-                + "  Position: 59"},
+                + "  Position:"},
         {LocalDate.now(), "date_column", "'2003-01-01'::DATE",
             "ERROR: column \"date_column\" is of type date but expression is of type integer\n"
                 + "  Hint: You will need to rewrite or cast the expression.\n"
-                + "  Position: 36"},
+                + "  Position:"},
         {LocalTime.now().truncatedTo(ChronoUnit.MICROS), "time_without_time_zone_column",
             "'07:23'::TIME WITHOUT TIME ZONE",
             "ERROR: column \"time_without_time_zone_column\" is of type time without time zone but expression is of type integer\n"
                 + "  Hint: You will need to rewrite or cast the expression.\n"
-                + "  Position: 54"}
+                + "  Position:"}
     });
   }
 
@@ -128,7 +129,7 @@ public class UpdateObject310Test {
 
       fail("should have thrown an Exception");
     } catch (PSQLException e) {
-      assertEquals(errorMessage, e.getMessage());
+      assertTrue(e.getMessage().contains(errorMessage));
     } finally {
       if (rs != null) {
         rs.close();

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc42/UpdateObject310Test.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc42/UpdateObject310Test.java
@@ -61,12 +61,12 @@ public class UpdateObject310Test {
     TestUtil.closeDB(con);
   }
 
-  private Object updateDate;
+  private Object newValue;
   private String columnName;
   private String originalValue;
 
-  public UpdateObject310Test(Object updateDate, String columnName, String originalValue) {
-    this.updateDate = updateDate;
+  public UpdateObject310Test(Object newValue, String columnName, String originalValue) {
+    this.newValue = newValue;
     this.columnName = columnName;
     this.originalValue = originalValue;
   }
@@ -83,13 +83,13 @@ public class UpdateObject310Test {
       s.executeUpdate("INSERT INTO table1(" + columnName + ") VALUES(" + originalValue + ")");
       rs = s.executeQuery(TestUtil.selectSQL("table1", "table1_id, " + columnName));
       rs.next();
-      rs.updateObject(2, updateDate);
+      rs.updateObject(2, newValue);
       rs.updateRow();
       rs.close();
 
       rs = s.executeQuery(TestUtil.selectSQL("table1", columnName));
       rs.next();
-      assertEquals(updateDate, rs.getObject(1, updateDate.getClass()));
+      assertEquals(newValue, rs.getObject(1, newValue.getClass()));
     } finally {
       if (rs != null) {
         rs.close();

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc42/UpdateObject310Test.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc42/UpdateObject310Test.java
@@ -6,8 +6,10 @@
 package org.postgresql.test.jdbc42;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import org.postgresql.test.TestUtil;
+import org.postgresql.util.PSQLException;
 
 import org.junit.After;
 import org.junit.Before;
@@ -36,9 +38,20 @@ public class UpdateObject310Test {
   @Parameterized.Parameters
   public static Collection<Object[]> data() {
     return Arrays.asList(new Object[][]{
-        {LocalDateTime.now().truncatedTo(ChronoUnit.MICROS), "timestamp_without_time_zone_column", "'2003-01-01'::TIMESTAMP"},
-        {LocalDate.now(), "date_column", "'2003-01-01'::DATE"},
-        {LocalTime.now().truncatedTo(ChronoUnit.MICROS), "time_without_time_zone_column", "'07:23'::TIME WITHOUT TIME ZONE"}
+        {LocalDateTime.now().truncatedTo(ChronoUnit.MICROS), "timestamp_without_time_zone_column",
+            "'2003-01-01'::TIMESTAMP",
+            "ERROR: column \"timestamp_without_time_zone_column\" is of type timestamp without time zone but expression is of type integer\n"
+                + "  Hint: You will need to rewrite or cast the expression.\n"
+                + "  Position: 59"},
+        {LocalDate.now(), "date_column", "'2003-01-01'::DATE",
+            "ERROR: column \"date_column\" is of type date but expression is of type integer\n"
+                + "  Hint: You will need to rewrite or cast the expression.\n"
+                + "  Position: 36"},
+        {LocalTime.now().truncatedTo(ChronoUnit.MICROS), "time_without_time_zone_column",
+            "'07:23'::TIME WITHOUT TIME ZONE",
+            "ERROR: column \"time_without_time_zone_column\" is of type time without time zone but expression is of type integer\n"
+                + "  Hint: You will need to rewrite or cast the expression.\n"
+                + "  Position: 54"}
     });
   }
 
@@ -61,15 +74,17 @@ public class UpdateObject310Test {
   private Object updateDate;
   private String columnName;
   private String originalValue;
+  private String errorMessage;
 
-  public UpdateObject310Test(Object updateDate, String columnName, String originalValue) {
+  public UpdateObject310Test(Object updateDate, String columnName, String originalValue, String errorMessage) {
     this.updateDate = updateDate;
     this.columnName = columnName;
     this.originalValue = originalValue;
+    this.errorMessage = errorMessage;
   }
 
   /**
-   * Test the behavior of setObject for timestamp columns.
+   * Test the behavior of updateObject for timestamp columns.
    */
   @Test
   public void test() throws SQLException {
@@ -87,6 +102,33 @@ public class UpdateObject310Test {
       rs = s.executeQuery(TestUtil.selectSQL("table1", columnName));
       rs.next();
       assertEquals(updateDate, rs.getObject(1, updateDate.getClass()));
+    } finally {
+      if (rs != null) {
+        rs.close();
+      }
+      s.close();
+    }
+  }
+
+  /**
+   * Test the behavior of updateObject for timestamp columns.
+   */
+  @Test
+  public void testWrongClass() throws SQLException {
+    Statement s = con.createStatement(ResultSet.TYPE_SCROLL_SENSITIVE, ResultSet.CONCUR_UPDATABLE);
+    ResultSet rs = null;
+
+    try {
+      s.executeUpdate("INSERT INTO table1(" + columnName + ") VALUES(" + originalValue + ")");
+      rs = s.executeQuery(TestUtil.selectSQL("table1", "table1_id, " + columnName));
+      rs.next();
+      rs.updateObject(2, 23);
+      rs.updateRow();
+      rs.close();
+
+      fail("should have thrown an Exception");
+    } catch (PSQLException e) {
+      assertEquals(errorMessage, e.getMessage());
     } finally {
       if (rs != null) {
         rs.close();

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc42/UpdateObject310Test.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc42/UpdateObject310Test.java
@@ -12,30 +12,42 @@ import org.postgresql.test.TestUtil;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.TimeZone;
 
+@RunWith(Parameterized.class)
 public class UpdateObject310Test {
-
   private static final TimeZone saveTZ = TimeZone.getDefault();
 
   private Connection con;
 
+  @Parameterized.Parameters
+  public static Collection<Object[]> data() {
+    return Arrays.asList(new Object[][]{
+        {LocalDateTime.now(), "timestamp_without_time_zone_column", "'2003-01-01'::TIMESTAMP"},
+        {LocalDate.now(), "date_column", "'2003-01-01'::DATE"},
+        {LocalTime.now(), "time_without_time_zone_column", "'07:23'::TIME WITHOUT TIME ZONE"}
+    });
+  }
+
   @Before
   public void setUp() throws Exception {
     con = TestUtil.openDB();
-    Statement s = con.createStatement();
-    s.executeUpdate("DROP TABLE IF EXISTS UpdateObject310Test");
-    s.executeUpdate("CREATE TABLE UpdateObject310Test (\n"
-        + "  table_id SERIAL PRIMARY KEY,\n"
-        + "  timestamp_without_time_zone_column TIMESTAMP WITHOUT TIME ZONE NULL"
-        + ")");
-    s.close();
+    TestUtil.createTableWithPrimaryKey(con, "table1", "timestamp_without_time_zone_column timestamp without time zone,"
+        + "date_column date,"
+        + "time_without_time_zone_column time without time zone"
+    );
   }
 
   @After
@@ -45,30 +57,35 @@ public class UpdateObject310Test {
     TestUtil.closeDB(con);
   }
 
+  private Object updateDate;
+  private String columnName;
+  private String originalValue;
+
+  public UpdateObject310Test(Object updateDate, String columnName, String originalValue) {
+    this.updateDate = updateDate;
+    this.columnName = columnName;
+    this.originalValue = originalValue;
+  }
+
   /**
    * Test the behavior of setObject for timestamp columns.
    */
   @Test
-  public void insert() throws SQLException {
+  public void test() throws SQLException {
     Statement s = con.createStatement(ResultSet.TYPE_SCROLL_SENSITIVE, ResultSet.CONCUR_UPDATABLE);
     ResultSet rs = null;
 
-    LocalDateTime updateDate = LocalDateTime.now();
     try {
-      s.executeUpdate(
-          "insert into UpdateObject310Test(timestamp_without_time_zone_column) values"
-              + "('2003-01-01'::timestamp)");
-      rs = s.executeQuery(TestUtil
-          .selectSQL("UpdateObject310Test", "table_id, timestamp_without_time_zone_column"));
+      s.executeUpdate("INSERT INTO table1(" + columnName + ") VALUES(" + originalValue + ")");
+      rs = s.executeQuery(TestUtil.selectSQL("table1", "table1_id, " + columnName));
       rs.next();
       rs.updateObject(2, updateDate);
       rs.updateRow();
       rs.close();
 
-      rs = s.executeQuery(TestUtil
-          .selectSQL("UpdateObject310Test", "table_id, timestamp_without_time_zone_column"));
+      rs = s.executeQuery(TestUtil.selectSQL("table1", columnName));
       rs.next();
-      assertEquals(updateDate, rs.getObject(2, LocalDateTime.class));
+      assertEquals(updateDate, rs.getObject(1, updateDate.getClass()));
     } finally {
       if (rs != null) {
         rs.close();
@@ -76,5 +93,4 @@ public class UpdateObject310Test {
       s.close();
     }
   }
-
 }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc42/UpdateObject310Test.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc42/UpdateObject310Test.java
@@ -38,10 +38,14 @@ public class UpdateObject310Test {
   @Parameterized.Parameters
   public static Collection<Object[]> data() {
     return Arrays.asList(new Object[][]{
-        {LocalDateTime.of(2017, 1, 2, 3, 4, 5, 6000).truncatedTo(ChronoUnit.MICROS), "timestamp_without_time_zone_column", "'2003-01-01'::TIMESTAMP"},
-        {OffsetDateTime.of(2017, 1, 2, 3, 4, 5, 6000, ZoneOffset.UTC).truncatedTo(ChronoUnit.MICROS), "timestamp_with_time_zone_column", "'2007-06-03'::TIMESTAMP"},
-        {LocalDate.of(2017, 1, 2), "date_column", "'2003-01-01'::DATE"},
-        {LocalTime.of(11, 12, 13).truncatedTo(ChronoUnit.MICROS), "time_without_time_zone_column", "'07:23'::TIME WITHOUT TIME ZONE"}
+        {LocalDateTime.of(2017, 1, 2, 3, 4, 5, 6000).truncatedTo(ChronoUnit.MICROS), LocalDateTime.class, "timestamp_without_time_zone_column", "'2003-01-01'::TIMESTAMP"},
+        {OffsetDateTime.of(2017, 1, 2, 3, 4, 5, 6000, ZoneOffset.UTC).truncatedTo(ChronoUnit.MICROS), OffsetDateTime.class, "timestamp_with_time_zone_column", "'2007-06-03'::TIMESTAMP"},
+        {LocalDate.of(2017, 1, 2), LocalDate.class, "date_column", "'2003-01-01'::DATE"},
+        {LocalTime.of(11, 12, 13).truncatedTo(ChronoUnit.MICROS), LocalTime.class, "time_without_time_zone_column", "'07:23'::TIME WITHOUT TIME ZONE"},
+        {null, LocalDateTime.class, "timestamp_without_time_zone_column", "'2003-01-01'::TIMESTAMP"},
+        {null, OffsetDateTime.class, "timestamp_with_time_zone_column", "'2007-06-03'::TIMESTAMP"},
+        {null, LocalDate.class, "date_column", "'2003-01-01'::DATE"},
+        {null, LocalTime.class, "time_without_time_zone_column", "'07:23'::TIME WITHOUT TIME ZONE"}
     });
   }
 
@@ -62,11 +66,13 @@ public class UpdateObject310Test {
   }
 
   private Object newValue;
+  private Class newValueClass;
   private String columnName;
   private String originalValue;
 
-  public UpdateObject310Test(Object newValue, String columnName, String originalValue) {
+  public UpdateObject310Test(Object newValue, Class newValueClass, String columnName, String originalValue) {
     this.newValue = newValue;
+    this.newValueClass = newValueClass;
     this.columnName = columnName;
     this.originalValue = originalValue;
   }
@@ -89,7 +95,7 @@ public class UpdateObject310Test {
 
       rs = s.executeQuery(TestUtil.selectSQL("table1", columnName));
       rs.next();
-      assertEquals("Object wasn't identical when it got read back from the database", newValue, rs.getObject(1, newValue.getClass()));
+      assertEquals("Object wasn't identical when it got read back from the database", newValue, rs.getObject(1, newValueClass));
     } finally {
       TestUtil.closeQuietly(rs);
       TestUtil.closeQuietly(s);

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc42/UpdateObject310Test.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc42/UpdateObject310Test.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2004, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.test.jdbc42;
+
+import static org.junit.Assert.assertEquals;
+
+import org.postgresql.test.TestUtil;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.LocalDateTime;
+import java.util.TimeZone;
+
+public class UpdateObject310Test {
+
+  private static final TimeZone saveTZ = TimeZone.getDefault();
+
+  private Connection con;
+
+  @Before
+  public void setUp() throws Exception {
+    con = TestUtil.openDB();
+    Statement s = con.createStatement();
+    s.executeUpdate("DROP TABLE IF EXISTS UpdateObject310Test");
+    s.executeUpdate("CREATE TABLE UpdateObject310Test (\n"
+        + "  table_id SERIAL PRIMARY KEY,\n"
+        + "  timestamp_without_time_zone_column TIMESTAMP WITHOUT TIME ZONE NULL"
+        + ")");
+    s.close();
+  }
+
+  @After
+  public void tearDown() throws SQLException {
+    TimeZone.setDefault(saveTZ);
+    TestUtil.dropTable(con, "table1");
+    TestUtil.closeDB(con);
+  }
+
+  /**
+   * Test the behavior of setObject for timestamp columns.
+   */
+  @Test
+  public void insert() throws SQLException {
+    Statement s = con.createStatement(ResultSet.TYPE_SCROLL_SENSITIVE, ResultSet.CONCUR_UPDATABLE);
+    ResultSet rs = null;
+
+    LocalDateTime updateDate = LocalDateTime.now();
+    try {
+      s.executeUpdate(
+          "insert into UpdateObject310Test(timestamp_without_time_zone_column) values"
+              + "('2003-01-01'::timestamp)");
+      rs = s.executeQuery(TestUtil
+          .selectSQL("UpdateObject310Test", "table_id, timestamp_without_time_zone_column"));
+      rs.next();
+      rs.updateObject(2, updateDate);
+      rs.updateRow();
+      rs.close();
+
+      rs = s.executeQuery(TestUtil
+          .selectSQL("UpdateObject310Test", "table_id, timestamp_without_time_zone_column"));
+      rs.next();
+      assertEquals(updateDate, rs.getObject(2, LocalDateTime.class));
+    } finally {
+      if (rs != null) {
+        rs.close();
+      }
+      s.close();
+    }
+  }
+
+}

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc42/UpdateObject310Test.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc42/UpdateObject310Test.java
@@ -22,6 +22,7 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -38,6 +39,9 @@ public class UpdateObject310Test {
   @Parameterized.Parameters
   public static Collection<Object[]> data() {
     return Arrays.asList(new Object[][]{
+        {new java.sql.Time(3600000), java.sql.Time.class, "time_without_time_zone_column", "'07:23'::TIME WITHOUT TIME ZONE"},
+        {new java.sql.Date(82800000), java.sql.Date.class, "date_column", "'2007-06-03'::DATE"},
+        {Timestamp.from(LocalDateTime.of(2017, 1, 2, 3, 4, 5, 6000).truncatedTo(ChronoUnit.MICROS).toInstant(ZoneOffset.UTC)), Timestamp.class, "timestamp_without_time_zone_column", "'2007-06-03'::TIMESTAMP"},
         {LocalDateTime.of(2017, 1, 2, 3, 4, 5, 6000).truncatedTo(ChronoUnit.MICROS), LocalDateTime.class, "timestamp_without_time_zone_column", "'2003-01-01'::TIMESTAMP"},
         {OffsetDateTime.of(2017, 1, 2, 3, 4, 5, 6000, ZoneOffset.UTC).truncatedTo(ChronoUnit.MICROS), OffsetDateTime.class, "timestamp_with_time_zone_column", "'2007-06-03'::TIMESTAMP"},
         {LocalDate.of(2017, 1, 2), LocalDate.class, "date_column", "'2003-01-01'::DATE"},
@@ -65,12 +69,12 @@ public class UpdateObject310Test {
     TestUtil.closeDB(con);
   }
 
-  private Object newValue;
-  private Class newValueClass;
-  private String columnName;
-  private String originalValue;
+  private final Object newValue;
+  private final Class<?> newValueClass;
+  private final String columnName;
+  private final String originalValue;
 
-  public UpdateObject310Test(Object newValue, Class newValueClass, String columnName, String originalValue) {
+  public UpdateObject310Test(Object newValue, Class<?> newValueClass, String columnName, String originalValue) {
     this.newValue = newValue;
     this.newValueClass = newValueClass;
     this.columnName = columnName;


### PR DESCRIPTION
Fix for issue #863 

Adds support for LocalDateTime, LocalDate and LocalTime to updateObject()