### PR TITLE
docs: remove protocolVersion

### DIFF
--- a/docs/documentation/head/connect.md
+++ b/docs/documentation/head/connect.md
@@ -135,11 +135,6 @@ Connection conn = DriverManager.getConnection(url);
 
 	Sets SO_RCVBUF on the connection stream
 
-* **protocolVersion** = int
-
-	The driver supports the V3 frontend/backend protocols. The V3 protocol was introduced in 7.4 and
-	the driver will by default try to	connect using the V3 protocol.
- 
 * **loggerLevel** = String
 
 	Logger level of the driver. Allowed values: <code>OFF</code>, <code>DEBUG</code> or <code>TRACE</code>.


### PR DESCRIPTION
The only supported backend/frontend protocol version is V3 since REL42.0.0 (committed Nov 14, 2016, released Feb 18, 2017).
Removing it here makes this list consistent with pgjdbc/README.md in regards to protocolVersion.