### PR TITLE
fix: configure benchmark forks to >= 1

### DIFF
--- a/ubenchmark/src/main/java/org/postgresql/benchmark/statement/BindBoolean.java
+++ b/ubenchmark/src/main/java/org/postgresql/benchmark/statement/BindBoolean.java
@@ -35,7 +35,7 @@ import java.sql.Types;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
-@Fork(value = 0, jvmArgsPrepend = "-Xmx128m")
+@Fork(value = 1, jvmArgsPrepend = "-Xmx128m")
 @Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
 @Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
 @State(Scope.Thread)

--- a/ubenchmark/src/main/java/org/postgresql/benchmark/time/AddPaddingZeros.java
+++ b/ubenchmark/src/main/java/org/postgresql/benchmark/time/AddPaddingZeros.java
@@ -25,7 +25,7 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 import java.sql.Timestamp;
 import java.util.concurrent.TimeUnit;
 
-@Fork(value = 0, jvmArgsPrepend = "-Xmx128m")
+@Fork(value = 1, jvmArgsPrepend = "-Xmx128m")
 @Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
 @Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
 @State(Scope.Thread)


### PR DESCRIPTION
We are conducting a scientific study to investigate bad practices/anti-patterns on creating micro-benchmarks using JMH, and we found two instances of harmfull zero fork configuration in two benchmark classes.

Benchmarks configured with zero forks are prone to profile-guided optimizations tat offsets the measurements considerably (see [JMH Sample Documentation](http://hg.openjdk.java.net/code-tools/jmh/file/3769055ad883/jmh-samples/src/main/java/org/openjdk/jmh/samples/JMHSample_12_Forking.java) ). Essentially this means that every benchmark will be run on the same JVM instance, and the profile-guided optimization might artificially speed-up some benchmarks by analyzing the execution patterns of the first ones.

I believe this was a simple mistake in the configuration and simply changed @Fork to 1.

I have attached a csv with benchmarks runs from those two classes, before and after the patch.

We run the entire benchmark 10 times with default parameters (iterations, forks, warmups kept as default)
- Median score reported
- Factor zero means no significant difference (Moore media's test)
Attached Summary: [pgjdbc-FORK-summary.zip](https://github.com/pgjdbc/pgjdbc/files/2080851/pgjdbc-FORK-summary.zip)

Environment:
Tests run on a Computational server with CPU: E5-1660-3.3GHZ  (6 cores + HT), 64 GB RAM.

