### PR TITLE
chore: add missing javadoc tags to avoid warnings

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/copy/CopyManager.java
+++ b/pgjdbc/src/main/java/org/postgresql/copy/CopyManager.java
@@ -3,10 +3,6 @@
  * See the LICENSE file in the project root for more information.
  */
 
-/**
- * Bulk data copy for PostgreSQL
- */
-
 package org.postgresql.copy;
 
 import org.postgresql.core.BaseConnection;

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
@@ -3027,7 +3027,7 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
    * @param bytes The bytes of the numeric field.
    * @param oid The oid of the field.
    * @param minVal the minimum value allowed.
-   * @param minVal the maximum value allowed.
+   * @param maxVal the maximum value allowed.
    * @param targetType The target type. Used for error reporting.
    * @return The value as long.
    * @throws PSQLException If the field type is not supported numeric type or if the value is out of

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/TimestampUtils.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/TimestampUtils.java
@@ -766,6 +766,8 @@ public class TimestampUtils {
   /**
    * Formats {@link LocalDateTime} to be sent to the backend, thus it adds time zone.
    * Do not use this method in {@link java.sql.ResultSet#getString(int)}
+   * @param localDateTime The local date to format as a String
+   * @return The formatted local date
    */
   public synchronized String toString(LocalDateTime localDateTime) {
     if (LocalDateTime.MAX.equals(localDateTime)) {

--- a/pgjdbc/src/main/java/org/postgresql/replication/PGReplicationConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/replication/PGReplicationConnection.java
@@ -39,6 +39,7 @@ public interface PGReplicationConnection {
 
   /**
    * @param slotName not null replication slot name exists in database that should be drop
+   * @throws SQLException if the replication slot cannot be dropped.
    */
   void dropReplicationSlot(String slotName) throws SQLException;
 }

--- a/pgjdbc/src/main/java/org/postgresql/replication/fluent/ChainedCommonStreamBuilder.java
+++ b/pgjdbc/src/main/java/org/postgresql/replication/fluent/ChainedCommonStreamBuilder.java
@@ -20,6 +20,7 @@ public interface ChainedCommonStreamBuilder<T extends ChainedCommonStreamBuilder
    * rows which could cause a recovery conflict even when the standby is disconnected.
    *
    * @param slotName not null replication slot already exists on server.
+   * @return this instance as a fluent interface
    */
   T withSlotName(String slotName);
 

--- a/pgjdbc/src/main/java/org/postgresql/sspi/NTDSAPI.java
+++ b/pgjdbc/src/main/java/org/postgresql/sspi/NTDSAPI.java
@@ -36,7 +36,8 @@ interface NTDSAPI extends StdCallLibrary {
    *        terminator (out)
    * @param spn SPN buffer (in/out)
    * @return Error code ERROR_SUCCESS, ERROR_BUFFER_OVERFLOW or ERROR_INVALID_PARAMETER
-   * @see "http://msdn.microsoft.com/en-us/library/ms676007(v=vs.85).aspx"
+   * @see <a href="https://msdn.microsoft.com/en-us/library/ms676007(v=vs.85).aspx">
+   *     https://msdn.microsoft.com/en-us/library/ms676007(v=vs.85).aspx</a>
    */
   int DsMakeSpnW(WString serviceClass, /* in */
       WString serviceName, /* in */

--- a/pgjdbc/src/main/java/org/postgresql/sspi/NTDSAPIWrapper.java
+++ b/pgjdbc/src/main/java/org/postgresql/sspi/NTDSAPIWrapper.java
@@ -24,8 +24,8 @@ public class NTDSAPIWrapper {
    * @param referrer See MSDN
    * @return SPN generated
    * @throws LastErrorException If buffer too small or parameter incorrect
-   * @see <a href="http://msdn.microsoft.com/en-us/library/ms676007(v=vs.85).aspx">http://msdn.
-   *      microsoft.com/en-us/library/ms676007</a>
+   * @see <a href="https://msdn.microsoft.com/en-us/library/ms676007(v=vs.85).aspx">
+   *     https://msdn.microsoft.com/en-us/library/ms676007(v=vs.85).aspx</a>
    */
   public String DsMakeSpn(String serviceClass, String serviceName, String instanceName,
       short instancePort, String referrer) throws LastErrorException {

--- a/pgjdbc/src/main/java/org/postgresql/util/Base64.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/Base64.java
@@ -126,7 +126,7 @@ public class Base64 {
       (byte) '6', (byte) '7', (byte) '8', (byte) '9', (byte) '+', (byte) '/'
   };
 
-  /** Determine which ALPHABET to use. */
+  /* Determine which ALPHABET to use. */
   static {
     byte[] __bytes;
     try {

--- a/pgjdbc/src/main/java/org/postgresql/util/MD5Digest.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/MD5Digest.java
@@ -5,15 +5,14 @@
 
 package org.postgresql.util;
 
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
 /**
  * MD5-based utility function to obfuscate passwords before network transmission.
  *
  * @author Jeremy Wohl
  */
-
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-
 public class MD5Digest {
   private MD5Digest() {
   }

--- a/pgjdbc/src/main/java/org/postgresql/util/WriterHandler.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/WriterHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements. See the NOTICE file
  * distributed with this work for additional information
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 
 package org.postgresql.util;
 

--- a/pgjdbc/src/main/java/org/postgresql/xa/PGXAConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/xa/PGXAConnection.java
@@ -152,9 +152,6 @@ public class PGXAConnection extends PGPooledConnection implements XAConnection, 
     }
   }
 
-
-  /**** XAResource interface ****/
-
   /**
    * Preconditions: 1. flags must be one of TMNOFLAGS, TMRESUME or TMJOIN 2. xid != null 3.
    * connection must not be associated with a transaction 4. the TM hasn't seen the xid before


### PR DESCRIPTION
Resolve a small number of warnings when generating the Javadoc