### PR TITLE
Filter DatabaseMetaData

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -419,7 +419,12 @@ public enum PGProperty {
           + "to the database specified in the dbname parameter, "
           + "which will allow the connection to be used for logical replication "
           + "from that database. "
-          + "(backend >= 9.4)");
+          + "(backend >= 9.4)"),
+  /**
+   * Enable mode to filter out the names of database objects for which the current user has no privileges granted from appearing in the DatabaseMetaData returned by the driver.
+   */
+  HIDE_UNPRIVILEGED_OBJECTS("hideUnprivilegedObjects", "false",
+        "Enable hiding of database objects for which the current user has no privileges granted from the DatabaseMetaData");
 
   private String _name;
   private String _defaultValue;

--- a/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
+++ b/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
@@ -1315,4 +1315,20 @@ public abstract class BaseDataSource implements CommonDataSource, Referenceable 
     return Logger.getLogger("org.postgresql");
   }
   //#endif
+
+  /**
+   * @see PGProperty#HIDE_UNPRIVILEGED_OBJECTS
+   * @return boolean indicating property is enabled or not.
+   */
+  public boolean getHideUnprivilegedObjects() {
+    return PGProperty.HIDE_UNPRIVILEGED_OBJECTS.getBoolean(properties);
+  }
+
+  /**
+   * @see PGProperty#HIDE_UNPRIVILEGED_OBJECTS
+   * @param hideUnprivileged boolean value to set the property in the properties collection
+   */
+  public void setHideUnprivilegedObjects(boolean hideUnprivileged) {
+    PGProperty.HIDE_UNPRIVILEGED_OBJECTS.set(properties, hideUnprivileged);
+  }
 }

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
@@ -122,6 +122,8 @@ public class PgConnection implements BaseConnection {
   private boolean autoCommit = true;
   // Connection's readonly state.
   private boolean readOnly = false;
+  // Filter out database objects for which the current user has no privileges granted from the DatabaseMetaData
+  private boolean  hideUnprivilegedObjects ;
 
   // Bind String to UNSPECIFIED or VARCHAR?
   private final boolean bindStringAsVarchar;
@@ -203,6 +205,7 @@ public class PgConnection implements BaseConnection {
     if (PGProperty.READ_ONLY.getBoolean(info)) {
       setReadOnly(true);
     }
+    this.hideUnprivilegedObjects = PGProperty.HIDE_UNPRIVILEGED_OBJECTS.getBoolean(info);
 
     boolean binaryTransfer = PGProperty.BINARY_TRANSFER.getBoolean(info);
     // Formats that currently have binary protocol support
@@ -863,6 +866,10 @@ public class PgConnection implements BaseConnection {
   public String getCatalog() throws SQLException {
     checkClosed();
     return queryExecutor.getDatabase();
+  }
+
+  public boolean getHideUnprivilegedObjects() {
+    return hideUnprivilegedObjects;
   }
 
   /**

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
@@ -49,6 +49,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
 
   private int NAMEDATALEN = 0; // length for name datatype
   private int INDEX_MAX_KEYS = 0; // maximum number of keys in an index.
+
   protected int getMaxIndexKeys() throws SQLException {
     if (INDEX_MAX_KEYS == 0) {
       String sql;

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
@@ -968,7 +968,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
     if (schemaPattern != null && !schemaPattern.isEmpty()) {
       sql += " AND n.nspname LIKE " + escapeQuotes(schemaPattern);
     }
-    if(connection.getHideUnprivilegedObjects()) {
+    if (connection.getHideUnprivilegedObjects()) {
       sql += " AND has_function_privilege(p.oid,'EXECUTE')";
     }
     if (procedureNamePattern != null && !procedureNamePattern.isEmpty()) {
@@ -1230,7 +1230,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
     if (schemaPattern != null && !schemaPattern.isEmpty()) {
       select += " AND n.nspname LIKE " + escapeQuotes(schemaPattern);
     }
-    if(connection.getHideUnprivilegedObjects()) {
+    if (connection.getHideUnprivilegedObjects()) {
       select += " AND has_table_privilege(c.oid, "
         + " 'SELECT, INSERT, UPDATE, DELETE, RULE, REFERENCES, TRIGGER')";
     }
@@ -1350,7 +1350,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
     if (schemaPattern != null && !schemaPattern.isEmpty()) {
       sql += " AND nspname LIKE " + escapeQuotes(schemaPattern);
     }
-    if(connection.getHideUnprivilegedObjects()) {
+    if (connection.getHideUnprivilegedObjects()) {
       sql += " AND has_schema_privilege(nspname, 'USAGE, CREATE')";
     }
     sql += " ORDER BY TABLE_SCHEM";
@@ -2168,7 +2168,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
     sql = "SELECT t.typname,t.oid FROM pg_catalog.pg_type t"
           + " JOIN pg_catalog.pg_namespace n ON (t.typnamespace = n.oid) "
           + " WHERE n.nspname  != 'pg_toast'";
-    if(connection.getHideUnprivilegedObjects() && connection.haveMinimumServerVersion(ServerVersion.v9_2)) {
+    if (connection.getHideUnprivilegedObjects() && connection.haveMinimumServerVersion(ServerVersion.v9_2)) {
       sql += " AND has_type_privilege(t.oid, 'USAGE')";
     }
 
@@ -2480,7 +2480,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
       toAdd.append(" and n.nspname like ").append(escapeQuotes(schemaPattern));
     }
     sql += toAdd.toString();
-    if(connection.getHideUnprivilegedObjects() && connection.haveMinimumServerVersion(ServerVersion.v9_2)) {
+    if (connection.getHideUnprivilegedObjects() && connection.haveMinimumServerVersion(ServerVersion.v9_2)) {
       sql += " AND has_type_privilege(t.oid, 'USAGE')";
     }
     sql += " order by data_type, type_schem, type_name";

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
@@ -1231,8 +1231,13 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
       select += " AND n.nspname LIKE " + escapeQuotes(schemaPattern);
     }
     if (connection.getHideUnprivilegedObjects()) {
-      select += " AND has_table_privilege(c.oid, "
-        + " 'SELECT, INSERT, UPDATE, DELETE, RULE, REFERENCES, TRIGGER')";
+      select += " AND ( has_table_privilege(c.oid, 'SELECT') "
+        + " OR  has_table_privilege(c.oid, 'INSERT')"
+        + " OR  has_table_privilege(c.oid, 'UPDATE')"
+        + " OR  has_table_privilege(c.oid, 'DELETE')"
+        + " OR  has_table_privilege(c.oid, 'RULE')"
+        + " OR  has_table_privilege(c.oid, 'REFERENCES')"
+        + " OR  has_table_privilege(c.oid, 'TRIGGER') )";
     }
     orderby = " ORDER BY TABLE_TYPE,TABLE_SCHEM,TABLE_NAME ";
 
@@ -1351,7 +1356,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
       sql += " AND nspname LIKE " + escapeQuotes(schemaPattern);
     }
     if (connection.getHideUnprivilegedObjects()) {
-      sql += " AND has_schema_privilege(nspname, 'USAGE, CREATE')";
+      sql += " AND ( has_schema_privilege(nspname, 'USAGE') OR has_schema_privilege(nspname, 'CREATE') )";
     }
     sql += " ORDER BY TABLE_SCHEM";
 

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
@@ -2598,8 +2598,10 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
     if (functionNamePattern != null && !functionNamePattern.isEmpty()) {
       sql += " AND p.proname LIKE " + escapeQuotes(functionNamePattern);
     }
+    if (connection.getHideUnprivilegedObjects()) {
+      sql += " AND has_function_privilege(p.oid,'EXECUTE')";
+    }
     sql += " ORDER BY FUNCTION_SCHEM, FUNCTION_NAME, p.oid::text ";
-
     return createMetaDataStatement().executeQuery(sql);
   }
 

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
@@ -139,7 +139,12 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
    * Retrieves the name of this database product. We hope that it is PostgreSQL, so we return that
    * explicitly.
    *
+<<<<<<< HEAD
    * @return "PostgreSQL"
+=======
+   * @return the database product name
+   * @throws SQLException if a database access error occurs
+>>>>>>> Filter DatabaseMetaData to show only the items for which the current user has access.
    */
   @Override
   public String getDatabaseProductName() throws SQLException {
@@ -182,7 +187,8 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
   }
 
   /**
-   * Does the database use a file for each table? Well, not really, since it doesn't use local files.
+   * Does the database use a file for each table? Well, not really, since it doesn't use local
+   * files.
    *
    * @return true if so
    * @throws SQLException if a database access error occurs
@@ -973,6 +979,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
     }
     if (procedureNamePattern != null && !procedureNamePattern.isEmpty()) {
       sql += " AND p.proname LIKE " + escapeQuotes(procedureNamePattern);
+
     }
     sql += " ORDER BY PROCEDURE_SCHEM, PROCEDURE_NAME, p.oid::text ";
 
@@ -1538,7 +1545,8 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
       }
 
       tuple[10] = connection.encodeString(Integer.toString(rs.getBoolean("attnotnull")
-          ? java.sql.DatabaseMetaData.columnNoNulls : java.sql.DatabaseMetaData.columnNullable)); // Nullable
+          ? java.sql.DatabaseMetaData.columnNoNulls
+          : java.sql.DatabaseMetaData.columnNullable)); // Nullable
       tuple[11] = rs.getBytes("description"); // Description (if any)
       tuple[12] = rs.getBytes("adsrc"); // Column default
       tuple[13] = null; // sql data type (unused)
@@ -1767,7 +1775,8 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
    * Add the user described by the given acl to the Lists of users with the privileges described by
    * the acl.
    */
-  private static void addACLPrivileges(String acl, Map<String, Map<String, List<String[]>>> privileges) {
+  private static void addACLPrivileges(String acl,
+      Map<String, Map<String, List<String[]>>> privileges) {
     int equalIndex = acl.lastIndexOf("=");
     int slashIndex = acl.lastIndexOf("/");
     if (equalIndex == -1) {
@@ -1870,7 +1879,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
    * For instance: {@code SELECT -> user1 -> list of [grantor, grantable]}
    *
    * @param aclArray ACL array
-   * @param owner owner
+   * @param owner    owner
    * @return a Map mapping the SQL permission name
    */
   public Map<String, Map<String, List<String[]>>> parseACL(String aclArray, String owner) {
@@ -2032,11 +2041,11 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
 
   /**
    * @param primaryCatalog primary catalog
-   * @param primarySchema primary schema
-   * @param primaryTable if provided will get the keys exported by this table
+   * @param primarySchema  primary schema
+   * @param primaryTable   if provided will get the keys exported by this table
    * @param foreignCatalog foreign catalog
-   * @param foreignSchema foreign schema
-   * @param foreignTable if provided will get the keys imported by this table
+   * @param foreignSchema  foreign schema
+   * @param foreignTable   if provided will get the keys imported by this table
    * @return ResultSet
    * @throws SQLException if something wrong happens
    */
@@ -2135,7 +2144,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
 
   public ResultSet getCrossReference(String primaryCatalog, String primarySchema,
       String primaryTable, String foreignCatalog, String foreignSchema, String foreignTable)
-          throws SQLException {
+      throws SQLException {
     return getImportedExportedKeys(primaryCatalog, primarySchema, primaryTable, foreignCatalog,
         foreignSchema, foreignTable);
   }
@@ -2481,7 +2490,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
     }
     sql += toAdd.toString();
     if(connection.getHideUnprivilegedObjects() && connection.haveMinimumServerVersion(ServerVersion.v9_2)) {
-     sql += " AND has_type_privilege(t.oid, 'USAGE')";
+      sql += " AND has_type_privilege(t.oid, 'USAGE')";
     }
     sql += " order by data_type, type_schem, type_name";
     return createMetaDataStatement().executeQuery(sql);

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
@@ -139,12 +139,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
    * Retrieves the name of this database product. We hope that it is PostgreSQL, so we return that
    * explicitly.
    *
-<<<<<<< HEAD
    * @return "PostgreSQL"
-=======
-   * @return the database product name
-   * @throws SQLException if a database access error occurs
->>>>>>> Filter DatabaseMetaData to show only the items for which the current user has access.
    */
   @Override
   public String getDatabaseProductName() throws SQLException {
@@ -187,8 +182,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
   }
 
   /**
-   * Does the database use a file for each table? Well, not really, since it doesn't use local
-   * files.
+   * Does the database use a file for each table? Well, not really, since it doesn't use local files.
    *
    * @return true if so
    * @throws SQLException if a database access error occurs
@@ -979,7 +973,6 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
     }
     if (procedureNamePattern != null && !procedureNamePattern.isEmpty()) {
       sql += " AND p.proname LIKE " + escapeQuotes(procedureNamePattern);
-
     }
     sql += " ORDER BY PROCEDURE_SCHEM, PROCEDURE_NAME, p.oid::text ";
 
@@ -1545,8 +1538,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
       }
 
       tuple[10] = connection.encodeString(Integer.toString(rs.getBoolean("attnotnull")
-          ? java.sql.DatabaseMetaData.columnNoNulls
-          : java.sql.DatabaseMetaData.columnNullable)); // Nullable
+          ? java.sql.DatabaseMetaData.columnNoNulls : java.sql.DatabaseMetaData.columnNullable)); // Nullable
       tuple[11] = rs.getBytes("description"); // Description (if any)
       tuple[12] = rs.getBytes("adsrc"); // Column default
       tuple[13] = null; // sql data type (unused)
@@ -1775,8 +1767,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
    * Add the user described by the given acl to the Lists of users with the privileges described by
    * the acl.
    */
-  private static void addACLPrivileges(String acl,
-      Map<String, Map<String, List<String[]>>> privileges) {
+  private static void addACLPrivileges(String acl, Map<String, Map<String, List<String[]>>> privileges) {
     int equalIndex = acl.lastIndexOf("=");
     int slashIndex = acl.lastIndexOf("/");
     if (equalIndex == -1) {
@@ -1879,7 +1870,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
    * For instance: {@code SELECT -> user1 -> list of [grantor, grantable]}
    *
    * @param aclArray ACL array
-   * @param owner    owner
+   * @param owner owner
    * @return a Map mapping the SQL permission name
    */
   public Map<String, Map<String, List<String[]>>> parseACL(String aclArray, String owner) {
@@ -2041,11 +2032,11 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
 
   /**
    * @param primaryCatalog primary catalog
-   * @param primarySchema  primary schema
-   * @param primaryTable   if provided will get the keys exported by this table
+   * @param primarySchema primary schema
+   * @param primaryTable if provided will get the keys exported by this table
    * @param foreignCatalog foreign catalog
-   * @param foreignSchema  foreign schema
-   * @param foreignTable   if provided will get the keys imported by this table
+   * @param foreignSchema foreign schema
+   * @param foreignTable if provided will get the keys imported by this table
    * @return ResultSet
    * @throws SQLException if something wrong happens
    */
@@ -2144,7 +2135,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
 
   public ResultSet getCrossReference(String primaryCatalog, String primarySchema,
       String primaryTable, String foreignCatalog, String foreignSchema, String foreignTable)
-      throws SQLException {
+          throws SQLException {
     return getImportedExportedKeys(primaryCatalog, primarySchema, primaryTable, foreignCatalog,
         foreignSchema, foreignTable);
   }
@@ -2602,6 +2593,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
       sql += " AND has_function_privilege(p.oid,'EXECUTE')";
     }
     sql += " ORDER BY FUNCTION_SCHEM, FUNCTION_NAME, p.oid::text ";
+
     return createMetaDataStatement().executeQuery(sql);
   }
 

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc4/DatabaseMetaDataHideUnprivilegedObjectsTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc4/DatabaseMetaDataHideUnprivilegedObjectsTest.java
@@ -12,6 +12,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 import org.postgresql.PGProperty;
+import org.postgresql.core.Utils;
 import org.postgresql.test.TestUtil;
 
 import org.junit.AfterClass;
@@ -395,8 +396,11 @@ public class DatabaseMetaDataHideUnprivilegedObjectsTest {
     // has a WHERE clause that uses pg_function_is_visible(oid). This function returns
     // a boolean that describes whether or not the function is visible in your
     // session's search_path (as well as whether or not the role has usage on the schema).
-    databaseMetaData.getConnection().setSchema(schemaPattern);
-
+    // N.B. do not use Connection.setSchema() because pgjdbc needs to work with openjdk6.
+    Statement stmt = databaseMetaData.getConnection().createStatement();
+    stmt.executeUpdate("SET SESSION search_path TO '"+schemaPattern+"',public");
+    stmt.close();
+    
     ResultSet rs = databaseMetaData.getFunctions(null, schemaPattern, null);
     while (rs.next()) {
       functionNames.add(rs.getString("FUNCTION_NAME"));

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc4/DatabaseMetaDataHideUnprivilegedObjectsTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc4/DatabaseMetaDataHideUnprivilegedObjectsTest.java
@@ -1,0 +1,455 @@
+/*-------------------------------------------------------------------------
+*
+* Copyright (c) 2004-2016, PostgreSQL Global Development Group
+*
+*
+*-------------------------------------------------------------------------
+*/
+package org.postgresql.test.jdbc4;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertThat;
+
+import org.postgresql.test.TestUtil;
+import org.postgresql.PGProperty;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.fail;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+/**
+ * Tests that database objects for which the current user has no privileges are filtered out from
+ * the DatabaseMetaData depending on whether the connection parameter hideUnprivilegedObjects is
+ * set to true.
+ */
+public class DatabaseMetaDataHideUnprivilegedObjectsTest {
+  public static final String COLUMNS = "digit int4, name text";
+  private static Connection hidingCon;
+  private static Connection nonhidingCon;
+  private static Connection privilegedCon;
+  private static DatabaseMetaData hidingDatabaseMetaData;
+  private static DatabaseMetaData nonhidingDatabaseMetaData;
+
+  @BeforeClass
+  public static void setUp() throws Exception {
+    Properties props = new Properties();
+    privilegedCon = TestUtil.openPrivilegedDB();
+    Statement stmt = privilegedCon.createStatement();
+
+    createTestDataObjectsWithRangeOfPrivilegesInSchema("high_privileges_schema");
+    // Grant Test User ALL privileges on schema.
+    stmt.executeUpdate("GRANT ALL ON SCHEMA high_privileges_schema TO " + TestUtil.getUser());
+    stmt.executeUpdate("REVOKE ALL ON SCHEMA high_privileges_schema FROM public");
+
+    createTestDataObjectsWithRangeOfPrivilegesInSchema("low_privileges_schema");
+    // Grant Test User USAGE privileges on schema.
+    stmt.executeUpdate("GRANT USAGE ON SCHEMA low_privileges_schema TO " + TestUtil.getUser());
+    stmt.executeUpdate("REVOKE ALL ON SCHEMA low_privileges_schema FROM public");
+
+    createTestDataObjectsWithRangeOfPrivilegesInSchema("no_privileges_schema");
+    // Revoke ALL privileges from Test User USAGE on schema.
+    stmt.executeUpdate("REVOKE ALL ON SCHEMA no_privileges_schema FROM " + TestUtil.getUser());
+    stmt.executeUpdate("REVOKE ALL ON SCHEMA no_privileges_schema FROM public");
+
+    stmt.close();
+
+    nonhidingDatabaseMetaData = getNonHidingDatabaseMetaData(props);
+    hidingDatabaseMetaData = getHidingDatabaseMetaData(props);
+  }
+
+  private static DatabaseMetaData getHidingDatabaseMetaData(Properties props) throws Exception {
+    PGProperty.HIDE_UNPRIVILEGED_OBJECTS.set(props, true);
+    hidingCon = TestUtil.openDB(props);
+    if (isSuperUser(hidingCon)) {
+      fail("Test for hiding database objects will not work while:" + TestUtil.getUser()
+          + " has a SUPERUSER role.");
+    }
+    return hidingCon.getMetaData();
+  }
+
+  private static DatabaseMetaData getNonHidingDatabaseMetaData(Properties props) throws Exception {
+    nonhidingCon = TestUtil.openDB(props);
+    return nonhidingCon.getMetaData();
+  }
+
+  private static void createTestDataObjectsWithRangeOfPrivilegesInSchema(String schema)
+      throws SQLException {
+    TestUtil.createSchema(privilegedCon, schema);
+    createSimpleTablesInSchema(schema,
+        new String[]{"owned_table", "all_grants_table", "insert_granted_table",
+            "select_granted_table", "no_grants_table"});
+
+    Statement stmt = privilegedCon.createStatement();
+    stmt.executeUpdate(
+        "CREATE FUNCTION " + schema + "."
+            + "execute_granted_add_function(integer, integer) RETURNS integer AS 'select $1 + $2;' LANGUAGE SQL IMMUTABLE  RETURNS NULL ON NULL INPUT");
+    stmt.executeUpdate(
+        "CREATE FUNCTION " + schema + "."
+            + "no_grants_add_function(integer, integer) RETURNS integer AS 'select $1 + $2;' LANGUAGE SQL IMMUTABLE  RETURNS NULL ON NULL INPUT");
+    stmt.executeUpdate(
+        "CREATE OR REPLACE VIEW " + schema + "." + "select_granted_view AS SELECT name FROM "
+            + schema + "." + "select_granted_table");
+    stmt.executeUpdate(
+        "CREATE OR REPLACE VIEW " + schema + "." + "no_grants_view AS SELECT name FROM " + schema
+            + "." + "owned_table");
+    stmt.executeUpdate(
+        "CREATE TYPE " + schema + "." + "usage_granted_composite_type AS (f1 int, f2 text)");
+    stmt.executeUpdate(
+        "CREATE TYPE " + schema + "." + "no_grants_composite_type AS (f1 int, f2 text)");
+    stmt.executeUpdate(
+        "CREATE DOMAIN " + schema + "." + "usage_granted_us_postal_code_domain CHAR(5) NOT NULL");
+    stmt.executeUpdate(
+        "CREATE DOMAIN " + schema + "." + "no_grants_us_postal_code_domain AS CHAR(5) NOT NULL");
+    stmt.executeUpdate(
+        "REVOKE ALL ON TYPE " + schema + "." + "usage_granted_composite_type FROM public RESTRICT");
+    stmt.executeUpdate(
+        "REVOKE ALL ON TYPE " + schema + "." + "no_grants_composite_type FROM public RESTRICT");
+    stmt.executeUpdate("GRANT USAGE on TYPE " + schema + "." + "usage_granted_composite_type TO "
+        + TestUtil.getUser());
+    stmt.executeUpdate(
+        "REVOKE ALL ON TYPE " + schema + "."
+            + "usage_granted_us_postal_code_domain FROM public RESTRICT");
+    stmt.executeUpdate(
+        "REVOKE ALL ON TYPE " + schema + "."
+            + "no_grants_us_postal_code_domain FROM public RESTRICT");
+    stmt.executeUpdate(
+        "GRANT USAGE on TYPE " + schema + "." + "usage_granted_us_postal_code_domain TO "
+            + TestUtil.getUser());
+    stmt.executeUpdate(
+        "REVOKE ALL ON ALL FUNCTIONS IN SCHEMA " + schema + " FROM public RESTRICT");
+    stmt.executeUpdate(
+        "REVOKE ALL ON ALL FUNCTIONS IN SCHEMA " + schema + " FROM " + TestUtil.getUser()
+            + " RESTRICT");
+    stmt.executeUpdate(
+        "REVOKE ALL ON ALL TABLES IN SCHEMA " + schema + " FROM public RESTRICT");
+    stmt.executeUpdate(
+        "REVOKE ALL ON ALL TABLES IN SCHEMA " + schema + " FROM " + TestUtil.getUser()
+            + " RESTRICT");
+    stmt.executeUpdate(
+        "GRANT ALL ON FUNCTION " + schema + "."
+            + "execute_granted_add_function(integer, integer) TO "
+            + TestUtil.getUser());
+    stmt.executeUpdate(
+        "ALTER TABLE " + schema + "." + "owned_table OWNER TO " + TestUtil.getUser());
+    stmt.executeUpdate(
+        "GRANT ALL ON TABLE " + schema + "." + "all_grants_table TO " + TestUtil.getUser());
+    stmt.executeUpdate("GRANT INSERT ON TABLE " + schema + "." + "insert_granted_table TO "
+        + TestUtil.getUser());
+    stmt.executeUpdate("GRANT SELECT ON TABLE " + schema + "." + "select_granted_table TO "
+        + TestUtil.getUser());
+    stmt.executeUpdate("GRANT SELECT ON TABLE " + schema + "." + "select_granted_view TO "
+        + TestUtil.getUser());
+    stmt.close();
+  }
+
+  private static void createSimpleTablesInSchema(String schema, String[] tables
+  ) throws SQLException {
+    for (String tableName : tables) {
+      TestUtil.createTable(privilegedCon, schema + "." + tableName,
+          COLUMNS);
+    }
+  }
+
+  @AfterClass
+  public static void tearDown() throws SQLException {
+    TestUtil.closeDB(hidingCon);
+    TestUtil.closeDB(nonhidingCon);
+    TestUtil.dropSchema(privilegedCon, "high_privileges_schema");
+    TestUtil.dropSchema(privilegedCon, "low_privileges_schema");
+    TestUtil.dropSchema(privilegedCon, "no_privileges_schema");
+    TestUtil.closeDB(privilegedCon);
+  }
+
+  private static boolean isSuperUser(Connection connection) throws SQLException {
+    // Check if we're operating as a superuser.
+    Statement st = connection.createStatement();
+    st.executeQuery("SHOW is_superuser;");
+    ResultSet rs = st.getResultSet();
+    rs.next(); // One row is guaranteed
+    boolean connIsSuper = rs.getString(1).equalsIgnoreCase("on");
+    st.close();
+    return connIsSuper;
+  }
+
+  @Test
+  public void testGetSchemas() throws SQLException {
+    List<String> schemasWithHiding = getSchemaNames(hidingDatabaseMetaData);
+    assertThat(schemasWithHiding,
+        hasItems("pg_catalog", "information_schema",
+            "high_privileges_schema", "low_privileges_schema"));
+    assertThat(schemasWithHiding,
+        not(hasItem("no_privileges_schema")));
+
+    List<String> schemasWithNoHiding = getSchemaNames(nonhidingDatabaseMetaData);
+    assertThat(schemasWithNoHiding,
+        hasItems("pg_catalog", "information_schema",
+            "high_privileges_schema", "low_privileges_schema", "no_privileges_schema"));
+  }
+
+  List<String> getSchemaNames(DatabaseMetaData databaseMetaData) throws SQLException {
+    List<String> schemaNames = new ArrayList<String>();
+    ResultSet rs = databaseMetaData.getSchemas();
+    while (rs.next()) {
+      schemaNames.add(rs.getString("TABLE_SCHEM"));
+    }
+    return schemaNames;
+  }
+
+  @Test
+  public void testGetTables() throws SQLException {
+    List<String> tablesWithHiding = getTableNames(hidingDatabaseMetaData, "high_privileges_schema");
+
+    assertThat(tablesWithHiding,
+        hasItems(
+            "owned_table",
+            "all_grants_table",
+            "insert_granted_table",
+            "select_granted_table"));
+    assertThat(tablesWithHiding,
+        not(hasItem("no_grants_table")));
+
+    List<String> tablesWithNoHiding =
+        getTableNames(nonhidingDatabaseMetaData, "high_privileges_schema");
+    assertThat(tablesWithNoHiding,
+        hasItems(
+            "owned_table",
+            "all_grants_table",
+            "insert_granted_table",
+            "select_granted_table",
+            "no_grants_table"));
+
+    tablesWithHiding = getTableNames(hidingDatabaseMetaData, "low_privileges_schema");
+
+    assertThat(tablesWithHiding,
+        hasItems(
+            "owned_table",
+            "all_grants_table",
+            "insert_granted_table",
+            "select_granted_table"));
+    assertThat(tablesWithHiding,
+        not(hasItem("no_grants_table")));
+
+    tablesWithNoHiding =
+        getTableNames(nonhidingDatabaseMetaData, "low_privileges_schema");
+    assertThat(tablesWithNoHiding,
+        hasItems(
+            "owned_table",
+            "all_grants_table",
+            "insert_granted_table",
+            "select_granted_table",
+            "no_grants_table"));
+
+    // Or should the the tables names not be returned because the schema is not visible?
+    tablesWithHiding = getTableNames(hidingDatabaseMetaData, "no_privileges_schema");
+
+    assertThat(tablesWithHiding,
+        hasItems(
+            "owned_table",
+            "all_grants_table",
+            "insert_granted_table",
+            "select_granted_table"));
+    assertThat(tablesWithHiding,
+        not(hasItem("no_grants_table")));
+
+    tablesWithNoHiding =
+        getTableNames(nonhidingDatabaseMetaData, "no_privileges_schema");
+    assertThat(tablesWithNoHiding,
+        hasItems(
+            "owned_table",
+            "all_grants_table",
+            "insert_granted_table",
+            "select_granted_table",
+            "no_grants_table"));
+
+  }
+
+  List<String> getTableNames(DatabaseMetaData databaseMetaData, String schemaPattern)
+      throws SQLException {
+    List<String> tableNames = new ArrayList<String>();
+    ResultSet rs = databaseMetaData.getTables(null, schemaPattern, null, new String[]{"TABLE"});
+    while (rs.next()) {
+      tableNames.add(rs.getString("TABLE_NAME"));
+    }
+    return tableNames;
+  }
+
+  @Test
+  public void testGetViews() throws SQLException {
+    List<String> viewsWithHiding = getViewNames(hidingDatabaseMetaData, "high_privileges_schema");
+
+    assertThat(viewsWithHiding,
+        hasItems(
+            "select_granted_view"));
+    assertThat(viewsWithHiding,
+        not(hasItem("no_grants_view")));
+
+    List<String> viewsWithNoHiding =
+        getViewNames(nonhidingDatabaseMetaData, "high_privileges_schema");
+    assertThat(viewsWithNoHiding,
+        hasItems(
+            "select_granted_view",
+            "no_grants_view"));
+
+    viewsWithHiding = getViewNames(hidingDatabaseMetaData, "low_privileges_schema");
+
+    assertThat(viewsWithHiding,
+        hasItems(
+            "select_granted_view"));
+    assertThat(viewsWithHiding,
+        not(hasItem("no_grants_view")));
+
+    viewsWithNoHiding =
+        getViewNames(nonhidingDatabaseMetaData, "low_privileges_schema");
+    assertThat(viewsWithNoHiding,
+        hasItems(
+            "select_granted_view",
+            "no_grants_view"));
+
+    // Or should the the view names not be returned because the schema is not visible?
+    viewsWithHiding = getViewNames(hidingDatabaseMetaData, "no_privileges_schema");
+
+    assertThat(viewsWithHiding,
+        hasItems(
+            "select_granted_view"));
+    assertThat(viewsWithHiding,
+        not(hasItem("no_grants_view")));
+
+    viewsWithNoHiding =
+        getViewNames(nonhidingDatabaseMetaData, "no_privileges_schema");
+    assertThat(viewsWithNoHiding,
+        hasItems(
+            "select_granted_view",
+            "no_grants_view"));
+
+  }
+
+  List<String> getViewNames(DatabaseMetaData databaseMetaData, String schemaPattern)
+      throws SQLException {
+    List<String> viewNames = new ArrayList<String>();
+    ResultSet rs = databaseMetaData.getTables(null, schemaPattern, null, new String[]{"VIEW"});
+    while (rs.next()) {
+      viewNames.add(rs.getString("TABLE_NAME"));
+    }
+    return viewNames;
+  }
+
+  @Test
+  public void testGetFunctions() throws SQLException {
+    List<String> functionsWithHiding =
+        getFunctionNames(hidingDatabaseMetaData, "high_privileges_schema");
+    assertThat(functionsWithHiding,
+        hasItem("execute_granted_add_function"));
+    assertThat(functionsWithHiding,
+        not(hasItem("no_grants_add_function")));
+
+    List<String> functionsWithNoHiding =
+        getFunctionNames(nonhidingDatabaseMetaData, "high_privileges_schema");
+    assertThat(functionsWithNoHiding,
+        hasItems("execute_granted_add_function", "no_grants_add_function"));
+
+    functionsWithHiding =
+        getFunctionNames(hidingDatabaseMetaData, "low_privileges_schema");
+    assertThat(functionsWithHiding,
+        hasItem("execute_granted_add_function"));
+    assertThat(functionsWithHiding,
+        not(hasItem("no_grants_add_function")));
+
+    functionsWithNoHiding =
+        getFunctionNames(nonhidingDatabaseMetaData, "low_privileges_schema");
+    assertThat(functionsWithNoHiding,
+        hasItems("execute_granted_add_function", "no_grants_add_function"));
+
+    // Or should the the function names not be returned because the schema is not visible?
+    functionsWithHiding =
+        getFunctionNames(hidingDatabaseMetaData, "no_privileges_schema");
+    assertThat(functionsWithHiding,
+        hasItem("execute_granted_add_function"));
+    assertThat(functionsWithHiding,
+        not(hasItem("no_grants_add_function")));
+
+    functionsWithNoHiding =
+        getFunctionNames(nonhidingDatabaseMetaData, "no_privileges_schema");
+    assertThat(functionsWithNoHiding,
+        hasItems("execute_granted_add_function", "no_grants_add_function"));
+
+  }
+
+  List<String> getFunctionNames(DatabaseMetaData databaseMetaData, String schemaPattern)
+      throws SQLException {
+    List<String> functionNames = new ArrayList<String>();
+    ResultSet rs = databaseMetaData.getFunctions(null, schemaPattern, null);
+    while (rs.next()) {
+      // TODO: According to JDBC JavaDoc, column should be called FUNCTION_NAME.
+      functionNames.add(rs.getString("PROCEDURE_NAME"));
+    }
+    return functionNames;
+  }
+
+  @Test
+  /*
+   *  According to the JDBC JavaDoc, the applicable UDTs are: JAVA_OBJECT, STRUCT, or DISTINCT.
+   */
+  public void testGetUDTs() throws SQLException {
+    List<String> typesWithHiding = getTypeNames(hidingDatabaseMetaData, "high_privileges_schema");
+    assertThat(typesWithHiding,
+        hasItems("usage_granted_composite_type", "usage_granted_us_postal_code_domain"));
+    assertThat(typesWithHiding,
+        not(hasItems("no_grants_composite_type", "no_grants_us_postal_code_domain")));
+    List<String> typesWithNoHiding =
+        getTypeNames(nonhidingDatabaseMetaData, "high_privileges_schema");
+    assertThat(typesWithNoHiding,
+        hasItems("usage_granted_composite_type", "no_grants_composite_type",
+            "usage_granted_us_postal_code_domain", "no_grants_us_postal_code_domain"));
+
+    typesWithHiding = getTypeNames(hidingDatabaseMetaData, "low_privileges_schema");
+    assertThat(typesWithHiding,
+        hasItems("usage_granted_composite_type", "usage_granted_us_postal_code_domain"));
+    assertThat(typesWithHiding,
+        not(hasItems("no_grants_composite_type", "no_grants_us_postal_code_domain")));
+    typesWithNoHiding =
+        getTypeNames(nonhidingDatabaseMetaData, "low_privileges_schema");
+    assertThat(typesWithNoHiding,
+        hasItems("usage_granted_composite_type", "no_grants_composite_type",
+            "usage_granted_us_postal_code_domain", "no_grants_us_postal_code_domain"));
+
+    // Or should the the types names not be returned because the schema is not visible?
+    typesWithHiding = getTypeNames(hidingDatabaseMetaData, "no_privileges_schema");
+    assertThat(typesWithHiding,
+        hasItems("usage_granted_composite_type", "usage_granted_us_postal_code_domain"));
+    assertThat(typesWithHiding,
+        not(hasItems("no_grants_composite_type", "no_grants_us_postal_code_domain")));
+    typesWithNoHiding =
+        getTypeNames(nonhidingDatabaseMetaData, "no_privileges_schema");
+    assertThat(typesWithNoHiding,
+        hasItems("usage_granted_composite_type", "no_grants_composite_type",
+            "usage_granted_us_postal_code_domain", "no_grants_us_postal_code_domain"));
+  }
+
+  /*
+  From the Postgres JDBC driver source code, we are mapping the types:
+      java.sql.Types.DISTINCT to the Postgres type:  TYPTYPE_COMPOSITE  'c'   # composite (e.g., table's rowtype)
+      java.sql.Types.STRUCT   to the Postgres type:  TYPTYPE_DOMAIN     'd'   # domain over another type
+   */
+  List<String> getTypeNames(DatabaseMetaData databaseMetaData, String schemaPattern)
+      throws SQLException {
+    List<String> typeNames = new ArrayList<String>();
+    ResultSet rs = databaseMetaData.getUDTs(null, schemaPattern, null, null);
+    while (rs.next()) {
+      typeNames.add(rs.getString("TYPE_NAME"));
+    }
+    return typeNames;
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc4/DatabaseMetaDataHideUnprivilegedObjectsTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc4/DatabaseMetaDataHideUnprivilegedObjectsTest.java
@@ -86,9 +86,10 @@ public class DatabaseMetaDataHideUnprivilegedObjectsTest {
   private static void createTestDataObjectsWithRangeOfPrivilegesInSchema(String schema)
       throws SQLException {
     TestUtil.createSchema(privilegedCon, schema);
-    createSimpleTablesInSchema(schema,
-        new String[]{"owned_table", "all_grants_table", "insert_granted_table",
-            "select_granted_table", "no_grants_table"});
+
+    String[] tables = new String[]{"owned_table", "all_grants_table", "insert_granted_table",
+        "select_granted_table", "no_grants_table"};
+    createSimpleTablesInSchema(schema,tables);
 
     Statement stmt = privilegedCon.createStatement();
     stmt.executeUpdate(
@@ -129,16 +130,26 @@ public class DatabaseMetaDataHideUnprivilegedObjectsTest {
           "GRANT USAGE on TYPE " + schema + "." + "usage_granted_us_postal_code_domain TO "
               + TestUtil.getUser());
     }
+
     stmt.executeUpdate(
-        "REVOKE ALL ON ALL FUNCTIONS IN SCHEMA " + schema + " FROM public RESTRICT");
+        "REVOKE ALL ON FUNCTION " + schema + ".execute_granted_add_function(integer, integer) FROM public RESTRICT");
     stmt.executeUpdate(
-        "REVOKE ALL ON ALL FUNCTIONS IN SCHEMA " + schema + " FROM " + TestUtil.getUser()
+        "REVOKE ALL ON FUNCTION " + schema + ".no_grants_add_function(integer, integer) FROM public RESTRICT");
+    stmt.executeUpdate(
+        "REVOKE ALL ON FUNCTION " + schema + ".execute_granted_add_function(integer, integer) FROM " + TestUtil.getUser()
             + " RESTRICT");
     stmt.executeUpdate(
-        "REVOKE ALL ON ALL TABLES IN SCHEMA " + schema + " FROM public RESTRICT");
-    stmt.executeUpdate(
-        "REVOKE ALL ON ALL TABLES IN SCHEMA " + schema + " FROM " + TestUtil.getUser()
+        "REVOKE ALL ON FUNCTION " + schema + ".no_grants_add_function(integer, integer) FROM " + TestUtil.getUser()
             + " RESTRICT");
+
+    for (String table : tables) {
+      stmt.executeUpdate(
+          "REVOKE ALL ON TABLE " + schema + "." + table + " FROM public RESTRICT");
+      stmt.executeUpdate(
+          "REVOKE ALL ON TABLE " + schema + "." + table + " FROM " + TestUtil.getUser()
+              + " RESTRICT");
+    }
+
     stmt.executeUpdate(
         "GRANT ALL ON FUNCTION " + schema + "."
             + "execute_granted_add_function(integer, integer) TO "

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc4/DatabaseMetaDataHideUnprivilegedObjectsTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc4/DatabaseMetaDataHideUnprivilegedObjectsTest.java
@@ -12,7 +12,6 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 import org.postgresql.PGProperty;
-import org.postgresql.core.Utils;
 import org.postgresql.test.TestUtil;
 
 import org.junit.AfterClass;
@@ -398,9 +397,9 @@ public class DatabaseMetaDataHideUnprivilegedObjectsTest {
     // session's search_path (as well as whether or not the role has usage on the schema).
     // N.B. do not use Connection.setSchema() because pgjdbc needs to work with openjdk6.
     Statement stmt = databaseMetaData.getConnection().createStatement();
-    stmt.executeUpdate("SET SESSION search_path TO '"+schemaPattern+"',public");
+    stmt.executeUpdate("SET SESSION search_path TO '" + schemaPattern + "',public");
     stmt.close();
-    
+
     ResultSet rs = databaseMetaData.getFunctions(null, schemaPattern, null);
     while (rs.next()) {
       functionNames.add(rs.getString("FUNCTION_NAME"));

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc4/DatabaseMetaDataHideUnprivilegedObjectsTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc4/DatabaseMetaDataHideUnprivilegedObjectsTest.java
@@ -1,25 +1,22 @@
-/*-------------------------------------------------------------------------
-*
-* Copyright (c) 2004-2016, PostgreSQL Global Development Group
-*
-*
-*-------------------------------------------------------------------------
-*/
+/*
+ * Copyright (c) 2017, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
 package org.postgresql.test.jdbc4;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
-import org.postgresql.test.TestUtil;
 import org.postgresql.PGProperty;
+import org.postgresql.test.TestUtil;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
-import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.fail;
 
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
@@ -393,13 +390,13 @@ public class DatabaseMetaDataHideUnprivilegedObjectsTest {
   List<String> getFunctionNames(DatabaseMetaData databaseMetaData, String schemaPattern)
       throws SQLException {
     List<String> functionNames = new ArrayList<String>();
-    
+
     // Set the search_path to schemaPattern because PgDatabaseMetaData.getFunctions()
     // has a WHERE clause that uses pg_function_is_visible(oid). This function returns
-    // a boolean that describes whether or not the function is visible in your 
+    // a boolean that describes whether or not the function is visible in your
     // session's search_path (as well as whether or not the role has usage on the schema).
     databaseMetaData.getConnection().setSchema(schemaPattern);
-    
+
     ResultSet rs = databaseMetaData.getFunctions(null, schemaPattern, null);
     while (rs.next()) {
       functionNames.add(rs.getString("FUNCTION_NAME"));

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc4/Jdbc4TestSuite.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc4/Jdbc4TestSuite.java
@@ -25,7 +25,8 @@ import org.junit.runners.Suite;
         CharacterStreamTest.class,
         UUIDTest.class,
         LibPQFactoryHostNameTest.class,
-        XmlTest.class
+        XmlTest.class,
+        DatabaseMetaDataHideUnprivilegedObjectsTest.class
 })
 public class Jdbc4TestSuite {
 }


### PR DESCRIPTION
This pull request asks for the same change as #647. However, I have taken Scott's changes and rebased them against the current master. Here's the text from Scott's original pull request:

... to show only the items for which the current user has access.

I named the connection parameter:
hideUnprivilegedObjects
and defaulted it to 'false'.

This works for me. I did not add a test case. If I did so, it would need to use the privileged user. Let me know if that's what you'd like me to do.

Thanks.