### PR TITLE
Encode url parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Wrong results when single statement is used with different bind types[PR 1137](https://github.com/pgjdbc/pgjdbc/pull/1137)
 - Support generated keys for WITH queries that miss RETURNING [PR 1138](https://github.com/pgjdbc/pgjdbc/pull/1138)
 - Support generated keys when INSERT/UPDATE/DELETE keyword is followed by a comment [PR 1138](https://github.com/pgjdbc/pgjdbc/pull/1138)
+- Properly encode special symbols in passwords in BaseDataSource [PR 1201](https://github.com/pgjdbc/pgjdbc/pull/1201)
 
 ## [42.2.1] (2018-01-25)
 ### Known issues

--- a/pgjdbc/src/main/java/org/postgresql/Driver.java
+++ b/pgjdbc/src/main/java/org/postgresql/Driver.java
@@ -14,13 +14,12 @@ import org.postgresql.util.HostSpec;
 import org.postgresql.util.PSQLException;
 import org.postgresql.util.PSQLState;
 import org.postgresql.util.SharedTimer;
+import org.postgresql.util.URLCoder;
 import org.postgresql.util.WriterHandler;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
 import java.net.URL;
-import java.net.URLDecoder;
 import java.security.AccessController;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
@@ -532,14 +531,6 @@ public class Driver implements java.sql.Driver {
     return false;
   }
 
-  private static String urlDecode(String encoded) {
-    try {
-      return URLDecoder.decode(encoded, "UTF-8");
-    } catch (UnsupportedEncodingException e) {
-      throw new IllegalStateException("Unable to decode via UTF-8. This should not happen", e);
-    }
-  }
-
   /**
    * Constructs a new DriverURL, splitting the specified URL into its component parts
    *
@@ -570,7 +561,7 @@ public class Driver implements java.sql.Driver {
       if (slash == -1) {
         return null;
       }
-      urlProps.setProperty("PGDBNAME", urlDecode(l_urlServer.substring(slash + 1));
+      urlProps.setProperty("PGDBNAME", URLCoder.decode(l_urlServer.substring(slash + 1)));
 
       String[] addresses = l_urlServer.substring(0, slash).split(",");
       StringBuilder hosts = new StringBuilder();
@@ -611,7 +602,7 @@ public class Driver implements java.sql.Driver {
         urlProps.setProperty("PGHOST", "localhost");
       }
       if (defaults == null || !defaults.containsKey("PGDBNAME")) {
-        urlProps.setProperty("PGDBNAME", urlDecode(l_urlServer));
+        urlProps.setProperty("PGDBNAME", URLCoder.decode(l_urlServer));
       }
     }
 
@@ -625,7 +616,7 @@ public class Driver implements java.sql.Driver {
       if (l_pos == -1) {
         urlProps.setProperty(token, "");
       } else {
-        urlProps.setProperty(token.substring(0, l_pos), urlDecode(token.substring(l_pos + 1)));
+        urlProps.setProperty(token.substring(0, l_pos), URLCoder.decode(token.substring(l_pos + 1)));
       }
     }
 

--- a/pgjdbc/src/main/java/org/postgresql/Driver.java
+++ b/pgjdbc/src/main/java/org/postgresql/Driver.java
@@ -18,6 +18,7 @@ import org.postgresql.util.WriterHandler;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.net.URLDecoder;
 import java.security.AccessController;
@@ -531,6 +532,14 @@ public class Driver implements java.sql.Driver {
     return false;
   }
 
+  private static String urlDecode(String encoded) {
+    try {
+      return URLDecoder.decode(encoded, "UTF-8");
+    } catch (UnsupportedEncodingException e) {
+      throw new IllegalStateException("Unable to decode via UTF-8. This should not happen", e);
+    }
+  }
+
   /**
    * Constructs a new DriverURL, splitting the specified URL into its component parts
    *
@@ -561,7 +570,7 @@ public class Driver implements java.sql.Driver {
       if (slash == -1) {
         return null;
       }
-      urlProps.setProperty("PGDBNAME", URLDecoder.decode(l_urlServer.substring(slash + 1)));
+      urlProps.setProperty("PGDBNAME", urlDecode(l_urlServer.substring(slash + 1));
 
       String[] addresses = l_urlServer.substring(0, slash).split(",");
       StringBuilder hosts = new StringBuilder();
@@ -602,7 +611,7 @@ public class Driver implements java.sql.Driver {
         urlProps.setProperty("PGHOST", "localhost");
       }
       if (defaults == null || !defaults.containsKey("PGDBNAME")) {
-        urlProps.setProperty("PGDBNAME", URLDecoder.decode(l_urlServer));
+        urlProps.setProperty("PGDBNAME", urlDecode(l_urlServer));
       }
     }
 
@@ -616,7 +625,7 @@ public class Driver implements java.sql.Driver {
       if (l_pos == -1) {
         urlProps.setProperty(token, "");
       } else {
-        urlProps.setProperty(token.substring(0, l_pos), URLDecoder.decode(token.substring(l_pos + 1)));
+        urlProps.setProperty(token.substring(0, l_pos), urlDecode(token.substring(l_pos + 1)));
       }
     }
 

--- a/pgjdbc/src/main/java/org/postgresql/core/UTF8Encoding.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/UTF8Encoding.java
@@ -8,6 +8,9 @@ package org.postgresql.core;
 import org.postgresql.util.GT;
 
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
 
 class UTF8Encoding extends Encoding {
   private static final int MIN_2_BYTES = 0x80;

--- a/pgjdbc/src/main/java/org/postgresql/core/UTF8Encoding.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/UTF8Encoding.java
@@ -8,9 +8,6 @@ package org.postgresql.core;
 import org.postgresql.util.GT;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.net.URLDecoder;
-import java.net.URLEncoder;
 
 class UTF8Encoding extends Encoding {
   private static final int MIN_2_BYTES = 0x80;

--- a/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
+++ b/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
@@ -19,6 +19,8 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.PrintWriter;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
@@ -1063,32 +1065,36 @@ public abstract class BaseDataSource implements CommonDataSource, Referenceable 
    * @return {@link DriverManager} URL from the other properties supplied
    */
   public String getUrl() {
-    StringBuilder url = new StringBuilder(100);
-    url.append("jdbc:postgresql://");
-    url.append(serverName);
-    if (portNumber != 0) {
-      url.append(":").append(portNumber);
-    }
-    url.append("/").append(databaseName);
-
-    StringBuilder query = new StringBuilder(100);
-    for (PGProperty property : PGProperty.values()) {
-      if (property.isPresent(properties)) {
-        if (query.length() != 0) {
-          query.append("&");
-        }
-        query.append(property.getName());
-        query.append("=");
-        query.append(property.get(properties));
+    try {
+      StringBuilder url = new StringBuilder(100);
+      url.append("jdbc:postgresql://");
+      url.append(serverName);
+      if (portNumber != 0) {
+        url.append(":").append(portNumber);
       }
-    }
+      url.append("/").append(URLEncoder.encode(databaseName, "UTF-8"));
 
-    if (query.length() > 0) {
-      url.append("?");
-      url.append(query);
-    }
+      StringBuilder query = new StringBuilder(100);
+      for (PGProperty property : PGProperty.values()) {
+        if (property.isPresent(properties)) {
+          if (query.length() != 0) {
+            query.append("&");
+          }
+          query.append(property.getName());
+          query.append("=");
+          query.append(URLEncoder.encode(property.get(properties), "UTF-8"));
+        }
+      }
 
-    return url.toString();
+      if (query.length() > 0) {
+        url.append("?");
+        url.append(query);
+      }
+
+      return url.toString();
+    } catch (UnsupportedEncodingException e) {
+      throw new AssertionError("JVM claims UTF-8 is unsupported, cannot happen");
+    }
   }
 
   /**

--- a/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
+++ b/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
@@ -1216,11 +1216,9 @@ public abstract class BaseDataSource implements CommonDataSource, Referenceable 
       portNumber = Integer.parseInt(port);
     }
     serverName = getReferenceProperty(ref, "serverName");
-    user = getReferenceProperty(ref, "user");
-    password = getReferenceProperty(ref, "password");
 
     for (PGProperty property : PGProperty.values()) {
-      property.set(properties, getReferenceProperty(ref, property.getName()));
+      setProperty(property, getReferenceProperty(ref, property.getName()));
     }
   }
 

--- a/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
+++ b/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
@@ -12,6 +12,7 @@ import org.postgresql.util.ExpressionProperties;
 import org.postgresql.util.GT;
 import org.postgresql.util.PSQLException;
 import org.postgresql.util.PSQLState;
+import org.postgresql.util.URLCoder;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -19,8 +20,6 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.PrintWriter;
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
@@ -1058,14 +1057,6 @@ public abstract class BaseDataSource implements CommonDataSource, Referenceable 
     PGProperty.LOGGER_FILE.set(properties, loggerFile);
   }
 
-  private static String urlEncode(String plain) {
-    try {
-      return URLEncoder.encode(plain, "UTF-8");
-    } catch (UnsupportedEncodingException e) {
-      throw new IllegalStateException("Unable to encode via UTF-8. This should not happen", e);
-    }
-  }
-
   /**
    * Generates a {@link DriverManager} URL from the other properties supplied.
    *
@@ -1078,7 +1069,7 @@ public abstract class BaseDataSource implements CommonDataSource, Referenceable 
     if (portNumber != 0) {
       url.append(":").append(portNumber);
     }
-    url.append("/").append(urlEncode(databaseName));
+    url.append("/").append(URLCoder.encode(databaseName));
 
     StringBuilder query = new StringBuilder(100);
     for (PGProperty property: PGProperty.values()) {
@@ -1088,7 +1079,7 @@ public abstract class BaseDataSource implements CommonDataSource, Referenceable 
         }
         query.append(property.getName());
         query.append("=");
-        query.append(urlEncode(property.get(properties)));
+        query.append(URLCoder.encode(property.get(properties)));
       }
     }
 

--- a/pgjdbc/src/main/java/org/postgresql/util/URLCoder.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/URLCoder.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2018, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.util;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+
+/**
+ * This class helps with URL encoding and decoding. UTF-8 encoding is used by default to make
+ * encoding consistent across the driver, and encoding might be changed via {@code
+ * postgresql.url.encoding} property
+ *
+ * Note: this should not be used outside of PostgreSQL source, this is not a public API of the
+ * driver.
+ */
+public final class URLCoder {
+  private static final String ENCODING_FOR_URL =
+      System.getProperty("postgresql.url.encoding", "UTF-8");
+
+  /**
+   * Decodes {@code x-www-form-urlencoded} string into Java string.
+   *
+   * @param encoded encoded value
+   * @return decoded value
+   * @see URLDecoder#decode(String, String)
+   */
+  public static String decode(String encoded) {
+    try {
+      return URLDecoder.decode(encoded, ENCODING_FOR_URL);
+    } catch (UnsupportedEncodingException e) {
+      throw new IllegalStateException(
+          "Unable to decode URL entry via " + ENCODING_FOR_URL + ". This should not happen", e);
+    }
+  }
+
+  /**
+   * Encodes Java string into {@code x-www-form-urlencoded} format
+   *
+   * @param plain input value
+   * @return encoded value
+   * @see URLEncoder#encode(String, String)
+   */
+  public static String encode(String plain) {
+    try {
+      return URLEncoder.encode(plain, "UTF-8");
+    } catch (UnsupportedEncodingException e) {
+      throw new IllegalStateException(
+          "Unable to encode URL entry via " + ENCODING_FOR_URL + ". This should not happen", e);
+    }
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DriverTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DriverTest.java
@@ -16,13 +16,13 @@ import org.postgresql.Driver;
 import org.postgresql.PGProperty;
 import org.postgresql.test.TestUtil;
 import org.postgresql.util.NullOutputStream;
+import org.postgresql.util.URLCoder;
 import org.postgresql.util.WriterHandler;
 
 import org.junit.Test;
 
 import java.io.PrintWriter;
 import java.lang.reflect.Method;
-import java.net.URLEncoder;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
@@ -107,7 +107,9 @@ public class DriverTest {
 
     // Test with the username in the url
     con = DriverManager.getConnection(
-        TestUtil.getURL() + "&user=" + TestUtil.getUser() + "&password=" + URLEncoder.encode(TestUtil.getPassword()));
+        TestUtil.getURL()
+            + "&user=" + URLCoder.encode(TestUtil.getUser())
+            + "&password=" + URLCoder.encode(TestUtil.getPassword()));
     assertNotNull(con);
     con.close();
 

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DriverTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DriverTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 
 import java.io.PrintWriter;
 import java.lang.reflect.Method;
+import java.net.URLEncoder;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
@@ -106,7 +107,7 @@ public class DriverTest {
 
     // Test with the username in the url
     con = DriverManager.getConnection(
-        TestUtil.getURL() + "&user=" + TestUtil.getUser() + "&password=" + TestUtil.getPassword());
+        TestUtil.getURL() + "&user=" + TestUtil.getUser() + "&password=" + URLEncoder.encode(TestUtil.getPassword()));
     assertNotNull(con);
     con.close();
 

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PGPropertyTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PGPropertyTest.java
@@ -257,4 +257,25 @@ public class PGPropertyTest {
       }
     }
   }
+
+  @Test
+  public void testEncodedUrlValuesFromDataSource() {
+    String databaseName = "d&a%ta+base";
+    String userName = "&u%ser";
+    String password = "p%a&s^s#w!o@r*";
+    String applicationName = "Laurel&Hardy=Best?Yes";
+    PGSimpleDataSource dataSource = new PGSimpleDataSource();
+
+    dataSource.setDatabaseName(databaseName);
+    dataSource.setUser(userName);
+    dataSource.setPassword(password);
+    dataSource.setApplicationName(applicationName);
+
+    Properties parsed = Driver.parseURL(dataSource.getURL(), new Properties());
+    assertEquals("database", databaseName, PGProperty.PG_DBNAME.get(parsed));
+    // datasources do not pass username and password as URL parameters
+    assertNull("user", PGProperty.USER.get(parsed));
+    assertNull("password", PGProperty.PASSWORD.get(parsed));
+    assertEquals("APPLICATION_NAME", applicationName, PGProperty.APPLICATION_NAME.get(parsed));
+  }
 }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PGPropertyTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PGPropertyTest.java
@@ -16,6 +16,7 @@ import org.postgresql.PGProperty;
 import org.postgresql.ds.PGSimpleDataSource;
 import org.postgresql.ds.common.BaseDataSource;
 import org.postgresql.test.TestUtil;
+import org.postgresql.util.URLCoder;
 
 import org.junit.After;
 import org.junit.Before;
@@ -24,7 +25,6 @@ import org.junit.Test;
 import java.beans.BeanInfo;
 import java.beans.Introspector;
 import java.beans.PropertyDescriptor;
-import java.net.URLEncoder;
 import java.sql.DriverPropertyInfo;
 import java.util.ArrayList;
 import java.util.Map;
@@ -205,10 +205,10 @@ public class PGPropertyTest {
     String userName = "&u%ser";
     String password = "p%a&s^s#w!o@r*";
     String url = "jdbc:postgresql://"
-            + "localhost" + ":" + 5432 + "/"
-            + URLEncoder.encode(databaseName)
-            + "?user=" + URLEncoder.encode(userName)
-            + "&password=" + URLEncoder.encode(password);
+        + "localhost" + ":" + 5432 + "/"
+        + URLCoder.encode(databaseName)
+        + "?user=" + URLCoder.encode(userName)
+        + "&password=" + URLCoder.encode(password);
     Properties parsed = Driver.parseURL(url, new Properties());
     assertEquals("database", databaseName, PGProperty.PG_DBNAME.get(parsed));
     assertEquals("user", userName, PGProperty.USER.get(parsed));
@@ -274,8 +274,8 @@ public class PGPropertyTest {
     Properties parsed = Driver.parseURL(dataSource.getURL(), new Properties());
     assertEquals("database", databaseName, PGProperty.PG_DBNAME.get(parsed));
     // datasources do not pass username and password as URL parameters
-    assertNull("user", PGProperty.USER.get(parsed));
-    assertNull("password", PGProperty.PASSWORD.get(parsed));
+    assertFalse("user", PGProperty.USER.isPresent(parsed));
+    assertFalse("password", PGProperty.PASSWORD.isPresent(parsed));
     assertEquals("APPLICATION_NAME", applicationName, PGProperty.APPLICATION_NAME.get(parsed));
   }
 }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/optional/BaseDataSourceTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/optional/BaseDataSourceTest.java
@@ -5,6 +5,7 @@
 
 package org.postgresql.test.jdbc2.optional;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
@@ -197,6 +198,7 @@ public abstract class BaseDataSourceTest {
   public void testJndi() {
     initializeDataSource();
     BaseDataSource oldbds = bds;
+    String oldurl = bds.getURL();
     InitialContext ic = getInitialContext();
     try {
       ic.rebind(DATA_SOURCE_JNDI, bds);
@@ -207,9 +209,12 @@ public abstract class BaseDataSourceTest {
       fail(e.getMessage());
     }
     oldbds = bds;
+    String url = bds.getURL();
     testUseConnection();
     assertSame("Test should not have changed DataSource (" + bds + " != " + oldbds + ")!",
         oldbds , bds);
+    assertEquals("Test should not have changed DataSource URL",
+        oldurl, url);
   }
 
   /**


### PR DESCRIPTION
BaseDataSource did not properly encode url parameters, meaning that users could
not log in if their password contained illegal characters. The error can be
reproduced by setting the test user password to ';/?:@&=+$,' (a bunch of illegal
characters for query parameters).

DriverTest then failed because it did not encode the parameters either.