### PR TITLE
perf: remove unneeded cache memory allocations

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/BaseQueryKey.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/BaseQueryKey.java
@@ -31,6 +31,11 @@ class BaseQueryKey {
         + '}';
   }
 
+  public long getEstimatedSize() {
+    return (sql != null ? sql.length() : 0) * 2L
+        + 2L;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/pgjdbc/src/main/java/org/postgresql/core/CachedQuery.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/CachedQuery.java
@@ -55,7 +55,12 @@ public class CachedQuery implements CanEstimateSize {
 
   @Override
   public long getSize() {
-    int queryLength = String.valueOf(key).length() * 2 /* 2 bytes per char */;
+    long queryLength = 0;
+    if (key instanceof BaseQueryKey) {
+      queryLength = ((BaseQueryKey) key).getEstimatedSize();
+    } else {
+      queryLength = String.valueOf(key).length() * 2L /* 2 bytes per char */;
+    }
     return queryLength * 2 /* original query and native sql */
         + 100L /* entry in hash map, CachedQuery wrapper, etc */;
   }

--- a/pgjdbc/src/main/java/org/postgresql/core/QueryWithReturningColumnsKey.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/QueryWithReturningColumnsKey.java
@@ -38,6 +38,16 @@ class QueryWithReturningColumnsKey extends BaseQueryKey {
   }
 
   @Override
+  public long getEstimatedSize() {
+    long size = super.getEstimatedSize();
+    for (String name : columnNames) {
+      size += name.length() * 2L;
+    }
+
+    return size;
+  }
+
+  @Override
   public boolean equals(Object o) {
     if (this == o) {
       return true;
@@ -61,4 +71,5 @@ class QueryWithReturningColumnsKey extends BaseQueryKey {
     result = 31 * result + Arrays.hashCode(columnNames);
     return result;
   }
+
 }


### PR DESCRIPTION
When the cache is enabled through 'preferQueryMode', the driver allocates more memory than if the cache is disabled
(transient allocations not the cache memory usage)

It comes from the cache key memory size estimation
(CachedQuery#getSize)
On cache borrow / release the size is estimated by generating a string
from the key and computing its length.

On simple tests it accounts for 60% of the allocated memory.

This patch creates a custom method in BaseQueryKey to estimate the size
without allocating too much memory.

Note that the new estimated size and the one before this patch might be
slightly different.