### PR TITLE
test: Add openjdk8 to travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,7 @@ script:
   - rm -rf $HOME/.m2/repository/org/postgresql || true
   - test -d "${JDK6_HOME}" || export JDK6_HOME=$(jdk_switcher home openjdk6)
   - test -d "${JDK7_HOME}" || export JDK7_HOME=$(jdk_switcher home openjdk7)
+  - test -d "${JDK8_HOME}" || export JDK8_HOME=$(jdk_switcher home openjdk8)
   - test -d "${JDK8_HOME}" || export JDK8_HOME=$(jdk_switcher home oraclejdk8)
   - test -d "${JDK9_HOME}" || export JDK9_HOME=$(jdk_switcher home oraclejdk9)
   - test -d "${JDK9_HOME}" || export JDK9_HOME=$(jdk_switcher home oraclejdk8) # JDK9 missing on precise, fallback to JDK8
@@ -153,6 +154,13 @@ matrix:
         - PG_VERSION=9.6
         - SSLTEST=Y
         - COVERAGE=Y
+    - jdk: openjdk8
+      addons:
+        postgresql: "9.6"
+      env:
+        - PG_VERSION=9.6
+        - JDK=8
+        - TZ=UTC
     - jdk: openjdk7
       sudo: required
       addons:


### PR DESCRIPTION
Adds openjdk8 to travis build matrix tested against backend server 9.6.

I added the config via a copy pasta of the oraclejdk9 matrix. It built okay but the overall Travis config is more complicated than the last time I've looked at this so would be good for someone else to spot check the change. Specifically I'm not sure if the addition on line 58 will mess up the existing oraclejdk8 setup: https://github.com/sehrope/pgjdbc/blob/6519725222ce7a20698043a820037687a8d86d7a/.travis.yml#L58