### PR TITLE
docs: improve documentation and tests for server-side prepared statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Notable changes since version 42.0.0, read the complete [History of Changes](htt
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+### Added
+- Documentation on server-side prepared statements [PR 1135](https://github.com/pgjdbc/pgjdbc/pull/1135)
+
 ### Fixed
 - Avoid failure for `insert ... on conflict...update` for `reWriteBatchedInserts=true` case [PR 1130](https://github.com/pgjdbc/pgjdbc/pull/1130)
 - fix: allowEncodingChanges should allow set client_encoding=... [PR 1125](https://github.com/pgjdbc/pgjdbc/pull/1125)

--- a/docs/documentation/head/server-prepare.md
+++ b/docs/documentation/head/server-prepare.md
@@ -18,11 +18,10 @@ beginning with server version 7.3, and at the protocol level beginning with serv
 version 7.4, but as Java developers we really just want to use the standard
 `PreparedStatement` interface.
 
-> Server side prepared statements are planned only once by the server. This avoids
-the cost of replanning the query every time, but also means that the planner
-cannot take advantage of the particular parameter values used in a particular
-execution of the query. You should be cautious about enabling the use of server
-side prepared statements globally.
+> PostgreSQL 9.2 release notes: prepared statements used to be optimized once, without any knowledge
+of the parameters' values. With 9.2, the planner will use specific plans regarding to the parameters
+sent (the query will be planned at execution), except if the query is executed several times and
+the planner decides that the generic plan is not too much more expensive than the specific plans.
 
 Server side prepared statements can improve execution speed as
 1. It sends just statement handle (e.g. `S_1`) instead of full SQL text

--- a/docs/documentation/head/server-prepare.md
+++ b/docs/documentation/head/server-prepare.md
@@ -107,7 +107,7 @@ The recommendation is:
 
 There are explicit commands to deallocate all server side prepared statements. It would result in
 the following server-side error message: `prepared statement name is invalid`.
-Of course it could defeat pgjdbc, however there are cases when you need to discard statements (e.g. after lots of DLLs)
+Of course it could defeat pgjdbc, however there are cases when you need to discard statements (e.g. after lots of DDLs)
 
 The recommendation is:
 1. Use simple `DEALLOCATE ALL` and/or `DISCARD ALL` commands, avoid nesting the commands into pl/pgsql or alike. The driver does understand top-level DEALLOCATE/DISCARD commands, and it invalidates client-side cache as well

--- a/docs/documentation/head/server-prepare.md
+++ b/docs/documentation/head/server-prepare.md
@@ -46,23 +46,23 @@ reaches the threshold it will start to use server side prepared statements.
 Even though reusing of the same `PreparedStatement` object good for performance reasons, the driver
 is able to server-prepare statements automatically across `connection.prepareStatement(...)` calls.
 
-Server-prepared statements consume memory both at client and server side, so pgjdbc limits the number
+Server-prepared statements consume memory both on the client and the server, so pgjdbc limits the number
 of server-prepared statements per connection. It can be configured via `preparedStatementCacheQueries`
 (default `256`, the number of queries known to pgjdbc), and `preparedStatementCacheSizeMiB` (default `5`,
-that is client side cache size in megabytes per connection). Only a subset of `statement cache` is
+that is the client side cache size in megabytes per connection). Only a subset of `statement cache` is
 server-prepared as some of the statements might fail to reach `prepareThreshold`.
 
 ### Deactivation
 
 There might be cases when you would want to disable use of server-prepared statements.
-For instance, if you route connections through a balancer that is unable to speak server-prepared statements,
+For instance, if you route connections through a balancer that is incompatible with server-prepared statements,
 you have little choice.
 
 You can disable usage of server side prepared statements by setting `prepareThreshold=0`
 
 ### Corner cases
 
-#### DLL
+#### DDL
 
 V3 protocol avoids sending column metadata on each execution, and BIND message specifies output column format.
 That creates a problem for cases like
@@ -98,7 +98,7 @@ With great power the following case could happen:
     SELECT * FROM mytable; -- Does mytable mean app_v1.mytable or app_v2.mytable here?
 
 Server side prepared statements are linked to database object IDs, so it could fetch data from "old"
-`app_v1.mytable` table. It is hard to tell which behavior is expected, however pgjdbc tries to track
+`app_v1.mytable` table. It is hard to tell which behaviour is expected, however pgjdbc tries to track
 `search_path` changes, and it invalidates prepare cache accordingly.
 
 The recommendation is:
@@ -108,14 +108,14 @@ pgjdbc won't be able to identify `search_path` change
 
 #### Re-execution of failed statements
 
-It is a pity that a single `cached plan must not change result type` could fail the whole transaction.
+It is a pity that a single `cached plan must not change result type` could cause the whole transaction to fail.
 The driver could re-execute the statement automatically in certain cases.
 
-1. In case the transaction is not failed (e.g. the transaction did not exist before execution of
+1. In case the transaction has not failed (e.g. the transaction did not exist before execution of
 the statement that caused `cached plan...` error), then pgjdbc re-executes the statement automatically.
-This makes application happy, and avoids unnecessary errors.
+This makes the application happy, and avoids unnecessary errors.
 1. In case the transaction is in a failed state, there's nothing to do but rollback it. pgjdbc does have
-"automatic savepoint" feature, and it could automatically rollback and retry the statement. The behavior
+"automatic savepoint" feature, and it could automatically rollback and retry the statement. The behaviour
 is controlled via `autosave` property (default `never`). The value of `conservative` would auto-rollback
 for the errors related to invalid server-prepared statements.
 Note: `autosave` might result in **severe** performance issues for long transactions, as PostgreSQL backend
@@ -124,7 +124,7 @@ is not optimized for the case of long transactions and lots of savepoints.
 #### Replication connection
 
 PostgreSQL replication connection does not allow to use server side prepared statements, so pgjdbc
-uses simple queries in case `replication` connection property is activated.
+uses simple queries in the case where `replication` connection property is activated.
 
 #### Use of server-prepared statements for con.createStatement()
 
@@ -135,7 +135,7 @@ performance by caching the statement. Of course it is better to use `PreparedSta
 however the driver has an option to cache simple statements as well.
 
 You can do that by setting `preferQueryMode` to `extendedCacheEverything`.
-Note: the option is more of a diagnostinc/debugging sort, so be careful as you change it.
+Note: the option is more of a diagnostinc/debugging sort, so be careful how you use it .
 
 #### Bind placeholder datatypes
 
@@ -162,7 +162,7 @@ parameter types.
 This gets especially painful for batch operations as you don't want to interrupt the batch
 by using alternating datatypes.
 
-The most typical case is as follows (don't **ever** use that in production):
+The most typical case is as follows (don't ever use this in production):
 
     PreparedStatement ps = con.prepareStatement("select id from rooms where ...");
     if (param instanceof String) {

--- a/docs/documentation/head/server-prepare.md
+++ b/docs/documentation/head/server-prepare.md
@@ -26,8 +26,8 @@ side prepared statements globally.
 
 Server side prepared statements can improve execution speed as
 1. It sends just statement handle (e.g. `S_1`) instead of full SQL text
-1. It enables use of binary transfer (e.g. binary int4, binary timestamps, etc), and it is much faster to parse
-1. It enables to reuse server-side execution plan
+1. It enables use of binary transfer (e.g. binary int4, binary timestamps, etc); the parameters and results are much faster to parse
+1. It enables the reuse server-side execution plan
 1. The client can reuse result set column definition, so it does not have to receive and parse metadata on each execution
 
 ### Activation

--- a/docs/documentation/head/server-prepare.md
+++ b/docs/documentation/head/server-prepare.md
@@ -167,18 +167,20 @@ The most typical case is as follows (don't **ever** use that in production):
     PreparedStatement ps = con.prepareStatement("select id from rooms where ...");
     if (param instanceof String) {
         ps.setString(1, param);
-    } else if (param instanceof String) {
+    } else if (param instanceof Integer) {
         ps.setInt(1, ((Integer) param).intValue());
     } else {
         // Does it really matter which type of NULL to use?
-        ps.setNull(1, Types.OTHER);
+        // In fact, it does since data types specify which server-procedure to call
+        ps.setNull(1, Types.INTEGER);
     }
 
-As you might guess, `setString` vs `setNull(..., Types.OTHER)` result in alternating datatypes,
+As you might guess, `setString` vs `setNull(..., Types.INTEGER)` result in alternating datatypes,
 and it forces the driver to invalidate and re-prepare server side statement.
 
 Recommendation is to use the consistent datatype for each bind placeholder, and use the same type
 for `setNull`.
+Check out `org.postgresql.test.jdbc2.PreparedStatementTest.testAlternatingBindType` example for more details.
 
 #### Debugging
 

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/AutoRollbackTestSuite.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/AutoRollbackTestSuite.java
@@ -135,6 +135,10 @@ public class AutoRollbackTestSuite extends BaseTest4 {
   @Override
   public void setUp() throws Exception {
     super.setUp();
+    if (testSql == TestStatement.WITH_INSERT_SELECT) {
+      assumeMinimumServerVersion(ServerVersion.v9_1);
+    }
+
     TestUtil.createTable(con, "rollbacktest", "a int, str text");
     con.setAutoCommit(autoCommit == AutoCommit.YES);
     BaseConnection baseConnection = con.unwrap(BaseConnection.class);

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/AutoRollbackTestSuite.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/AutoRollbackTestSuite.java
@@ -210,7 +210,7 @@ public class AutoRollbackTestSuite extends BaseTest4 {
   @Test
   public void run() throws SQLException {
     if (continueMode == ContinueMode.IS_VALID) {
-      // make "isValid" a server-prepared testSql
+      // make "isValid" a server-prepared statement
       con.isValid(4);
     } else if (continueMode == ContinueMode.COMMIT) {
       doCommit();
@@ -284,7 +284,7 @@ public class AutoRollbackTestSuite extends BaseTest4 {
           if (!flushCacheOnDeallocate && DEALLOCATES.contains(failMode)
               && autoSave == AutoSave.NEVER) {
             Assert.assertEquals(
-                "flushCacheOnDeallocate is disabled, thus " + failMode + " should cause 'prepared testSql \"...\" does not exist'"
+                "flushCacheOnDeallocate is disabled, thus " + failMode + " should cause 'prepared statement \"...\" does not exist'"
                     + " error message is " + e.getMessage(),
                 PSQLState.INVALID_SQL_STATEMENT_NAME.getState(), e.getSQLState());
             return;
@@ -309,7 +309,7 @@ public class AutoRollbackTestSuite extends BaseTest4 {
     }
 
     try {
-      // Try execute server-prepared testSql again
+      // Try execute server-prepared statement again
       ps.executeQuery().close();
       rowsExpected += testSql.rowsInserted;
       executeSqlSuccess();
@@ -325,7 +325,7 @@ public class AutoRollbackTestSuite extends BaseTest4 {
       if (autoSave == AutoSave.NEVER && autoCommit == AutoCommit.NO) {
         if (DEALLOCATES.contains(failMode) && !flushCacheOnDeallocate) {
           Assert.assertEquals(
-              "flushCacheOnDeallocate is disabled, thus " + failMode + " should cause 'prepared testSql \"...\" does not exist'"
+              "flushCacheOnDeallocate is disabled, thus " + failMode + " should cause 'prepared statement \"...\" does not exist'"
                   + " error message is " + e.getMessage(),
               PSQLState.INVALID_SQL_STATEMENT_NAME.getState(), e.getSQLState());
         } else if (failMode == FailMode.ALTER) {

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BaseTest4.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BaseTest4.java
@@ -104,6 +104,11 @@ public class BaseTest4 {
     Assume.assumeTrue(binaryMode == BinaryMode.REGULAR);
   }
 
+  public void assumeBinaryModeForce() {
+    Assume.assumeTrue(binaryMode == BinaryMode.FORCE);
+    Assume.assumeTrue(preferQueryMode != PreferQueryMode.SIMPLE);
+  }
+
   /**
    * Shorthand for {@code Assume.assumeTrue(TestUtil.haveMinimumServerVersion(conn, version)}
    */


### PR DESCRIPTION
Just in case: I have added `with x as (insert into rollbacktest(a, str) values(43, 'abc') returning ${cols})
select * from x` test case, and it does work "as expected".

That is it might produce `cached plan...` error in case it is using `returning *`. When that happens, pgjdbc could auto re-execute the statement (e.g. if no transaction was present) and it does overcome the error automatically. 

The PR depends on #1137