### PR TITLE
chore: update after_n_builds to 10

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,6 @@
 codecov:
   notify:
-    after_n_builds: 9
+    after_n_builds: 10
     require_ci_to_pass: false
 comment:
   layout: header, changes, diff


### PR DESCRIPTION
In .travis.yml there are actually 10 COVERAGE=Y