### PR TITLE
feat: Allow PgConnection with custom QueryExecutor

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
@@ -179,9 +179,24 @@ public class PgConnection implements BaseConnection {
                       String database,
                       Properties info,
                       String url) throws SQLException {
+    // Make the initial connection and set up local state
+    this(defaultQueryExecutor(hostSpecs, user, database, info), info, url);
+  }
+
+  private static QueryExecutor defaultQueryExecutor(HostSpec[] hostSpecs,
+                                                    String user,
+                                                    String database,
+                                                    Properties info) throws SQLException {
     // Print out the driver version number
     LOGGER.log(Level.FINE, org.postgresql.util.DriverInfo.DRIVER_FULL_NAME);
 
+    return ConnectionFactory.openConnection(hostSpecs, user, database, info);
+  }
+
+  // allow extending the driver via external behavior
+  public PgConnection(QueryExecutor executor, Properties info, String url) throws SQLException {
+
+    this.queryExecutor = executor;
     this.creatingURL = url;
 
     setDefaultFetchSize(PGProperty.DEFAULT_ROW_FETCH_SIZE.getInt(info));
@@ -190,9 +205,6 @@ public class PgConnection implements BaseConnection {
     if (prepareThreshold == -1) {
       setForceBinary(true);
     }
-
-    // Now make the initial connection and set up local state
-    this.queryExecutor = ConnectionFactory.openConnection(hostSpecs, user, database, info);
 
     // WARNING for unsupported servers (8.1 and lower are not supported)
     if (LOGGER.isLoggable(Level.WARNING) && !haveMinimumServerVersion(ServerVersion.v8_2)) {


### PR DESCRIPTION
Extension point for injecting custom behavior in the driver while retaining all of the existing functionality