### PR TITLE
fix: support generated keys for WITH queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Adjust XAException return codes for better compatibility with XA specification [PR 782](https://github.com/pgjdbc/pgjdbc/pull/782)
 - Wrong results when single statement is used with different bind types[PR 1137](https://github.com/pgjdbc/pgjdbc/pull/1137)
 - Support generated keys for WITH queries that miss RETURNING [PR 1138](https://github.com/pgjdbc/pgjdbc/pull/1138)
+- Support generated keys when INSERT/UPDATE/DELETE keyword is followed by a comment [PR 1138](https://github.com/pgjdbc/pgjdbc/pull/1138)
 
 ## [42.2.1] (2018-01-25)
 ### Known issues

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Wrong data from Blob/Clob when mark/reset is used [PR 971](https://github.com/pgjdbc/pgjdbc/pull/971)
 - Adjust XAException return codes for better compatibility with XA specification [PR 782](https://github.com/pgjdbc/pgjdbc/pull/782)
 - Wrong results when single statement is used with different bind types[PR 1137](https://github.com/pgjdbc/pgjdbc/pull/1137)
+- Support generated keys for WITH queries that miss RETURNING [PR 1138](https://github.com/pgjdbc/pgjdbc/pull/1138)
 
 ## [42.2.1] (2018-01-25)
 ### Known issues

--- a/pgjdbc/src/main/java/org/postgresql/core/Parser.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/Parser.java
@@ -294,7 +294,8 @@ public class Parser {
     }
     if (currentCommandType != SqlCommandType.INSERT
         && currentCommandType != SqlCommandType.UPDATE
-        && currentCommandType != SqlCommandType.DELETE) {
+        && currentCommandType != SqlCommandType.DELETE
+        && currentCommandType != SqlCommandType.WITH) {
       return false;
     }
 

--- a/pgjdbc/src/main/java/org/postgresql/core/SqlCommand.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/SqlCommand.java
@@ -6,6 +6,8 @@
 package org.postgresql.core;
 
 import static org.postgresql.core.SqlCommandType.INSERT;
+import static org.postgresql.core.SqlCommandType.SELECT;
+import static org.postgresql.core.SqlCommandType.WITH;
 
 /**
  * Data Modification Language inspection support.
@@ -35,6 +37,10 @@ public class SqlCommand {
 
   public boolean isReturningKeywordPresent() {
     return parsedSQLhasRETURNINGKeyword;
+  }
+
+  public boolean returnsRows() {
+    return parsedSQLhasRETURNINGKeyword || commandType == SELECT || commandType == WITH;
   }
 
   public static SqlCommand createStatementTypeInfo(SqlCommandType type,

--- a/pgjdbc/src/test/java/org/postgresql/core/ParserTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/core/ParserTest.java
@@ -163,6 +163,17 @@ public class ParserTest {
   }
 
   @Test
+  public void insertReturningInWith() throws SQLException {
+    String query =
+        "with x as (insert into mytab(x) values(1) returning x) insert test(id, name) select 1, 'value' from test2";
+    List<NativeQuery> qry =
+        Parser.parseJdbcSql(
+            query, true, true, true, true);
+    boolean returningKeywordPresent = qry.get(0).command.isReturningKeywordPresent();
+    Assert.assertFalse("There's no top-level <<returning>> clause " + query, returningKeywordPresent);
+  }
+
+  @Test
   public void insertBatchedReWriteOnConflict() throws SQLException {
     String query = "insert into test(id, name) values (:id,:name) ON CONFLICT (id) DO NOTHING";
     List<NativeQuery> qry = Parser.parseJdbcSql(query, true, true, true, true);

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc3/CompositeQueryParseTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc3/CompositeQueryParseTest.java
@@ -156,11 +156,19 @@ public class CompositeQueryParseTest {
   }
 
   @Test
-  public void testWith() throws SQLException {
+  public void testWithSelect() throws SQLException {
     List<NativeQuery> queries;
-    queries = Parser.parseJdbcSql("with update as insert (update foo set (a=?,b=?,c=?)) select * from update", true, true, false, true);
+    queries = Parser.parseJdbcSql("with update as (update foo set (a=?,b=?,c=?)) select * from update", true, true, false, true);
     NativeQuery query = queries.get(0);
-    assertEquals("This is a WITH command", SqlCommandType.WITH, query.command.getType());
+    assertEquals("with ... () select", SqlCommandType.SELECT, query.command.getType());
+  }
+
+  @Test
+  public void testWithInsert() throws SQLException {
+    List<NativeQuery> queries;
+    queries = Parser.parseJdbcSql("with update as (update foo set (a=?,b=?,c=?)) insert into table(select) values(1)", true, true, false, true);
+    NativeQuery query = queries.get(0);
+    assertEquals("with ... () insert", SqlCommandType.INSERT, query.command.getType());
   }
 
   @Test

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc3/GeneratedKeysTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc3/GeneratedKeysTest.java
@@ -13,6 +13,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import org.postgresql.PGStatement;
+import org.postgresql.core.ServerVersion;
 import org.postgresql.test.TestUtil;
 import org.postgresql.test.jdbc2.BaseTest4;
 import org.postgresql.util.PSQLState;
@@ -224,6 +225,7 @@ public class GeneratedKeysTest extends BaseTest4 {
 
   @Test
   public void testWithInsertInsert() throws SQLException {
+    assumeMinimumServerVersion(ServerVersion.v9_1);
     Statement stmt = con.createStatement();
     int count = stmt.executeUpdate(
         "WITH x as (INSERT INTO genkeys (b,c) VALUES ('a', 2) returning c) insert into genkeys(a,b,c) VALUES (1, 'a', 2)" + returningClause + "",

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc3/GeneratedKeysTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc3/GeneratedKeysTest.java
@@ -238,6 +238,20 @@ public class GeneratedKeysTest extends BaseTest4 {
   }
 
   @Test
+  public void testWithInsertSelect() throws SQLException {
+    assumeMinimumServerVersion(ServerVersion.v9_1);
+    Statement stmt = con.createStatement();
+    int count = stmt.executeUpdate(
+        "WITH x as (INSERT INTO genkeys(a,b,c) VALUES (1, 'a', 2) returning "+returningClause+") select * from x",
+        new String[]{"c", "b"});
+    assertEquals(1, count);
+    ResultSet rs = stmt.getGeneratedKeys();
+    assertTrue(rs.next());
+    assertCB1(rs);
+    assertTrue(!rs.next());
+  }
+
+  @Test
   public void testDelete() throws SQLException {
     Statement stmt = con.createStatement();
     stmt.executeUpdate("INSERT INTO genkeys VALUES (1, 'a', 2)");

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc3/GeneratedKeysTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc3/GeneratedKeysTest.java
@@ -18,6 +18,7 @@ import org.postgresql.test.TestUtil;
 import org.postgresql.test.jdbc2.BaseTest4;
 import org.postgresql.util.PSQLState;
 
+import org.junit.Assume;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -240,12 +241,14 @@ public class GeneratedKeysTest extends BaseTest4 {
   @Test
   public void testWithInsertSelect() throws SQLException {
     assumeMinimumServerVersion(ServerVersion.v9_1);
+    Assume.assumeTrue(returningInQuery != ReturningInQuery.NO);
     Statement stmt = con.createStatement();
     int count = stmt.executeUpdate(
-        "WITH x as (INSERT INTO genkeys(a,b,c) VALUES (1, 'a', 2) returning "+returningClause+") select * from x",
+        "WITH x as (INSERT INTO genkeys(a,b,c) VALUES (1, 'a', 2) "+returningClause+") select * from x",
         new String[]{"c", "b"});
-    assertEquals(1, count);
-    ResultSet rs = stmt.getGeneratedKeys();
+    assertEquals("rowcount", -1, count);
+    // TODO: should SELECT produce rows through getResultSet or getGeneratedKeys?
+    ResultSet rs = stmt.getResultSet();
     assertTrue(rs.next());
     assertCB1(rs);
     assertTrue(!rs.next());

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc3/GeneratedKeysTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc3/GeneratedKeysTest.java
@@ -244,7 +244,8 @@ public class GeneratedKeysTest extends BaseTest4 {
     Assume.assumeTrue(returningInQuery != ReturningInQuery.NO);
     Statement stmt = con.createStatement();
     int count = stmt.executeUpdate(
-        "WITH x as (INSERT INTO genkeys(a,b,c) VALUES (1, 'a', 2) "+returningClause+") select * from x",
+        "WITH x as (INSERT INTO genkeys(a,b,c) VALUES (1, 'a', 2) " + returningClause
+            + ") select * from x",
         new String[]{"c", "b"});
     assertEquals("rowcount", -1, count);
     // TODO: should SELECT produce rows through getResultSet or getGeneratedKeys?

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc3/GeneratedKeysTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc3/GeneratedKeysTest.java
@@ -200,7 +200,7 @@ public class GeneratedKeysTest extends BaseTest4 {
   public void testSerialWorks() throws SQLException {
     Statement stmt = con.createStatement();
     int count = stmt.executeUpdate(
-        "INSERT INTO genkeys (b,c) VALUES ('a', 2), ('b', 4)" + returningClause + "; ",
+        "INSERT/*fool parser*/ INTO genkeys (b,c) VALUES ('a', 2), ('b', 4)" + returningClause + "; ",
         new String[]{"a"});
     assertEquals(2, count);
     ResultSet rs = stmt.getGeneratedKeys();

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc3/GeneratedKeysTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc3/GeneratedKeysTest.java
@@ -223,6 +223,19 @@ public class GeneratedKeysTest extends BaseTest4 {
   }
 
   @Test
+  public void testWithInsertInsert() throws SQLException {
+    Statement stmt = con.createStatement();
+    int count = stmt.executeUpdate(
+        "WITH x as (INSERT INTO genkeys (b,c) VALUES ('a', 2) returning c) insert into genkeys(a,b,c) VALUES (1, 'a', 2)" + returningClause + "",
+        new String[]{"c", "b"});
+    assertEquals(1, count);
+    ResultSet rs = stmt.getGeneratedKeys();
+    assertTrue(rs.next());
+    assertCB1(rs);
+    assertTrue(!rs.next());
+  }
+
+  @Test
   public void testDelete() throws SQLException {
     Statement stmt = con.createStatement();
     stmt.executeUpdate("INSERT INTO genkeys VALUES (1, 'a', 2)");

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc3/Jdbc3TestSuite.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc3/Jdbc3TestSuite.java
@@ -16,6 +16,7 @@ import org.junit.runners.Suite;
     Jdbc3CallableStatementTest.class,
     GeneratedKeysTest.class,
     CompositeQueryParseTest.class,
+    SqlCommandParseTest.class,
     Jdbc3SavepointTest.class,
     TypesTest.class,
     ResultSetTest.class,

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc3/SqlCommandParseTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc3/SqlCommandParseTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2018, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
 package org.postgresql.test.jdbc3;
 
 import static org.junit.Assert.assertEquals;

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc3/SqlCommandParseTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc3/SqlCommandParseTest.java
@@ -1,0 +1,47 @@
+package org.postgresql.test.jdbc3;
+
+import static org.junit.Assert.assertEquals;
+
+import org.postgresql.core.NativeQuery;
+import org.postgresql.core.Parser;
+import org.postgresql.core.SqlCommandType;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.List;
+
+@RunWith(Parameterized.class)
+public class SqlCommandParseTest {
+  @Parameterized.Parameter(0)
+  public SqlCommandType type;
+  @Parameterized.Parameter(1)
+  public String sql;
+
+  @Parameterized.Parameters(name = "expected={0}, sql={1}")
+  public static Iterable<Object[]> data() {
+    return Arrays.asList(new Object[][]{
+        {SqlCommandType.INSERT, "insert/**/ into table(select) values(1)"},
+        {SqlCommandType.SELECT, "select'abc'/**/ as insert"},
+        {SqlCommandType.INSERT, "with update as (update foo set (a=?,b=?,c=?)) insert into table(select) values(1)"},
+        {SqlCommandType.INSERT, "with update as (update foo set (a=?,b=?,c=?)) insert/**/ into table(select) values(1)"},
+        {SqlCommandType.INSERT, "with update as (update foo set (a=?,b=?,c=?)) insert /**/ into table(select) values(1)"},
+        {SqlCommandType.SELECT, "with update as (update foo set (a=?,b=?,c=?)) insert --\nas () select 1"},
+        {SqlCommandType.SELECT, "with update as (update foo set (a=?,b=?,c=?)) insert --\n/* dfhg \n*/\nas () select 1"},
+        {SqlCommandType.SELECT, "WITH x as (INSERT INTO genkeys(a,b,c) VALUES (1, 'a', 2) returning  returning a, b) select * from x"},
+        // No idea if it works, but it should be parsed as WITH
+        {SqlCommandType.WITH, "with update as (update foo set (a=?,b=?,c=?)) copy from stdin"},
+    });
+  }
+
+  @Test
+  public void run() throws SQLException {
+    List<NativeQuery> queries;
+    queries = Parser.parseJdbcSql(sql, true, true, false, true);
+    NativeQuery query = queries.get(0);
+    assertEquals(sql, type, query.command.getType());
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc3/SqlCommandParseTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc3/SqlCommandParseTest.java
@@ -32,6 +32,7 @@ public class SqlCommandParseTest {
         {SqlCommandType.INSERT, "insert/**/ into table(select) values(1)"},
         {SqlCommandType.SELECT, "select'abc'/**/ as insert"},
         {SqlCommandType.INSERT, "with update as (update foo set (a=?,b=?,c=?)) insert into table(select) values(1)"},
+        {SqlCommandType.INSERT, "with update as (update foo set (a=?,b=?,c=?)) insert into table(select) select * from update"},
         {SqlCommandType.INSERT, "with update as (update foo set (a=?,b=?,c=?)) insert/**/ into table(select) values(1)"},
         {SqlCommandType.INSERT, "with update as (update foo set (a=?,b=?,c=?)) insert /**/ into table(select) values(1)"},
         {SqlCommandType.SELECT, "with update as (update foo set (a=?,b=?,c=?)) insert --\nas () select 1"},

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc3/SqlCommandParseTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc3/SqlCommandParseTest.java
@@ -31,6 +31,7 @@ public class SqlCommandParseTest {
     return Arrays.asList(new Object[][]{
         {SqlCommandType.INSERT, "insert/**/ into table(select) values(1)"},
         {SqlCommandType.SELECT, "select'abc'/**/ as insert"},
+        {SqlCommandType.INSERT, "INSERT/*fool /*nest comments -- parser*/*/ INTO genkeys (b,c) VALUES ('a', 2), ('b', 4) SELECT"},
         {SqlCommandType.INSERT, "with update as (update foo set (a=?,b=?,c=?)) insert into table(select) values(1)"},
         {SqlCommandType.INSERT, "with update as (update foo set (a=?,b=?,c=?)) insert into table(select) select * from update"},
         {SqlCommandType.INSERT, "with update as (update foo set (a=?,b=?,c=?)) insert/**/ into table(select) values(1)"},


### PR DESCRIPTION
pgjdbc ignored to add RETURNING to WITH queries even though it makes sense.

fixes #1104