### PR TITLE
fix: adjusted copy out API to flush the writer

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/copy/CopyManager.java
+++ b/pgjdbc/src/main/java/org/postgresql/copy/CopyManager.java
@@ -128,6 +128,7 @@ public class CopyManager {
       while ((buf = cp.readFromCopy()) != null) {
         to.write(buf);
       }
+	  to.flush();
       return cp.getHandledRowCount();
     } catch (IOException ioEX) {
       // if not handled this way the close call will hang, at least in 8.2

--- a/pgjdbc/src/main/java/org/postgresql/copy/CopyManager.java
+++ b/pgjdbc/src/main/java/org/postgresql/copy/CopyManager.java
@@ -93,6 +93,7 @@ public class CopyManager {
       while ((buf = cp.readFromCopy()) != null) {
         to.write(encoding.decode(buf));
       }
+      to.flush();
       return cp.getHandledRowCount();
     } catch (IOException ioEX) {
       // if not handled this way the close call will hang, at least in 8.2

--- a/pgjdbc/src/main/java/org/postgresql/copy/CopyManager.java
+++ b/pgjdbc/src/main/java/org/postgresql/copy/CopyManager.java
@@ -128,7 +128,7 @@ public class CopyManager {
       while ((buf = cp.readFromCopy()) != null) {
         to.write(buf);
       }
-	  to.flush();
+      to.flush();
       return cp.getHandledRowCount();
     } catch (IOException ioEX) {
       // if not handled this way the close call will hang, at least in 8.2

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/CopyTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/CopyTest.java
@@ -23,6 +23,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.BufferedOutputStream;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -222,7 +223,8 @@ public class CopyTest {
     testCopyInByRow(); // ensure we have some data.
     String sql = "COPY copytest TO STDOUT";
     ByteArrayOutputStream copydata = new ByteArrayOutputStream();
-    copyAPI.copyOut(sql, copydata);
+    BufferedOutputStream bufferedStream = new BufferedOutputStream(copydata);
+    copyAPI.copyOut(sql, bufferedStream);
     assertEquals(dataRows, getCount());
     // deep comparison of data written and read
     byte[] copybytes = copydata.toByteArray();


### PR DESCRIPTION
When using a BufferedOutputStream with the copyOut API, if flush is not called, part of the data is not writed,.