### PR TITLE
docs: fix JavaDoc for getPreferQueryMode()

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/PGConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGConnection.java
@@ -204,12 +204,14 @@ public interface PGConnection {
   String escapeLiteral(String literal) throws SQLException;
 
   /**
-   * Returns true if the connection is configured to use "simple 'Q' execute" commands only
-   * When running in simple protocol only, certain features are not available: callable statements,
+   * Returns the query mode for this connection.
+   * <p>
+   * When running in simple query mode, certain features are not available: callable statements,
    * partial result set fetch, bytea type, etc.
    * The list of supported features is subject to change.
    *
-   * @return true if the connection is configured to use "simple 'Q' execute" commands only
+   * @return the preferred query mode
+   * @see PreferQueryMode
    */
   PreferQueryMode getPreferQueryMode();
 


### PR DESCRIPTION
Update the JavaDoc to show that the return type is PreferQueryMode rather than boolean.