### PR TITLE
perf: avoid BaseQueryKey.toString in CachedQuery.getSize

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/BaseQueryKey.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/BaseQueryKey.java
@@ -5,13 +5,15 @@
 
 package org.postgresql.core;
 
+import org.postgresql.util.CanEstimateSize;
+
 /**
  * This class is used as a cache key for simple statements that have no "returning columns".
  * Prepared statements that have no returning columns use just {@code String sql} as a key.
  * Simple and Prepared statements that have returning columns use {@link QueryWithReturningColumnsKey}
  * as a cache key.
  */
-class BaseQueryKey {
+class BaseQueryKey implements CanEstimateSize {
   public final String sql;
   public final boolean isParameterized;
   public final boolean escapeProcessing;
@@ -29,6 +31,14 @@ class BaseQueryKey {
         + ", isParameterized=" + isParameterized
         + ", escapeProcessing=" + escapeProcessing
         + '}';
+  }
+
+  @Override
+  public long getSize() {
+    if (sql == null) { // just in case
+      return 16;
+    }
+    return 16 + sql.length() * 2L; // 2 bytes per char, revise with Java 9's compact strings
   }
 
   @Override

--- a/pgjdbc/src/main/java/org/postgresql/core/CachedQuery.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/CachedQuery.java
@@ -25,6 +25,9 @@ public class CachedQuery implements CanEstimateSize {
   private int executeCount;
 
   public CachedQuery(Object key, Query query, boolean isFunction, boolean outParmBeforeFunc) {
+    assert key instanceof String || key instanceof CanEstimateSize
+        : "CachedQuery.key should either be String or implement CanEstimateSize."
+        + " Actual class is " + key.getClass();
     this.key = key;
     this.query = query;
     this.isFunction = isFunction;
@@ -55,7 +58,12 @@ public class CachedQuery implements CanEstimateSize {
 
   @Override
   public long getSize() {
-    int queryLength = String.valueOf(key).length() * 2 /* 2 bytes per char */;
+    long queryLength;
+    if (key instanceof String) {
+      queryLength = ((String) key).length() * 2L; // 2 bytes per char, revise with Java 9's compact strings
+    } else {
+      queryLength = ((CanEstimateSize) key).getSize();
+    }
     return queryLength * 2 /* original query and native sql */
         + 100L /* entry in hash map, CachedQuery wrapper, etc */;
   }

--- a/pgjdbc/src/main/java/org/postgresql/core/CachedQuery.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/CachedQuery.java
@@ -13,9 +13,7 @@ import org.postgresql.util.CanEstimateSize;
  */
 public class CachedQuery implements CanEstimateSize {
   /**
-   * Cache key. {@link String} or {@code org.postgresql.jdbc.CallableQueryKey}. It is assumed that
-   * {@code String.valueOf(key)*2} would give reasonable estimate of the number of retained bytes by
-   * given key (see {@link #getSize}).
+   * Cache key. {@link String} or {@code org.postgresql.util.CanEstimateSize}.
    */
   public final Object key;
   public final Query query;

--- a/pgjdbc/src/main/java/org/postgresql/core/QueryWithReturningColumnsKey.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/QueryWithReturningColumnsKey.java
@@ -16,6 +16,7 @@ import java.util.Arrays;
  */
 class QueryWithReturningColumnsKey extends BaseQueryKey {
   public final String[] columnNames;
+  private int size; // query length cannot exceed MAX_INT
 
   QueryWithReturningColumnsKey(String sql, boolean isParameterized, boolean escapeProcessing,
       String[] columnNames) {
@@ -29,13 +30,18 @@ class QueryWithReturningColumnsKey extends BaseQueryKey {
 
   @Override
   public long getSize() {
-    long size = super.getSize();
+    int size = this.size;
+    if (size != 0) {
+      return size;
+    }
+    size = (int) super.getSize();
     if (columnNames != null) {
       size += 16L; // array itself
       for (String columnName: columnNames) {
         size += columnName.length() * 2L; // 2 bytes per char, revise with Java 9's compact strings
       }
     }
+    this.size = size;
     return size;
   }
 

--- a/pgjdbc/src/main/java/org/postgresql/core/QueryWithReturningColumnsKey.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/QueryWithReturningColumnsKey.java
@@ -28,6 +28,17 @@ class QueryWithReturningColumnsKey extends BaseQueryKey {
   }
 
   @Override
+  public long getSize() {
+    long size = super.getSize();
+    if (columnNames != null) {
+      for (String columnName: columnNames) {
+        size += columnName.length() * 2L; // 2 bytes per char, revise with Java 9's compact strings
+      }
+    }
+    return size;
+  }
+
+  @Override
   public String toString() {
     return "QueryWithReturningColumnsKey{"
         + "sql='" + sql + '\''

--- a/pgjdbc/src/main/java/org/postgresql/core/QueryWithReturningColumnsKey.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/QueryWithReturningColumnsKey.java
@@ -31,6 +31,7 @@ class QueryWithReturningColumnsKey extends BaseQueryKey {
   public long getSize() {
     long size = super.getSize();
     if (columnNames != null) {
+      size += 16L; // array itself
       for (String columnName: columnNames) {
         size += columnName.length() * 2L; // 2 bytes per char, revise with Java 9's compact strings
       }


### PR DESCRIPTION
LruCache uses .getSize to limit the size of the cache, so this method
should refrain from doing memory allocations.

closes #1226