### PR TITLE
feat: Add cancelQuery() to PGConnection public interface

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/PGConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGConnection.java
@@ -183,6 +183,11 @@ public interface PGConnection {
   int getBackendPID();
 
   /**
+   * Sends a query cancellation for this connection.
+   */
+  void cancelQuery() throws SQLException;
+
+  /**
    * Return the given string suitably quoted to be used as an identifier in an SQL statement string.
    * Quotes are added only if necessary (i.e., if the string contains non-identifier characters or
    * would be case-folded). Embedded quotes are properly doubled.


### PR DESCRIPTION
Adds `cancelQuery()` to the extended public interface `PGConnection` to allow for issuing of cancels directly to connections rather than having to keep track of individual statements. The internals of the driver and the backend server already operate at a connection level (not a statement level) and this patch only exposes 
the existing cancelQuery() method publicly.

Exposing the `cancelQuery()` publicly is mainly a convenience thing as it's already part of all the concrete implementations. This is how how the server handles cancellation (i.e. at the connection, not statement, level) so I don't foresee any long term baggage associated with exposing this. The backend functionality is not going away.

There's been at least one other request for this in the past: #1084

Any thoughts on merging this in?