### PR TITLE
Support PGSERVICE

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -20,3 +20,4 @@ loggerLevel=OFF
 loggerFile=target/pgjdbc-tests.log
 protocolVersion=0
 sslpassword=sslpwd
+org.postgresql.pgservicefile=src/test/resources/pgservicestest.conf

--- a/docs/documentation/head/connect.md
+++ b/docs/documentation/head/connect.md
@@ -86,6 +86,13 @@ Connection conn = DriverManager.getConnection(url);
 	are considered to separate command-line arguments, unless escaped with
 	a backslash (`\`); `\\` represents a literal backslash.
 
+* **service** = String
+
+    Name of a service defined in a [Connection Service
+    File](https://www.postgresql.org/docs/current/static/libpq-pgservice.html).
+    You can override default service file using `PGSERVICEFILE` environment
+    variable or `org.postgresql.pgservicefile` property.
+
 * **ssl** = boolean
 
 	Connect using SSL. The driver must have been compiled with SSL support.

--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -179,6 +179,11 @@ public enum PGProperty {
       "Enable optimization that disables column name sanitiser"),
 
   /**
+   * Service name to pick properties from service file.
+   */
+  SERVICE("service", null, "Service name to pick properties from service file"),
+
+  /**
    * Control use of SSL: empty or {@code true} values imply {@code sslmode==verify-full}
    */
   SSL("ssl", null, "Control use of SSL (any non-null value causes SSL to be required)"),

--- a/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
+++ b/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
@@ -1351,6 +1351,14 @@ public abstract class BaseDataSource implements CommonDataSource, Referenceable 
     PGProperty.REWRITE_BATCHED_INSERTS.set(properties, reWrite);
   }
 
+  public String getService() {
+    return PGProperty.SERVICE.get(properties);
+  }
+
+  public void setService(String service) {
+    PGProperty.SERVICE.set(properties, service);
+  }
+
   //#if mvn.project.property.postgresql.jdbc.spec >= "JDBC4.1"
   public java.util.logging.Logger getParentLogger() {
     return Logger.getLogger("org.postgresql");

--- a/pgjdbc/src/main/java/org/postgresql/util/PGServiceFile.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/PGServiceFile.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2018, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.util;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.sql.SQLException;
+import java.text.MessageFormat;
+import java.text.ParseException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Scanner;
+
+/*
+ * See https://www.postgresql.org/docs/current/static/libpq-pgservice.html.
+ */
+public class PGServiceFile {
+  public static Map load(String service) throws Exception {
+    String filename = findPath();
+    PGServiceFile file = new PGServiceFile();
+    Scanner in = new Scanner(new FileInputStream(filename), "UTF-8");
+    try {
+      file.parse(in);
+    } finally {
+      in.close();
+    }
+    return file.getService(service);
+  }
+
+  private static String findPath() {
+    String filename = System.getProperty("org.postgresql.pgservicefile");
+    if (filename == null) {
+      filename = System.getenv().get("PGSERVICEFILE");
+    }
+    if (filename == null) {
+      filename = System.getProperty("user.home") + File.separator + ".pg_service.conf";
+    }
+    return filename;
+  }
+
+  private final Map<String, Map<String, String>> sections;
+
+  public PGServiceFile() {
+    sections = new HashMap();
+  }
+
+  private void parse(Scanner in) throws Exception {
+    int lineNum = 0;
+    String sectionName = null;
+    Map<String, String> section = null;
+
+    while (in.hasNextLine()) {
+      String line = in.nextLine();
+      lineNum++;
+      line = line.replaceAll("^\\s+", "");
+      if (line.isEmpty() || line.startsWith("#")) {
+        continue;
+      } else if (line.startsWith("[")) {
+        if (!line.endsWith("]")) {
+          String msg = MessageFormat.format("Error in service file line {0}: missing ].", lineNum);
+          throw new ParseException(msg, lineNum);
+        }
+        sectionName = line.substring(1, line.length() - 1);
+        section = new HashMap();
+        sections.put(sectionName, section);
+      } else if (section == null) {
+        String msg = MessageFormat.format("Error in service file line {0}: not in section.", lineNum);
+        throw new ParseException(msg, lineNum);
+      } else {
+        String[] segment = line.split("=", 2);
+        if (segment.length != 2) {
+          String msg = MessageFormat.format("Error in service file line {0}: bad syntax.", lineNum);
+          throw new ParseException(msg, lineNum);
+        }
+        section.put(segment[0], segment[1]);
+      }
+    }
+  }
+
+  public Map<String, String> getService(String name) throws SQLException {
+    if (sections.containsKey(name)) {
+      return sections.get(name);
+    } else {
+      throw new SQLException(MessageFormat.format("Unknown service {0}.", name));
+    }
+  }
+
+  public static void copyProperties(Map<String, String> service, Properties urlProps) throws Exception {
+    if (service.containsKey("port")) {
+      urlProps.setProperty("PGPORT", service.get("port"));
+    }
+    if (service.containsKey("host")) {
+      urlProps.setProperty("PGHOST", service.get("host"));
+    }
+    if (service.containsKey("dbname")) {
+      urlProps.setProperty("PGDBNAME", service.get("dbname"));
+    }
+    for (Map.Entry<String, String> entry : service.entrySet()) {
+      urlProps.setProperty(entry.getKey(), entry.getValue());
+    }
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DriverTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DriverTest.java
@@ -74,6 +74,7 @@ public class DriverTest {
     verifyUrl(drv, "jdbc:postgresql://127.0.0.1/anydbname", "127.0.0.1", "5432", "anydbname");
     verifyUrl(drv, "jdbc:postgresql://127.0.0.1:5433/hidden", "127.0.0.1", "5433", "hidden");
     verifyUrl(drv, "jdbc:postgresql://[::1]:5740/db", "[::1]", "5740", "db");
+    verifyUrl(drv, "jdbc:postgresql:///?service=testsrv", "srvhost", "5434", "srvdb");
 
     // Badly formatted url's
     assertFalse(drv.acceptsURL("jdbc:postgres:test"));

--- a/pgjdbc/src/test/resources/pgservicestest.conf
+++ b/pgjdbc/src/test/resources/pgservicestest.conf
@@ -1,0 +1,8 @@
+# Comment
+  # indented with ünîçodè
+
+[testsrv]
+host=srvhost
+port=5434
+user=srvuser
+dbname=srvdb


### PR DESCRIPTION
Hi.

This PR implements #1192 .

It supports `PGSERVICEFILE` and `PGSERVICE` envvars as well as `-Dpostgresql.pgservicefile=` option and `jdbc:postgresql:?service=` URL parameter.

I'm not a java developer so i would like some help on code architecture, error management, loggin, best practice, unit testing and documentation. I hope this is a good start !

Thanks,
Étienne