### PR TITLE
fix: support query timeouts exceeding 2147483 seconds (~25 days)

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgStatement.java
@@ -113,7 +113,7 @@ public class PgStatement implements Statement, BaseStatement {
   /**
    * Timeout (in milliseconds) for a query
    */
-  protected int timeout = 0;
+  protected long timeout = 0;
 
   protected boolean replaceProcessingEnabled = true;
 
@@ -518,11 +518,16 @@ public class PgStatement implements Statement, BaseStatement {
   }
 
   public int getQueryTimeout() throws SQLException {
-    return getQueryTimeoutMs() / 1000;
+    checkClosed();
+    long seconds = timeout / 1000;
+    if (seconds >= Integer.MAX_VALUE) {
+      return Integer.MAX_VALUE;
+    }
+    return (int) seconds;
   }
 
   public void setQueryTimeout(int seconds) throws SQLException {
-    setQueryTimeoutMs(seconds * 1000);
+    setQueryTimeoutMs(seconds * 1000L);
   }
 
   /**
@@ -532,7 +537,7 @@ public class PgStatement implements Statement, BaseStatement {
    * @return the current query timeout limit in milliseconds; 0 = unlimited
    * @throws SQLException if a database access error occurs
    */
-  public int getQueryTimeoutMs() throws SQLException {
+  public long getQueryTimeoutMs() throws SQLException {
     checkClosed();
     return timeout;
   }
@@ -543,7 +548,7 @@ public class PgStatement implements Statement, BaseStatement {
    * @param millis - the new query timeout limit in milliseconds
    * @throws SQLException if a database access error occurs
    */
-  public void setQueryTimeoutMs(int millis) throws SQLException {
+  public void setQueryTimeoutMs(long millis) throws SQLException {
     checkClosed();
 
     if (millis < 0) {

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/StatementTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/StatementTest.java
@@ -695,6 +695,17 @@ public class StatementTest {
     }
   }
 
+  @Test
+  public void testLongQueryTimeout() throws SQLException {
+    Statement stmt = con.createStatement();
+    stmt.setQueryTimeout(Integer.MAX_VALUE);
+    Assert.assertEquals("setQueryTimeout(Integer.MAX_VALUE)", Integer.MAX_VALUE,
+        stmt.getQueryTimeout());
+    stmt.setQueryTimeout(Integer.MAX_VALUE - 1);
+    Assert.assertEquals("setQueryTimeout(Integer.MAX_VALUE-1)", Integer.MAX_VALUE - 1,
+        stmt.getQueryTimeout());
+  }
+
   /**
    * Test executes two queries one after another. The first one has timeout of 1ms, and the second
    * one does not. The timeout of the first query should not impact the second one.


### PR DESCRIPTION
Use long field for timeout to avoid unexpected "Query timeout must be a value greater than or equals to 0" when query timeout exceeds 2147483=Integer.MAX_VALUE/1000

fixes #1223