### PR TITLE
Seperate HostnameVerifier from LibPQFactory

### DIFF
--- a/docs/documentation/head/connect.md
+++ b/docs/documentation/head/connect.md
@@ -117,7 +117,7 @@ Connection conn = DriverManager.getConnection(url);
 
 * **sslhostnameverifier** = String
 
-	Class name of hostname verifier. Defaults to using `org.postgresql.ssl.jdbc4.LibPQFactory.verify()`
+	Class name of hostname verifier. Defaults to using `org.postgresql.ssl.jdbc4.LibPQVerifier.verify()`
 
 * **sslpasswordcallback** = String
 

--- a/pgjdbc/src/main/java/org/postgresql/ssl/MakeSSL.java
+++ b/pgjdbc/src/main/java/org/postgresql/ssl/MakeSSL.java
@@ -8,6 +8,7 @@ package org.postgresql.ssl;
 import org.postgresql.PGProperty;
 import org.postgresql.core.PGStream;
 import org.postgresql.ssl.jdbc4.LibPQFactory;
+import org.postgresql.ssl.jdbc4.LibPQVerifier;
 import org.postgresql.util.GT;
 import org.postgresql.util.ObjectFactory;
 import org.postgresql.util.PSQLException;
@@ -86,8 +87,8 @@ public class MakeSSL extends ObjectFactory {
             PSQLState.CONNECTION_FAILURE);
       }
     } else {
-      if ("verify-full".equals(sslmode) && factory instanceof LibPQFactory) {
-        if (!(((LibPQFactory) factory).verify(stream.getHostSpec().getHost(),
+      if ("verify-full".equals(sslmode)) {
+        if (!(new LibPQVerifier().verify(stream.getHostSpec().getHost(),
             newConnection.getSession()))) {
           throw new PSQLException(
               GT.tr("The hostname {0} could not be verified.", stream.getHostSpec().getHost()),

--- a/pgjdbc/src/main/java/org/postgresql/ssl/jdbc4/LibPQFactory.java
+++ b/pgjdbc/src/main/java/org/postgresql/ssl/jdbc4/LibPQFactory.java
@@ -24,34 +24,21 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateFactory;
-import java.security.cert.CertificateParsingException;
-import java.security.cert.X509Certificate;
-import java.util.Collection;
-import java.util.List;
 import java.util.Properties;
 
-import javax.naming.InvalidNameException;
-import javax.naming.ldap.LdapName;
-import javax.naming.ldap.Rdn;
-import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLPeerUnverifiedException;
-import javax.net.ssl.SSLSession;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
 import javax.security.auth.callback.Callback;
 import javax.security.auth.callback.CallbackHandler;
 import javax.security.auth.callback.PasswordCallback;
 import javax.security.auth.callback.UnsupportedCallbackException;
-import javax.security.auth.x500.X500Principal;
 
 /**
  * Provide an SSLSocketFactory that is compatible with the libpq behaviour.
  */
-public class LibPQFactory extends WrappedFactory implements HostnameVerifier {
-
-  private static final int ALT_DNS_NAME = 2;
+public class LibPQFactory extends WrappedFactory {
 
   LazyKeyManager km = null;
   String sslmode;
@@ -232,98 +219,5 @@ public class LibPQFactory extends WrappedFactory implements HostnameVerifier {
       }
 
     }
-  }
-
-  public static boolean verifyHostName(String hostname, String pattern) {
-    if (hostname == null || pattern == null) {
-      return false;
-    }
-    if (!pattern.startsWith("*")) {
-      // No wildcard => just compare hostnames
-      return hostname.equalsIgnoreCase(pattern);
-    }
-    // pattern starts with *, so hostname should be at least (pattern.length-1) long
-    if (hostname.length() < pattern.length() - 1) {
-      return false;
-    }
-    // Compare ignore case
-    final boolean ignoreCase = true;
-    // Below code is "hostname.endsWithIgnoreCase(pattern.withoutFirstStar())"
-
-    // E.g. hostname==sub.host.com; pattern==*.host.com
-    // We need to start the offset of ".host.com" in hostname
-    // For this we take hostname.length() - pattern.length()
-    // and +1 is required since pattern is known to start with *
-    int toffset = hostname.length() - pattern.length() + 1;
-
-    // Wildcard covers just one domain level
-    // a.b.c.com should not be covered by *.c.com
-    if (hostname.lastIndexOf('.', toffset - 1) >= 0) {
-      // If there's a dot in between 0..toffset
-      return false;
-    }
-
-    return hostname.regionMatches(ignoreCase, toffset,
-        pattern, 1, pattern.length() - 1);
-  }
-
-  /**
-   * Verifies the server certificate according to the libpq rules. The cn attribute of the
-   * certificate is matched against the hostname. If the cn attribute starts with an asterisk (*),
-   * it will be treated as a wildcard, and will match all characters except a dot (.). This means
-   * the certificate will not match subdomains. If the connection is made using an IP address
-   * instead of a hostname, the IP address will be matched (without doing any DNS lookups).
-   *
-   * @param hostname Hostname or IP address of the server.
-   * @param session The SSL session.
-   * @return true if the certificate belongs to the server, false otherwise.
-   */
-  public boolean verify(String hostname, SSLSession session) {
-    X509Certificate[] peerCerts;
-    try {
-      peerCerts = (X509Certificate[]) session.getPeerCertificates();
-    } catch (SSLPeerUnverifiedException e) {
-      return false;
-    }
-    if (peerCerts == null || peerCerts.length == 0) {
-      return false;
-    }
-    // Extract the common name
-    X509Certificate serverCert = peerCerts[0];
-
-    try {
-      // Check for Subject Alternative Names (see RFC 6125)
-      Collection<List<?>> subjectAltNames = serverCert.getSubjectAlternativeNames();
-
-      if (subjectAltNames != null) {
-        for (List<?> sanit : subjectAltNames) {
-          Integer type = (Integer) sanit.get(0);
-          String san = (String) sanit.get(1);
-
-          // this mimics libpq check for ALT_DNS_NAME
-          if (type != null && type == ALT_DNS_NAME && verifyHostName(hostname, san)) {
-            return true;
-          }
-        }
-      }
-    } catch (CertificateParsingException e) {
-      return false;
-    }
-
-    LdapName DN;
-    try {
-      DN = new LdapName(serverCert.getSubjectX500Principal().getName(X500Principal.RFC2253));
-    } catch (InvalidNameException e) {
-      return false;
-    }
-    String CN = null;
-    for (Rdn rdn : DN.getRdns()) {
-      if ("CN".equals(rdn.getType())) {
-        // Multiple AVAs are not treated
-        CN = (String) rdn.getValue();
-        break;
-      }
-    }
-    return verifyHostName(hostname, CN);
   }
 }

--- a/pgjdbc/src/main/java/org/postgresql/ssl/jdbc4/LibPQVerifier.java
+++ b/pgjdbc/src/main/java/org/postgresql/ssl/jdbc4/LibPQVerifier.java
@@ -1,0 +1,111 @@
+package org.postgresql.ssl.jdbc4;
+
+import java.security.cert.CertificateParsingException;
+import java.security.cert.X509Certificate;
+import java.util.Collection;
+import java.util.List;
+import javax.naming.InvalidNameException;
+import javax.naming.ldap.LdapName;
+import javax.naming.ldap.Rdn;
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSession;
+import javax.security.auth.x500.X500Principal;
+
+public class LibPQVerifier implements HostnameVerifier {
+
+  private static final int ALT_DNS_NAME = 2;
+
+  public static boolean verifyHostName(String hostname, String pattern) {
+    if (hostname == null || pattern == null) {
+      return false;
+    }
+    if (!pattern.startsWith("*")) {
+      // No wildcard => just compare hostnames
+      return hostname.equalsIgnoreCase(pattern);
+    }
+    // pattern starts with *, so hostname should be at least (pattern.length-1) long
+    if (hostname.length() < pattern.length() - 1) {
+      return false;
+    }
+    // Compare ignore case
+    final boolean ignoreCase = true;
+    // Below code is "hostname.endsWithIgnoreCase(pattern.withoutFirstStar())"
+
+    // E.g. hostname==sub.host.com; pattern==*.host.com
+    // We need to start the offset of ".host.com" in hostname
+    // For this we take hostname.length() - pattern.length()
+    // and +1 is required since pattern is known to start with *
+    int toffset = hostname.length() - pattern.length() + 1;
+
+    // Wildcard covers just one domain level
+    // a.b.c.com should not be covered by *.c.com
+    if (hostname.lastIndexOf('.', toffset - 1) >= 0) {
+      // If there's a dot in between 0..toffset
+      return false;
+    }
+
+    return hostname.regionMatches(ignoreCase, toffset,
+        pattern, 1, pattern.length() - 1);
+  }
+
+  /**
+   * Verifies the server certificate according to the libpq rules. The cn attribute of the
+   * certificate is matched against the hostname. If the cn attribute starts with an asterisk (*),
+   * it will be treated as a wildcard, and will match all characters except a dot (.). This means
+   * the certificate will not match subdomains. If the connection is made using an IP address
+   * instead of a hostname, the IP address will be matched (without doing any DNS lookups).
+   *
+   * @param hostname Hostname or IP address of the server.
+   * @param session The SSL session.
+   * @return true if the certificate belongs to the server, false otherwise.
+   */
+  public boolean verify(String hostname, SSLSession session) {
+    X509Certificate[] peerCerts;
+    try {
+      peerCerts = (X509Certificate[]) session.getPeerCertificates();
+    } catch (SSLPeerUnverifiedException e) {
+      return false;
+    }
+    if (peerCerts == null || peerCerts.length == 0) {
+      return false;
+    }
+    // Extract the common name
+    X509Certificate serverCert = peerCerts[0];
+
+    try {
+      // Check for Subject Alternative Names (see RFC 6125)
+      Collection<List<?>> subjectAltNames = serverCert.getSubjectAlternativeNames();
+
+      if (subjectAltNames != null) {
+        for (List<?> sanit : subjectAltNames) {
+          Integer type = (Integer) sanit.get(0);
+          String san = (String) sanit.get(1);
+
+          // this mimics libpq check for ALT_DNS_NAME
+          if (type != null && type == ALT_DNS_NAME && verifyHostName(hostname, san)) {
+            return true;
+          }
+        }
+      }
+    } catch (CertificateParsingException e) {
+      return false;
+    }
+
+    LdapName DN;
+    try {
+      DN = new LdapName(serverCert.getSubjectX500Principal().getName(X500Principal.RFC2253));
+    } catch (InvalidNameException e) {
+      return false;
+    }
+    String CN = null;
+    for (Rdn rdn : DN.getRdns()) {
+      if ("CN".equals(rdn.getType())) {
+        // Multiple AVAs are not treated
+        CN = (String) rdn.getValue();
+        break;
+      }
+    }
+    return verifyHostName(hostname, CN);
+  }
+}

--- a/pgjdbc/src/main/java/org/postgresql/ssl/jdbc4/LibPQVerifier.java
+++ b/pgjdbc/src/main/java/org/postgresql/ssl/jdbc4/LibPQVerifier.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2004, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
 package org.postgresql.ssl.jdbc4;
 
 import java.security.cert.CertificateParsingException;

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc4/Jdbc4TestSuite.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc4/Jdbc4TestSuite.java
@@ -24,7 +24,7 @@ import org.junit.runners.Suite;
         BinaryStreamTest.class,
         CharacterStreamTest.class,
         UUIDTest.class,
-        LibPQFactoryHostNameTest.class,
+        LibPQVerifierHostNameTest.class,
         XmlTest.class
 })
 public class Jdbc4TestSuite {

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc4/LibPQVerifierHostNameTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc4/LibPQVerifierHostNameTest.java
@@ -5,7 +5,7 @@
 
 package org.postgresql.test.jdbc4;
 
-import org.postgresql.ssl.jdbc4.LibPQFactory;
+import org.postgresql.ssl.jdbc4.LibPQVerifier;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -15,13 +15,13 @@ import org.junit.runners.Parameterized;
 import java.util.Arrays;
 
 @RunWith(Parameterized.class)
-public class LibPQFactoryHostNameTest {
+public class LibPQVerifierHostNameTest {
 
   private final String hostname;
   private final String pattern;
   private final boolean expected;
 
-  public LibPQFactoryHostNameTest(String hostname, String pattern, boolean expected) {
+  public LibPQVerifierHostNameTest(String hostname, String pattern, boolean expected) {
     this.hostname = hostname;
     this.pattern = pattern;
     this.expected = expected;
@@ -52,6 +52,6 @@ public class LibPQFactoryHostNameTest {
 
   @Test
   public void checkPattern() throws Exception {
-    Assert.assertEquals(expected, LibPQFactory.verifyHostName(hostname, pattern));
+    Assert.assertEquals(expected, LibPQVerifier.verifyHostName(hostname, pattern));
   }
 }


### PR DESCRIPTION
Seperate hostname verification logic from LibPQFactory into LibPQVerifier.
This allows users to enable default hostname verification while using a custom SSLSocketFactory by specifying sslmode=verify-full or by setting the sslhostnameverifier property to the default LibPQVerifier implementation.

fixes #1140 