### PR TITLE
fix: setNull for types not in java.sql.Types (e.g. uuid)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 ### Changed
 - PreparedStatement.setNull(int parameterIndex, int t, String typeName) no longer ignores the typeName
-argument if it is not null [PR 1160]. 
+argument if it is not null [PR 1160](https://github.com/pgjdbc/pgjdbc/pull/1160)
+
 ### Added
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 ### Changed
-
+- PreparedStatement.setNull(int parameterIndex, int t, String typeName) no longer ignores the typeName
+argument if it is not null [PR 1160]. 
 ### Added
 
 ### Fixed

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
@@ -1232,9 +1232,23 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
     setLong(i, oid);
   }
 
-  public void setNull(int i, int t, String s) throws SQLException {
+  public void setNull(int parameterIndex, int t, String s) throws SQLException {
     checkClosed();
-    setNull(i, t);
+
+    if (s != null ) {
+      TypeInfo typeInfo = connection.getTypeInfo();
+
+      int oid = typeInfo.getPGType(s);
+
+      if (adjustIndex) {
+        parameterIndex--;
+      }
+
+      preparedParameters.setNull(parameterIndex, oid);
+
+    } else {
+      setNull(parameterIndex, t);
+    }
   }
 
   public void setRef(int i, Ref x) throws SQLException {

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
@@ -1232,23 +1232,25 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
     setLong(i, oid);
   }
 
-  public void setNull(int parameterIndex, int t, String s) throws SQLException {
+  public void setNull(int parameterIndex, int t, String typeName) throws SQLException {
+
+    if ( typeName == null ) {
+      setNull(parameterIndex, t);
+      return;
+    }
+
     checkClosed();
 
-    if (s != null ) {
-      TypeInfo typeInfo = connection.getTypeInfo();
+    TypeInfo typeInfo = connection.getTypeInfo();
 
-      int oid = typeInfo.getPGType(s);
+    int oid = typeInfo.getPGType(typeName);
 
-      if (adjustIndex) {
-        parameterIndex--;
-      }
-
-      preparedParameters.setNull(parameterIndex, oid);
-
-    } else {
-      setNull(parameterIndex, t);
+    if (adjustIndex) {
+      parameterIndex--;
     }
+
+    preparedParameters.setNull(parameterIndex, oid);
+
   }
 
   public void setRef(int i, Ref x) throws SQLException {

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
@@ -1234,7 +1234,7 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
 
   public void setNull(int parameterIndex, int t, String typeName) throws SQLException {
 
-    if ( typeName == null ) {
+    if (typeName == null) {
       setNull(parameterIndex, t);
       return;
     }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PreparedStatementTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PreparedStatementTest.java
@@ -7,12 +7,13 @@ package org.postgresql.test.jdbc2;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import org.postgresql.PGStatement;
+import org.postgresql.core.ServerVersion;
+import org.postgresql.core.Version;
 import org.postgresql.jdbc.PgStatement;
 import org.postgresql.jdbc.PreferQueryMode;
 import org.postgresql.test.TestUtil;
@@ -288,6 +289,7 @@ public class PreparedStatementTest extends BaseTest4 {
 
     pstmt.close();
 
+    assumeMinimumServerVersion(ServerVersion.v8_3);
     pstmt = con.prepareStatement("select 'ok' where ?=? or (? is null) ");
     pstmt.setObject(1, UUID.randomUUID(), Types.OTHER);
     pstmt.setNull(2, Types.OTHER, "uuid");

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PreparedStatementTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PreparedStatementTest.java
@@ -7,6 +7,7 @@ package org.postgresql.test.jdbc2;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -293,9 +294,9 @@ public class PreparedStatementTest extends BaseTest4 {
     pstmt.setNull(3, Types.OTHER, "uuid");
     ResultSet rs = pstmt.executeQuery();
 
-    while (rs.next()) {
-      assertEquals("ok",rs.getObject(1));
-    }
+    assertTrue(rs.next());
+    assertEquals("ok",rs.getObject(1));
+
     rs.close();
     pstmt.close();
 

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PreparedStatementTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PreparedStatementTest.java
@@ -13,7 +13,6 @@ import static org.junit.Assert.fail;
 
 import org.postgresql.PGStatement;
 import org.postgresql.core.ServerVersion;
-import org.postgresql.core.Version;
 import org.postgresql.jdbc.PgStatement;
 import org.postgresql.jdbc.PreferQueryMode;
 import org.postgresql.test.TestUtil;

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PreparedStatementTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PreparedStatementTest.java
@@ -294,9 +294,11 @@ public class PreparedStatementTest extends BaseTest4 {
     ResultSet rs = pstmt.executeQuery();
 
     while (rs.next()) {
-      rs.getObject(1);
+      assertEquals("ok",rs.getObject(1));
     }
+    rs.close();
     pstmt.close();
+
   }
 
   @Test

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PreparedStatementTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PreparedStatementTest.java
@@ -39,6 +39,7 @@ import java.sql.Timestamp;
 import java.sql.Types;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Handler;
@@ -284,6 +285,17 @@ public class PreparedStatementTest extends BaseTest4 {
     pstmt.setNull(1, Types.OTHER);
     pstmt.executeUpdate();
 
+    pstmt.close();
+
+    pstmt = con.prepareStatement("select 'ok' where ?=? or (? is null) ");
+    pstmt.setObject(1, UUID.randomUUID(), Types.OTHER);
+    pstmt.setNull(2, Types.OTHER, "uuid");
+    pstmt.setNull(3, Types.OTHER, "uuid");
+    ResultSet rs = pstmt.executeQuery();
+
+    while (rs.next()) {
+      rs.getObject(1);
+    }
     pstmt.close();
   }
 

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc4/ArrayTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc4/ArrayTest.java
@@ -560,7 +560,7 @@ public class ArrayTest extends BaseTest4 {
   public void nullArray() throws SQLException {
     PreparedStatement ps = con.prepareStatement("INSERT INTO arrtest(floatarr) VALUES (?)");
 
-    ps.setNull(1, Types.ARRAY, "float8");
+    ps.setNull(1, Types.ARRAY, "float8[]");
     ps.execute();
 
     ps.close();


### PR DESCRIPTION
Implement public void setNull(int parameterIndex, int t, String s)

Fixes #1159 