### PR TITLE
perf: reuse Matcher in interpretCommandStatus

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -74,7 +74,7 @@ public class QueryExecutorImpl extends QueryExecutorBase {
 
   private static final Logger LOGGER = Logger.getLogger(QueryExecutorImpl.class.getName());
   private static final Pattern COMMAND_COMPLETE_PATTERN = Pattern.compile("^([a-zA-Z][^ ]*+(?: [a-zA-Z][^ ]*+)*+)(?: (\\d++))?+(?: (\\d++))?+$");
-  private static final Matcher COMMAND_COMPLETE_MATCHER = COMMAND_COMPLETE_PATTERN.matcher("");
+  private final Matcher commandCompleteMatcher = COMMAND_COMPLETE_PATTERN.matcher("");
 
   /**
    * TimeZone of the current connection (TimeZone backend parameter)
@@ -2470,7 +2470,7 @@ public class QueryExecutorImpl extends QueryExecutorBase {
   private void interpretCommandStatus(String status, ResultHandler handler) {
     long oid = 0;
     long count = 0;
-    Matcher matcher = COMMAND_COMPLETE_MATCHER.reset(status);
+    Matcher matcher = commandCompleteMatcher.reset(status);
     if (matcher.matches()) {
       // String command = matcher.group(1);
       String group2 = matcher.group(2);

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -73,7 +73,8 @@ import java.util.regex.Pattern;
 public class QueryExecutorImpl extends QueryExecutorBase {
 
   private static final Logger LOGGER = Logger.getLogger(QueryExecutorImpl.class.getName());
-  private static final Pattern COMMAND_COMPLETE_PATTERN = Pattern.compile("^([A-Za-z]++)(?: (\\d++))?+(?: (\\d++))?+$");
+  private static final Pattern COMMAND_COMPLETE_PATTERN = Pattern.compile("^([a-zA-Z][^ ]*+(?: [a-zA-Z][^ ]*+)*+)(?: (\\d++))?+(?: (\\d++))?+$");
+  private static final Matcher COMMAND_COMPLETE_MATCHER = COMMAND_COMPLETE_PATTERN.matcher("");
 
   /**
    * TimeZone of the current connection (TimeZone backend parameter)
@@ -2469,7 +2470,7 @@ public class QueryExecutorImpl extends QueryExecutorBase {
   private void interpretCommandStatus(String status, ResultHandler handler) {
     long oid = 0;
     long count = 0;
-    Matcher matcher = COMMAND_COMPLETE_PATTERN.matcher(status);
+    Matcher matcher = COMMAND_COMPLETE_MATCHER.reset(status);
     if (matcher.matches()) {
       // String command = matcher.group(1);
       String group2 = matcher.group(2);


### PR DESCRIPTION
This slightly reduces memory allocation for DML statements
I've adjusted the regexp to support "commands with spaces"

see #1219 

I did try benchmark via https://github.com/pgjdbc/benchmarks/blob/2d61b5714094f833311afc177b88a09216c643d4/src/main/java/org/postgresql/benchmark/statement/UpdateBatch.java , however it looks like my notebook goes into thermal throttling, so response times are not reliable.

The results for "insert 0 rows via batch of 100"  (100 no-op insert statements in a batch) is as follows:

```
Java->        1.8u152  9.0.4 Units
master          50177  51776 bytes/op
#1219           30177  26976 bytes/op
matcher reuse   30177  29376 bytes/op
```

Run statistics (Java 1.8u152) looks as follows (DB is at localhost):

```
# Run complete. Total time: 00:02:32

Benchmark                                                 (nrows)  Mode  Cnt      Score      Error   Units
UpdateBatch.updateBatch                                       100  avgt   50    868.020 ±   10.059   us/op
UpdateBatch.updateBatch:·gc.alloc.rate                        100  avgt   50     22.091 ±    0.264  MB/sec
UpdateBatch.updateBatch:·gc.alloc.rate.norm                   100  avgt   50  30177.445 ±    1.593    B/op
UpdateBatch.updateBatch:·gc.churn.PS_Eden_Space               100  avgt   50     22.788 ±    4.195  MB/sec
UpdateBatch.updateBatch:·gc.churn.PS_Eden_Space.norm          100  avgt   50  31217.650 ± 5868.051    B/op
UpdateBatch.updateBatch:·gc.churn.PS_Survivor_Space           100  avgt   50      0.017 ±    0.014  MB/sec
UpdateBatch.updateBatch:·gc.churn.PS_Survivor_Space.norm      100  avgt   50     23.814 ±   18.595    B/op
UpdateBatch.updateBatch:·gc.count                             100  avgt   50     65.000             counts
UpdateBatch.updateBatch:·gc.time                              100  avgt   50     45.000                 ms
```