### PR TITLE
Fix typos in java8-date-time.md

### DIFF
--- a/docs/documentation/head/java8-date-time.md
+++ b/docs/documentation/head/java8-date-time.md
@@ -14,7 +14,7 @@ The PostgreSQL™ JDBC driver implements native support for the
 (JSR-310) using JDBC 4.2.
 
 <a name="8-date-time-supported-data-types"></a>
-**Table 5.1. Supported escaped numeric functions**
+**Table 5.1. Supported Java 8 Date and Time classes**
 
 <table summary="Supported data type" class="CALSTABLE" border="1">
   <tr>
@@ -43,12 +43,12 @@ The PostgreSQL™ JDBC driver implements native support for the
 
 This is closely aligned with tables B-4 and B-5 of the JDBC 4.2 specification.
 Note that `ZonedDateTime`, `Instant` and
-`OffsetTime / TIME [ WITHOUT TIME ZONE ]` are not supported. Also note
-that all `OffsetDateTime` will instances will have be in UTC (have offset 0).
+`OffsetTime / TIME WITH TIME ZONE` are not supported. Also note
+that all `OffsetDateTime` instances will have be in UTC (have offset 0).
 This is because the backend stores them as UTC.
 
 <a name="reading-example"></a>
-**Example 5.5. Reading Java 8 Date and Time values using JDBC**
+**Example 5.2. Reading Java 8 Date and Time values using JDBC**
 
 ```java
 Statement st = conn.createStatement();
@@ -68,7 +68,7 @@ Note that the Java data types needs to match the SQL data types in table 7.1.
 
 
 <a name="writing-example"></a>
-**Example 5.5. Writing Java 8 Date and Time values using JDBC**
+**Example 5.3. Writing Java 8 Date and Time values using JDBC**
 
 ```java
 LocalDate localDate = LocalDate.now();


### PR DESCRIPTION
Fix typos
Only OffsetTime / TIME [WITHOUT TIME ZONE] should be OffsetTime WITH TIME ZONE ...
Inconsistent examples numerous