### PR TITLE
fix: handle Timestamp values with fractional seconds < 1 microsecond correctly in PreparedStatement arguments

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/TimestampUtils.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/TimestampUtils.java
@@ -654,17 +654,18 @@ public class TimestampUtils {
     sb.append(':');
     sb.append(NUMBERS[seconds]);
 
-    // Add nanoseconds.
+    // Add microseconds, rounded.
     // This won't work for server versions < 7.2 which only want
     // a two digit fractional second, but we don't need to support 7.1
     // anymore and getting the version number here is difficult.
     //
-    if (nanos == 0) {
+    int microseconds = (nanos / 1000) + (((nanos % 1000) + 500) / 1000);
+    if (microseconds == 0) {
       return;
     }
     sb.append('.');
     int len = sb.length();
-    sb.append(nanos / 1000); // append microseconds
+    sb.append(microseconds);
     int needZeros = 6 - (sb.length() - len);
     if (needZeros > 0) {
       sb.insert(len, ZEROS, 0, needZeros);

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/TimestampTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/TimestampTest.java
@@ -332,6 +332,10 @@ public class TimestampTest extends BaseTest4 {
         stmt.executeUpdate(TestUtil.insertSQL(TSWOTZ_TABLE, "'" + TS6WOTZ_PGFORMAT + "'")));
     assertEquals(1,
         stmt.executeUpdate(TestUtil.insertSQL(TSWOTZ_TABLE, "'" + TS7WOTZ_PGFORMAT + "'")));
+    assertEquals(1,
+        stmt.executeUpdate(TestUtil.insertSQL(TSWOTZ_TABLE, "'" + TS8WOTZ_PGFORMAT + "'")));
+    assertEquals(1,
+        stmt.executeUpdate(TestUtil.insertSQL(TSWOTZ_TABLE, "'" + TS9WOTZ_PGFORMAT + "'")));
 
     assertEquals(1,
         stmt.executeUpdate(TestUtil.insertSQL(TSWOTZ_TABLE, "'" + TS1WOTZ_PGFORMAT + "'")));
@@ -347,6 +351,10 @@ public class TimestampTest extends BaseTest4 {
         stmt.executeUpdate(TestUtil.insertSQL(TSWOTZ_TABLE, "'" + TS6WOTZ_PGFORMAT + "'")));
     assertEquals(1,
         stmt.executeUpdate(TestUtil.insertSQL(TSWOTZ_TABLE, "'" + TS7WOTZ_PGFORMAT + "'")));
+    assertEquals(1,
+        stmt.executeUpdate(TestUtil.insertSQL(TSWOTZ_TABLE, "'" + TS8WOTZ_PGFORMAT + "'")));
+    assertEquals(1,
+        stmt.executeUpdate(TestUtil.insertSQL(TSWOTZ_TABLE, "'" + TS9WOTZ_PGFORMAT + "'")));
 
     assertEquals(1,
         stmt.executeUpdate(TestUtil.insertSQL(TSWOTZ_TABLE, "'" + TS1WOTZ_PGFORMAT + "'")));
@@ -362,6 +370,10 @@ public class TimestampTest extends BaseTest4 {
         stmt.executeUpdate(TestUtil.insertSQL(TSWOTZ_TABLE, "'" + TS6WOTZ_PGFORMAT + "'")));
     assertEquals(1,
         stmt.executeUpdate(TestUtil.insertSQL(TSWOTZ_TABLE, "'" + TS7WOTZ_PGFORMAT + "'")));
+    assertEquals(1,
+        stmt.executeUpdate(TestUtil.insertSQL(TSWOTZ_TABLE, "'" + TS8WOTZ_PGFORMAT + "'")));
+    assertEquals(1,
+        stmt.executeUpdate(TestUtil.insertSQL(TSWOTZ_TABLE, "'" + TS9WOTZ_PGFORMAT + "'")));
 
     assertEquals(1, stmt.executeUpdate(TestUtil.insertSQL(TSWOTZ_TABLE,
         "'" + tsu.toString(null, new java.sql.Timestamp(tmpDate1WOTZ.getTime())) + "'")));
@@ -377,6 +389,8 @@ public class TimestampTest extends BaseTest4 {
         "'" + tsu.toString(null, new java.sql.Timestamp(tmpDate6WOTZ.getTime())) + "'")));
     assertEquals(1, stmt.executeUpdate(TestUtil.insertSQL(TSWOTZ_TABLE,
         "'" + tsu.toString(null, new java.sql.Timestamp(tmpDate7WOTZ.getTime())) + "'")));
+    assertEquals(1, stmt.executeUpdate(TestUtil.insertSQL(TSWOTZ_TABLE,
+        "'" + tsu.toString(null, new java.sql.Timestamp(tmpDate8WOTZ.getTime())) + "'")));
 
     assertEquals(1, stmt.executeUpdate(TestUtil.insertSQL(TSWOTZ_TABLE,
         "'" + tsu.toString(null, new java.sql.Timestamp(tmpTime1WOTZ.getTime())) + "'")));
@@ -392,11 +406,13 @@ public class TimestampTest extends BaseTest4 {
         "'" + tsu.toString(null, new java.sql.Timestamp(tmpTime6WOTZ.getTime())) + "'")));
     assertEquals(1, stmt.executeUpdate(TestUtil.insertSQL(TSWOTZ_TABLE,
         "'" + tsu.toString(null, new java.sql.Timestamp(tmpTime7WOTZ.getTime())) + "'")));
+    assertEquals(1, stmt.executeUpdate(TestUtil.insertSQL(TSWOTZ_TABLE,
+        "'" + tsu.toString(null, new java.sql.Timestamp(tmpTime8WOTZ.getTime())) + "'")));
 
     // Fall through helper
     timestampTestWOTZ();
 
-    assertEquals(35, stmt.executeUpdate("DELETE FROM " + TSWOTZ_TABLE));
+    assertEquals(43, stmt.executeUpdate("DELETE FROM " + TSWOTZ_TABLE));
 
     stmt.close();
   }
@@ -436,6 +452,12 @@ public class TimestampTest extends BaseTest4 {
     pstmt.setTimestamp(1, TS7WOTZ);
     assertEquals(1, pstmt.executeUpdate());
 
+    pstmt.setTimestamp(1, TS8WOTZ);
+    assertEquals(1, pstmt.executeUpdate());
+
+    pstmt.setTimestamp(1, TS9WOTZ);
+    assertEquals(1, pstmt.executeUpdate());
+
     // With java.sql.Timestamp
     pstmt.setObject(1, TS1WOTZ, Types.TIMESTAMP);
     assertEquals(1, pstmt.executeUpdate());
@@ -450,6 +472,10 @@ public class TimestampTest extends BaseTest4 {
     pstmt.setObject(1, TS6WOTZ, Types.TIMESTAMP);
     assertEquals(1, pstmt.executeUpdate());
     pstmt.setObject(1, TS7WOTZ, Types.TIMESTAMP);
+    assertEquals(1, pstmt.executeUpdate());
+    pstmt.setObject(1, TS8WOTZ, Types.TIMESTAMP);
+    assertEquals(1, pstmt.executeUpdate());
+    pstmt.setObject(1, TS9WOTZ, Types.TIMESTAMP);
     assertEquals(1, pstmt.executeUpdate());
 
     // With Strings
@@ -467,6 +493,10 @@ public class TimestampTest extends BaseTest4 {
     assertEquals(1, pstmt.executeUpdate());
     pstmt.setObject(1, TS7WOTZ_PGFORMAT, Types.TIMESTAMP);
     assertEquals(1, pstmt.executeUpdate());
+    pstmt.setObject(1, TS8WOTZ_PGFORMAT, Types.TIMESTAMP);
+    assertEquals(1, pstmt.executeUpdate());
+    pstmt.setObject(1, TS9WOTZ_PGFORMAT, Types.TIMESTAMP);
+    assertEquals(1, pstmt.executeUpdate());
 
     // With java.sql.Date
     pstmt.setObject(1, tmpDate1WOTZ, Types.TIMESTAMP);
@@ -482,6 +512,8 @@ public class TimestampTest extends BaseTest4 {
     pstmt.setObject(1, tmpDate6WOTZ, Types.TIMESTAMP);
     assertEquals(1, pstmt.executeUpdate());
     pstmt.setObject(1, tmpDate7WOTZ, Types.TIMESTAMP);
+    assertEquals(1, pstmt.executeUpdate());
+    pstmt.setObject(1, tmpDate8WOTZ, Types.TIMESTAMP);
     assertEquals(1, pstmt.executeUpdate());
 
     // With java.sql.Time
@@ -499,10 +531,12 @@ public class TimestampTest extends BaseTest4 {
     assertEquals(1, pstmt.executeUpdate());
     pstmt.setObject(1, tmpTime7WOTZ, Types.TIMESTAMP);
     assertEquals(1, pstmt.executeUpdate());
+    pstmt.setObject(1, tmpTime8WOTZ, Types.TIMESTAMP);
+    assertEquals(1, pstmt.executeUpdate());
     // Fall through helper
     timestampTestWOTZ();
 
-    assertEquals(35, stmt.executeUpdate("DELETE FROM " + TSWOTZ_TABLE));
+    assertEquals(43, stmt.executeUpdate("DELETE FROM " + TSWOTZ_TABLE));
 
     pstmt.close();
     stmt.close();
@@ -663,6 +697,24 @@ public class TimestampTest extends BaseTest4 {
       tString = rs.getString(1);
       assertNotNull(tString);
       assertEquals(TS7WOTZ_PGFORMAT, tString);
+
+      assertTrue(rs.next());
+      t = rs.getTimestamp(1);
+      assertNotNull(t);
+      assertEquals(TS8WOTZ, t);
+
+      tString = rs.getString(1);
+      assertNotNull(tString);
+      assertEquals(TS8WOTZ_PGFORMAT, tString);
+
+      assertTrue(rs.next());
+      t = rs.getTimestamp(1);
+      assertNotNull(t);
+      assertEquals(TS9WOTZ_ROUNDED, t);
+
+      tString = rs.getString(1);
+      assertNotNull(tString);
+      assertEquals(TS9WOTZ_ROUNDED_PGFORMAT, tString);
     }
 
     // Testing for Date
@@ -701,6 +753,11 @@ public class TimestampTest extends BaseTest4 {
     assertNotNull(t);
     assertEquals(tmpDate7WOTZ.getTime(), t.getTime());
 
+    assertTrue(rs.next());
+    t = rs.getTimestamp(1);
+    assertNotNull(t);
+    assertEquals(tmpDate8WOTZ.getTime(), t.getTime());
+
     // Testing for Time
     assertTrue(rs.next());
     t = rs.getTimestamp(1);
@@ -736,6 +793,11 @@ public class TimestampTest extends BaseTest4 {
     t = rs.getTimestamp(1);
     assertNotNull(t);
     assertEquals(tmpTime7WOTZ.getTime(), t.getTime());
+
+    assertTrue(rs.next());
+    t = rs.getTimestamp(1);
+    assertNotNull(t);
+    assertEquals(tmpTime8WOTZ.getTime(), t.getTime());
 
     assertTrue(!rs.next()); // end of table. Fail if more entries exist.
 
@@ -816,6 +878,17 @@ public class TimestampTest extends BaseTest4 {
       getTimestamp(2000, 7, 7, 15, 0, 0, 0, null);
   private static final String TS7WOTZ_PGFORMAT = "2000-07-07 15:00:00";
 
+  private static final java.sql.Timestamp TS8WOTZ =
+      getTimestamp(2000, 7, 7, 15, 0, 0, 20400000, null);
+  private static final String TS8WOTZ_PGFORMAT = "2000-07-07 15:00:00.0204";
+
+  private static final java.sql.Timestamp TS9WOTZ =
+      getTimestamp(2000, 2, 7, 15, 0, 0, 789, null);
+  private static final String TS9WOTZ_PGFORMAT = "2000-02-07 15:00:00.000000789";
+  private static final java.sql.Timestamp TS9WOTZ_ROUNDED =
+      getTimestamp(2000, 2, 7, 15, 0, 0, 1000, null);
+  private static final String TS9WOTZ_ROUNDED_PGFORMAT = "2000-02-07 15:00:00.000001";
+
   private static final String TSWTZ_TABLE = "testtimestampwtz";
   private static final String TSWOTZ_TABLE = "testtimestampwotz";
   private static final String DATE_TABLE = "testtimestampdate";
@@ -843,6 +916,7 @@ public class TimestampTest extends BaseTest4 {
   private static final java.sql.Date tmpTime6WOTZ = new java.sql.Date(TS6WOTZ.getTime());
   private static final java.sql.Date tmpDate7WOTZ = new java.sql.Date(TS7WOTZ.getTime());
   private static final java.sql.Time tmpTime7WOTZ = new java.sql.Time(TS7WOTZ.getTime());
-
+  private static final java.sql.Date tmpDate8WOTZ = new java.sql.Date(TS8WOTZ.getTime());
+  private static final java.sql.Time tmpTime8WOTZ = new java.sql.Time(TS8WOTZ.getTime());
 
 }


### PR DESCRIPTION
When Timestamp values with nanosecond values < 1000 are submitted as arguments to a PreparedStatement,
avoid formatting them with a trailing dot '.' after the seconds part. This fixes a regression introduced
with PR #896.

closes #1117

Implementation note: the rounding with `Math.round` is necessary to ensure consistent behavior when inserting a timestamp value inlined or as prepared statement argument:

This will insert `2000-02-07 15:00:00.000001`:

```
INSERT INTO testtable (col)
VALUES (timestamp '2000-02-07 15:00:00.000000789')
```
whereas this Statement
```
INSERT INTO testtable (col)
VALUES (timestamp ?)
```
will first format the timestamp as a string with microsecond precision and send that to the server. Without rounding, there would be no way to make both the `testSetTimestampWOTZ` and `testGetTimestampWOTZ` green at the same time, no matter whether I expect 0.000000789 to be rounded up or down.