### PR TITLE
set the loggerName of the locally generated LogRecords (#1167)

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java
@@ -312,6 +312,8 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
       return;
     }
     LogRecord rec = new LogRecord(level, msg);
+    // Set the loggerName of the LogRecord with the current logger
+    rec.setLoggerName(LOGGER.getName());
     rec.setParameters(params);
     rec.setThrown(thrown);
     LOGGER.log(rec);


### PR DESCRIPTION
In ConnectionFactoryImpl.log function locally generates the logRecord
but doesn't set the loggerName of the current Logger, as a result
the log ignores the class or package level logging configuration