### PR TITLE
fix: logger should be generally quiet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Notable changes since version 42.0.0, read the complete [History of Changes](htt
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+### Changed
+- Avoid the print of highest logger levels when the exception is re-thrown. [PR 1187](https://github.com/pgjdbc/pgjdbc/pull/1187)
 
 ## [42.2.2] (2018-03-15)
 ### Added

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -2608,7 +2608,7 @@ public class QueryExecutorImpl extends QueryExecutorBase {
     if (name.equals("client_encoding")) {
       if (allowEncodingChanges) {
         if (!value.equalsIgnoreCase("UTF8") && !value.equalsIgnoreCase("UTF-8")) {
-          LOGGER.log(Level.WARNING,
+          LOGGER.log(Level.FINE,
               "pgjdbc expects client_encoding to be UTF8 for proper operation. Actual encoding is {0}",
               value);
         }

--- a/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
+++ b/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
@@ -97,7 +97,7 @@ public abstract class BaseDataSource implements CommonDataSource, Referenceable 
       }
       return con;
     } catch (SQLException e) {
-      LOGGER.log(Level.SEVERE, "Failed to create a {0} for {1} at {2}: {3}",
+      LOGGER.log(Level.FINE, "Failed to create a {0} for {1} at {2}: {3}",
           new Object[]{getDescription(), user, getUrl(), e});
       throw e;
     }

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
@@ -1386,7 +1386,7 @@ public class PgConnection implements BaseConnection {
         // "current transaction aborted", assume the connection is up and running
         return true;
       }
-      LOGGER.log(Level.WARNING, GT.tr("Validating connection."), e);
+      LOGGER.log(Level.FINE, GT.tr("Validating connection."), e);
     }
     return false;
   }

--- a/pgjdbc/src/main/java/org/postgresql/sspi/SSPIClient.java
+++ b/pgjdbc/src/main/java/org/postgresql/sspi/SSPIClient.java
@@ -88,7 +88,7 @@ public class SSPIClient implements ISSPIClient {
        * won't have JNA and this will throw a NoClassDefFoundError.
        */
       if (!Platform.isWindows()) {
-        LOGGER.log(Level.WARNING, "SSPI not supported: non-Windows host");
+        LOGGER.log(Level.FINE, "SSPI not supported: non-Windows host");
         return false;
       }
       /* Waffle must be on the CLASSPATH */

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DriverTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DriverTest.java
@@ -65,10 +65,13 @@ public class DriverTest {
     verifyUrl(drv, "jdbc:postgresql://[::1]:5740/db", "[::1]", "5740", "db");
 
     // Badly formatted url's
-    assertTrue(!drv.acceptsURL("jdbc:postgres:test"));
-    assertTrue(!drv.acceptsURL("postgresql:test"));
-    assertTrue(!drv.acceptsURL("db"));
-    assertTrue(!drv.acceptsURL("jdbc:postgresql://localhost:5432a/test"));
+    assertFalse(drv.acceptsURL("jdbc:postgres:test"));
+    assertFalse(drv.acceptsURL("postgresql:test"));
+    assertFalse(drv.acceptsURL("db"));
+    assertFalse(drv.acceptsURL("jdbc:postgresql://localhost:5432a/test"));
+    assertFalse(drv.acceptsURL("jdbc:postgresql://localhost:500000/test"));
+    assertFalse(drv.acceptsURL("jdbc:postgresql://localhost:0/test"));
+    assertFalse(drv.acceptsURL("jdbc:postgresql://localhost:-2/test"));
 
     // failover urls
     verifyUrl(drv, "jdbc:postgresql://localhost,127.0.0.1:5432/test", "localhost,127.0.0.1",


### PR DESCRIPTION
The logger used in the driver has some calls to levels WARNING and SEVERE, this lower the level to FINE to make the logger quiet.

Changing SEVERE to WARNING is not enough, as WARNING is higher than INFO the default global logging level.

fixes #1009
fixes #1162
closes #1149