### PR TITLE
Make JSON type loading conditional upon server support

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/Oid.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/Oid.java
@@ -70,6 +70,7 @@ public class Oid {
   public static final int POINT = 600;
   public static final int POINT_ARRAY = 1017;
   public static final int BOX = 603;
+  public static final int JSONB = 3802;
   public static final int JSONB_ARRAY = 3807;
   public static final int JSON = 114;
   public static final int JSON_ARRAY = 199;

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
@@ -311,6 +311,14 @@ public class PgConnection implements BaseConnection {
       types.addCoreType("xml", Oid.XML, Types.SQLXML, "java.sql.SQLXML", Oid.XML_ARRAY);
     }
 
+    if (haveMinimumServerVersion(ServerVersion.v9_2)) {
+      types.addCoreType("json", Oid.JSON, Types.JAVA_OBJECT, "org.postgresql.util.PGobject", Oid.JSON_ARRAY);
+    }
+
+    if (haveMinimumServerVersion(ServerVersion.v9_4)) {
+      types.addCoreType("jsonb", Oid.JSONB, Types.JAVA_OBJECT, "org.postgresql.util.PGobject", Oid.JSONB_ARRAY);
+    }
+
     this._clientInfo = new Properties();
     if (haveMinimumServerVersion(ServerVersion.v9_0)) {
       String appName = PGProperty.APPLICATION_NAME.get(info);

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
@@ -241,6 +241,7 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
       case Types.DISTINCT:
       case Types.STRUCT:
       case Types.NULL:
+      case Types.JAVA_OBJECT:
       case Types.OTHER:
         oid = Oid.UNSPECIFIED;
         break;

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
@@ -90,7 +90,6 @@ public class TypeInfoCache implements TypeInfo {
       //#if mvn.project.property.postgresql.jdbc.spec >= "JDBC4.2"
       {"refcursor", Oid.REF_CURSOR, Types.REF_CURSOR, "java.sql.ResultSet", Oid.REF_CURSOR_ARRAY},
       //#endif
-      {"json", Oid.JSON, Types.OTHER, "org.postgresql.util.PGobject", Oid.JSON_ARRAY},
       {"point", Oid.POINT, Types.OTHER, "org.postgresql.geometric.PGpoint", Oid.POINT_ARRAY}
   };
 


### PR DESCRIPTION
It's partly feature, partly fix. Not sure how to tag it.

And adding the JAVA_OBJECT to the acceptable null types fixes a small issue in an experiment of mine. The rest of the time it works fine, when the values are not nulls.

Changing the SQL type integer constant from OTHER to JAVA_OBJECT (while having no positive or negative effect) makes it consistent with the Hibernate JPA provider's choice for type association. Even though they don't fully support it out-of-the-box. I've checked with EclipseLink and OpenJPA and they're even further behind on this, with no

Reference [1](https://github.com/hibernate/hibernate-orm/blob/master/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQL92Dialect.java)