### PR TITLE
chore: Correct the Javadoc and enforce with Checkstyle

### DIFF
--- a/pgjdbc/src/main/checkstyle/checks.xml
+++ b/pgjdbc/src/main/checkstyle/checks.xml
@@ -209,7 +209,7 @@
     <!--<module name="SummaryJavadoc">-->
     <!--<property name="forbiddenSummaryFragments" value="^@return the *|^This method returns |^A [{]@code [a-zA-Z0-9]+[}]( is a )"/>-->
     <!--</module>-->
-    <!--<module name="JavadocParagraph"/>-->
+    <module name="JavadocParagraph"/>
     <!--<module name="AtclauseOrder">-->
     <!--<property name="tagOrder" value="@param, @return, @throws, @deprecated"/>-->
     <!--<property name="target" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>-->

--- a/pgjdbc/src/main/checkstyle/checks.xml
+++ b/pgjdbc/src/main/checkstyle/checks.xml
@@ -204,7 +204,7 @@
       <property name="allowSamelineMultipleAnnotations" value="true"/>
     </module>
     <module name="NonEmptyAtclauseDescription"/>
-    <!--<module name="JavadocTagContinuationIndentation"/>-->
+    <module name="JavadocTagContinuationIndentation"/>
     <!--Causes lots of "first sentence of javadoc is not followed by a period"-->
     <!--<module name="SummaryJavadoc">-->
     <!--<property name="forbiddenSummaryFragments" value="^@return the *|^This method returns |^A [{]@code [a-zA-Z0-9]+[}]( is a )"/>-->

--- a/pgjdbc/src/main/java/org/postgresql/Driver.java
+++ b/pgjdbc/src/main/java/org/postgresql/Driver.java
@@ -191,12 +191,11 @@ public class Driver implements java.sql.Driver {
    * probably want to have set up the Postgres database itself to use the same encoding, with the
    * {@code -E <encoding>} argument to createdb.</p>
    *
-   * <p>Our protocol takes the forms:
+   * <p>Our protocol takes the forms:</p>
    *
-   * <PRE>
+   * <pre>
    *  jdbc:postgresql://host:port/database?param1=val1&amp;...
-   * </PRE>
-   * </p>
+   * </pre>
    *
    * @param url the URL of the database to connect to
    * @param info a list of arbitrary tag/value pairs as connection arguments

--- a/pgjdbc/src/main/java/org/postgresql/Driver.java
+++ b/pgjdbc/src/main/java/org/postgresql/Driver.java
@@ -38,21 +38,18 @@ import java.util.logging.SimpleFormatter;
 import java.util.logging.StreamHandler;
 
 /**
- * The Java SQL framework allows for multiple database drivers. Each driver should supply a class
- * that implements the Driver interface
+ * <p>The Java SQL framework allows for multiple database drivers. Each driver should supply a class
+ * that implements the Driver interface</p>
  *
- * <p>
- * The DriverManager will try to load as many drivers as it can find and then for any given
- * connection request, it will ask each driver in turn to try to connect to the target URL.
+ * <p>The DriverManager will try to load as many drivers as it can find and then for any given
+ * connection request, it will ask each driver in turn to try to connect to the target URL.</p>
  *
- * <p>
- * It is strongly recommended that each Driver class should be small and standalone so that the
- * Driver class can be loaded and queried without bringing in vast quantities of supporting code.
+ * <p>It is strongly recommended that each Driver class should be small and standalone so that the
+ * Driver class can be loaded and queried without bringing in vast quantities of supporting code.</p>
  *
- * <p>
- * When a Driver class is loaded, it should create an instance of itself and register it with the
+ * <p>When a Driver class is loaded, it should create an instance of itself and register it with the
  * DriverManager. This means that a user can load and register a driver by doing
- * Class.forName("foo.bah.Driver")
+ * Class.forName("foo.bah.Driver")</p>
  *
  * @see org.postgresql.PGConnection
  * @see java.sql.Driver
@@ -157,46 +154,49 @@ public class Driver implements java.sql.Driver {
   }
 
   /**
-   * Try to make a database connection to the given URL. The driver should return "null" if it
+   * <p>Try to make a database connection to the given URL. The driver should return "null" if it
    * realizes it is the wrong kind of driver to connect to the given URL. This will be common, as
    * when the JDBC driverManager is asked to connect to a given URL, it passes the URL to each
-   * loaded driver in turn.
+   * loaded driver in turn.</p>
    *
-   * <p>
-   * The driver should raise an SQLException if it is the right driver to connect to the given URL,
-   * but has trouble connecting to the database.
+   * <p>The driver should raise an SQLException if it is the right driver to connect to the given URL,
+   * but has trouble connecting to the database.</p>
    *
-   * <p>
-   * The java.util.Properties argument can be used to pass arbitrary string tag/value pairs as
-   * connection arguments.
+   * <p>The java.util.Properties argument can be used to pass arbitrary string tag/value pairs as
+   * connection arguments.</p>
    *
-   * user - (required) The user to connect as password - (optional) The password for the user ssl -
-   * (optional) Use SSL when connecting to the server readOnly - (optional) Set connection to
-   * read-only by default charSet - (optional) The character set to be used for converting to/from
+   * <ul>
+   * <li>user - (required) The user to connect as</li>
+   * <li>password - (optional) The password for the user</li>
+   * <li>ssl -(optional) Use SSL when connecting to the server</li>
+   * <li>readOnly - (optional) Set connection to read-only by default</li>
+   * <li>charSet - (optional) The character set to be used for converting to/from
    * the database to unicode. If multibyte is enabled on the server then the character set of the
    * database is used as the default, otherwise the jvm character encoding is used as the default.
-   * This value is only used when connecting to a 7.2 or older server. loglevel - (optional) Enable
-   * logging of messages from the driver. The value is an integer from 0 to 2 where: OFF = 0, INFO =
-   * 1, DEBUG = 2 The output is sent to DriverManager.getPrintWriter() if set, otherwise it is sent
-   * to System.out. compatible - (optional) This is used to toggle between different functionality
+   * This value is only used when connecting to a 7.2 or older server.</li>
+   * <li>loglevel - (optional) Enable logging of messages from the driver. The value is an integer
+   * from 0 to 2 where: OFF = 0, INFO =1, DEBUG = 2 The output is sent to
+   * DriverManager.getPrintWriter() if set, otherwise it is sent to System.out.</li>
+   * <li>compatible - (optional) This is used to toggle between different functionality
    * as it changes across different releases of the jdbc driver code. The values here are versions
    * of the jdbc client and not server versions. For example in 7.1 get/setBytes worked on
    * LargeObject values, in 7.2 these methods were changed to work on bytea values. This change in
    * functionality could be disabled by setting the compatible level to be "7.1", in which case the
-   * driver will revert to the 7.1 functionality.
+   * driver will revert to the 7.1 functionality.</li>
+   * </ul>
    *
-   * <p>
-   * Normally, at least "user" and "password" properties should be included in the properties. For a
+   * <p>Normally, at least "user" and "password" properties should be included in the properties. For a
    * list of supported character encoding , see
    * http://java.sun.com/products/jdk/1.2/docs/guide/internat/encoding.doc.html Note that you will
    * probably want to have set up the Postgres database itself to use the same encoding, with the
-   * {@code -E <encoding>} argument to createdb.
+   * {@code -E <encoding>} argument to createdb.</p>
    *
-   * Our protocol takes the forms:
+   * <p>Our protocol takes the forms:
    *
    * <PRE>
    *  jdbc:postgresql://host:port/database?param1=val1&amp;...
    * </PRE>
+   * </p>
    *
    * @param url the URL of the database to connect to
    * @param info a list of arbitrary tag/value pairs as connection arguments
@@ -285,9 +285,9 @@ public class Driver implements java.sql.Driver {
   private static String loggerHandlerFile;
 
   /**
-   * Setup java.util.logging.Logger using connection properties.
-   * <p>
-   * See {@link PGProperty#LOGGER_FILE} and {@link PGProperty#LOGGER_FILE}
+   * <p>Setup java.util.logging.Logger using connection properties.</p>
+   *
+   * <p>See {@link PGProperty#LOGGER_FILE} and {@link PGProperty#LOGGER_FILE}</p>
    *
    * @param props Connection Properties
    */
@@ -470,12 +470,11 @@ public class Driver implements java.sql.Driver {
   }
 
   /**
-   * The getPropertyInfo method is intended to allow a generic GUI tool to discover what properties
-   * it should prompt a human for in order to get enough information to connect to a database.
+   * <p>The getPropertyInfo method is intended to allow a generic GUI tool to discover what properties
+   * it should prompt a human for in order to get enough information to connect to a database.</p>
    *
-   * <p>
-   * Note that depending on the values the human has supplied so far, additional values may become
-   * necessary, so it may be necessary to iterate through several calls to getPropertyInfo
+   * <p>Note that depending on the values the human has supplied so far, additional values may become
+   * necessary, so it may be necessary to iterate through several calls to getPropertyInfo</p>
    *
    * @param url the Url of the database to connect to
    * @param info a proposed list of tag/value pairs that will be sent on connect open.
@@ -522,12 +521,11 @@ public class Driver implements java.sql.Driver {
   }
 
   /**
-   * Report whether the driver is a genuine JDBC compliant driver. A driver may only report "true"
+   * <p>Report whether the driver is a genuine JDBC compliant driver. A driver may only report "true"
    * here if it passes the JDBC compliance tests, otherwise it is required to return false. JDBC
-   * compliance requires full support for the JDBC API and full support for SQL 92 Entry Level.
+   * compliance requires full support for the JDBC API and full support for SQL 92 Entry Level.</p>
    *
-   * <p>
-   * For PostgreSQL, this is not yet possible, as we are not SQL92 compliant (yet).
+   * <p>For PostgreSQL, this is not yet possible, as we are not SQL92 compliant (yet).</p>
    */
   @Override
   public boolean jdbcCompliant() {

--- a/pgjdbc/src/main/java/org/postgresql/Driver.java
+++ b/pgjdbc/src/main/java/org/postgresql/Driver.java
@@ -535,7 +535,7 @@ public class Driver implements java.sql.Driver {
   }
 
   /**
-   * Constructs a new DriverURL, splitting the specified URL into its component parts
+   * Constructs a new DriverURL, splitting the specified URL into its component parts.
    *
    * @param url JDBC URL to parse
    * @param defaults Default properties

--- a/pgjdbc/src/main/java/org/postgresql/PGConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGConnection.java
@@ -116,14 +116,13 @@ public interface PGConnection {
    *
    * <p><b>NOTE:</b> This is not part of JDBC, but an extension.</p>
    *
-   * <p>The best way to use this is as follows:
+   * <p>The best way to use this is as follows:</p>
    *
    * <pre>
    * ...
    * ((org.postgresql.PGConnection)myconn).addDataType("mytype", my.class.name.class);
    * ...
    * </pre>
-   * </p>
    *
    * <p>where myconn is an open Connection to org.postgresql.</p>
    *

--- a/pgjdbc/src/main/java/org/postgresql/PGConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGConnection.java
@@ -112,25 +112,22 @@ public interface PGConnection {
   void addDataType(String type, String className);
 
   /**
-   * This allows client code to add a handler for one of org.postgresql's more unique data types.
+   * <p>This allows client code to add a handler for one of org.postgresql's more unique data types.</p>
    *
-   * <p>
-   * <b>NOTE:</b> This is not part of JDBC, but an extension.
+   * <p><b>NOTE:</b> This is not part of JDBC, but an extension.</p>
    *
-   * <p>
-   * The best way to use this is as follows:
+   * <p>The best way to use this is as follows:
    *
    * <pre>
    * ...
    * ((org.postgresql.PGConnection)myconn).addDataType("mytype", my.class.name.class);
    * ...
    * </pre>
+   * </p>
    *
-   * <p>
-   * where myconn is an open Connection to org.postgresql.
+   * <p>where myconn is an open Connection to org.postgresql.</p>
    *
-   * <p>
-   * The handling class must extend org.postgresql.util.PGobject
+   * <p>The handling class must extend org.postgresql.util.PGobject</p>
    *
    * @param type the PostgreSQL type to register
    * @param klass the class implementing the Java representation of the type; this class must
@@ -209,11 +206,11 @@ public interface PGConnection {
   String escapeLiteral(String literal) throws SQLException;
 
   /**
-   * Returns the query mode for this connection.
-   * <p>
-   * When running in simple query mode, certain features are not available: callable statements,
-   * partial result set fetch, bytea type, etc.
-   * The list of supported features is subject to change.
+   * <p>Returns the query mode for this connection.</p>
+   *
+   * <p>When running in simple query mode, certain features are not available: callable statements,
+   * partial result set fetch, bytea type, etc.</p>
+   * <p>The list of supported features is subject to change.</p>
    *
    * @return the preferred query mode
    * @see PreferQueryMode

--- a/pgjdbc/src/main/java/org/postgresql/PGConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGConnection.java
@@ -161,7 +161,7 @@ public interface PGConnection {
   int getPrepareThreshold();
 
   /**
-   * Set the default fetch size for statements created from this connection
+   * Set the default fetch size for statements created from this connection.
    *
    * @param fetchSize new default fetch size
    * @throws SQLException if specified negative <code>fetchSize</code> parameter
@@ -171,7 +171,7 @@ public interface PGConnection {
 
 
   /**
-   * Get the default fetch size for statements created from this connection
+   * Get the default fetch size for statements created from this connection.
    *
    * @return current state for default fetch size
    * @see PGProperty#DEFAULT_ROW_FETCH_SIZE

--- a/pgjdbc/src/main/java/org/postgresql/PGNotification.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGNotification.java
@@ -6,11 +6,11 @@
 package org.postgresql;
 
 /**
- * This interface defines the public PostgreSQL extension for Notifications
+ * This interface defines the public PostgreSQL extension for Notifications.
  */
 public interface PGNotification {
   /**
-   * Returns name of this notification
+   * Returns name of this notification.
    *
    * @return name of this notification
    * @since 7.3
@@ -18,7 +18,7 @@ public interface PGNotification {
   String getName();
 
   /**
-   * Returns the process id of the backend process making this notification
+   * Returns the process id of the backend process making this notification.
    *
    * @return process id of the backend process making this notification
    * @since 7.3

--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -56,27 +56,29 @@ public enum PGProperty {
       false, "3"),
 
   /**
-   * Logger level of the driver. Allowed values: {@code OFF}, {@code DEBUG} or {@code TRACE}.
-   * <p>
-   * This enable the {@link java.util.logging.Logger} of the driver based on the following mapping
+   * <p>Logger level of the driver. Allowed values: {@code OFF}, {@code DEBUG} or {@code TRACE}.</p>
+   *
+   * <p>This enable the {@link java.util.logging.Logger} of the driver based on the following mapping
    * of levels:
-   * <p>
-   * FINE -&gt; DEBUG<br>
-   * FINEST -&gt; TRACE
-   * <p>
-   * <b>NOTE:</b> The recommended approach to enable java.util.logging is using a
+   * <ul>
+   *     <li>FINE -&gt; DEBUG</li>
+   *     <li>FINEST -&gt; TRACE</li>
+   * </ul>
+   * </p>
+   *
+   * <p><b>NOTE:</b> The recommended approach to enable java.util.logging is using a
    * {@code logging.properties} configuration file with the property
    * {@code -Djava.util.logging.config.file=myfile} or if your are using an application server
-   * you should use the appropriate logging subsystem.
+   * you should use the appropriate logging subsystem.</p>
    */
   LOGGER_LEVEL("loggerLevel", null, "Logger level of the driver", false, "OFF", "DEBUG", "TRACE"),
 
   /**
-   * File name output of the Logger, if set, the Logger will use a
+   * <p>File name output of the Logger, if set, the Logger will use a
    * {@link java.util.logging.FileHandler} to write to a specified file. If the parameter is not set
-   * or the file can't be created the {@link java.util.logging.ConsoleHandler} will be used instead.
-   * <p>
-   * Parameter should be use together with {@link PGProperty#LOGGER_LEVEL}
+   * or the file can't be created the {@link java.util.logging.ConsoleHandler} will be used instead.</p>
+   *
+   * <p>Parameter should be use together with {@link PGProperty#LOGGER_LEVEL}</p>
    */
   LOGGER_FILE("loggerFile", null, "File name output of the Logger"),
 
@@ -248,10 +250,10 @@ public enum PGProperty {
       "Specify how long to wait for establishment of a database connection."),
 
   /**
-   * The timeout value used for socket connect operations. If connecting to the server takes longer
-   * than this value, the connection is broken.
-   * <p>
-   * The timeout is specified in seconds and a value of zero means that it is disabled.
+   * <p>The timeout value used for socket connect operations. If connecting to the server takes longer
+   * than this value, the connection is broken.</p>
+   *
+   * <p>The timeout is specified in seconds and a value of zero means that it is disabled.</p>
    */
   CONNECT_TIMEOUT("connectTimeout", "10", "The timeout value used for socket connect operations."),
 
@@ -370,11 +372,11 @@ public enum PGProperty {
       "Specifies period (seconds) after which the host status is checked again in case it has changed"),
 
   /**
-   * Specifies which mode is used to execute queries to database: simple means ('Q' execute, no parse, no bind, text mode only),
+   * <p>Specifies which mode is used to execute queries to database: simple means ('Q' execute, no parse, no bind, text mode only),
    * extended means always use bind/execute messages, extendedForPrepared means extended for prepared statements only,
-   * extendedCacheEverything means use extended protocol and try cache every statement (including Statement.execute(String sql)) in a query cache.
+   * extendedCacheEverything means use extended protocol and try cache every statement (including Statement.execute(String sql)) in a query cache.</p>
    *
-   * This mode is meant for debugging purposes and/or for cases when extended protocol cannot be used (e.g. logical replication protocol)
+   * <p>This mode is meant for debugging purposes and/or for cases when extended protocol cannot be used (e.g. logical replication protocol)</p>
    */
   PREFER_QUERY_MODE("preferQueryMode", "extended",
       "Specifies which mode is used to execute queries to database: simple means ('Q' execute, no parse, no bind, text mode only), "
@@ -407,8 +409,9 @@ public enum PGProperty {
    * of replication commands can be issued instead of SQL statements. Only the simple query protocol
    * can be used in walsender mode. Passing "database" as the value instructs walsender to connect
    * to the database specified in the dbname parameter, which will allow the connection to be used
-   * for logical replication from that database. <p>Parameter should be use together with {@link
-   * PGProperty#ASSUME_MIN_SERVER_VERSION} with parameter &gt;= 9.4 (backend &gt;= 9.4)
+   * for logical replication from that database.</p>
+   * <p>Parameter should be use together with {@link PGProperty#ASSUME_MIN_SERVER_VERSION} with
+   * parameter &gt;= 9.4 (backend &gt;= 9.4)</p>
    */
   REPLICATION("replication", null,
       "Connection parameter passed in startup message, one of 'true' or 'database' "

--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -59,12 +59,11 @@ public enum PGProperty {
    * <p>Logger level of the driver. Allowed values: {@code OFF}, {@code DEBUG} or {@code TRACE}.</p>
    *
    * <p>This enable the {@link java.util.logging.Logger} of the driver based on the following mapping
-   * of levels:
+   * of levels:</p>
    * <ul>
    *     <li>FINE -&gt; DEBUG</li>
    *     <li>FINEST -&gt; TRACE</li>
    * </ul>
-   * </p>
    *
    * <p><b>NOTE:</b> The recommended approach to enable java.util.logging is using a
    * {@code logging.properties} configuration file with the property

--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -20,19 +20,19 @@ import java.util.Properties;
 public enum PGProperty {
 
   /**
-   * Database name to connect to (may be specified directly in the JDBC URL)
+   * Database name to connect to (may be specified directly in the JDBC URL).
    */
   PG_DBNAME("PGDBNAME", null,
       "Database name to connect to (may be specified directly in the JDBC URL)", true),
 
   /**
-   * Hostname of the PostgreSQL server (may be specified directly in the JDBC URL)
+   * Hostname of the PostgreSQL server (may be specified directly in the JDBC URL).
    */
   PG_HOST("PGHOST", null,
       "Hostname of the PostgreSQL server (may be specified directly in the JDBC URL)", false),
 
   /**
-   * Port of the PostgreSQL server (may be specified directly in the JDBC URL)
+   * Port of the PostgreSQL server (may be specified directly in the JDBC URL).
    */
   PG_PORT("PGPORT", null,
       "Port of the PostgreSQL server (may be specified directly in the JDBC URL)"),
@@ -190,7 +190,7 @@ public enum PGProperty {
   SSL_FACTORY("sslfactory", null, "Provide a SSLSocketFactory class when using SSL."),
 
   /**
-   * The String argument to give to the constructor of the SSL Factory
+   * The String argument to give to the constructor of the SSL Factory.
    */
   SSL_FACTORY_ARG("sslfactoryarg", null,
       "Argument forwarded to constructor of SSLSocketFactory class."),
@@ -229,7 +229,7 @@ public enum PGProperty {
       "The password for the client's ssl key (ignored if sslpasswordcallback is set)"),
 
   /**
-   * The classname instantiating {@code javax.security.auth.callback.CallbackHandler} to use
+   * The classname instantiating {@code javax.security.auth.callback.CallbackHandler} to use.
    */
   SSL_PASSWORD_CALLBACK("sslpasswordcallback", null,
       "A class, implementing javax.security.auth.callback.CallbackHandler that can handle PassworCallback for the ssl password."),
@@ -277,7 +277,7 @@ public enum PGProperty {
   SOCKET_FACTORY("socketFactory", null, "Specify a socket factory for socket creation"),
 
   /**
-   * The String argument to give to the constructor of the Socket Factory
+   * The String argument to give to the constructor of the Socket Factory.
    */
   SOCKET_FACTORY_ARG("socketFactoryArg", null,
       "Argument forwarded to constructor of SocketFactory class."),
@@ -295,13 +295,13 @@ public enum PGProperty {
   SEND_BUFFER_SIZE("sendBufferSize", "-1", "Socket write buffer size"),
 
   /**
-   * Assume the server is at least that version
+   * Assume the server is at least that version.
    */
   ASSUME_MIN_SERVER_VERSION("assumeMinServerVersion", null,
       "Assume the server is at least that version"),
 
   /**
-   * The application name (require server version &gt;= 9.0)
+   * The application name (require server version &gt;= 9.0).
    */
   APPLICATION_NAME("ApplicationName", DriverInfo.DRIVER_NAME, "Name of the Application (backend >= 9.0)"),
 
@@ -326,7 +326,7 @@ public enum PGProperty {
       "The Kerberos service name to use when authenticating with GSSAPI."),
 
   /**
-   * Use SPNEGO in SSPI authentication requests
+   * Use SPNEGO in SSPI authentication requests.
    */
   USE_SPNEGO("useSpnego", "false", "Use SPNEGO in SSPI authentication requests"),
 
@@ -455,7 +455,7 @@ public enum PGProperty {
   }
 
   /**
-   * Returns the default value for this connection parameter
+   * Returns the default value for this connection parameter.
    *
    * @return the default value for this connection parameter or null
    */
@@ -464,7 +464,7 @@ public enum PGProperty {
   }
 
   /**
-   * Returns the available values for this connection parameter
+   * Returns the available values for this connection parameter.
    *
    * @return the available values for this connection parameter or null
    */
@@ -474,7 +474,7 @@ public enum PGProperty {
 
   /**
    * Returns the value of the connection parameters according to the given {@code Properties} or the
-   * default value
+   * default value.
    *
    * @param properties properties to take actual value from
    * @return evaluated value for this connection parameter
@@ -484,7 +484,7 @@ public enum PGProperty {
   }
 
   /**
-   * Set the value for this connection parameter in the given {@code Properties}
+   * Set the value for this connection parameter in the given {@code Properties}.
    *
    * @param properties properties in which the value should be set
    * @param value value for this connection parameter
@@ -498,7 +498,7 @@ public enum PGProperty {
   }
 
   /**
-   * Return the boolean value for this connection parameter in the given {@code Properties}
+   * Return the boolean value for this connection parameter in the given {@code Properties}.
    *
    * @param properties properties to take actual value from
    * @return evaluated value for this connection parameter converted to boolean
@@ -509,7 +509,7 @@ public enum PGProperty {
 
   /**
    * Return the int value for this connection parameter in the given {@code Properties}. Prefer the
-   * use of {@link #getInt(Properties)} anywhere you can throw an {@link java.sql.SQLException}
+   * use of {@link #getInt(Properties)} anywhere you can throw an {@link java.sql.SQLException}.
    *
    * @param properties properties to take actual value from
    * @return evaluated value for this connection parameter converted to int
@@ -521,7 +521,7 @@ public enum PGProperty {
   }
 
   /**
-   * Return the int value for this connection parameter in the given {@code Properties}
+   * Return the int value for this connection parameter in the given {@code Properties}.
    *
    * @param properties properties to take actual value from
    * @return evaluated value for this connection parameter converted to int
@@ -538,7 +538,7 @@ public enum PGProperty {
   }
 
   /**
-   * Return the {@code Integer} value for this connection parameter in the given {@code Properties}
+   * Return the {@code Integer} value for this connection parameter in the given {@code Properties}.
    *
    * @param properties properties to take actual value from
    * @return evaluated value for this connection parameter converted to Integer or null
@@ -558,7 +558,7 @@ public enum PGProperty {
   }
 
   /**
-   * Set the boolean value for this connection parameter in the given {@code Properties}
+   * Set the boolean value for this connection parameter in the given {@code Properties}.
    *
    * @param properties properties in which the value should be set
    * @param value boolean value for this connection parameter
@@ -568,7 +568,7 @@ public enum PGProperty {
   }
 
   /**
-   * Set the int value for this connection parameter in the given {@code Properties}
+   * Set the int value for this connection parameter in the given {@code Properties}.
    *
    * @param properties properties in which the value should be set
    * @param value int value for this connection parameter
@@ -578,7 +578,7 @@ public enum PGProperty {
   }
 
   /**
-   * Test whether this property is present in the given {@code Properties}
+   * Test whether this property is present in the given {@code Properties}.
    *
    * @param properties set of properties to check current in
    * @return true if the parameter is specified in the given properties
@@ -589,7 +589,7 @@ public enum PGProperty {
 
   /**
    * Convert this connection parameter and the value read from the given {@code Properties} into a
-   * {@code DriverPropertyInfo}
+   * {@code DriverPropertyInfo}.
    *
    * @param properties properties to take actual value from
    * @return a DriverPropertyInfo representing this connection parameter

--- a/pgjdbc/src/main/java/org/postgresql/PGStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGStatement.java
@@ -56,15 +56,15 @@ public interface PGStatement {
   boolean isUseServerPrepare();
 
   /**
-   * Sets the reuse threshold for using server-prepared statements.
-   * <p>
-   * If <code>threshold</code> is a non-zero value N, the Nth and subsequent reuses of a
-   * PreparedStatement will use server-side prepare.
-   * <p>
-   * If <code>threshold</code> is zero, server-side prepare will not be used.
-   * <p>
-   * The reuse threshold is only used by PreparedStatement and CallableStatement objects; it is
-   * ignored for plain Statements.
+   * <p>Sets the reuse threshold for using server-prepared statements.</p>
+   *
+   * <p>If <code>threshold</code> is a non-zero value N, the Nth and subsequent reuses of a
+   * PreparedStatement will use server-side prepare.</p>
+   *
+   * <p>If <code>threshold</code> is zero, server-side prepare will not be used.</p>
+   *
+   * <p>The reuse threshold is only used by PreparedStatement and CallableStatement objects; it is
+   * ignored for plain Statements.</p>
    *
    * @param threshold the new threshold for this statement
    * @throws SQLException if an exception occurs while changing the threshold

--- a/pgjdbc/src/main/java/org/postgresql/copy/CopyManager.java
+++ b/pgjdbc/src/main/java/org/postgresql/copy/CopyManager.java
@@ -20,7 +20,7 @@ import java.io.Writer;
 import java.sql.SQLException;
 
 /**
- * API for PostgreSQL COPY bulk data transfer
+ * API for PostgreSQL COPY bulk data transfer.
  */
 public class CopyManager {
   // I don't know what the best buffer size is, so we let people specify it if

--- a/pgjdbc/src/main/java/org/postgresql/copy/PGCopyInputStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/copy/PGCopyInputStream.java
@@ -28,7 +28,7 @@ public class PGCopyInputStream extends InputStream implements CopyOut {
    *
    * @param connection database connection to use for copying (protocol version 3 required)
    * @param sql COPY TO STDOUT statement
-   * @throws SQLException if initializing the operation failsFastpath
+   * @throws SQLException if initializing the operation fails
    */
   public PGCopyInputStream(PGConnection connection, String sql) throws SQLException {
     this(connection.getCopyAPI().copyOut(sql));

--- a/pgjdbc/src/main/java/org/postgresql/copy/PGCopyInputStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/copy/PGCopyInputStream.java
@@ -15,7 +15,7 @@ import java.io.InputStream;
 import java.sql.SQLException;
 
 /**
- * InputStream for reading from a PostgreSQL COPY TO STDOUT operation
+ * InputStream for reading from a PostgreSQL COPY TO STDOUT operation.
  */
 public class PGCopyInputStream extends InputStream implements CopyOut {
   private CopyOut op;
@@ -24,18 +24,18 @@ public class PGCopyInputStream extends InputStream implements CopyOut {
   private int len;
 
   /**
-   * Uses given connection for specified COPY TO STDOUT operation
+   * Uses given connection for specified COPY TO STDOUT operation.
    *
    * @param connection database connection to use for copying (protocol version 3 required)
    * @param sql COPY TO STDOUT statement
-   * @throws SQLException if initializing the operation fails
+   * @throws SQLException if initializing the operation failsFastpath
    */
   public PGCopyInputStream(PGConnection connection, String sql) throws SQLException {
     this(connection.getCopyAPI().copyOut(sql));
   }
 
   /**
-   * Use given CopyOut operation for reading
+   * Use given CopyOut operation for reading.
    *
    * @param op COPY TO STDOUT operation
    */

--- a/pgjdbc/src/main/java/org/postgresql/copy/PGCopyOutputStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/copy/PGCopyOutputStream.java
@@ -13,7 +13,7 @@ import java.io.OutputStream;
 import java.sql.SQLException;
 
 /**
- * OutputStream for buffered input into a PostgreSQL COPY FROM STDIN operation
+ * OutputStream for buffered input into a PostgreSQL COPY FROM STDIN operation.
  */
 public class PGCopyOutputStream extends OutputStream implements CopyIn {
   private CopyIn op;
@@ -22,7 +22,7 @@ public class PGCopyOutputStream extends OutputStream implements CopyIn {
   private int at = 0;
 
   /**
-   * Uses given connection for specified COPY FROM STDIN operation
+   * Uses given connection for specified COPY FROM STDIN operation.
    *
    * @param connection database connection to use for copying (protocol version 3 required)
    * @param sql        COPY FROM STDIN statement
@@ -33,7 +33,7 @@ public class PGCopyOutputStream extends OutputStream implements CopyIn {
   }
 
   /**
-   * Uses given connection for specified COPY FROM STDIN operation
+   * Uses given connection for specified COPY FROM STDIN operation.
    *
    * @param connection database connection to use for copying (protocol version 3 required)
    * @param sql        COPY FROM STDIN statement
@@ -46,7 +46,7 @@ public class PGCopyOutputStream extends OutputStream implements CopyIn {
   }
 
   /**
-   * Use given CopyIn operation for writing
+   * Use given CopyIn operation for writing.
    *
    * @param op COPY FROM STDIN operation
    */
@@ -55,7 +55,7 @@ public class PGCopyOutputStream extends OutputStream implements CopyIn {
   }
 
   /**
-   * Use given CopyIn operation for writing
+   * Use given CopyIn operation for writing.
    *
    * @param op         COPY FROM STDIN operation
    * @param bufferSize try to send this many bytes at a time

--- a/pgjdbc/src/main/java/org/postgresql/core/BaseConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/BaseConnection.java
@@ -184,7 +184,7 @@ public interface BaseConnection extends PGConnection, Connection {
   void purgeTimerTasks();
 
   /**
-   * Return metadata cache for given connection
+   * Return metadata cache for given connection.
    *
    * @return metadata cache
    */

--- a/pgjdbc/src/main/java/org/postgresql/core/BaseConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/BaseConnection.java
@@ -64,12 +64,12 @@ public interface BaseConnection extends PGConnection, Connection {
   ReplicationProtocol getReplicationProtocol();
 
   /**
-   * Construct and return an appropriate object for the given type and value. This only considers
+   * <p>Construct and return an appropriate object for the given type and value. This only considers
    * the types registered via {@link org.postgresql.PGConnection#addDataType(String, Class)} and
-   * {@link org.postgresql.PGConnection#addDataType(String, String)}.
-   * <p>
-   * If no class is registered as handling the given type, then a generic
-   * {@link org.postgresql.util.PGobject} instance is returned.
+   * {@link org.postgresql.PGConnection#addDataType(String, String)}.</p>
+   *
+   * <p>If no class is registered as handling the given type, then a generic
+   * {@link org.postgresql.util.PGobject} instance is returned.</p>
    *
    * @param type the backend typename
    * @param value the type-specific string representation of the value
@@ -84,10 +84,10 @@ public interface BaseConnection extends PGConnection, Connection {
   TypeInfo getTypeInfo();
 
   /**
-   * Check if we have at least a particular server version.
+   * <p>Check if we have at least a particular server version.</p>
    *
-   * The input version is of the form xxyyzz, matching a PostgreSQL version like xx.yy.zz. So 9.0.12
-   * is 90012 .
+   * <p>The input version is of the form xxyyzz, matching a PostgreSQL version like xx.yy.zz. So 9.0.12
+   * is 90012.</p>
    *
    * @param ver the server version to check, of the form xxyyzz eg 90401
    * @return true if the server version is at least "ver".
@@ -95,10 +95,10 @@ public interface BaseConnection extends PGConnection, Connection {
   boolean haveMinimumServerVersion(int ver);
 
   /**
-   * Check if we have at least a particular server version.
+   * <p>Check if we have at least a particular server version.</p>
    *
-   * The input version is of the form xxyyzz, matching a PostgreSQL version like xx.yy.zz. So 9.0.12
-   * is 90012 .
+   * <p>The input version is of the form xxyyzz, matching a PostgreSQL version like xx.yy.zz. So 9.0.12
+   * is 90012.</p>
    *
    * @param ver the server version to check
    * @return true if the server version is at least "ver".

--- a/pgjdbc/src/main/java/org/postgresql/core/CachedQuery.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/CachedQuery.java
@@ -44,7 +44,7 @@ public class CachedQuery implements CanEstimateSize {
   }
 
   /**
-   * Number of times this statement has been used
+   * Number of times this statement has been used.
    *
    * @return number of times this statement has been used
    */

--- a/pgjdbc/src/main/java/org/postgresql/core/ConnectionFactory.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/ConnectionFactory.java
@@ -24,12 +24,12 @@ import java.util.Properties;
  */
 public abstract class ConnectionFactory {
   /**
-   * Establishes and initializes a new connection.
-   * <p>
-   * If the "protocolVersion" property is specified, only that protocol version is tried. Otherwise,
-   * all protocols are tried in order, falling back to older protocols as necessary.
-   * <p>
-   * Currently, protocol versions 3 (7.4+) is supported.
+   * <p>Establishes and initializes a new connection.</p>
+   *
+   * <p>If the "protocolVersion" property is specified, only that protocol version is tried. Otherwise,
+   * all protocols are tried in order, falling back to older protocols as necessary.</p>
+   *
+   * <p>Currently, protocol versions 3 (7.4+) is supported.</p>
    *
    * @param hostSpecs at least one host and port to connect to; multiple elements for round-robin
    *        failover

--- a/pgjdbc/src/main/java/org/postgresql/core/Encoding.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/Encoding.java
@@ -118,7 +118,7 @@ public class Encoding {
    *
    * @param jvmEncoding the name of the JVM encoding
    * @return an Encoding instance for the specified encoding, or an Encoding instance for the
-   * default JVM encoding if the specified encoding is unavailable.
+   *     default JVM encoding if the specified encoding is unavailable.
    */
   public static Encoding getJVMEncoding(String jvmEncoding) {
     if ("UTF-8".equals(jvmEncoding)) {
@@ -136,7 +136,7 @@ public class Encoding {
    *
    * @param databaseEncoding the name of the database encoding
    * @return an Encoding instance for the specified encoding, or an Encoding instance for the
-   * default JVM encoding if the specified encoding is unavailable.
+   *     default JVM encoding if the specified encoding is unavailable.
    */
   public static Encoding getDatabaseEncoding(String databaseEncoding) {
     if ("UTF8".equals(databaseEncoding)) {

--- a/pgjdbc/src/main/java/org/postgresql/core/EncodingPredictor.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/EncodingPredictor.java
@@ -8,7 +8,8 @@ package org.postgresql.core;
 import java.io.IOException;
 
 /**
- * Predicts encoding for error messages based on some heuristics:
+ * Predicts encoding for error messages based on some heuristics.
+ *
  * 1) For certain languages, it is known how "FATAL" is translated
  * 2) For Japanese, several common words are hardcoded
  * 3) Then try various LATIN encodings

--- a/pgjdbc/src/main/java/org/postgresql/core/EncodingPredictor.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/EncodingPredictor.java
@@ -8,11 +8,13 @@ package org.postgresql.core;
 import java.io.IOException;
 
 /**
- * Predicts encoding for error messages based on some heuristics.
+ * <p>Predicts encoding for error messages based on some heuristics.</p>
  *
- * 1) For certain languages, it is known how "FATAL" is translated
- * 2) For Japanese, several common words are hardcoded
- * 3) Then try various LATIN encodings
+ * <ol>
+ * <li>For certain languages, it is known how "FATAL" is translated</li>
+ * <li>For Japanese, several common words are hardcoded</li>
+ * <li>Then try various LATIN encodings</li>
+ * </ol>
  */
 public class EncodingPredictor {
   /**

--- a/pgjdbc/src/main/java/org/postgresql/core/JavaVersion.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/JavaVersion.java
@@ -25,7 +25,7 @@ public enum JavaVersion {
   }
 
   /**
-   * Java version string like in {@code "java.version"} property
+   * Java version string like in {@code "java.version"} property.
    *
    * @param version string like 1.6, 1.7, etc
    * @return JavaVersion enum

--- a/pgjdbc/src/main/java/org/postgresql/core/JdbcCallParseInfo.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/JdbcCallParseInfo.java
@@ -18,7 +18,7 @@ public class JdbcCallParseInfo {
   }
 
   /**
-   * SQL in a native for certain backend version
+   * SQL in a native for certain backend version.
    *
    * @return SQL in a native for certain backend version
    */
@@ -27,7 +27,7 @@ public class JdbcCallParseInfo {
   }
 
   /**
-   * Returns if given SQL is a function
+   * Returns if given SQL is a function.
    *
    * @return {@code true} if given SQL is a function
    */

--- a/pgjdbc/src/main/java/org/postgresql/core/PGStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/PGStream.java
@@ -190,7 +190,7 @@ public class PGStream implements Closeable, Flushable {
   }
 
   /**
-   * Sends a single character to the back end
+   * Sends a single character to the back end.
    *
    * @param val the character to be sent
    * @throws IOException if an I/O error occurs
@@ -200,7 +200,7 @@ public class PGStream implements Closeable, Flushable {
   }
 
   /**
-   * Sends a 4-byte integer to the back end
+   * Sends a 4-byte integer to the back end.
    *
    * @param val the integer to be sent
    * @throws IOException if an I/O error occurs
@@ -214,7 +214,7 @@ public class PGStream implements Closeable, Flushable {
   }
 
   /**
-   * Sends a 2-byte integer (short) to the back end
+   * Sends a 2-byte integer (short) to the back end.
    *
    * @param val the integer to be sent
    * @throws IOException if an I/O error occurs or {@code val} cannot be encoded in 2 bytes
@@ -230,7 +230,7 @@ public class PGStream implements Closeable, Flushable {
   }
 
   /**
-   * Send an array of bytes to the backend
+   * Send an array of bytes to the backend.
    *
    * @param buf The array of bytes to be sent
    * @throws IOException if an I/O error occurs
@@ -284,7 +284,7 @@ public class PGStream implements Closeable, Flushable {
   }
 
   /**
-   * Receives a single character from the backend
+   * Receives a single character from the backend.
    *
    * @return the character received
    * @throws IOException if an I/O Error occurs
@@ -298,7 +298,7 @@ public class PGStream implements Closeable, Flushable {
   }
 
   /**
-   * Receives a four byte integer from the backend
+   * Receives a four byte integer from the backend.
    *
    * @return the integer received from the backend
    * @throws IOException if an I/O error occurs
@@ -313,7 +313,7 @@ public class PGStream implements Closeable, Flushable {
   }
 
   /**
-   * Receives a two byte integer from the backend
+   * Receives a two byte integer from the backend.
    *
    * @return the integer received from the backend
    * @throws IOException if an I/O error occurs
@@ -422,7 +422,7 @@ public class PGStream implements Closeable, Flushable {
   }
 
   /**
-   * Reads in a given number of bytes from the backend
+   * Reads in a given number of bytes from the backend.
    *
    * @param siz number of bytes to read
    * @return array of bytes received
@@ -435,7 +435,7 @@ public class PGStream implements Closeable, Flushable {
   }
 
   /**
-   * Reads in a given number of bytes from the backend
+   * Reads in a given number of bytes from the backend.
    *
    * @param buf buffer to store result
    * @param off offset in buffer
@@ -515,7 +515,7 @@ public class PGStream implements Closeable, Flushable {
   }
 
   /**
-   * Consume an expected EOF from the backend
+   * Consume an expected EOF from the backend.
    *
    * @throws IOException if an I/O error occurs
    * @throws SQLException if we get something other than an EOF
@@ -530,7 +530,7 @@ public class PGStream implements Closeable, Flushable {
   }
 
   /**
-   * Closes the connection
+   * Closes the connection.
    *
    * @throws IOException if an I/O Error occurs
    */

--- a/pgjdbc/src/main/java/org/postgresql/core/PGStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/PGStream.java
@@ -25,11 +25,11 @@ import java.sql.SQLException;
 import javax.net.SocketFactory;
 
 /**
- * Wrapper around the raw connection to the server that implements some basic primitives
- * (reading/writing formatted data, doing string encoding, etc).
- * <p>
- * In general, instances of PGStream are not threadsafe; the caller must ensure that only one thread
- * at a time is accessing a particular PGStream instance.
+ * <p>Wrapper around the raw connection to the server that implements some basic primitives
+ * (reading/writing formatted data, doing string encoding, etc).</p>
+ *
+ * <p>In general, instances of PGStream are not threadsafe; the caller must ensure that only one thread
+ * at a time is accessing a particular PGStream instance.</p>
  */
 public class PGStream implements Closeable, Flushable {
   private final SocketFactory socketFactory;
@@ -172,12 +172,12 @@ public class PGStream implements Closeable, Flushable {
   }
 
   /**
-   * Get a Writer instance that encodes directly onto the underlying stream.
-   * <p>
-   * The returned Writer should not be closed, as it's a shared object. Writer.flush needs to be
+   * <p>Get a Writer instance that encodes directly onto the underlying stream.</p>
+   *
+   * <p>The returned Writer should not be closed, as it's a shared object. Writer.flush needs to be
    * called when switching between use of the Writer and use of the PGStream write methods, but it
    * won't actually flush output all the way out -- call {@link #flush} to actually ensure all
-   * output has been pushed to the server.
+   * output has been pushed to the server.</p>
    *
    * @return the shared Writer instance
    * @throws IOException if something goes wrong.

--- a/pgjdbc/src/main/java/org/postgresql/core/ParameterList.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/ParameterList.java
@@ -10,15 +10,15 @@ import java.io.InputStream;
 import java.sql.SQLException;
 
 /**
- * Abstraction of a list of parameters to be substituted into a Query. The protocol-specific details
+ * <p>Abstraction of a list of parameters to be substituted into a Query. The protocol-specific details
  * of how to efficiently store and stream the parameters is hidden behind implementations of this
- * interface.
- * <p>
- * In general, instances of ParameterList are associated with a particular Query object (the one
- * that created them) and shouldn't be used against another Query.
- * <p>
- * Parameter indexes are 1-based to match JDBC's PreparedStatement, i.e. the first parameter has
- * index 1.
+ * interface.</p>
+ *
+ * <p>In general, instances of ParameterList are associated with a particular Query object (the one
+ * that created them) and shouldn't be used against another Query.</p>
+ *
+ * <p>Parameter indexes are 1-based to match JDBC's PreparedStatement, i.e. the first parameter has
+ * index 1.</p>
  *
  * @author Oliver Jowett (oliver@opencloud.com)
  */

--- a/pgjdbc/src/main/java/org/postgresql/core/Parser.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/Parser.java
@@ -1247,7 +1247,7 @@ public class Parser {
   }
 
   /**
-   * generate sql for escaped functions
+   * Generate sql for escaped functions.
    *
    * @param newsql destination StringBuilder
    * @param functionName the escaped function name

--- a/pgjdbc/src/main/java/org/postgresql/core/Parser.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/Parser.java
@@ -736,7 +736,7 @@ public class Parser {
   /**
    * @param c character
    * @return true if the given character is a valid character for an operator in the backend's
-   * parser
+   *     parser
    */
   public static boolean isOperatorChar(char c) {
     /*

--- a/pgjdbc/src/main/java/org/postgresql/core/Parser.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/Parser.java
@@ -382,11 +382,11 @@ public class Parser {
   }
 
   /**
-   * Find the end of the single-quoted string starting at the given offset.
+   * <p>Find the end of the single-quoted string starting at the given offset.</p>
    *
-   * Note: for <tt>'single '' quote in string'</tt>, this method currently returns the offset of
+   * <p>Note: for <tt>'single '' quote in string'</tt>, this method currently returns the offset of
    * first <tt>'</tt> character after the initial one. The caller must call the method a second time
-   * for the second part of the quoted string.
+   * for the second part of the quoted string.</p>
    *
    * @param query                     query
    * @param offset                    start offset
@@ -432,11 +432,11 @@ public class Parser {
   }
 
   /**
-   * Find the end of the double-quoted string starting at the given offset.
+   * <p>Find the end of the double-quoted string starting at the given offset.</p>
    *
-   * Note: for <tt>&quot;double &quot;&quot; quote in string&quot;</tt>, this method currently
+   * <p>Note: for <tt>&quot;double &quot;&quot; quote in string&quot;</tt>, this method currently
    * returns the offset of first <tt>&quot;</tt> character after the initial one. The caller must
-   * call the method a second time for the second part of the quoted string.
+   * call the method a second time for the second part of the quoted string.</p>
    *
    * @param query  query
    * @param offset start offset
@@ -1052,13 +1052,13 @@ public class Parser {
   }
 
   /**
-   * Filter the SQL string of Java SQL Escape clauses.
-   * <p>
-   * Currently implemented Escape clauses are those mentioned in 11.3 in the specification.
+   * <p>Filter the SQL string of Java SQL Escape clauses.</p>
+   *
+   * <p>Currently implemented Escape clauses are those mentioned in 11.3 in the specification.
    * Basically we look through the sql string for {d xxx}, {t xxx}, {ts xxx}, {oj xxx} or {fn xxx}
    * in non-string sql code. When we find them, we just strip the escape part leaving only the xxx
    * part. So, something like "select * from x where d={d '2001-10-09'}" would return "select * from
-   * x where d= '2001-10-09'".
+   * x where d= '2001-10-09'".</p>
    *
    * @param p_sql                     the original query text
    * @param replaceProcessingEnabled  whether replace_processing_enabled is on

--- a/pgjdbc/src/main/java/org/postgresql/core/Query.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/Query.java
@@ -40,7 +40,7 @@ public interface Query {
   String toString(ParameterList parameters);
 
   /**
-   * Returns SQL in native for database format
+   * Returns SQL in native for database format.
    * @return SQL in native for database format
    */
   String getNativeSql();

--- a/pgjdbc/src/main/java/org/postgresql/core/Query.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/Query.java
@@ -9,21 +9,21 @@ package org.postgresql.core;
 import java.util.Map;
 
 /**
- * Abstraction of a generic Query, hiding the details of any protocol-version-specific data needed
- * to execute the query efficiently.
- * <p>
- * Query objects should be explicitly closed when no longer needed; if resources are allocated on
- * the server for this query, their cleanup is triggered by closing the Query.
+ * <p>Abstraction of a generic Query, hiding the details of any protocol-version-specific data needed
+ * to execute the query efficiently.</p>
+ *
+ * <p>Query objects should be explicitly closed when no longer needed; if resources are allocated on
+ * the server for this query, their cleanup is triggered by closing the Query.</p>
  *
  * @author Oliver Jowett (oliver@opencloud.com)
  */
 public interface Query {
   /**
-   * Create a ParameterList suitable for storing parameters associated with this Query.
-   * <p>
-   * If this query has no parameters, a ParameterList will be returned, but it may be a shared
+   * <p>Create a ParameterList suitable for storing parameters associated with this Query.</p>
+   *
+   * <p>If this query has no parameters, a ParameterList will be returned, but it may be a shared
    * immutable object. If this query does have parameters, the returned ParameterList is a new list,
-   * unshared by other callers.
+   * unshared by other callers.</p>
    *
    * @return a suitable ParameterList instance for this query
    */
@@ -52,10 +52,10 @@ public interface Query {
   SqlCommand getSqlCommand();
 
   /**
-   * Close this query and free any server-side resources associated with it. The resources may not
-   * be immediately deallocated, but closing a Query may make the deallocation more prompt.
-   * <p>
-   * A closed Query should not be executed.
+   * <p>Close this query and free any server-side resources associated with it. The resources may not
+   * be immediately deallocated, but closing a Query may make the deallocation more prompt.</p>
+   *
+   * <p>A closed Query should not be executed.</p>
    */
   void close();
 

--- a/pgjdbc/src/main/java/org/postgresql/core/QueryExecutor.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/QueryExecutor.java
@@ -22,9 +22,9 @@ import java.util.Set;
 import java.util.TimeZone;
 
 /**
- * Abstracts the protocol-specific details of executing a query.
- * <p>
- * Every connection has a single QueryExecutor implementation associated with it. This object
+ * <p>Abstracts the protocol-specific details of executing a query.</p>
+ *
+ * <p>Every connection has a single QueryExecutor implementation associated with it. This object
  * provides:
  *
  * <ul>
@@ -35,19 +35,18 @@ import java.util.TimeZone;
  * {@link #execute(Query[], ParameterList[], BatchResultHandler, int, int, int)} for batches of queries)
  * <li>a fastpath call interface ({@link #createFastpathParameters} and {@link #fastpathCall}).
  * </ul>
+ * </p>
  *
- * <p>
- * Query objects may represent a query that has parameter placeholders. To provide actual values for
+ * <p>Query objects may represent a query that has parameter placeholders. To provide actual values for
  * these parameters, a {@link ParameterList} object is created via a factory method (
  * {@link Query#createParameterList}). The parameters are filled in by the caller and passed along
  * with the query to the query execution methods. Several ParameterLists for a given query might
  * exist at one time (or over time); this allows the underlying Query to be reused for several
- * executions, or for batch execution of the same Query.
+ * executions, or for batch execution of the same Query.</p>
  *
- * <p>
- * In general, a Query created by a particular QueryExecutor may only be executed by that
+ * <p>In general, a Query created by a particular QueryExecutor may only be executed by that
  * QueryExecutor, and a ParameterList created by a particular Query may only be used as parameters
- * to that Query. Unpredictable things will happen if this isn't done.
+ * to that Query. Unpredictable things will happen if this isn't done.</p>
  *
  * @author Oliver Jowett (oliver@opencloud.com)
  */
@@ -350,14 +349,14 @@ public interface QueryExecutor extends TypeTransferModeRegistry {
   boolean isClosed();
 
   /**
-   * Return the server version from the server_version GUC.
+   * <p>Return the server version from the server_version GUC.</p>
    *
-   * Note that there's no requirement for this to be numeric or of the form x.y.z. PostgreSQL
+   * <p>Note that there's no requirement for this to be numeric or of the form x.y.z. PostgreSQL
    * development releases usually have the format x.ydevel e.g. 9.4devel; betas usually x.ybetan
-   * e.g. 9.4beta1. The --with-extra-version configure option may add an arbitrary string to this.
+   * e.g. 9.4beta1. The --with-extra-version configure option may add an arbitrary string to this.</p>
    *
-   * Don't use this string for logic, only use it when displaying the server version to the user.
-   * Prefer getServerVersionNum() for all logic purposes.
+   * <p>Don't use this string for logic, only use it when displaying the server version to the user.
+   * Prefer getServerVersionNum() for all logic purposes.</p>
    *
    * @return the server version string from the server_version guc
    */
@@ -380,12 +379,12 @@ public interface QueryExecutor extends TypeTransferModeRegistry {
   SQLWarning getWarnings();
 
   /**
-   * Get a machine-readable server version.
+   * <p>Get a machine-readable server version.</p>
    *
-   * This returns the value of the server_version_num GUC. If no such GUC exists, it falls back on
+   * <p>This returns the value of the server_version_num GUC. If no such GUC exists, it falls back on
    * attempting to parse the text server version for the major version. If there's no minor version
    * (e.g. a devel or beta release) then the minor version is set to zero. If the version could not
-   * be parsed, zero is returned.
+   * be parsed, zero is returned.</p>
    *
    * @return the server version in numeric XXYYZZ form, eg 090401, from server_version_num
    */

--- a/pgjdbc/src/main/java/org/postgresql/core/QueryExecutor.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/QueryExecutor.java
@@ -25,7 +25,7 @@ import java.util.TimeZone;
  * <p>Abstracts the protocol-specific details of executing a query.</p>
  *
  * <p>Every connection has a single QueryExecutor implementation associated with it. This object
- * provides:
+ * provides:</p>
  *
  * <ul>
  * <li>factory methods for Query objects ({@link #createSimpleQuery(String)} and
@@ -35,7 +35,6 @@ import java.util.TimeZone;
  * {@link #execute(Query[], ParameterList[], BatchResultHandler, int, int, int)} for batches of queries)
  * <li>a fastpath call interface ({@link #createFastpathParameters} and {@link #fastpathCall}).
  * </ul>
- * </p>
  *
  * <p>Query objects may represent a query that has parameter placeholders. To provide actual values for
  * these parameters, a {@link ParameterList} object is created via a factory method (

--- a/pgjdbc/src/main/java/org/postgresql/core/QueryExecutor.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/QueryExecutor.java
@@ -202,7 +202,7 @@ public interface QueryExecutor extends TypeTransferModeRegistry {
   void releaseQuery(CachedQuery cachedQuery);
 
   /**
-   * Wrap given native query into a ready for execution format
+   * Wrap given native query into a ready for execution format.
    * @param queries list of queries in native to database syntax
    * @return query object ready for execution by this query executor
    */

--- a/pgjdbc/src/main/java/org/postgresql/core/ReplicationProtocol.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/ReplicationProtocol.java
@@ -12,8 +12,9 @@ import org.postgresql.replication.fluent.physical.PhysicalReplicationOptions;
 import java.sql.SQLException;
 
 /**
- * <p>Abstracts the protocol-specific details of physic and logic replication. <p>With each
- * connection open with replication options associate own instance ReplicationProtocol.
+ * <p>Abstracts the protocol-specific details of physic and logic replication.</p>
+ *
+ * <p>With each connection open with replication options associate own instance ReplicationProtocol.</p>
  */
 public interface ReplicationProtocol {
   /**

--- a/pgjdbc/src/main/java/org/postgresql/core/ReplicationProtocol.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/ReplicationProtocol.java
@@ -19,7 +19,7 @@ public interface ReplicationProtocol {
   /**
    * @param options not null options for logical replication stream
    * @return not null stream instance from which available fetch wal logs that was decode by output
-   * plugin
+   *     plugin
    * @throws SQLException on error
    */
   PGReplicationStream startLogical(LogicalReplicationOptions options) throws SQLException;

--- a/pgjdbc/src/main/java/org/postgresql/core/ResultHandler.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/ResultHandler.java
@@ -11,16 +11,16 @@ import java.sql.SQLWarning;
 import java.util.List;
 
 /**
- * Callback interface for passing query results from the protocol-specific layer to the
- * protocol-independent JDBC implementation code.
- * <p>
- * In general, a single query execution will consist of a number of calls to handleResultRows,
+ * <p>Callback interface for passing query results from the protocol-specific layer to the
+ * protocol-independent JDBC implementation code.</p>
+ *
+ * <p>In general, a single query execution will consist of a number of calls to handleResultRows,
  * handleCommandStatus, handleWarning, and handleError, followed by a single call to
  * handleCompletion when query execution is complete. If the caller wants to throw SQLException,
- * this can be done in handleCompletion.
- * <p>
- * Each executed query ends with a call to handleResultRows, handleCommandStatus, or handleError. If
- * an error occurs, subsequent queries won't generate callbacks.
+ * this can be done in handleCompletion.</p>
+ *
+ * <p>Each executed query ends with a call to handleResultRows, handleCommandStatus, or handleError. If
+ * an error occurs, subsequent queries won't generate callbacks.</p>
  *
  * @author Oliver Jowett (oliver@opencloud.com)
  */

--- a/pgjdbc/src/main/java/org/postgresql/core/ServerVersion.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/ServerVersion.java
@@ -44,10 +44,10 @@ public enum ServerVersion implements Version {
   }
 
   /**
-   * Attempt to parse the server version string into an XXYYZZ form version number into a
-   * {@link Version}.
+   * <p>Attempt to parse the server version string into an XXYYZZ form version number into a
+   * {@link Version}.</p>
    *
-   * If the specified version cannot be parsed, the {@link Version#getVersionNum()} will return 0.
+   * <p>If the specified version cannot be parsed, the {@link Version#getVersionNum()} will return 0.</p>
    *
    * @param version version in numeric XXYYZZ form, e.g. "090401" for 9.4.1
    * @return a {@link Version} representing the specified version string.
@@ -81,18 +81,18 @@ public enum ServerVersion implements Version {
   }
 
   /**
-   * Attempt to parse the server version string into an XXYYZZ form version number.
+   * <p>Attempt to parse the server version string into an XXYYZZ form version number.</p>
    *
-   * Returns 0 if the version could not be parsed.
+   * <p>Returns 0 if the version could not be parsed.</p>
    *
-   * Returns minor version 0 if the minor version could not be determined, e.g. devel or beta
-   * releases.
+   * <p>Returns minor version 0 if the minor version could not be determined, e.g. devel or beta
+   * releases.</p>
    *
-   * If a single major part like 90400 is passed, it's assumed to be a pre-parsed version and
-   * returned verbatim. (Anything equal to or greater than 10000 is presumed to be this form).
+   * <p>If a single major part like 90400 is passed, it's assumed to be a pre-parsed version and
+   * returned verbatim. (Anything equal to or greater than 10000 is presumed to be this form).</p>
    *
-   * The yy or zz version parts may be larger than 99. A NumberFormatException is thrown if a
-   * version part is out of range.
+   * <p>The yy or zz version parts may be larger than 99. A NumberFormatException is thrown if a
+   * version part is out of range.</p>
    *
    * @param serverVersion server vertion in a XXYYZZ form
    * @return server version in number form

--- a/pgjdbc/src/main/java/org/postgresql/core/SocketFactoryFactory.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/SocketFactoryFactory.java
@@ -21,7 +21,7 @@ import javax.net.SocketFactory;
 public class SocketFactoryFactory {
 
   /**
-   * Instantiates {@link SocketFactory} based on the {@link PGProperty#SOCKET_FACTORY}
+   * Instantiates {@link SocketFactory} based on the {@link PGProperty#SOCKET_FACTORY}.
    *
    * @param info connection properties
    * @return socket factory

--- a/pgjdbc/src/main/java/org/postgresql/core/TypeInfo.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/TypeInfo.java
@@ -64,7 +64,7 @@ public interface TypeInfo {
   int getPGArrayElement(int oid) throws SQLException;
 
   /**
-   * Determine the oid of the given base postgresql type's array type
+   * Determine the oid of the given base postgresql type's array type.
    *
    * @param elementTypeName the base type's
    * @return the array type's OID, or 0 if unknown

--- a/pgjdbc/src/main/java/org/postgresql/core/Utils.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/Utils.java
@@ -173,18 +173,18 @@ public class Utils {
   }
 
   /**
-   * Attempt to parse the server version string into an XXYYZZ form version number.
+   * <p>Attempt to parse the server version string into an XXYYZZ form version number.</p>
    *
-   * Returns 0 if the version could not be parsed.
+   * <p>Returns 0 if the version could not be parsed.</p>
    *
-   * Returns minor version 0 if the minor version could not be determined, e.g. devel or beta
-   * releases.
+   * <p>Returns minor version 0 if the minor version could not be determined, e.g. devel or beta
+   * releases.</p>
    *
-   * If a single major part like 90400 is passed, it's assumed to be a pre-parsed version and
-   * returned verbatim. (Anything equal to or greater than 10000 is presumed to be this form).
+   * <p>If a single major part like 90400 is passed, it's assumed to be a pre-parsed version and
+   * returned verbatim. (Anything equal to or greater than 10000 is presumed to be this form).</p>
    *
-   * The yy or zz version parts may be larger than 99. A NumberFormatException is thrown if a
-   * version part is out of range.
+   * <p>The yy or zz version parts may be larger than 99. A NumberFormatException is thrown if a
+   * version part is out of range.</p>
    *
    * @param serverVersion server vertion in a XXYYZZ form
    * @return server version in number form

--- a/pgjdbc/src/main/java/org/postgresql/core/Utils.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/Utils.java
@@ -75,7 +75,7 @@ public class Utils {
   }
 
   /**
-   * Common part for {@link #escapeLiteral(StringBuilder, String, boolean)}
+   * Common part for {@link #escapeLiteral(StringBuilder, String, boolean)}.
    *
    * @param sbuf Either StringBuffer or StringBuilder as we do not expect any IOException to be
    *        thrown
@@ -143,7 +143,7 @@ public class Utils {
   }
 
   /**
-   * Common part for appendEscapedIdentifier
+   * Common part for appendEscapedIdentifier.
    *
    * @param sbuf Either StringBuffer or StringBuilder as we do not expect any IOException to be
    *        thrown.

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/CopyInImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/CopyInImpl.java
@@ -13,9 +13,9 @@ import org.postgresql.util.PSQLState;
 import java.sql.SQLException;
 
 /**
- * COPY FROM STDIN operation.
+ * <p>COPY FROM STDIN operation.</p>
  *
- * Anticipated flow:
+ * <p>Anticipated flow:
  *
  * CopyManager.copyIn() -&gt;QueryExecutor.startCopy() - sends given query to server
  * -&gt;processCopyResults(): - receives CopyInResponse from Server - creates new CopyInImpl
@@ -29,7 +29,7 @@ import java.sql.SQLException;
  * -&gt;QueryExecutorImpl.endCopy() - sends CopyDone - processCopyResults() - on CommandComplete
  * -&gt;CopyOperationImpl.handleCommandComplete() - sets updatedRowCount when applicable - on
  * ReadyForQuery unlock() connection for use by other operations &lt;-return:
- * CopyInImpl.getUpdatedRowCount()
+ * CopyInImpl.getUpdatedRowCount()</p>
  */
 public class CopyInImpl extends CopyOperationImpl implements CopyIn {
 

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/CopyInImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/CopyInImpl.java
@@ -13,7 +13,9 @@ import org.postgresql.util.PSQLState;
 import java.sql.SQLException;
 
 /**
- * Anticipated flow of a COPY FROM STDIN operation:
+ * COPY FROM STDIN operation.
+ *
+ * Anticipated flow:
  *
  * CopyManager.copyIn() -&gt;QueryExecutor.startCopy() - sends given query to server
  * -&gt;processCopyResults(): - receives CopyInResponse from Server - creates new CopyInImpl

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/CopyOperationImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/CopyOperationImpl.java
@@ -57,7 +57,7 @@ public abstract class CopyOperationImpl implements CopyOperation {
   }
 
   /**
-   * Consume received copy data
+   * Consume received copy data.
    *
    * @param data data that was receive by copy protocol
    * @throws PSQLException if some internal problem occurs

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/CopyOutImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/CopyOutImpl.java
@@ -10,9 +10,9 @@ import org.postgresql.copy.CopyOut;
 import java.sql.SQLException;
 
 /**
- * Anticipated flow of a COPY TO STDOUT operation:
+ * <p>Anticipated flow of a COPY TO STDOUT operation:</p>
  *
- * CopyManager.copyOut() -&gt;QueryExecutor.startCopy() - sends given query to server
+ * <p>CopyManager.copyOut() -&gt;QueryExecutor.startCopy() - sends given query to server
  * -&gt;processCopyResults(): - receives CopyOutResponse from Server - creates new CopyOutImpl
  * -&gt;initCopy(): - receives copy metadata from server -&gt;CopyOutImpl.init() -&gt;lock()
  * connection for this operation - if query fails an exception is thrown - if query returns wrong
@@ -21,7 +21,7 @@ import java.sql.SQLException;
  * -&gt;CopyOutImpl.readFromCopy() -&gt;QueryExecutorImpl.readFromCopy() -&gt;processCopyResults() -
  * on copydata row from server -&gt;CopyOutImpl.handleCopydata() stores reference to byte array - on
  * CopyDone, CommandComplete, ReadyForQuery -&gt;unlock() connection for use by other operations
- * &lt;-returned: byte array of data received from server or null at end.
+ * &lt;-returned: byte array of data received from server or null at end.</p>
  */
 public class CopyOutImpl extends CopyOperationImpl implements CopyOut {
   private byte[] currentDataRow;

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/ExecuteRequest.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/ExecuteRequest.java
@@ -6,7 +6,7 @@
 package org.postgresql.core.v3;
 
 /**
- * Information for "pending execute queue"
+ * Information for "pending execute queue".
  *
  * @see QueryExecutorImpl#pendingExecuteQueue
  */

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -76,12 +76,12 @@ public class QueryExecutorImpl extends QueryExecutorBase {
   private static final Pattern COMMAND_COMPLETE_PATTERN = Pattern.compile("^([A-Za-z]++)(?: (\\d++))?+(?: (\\d++))?+$");
 
   /**
-   * TimeZone of the current connection (TimeZone backend parameter)
+   * TimeZone of the current connection (TimeZone backend parameter).
    */
   private TimeZone timeZone;
 
   /**
-   * application_name connection property
+   * application_name connection property.
    */
   private String applicationName;
 
@@ -102,7 +102,7 @@ public class QueryExecutorImpl extends QueryExecutorBase {
 
   /**
    * This is a fake query object so processResults can distinguish "ReadyForQuery" messages
-   * from Sync messages vs from simple execute (aka 'Q')
+   * from Sync messages vs from simple execute (aka 'Q').
    */
   private final SimpleQuery sync = (SimpleQuery) createQuery("SYNC", false, true).query;
 
@@ -847,9 +847,9 @@ public class QueryExecutorImpl extends QueryExecutorBase {
 
   /**
    * Locks connection and calls initializer for a new CopyOperation Called via startCopy ->
-   * processCopyResults
+   * processCopyResults.
    *
-   * @param op an unitialized CopyOperation
+   * @param op an uninitialized CopyOperation
    * @throws SQLException on locking failure
    * @throws IOException on database connection failure
    */
@@ -941,7 +941,7 @@ public class QueryExecutorImpl extends QueryExecutorBase {
   }
 
   /**
-   * Finishes writing to copy and unlocks connection
+   * Finishes writing to copy and unlocks connection.
    *
    * @param op the copy operation presumably currently holding lock on this connection
    * @return number of rows updated for server versions 8.2 or newer
@@ -1017,7 +1017,7 @@ public class QueryExecutorImpl extends QueryExecutorBase {
 
   /**
    * Wait for a row of data to be received from server on an active copy operation
-   * Connection gets unlocked by processCopyResults() at end of operation
+   * Connection gets unlocked by processCopyResults() at end of operation.
    *
    * @param op the copy operation presumably currently holding lock on this connection
    * @param block whether to block waiting for input

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -137,16 +137,16 @@ public class QueryExecutorImpl extends QueryExecutorBase {
   }
 
   /**
-   * Supplement to synchronization of public methods on current QueryExecutor.
+   * <p>Supplement to synchronization of public methods on current QueryExecutor.</p>
    *
-   * Necessary for keeping the connection intact between calls to public methods sharing a state
+   * <p>Necessary for keeping the connection intact between calls to public methods sharing a state
    * such as COPY subprotocol. waitOnLock() must be called at beginning of each connection access
-   * point.
+   * point.</p>
    *
-   * Public methods sharing that state must then be synchronized among themselves. Normal method
-   * synchronization typically suffices for that.
+   * <p>Public methods sharing that state must then be synchronized among themselves. Normal method
+   * synchronization typically suffices for that.</p>
    *
-   * See notes on related methods as well as currentCopy() below.
+   * <p>See notes on related methods as well as currentCopy() below.</p>
    */
   private Object lockedFor = null;
 
@@ -2731,12 +2731,12 @@ public class QueryExecutorImpl extends QueryExecutorBase {
 
 
   /**
-   * The estimated server response size since we last consumed the input stream from the server, in
-   * bytes.
+   * <p>The estimated server response size since we last consumed the input stream from the server, in
+   * bytes.</p>
    *
-   * Starts at zero, reset by every Sync message. Mainly used for batches.
+   * <p>Starts at zero, reset by every Sync message. Mainly used for batches.</p>
    *
-   * Used to avoid deadlocks, see MAX_BUFFERED_RECV_BYTES.
+   * <p>Used to avoid deadlocks, see MAX_BUFFERED_RECV_BYTES.</p>
    */
   private int estimatedReceiveBufferBytes = 0;
 

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/SimpleQuery.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/SimpleQuery.java
@@ -67,10 +67,10 @@ class SimpleQuery implements Query {
   }
 
   /**
-   * Return maximum size in bytes that each result row from this query may return. Mainly used for
-   * batches that return results.
+   * <p>Return maximum size in bytes that each result row from this query may return. Mainly used for
+   * batches that return results.</p>
    *
-   * Results are cached until/unless the query is re-described.
+   * <p>Results are cached until/unless the query is re-described.</p>
    *
    * @return Max size of result data in bytes according to returned fields, 0 if no results, -1 if
    *         result is unbounded.

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/TypeTransferModeRegistry.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/TypeTransferModeRegistry.java
@@ -7,14 +7,14 @@ package org.postgresql.core.v3;
 
 public interface TypeTransferModeRegistry {
   /**
-   * Returns if given oid should be sent in binary format
+   * Returns if given oid should be sent in binary format.
    * @param oid type oid
    * @return true if given oid should be sent in binary format
    */
   boolean useBinaryForSend(int oid);
 
   /**
-   * Returns if given oid should be received in binary format
+   * Returns if given oid should be received in binary format.
    * @param oid type oid
    * @return true if given oid should be received in binary format
    */

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/replication/V3PGReplicationStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/replication/V3PGReplicationStream.java
@@ -33,7 +33,7 @@ public class V3PGReplicationStream implements PGReplicationStream {
 
   private LogSequenceNumber lastServerLSN = LogSequenceNumber.INVALID_LSN;
   /**
-   * Last receive LSN + payload size
+   * Last receive LSN + payload size.
    */
   private LogSequenceNumber lastReceiveLSN = LogSequenceNumber.INVALID_LSN;
   private LogSequenceNumber lastAppliedLSN = LogSequenceNumber.INVALID_LSN;

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/replication/V3ReplicationProtocol.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/replication/V3ReplicationProtocol.java
@@ -66,7 +66,7 @@ public class V3ReplicationProtocol implements ReplicationProtocol {
   }
 
   /**
-   * START_REPLICATION [SLOT slot_name] [PHYSICAL] XXX/XXX
+   * START_REPLICATION [SLOT slot_name] [PHYSICAL] XXX/XXX.
    */
   private String createStartPhysicalQuery(PhysicalReplicationOptions options) {
     StringBuilder builder = new StringBuilder();

--- a/pgjdbc/src/main/java/org/postgresql/ds/PGPooledConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/ds/PGPooledConnection.java
@@ -368,13 +368,13 @@ public class PGPooledConnection implements PooledConnection {
   }
 
   /**
-   * Instead of declaring classes implementing Statement, PreparedStatement, and CallableStatement,
+   * <p>Instead of declaring classes implementing Statement, PreparedStatement, and CallableStatement,
    * which would have to be updated for every JDK rev, use a dynamic proxy to handle all calls
    * through the Statement interfaces. This is the part that requires JDK 1.3 or higher, though JDK
-   * 1.2 could be supported with a 3rd-party proxy package.
+   * 1.2 could be supported with a 3rd-party proxy package.</p>
    *
-   * The StatementHandler is required in order to return the proper Connection proxy for the
-   * getConnection method.
+   * <p>The StatementHandler is required in order to return the proper Connection proxy for the
+   * getConnection method.</p>
    */
   private class StatementHandler implements InvocationHandler {
     private ConnectionHandler con;

--- a/pgjdbc/src/main/java/org/postgresql/ds/PGPoolingDataSource.java
+++ b/pgjdbc/src/main/java/org/postgresql/ds/PGPoolingDataSource.java
@@ -55,7 +55,7 @@ import javax.sql.PooledConnection;
  * @author Aaron Mulder (ammulder@chariotsolutions.com)
  *
  * @deprecated Since 42.0.0, instead of this class you should use a fully featured connection pool
- * like HikariCP, vibur-dbcp, commons-dbcp, c3p0, etc.
+ *     like HikariCP, vibur-dbcp, commons-dbcp, c3p0, etc.
  */
 @Deprecated
 public class PGPoolingDataSource extends BaseDataSource implements DataSource {

--- a/pgjdbc/src/main/java/org/postgresql/fastpath/Fastpath.java
+++ b/pgjdbc/src/main/java/org/postgresql/fastpath/Fastpath.java
@@ -47,7 +47,7 @@ public class Fastpath {
   private final BaseConnection connection;
 
   /**
-   * Initialises the fastpath system
+   * Initialises the fastpath system.
    *
    * @param conn BaseConnection to attach to
    */
@@ -57,7 +57,7 @@ public class Fastpath {
   }
 
   /**
-   * Send a function call to the PostgreSQL backend
+   * Send a function call to the PostgreSQL backend.
    *
    * @param fnId Function id
    * @param resultType True if the result is a numeric (Integer or Long)
@@ -89,7 +89,7 @@ public class Fastpath {
   }
 
   /**
-   * Send a function call to the PostgreSQL backend
+   * Send a function call to the PostgreSQL backend.
    *
    * @param fnId Function id
    * @param args FastpathArguments to pass to fastpath
@@ -149,7 +149,7 @@ public class Fastpath {
   }
 
   /**
-   * This convenience method assumes that the return value is an integer
+   * This convenience method assumes that the return value is an integer.
    *
    * @param name Function name
    * @param args Function arguments
@@ -174,7 +174,7 @@ public class Fastpath {
   }
 
   /**
-   * This convenience method assumes that the return value is a long (bigint)
+   * This convenience method assumes that the return value is a long (bigint).
    *
    * @param name Function name
    * @param args Function arguments
@@ -216,7 +216,7 @@ public class Fastpath {
   }
 
   /**
-   * This convenience method assumes that the return value is not an Integer
+   * This convenience method assumes that the return value is not an Integer.
    *
    * @param name Function name
    * @param args Function arguments

--- a/pgjdbc/src/main/java/org/postgresql/fastpath/Fastpath.java
+++ b/pgjdbc/src/main/java/org/postgresql/fastpath/Fastpath.java
@@ -20,13 +20,11 @@ import java.util.Map;
 import java.util.logging.Level;
 
 /**
- * This class implements the Fastpath api.
+ * <p>This class implements the Fastpath api.</p>
  *
- * <p>
- * This is a means of executing functions embedded in the backend from within a java application.
+ * <p>This is a means of executing functions embedded in the backend from within a java application.</p>
  *
- * <p>
- * It is based around the file src/interfaces/libpq/fe-exec.c
+ * <p>It is based around the file src/interfaces/libpq/fe-exec.c</p>
  *
  * @deprecated This API is somewhat obsolete, as one may achieve similar performance
  *         and greater functionality by setting up a prepared statement to define
@@ -127,15 +125,15 @@ public class Fastpath {
   }
 
   /**
-   * Send a function call to the PostgreSQL backend by name.
+   * <p>Send a function call to the PostgreSQL backend by name.</p>
    *
-   * Note: the mapping for the procedure name to function id needs to exist, usually to an earlier
-   * call to addfunction().
+   * <p>Note: the mapping for the procedure name to function id needs to exist, usually to an earlier
+   * call to addfunction().</p>
    *
-   * This is the preferred method to call, as function id's can/may change between versions of the
-   * backend.
+   * <p>This is the preferred method to call, as function id's can/may change between versions of the
+   * backend.</p>
    *
-   * For an example of how this works, refer to org.postgresql.largeobject.LargeObject
+   * <p>For an example of how this works, refer to org.postgresql.largeobject.LargeObject</p>
    *
    * @param name Function name
    * @param args FastpathArguments to pass to fastpath
@@ -228,12 +226,11 @@ public class Fastpath {
   }
 
   /**
-   * This adds a function to our lookup table.
+   * <p>This adds a function to our lookup table.</p>
    *
-   * <p>
-   * User code should use the addFunctions method, which is based upon a query, rather than hard
+   * <p>User code should use the addFunctions method, which is based upon a query, rather than hard
    * coding the oid. The oid for a function is not guaranteed to remain static, even on different
-   * servers of the same version.
+   * servers of the same version.</p>
    *
    * @param name Function name
    * @param fnid Function id
@@ -243,35 +240,28 @@ public class Fastpath {
   }
 
   /**
-   * This takes a ResultSet containing two columns. Column 1 contains the function name, Column 2
-   * the oid.
+   * <p>This takes a ResultSet containing two columns. Column 1 contains the function name, Column 2
+   * the oid.</p>
    *
-   * <p>
-   * It reads the entire ResultSet, loading the values into the function table.
+   * <p>It reads the entire ResultSet, loading the values into the function table.</p>
    *
-   * <p>
-   * <b>REMEMBER</b> to close() the resultset after calling this!!
+   * <p><b>REMEMBER</b> to close() the resultset after calling this!!</p>
    *
-   * <p>
-   * <b><em>Implementation note about function name lookups:</em></b>
+   * <p><b><em>Implementation note about function name lookups:</em></b></p>
    *
-   * <p>
-   * PostgreSQL stores the function id's and their corresponding names in the pg_proc table. To
+   * <p>PostgreSQL stores the function id's and their corresponding names in the pg_proc table. To
    * speed things up locally, instead of querying each function from that table when required, a
    * HashMap is used. Also, only the function's required are entered into this table, keeping
-   * connection times as fast as possible.
+   * connection times as fast as possible.</p>
    *
-   * <p>
-   * The org.postgresql.largeobject.LargeObject class performs a query upon it's startup, and passes
-   * the returned ResultSet to the addFunctions() method here.
+   * <p>The org.postgresql.largeobject.LargeObject class performs a query upon it's startup, and passes
+   * the returned ResultSet to the addFunctions() method here.</p>
    *
-   * <p>
-   * Once this has been done, the LargeObject api refers to the functions by name.
+   * <p>Once this has been done, the LargeObject api refers to the functions by name.</p>
    *
-   * <p>
-   * Dont think that manually converting them to the oid's will work. Ok, they will for now, but
+   * <p>Don't think that manually converting them to the oid's will work. Ok, they will for now, but
    * they can change during development (there was some discussion about this for V7.0), so this is
-   * implemented to prevent any unwarranted headaches in the future.
+   * implemented to prevent any unwarranted headaches in the future.</p>
    *
    * @param rs ResultSet
    * @throws SQLException if a database-access error occurs.
@@ -284,11 +274,10 @@ public class Fastpath {
   }
 
   /**
-   * This returns the function id associated by its name.
+   * <p>This returns the function id associated by its name.</p>
    *
-   * <p>
-   * If addFunction() or addFunctions() have not been called for this name, then an SQLException is
-   * thrown.
+   * <p>If addFunction() or addFunctions() have not been called for this name, then an SQLException is
+   * thrown.</p>
    *
    * @param name Function name to lookup
    * @return Function ID for fastpath call

--- a/pgjdbc/src/main/java/org/postgresql/fastpath/FastpathArg.java
+++ b/pgjdbc/src/main/java/org/postgresql/fastpath/FastpathArg.java
@@ -33,7 +33,7 @@ public class FastpathArg {
   private final int bytesLength;
 
   /**
-   * Constructs an argument that consists of an integer value
+   * Constructs an argument that consists of an integer value.
    *
    * @param value int value to set
    */
@@ -48,7 +48,7 @@ public class FastpathArg {
   }
 
   /**
-   * Constructs an argument that consists of an integer value
+   * Constructs an argument that consists of an integer value.
    *
    * @param value int value to set
    */
@@ -67,7 +67,7 @@ public class FastpathArg {
   }
 
   /**
-   * Constructs an argument that consists of an array of bytes
+   * Constructs an argument that consists of an array of bytes.
    *
    * @param bytes array to store
    */
@@ -76,7 +76,7 @@ public class FastpathArg {
   }
 
   /**
-   * Constructs an argument that consists of part of a byte array
+   * Constructs an argument that consists of part of a byte array.
    *
    * @param buf source array
    * @param off offset within array

--- a/pgjdbc/src/main/java/org/postgresql/geometric/PGbox.java
+++ b/pgjdbc/src/main/java/org/postgresql/geometric/PGbox.java
@@ -56,7 +56,7 @@ public class PGbox extends PGobject implements PGBinaryObject, Serializable, Clo
   }
 
   /**
-   * Required constructor
+   * Required constructor.
    */
   public PGbox() {
     setType("box");

--- a/pgjdbc/src/main/java/org/postgresql/geometric/PGcircle.java
+++ b/pgjdbc/src/main/java/org/postgresql/geometric/PGcircle.java
@@ -15,16 +15,16 @@ import java.io.Serializable;
 import java.sql.SQLException;
 
 /**
- * This represents org.postgresql's circle datatype, consisting of a point and a radius
+ * This represents org.postgresql's circle datatype, consisting of a point and a radius.
  */
 public class PGcircle extends PGobject implements Serializable, Cloneable {
   /**
-   * This is the center point
+   * This is the center point.
    */
   public PGpoint center;
 
   /**
-   * This is the radius
+   * This is the radius.
    */
   public double radius;
 

--- a/pgjdbc/src/main/java/org/postgresql/geometric/PGline.java
+++ b/pgjdbc/src/main/java/org/postgresql/geometric/PGline.java
@@ -15,22 +15,22 @@ import java.io.Serializable;
 import java.sql.SQLException;
 
 /**
- * This implements a line represented by the linear equation Ax + By + C = 0
+ * This implements a line represented by the linear equation Ax + By + C = 0.
  **/
 public class PGline extends PGobject implements Serializable, Cloneable {
 
   /**
-   * Coefficient of x
+   * Coefficient of x.
    */
   public double a;
 
   /**
-   * Coefficient of y
+   * Coefficient of y.
    */
   public double b;
 
   /**
-   * Constant
+   * Constant.
    */
   public double c;
 
@@ -89,7 +89,7 @@ public class PGline extends PGobject implements Serializable, Cloneable {
   }
 
   /**
-   * required by the driver
+   * required by the driver.
    */
   public PGline() {
     setType("line");

--- a/pgjdbc/src/main/java/org/postgresql/geometric/PGlseg.java
+++ b/pgjdbc/src/main/java/org/postgresql/geometric/PGlseg.java
@@ -15,7 +15,7 @@ import java.io.Serializable;
 import java.sql.SQLException;
 
 /**
- * This implements a lseg (line segment) consisting of two points
+ * This implements a lseg (line segment) consisting of two points.
  */
 public class PGlseg extends PGobject implements Serializable, Cloneable {
   /**
@@ -53,7 +53,7 @@ public class PGlseg extends PGobject implements Serializable, Cloneable {
   }
 
   /**
-   * reuired by the driver
+   * required by the driver.
    */
   public PGlseg() {
     setType("lseg");

--- a/pgjdbc/src/main/java/org/postgresql/geometric/PGpath.java
+++ b/pgjdbc/src/main/java/org/postgresql/geometric/PGpath.java
@@ -15,16 +15,16 @@ import java.io.Serializable;
 import java.sql.SQLException;
 
 /**
- * This implements a path (a multiple segmented line, which may be closed)
+ * This implements a path (a multiple segmented line, which may be closed).
  */
 public class PGpath extends PGobject implements Serializable, Cloneable {
   /**
-   * True if the path is open, false if closed
+   * True if the path is open, false if closed.
    */
   public boolean open;
 
   /**
-   * The points defining this path
+   * The points defining this path.
    */
   public PGpoint[] points;
 
@@ -39,7 +39,7 @@ public class PGpath extends PGobject implements Serializable, Cloneable {
   }
 
   /**
-   * Required by the driver
+   * Required by the driver.
    */
   public PGpath() {
     setType("path");
@@ -127,7 +127,7 @@ public class PGpath extends PGobject implements Serializable, Cloneable {
   }
 
   /**
-   * This returns the path in the syntax expected by org.postgresql
+   * This returns the path in the syntax expected by org.postgresql.
    */
   public String getValue() {
     StringBuilder b = new StringBuilder(open ? "[" : "(");

--- a/pgjdbc/src/main/java/org/postgresql/geometric/PGpoint.java
+++ b/pgjdbc/src/main/java/org/postgresql/geometric/PGpoint.java
@@ -24,12 +24,12 @@ import java.sql.SQLException;
  */
 public class PGpoint extends PGobject implements PGBinaryObject, Serializable, Cloneable {
   /**
-   * The X coordinate of the point
+   * The X coordinate of the point.
    */
   public double x;
 
   /**
-   * The Y coordinate of the point
+   * The Y coordinate of the point.
    */
   public double y;
 
@@ -56,7 +56,7 @@ public class PGpoint extends PGobject implements PGBinaryObject, Serializable, C
   }
 
   /**
-   * Required by the driver
+   * Required by the driver.
    */
   public PGpoint() {
     setType("point");
@@ -116,7 +116,7 @@ public class PGpoint extends PGobject implements PGBinaryObject, Serializable, C
   }
 
   /**
-   * Populate the byte array with PGpoint in the binary syntax expected by org.postgresql
+   * Populate the byte array with PGpoint in the binary syntax expected by org.postgresql.
    */
   public void toBytes(byte[] b, int offset) {
     ByteConverter.float8(b, offset, x);
@@ -166,7 +166,7 @@ public class PGpoint extends PGobject implements PGBinaryObject, Serializable, C
   }
 
   /**
-   * Moves the point to the supplied coordinates. refer to java.awt.Point for description of this
+   * Moves the point to the supplied coordinates. refer to java.awt.Point for description of this.
    *
    * @param x integer coordinate
    * @param y integer coordinate
@@ -177,7 +177,7 @@ public class PGpoint extends PGobject implements PGBinaryObject, Serializable, C
   }
 
   /**
-   * Moves the point to the supplied java.awt.Point refer to java.awt.Point for description of this
+   * Moves the point to the supplied java.awt.Point refer to java.awt.Point for description of this.
    *
    * @param p Point to move to
    * @see java.awt.Point

--- a/pgjdbc/src/main/java/org/postgresql/geometric/PGpoint.java
+++ b/pgjdbc/src/main/java/org/postgresql/geometric/PGpoint.java
@@ -18,9 +18,9 @@ import java.io.Serializable;
 import java.sql.SQLException;
 
 /**
- * It maps to the point datatype in org.postgresql.
+ * <p>It maps to the point datatype in org.postgresql.</p>
  *
- * This implements a version of java.awt.Point, except it uses double to represent the coordinates.
+ * <p>This implements a version of java.awt.Point, except it uses double to represent the coordinates.</p>
  */
 public class PGpoint extends PGobject implements PGBinaryObject, Serializable, Cloneable {
   /**

--- a/pgjdbc/src/main/java/org/postgresql/geometric/PGpolygon.java
+++ b/pgjdbc/src/main/java/org/postgresql/geometric/PGpolygon.java
@@ -16,12 +16,12 @@ import java.sql.SQLException;
  */
 public class PGpolygon extends PGobject implements Serializable, Cloneable {
   /**
-   * The points defining the polygon
+   * The points defining the polygon.
    */
   public PGpoint[] points;
 
   /**
-   * Creates a polygon using an array of PGpoints
+   * Creates a polygon using an array of PGpoints.
    *
    * @param points the points defining the polygon
    */
@@ -40,7 +40,7 @@ public class PGpolygon extends PGobject implements Serializable, Cloneable {
   }
 
   /**
-   * Required by the driver
+   * Required by the driver.
    */
   public PGpolygon() {
     setType("polygon");

--- a/pgjdbc/src/main/java/org/postgresql/hostchooser/HostRequirement.java
+++ b/pgjdbc/src/main/java/org/postgresql/hostchooser/HostRequirement.java
@@ -33,13 +33,12 @@ public enum HostRequirement {
   public abstract boolean allowConnectingTo(HostStatus status);
 
   /**
-   *
-   * The postgreSQL project has decided not to use the term slave to refer to alternate servers.
+   * <p>The postgreSQL project has decided not to use the term slave to refer to alternate servers.
    * secondary or standby is preferred. We have arbitrarily chosen secondary.
    * As of Jan 2018 in order not to break existint code we are going to accept both slave or
-   * secondary for names of alternate servers.
+   * secondary for names of alternate servers.</p>
    *
-   * The current policy is to keep accepting this silently but not document slave, or slave preferSlave
+   * <p>The current policy is to keep accepting this silently but not document slave, or slave preferSlave</p>
    *
    * @param targetServerType the value of {@code targetServerType} connection property
    * @return HostRequirement

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/AbstractBlobClob.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/AbstractBlobClob.java
@@ -128,7 +128,7 @@ public abstract class AbstractBlobClob {
   }
 
   /**
-   * Iterate over the buffer looking for the specified pattern
+   * Iterate over the buffer looking for the specified pattern.
    *
    * @param pattern A pattern of bytes to search the blob for
    * @param start The position to start reading from
@@ -194,7 +194,7 @@ public abstract class AbstractBlobClob {
 
 
   /**
-   * This is simply passing the byte value of the pattern Blob
+   * This is simply passing the byte value of the pattern Blob.
    *
    * @param pattern search pattern
    * @param start start position

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/BooleanTypeUtil.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/BooleanTypeUtil.java
@@ -13,10 +13,10 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Helper class to handle boolean type of PostgreSQL.
- * <p>
- * Based on values accepted by the PostgreSQL server:
- * https://www.postgresql.org/docs/current/static/datatype-boolean.html
+ * <p>Helper class to handle boolean type of PostgreSQL.</p>
+ *
+ * <p>Based on values accepted by the PostgreSQL server:
+ * https://www.postgresql.org/docs/current/static/datatype-boolean.html</p>
  */
 class BooleanTypeUtil {
 

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/EscapedFunctions.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/EscapedFunctions.java
@@ -17,7 +17,7 @@ import java.util.Locale;
 import java.util.Map;
 
 /**
- * This class stores supported escaped function
+ * This class stores supported escaped function.
  *
  * @author Xavier Poinsard
  * @deprecated see {@link EscapedFunctions2}
@@ -115,7 +115,7 @@ public class EscapedFunctions {
 
 
   /**
-   * storage for functions implementations
+   * storage for functions implementations.
    */
   private static Map<String, Method> functionMap = createFunctionMap();
 
@@ -131,7 +131,7 @@ public class EscapedFunctions {
   }
 
   /**
-   * get Method object implementing the given function
+   * get Method object implementing the given function.
    *
    * @param functionName name of the searched function
    * @return a Method object or null if not found
@@ -143,7 +143,7 @@ public class EscapedFunctions {
   // ** numeric functions translations **
 
   /**
-   * ceiling to ceil translation
+   * ceiling to ceil translation.
    *
    * @param parsedArgs arguments
    * @return sql call
@@ -154,7 +154,7 @@ public class EscapedFunctions {
   }
 
   /**
-   * log to ln translation
+   * log to ln translation.
    *
    * @param parsedArgs arguments
    * @return sql call
@@ -165,7 +165,7 @@ public class EscapedFunctions {
   }
 
   /**
-   * log10 to log translation
+   * log10 to log translation.
    *
    * @param parsedArgs arguments
    * @return sql call
@@ -176,7 +176,7 @@ public class EscapedFunctions {
   }
 
   /**
-   * power to pow translation
+   * power to pow translation.
    *
    * @param parsedArgs arguments
    * @return sql call
@@ -187,7 +187,7 @@ public class EscapedFunctions {
   }
 
   /**
-   * truncate to trunc translation
+   * truncate to trunc translation.
    *
    * @param parsedArgs arguments
    * @return sql call
@@ -200,7 +200,7 @@ public class EscapedFunctions {
   // ** string functions translations **
 
   /**
-   * char to chr translation
+   * char to chr translation.
    *
    * @param parsedArgs arguments
    * @return sql call
@@ -211,7 +211,7 @@ public class EscapedFunctions {
   }
 
   /**
-   * concat translation
+   * concat translation.
    *
    * @param parsedArgs arguments
    * @return sql call
@@ -229,7 +229,7 @@ public class EscapedFunctions {
   }
 
   /**
-   * insert to overlay translation
+   * insert to overlay translation.
    *
    * @param parsedArgs arguments
    * @return sql call
@@ -248,7 +248,7 @@ public class EscapedFunctions {
   }
 
   /**
-   * lcase to lower translation
+   * lcase to lower translation.
    *
    * @param parsedArgs arguments
    * @return sql call
@@ -259,7 +259,7 @@ public class EscapedFunctions {
   }
 
   /**
-   * left to substring translation
+   * left to substring translation.
    *
    * @param parsedArgs arguments
    * @return sql call
@@ -277,7 +277,7 @@ public class EscapedFunctions {
   }
 
   /**
-   * length translation
+   * length translation.
    *
    * @param parsedArgs arguments
    * @return sql call
@@ -295,7 +295,7 @@ public class EscapedFunctions {
   }
 
   /**
-   * locate translation
+   * locate translation.
    *
    * @param parsedArgs arguments
    * @return sql call
@@ -315,7 +315,7 @@ public class EscapedFunctions {
   }
 
   /**
-   * ltrim translation
+   * ltrim translation.
    *
    * @param parsedArgs arguments
    * @return sql call
@@ -326,7 +326,7 @@ public class EscapedFunctions {
   }
 
   /**
-   * right to substring translation
+   * right to substring translation.
    *
    * @param parsedArgs arguments
    * @return sql call
@@ -348,7 +348,7 @@ public class EscapedFunctions {
   }
 
   /**
-   * rtrim translation
+   * rtrim translation.
    *
    * @param parsedArgs arguments
    * @return sql call
@@ -359,7 +359,7 @@ public class EscapedFunctions {
   }
 
   /**
-   * space translation
+   * space translation.
    *
    * @param parsedArgs arguments
    * @return sql call
@@ -370,7 +370,7 @@ public class EscapedFunctions {
   }
 
   /**
-   * substring to substr translation
+   * substring to substr translation.
    *
    * @param parsedArgs arguments
    * @return sql call
@@ -389,7 +389,7 @@ public class EscapedFunctions {
   }
 
   /**
-   * ucase to upper translation
+   * ucase to upper translation.
    *
    * @param parsedArgs arguments
    * @return sql call
@@ -400,7 +400,7 @@ public class EscapedFunctions {
   }
 
   /**
-   * curdate to current_date translation
+   * curdate to current_date translation.
    *
    * @param parsedArgs arguments
    * @return sql call
@@ -415,7 +415,7 @@ public class EscapedFunctions {
   }
 
   /**
-   * curtime to current_time translation
+   * curtime to current_time translation.
    *
    * @param parsedArgs arguments
    * @return sql call
@@ -430,7 +430,7 @@ public class EscapedFunctions {
   }
 
   /**
-   * dayname translation
+   * dayname translation.
    *
    * @param parsedArgs arguments
    * @return sql call
@@ -445,7 +445,7 @@ public class EscapedFunctions {
   }
 
   /**
-   * dayofmonth translation
+   * dayofmonth translation.
    *
    * @param parsedArgs arguments
    * @return sql call
@@ -456,7 +456,7 @@ public class EscapedFunctions {
   }
 
   /**
-   * dayofweek translation adding 1 to postgresql function since we expect values from 1 to 7
+   * dayofweek translation adding 1 to postgresql function since we expect values from 1 to 7.
    *
    * @param parsedArgs arguments
    * @return sql call
@@ -471,7 +471,7 @@ public class EscapedFunctions {
   }
 
   /**
-   * dayofyear translation
+   * dayofyear translation.
    *
    * @param parsedArgs arguments
    * @return sql call
@@ -482,7 +482,7 @@ public class EscapedFunctions {
   }
 
   /**
-   * hour translation
+   * hour translation.
    *
    * @param parsedArgs arguments
    * @return sql call
@@ -493,7 +493,7 @@ public class EscapedFunctions {
   }
 
   /**
-   * minute translation
+   * minute translation.
    *
    * @param parsedArgs arguments
    * @return sql call
@@ -504,7 +504,7 @@ public class EscapedFunctions {
   }
 
   /**
-   * month translation
+   * month translation.
    *
    * @param parsedArgs arguments
    * @return sql call
@@ -515,7 +515,7 @@ public class EscapedFunctions {
   }
 
   /**
-   * monthname translation
+   * monthname translation.
    *
    * @param parsedArgs arguments
    * @return sql call
@@ -530,7 +530,7 @@ public class EscapedFunctions {
   }
 
   /**
-   * quarter translation
+   * quarter translation.
    *
    * @param parsedArgs arguments
    * @return sql call
@@ -541,7 +541,7 @@ public class EscapedFunctions {
   }
 
   /**
-   * second translation
+   * second translation.
    *
    * @param parsedArgs arguments
    * @return sql call
@@ -552,7 +552,7 @@ public class EscapedFunctions {
   }
 
   /**
-   * week translation
+   * week translation.
    *
    * @param parsedArgs arguments
    * @return sql call
@@ -563,7 +563,7 @@ public class EscapedFunctions {
   }
 
   /**
-   * year translation
+   * year translation.
    *
    * @param parsedArgs arguments
    * @return sql call
@@ -574,7 +574,7 @@ public class EscapedFunctions {
   }
 
   /**
-   * time stamp add
+   * time stamp add.
    *
    * @param parsedArgs arguments
    * @return sql call
@@ -627,7 +627,7 @@ public class EscapedFunctions {
 
 
   /**
-   * time stamp diff
+   * time stamp diff.
    *
    * @param parsedArgs arguments
    * @return sql call
@@ -682,7 +682,7 @@ public class EscapedFunctions {
   }
 
   /**
-   * database translation
+   * database translation.
    *
    * @param parsedArgs arguments
    * @return sql call
@@ -697,7 +697,7 @@ public class EscapedFunctions {
   }
 
   /**
-   * ifnull translation
+   * ifnull translation.
    *
    * @param parsedArgs arguments
    * @return sql call
@@ -708,7 +708,7 @@ public class EscapedFunctions {
   }
 
   /**
-   * user translation
+   * user translation.
    *
    * @param parsedArgs arguments
    * @return sql call

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/EscapedFunctions2.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/EscapedFunctions2.java
@@ -80,6 +80,7 @@ public final class EscapedFunctions2 {
   /**
    * ceiling to ceil translation
    *
+   * @param buf The buffer to append into
    * @param parsedArgs arguments
    * @throws SQLException if something wrong happens
    */
@@ -90,6 +91,7 @@ public final class EscapedFunctions2 {
   /**
    * log to ln translation
    *
+   * @param buf The buffer to append into
    * @param parsedArgs arguments
    * @throws SQLException if something wrong happens
    */
@@ -100,6 +102,7 @@ public final class EscapedFunctions2 {
   /**
    * log10 to log translation
    *
+   * @param buf The buffer to append into
    * @param parsedArgs arguments
    * @throws SQLException if something wrong happens
    */
@@ -110,6 +113,7 @@ public final class EscapedFunctions2 {
   /**
    * power to pow translation
    *
+   * @param buf The buffer to append into
    * @param parsedArgs arguments
    * @throws SQLException if something wrong happens
    */
@@ -120,6 +124,7 @@ public final class EscapedFunctions2 {
   /**
    * truncate to trunc translation
    *
+   * @param buf The buffer to append into
    * @param parsedArgs arguments
    * @throws SQLException if something wrong happens
    */
@@ -132,6 +137,7 @@ public final class EscapedFunctions2 {
   /**
    * char to chr translation
    *
+   * @param buf The buffer to append into
    * @param parsedArgs arguments
    * @throws SQLException if something wrong happens
    */
@@ -142,6 +148,7 @@ public final class EscapedFunctions2 {
   /**
    * concat translation
    *
+   * @param buf The buffer to append into
    * @param parsedArgs arguments
    */
   public static void sqlconcat(StringBuilder buf, List<? extends CharSequence> parsedArgs) {
@@ -151,6 +158,7 @@ public final class EscapedFunctions2 {
   /**
    * insert to overlay translation
    *
+   * @param buf The buffer to append into
    * @param parsedArgs arguments
    * @throws SQLException if something wrong happens
    */
@@ -168,6 +176,7 @@ public final class EscapedFunctions2 {
   /**
    * lcase to lower translation
    *
+   * @param buf The buffer to append into
    * @param parsedArgs arguments
    * @throws SQLException if something wrong happens
    */
@@ -178,6 +187,7 @@ public final class EscapedFunctions2 {
   /**
    * left to substring translation
    *
+   * @param buf The buffer to append into
    * @param parsedArgs arguments
    * @throws SQLException if something wrong happens
    */
@@ -192,6 +202,7 @@ public final class EscapedFunctions2 {
   /**
    * length translation
    *
+   * @param buf The buffer to append into
    * @param parsedArgs arguments
    * @throws SQLException if something wrong happens
    */
@@ -206,6 +217,7 @@ public final class EscapedFunctions2 {
   /**
    * locate translation
    *
+   * @param buf The buffer to append into
    * @param parsedArgs arguments
    * @throws SQLException if something wrong happens
    */
@@ -231,6 +243,7 @@ public final class EscapedFunctions2 {
   /**
    * ltrim translation
    *
+   * @param buf The buffer to append into
    * @param parsedArgs arguments
    * @throws SQLException if something wrong happens
    */
@@ -241,6 +254,7 @@ public final class EscapedFunctions2 {
   /**
    * right to substring translation
    *
+   * @param buf The buffer to append into
    * @param parsedArgs arguments
    * @throws SQLException if something wrong happens
    */
@@ -261,6 +275,7 @@ public final class EscapedFunctions2 {
   /**
    * rtrim translation
    *
+   * @param buf The buffer to append into
    * @param parsedArgs arguments
    * @throws SQLException if something wrong happens
    */
@@ -271,6 +286,7 @@ public final class EscapedFunctions2 {
   /**
    * space translation
    *
+   * @param buf The buffer to append into
    * @param parsedArgs arguments
    * @throws SQLException if something wrong happens
    */
@@ -281,6 +297,7 @@ public final class EscapedFunctions2 {
   /**
    * substring to substr translation
    *
+   * @param buf The buffer to append into
    * @param parsedArgs arguments
    * @throws SQLException if something wrong happens
    */
@@ -296,6 +313,7 @@ public final class EscapedFunctions2 {
   /**
    * ucase to upper translation
    *
+   * @param buf The buffer to append into
    * @param parsedArgs arguments
    * @throws SQLException if something wrong happens
    */
@@ -306,6 +324,7 @@ public final class EscapedFunctions2 {
   /**
    * curdate to current_date translation
    *
+   * @param buf The buffer to append into
    * @param parsedArgs arguments
    * @throws SQLException if something wrong happens
    */
@@ -316,6 +335,7 @@ public final class EscapedFunctions2 {
   /**
    * curtime to current_time translation
    *
+   * @param buf The buffer to append into
    * @param parsedArgs arguments
    * @throws SQLException if something wrong happens
    */
@@ -326,6 +346,7 @@ public final class EscapedFunctions2 {
   /**
    * dayname translation
    *
+   * @param buf The buffer to append into
    * @param parsedArgs arguments
    * @throws SQLException if something wrong happens
    */
@@ -340,6 +361,7 @@ public final class EscapedFunctions2 {
   /**
    * dayofmonth translation
    *
+   * @param buf The buffer to append into
    * @param parsedArgs arguments
    * @throws SQLException if something wrong happens
    */
@@ -350,6 +372,7 @@ public final class EscapedFunctions2 {
   /**
    * dayofweek translation adding 1 to postgresql function since we expect values from 1 to 7
    *
+   * @param buf The buffer to append into
    * @param parsedArgs arguments
    * @throws SQLException if something wrong happens
    */
@@ -364,6 +387,7 @@ public final class EscapedFunctions2 {
   /**
    * dayofyear translation
    *
+   * @param buf The buffer to append into
    * @param parsedArgs arguments
    * @throws SQLException if something wrong happens
    */
@@ -374,6 +398,7 @@ public final class EscapedFunctions2 {
   /**
    * hour translation
    *
+   * @param buf The buffer to append into
    * @param parsedArgs arguments
    * @throws SQLException if something wrong happens
    */
@@ -384,6 +409,7 @@ public final class EscapedFunctions2 {
   /**
    * minute translation
    *
+   * @param buf The buffer to append into
    * @param parsedArgs arguments
    * @throws SQLException if something wrong happens
    */
@@ -394,6 +420,7 @@ public final class EscapedFunctions2 {
   /**
    * month translation
    *
+   * @param buf The buffer to append into
    * @param parsedArgs arguments
    * @throws SQLException if something wrong happens
    */
@@ -404,6 +431,7 @@ public final class EscapedFunctions2 {
   /**
    * monthname translation
    *
+   * @param buf The buffer to append into
    * @param parsedArgs arguments
    * @throws SQLException if something wrong happens
    */
@@ -418,6 +446,7 @@ public final class EscapedFunctions2 {
   /**
    * quarter translation
    *
+   * @param buf The buffer to append into
    * @param parsedArgs arguments
    * @throws SQLException if something wrong happens
    */
@@ -428,6 +457,7 @@ public final class EscapedFunctions2 {
   /**
    * second translation
    *
+   * @param buf The buffer to append into
    * @param parsedArgs arguments
    * @throws SQLException if something wrong happens
    */
@@ -438,6 +468,7 @@ public final class EscapedFunctions2 {
   /**
    * week translation
    *
+   * @param buf The buffer to append into
    * @param parsedArgs arguments
    * @throws SQLException if something wrong happens
    */
@@ -448,6 +479,7 @@ public final class EscapedFunctions2 {
   /**
    * year translation
    *
+   * @param buf The buffer to append into
    * @param parsedArgs arguments
    * @throws SQLException if something wrong happens
    */
@@ -458,6 +490,7 @@ public final class EscapedFunctions2 {
   /**
    * time stamp add
    *
+   * @param buf The buffer to append into
    * @param parsedArgs arguments
    * @throws SQLException if something wrong happens
    */
@@ -528,6 +561,7 @@ public final class EscapedFunctions2 {
   /**
    * time stamp diff
    *
+   * @param buf The buffer to append into
    * @param parsedArgs arguments
    * @throws SQLException if something wrong happens
    */
@@ -575,6 +609,7 @@ public final class EscapedFunctions2 {
   /**
    * database translation
    *
+   * @param buf The buffer to append into
    * @param parsedArgs arguments
    * @throws SQLException if something wrong happens
    */
@@ -585,6 +620,7 @@ public final class EscapedFunctions2 {
   /**
    * ifnull translation
    *
+   * @param buf The buffer to append into
    * @param parsedArgs arguments
    * @throws SQLException if something wrong happens
    */
@@ -595,6 +631,7 @@ public final class EscapedFunctions2 {
   /**
    * user translation
    *
+   * @param buf The buffer to append into
    * @param parsedArgs arguments
    * @throws SQLException if something wrong happens
    */

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgArray.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgArray.java
@@ -28,16 +28,14 @@ import java.util.Map;
 import java.util.logging.Level;
 
 /**
- * Array is used collect one column of query result data.
+ * <p>Array is used collect one column of query result data.</p>
  *
- * <p>
- * Read a field of type Array into either a natively-typed Java array object or a ResultSet.
- * Accessor methods provide the ability to capture array slices.
+ * <p>Read a field of type Array into either a natively-typed Java array object or a ResultSet.
+ * Accessor methods provide the ability to capture array slices.</p>
  *
- * <p>
- * Other than the constructor all methods are direct implementations of those specified for
+ * <p>Other than the constructor all methods are direct implementations of those specified for
  * java.sql.Array. Please refer to the javadoc for java.sql.Array for detailed descriptions of the
- * functionality and parameters of the methods of this class.
+ * functionality and parameters of the methods of this class.</p>
  *
  * @see ResultSet#getArray
  */

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgCallableStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgCallableStatement.java
@@ -388,7 +388,7 @@ class PgCallableStatement extends PgPreparedStatement implements CallableStateme
   }
 
   /**
-   * helperfunction for the getXXX calls to check isFunction and index == 1
+   * Helper function for the getXXX calls to check isFunction and index == 1.
    *
    * @param parameterIndex parameter index (1-based)
    * @param type type
@@ -411,7 +411,7 @@ class PgCallableStatement extends PgPreparedStatement implements CallableStateme
   }
 
   /**
-   * helperfunction for the getXXX calls to check isFunction and index == 1
+   * Helper function for the getXXX calls to check isFunction and index == 1.
    *
    * @param parameterIndex index of getXXX (index) check to make sure is a function and index == 1
    * @param fetchingData fetching data

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgCallableStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgCallableStatement.java
@@ -156,14 +156,13 @@ class PgCallableStatement extends PgPreparedStatement implements CallableStateme
   }
 
   /**
-   * Before executing a stored procedure call you must explicitly call registerOutParameter to
-   * register the java.sql.Type of each out parameter.
+   * <p>Before executing a stored procedure call you must explicitly call registerOutParameter to
+   * register the java.sql.Type of each out parameter.</p>
    *
-   * <p>
-   * Note: When reading the value of an out parameter, you must use the getXXX method whose Java
-   * type XXX corresponds to the parameter's registered SQL type.
+   * <p>Note: When reading the value of an out parameter, you must use the getXXX method whose Java
+   * type XXX corresponds to the parameter's registered SQL type.</p>
    *
-   * ONLY 1 RETURN PARAMETER if {?= call ..} syntax is used
+   * <p>ONLY 1 RETURN PARAMETER if {?= call ..} syntax is used</p>
    *
    * @param parameterIndex the first parameter is 1, the second is 2,...
    * @param sqlType SQL type code defined by java.sql.Types; for parameters of type Numeric or
@@ -222,11 +221,10 @@ class PgCallableStatement extends PgPreparedStatement implements CallableStateme
   }
 
   /**
-   * You must also specify the scale for numeric/decimal types:
+   * <p>You must also specify the scale for numeric/decimal types.</p>
    *
-   * <p>
-   * Note: When reading the value of an out parameter, you must use the getXXX method whose Java
-   * type XXX corresponds to the parameter's registered SQL type.
+   * <p>Note: When reading the value of an out parameter, you must use the getXXX method whose Java
+   * type XXX corresponds to the parameter's registered SQL type.</p>
    *
    * @param parameterIndex the first parameter is 1, the second is 2,...
    * @param sqlType use either java.sql.Type.NUMERIC or java.sql.Type.DECIMAL

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgClob.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgClob.java
@@ -67,7 +67,7 @@ public class PgClob extends AbstractBlobClob implements java.sql.Clob {
   }
 
   /**
-   * This should be simply passing the byte value of the pattern Blob
+   * This should be simply passing the byte value of the pattern Blob.
    */
   public synchronized long position(Clob pattern, long start) throws SQLException {
     checkFreed();

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
@@ -107,7 +107,7 @@ public class PgConnection implements BaseConnection {
   protected int prepareThreshold;
 
   /**
-   * Default fetch size for statement
+   * Default fetch size for statement.
    *
    * @see PGProperty#DEFAULT_ROW_FETCH_SIZE
    */
@@ -356,7 +356,7 @@ public class PgConnection implements BaseConnection {
   }
 
   /**
-   * The current type mappings
+   * The current type mappings.
    */
   protected Map<String, Class<?>> typemap;
 
@@ -493,7 +493,7 @@ public class PgConnection implements BaseConnection {
   }
 
   /**
-   * Method getUserName() brings back the User Name (again, we saved it)
+   * Method getUserName() brings back the User Name (again, we saved it).
    *
    * @return the user name
    * @throws SQLException just in case...
@@ -902,7 +902,7 @@ public class PgConnection implements BaseConnection {
   }
 
   /**
-   * Get server version number
+   * Get server version number.
    *
    * @return server version number
    */
@@ -911,7 +911,7 @@ public class PgConnection implements BaseConnection {
   }
 
   /**
-   * Get server major version
+   * Get server major version.
    *
    * @return server major version
    */
@@ -925,7 +925,7 @@ public class PgConnection implements BaseConnection {
   }
 
   /**
-   * Get server minor version
+   * Get server minor version.
    *
    * @return server minor version
    */
@@ -1004,7 +1004,7 @@ public class PgConnection implements BaseConnection {
   }
 
   /**
-   * Handler for transaction queries
+   * Handler for transaction queries.
    */
   private class TransactionCommandHandler extends ResultHandlerBase {
     public void handleCompletion() throws SQLException {

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
@@ -454,11 +454,11 @@ public class PgConnection implements BaseConnection {
   }
 
   /**
-   * In SQL, a result table can be retrieved through a cursor that is named. The current row of a
+   * <p>In SQL, a result table can be retrieved through a cursor that is named. The current row of a
    * result can be updated or deleted using a positioned update/delete statement that references the
-   * cursor name.
-   * <p>
-   * We do not support positioned update/delete, so this is a no-op.
+   * cursor name.</p>
+   *
+   * <p>We do not support positioned update/delete, so this is a no-op.</p>
    *
    * @param cursor the cursor name
    * @throws SQLException if a database access error occurs
@@ -480,10 +480,10 @@ public class PgConnection implements BaseConnection {
   }
 
   /**
-   * We are required to bring back certain information by the DatabaseMetaData class. These
-   * functions do that.
-   * <p>
-   * Method getURL() brings back the URL (good job we saved it)
+   * <p>We are required to bring back certain information by the DatabaseMetaData class. These
+   * functions do that.</p>
+   *
+   * <p>Method getURL() brings back the URL (good job we saved it)</p>
    *
    * @return the url
    * @throws SQLException just in case...
@@ -883,11 +883,11 @@ public class PgConnection implements BaseConnection {
   }
 
   /**
-   * Overrides finalize(). If called, it closes the connection.
-   * <p>
-   * This was done at the request of <a href="mailto:rachel@enlarion.demon.co.uk">Rachel
+   * <p>Overrides finalize(). If called, it closes the connection.</p>
+   *
+   * <p>This was done at the request of <a href="mailto:rachel@enlarion.demon.co.uk">Rachel
    * Greenham</a> who hit a problem where multiple clients didn't close the connection, and once a
-   * fortnight enough clients were open to kill the postgres server.
+   * fortnight enough clients were open to kill the postgres server.</p>
    */
   protected void finalize() throws Throwable {
     try {

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
@@ -244,8 +244,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
   /**
    * {@inheritDoc}
    *
-   * <p>
-   * From PostgreSQL 9.0+ return the keywords from pg_catalog.pg_get_keywords()
+   * <p>From PostgreSQL 9.0+ return the keywords from pg_catalog.pg_get_keywords()</p>
    *
    * @return a comma separated list of keywords we use
    * @throws SQLException if a database access error occurs
@@ -412,12 +411,11 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
   /**
    * {@inheritDoc}
    *
-   * <p>
-   * Postgresql allows any high-bit character to be used in an unquoted identifier, so we can't
-   * possibly list them all.
+   * <p>Postgresql allows any high-bit character to be used in an unquoted identifier, so we can't
+   * possibly list them all.</p>
    *
-   * From the file src/backend/parser/scan.l, an identifier is ident_start [A-Za-z\200-\377_]
-   * ident_cont [A-Za-z\200-\377_0-9\$] identifier {ident_start}{ident_cont}*
+   * <p>From the file src/backend/parser/scan.l, an identifier is ident_start [A-Za-z\200-\377_]
+   * ident_cont [A-Za-z\200-\377_0-9\$] identifier {ident_start}{ident_cont}*</p>
    *
    * @return a string containing the extra characters
    * @throws SQLException if a database access error occurs
@@ -527,14 +525,11 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
   /**
    * {@inheritDoc}
    *
-   * This grammar is defined at:
+   * <p>This grammar is defined at:
+   * <a href="http://www.microsoft.com/msdn/sdk/platforms/doc/odbc/src/intropr.htm">
+   *     http://www.microsoft.com/msdn/sdk/platforms/doc/odbc/src/intropr.htm</a></p>
    *
-   * <p>
-   * <a href="http://www.microsoft.com/msdn/sdk/platforms/doc/odbc/src/intropr.htm">http://www.
-   * microsoft.com/msdn/sdk/platforms/doc/odbc/src/intropr.htm</a>
-   *
-   * <p>
-   * In Appendix C. From this description, we seem to support the ODBC minimal (Level 0) grammar.
+   * <p>In Appendix C. From this description, we seem to support the ODBC minimal (Level 0) grammar.</p>
    *
    * @return true
    */
@@ -636,8 +631,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
 
   /**
    * {@inheritDoc}
-   * <p>
-   * PostgreSQL doesn't have schemas, but when it does, we'll use the term "schema".
+   * <p>PostgreSQL doesn't have schemas, but when it does, we'll use the term "schema".</p>
    *
    * @return {@code "schema"}
    */
@@ -819,10 +813,9 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
 
   /**
    * {@inheritDoc}
-   * <p>
-   * Can statements remain open across commits? They may, but this driver cannot guarantee that. In
+   * <p>Can statements remain open across commits? They may, but this driver cannot guarantee that. In
    * further reflection. we are talking a Statement object here, so the answer is yes, since the
-   * Statement is only a vehicle to ExecSQL()
+   * Statement is only a vehicle to ExecSQL()</p>
    *
    * @return true
    */
@@ -832,10 +825,9 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
 
   /**
    * {@inheritDoc}
-   * <p>
-   * Can statements remain open across rollbacks? They may, but this driver cannot guarantee that.
+   * <p>Can statements remain open across rollbacks? They may, but this driver cannot guarantee that.
    * In further contemplation, we are talking a Statement object here, so the answer is yes, since
-   * the Statement is only a vehicle to ExecSQL() in Connection
+   * the Statement is only a vehicle to ExecSQL() in Connection</p>
    *
    * @return true
    */
@@ -875,10 +867,9 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
    * {@inheritDoc} What is the maximum number of columns in a table? From the CREATE TABLE reference
    * page...
    *
-   * <p>
-   * "The new class is created as a heap with no initial data. A class can have no more than 1600
+   * <p>"The new class is created as a heap with no initial data. A class can have no more than 1600
    * attributes (realistically, this is limited by the fact that tuple sizes must be less than 8192
-   * bytes)..."
+   * bytes)..."</p>
    *
    * @return the max columns
    * @throws SQLException if a database access error occurs
@@ -959,9 +950,8 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
 
   /**
    * {@inheritDoc}
-   * <p>
-   * We only support TRANSACTION_SERIALIZABLE and TRANSACTION_READ_COMMITTED before 8.0; from 8.0
-   * READ_UNCOMMITTED and REPEATABLE_READ are accepted aliases for READ_COMMITTED.
+   * <p>We only support TRANSACTION_SERIALIZABLE and TRANSACTION_READ_COMMITTED before 8.0; from 8.0
+   * READ_UNCOMMITTED and REPEATABLE_READ are accepted aliases for READ_COMMITTED.</p>
    */
   public boolean supportsTransactionIsolationLevel(int level) throws SQLException {
     switch (level) {
@@ -984,7 +974,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
   }
 
   /**
-   * Does a data definition statement within a transaction force the transaction to commit? It seems
+   * <p>Does a data definition statement within a transaction force the transaction to commit? It seems
    * to mean something like:
    *
    * <pre>
@@ -997,7 +987,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
    * COMMIT;
    * </pre>
    *
-   * does the CREATE TABLE call cause a commit? The answer is no.
+   * Does the CREATE TABLE call cause a commit? The answer is no.</p>
    *
    * @return true if so
    * @throws SQLException if a database access error occurs

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
@@ -975,7 +975,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
 
   /**
    * <p>Does a data definition statement within a transaction force the transaction to commit? It seems
-   * to mean something like:
+   * to mean something like:</p>
    *
    * <pre>
    * CREATE TABLE T (A INT);
@@ -987,7 +987,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
    * COMMIT;
    * </pre>
    *
-   * Does the CREATE TABLE call cause a commit? The answer is no.</p>
+   * <p>Does the CREATE TABLE call cause a commit? The answer is no.</p>
    *
    * @return true if so
    * @throws SQLException if a database access error occurs

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
@@ -72,9 +72,9 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
   protected final ParameterList preparedParameters; // Parameter values for prepared statement.
 
   /**
-   * used to differentiate between new function call logic and old function call logic will be set
-   * to true if the server is &lt; 8.1 or if we are using v2 protocol There is an exception to this
-   * where we are using v3, and the call does not have an out parameter before the call
+   * Used to differentiate between new function call logic and old function call logic. Will be set
+   * to true if the server is &lt; 8.1 or if we are using v2 protocol. There is an exception to this
+   * where we are using v3, and the call does not have an out parameter before the call.
    */
   protected boolean adjustIndex = false;
 

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
@@ -1933,18 +1933,18 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
   }
 
   /**
-   * Retrieves the value of the designated column in the current row of this <code>ResultSet</code>
-   * object as a <code>boolean</code> in the Java programming language.
-   * <p>
-   * If the designated column has a Character datatype and is one of the following values: "1",
+   * <p>Retrieves the value of the designated column in the current row of this <code>ResultSet</code>
+   * object as a <code>boolean</code> in the Java programming language.</p>
+   *
+   * <p>If the designated column has a Character datatype and is one of the following values: "1",
    * "true", "t", "yes", "y" or "on", a value of <code>true</code> is returned. If the designated
    * column has a Character datatype and is one of the following values: "0", "false", "f", "no",
    * "n" or "off", a value of <code>false</code> is returned. Leading or trailing whitespace is
-   * ignored, and case does not matter.
-   * <p>
-   * If the designated column has a Numeric datatype and is a 1, a value of <code>true</code> is
+   * ignored, and case does not matter.</p>
+   *
+   * <p>If the designated column has a Numeric datatype and is a 1, a value of <code>true</code> is
    * returned. If the designated column has a Numeric datatype and is a 0, a value of
-   * <code>false</code> is returned.
+   * <code>false</code> is returned.</p>
    *
    * @param columnIndex the first column is 1, the second is 2, ...
    * @return the column value; if the value is SQL <code>NULL</code>, the value returned is
@@ -2362,13 +2362,11 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
   /**
    * {@inheritDoc}
    *
-   * <p>
-   * In normal use, the bytes represent the raw values returned by the backend. However, if the
+   * <p>In normal use, the bytes represent the raw values returned by the backend. However, if the
    * column is an OID, then it is assumed to refer to a Large Object, and that object is returned as
-   * a byte array.
+   * a byte array.</p>
    *
-   * <p>
-   * <b>Be warned</b> If the large object is huge, then you may run out of memory.
+   * <p><b>Be warned</b> If the large object is huge, then you may run out of memory.</p>
    */
   public byte[] getBytes(int columnIndex) throws SQLException {
     connection.getLogger().log(Level.FINEST, "  getBytes columnIndex: {0}", columnIndex);
@@ -2656,9 +2654,9 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
   }
 
   /**
-   * This is used to fix get*() methods on Money fields. It should only be used by those methods!
+   * <p>This is used to fix get*() methods on Money fields. It should only be used by those methods!</p>
    *
-   * It converts ($##.##) to -##.## and $##.## to ##.##
+   * <p>It converts ($##.##) to -##.## and $##.## to ##.##</p>
    *
    * @param col column position (1-based)
    * @return numeric-parsable representation of money string literal
@@ -3016,13 +3014,14 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
   }
 
   /**
-   * Converts any numeric binary field to long value.
-   * <p>
-   * This method is used by getByte,getShort,getInt and getLong. It must support a subset of the
+   * <p>Converts any numeric binary field to long value.</p>
+   *
+   * <p>This method is used by getByte,getShort,getInt and getLong. It must support a subset of the
    * following java types that use Binary encoding. (fields that use text encoding use a different
    * code path).
-   * <p>
+   *
    * <code>byte,short,int,long,float,double,BigDecimal,boolean,string</code>.
+   * </p>
    *
    * @param bytes The bytes of the numeric field.
    * @param oid The oid of the field.

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
@@ -1950,7 +1950,7 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
    * @return the column value; if the value is SQL <code>NULL</code>, the value returned is
    * <code>false</code>
    * @exception SQLException if the columnIndex is not valid; if a database access error occurs; if
-   * this method is called on a closed result set or is an invalid cast to boolean type.
+   *     this method is called on a closed result set or is an invalid cast to boolean type.
    * @see <a href="https://www.postgresql.org/docs/current/static/datatype-boolean.html">PostgreSQL
    * Boolean Type</a>
    */

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSetMetaData.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSetMetaData.java
@@ -31,6 +31,7 @@ public class PgResultSetMetaData implements ResultSetMetaData, PGResultSetMetaDa
   /**
    * Initialise for a result with a tuple set and a field descriptor set
    *
+   * @param connection the connection to retrieve metadata
    * @param fields the array of field descriptors
    */
   public PgResultSetMetaData(BaseConnection connection, Field[] fields) {

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgStatement.java
@@ -101,7 +101,7 @@ public class PgStatement implements Statement, BaseStatement {
   protected volatile PSQLWarningWrapper warnings = null;
 
   /**
-   * Maximum number of rows to return, 0 = unlimited
+   * Maximum number of rows to return, 0 = unlimited.
    */
   protected int maxrows = 0;
 
@@ -111,7 +111,7 @@ public class PgStatement implements Statement, BaseStatement {
   protected int fetchSize = 0;
 
   /**
-   * Timeout (in milliseconds) for a query
+   * Timeout (in milliseconds) for a query.
    */
   protected long timeout = 0;
 
@@ -342,7 +342,7 @@ public class PgStatement implements Statement, BaseStatement {
   }
 
   /**
-   * Returns true if query is unlikely to be reused
+   * Returns true if query is unlikely to be reused.
    *
    * @param cachedQuery to check (null if current query)
    * @return true if query is unlikely to be reused
@@ -543,7 +543,7 @@ public class PgStatement implements Statement, BaseStatement {
   }
 
   /**
-   * Sets the queryTimeout limit
+   * Sets the queryTimeout limit.
    *
    * @param millis - the new query timeout limit in milliseconds
    * @throws SQLException if a database access error occurs

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgStatement.java
@@ -559,11 +559,11 @@ public class PgStatement implements Statement, BaseStatement {
   }
 
   /**
-   * Either initializes new warning wrapper, or adds warning onto the chain.
+   * <p>Either initializes new warning wrapper, or adds warning onto the chain.</p>
    *
-   * Although warnings are expected to be added sequentially, the warnings chain may be cleared
+   * <p>Although warnings are expected to be added sequentially, the warnings chain may be cleared
    * concurrently at any time via {@link #clearWarnings()}, therefore it is possible that a warning
-   * added via this method is placed onto the end of the previous warning chain
+   * added via this method is placed onto the end of the previous warning chain</p>
    *
    * @param warn warning to add
    */
@@ -599,11 +599,11 @@ public class PgStatement implements Statement, BaseStatement {
   }
 
   /**
-   * Clears the warning chain.<p>
-   * Note that while it is safe to clear warnings while the query is executing, warnings that are
+   * <p>Clears the warning chain.</p>
+   * <p>Note that while it is safe to clear warnings while the query is executing, warnings that are
    * added between calls to {@link #getWarnings()} and #clearWarnings() may be missed.
    * Therefore you should hold a reference to the tail of the previous warning chain
-   * and verify if its {@link SQLWarning#getNextWarning()} value is holds any new value.
+   * and verify if its {@link SQLWarning#getNextWarning()} value is holds any new value.</p>
    */
   public void clearWarnings() throws SQLException {
     warnings = null;

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PreferQueryMode.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PreferQueryMode.java
@@ -6,10 +6,10 @@
 package org.postgresql.jdbc;
 
 /**
- * Specifies which mode is used to execute queries to database: simple means ('Q' execute, no parse, no bind, text mode only),
- * extended means always use bind/execute messages, extendedForPrepared means extended for prepared statements only.
+ * <p>Specifies which mode is used to execute queries to database: simple means ('Q' execute, no parse, no bind, text mode only),
+ * extended means always use bind/execute messages, extendedForPrepared means extended for prepared statements only.</p>
  *
- * Note: this is for debugging purposes only.
+ * <p>Note: this is for debugging purposes only.</p>
  *
  * @see org.postgresql.PGProperty#PREFER_QUERY_MODE
  */

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/TimestampUtils.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/TimestampUtils.java
@@ -1147,12 +1147,12 @@ public class TimestampUtils {
   //#endif
 
   /**
-   * Given a UTC timestamp {@code millis} finds another point in time that is rendered in given time
-   * zone {@code tz} exactly as "millis in UTC".
+   * <p>Given a UTC timestamp {@code millis} finds another point in time that is rendered in given time
+   * zone {@code tz} exactly as "millis in UTC".</p>
    *
-   * For instance, given 7 Jan 16:00 UTC and tz=GMT+02:00 it returns 7 Jan 14:00 UTC == 7 Jan 16:00
+   * <p>For instance, given 7 Jan 16:00 UTC and tz=GMT+02:00 it returns 7 Jan 14:00 UTC == 7 Jan 16:00
    * GMT+02:00 Note that is not trivial for timestamps near DST change. For such cases, we rely on
-   * {@link Calendar} to figure out the proper timestamp.
+   * {@link Calendar} to figure out the proper timestamp.</p>
    *
    * @param millis source timestamp
    * @param tz desired time zone

--- a/pgjdbc/src/main/java/org/postgresql/jdbc2/ArrayAssistant.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc2/ArrayAssistant.java
@@ -7,20 +7,20 @@ package org.postgresql.jdbc2;
 
 /**
  * Implement this interface and register the its instance to ArrayAssistantRegistry, to let Postgres
- * driver to support more array type
+ * driver to support more array type.
  *
  * @author Minglei Tu
  */
 public interface ArrayAssistant {
   /**
-   * get array base type
+   * get array base type.
    *
    * @return array base type
    */
   Class<?> baseType();
 
   /**
-   * build a array element from its binary bytes
+   * build a array element from its binary bytes.
    *
    * @param bytes input bytes
    * @param pos position in input array
@@ -30,7 +30,7 @@ public interface ArrayAssistant {
   Object buildElement(byte[] bytes, int pos, int len);
 
   /**
-   * build an array element from its literal string
+   * build an array element from its literal string.
    *
    * @param literal string representation of array element
    * @return array element

--- a/pgjdbc/src/main/java/org/postgresql/jdbc2/ArrayAssistantRegistry.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc2/ArrayAssistantRegistry.java
@@ -9,7 +9,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Array assistants register here
+ * Array assistants register here.
  *
  * @author Minglei Tu
  */

--- a/pgjdbc/src/main/java/org/postgresql/largeobject/BlobInputStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/largeobject/BlobInputStream.java
@@ -113,10 +113,9 @@ public class BlobInputStream extends InputStream {
 
 
   /**
-   * Closes this input stream and releases any system resources associated with the stream.
+   * <p>Closes this input stream and releases any system resources associated with the stream.</p>
    *
-   * <p>
-   * The <code>close</code> method of <code>InputStream</code> does nothing.
+   * <p>The <code>close</code> method of <code>InputStream</code> does nothing.</p>
    *
    * @throws IOException if an I/O error occurs.
    */
@@ -132,24 +131,21 @@ public class BlobInputStream extends InputStream {
   }
 
   /**
-   * Marks the current position in this input stream. A subsequent call to the <code>reset</code>
+   * <p>Marks the current position in this input stream. A subsequent call to the <code>reset</code>
    * method repositions this stream at the last marked position so that subsequent reads re-read the
-   * same bytes.
+   * same bytes.</p>
    *
-   * <p>
-   * The <code>readlimit</code> arguments tells this input stream to allow that many bytes to be
-   * read before the mark position gets invalidated.
+   * <p>The <code>readlimit</code> arguments tells this input stream to allow that many bytes to be
+   * read before the mark position gets invalidated.</p>
    *
-   * <p>
-   * The general contract of <code>mark</code> is that, if the method <code>markSupported</code>
+   * <p>The general contract of <code>mark</code> is that, if the method <code>markSupported</code>
    * returns <code>true</code>, the stream somehow remembers all the bytes read after the call to
    * <code>mark</code> and stands ready to supply those same bytes again if and whenever the method
    * <code>reset</code> is called. However, the stream is not required to remember any data at all
    * if more than <code>readlimit</code> bytes are read from the stream before <code>reset</code> is
-   * called.
+   * called.</p>
    *
-   * <p>
-   * Marking a closed stream should not have any effect on the stream.
+   * <p>Marking a closed stream should not have any effect on the stream.</p>
    *
    * @param readlimit the maximum limit of bytes that can be read before the mark position becomes
    *        invalid.

--- a/pgjdbc/src/main/java/org/postgresql/largeobject/BlobInputStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/largeobject/BlobInputStream.java
@@ -14,37 +14,37 @@ import java.sql.SQLException;
  */
 public class BlobInputStream extends InputStream {
   /**
-   * The parent LargeObject
+   * The parent LargeObject.
    */
   private LargeObject lo;
 
   /**
-   * The absolute position
+   * The absolute position.
    */
   private long apos;
 
   /**
-   * Buffer used to improve performance
+   * Buffer used to improve performance.
    */
   private byte[] buffer;
 
   /**
-   * Position within buffer
+   * Position within buffer.
    */
   private int bpos;
 
   /**
-   * The buffer size
+   * The buffer size.
    */
   private int bsize;
 
   /**
-   * The mark position
+   * The mark position.
    */
   private long mpos = 0;
 
   /**
-   * The limit
+   * The limit.
    */
   private long limit = -1;
 
@@ -79,7 +79,7 @@ public class BlobInputStream extends InputStream {
   }
 
   /**
-   * The minimum required to implement input stream
+   * The minimum required to implement input stream.
    */
   public int read() throws java.io.IOException {
     checkClosed();
@@ -161,7 +161,7 @@ public class BlobInputStream extends InputStream {
 
   /**
    * Repositions this stream to the position at the time the <code>mark</code> method was last
-   * called on this input stream. NB: If mark is not called we move to the begining.
+   * called on this input stream. NB: If mark is not called we move to the beginning.
    *
    * @see java.io.InputStream#mark(int)
    * @see java.io.IOException

--- a/pgjdbc/src/main/java/org/postgresql/largeobject/BlobOutputStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/largeobject/BlobOutputStream.java
@@ -10,31 +10,31 @@ import java.io.OutputStream;
 import java.sql.SQLException;
 
 /**
- * This implements a basic output stream that writes to a LargeObject
+ * This implements a basic output stream that writes to a LargeObject.
  */
 public class BlobOutputStream extends OutputStream {
   /**
-   * The parent LargeObject
+   * The parent LargeObject.
    */
   private LargeObject lo;
 
   /**
-   * Buffer
+   * Buffer.
    */
   private byte[] buf;
 
   /**
-   * Size of the buffer (default 1K)
+   * Size of the buffer (default 1K).
    */
   private int bsize;
 
   /**
-   * Position within the buffer
+   * Position within the buffer.
    */
   private int bpos;
 
   /**
-   * Create an OutputStream to a large object
+   * Create an OutputStream to a large object.
    *
    * @param lo LargeObject
    */
@@ -43,7 +43,7 @@ public class BlobOutputStream extends OutputStream {
   }
 
   /**
-   * Create an OutputStream to a large object
+   * Create an OutputStream to a large object.
    *
    * @param lo LargeObject
    * @param bsize The size of the buffer used to improve performance

--- a/pgjdbc/src/main/java/org/postgresql/largeobject/LargeObject.java
+++ b/pgjdbc/src/main/java/org/postgresql/largeobject/LargeObject.java
@@ -47,17 +47,17 @@ public class LargeObject
     //#endif
     /* hi, checkstyle */ {
   /**
-   * Indicates a seek from the begining of a file
+   * Indicates a seek from the begining of a file.
    */
   public static final int SEEK_SET = 0;
 
   /**
-   * Indicates a seek from the current position
+   * Indicates a seek from the current position.
    */
   public static final int SEEK_CUR = 1;
 
   /**
-   * Indicates a seek from the end of a file
+   * Indicates a seek from the end of a file.
    */
   public static final int SEEK_END = 2;
 
@@ -184,7 +184,7 @@ public class LargeObject
   }
 
   /**
-   * Reads some data from the object, and return as a byte[] array
+   * Reads some data from the object, and return as a byte[] array.
    *
    * @param len number of bytes to read
    * @return byte[] array containing data read
@@ -200,7 +200,7 @@ public class LargeObject
   }
 
   /**
-   * Reads some data from the object into an existing array
+   * Reads some data from the object into an existing array.
    *
    * @param buf destination array
    * @param off offset within array
@@ -218,7 +218,7 @@ public class LargeObject
   }
 
   /**
-   * Writes an array to the object
+   * Writes an array to the object.
    *
    * @param buf array to write
    * @throws SQLException if a database-access error occurs.
@@ -231,7 +231,7 @@ public class LargeObject
   }
 
   /**
-   * Writes some data from an array to the object
+   * Writes some data from an array to the object.
    *
    * @param buf destination array
    * @param off offset within array
@@ -265,7 +265,7 @@ public class LargeObject
   }
 
   /**
-   * Sets the current position within the object using 64-bit value (9.3+)
+   * Sets the current position within the object using 64-bit value (9.3+).
    *
    * @param pos position within object
    * @param ref Either SEEK_SET, SEEK_CUR or SEEK_END
@@ -390,7 +390,7 @@ public class LargeObject
 
   /**
    * Returns an {@link InputStream} from this object, that will limit the amount of data that is
-   * visible
+   * visible.
    *
    * @param limit maximum number of bytes the resulting stream will serve
    * @return {@link InputStream} from this object

--- a/pgjdbc/src/main/java/org/postgresql/largeobject/LargeObject.java
+++ b/pgjdbc/src/main/java/org/postgresql/largeobject/LargeObject.java
@@ -17,21 +17,18 @@ import java.io.OutputStream;
 import java.sql.SQLException;
 
 /**
- * This class provides the basic methods required to run the interface, plus a pair of methods that
- * provide InputStream and OutputStream classes for this object.
+ * <p>This class provides the basic methods required to run the interface, plus a pair of methods that
+ * provide InputStream and OutputStream classes for this object.</p>
  *
- * <p>
- * Normally, client code would use the getAsciiStream, getBinaryStream, or getUnicodeStream methods
+ * <p>Normally, client code would use the getAsciiStream, getBinaryStream, or getUnicodeStream methods
  * in ResultSet, or setAsciiStream, setBinaryStream, or setUnicodeStream methods in
- * PreparedStatement to access Large Objects.
+ * PreparedStatement to access Large Objects.</p>
  *
- * <p>
- * However, sometimes lower level access to Large Objects are required, that are not supported by
- * the JDBC specification.
+ * <p>However, sometimes lower level access to Large Objects are required, that are not supported by
+ * the JDBC specification.</p>
  *
- * <p>
- * Refer to org.postgresql.largeobject.LargeObjectManager on how to gain access to a Large Object,
- * or how to create one.
+ * <p>Refer to org.postgresql.largeobject.LargeObjectManager on how to gain access to a Large Object,
+ * or how to create one.</p>
  *
  * @see org.postgresql.largeobject.LargeObjectManager
  * @see java.sql.ResultSet#getAsciiStream
@@ -74,10 +71,9 @@ public class LargeObject
   private boolean commitOnClose; // Only initialized when open a LOB with CommitOnClose
 
   /**
-   * This opens a large object.
+   * <p>This opens a large object.</p>
    *
-   * <p>
-   * If the object does not exist, then an SQLException is thrown.
+   * <p>If the object does not exist, then an SQLException is thrown.</p>
    *
    * @param fp FastPath API for the connection to use
    * @param oid of the Large Object to open
@@ -107,10 +103,9 @@ public class LargeObject
   }
 
   /**
-   * This opens a large object.
+   * <p>This opens a large object.</p>
    *
-   * <p>
-   * If the object does not exist, then an SQLException is thrown.
+   * <p>If the object does not exist, then an SQLException is thrown.</p>
    *
    * @param fp FastPath API for the connection to use
    * @param oid of the Large Object to open
@@ -246,11 +241,10 @@ public class LargeObject
   }
 
   /**
-   * Sets the current position within the object.
+   * <p>Sets the current position within the object.</p>
    *
-   * <p>
-   * This is similar to the fseek() call in the standard C library. It allows you to have random
-   * access to the large object.
+   * <p>This is similar to the fseek() call in the standard C library. It allows you to have random
+   * access to the large object.</p>
    *
    * @param pos position within object
    * @param ref Either SEEK_SET, SEEK_CUR or SEEK_END
@@ -280,11 +274,10 @@ public class LargeObject
   }
 
   /**
-   * Sets the current position within the object.
+   * <p>Sets the current position within the object.</p>
    *
-   * <p>
-   * This is similar to the fseek() call in the standard C library. It allows you to have random
-   * access to the large object.
+   * <p>This is similar to the fseek() call in the standard C library. It allows you to have random
+   * access to the large object.</p>
    *
    * @param pos position within object from begining
    * @throws SQLException if a database-access error occurs.
@@ -314,11 +307,10 @@ public class LargeObject
   }
 
   /**
-   * This method is inefficient, as the only way to find out the size of the object is to seek to
-   * the end, record the current position, then return to the original position.
+   * <p>This method is inefficient, as the only way to find out the size of the object is to seek to
+   * the end, record the current position, then return to the original position.</p>
    *
-   * <p>
-   * A better method will be found in the future.
+   * <p>A better method will be found in the future.</p>
    *
    * @return the size of the large object
    * @throws SQLException if a database-access error occurs.
@@ -376,10 +368,9 @@ public class LargeObject
   }
 
   /**
-   * Returns an {@link InputStream} from this object.
+   * <p>Returns an {@link InputStream} from this object.</p>
    *
-   * <p>
-   * This {@link InputStream} can then be used in any method that requires an InputStream.
+   * <p>This {@link InputStream} can then be used in any method that requires an InputStream.</p>
    *
    * @return {@link InputStream} from this object
    * @throws SQLException if a database-access error occurs.
@@ -401,10 +392,9 @@ public class LargeObject
   }
 
   /**
-   * Returns an {@link OutputStream} to this object.
+   * <p>Returns an {@link OutputStream} to this object.</p>
    *
-   * <p>
-   * This OutputStream can then be used in any method that requires an OutputStream.
+   * <p>This OutputStream can then be used in any method that requires an OutputStream.</p>
    *
    * @return {@link OutputStream} from this object
    * @throws SQLException if a database-access error occurs.

--- a/pgjdbc/src/main/java/org/postgresql/largeobject/LargeObjectManager.java
+++ b/pgjdbc/src/main/java/org/postgresql/largeobject/LargeObjectManager.java
@@ -68,22 +68,22 @@ public class LargeObjectManager {
   private BaseConnection conn;
 
   /**
-   * This mode indicates we want to write to an object
+   * This mode indicates we want to write to an object.
    */
   public static final int WRITE = 0x00020000;
 
   /**
-   * This mode indicates we want to read an object
+   * This mode indicates we want to read an object.
    */
   public static final int READ = 0x00040000;
 
   /**
-   * This mode is the default. It indicates we want read and write access to a large object
+   * This mode is the default. It indicates we want read and write access to a large object.
    */
   public static final int READWRITE = READ | WRITE;
 
   /**
-   * This prevents us being created by mere mortals
+   * This prevents us being created by mere mortals.
    */
   private LargeObjectManager() {
   }
@@ -195,7 +195,7 @@ public class LargeObjectManager {
 
   /**
    * This opens an existing large object, same as previous method, but commits the transaction on
-   * close if asked
+   * close if asked.
    *
    * @param oid of large object
    * @param commitOnClose commit the transaction when this LOB will be closed
@@ -208,7 +208,7 @@ public class LargeObjectManager {
   }
 
   /**
-   * This opens an existing large object, based on its OID
+   * This opens an existing large object, based on its OID.
    *
    * @param oid of large object
    * @param mode mode of open
@@ -223,7 +223,7 @@ public class LargeObjectManager {
 
   /**
    * This opens an existing large object, same as previous method, but commits the transaction on
-   * close if asked
+   * close if asked.
    *
    * @param oid of large object
    * @param mode mode of open
@@ -237,7 +237,7 @@ public class LargeObjectManager {
   }
 
   /**
-   * This opens an existing large object, based on its OID
+   * This opens an existing large object, based on its OID.
    *
    * @param oid of large object
    * @param mode mode of open
@@ -249,7 +249,7 @@ public class LargeObjectManager {
   }
 
   /**
-   * This opens an existing large object, based on its OID
+   * This opens an existing large object, based on its OID.
    *
    * @param oid of large object
    * @param mode mode of open
@@ -294,7 +294,7 @@ public class LargeObjectManager {
   }
 
   /**
-   * This creates a large object, returning its OID
+   * This creates a large object, returning its OID.
    *
    * @param mode a bitmask describing different attributes of the new object
    * @return oid of new object
@@ -311,7 +311,7 @@ public class LargeObjectManager {
   }
 
   /**
-   * This creates a large object, returning its OID
+   * This creates a large object, returning its OID.
    *
    * @param mode a bitmask describing different attributes of the new object
    * @return oid of new object

--- a/pgjdbc/src/main/java/org/postgresql/largeobject/LargeObjectManager.java
+++ b/pgjdbc/src/main/java/org/postgresql/largeobject/LargeObjectManager.java
@@ -26,7 +26,7 @@ import java.util.logging.Level;
  *
  * <p>This class can only be created by {@link BaseConnection}</p>
  *
- * <p>To get access to this class, use the following segment of code: <br>
+ * <p>To get access to this class, use the following segment of code:</p>
  *
  * <pre>
  * import org.postgresql.largeobject.*;
@@ -38,7 +38,6 @@ import java.util.logging.Level;
  *
  * lobj = ((org.postgresql.PGConnection)myconn).getLargeObjectAPI();
  * </pre>
- * </p>
  *
  * <p>Normally, client code would use the getAsciiStream, getBinaryStream, or getUnicodeStream methods
  * in ResultSet, or setAsciiStream, setBinaryStream, or setUnicodeStream methods in

--- a/pgjdbc/src/main/java/org/postgresql/largeobject/LargeObjectManager.java
+++ b/pgjdbc/src/main/java/org/postgresql/largeobject/LargeObjectManager.java
@@ -20,16 +20,13 @@ import java.util.logging.Level;
 /**
  * This class implements the large object interface to org.postgresql.
  *
- * <p>
- * It provides methods that allow client code to create, open and delete large objects from the
+ * <p>It provides methods that allow client code to create, open and delete large objects from the
  * database. When opening an object, an instance of org.postgresql.largeobject.LargeObject is
- * returned, and its methods then allow access to the object.
+ * returned, and its methods then allow access to the object.</p>
  *
- * <p>
- * This class can only be created by {@link BaseConnection}
+ * <p>This class can only be created by {@link BaseConnection}</p>
  *
- * <p>
- * To get access to this class, use the following segment of code: <br>
+ * <p>To get access to this class, use the following segment of code: <br>
  *
  * <pre>
  * import org.postgresql.largeobject.*;
@@ -41,19 +38,17 @@ import java.util.logging.Level;
  *
  * lobj = ((org.postgresql.PGConnection)myconn).getLargeObjectAPI();
  * </pre>
+ * </p>
  *
- * <p>
- * Normally, client code would use the getAsciiStream, getBinaryStream, or getUnicodeStream methods
+ * <p>Normally, client code would use the getAsciiStream, getBinaryStream, or getUnicodeStream methods
  * in ResultSet, or setAsciiStream, setBinaryStream, or setUnicodeStream methods in
- * PreparedStatement to access Large Objects.
+ * PreparedStatement to access Large Objects.</p>
  *
- * <p>
- * However, sometimes lower level access to Large Objects are required, that are not supported by
- * the JDBC specification.
+ * <p>However, sometimes lower level access to Large Objects are required, that are not supported by
+ * the JDBC specification.</p>
  *
- * <p>
- * Refer to org.postgresql.largeobject.LargeObject on how to manipulate the contents of a Large
- * Object.
+ * <p>Refer to org.postgresql.largeobject.LargeObject on how to manipulate the contents of a Large
+ * Object.</p>
  *
  * @see java.sql.ResultSet#getAsciiStream
  * @see java.sql.ResultSet#getBinaryStream
@@ -89,16 +84,14 @@ public class LargeObjectManager {
   }
 
   /**
-   * Constructs the LargeObject API.
+   * <p>Constructs the LargeObject API.</p>
    *
-   * <p>
-   * <b>Important Notice</b> <br>
-   * This method should only be called by {@link BaseConnection}
+   * <p><b>Important Notice</b> <br>
+   * This method should only be called by {@link BaseConnection}</p>
    *
-   * <p>
-   * There should only be one LargeObjectManager per Connection. The {@link BaseConnection} class
+   * <p>There should only be one LargeObjectManager per Connection. The {@link BaseConnection} class
    * keeps track of the various extension API's and it's advised you use those to gain access, and
-   * not going direct.
+   * not going direct.</p>
    *
    * @param conn connection
    * @throws SQLException if something wrong happens
@@ -266,10 +259,9 @@ public class LargeObjectManager {
   }
 
   /**
-   * This creates a large object, returning its OID.
+   * <p>This creates a large object, returning its OID.</p>
    *
-   * <p>
-   * It defaults to READWRITE for the new object's attributes.
+   * <p>It defaults to READWRITE for the new object's attributes.</p>
    *
    * @return oid of new object
    * @throws SQLException on error
@@ -281,10 +273,9 @@ public class LargeObjectManager {
   }
 
   /**
-   * This creates a large object, returning its OID.
+   * <p>This creates a large object, returning its OID.</p>
    *
-   * <p>
-   * It defaults to READWRITE for the new object's attributes.
+   * <p>It defaults to READWRITE for the new object's attributes.</p>
    *
    * @return oid of new object
    * @throws SQLException if something wrong happens
@@ -337,10 +328,9 @@ public class LargeObjectManager {
   }
 
   /**
-   * This deletes a large object.
+   * <p>This deletes a large object.</p>
    *
-   * <p>
-   * It is identical to the delete method, and is supplied as the C API uses unlink.
+   * <p>It is identical to the delete method, and is supplied as the C API uses unlink.</p>
    *
    * @param oid describing object to delete
    * @throws SQLException on error
@@ -352,10 +342,9 @@ public class LargeObjectManager {
   }
 
   /**
-   * This deletes a large object.
+   * <p>This deletes a large object.</p>
    *
-   * <p>
-   * It is identical to the delete method, and is supplied as the C API uses unlink.
+   * <p>It is identical to the delete method, and is supplied as the C API uses unlink.</p>
    *
    * @param oid describing object to delete
    * @throws SQLException on error

--- a/pgjdbc/src/main/java/org/postgresql/osgi/PGBundleActivator.java
+++ b/pgjdbc/src/main/java/org/postgresql/osgi/PGBundleActivator.java
@@ -16,7 +16,7 @@ import java.util.Dictionary;
 import java.util.Hashtable;
 
 /**
- * This class is an OSGi Bundle Activator and should only be used internally by the OSGi Framework
+ * This class is an OSGi Bundle Activator and should only be used internally by the OSGi Framework.
  */
 public class PGBundleActivator implements BundleActivator {
   private ServiceRegistration<?> _registration;

--- a/pgjdbc/src/main/java/org/postgresql/osgi/PGDataSourceFactory.java
+++ b/pgjdbc/src/main/java/org/postgresql/osgi/PGDataSourceFactory.java
@@ -32,7 +32,7 @@ public class PGDataSourceFactory implements DataSourceFactory {
 
   /**
    * A class that removes properties as they are used (without modifying the supplied initial
-   * Properties)
+   * Properties).
    */
   private static class SingleUseProperties extends Properties {
     private static final long serialVersionUID = 1L;
@@ -109,7 +109,7 @@ public class PGDataSourceFactory implements DataSourceFactory {
   /**
    * Will create and return either a {@link SimpleDataSource} or a {@link PoolingDataSource}
    * depending on the presence in the supplied properties of any pool-related property (eg.: {@code
-   * JDBC_INITIAL_POOL_SIZE} or {@code JDBC_MAX_POOL_SIZE})
+   * JDBC_INITIAL_POOL_SIZE} or {@code JDBC_MAX_POOL_SIZE}).
    */
   public DataSource createDataSource(Properties props) throws SQLException {
     props = new SingleUseProperties(props);

--- a/pgjdbc/src/main/java/org/postgresql/replication/LogSequenceNumber.java
+++ b/pgjdbc/src/main/java/org/postgresql/replication/LogSequenceNumber.java
@@ -8,7 +8,7 @@ package org.postgresql.replication;
 import java.nio.ByteBuffer;
 
 /**
- * LSN (Log Sequence Number) data which is a pointer to a location in the XLOG
+ * LSN (Log Sequence Number) data which is a pointer to a location in the XLOG.
  */
 public final class LogSequenceNumber {
   /**
@@ -32,7 +32,7 @@ public final class LogSequenceNumber {
   }
 
   /**
-   * Create LSN instance by string represent LSN
+   * Create LSN instance by string represent LSN.
    *
    * @param strValue not null string as two hexadecimal numbers of up to 8 digits each, separated by
    *                 a slash. For example {@code 16/3002D50}, {@code 0/15D68C50}

--- a/pgjdbc/src/main/java/org/postgresql/replication/LogSequenceNumber.java
+++ b/pgjdbc/src/main/java/org/postgresql/replication/LogSequenceNumber.java
@@ -69,7 +69,7 @@ public final class LogSequenceNumber {
 
   /**
    * @return String represent position in the write-ahead log stream as two hexadecimal numbers of
-   * up to 8 digits each, separated by a slash. For example {@code 16/3002D50}, {@code 0/15D68C50}
+   *     up to 8 digits each, separated by a slash. For example {@code 16/3002D50}, {@code 0/15D68C50}
    */
   public String asString() {
     ByteBuffer buf = ByteBuffer.allocate(8);

--- a/pgjdbc/src/main/java/org/postgresql/replication/PGReplicationConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/replication/PGReplicationConnection.java
@@ -27,11 +27,11 @@ public interface PGReplicationConnection {
   ChainedStreamBuilder replicationStream();
 
   /**
-   * <p>Create replication slot, that can be next use in {@link PGReplicationConnection#replicationStream()}
+   * <p>Create replication slot, that can be next use in {@link PGReplicationConnection#replicationStream()}</p>
    *
    * <p>Replication slots provide an automated way to ensure that the master does not remove WAL
    * segments until they have been received by all standbys, and that the master does not remove
-   * rows which could cause a recovery conflict even when the standby is disconnected.
+   * rows which could cause a recovery conflict even when the standby is disconnected.</p>
    *
    * @return not null fluent api for build create replication slot
    */

--- a/pgjdbc/src/main/java/org/postgresql/replication/PGReplicationStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/replication/PGReplicationStream.java
@@ -33,7 +33,7 @@ public interface PGReplicationStream
    * can be sent in different XLogData messages.
    *
    * @return not null byte array received by replication protocol, return ByteBuffer wrap around
-   * received byte array with use offset, so, use {@link ByteBuffer#array()} carefully
+   *     received byte array with use offset, so, use {@link ByteBuffer#array()} carefully
    * @throws SQLException when some internal exception occurs during read from stream
    */
   ByteBuffer read() throws SQLException;
@@ -50,8 +50,8 @@ public interface PGReplicationStream
    * can be sent in different XLogData messages.
    *
    * @return byte array received by replication protocol or null if pending message from server
-   * absent. Returns ByteBuffer wrap around received byte array with use offset, so, use {@link
-   * ByteBuffer#array()} carefully.
+   *     absent. Returns ByteBuffer wrap around received byte array with use offset, so, use {@link
+   *     ByteBuffer#array()} carefully.
    * @throws SQLException when some internal exception occurs during read from stream
    */
   ByteBuffer readPending() throws SQLException;
@@ -60,7 +60,7 @@ public interface PGReplicationStream
    * Parameter updates by execute {@link PGReplicationStream#read()} method.
    *
    * @return not null LSN position that was receive last time via {@link PGReplicationStream#read()}
-   * method
+   *     method
    */
   LogSequenceNumber getLastReceiveLSN();
 

--- a/pgjdbc/src/main/java/org/postgresql/replication/PGReplicationStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/replication/PGReplicationStream.java
@@ -25,12 +25,12 @@ public interface PGReplicationStream
 
   /**
    * <p>Read next wal record from backend. It method can be block until new message will not get
-   * from server.
+   * from server.</p>
    *
    * <p>A single WAL record is never split across two XLogData messages. When a WAL record crosses a
    * WAL page boundary, and is therefore already split using continuation records, it can be split
    * at the page boundary. In other words, the first main WAL record and its continuation records
-   * can be sent in different XLogData messages.
+   * can be sent in different XLogData messages.</p>
    *
    * @return not null byte array received by replication protocol, return ByteBuffer wrap around
    *     received byte array with use offset, so, use {@link ByteBuffer#array()} carefully
@@ -42,12 +42,12 @@ public interface PGReplicationStream
    * <p>Read next wal record from backend. It method can't be block and in contrast to {@link
    * PGReplicationStream#read()}. If message from backend absent return null. It allow periodically
    * check message in stream and if they absent sleep some time, but it time should be less than
-   * {@link CommonOptions#getStatusInterval()} to avoid disconnect from the server.
+   * {@link CommonOptions#getStatusInterval()} to avoid disconnect from the server.</p>
    *
    * <p>A single WAL record is never split across two XLogData messages. When a WAL record crosses a
    * WAL page boundary, and is therefore already split using continuation records, it can be split
    * at the page boundary. In other words, the first main WAL record and its continuation records
-   * can be sent in different XLogData messages.
+   * can be sent in different XLogData messages.</p>
    *
    * @return byte array received by replication protocol or null if pending message from server
    *     absent. Returns ByteBuffer wrap around received byte array with use offset, so, use {@link
@@ -115,14 +115,14 @@ public interface PGReplicationStream
 
   /**
    * <p>Stop replication changes from server and free resources. After that connection can be reuse
-   * to another queries. Also after close current stream they cannot be used anymore.
+   * to another queries. Also after close current stream they cannot be used anymore.</p>
    *
    * <p><b>Note:</b> This method can spend much time for logical replication stream on postgresql
    * version 9.6 and lower, because postgresql have bug - during decode big transaction to logical
    * form and during wait new changes postgresql ignore messages from client. As workaround you can
    * close replication connection instead of close replication stream. For more information about it
    * problem see mailing list thread <a href="http://www.postgresql.org/message-id/CAFgjRd3hdYOa33m69TbeOfNNer2BZbwa8FFjt2V5VFzTBvUU3w@mail.gmail.com">
-   * Stopping logical replication protocol</a>
+   * Stopping logical replication protocol</a></p>
    *
    * @throws SQLException when some internal exception occurs during end streaming
    */

--- a/pgjdbc/src/main/java/org/postgresql/replication/fluent/ChainedCommonCreateSlotBuilder.java
+++ b/pgjdbc/src/main/java/org/postgresql/replication/fluent/ChainedCommonCreateSlotBuilder.java
@@ -23,7 +23,7 @@ public interface ChainedCommonCreateSlotBuilder<T extends ChainedCommonCreateSlo
   T withSlotName(String slotName);
 
   /**
-   * Create slot with specified parameters in database
+   * Create slot with specified parameters in database.
    * @throws SQLException on error
    */
   void make() throws SQLException;

--- a/pgjdbc/src/main/java/org/postgresql/replication/fluent/ChainedCommonStreamBuilder.java
+++ b/pgjdbc/src/main/java/org/postgresql/replication/fluent/ChainedCommonStreamBuilder.java
@@ -9,7 +9,7 @@ import org.postgresql.replication.LogSequenceNumber;
 
 import java.util.concurrent.TimeUnit;
 
-/***
+/**
  * Fluent interface for specify common parameters for Logical and Physical replication.
  */
 public interface ChainedCommonStreamBuilder<T extends ChainedCommonStreamBuilder<T>> {
@@ -24,7 +24,7 @@ public interface ChainedCommonStreamBuilder<T extends ChainedCommonStreamBuilder
    */
   T withSlotName(String slotName);
 
-  /***
+  /**
    * Specifies the number of time between status packets sent back to the server. This allows for
    * easier monitoring of the progress from server. A value of zero disables the periodic status
    * updates completely, although an update will still be sent when requested by the server, to

--- a/pgjdbc/src/main/java/org/postgresql/replication/fluent/ChainedCreateReplicationSlotBuilder.java
+++ b/pgjdbc/src/main/java/org/postgresql/replication/fluent/ChainedCreateReplicationSlotBuilder.java
@@ -8,7 +8,7 @@ package org.postgresql.replication.fluent;
 import org.postgresql.replication.fluent.logical.ChainedLogicalCreateSlotBuilder;
 import org.postgresql.replication.fluent.physical.ChainedPhysicalCreateSlotBuilder;
 
-/***
+/**
  * Fluent interface for specify common parameters for Logical and Physical replication.
  */
 public interface ChainedCreateReplicationSlotBuilder {
@@ -48,9 +48,9 @@ public interface ChainedCreateReplicationSlotBuilder {
   ChainedLogicalCreateSlotBuilder logical();
 
   /**
-   * Create physical replication stream for process wal logs in binary form.
+   * <p>Create physical replication stream for process wal logs in binary form.</p>
    *
-   * Example usage:
+   * <p>Example usage:
    * <pre>
    *   {@code
    *
@@ -76,6 +76,7 @@ public interface ChainedCreateReplicationSlotBuilder {
    *
    *   }
    * </pre>
+   * </p>
    * @return not null fluent api
    */
   ChainedPhysicalCreateSlotBuilder physical();

--- a/pgjdbc/src/main/java/org/postgresql/replication/fluent/ChainedCreateReplicationSlotBuilder.java
+++ b/pgjdbc/src/main/java/org/postgresql/replication/fluent/ChainedCreateReplicationSlotBuilder.java
@@ -13,6 +13,7 @@ import org.postgresql.replication.fluent.physical.ChainedPhysicalCreateSlotBuild
  */
 public interface ChainedCreateReplicationSlotBuilder {
   /**
+   * Get the logical slot builder.
    * Example usage:
    * <pre>
    *   {@code

--- a/pgjdbc/src/main/java/org/postgresql/replication/fluent/ChainedCreateReplicationSlotBuilder.java
+++ b/pgjdbc/src/main/java/org/postgresql/replication/fluent/ChainedCreateReplicationSlotBuilder.java
@@ -50,7 +50,7 @@ public interface ChainedCreateReplicationSlotBuilder {
   /**
    * <p>Create physical replication stream for process wal logs in binary form.</p>
    *
-   * <p>Example usage:
+   * <p>Example usage:</p>
    * <pre>
    *   {@code
    *
@@ -76,7 +76,7 @@ public interface ChainedCreateReplicationSlotBuilder {
    *
    *   }
    * </pre>
-   * </p>
+   *
    * @return not null fluent api
    */
   ChainedPhysicalCreateSlotBuilder physical();

--- a/pgjdbc/src/main/java/org/postgresql/replication/fluent/ChainedStreamBuilder.java
+++ b/pgjdbc/src/main/java/org/postgresql/replication/fluent/ChainedStreamBuilder.java
@@ -14,13 +14,14 @@ import org.postgresql.replication.fluent.physical.ChainedPhysicalStreamBuilder;
  */
 public interface ChainedStreamBuilder {
   /**
-   * Create logical replication stream that decode raw wal logs by output plugin to logical form.
+   * <p>Create logical replication stream that decode raw wal logs by output plugin to logical form.
    * Default about logical decoding you can see by following link
    * <a href="http://www.postgresql.org/docs/current/static/logicaldecoding-explanation.html">
-   *   Logical Decoding Concepts
+   *     Logical Decoding Concepts
    * </a>.
+   * </p>
    *
-   * Example usage:
+   * <p>Example usage:
    * <pre>
    *   {@code
    *
@@ -41,14 +42,15 @@ public interface ChainedStreamBuilder {
    *
    *   }
    * </pre>
+   * </p>
    * @return not null fluent api
    */
   ChainedLogicalStreamBuilder logical();
 
   /**
-   * Create physical replication stream for process wal logs in binary form.
+   * <p>Create physical replication stream for process wal logs in binary form.</p>
    *
-   * Example usage:
+   * <p>Example usage:
    * <pre>
    *   {@code
    *
@@ -69,6 +71,7 @@ public interface ChainedStreamBuilder {
    *
    *   }
    * </pre>
+   * </p>
    * @return not null fluent api
    */
   ChainedPhysicalStreamBuilder physical();

--- a/pgjdbc/src/main/java/org/postgresql/replication/fluent/ChainedStreamBuilder.java
+++ b/pgjdbc/src/main/java/org/postgresql/replication/fluent/ChainedStreamBuilder.java
@@ -21,7 +21,7 @@ public interface ChainedStreamBuilder {
    * </a>.
    * </p>
    *
-   * <p>Example usage:
+   * <p>Example usage:</p>
    * <pre>
    *   {@code
    *
@@ -42,7 +42,7 @@ public interface ChainedStreamBuilder {
    *
    *   }
    * </pre>
-   * </p>
+   *
    * @return not null fluent api
    */
   ChainedLogicalStreamBuilder logical();
@@ -50,7 +50,7 @@ public interface ChainedStreamBuilder {
   /**
    * <p>Create physical replication stream for process wal logs in binary form.</p>
    *
-   * <p>Example usage:
+   * <p>Example usage:</p>
    * <pre>
    *   {@code
    *
@@ -71,7 +71,7 @@ public interface ChainedStreamBuilder {
    *
    *   }
    * </pre>
-   * </p>
+   *
    * @return not null fluent api
    */
   ChainedPhysicalStreamBuilder physical();

--- a/pgjdbc/src/main/java/org/postgresql/replication/fluent/CommonOptions.java
+++ b/pgjdbc/src/main/java/org/postgresql/replication/fluent/CommonOptions.java
@@ -8,7 +8,7 @@ package org.postgresql.replication.fluent;
 import org.postgresql.replication.LogSequenceNumber;
 
 /**
- * Common parameters for logical and physical replication
+ * Common parameters for logical and physical replication.
  */
 public interface CommonOptions {
   /**

--- a/pgjdbc/src/main/java/org/postgresql/replication/fluent/logical/ChainedLogicalCreateSlotBuilder.java
+++ b/pgjdbc/src/main/java/org/postgresql/replication/fluent/logical/ChainedLogicalCreateSlotBuilder.java
@@ -8,7 +8,7 @@ package org.postgresql.replication.fluent.logical;
 import org.postgresql.replication.fluent.ChainedCommonCreateSlotBuilder;
 
 /**
- * Logical replication slot specific parameters
+ * Logical replication slot specific parameters.
  */
 public interface ChainedLogicalCreateSlotBuilder
     extends ChainedCommonCreateSlotBuilder<ChainedLogicalCreateSlotBuilder> {

--- a/pgjdbc/src/main/java/org/postgresql/replication/fluent/logical/ChainedLogicalCreateSlotBuilder.java
+++ b/pgjdbc/src/main/java/org/postgresql/replication/fluent/logical/ChainedLogicalCreateSlotBuilder.java
@@ -15,10 +15,10 @@ public interface ChainedLogicalCreateSlotBuilder
 
   /**
    * <p>Output plugin that should be use for decode physical represent WAL to some logical form.
-   * Output plugin should be installed on server(exists in shared_preload_libraries).
+   * Output plugin should be installed on server(exists in shared_preload_libraries).</p>
    *
    * <p>Package postgresql-contrib provides sample output plugin <b>test_decoding</b> that can be
-   * use for test logical replication api
+   * use for test logical replication api</p>
    *
    * @param outputPlugin not null name of the output plugin used for logical decoding
    * @return the logical slot builder

--- a/pgjdbc/src/main/java/org/postgresql/replication/fluent/logical/ChainedLogicalStreamBuilder.java
+++ b/pgjdbc/src/main/java/org/postgresql/replication/fluent/logical/ChainedLogicalStreamBuilder.java
@@ -14,7 +14,7 @@ import java.util.Properties;
 public interface ChainedLogicalStreamBuilder
     extends ChainedCommonStreamBuilder<ChainedLogicalStreamBuilder> {
   /**
-   * Open logical replication stream
+   * Open logical replication stream.
    *
    * @return not null PGReplicationStream available for fetch data in logical form
    * @throws SQLException  if there are errors

--- a/pgjdbc/src/main/java/org/postgresql/replication/fluent/logical/LogicalReplicationOptions.java
+++ b/pgjdbc/src/main/java/org/postgresql/replication/fluent/logical/LogicalReplicationOptions.java
@@ -11,7 +11,7 @@ import java.util.Properties;
 
 public interface LogicalReplicationOptions extends CommonOptions {
   /**
-   * Required parameter for logical replication
+   * Required parameter for logical replication.
    *
    * @return not null logical replication slot name that already exists on server and free.
    */

--- a/pgjdbc/src/main/java/org/postgresql/replication/fluent/physical/ChainedPhysicalCreateSlotBuilder.java
+++ b/pgjdbc/src/main/java/org/postgresql/replication/fluent/physical/ChainedPhysicalCreateSlotBuilder.java
@@ -8,7 +8,7 @@ package org.postgresql.replication.fluent.physical;
 import org.postgresql.replication.fluent.ChainedCommonCreateSlotBuilder;
 
 /**
- * Physical replication slot specific parameters
+ * Physical replication slot specific parameters.
  */
 public interface ChainedPhysicalCreateSlotBuilder extends
     ChainedCommonCreateSlotBuilder<ChainedPhysicalCreateSlotBuilder> {

--- a/pgjdbc/src/main/java/org/postgresql/replication/fluent/physical/ChainedPhysicalStreamBuilder.java
+++ b/pgjdbc/src/main/java/org/postgresql/replication/fluent/physical/ChainedPhysicalStreamBuilder.java
@@ -14,7 +14,7 @@ public interface ChainedPhysicalStreamBuilder extends
     ChainedCommonStreamBuilder<ChainedPhysicalStreamBuilder> {
 
   /**
-   * Open physical replication stream
+   * Open physical replication stream.
    *
    * @return not null PGReplicationStream available for fetch wal logs in binary form
    * @throws SQLException on error

--- a/pgjdbc/src/main/java/org/postgresql/ssl/SingleCertValidatingFactory.java
+++ b/pgjdbc/src/main/java/org/postgresql/ssl/SingleCertValidatingFactory.java
@@ -35,8 +35,8 @@ import javax.net.ssl.X509TrustManager;
  * <code>sslfactoryarg</code>. The value of this property is the PEM-encoded remote server's SSL
  * certificate.
  * </p>
- * <p>
- * Where the certificate is loaded from is based upon the prefix of the
+ *
+ * <p>Where the certificate is loaded from is based upon the prefix of the
  *
  * <pre>
  * <code>sslfactoryarg</code>
@@ -151,6 +151,7 @@ import javax.net.ssl.X509TrustManager;
  * <td>Loaded from string value of the argument.</td>
  * </tr>
  * </table>
+ * </p>
  */
 
 public class SingleCertValidatingFactory extends WrappedFactory {

--- a/pgjdbc/src/main/java/org/postgresql/ssl/SingleCertValidatingFactory.java
+++ b/pgjdbc/src/main/java/org/postgresql/ssl/SingleCertValidatingFactory.java
@@ -25,133 +25,58 @@ import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509TrustManager;
 
 /**
- * Provides a SSLSocketFactory that authenticates the remote server against an explicit pre-shared
+ * <p>Provides a SSLSocketFactory that authenticates the remote server against an explicit pre-shared
  * SSL certificate. This is more secure than using the NonValidatingFactory as it prevents "man in
  * the middle" attacks. It is also more secure than relying on a central CA signing your server's
- * certificate as it pins the server's certificate.
+ * certificate as it pins the server's certificate.</p>
  *
- * <p>
- * This class requires a single String parameter specified by setting the connection property
+ * <p>This class requires a single String parameter specified by setting the connection property
  * <code>sslfactoryarg</code>. The value of this property is the PEM-encoded remote server's SSL
- * certificate.
- * </p>
+ * certificate.</p>
  *
- * <p>Where the certificate is loaded from is based upon the prefix of the
+ * <p>Where the certificate is loaded from is based upon the prefix of the <code>sslfactoryarg</code> property.
+ * The following table lists the valid set of prefixes.</p>
  *
- * <pre>
- * <code>sslfactoryarg</code>
- * </pre>
- *
- * property. The following table lists the valid set of prefixes.
  * <table border="1" summary="Valid prefixes for sslfactoryarg">
  * <tr>
- * <th>Prefix</th>
- * <th>Example</th>
- * <th>Explanation</th>
+ *     <th>Prefix</th>
+ *     <th>Example</th>
+ *     <th>Explanation</th>
  * </tr>
  * <tr>
- * <td>
- *
- * <pre>
- * <code>classpath:</code>
- * </pre>
- *
- * </td>
- * <td>
- *
- * <pre>
- * <code>classpath:ssl/server.crt</code>
- * </pre>
- *
- * </td>
- * <td>Loaded from the classpath.</td>
+ *     <td><code>classpath:</code></td>
+ *     <td><code>classpath:ssl/server.crt</code></td>
+ *     <td>Loaded from the classpath.</td>
  * </tr>
  * <tr>
- * <td>
- *
- * <pre>
- * <code>file:</code>
- * </pre>
- *
- * </td>
- * <td>
- *
- * <pre>
- * <code>file:/foo/bar/server.crt</code>
- * </pre>
- *
- * </td>
- * <td>Loaded from the filesystem.</td>
+ *     <td><code>file:</code></td>
+ *     <td><code>file:/foo/bar/server.crt</code></td>
+ *     <td>Loaded from the filesystem.</td>
  * </tr>
  * <tr>
- * <td>
- *
- * <pre>
- * <code>env:</code>
- * </pre>
- *
- * </td>
- * <td>
- *
- * <pre>
- * <code>env:mydb_cert</code>
- * </pre>
- *
- * </td>
- * <td>Loaded from string value of the
- *
- * <pre>
- * <code>mydb_cert</code>
- * </pre>
- *
- * environment variable.</td>
+ *     <td><code>env:</code></td>
+ *     <td><code>env:mydb_cert</code></td>
+ *     <td>Loaded from string value of the <code>mydb_cert</code> environment variable.</td>
  * </tr>
  * <tr>
- * <td>
- *
- * <pre>
- * <code>sys:</code>
- * </pre>
- *
- * </td>
- * <td>
- *
- * <pre>
- * <code>sys:mydb_cert</code>
- * </pre>
- *
- * </td>
- * <td>Loaded from string value of the
- *
- * <pre>
- * <code>mydb_cert</code>
- * </pre>
- *
- * system property.</td>
+ *     <td><code>sys:</code></td>
+ *     <td><code>sys:mydb_cert</code></td>
+ *     <td>Loaded from string value of the <code>mydb_cert</code> system property.</td>
  * </tr>
  * <tr>
- * <td>
- *
- * <pre>
- * -----BEGIN CERTIFICATE------
- * </pre>
- *
- * </td>
- * <td>
- *
- * <pre>
+ *     <td><pre>-----BEGIN CERTIFICATE------</pre></td>
+ *     <td>
+ *         <pre>
  * -----BEGIN CERTIFICATE-----
  * MIIDQzCCAqygAwIBAgIJAOd1tlfiGoEoMA0GCSqGSIb3DQEBBQUAMHUxCzAJBgNV
  * [... truncated ...]
  * UCmmYqgiVkAGWRETVo+byOSDZ4swb10=
  * -----END CERTIFICATE-----
- * </pre>
- *
- * </td>
- * <td>Loaded from string value of the argument.</td>
+ *         </pre>
+*      </td>
+ *     <td>Loaded from string value of the argument.</td>
  * </tr>
  * </table>
- * </p>
  */
 
 public class SingleCertValidatingFactory extends WrappedFactory {

--- a/pgjdbc/src/main/java/org/postgresql/ssl/jdbc4/LazyKeyManager.java
+++ b/pgjdbc/src/main/java/org/postgresql/ssl/jdbc4/LazyKeyManager.java
@@ -73,7 +73,7 @@ public class LazyKeyManager implements X509KeyManager {
 
   /**
    * getCertificateChain and getPrivateKey cannot throw exeptions, therefore any exception is stored
-   * in {@link #error} and can be raised by this method
+   * in {@link #error} and can be raised by this method.
    *
    * @throws PSQLException if any exception is stored in {@link #error} and can be raised
    */

--- a/pgjdbc/src/main/java/org/postgresql/ssl/jdbc4/LibPQFactory.java
+++ b/pgjdbc/src/main/java/org/postgresql/ssl/jdbc4/LibPQFactory.java
@@ -179,7 +179,7 @@ public class LibPQFactory extends WrappedFactory implements HostnameVerifier {
   }
 
   /**
-   * Propagates any exception from {@link LazyKeyManager}
+   * Propagates any exception from {@link LazyKeyManager}.
    *
    * @throws PSQLException if there is an exception to propagate
    */

--- a/pgjdbc/src/main/java/org/postgresql/sspi/ISSPIClient.java
+++ b/pgjdbc/src/main/java/org/postgresql/sspi/ISSPIClient.java
@@ -10,10 +10,10 @@ import java.io.IOException;
 import java.sql.SQLException;
 
 /**
- * Use Waffle-JNI to support SSPI authentication when PgJDBC is running on a Windows
- * client and talking to a Windows server.
+ * <p>Use Waffle-JNI to support SSPI authentication when PgJDBC is running on a Windows
+ * client and talking to a Windows server.</p>
  *
- * SSPI is not supported on a non-Windows client.
+ * <p>SSPI is not supported on a non-Windows client.</p>
  */
 public interface ISSPIClient {
   boolean isSSPISupported();

--- a/pgjdbc/src/main/java/org/postgresql/sspi/NTDSAPI.java
+++ b/pgjdbc/src/main/java/org/postgresql/sspi/NTDSAPI.java
@@ -17,15 +17,15 @@ interface NTDSAPI extends StdCallLibrary {
   NTDSAPI instance = (NTDSAPI) Native.loadLibrary("NTDSAPI", NTDSAPI.class);
 
   /**
-   * Wrap DsMakeSpn
+   * <p>Wrap DsMakeSpn</p>
    *
-   * To get the String result, call
+   * <p>To get the String result, call
    *
    * <pre>
    * new String(buf, 0, spnLength)
    * </pre>
    *
-   * on the byte[] buffer passed to 'spn' after testing to ensure ERROR_SUCCESS.
+   * on the byte[] buffer passed to 'spn' after testing to ensure ERROR_SUCCESS.</p>
    *
    * @param serviceClass SPN service class (in)
    * @param serviceName SPN service name (in)

--- a/pgjdbc/src/main/java/org/postgresql/sspi/SSPIClient.java
+++ b/pgjdbc/src/main/java/org/postgresql/sspi/SSPIClient.java
@@ -26,10 +26,10 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Use Waffle-JNI to support SSPI authentication when PgJDBC is running on a Windows client and
- * talking to a Windows server.
+ * <p>Use Waffle-JNI to support SSPI authentication when PgJDBC is running on a Windows client and
+ * talking to a Windows server.</p>
  *
- * SSPI is not supported on a non-Windows client.
+ * <p>SSPI is not supported on a non-Windows client.</p>
  *
  * @author craig
  */
@@ -48,12 +48,12 @@ public class SSPIClient implements ISSPIClient {
 
 
   /**
-   * Instantiate an SSPIClient for authentication of a connection.
+   * <p>Instantiate an SSPIClient for authentication of a connection.</p>
    *
-   * SSPIClient is not re-usable across connections.
+   * <p>SSPIClient is not re-usable across connections.</p>
    *
-   * It is safe to instantiate SSPIClient even if Waffle and JNA are missing or on non-Windows
-   * platforms, however you may not call any methods other than isSSPISupported().
+   * <p>It is safe to instantiate SSPIClient even if Waffle and JNA are missing or on non-Windows
+   * platforms, however you may not call any methods other than isSSPISupported().</p>
    *
    * @param pgStream PostgreSQL connection stream
    * @param spnServiceClass SSPI SPN service class, defaults to POSTGRES if null

--- a/pgjdbc/src/main/java/org/postgresql/util/Base64.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/Base64.java
@@ -77,7 +77,7 @@ public class Base64 {
 
 
   /**
-   * Don't break lines when encoding (violates strict Base64 specification)
+   * Don't break lines when encoding (violates strict Base64 specification).
    */
   public static final int DONT_BREAK_LINES = 8;
 

--- a/pgjdbc/src/main/java/org/postgresql/util/Base64.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/Base64.java
@@ -6,13 +6,13 @@
 package org.postgresql.util;
 
 /**
- * This code is a stripped down version of Robert Harder's Public Domain Base64 implementation. GZIP
+ * <p>This code is a stripped down version of Robert Harder's Public Domain Base64 implementation. GZIP
  * support, InputStream and OutputStream stuff and some unneeded encode/decode methods have been
- * removed.
+ * removed.</p>
  *
- * -- Original comments follow --
+ * <p>-- Original comments follow --</p>
  *
- * Encodes and decodes to and from Base64 notation.
+ * <p>Encodes and decodes to and from Base64 notation.</p>
  *
  * <p>
  * Change Log:
@@ -286,20 +286,20 @@ public class Base64 {
 
 
   /**
-   * Encodes a byte array into Base64 notation.
-   * <p>
-   * Valid options:
+   * <p>Encodes a byte array into Base64 notation.</p>
+   *
+   * <p>Valid options:</p>
    *
    * <pre>
    *   GZIP: gzip-compresses object before encoding it.
    *   DONT_BREAK_LINES: don't break lines at 76 characters
    *     <i>Note: Technically, this makes your encoding non-compliant.</i>
    * </pre>
-   * <p>
-   * Example: <code>encodeBytes( myData, Base64.GZIP )</code> or
-   * <p>
-   * Example: <code>encodeBytes(
-   * myData, Base64.GZIP | Base64.DONT_BREAK_LINES )</code>
+   *
+   * <p>Example: <code>encodeBytes( myData, Base64.GZIP )</code> or</p>
+   *
+   * <p>Example: <code>encodeBytes(
+   * myData, Base64.GZIP | Base64.DONT_BREAK_LINES )</code></p>
    *
    * @param source The data to convert
    * @param options Specified options
@@ -327,20 +327,20 @@ public class Base64 {
 
 
   /**
-   * Encodes a byte array into Base64 notation.
-   * <p>
-   * Valid options:
+   * <p>Encodes a byte array into Base64 notation.</p>
+   *
+   * <p>Valid options:</p>
    *
    * <pre>
    *   GZIP: gzip-compresses object before encoding it.
    *   DONT_BREAK_LINES: don't break lines at 76 characters
    *     <i>Note: Technically, this makes your encoding non-compliant.</i>
    * </pre>
-   * <p>
-   * Example: <code>encodeBytes( myData, Base64.GZIP )</code> or
-   * <p>
-   * Example: <code>encodeBytes(
-   * myData, Base64.GZIP | Base64.DONT_BREAK_LINES )</code>
+   *
+   * <p>Example: <code>encodeBytes( myData, Base64.GZIP )</code> or</p>
+   *
+   * <p>Example: <code>encodeBytes(
+   * myData, Base64.GZIP | Base64.DONT_BREAK_LINES )</code></p>
    *
    * @param source The data to convert
    * @param off Offset in array where conversion should begin

--- a/pgjdbc/src/main/java/org/postgresql/util/ExpressionProperties.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/ExpressionProperties.java
@@ -51,7 +51,7 @@ public class ExpressionProperties extends Properties {
   }
 
   /**
-   * Returns raw value of a property without any replacements
+   * Returns raw value of a property without any replacements.
    * @param key property name
    * @return raw property value
    */

--- a/pgjdbc/src/main/java/org/postgresql/util/ExpressionProperties.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/ExpressionProperties.java
@@ -25,10 +25,10 @@ public class ExpressionProperties extends Properties {
   }
 
   /**
-   * Returns property value with all {@code ${propKey}} like references replaced with the value of
-   * the relevant property with recursive resolution.
+   * <p>Returns property value with all {@code ${propKey}} like references replaced with the value of
+   * the relevant property with recursive resolution.</p>
    *
-   * The method returns <code>null</code> if the property is not found.
+   * <p>The method returns <code>null</code> if the property is not found.</p>
    *
    * @param key the property key.
    *

--- a/pgjdbc/src/main/java/org/postgresql/util/LruCache.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/LruCache.java
@@ -119,7 +119,7 @@ public class LruCache<Key, Value extends CanEstimateSize> implements Gettable<Ke
   }
 
   /**
-   * Returns given value to the cache
+   * Returns given value to the cache.
    *
    * @param key key
    * @param value value

--- a/pgjdbc/src/main/java/org/postgresql/util/LruCache.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/LruCache.java
@@ -146,6 +146,8 @@ public class LruCache<Key, Value extends CanEstimateSize> implements Gettable<Ke
 
   /**
    * Puts all the values from the given map into the cache.
+   *
+   * @param m The map containing entries to put into the cache
    */
   public synchronized void putAll(Map<Key, Value> m) {
     for (Map.Entry<Key, Value> entry : m.entrySet()) {

--- a/pgjdbc/src/main/java/org/postgresql/util/MD5Digest.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/MD5Digest.java
@@ -18,7 +18,7 @@ public class MD5Digest {
   }
 
   /**
-   * Encodes user/password/salt information in the following way: MD5(MD5(password + user) + salt)
+   * Encodes user/password/salt information in the following way: MD5(MD5(password + user) + salt).
    *
    * @param user The connecting user.
    * @param password The connecting user's password.

--- a/pgjdbc/src/main/java/org/postgresql/util/PGInterval.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/PGInterval.java
@@ -14,7 +14,7 @@ import java.util.Date;
 import java.util.StringTokenizer;
 
 /**
- * This implements a class that handles the PostgreSQL interval type
+ * This implements a class that handles the PostgreSQL interval type.
  */
 public class PGInterval extends PGobject implements Serializable, Cloneable {
 
@@ -35,14 +35,14 @@ public class PGInterval extends PGobject implements Serializable, Cloneable {
   }
 
   /**
-   * required by the driver
+   * required by the driver.
    */
   public PGInterval() {
     setType("interval");
   }
 
   /**
-   * Initialize a interval with a given interval string representation
+   * Initialize a interval with a given interval string representation.
    *
    * @param value String representated interval (e.g. '3 years 2 mons')
    * @throws SQLException Is thrown if the string representation has an unknown format
@@ -54,7 +54,7 @@ public class PGInterval extends PGobject implements Serializable, Cloneable {
   }
 
   /**
-   * Initializes all values of this interval to the specified values
+   * Initializes all values of this interval to the specified values.
    *
    * @param years years
    * @param months months
@@ -71,7 +71,7 @@ public class PGInterval extends PGobject implements Serializable, Cloneable {
 
   /**
    * Sets a interval string represented value to this instance. This method only recognize the
-   * format, that Postgres returns - not all input formats are supported (e.g. '1 yr 2 m 3 s')!
+   * format, that Postgres returns - not all input formats are supported (e.g. '1 yr 2 m 3 s').
    *
    * @param value String representated interval (e.g. '3 years 2 mons')
    * @throws SQLException Is thrown if the string representation has an unknown format
@@ -162,7 +162,7 @@ public class PGInterval extends PGobject implements Serializable, Cloneable {
   }
 
   /**
-   * Set all values of this interval to the specified values
+   * Set all values of this interval to the specified values.
    *
    * @param years years
    * @param months months
@@ -181,7 +181,7 @@ public class PGInterval extends PGobject implements Serializable, Cloneable {
   }
 
   /**
-   * Returns the stored interval information as a string
+   * Returns the stored interval information as a string.
    *
    * @return String represented interval
    */
@@ -195,7 +195,7 @@ public class PGInterval extends PGobject implements Serializable, Cloneable {
   }
 
   /**
-   * Returns the years represented by this interval
+   * Returns the years represented by this interval.
    *
    * @return years represented by this interval
    */
@@ -204,7 +204,7 @@ public class PGInterval extends PGobject implements Serializable, Cloneable {
   }
 
   /**
-   * Set the years of this interval to the specified value
+   * Set the years of this interval to the specified value.
    *
    * @param years years to set
    */
@@ -213,7 +213,7 @@ public class PGInterval extends PGobject implements Serializable, Cloneable {
   }
 
   /**
-   * Returns the months represented by this interval
+   * Returns the months represented by this interval.
    *
    * @return months represented by this interval
    */
@@ -222,7 +222,7 @@ public class PGInterval extends PGobject implements Serializable, Cloneable {
   }
 
   /**
-   * Set the months of this interval to the specified value
+   * Set the months of this interval to the specified value.
    *
    * @param months months to set
    */
@@ -231,7 +231,7 @@ public class PGInterval extends PGobject implements Serializable, Cloneable {
   }
 
   /**
-   * Returns the days represented by this interval
+   * Returns the days represented by this interval.
    *
    * @return days represented by this interval
    */
@@ -240,7 +240,7 @@ public class PGInterval extends PGobject implements Serializable, Cloneable {
   }
 
   /**
-   * Set the days of this interval to the specified value
+   * Set the days of this interval to the specified value.
    *
    * @param days days to set
    */
@@ -249,7 +249,7 @@ public class PGInterval extends PGobject implements Serializable, Cloneable {
   }
 
   /**
-   * Returns the hours represented by this interval
+   * Returns the hours represented by this interval.
    *
    * @return hours represented by this interval
    */
@@ -258,7 +258,7 @@ public class PGInterval extends PGobject implements Serializable, Cloneable {
   }
 
   /**
-   * Set the hours of this interval to the specified value
+   * Set the hours of this interval to the specified value.
    *
    * @param hours hours to set
    */
@@ -267,7 +267,7 @@ public class PGInterval extends PGobject implements Serializable, Cloneable {
   }
 
   /**
-   * Returns the minutes represented by this interval
+   * Returns the minutes represented by this interval.
    *
    * @return minutes represented by this interval
    */
@@ -276,7 +276,7 @@ public class PGInterval extends PGobject implements Serializable, Cloneable {
   }
 
   /**
-   * Set the minutes of this interval to the specified value
+   * Set the minutes of this interval to the specified value.
    *
    * @param minutes minutes to set
    */
@@ -285,7 +285,7 @@ public class PGInterval extends PGobject implements Serializable, Cloneable {
   }
 
   /**
-   * Returns the seconds represented by this interval
+   * Returns the seconds represented by this interval.
    *
    * @return seconds represented by this interval
    */
@@ -294,7 +294,7 @@ public class PGInterval extends PGobject implements Serializable, Cloneable {
   }
 
   /**
-   * Set the seconds of this interval to the specified value
+   * Set the seconds of this interval to the specified value.
    *
    * @param seconds seconds to set
    */
@@ -303,7 +303,7 @@ public class PGInterval extends PGobject implements Serializable, Cloneable {
   }
 
   /**
-   * Rolls this interval on a given calendar
+   * Rolls this interval on a given calendar.
    *
    * @param cal Calendar instance to add to
    */
@@ -322,7 +322,7 @@ public class PGInterval extends PGobject implements Serializable, Cloneable {
   }
 
   /**
-   * Rolls this interval on a given date
+   * Rolls this interval on a given date.
    *
    * @param date Date instance to add to
    */
@@ -366,7 +366,7 @@ public class PGInterval extends PGobject implements Serializable, Cloneable {
   }
 
   /**
-   * Returns integer value of value or 0 if value is null
+   * Returns integer value of value or 0 if value is null.
    *
    * @param value integer as string value
    * @return integer parsed from string value
@@ -377,7 +377,7 @@ public class PGInterval extends PGobject implements Serializable, Cloneable {
   }
 
   /**
-   * Returns double value of value or 0 if value is null
+   * Returns double value of value or 0 if value is null.
    *
    * @param value double as string value
    * @return double parsed from string value
@@ -388,7 +388,7 @@ public class PGInterval extends PGobject implements Serializable, Cloneable {
   }
 
   /**
-   * Returns whether an object is equal to this one or not
+   * Returns whether an object is equal to this one or not.
    *
    * @param obj Object to compare with
    * @return true if the two intervals are identical
@@ -417,7 +417,7 @@ public class PGInterval extends PGobject implements Serializable, Cloneable {
   }
 
   /**
-   * Returns a hashCode for this object
+   * Returns a hashCode for this object.
    *
    * @return hashCode
    */

--- a/pgjdbc/src/main/java/org/postgresql/util/PGTimestamp.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/PGTimestamp.java
@@ -37,15 +37,15 @@ public class PGTimestamp extends Timestamp {
   }
 
   /**
-   * Constructs a <code>PGTimestamp</code> with the given time zone. The integral seconds are stored
+   * <p>Constructs a <code>PGTimestamp</code> with the given time zone. The integral seconds are stored
    * in the underlying date value; the fractional seconds are stored in the <code>nanos</code> field
-   * of the <code>Timestamp</code> object.
-   * <p>
-   * The calendar object is optional. If absent, the driver will treat the timestamp as
+   * of the <code>Timestamp</code> object.</p>
+   *
+   * <p>The calendar object is optional. If absent, the driver will treat the timestamp as
    * <code>timestamp without time zone</code>. When present, the driver will treat the timestamp as
    * a <code>timestamp with time zone</code> using the <code>TimeZone</code> in the calendar object.
    * Furthermore, this calendar will be used instead of the calendar object passed to
-   * {@link java.sql.PreparedStatement#setTimestamp(int, Timestamp, Calendar)}.
+   * {@link java.sql.PreparedStatement#setTimestamp(int, Timestamp, Calendar)}.</p>
    *
    * @param time milliseconds since January 1, 1970, 00:00:00 GMT. A negative number is the number
    *        of milliseconds before January 1, 1970, 00:00:00 GMT.

--- a/pgjdbc/src/main/java/org/postgresql/util/PGmoney.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/PGmoney.java
@@ -10,7 +10,7 @@ import java.io.Serializable;
 import java.sql.SQLException;
 
 /**
- * This implements a class that handles the PostgreSQL money and cash types
+ * This implements a class that handles the PostgreSQL money and cash types.
  */
 public class PGmoney extends PGobject implements Serializable, Cloneable {
   /*

--- a/pgjdbc/src/main/java/org/postgresql/util/PGobject.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/PGobject.java
@@ -11,7 +11,7 @@ import java.sql.SQLException;
 
 /**
  * PGobject is a class used to describe unknown types An unknown type is any type that is unknown by
- * JDBC Standards
+ * JDBC Standards.
  */
 public class PGobject implements Serializable, Cloneable {
   protected String type;
@@ -65,7 +65,7 @@ public class PGobject implements Serializable, Cloneable {
   }
 
   /**
-   * This must be overidden to allow comparisons of objects
+   * This must be overidden to allow comparisons of objects.
    *
    * @param obj Object to compare with
    * @return true if the two boxes are identical
@@ -83,7 +83,7 @@ public class PGobject implements Serializable, Cloneable {
   }
 
   /**
-   * This must be overidden to allow the object to be cloned
+   * This must be overidden to allow the object to be cloned.
    */
   public Object clone() throws CloneNotSupportedException {
     return super.clone();

--- a/pgjdbc/src/main/java/org/postgresql/util/PGobject.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/PGobject.java
@@ -24,10 +24,9 @@ public class PGobject implements Serializable, Cloneable {
   }
 
   /**
-   * This method sets the type of this object.
+   * <p>This method sets the type of this object.</p>
    *
-   * <p>
-   * It should not be extended by subclasses, hence its final
+   * <p>It should not be extended by subclasses, hence it is final</p>
    *
    * @param type a string describing the type of the object
    */
@@ -36,7 +35,7 @@ public class PGobject implements Serializable, Cloneable {
   }
 
   /**
-   * This method sets the value of this object. It must be overidden.
+   * This method sets the value of this object. It must be overridden.
    *
    * @param value a string representation of the value of the object
    * @throws SQLException thrown if value is invalid for this type

--- a/pgjdbc/src/main/java/org/postgresql/util/PGtokenizer.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/PGtokenizer.java
@@ -130,7 +130,7 @@ public class PGtokenizer {
   }
 
   /**
-   * This removes the lead/trailing strings from a string
+   * This removes the lead/trailing strings from a string.
    *
    * @param s Source string
    * @param l Leading string to remove
@@ -148,7 +148,7 @@ public class PGtokenizer {
   }
 
   /**
-   * This removes the lead/trailing strings from all tokens
+   * This removes the lead/trailing strings from all tokens.
    *
    * @param l Leading string to remove
    * @param t Trailing string to remove
@@ -160,7 +160,7 @@ public class PGtokenizer {
   }
 
   /**
-   * Removes ( and ) from the beginning and end of a string
+   * Removes ( and ) from the beginning and end of a string.
    *
    * @param s String to remove from
    * @return String without the ( or )
@@ -170,14 +170,14 @@ public class PGtokenizer {
   }
 
   /**
-   * Removes ( and ) from the beginning and end of all tokens
+   * Removes ( and ) from the beginning and end of all tokens.
    */
   public void removePara() {
     remove("(", ")");
   }
 
   /**
-   * Removes [ and ] from the beginning and end of a string
+   * Removes [ and ] from the beginning and end of a string.
    *
    * @param s String to remove from
    * @return String without the [ or ]
@@ -187,14 +187,14 @@ public class PGtokenizer {
   }
 
   /**
-   * Removes [ and ] from the beginning and end of all tokens
+   * Removes [ and ] from the beginning and end of all tokens.
    */
   public void removeBox() {
     remove("[", "]");
   }
 
   /**
-   * Removes &lt; and &gt; from the beginning and end of a string
+   * Removes &lt; and &gt; from the beginning and end of a string.
    *
    * @param s String to remove from
    * @return String without the &lt; or &gt;
@@ -204,14 +204,14 @@ public class PGtokenizer {
   }
 
   /**
-   * Removes &lt; and &gt; from the beginning and end of all tokens
+   * Removes &lt; and &gt; from the beginning and end of all tokens.
    */
   public void removeAngle() {
     remove("<", ">");
   }
 
   /**
-   * Removes curly braces { and } from the beginning and end of a string
+   * Removes curly braces { and } from the beginning and end of a string.
    *
    * @param s String to remove from
    * @return String without the { or }
@@ -221,7 +221,7 @@ public class PGtokenizer {
   }
 
   /**
-   * Removes &lt; and &gt; from the beginning and end of all tokens
+   * Removes &lt; and &gt; from the beginning and end of all tokens.
    */
   public void removeCurlyBrace() {
     remove("{", "}");

--- a/pgjdbc/src/main/java/org/postgresql/util/PGtokenizer.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/PGtokenizer.java
@@ -26,11 +26,10 @@ public class PGtokenizer {
   protected List<String> tokens;
 
   /**
-   * Create a tokeniser.
+   * <p>Create a tokeniser.</p>
    *
-   * <p>
-   * We could have used StringTokenizer to do this, however, we needed to handle nesting of '(' ')'
-   * '[' ']' '&lt;' and '&gt;' as these are used by the geometric data types.
+   * <p>We could have used StringTokenizer to do this, however, we needed to handle nesting of '(' ')'
+   * '[' ']' '&lt;' and '&gt;' as these are used by the geometric data types.</p>
    *
    * @param string containing tokens
    * @param delim single character to split the tokens
@@ -117,9 +116,9 @@ public class PGtokenizer {
   }
 
   /**
-   * This returns a new tokenizer based on one of our tokens.
+   * <p>This returns a new tokenizer based on one of our tokens.</p>
    *
-   * The geometric datatypes use this to process nested tokens (usually PGpoint).
+   * <p>The geometric datatypes use this to process nested tokens (usually PGpoint).</p>
    *
    * @param n Token number ( 0 ... getSize()-1 )
    * @param delim The delimiter to use

--- a/pgjdbc/src/main/java/org/postgresql/util/ReaderInputStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/ReaderInputStream.java
@@ -16,11 +16,11 @@ import java.nio.charset.CharsetEncoder;
 import java.nio.charset.CoderResult;
 
 /**
- * ReaderInputStream accepts a UTF-16 char stream (Reader) as input and
- * converts it to a UTF-8 byte stream (InputStream) as output.
+ * <p>ReaderInputStream accepts a UTF-16 char stream (Reader) as input and
+ * converts it to a UTF-8 byte stream (InputStream) as output.</p>
  *
- * This is the inverse of java.io.InputStreamReader which converts a
- * binary stream to a character stream.
+ * <p>This is the inverse of java.io.InputStreamReader which converts a
+ * binary stream to a character stream.</p>
  */
 public class ReaderInputStream extends InputStream {
   private static final int DEFAULT_CHAR_BUFFER_SIZE = 8 * 1024;

--- a/pgjdbc/src/main/java/org/postgresql/util/ReaderInputStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/ReaderInputStream.java
@@ -33,7 +33,7 @@ public class ReaderInputStream extends InputStream {
   private final CharBuffer cbuf;
 
   /**
-   * true when all of the characters have been read from the reader into inbuf
+   * true when all of the characters have been read from the reader into inbuf.
    */
   private boolean endOfInput;
   private final byte[] oneByte = new byte[1];

--- a/pgjdbc/src/main/java/org/postgresql/util/URLCoder.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/URLCoder.java
@@ -10,12 +10,12 @@ import java.net.URLDecoder;
 import java.net.URLEncoder;
 
 /**
- * This class helps with URL encoding and decoding. UTF-8 encoding is used by default to make
+ * <p>This class helps with URL encoding and decoding. UTF-8 encoding is used by default to make
  * encoding consistent across the driver, and encoding might be changed via {@code
- * postgresql.url.encoding} property
+ * postgresql.url.encoding} property</p>
  *
- * Note: this should not be used outside of PostgreSQL source, this is not a public API of the
- * driver.
+ * <p>Note: this should not be used outside of PostgreSQL source, this is not a public API of the
+ * driver.</p>
  */
 public final class URLCoder {
   private static final String ENCODING_FOR_URL =

--- a/pgjdbc/src/main/java/org/postgresql/xa/PGXAConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/xa/PGXAConnection.java
@@ -153,29 +153,26 @@ public class PGXAConnection extends PGPooledConnection implements XAConnection, 
   }
 
   /**
-   * <p>Preconditions:
+   * <p>Preconditions:</p>
    * <ol>
    *     <li>Flags must be one of TMNOFLAGS, TMRESUME or TMJOIN</li>
    *     <li>xid != null</li>
    *     <li>Connection must not be associated with a transaction</li>
    *     <li>The TM hasn't seen the xid before</li>
    * </ol>
-   * </p>
    *
-   * <p>Implementation deficiency preconditions:
+   * <p>Implementation deficiency preconditions:</p>
    * <ol>
    *     <li>TMRESUME not supported.</li>
    *     <li>If flags is TMJOIN, we must be in ended state, and xid must be the current transaction</li>
    *     <li>Unless flags is TMJOIN, previous transaction using the connection must be committed or prepared or rolled
    *     back</li>
    * </ol>
-   * </p>
    *
-   * <p>Postconditions:
+   * <p>Postconditions:</p>
    * <ol>
    *     <li>Connection is associated with the transaction</li>
    * </ol>
-   * </p>
    */
   @Override
   public void start(Xid xid, int flags) throws XAException {
@@ -245,25 +242,22 @@ public class PGXAConnection extends PGPooledConnection implements XAConnection, 
   }
 
   /**
-   * <p>Preconditions:
+   * <p>Preconditions:</p>
    * <ol>
    *     <li>Flags is one of TMSUCCESS, TMFAIL, TMSUSPEND</li>
    *     <li>xid != null</li>
    *     <li>Connection is associated with transaction xid</li>
    * </ol>
-   * </p>
    *
-   * <p>Implementation deficiency preconditions:
+   * <p>Implementation deficiency preconditions:</p>
    * <ol>
    *     <li>Flags is not TMSUSPEND</li>
    * </ol>
-   * </p>
    *
-   * <p>Postconditions:
+   * <p>Postconditions:</p>
    * <ol>
    *     <li>Connection is disassociated from the transaction.</li>
    * </ol>
-   * </p>
    */
   @Override
   public void end(Xid xid, int flags) throws XAException {
@@ -300,24 +294,21 @@ public class PGXAConnection extends PGPooledConnection implements XAConnection, 
   }
 
   /**
-   * <p>Prepares transaction. Preconditions:
+   * <p>Prepares transaction. Preconditions:</p>
    * <ol>
    *     <li>xid != null</li>
    *     <li>xid is in ended state</li>
    * </ol>
-   * </p>
    *
-   * <p>Implementation deficiency preconditions:
+   * <p>Implementation deficiency preconditions:</p>
    * <ol>
    *     <li>xid was associated with this connection</li>
    * </ol>
-   * </p>
    *
-   * <p>Postconditions:
+   * <p>Postconditions:</p>
    * <ol>
    *     <li>Transaction is prepared</li>
    * </ol>
-   * </p>
    */
   @Override
   public int prepare(Xid xid) throws XAException {
@@ -371,18 +362,16 @@ public class PGXAConnection extends PGPooledConnection implements XAConnection, 
   }
 
   /**
-   * <p>Recovers transaction. Preconditions:
+   * <p>Recovers transaction. Preconditions:</p>
    * <ol>
    *     <li>flag must be one of TMSTARTRSCAN, TMENDRSCAN, TMNOFLAGS or TMSTARTTRSCAN | TMENDRSCAN</li>
    *     <li>If flag isn't TMSTARTRSCAN or TMSTARTRSCAN | TMENDRSCAN, a recovery scan must be in progress</li>
    * </ol>
-   * </p>
    *
-   * <p>Postconditions:
+   * <p>Postconditions:</p>
    * <ol>
    *     <li>list of prepared xids is returned</li>
    * </ol>
-   * </p>
    */
   @Override
   public Xid[] recover(int flag) throws XAException {
@@ -430,23 +419,20 @@ public class PGXAConnection extends PGPooledConnection implements XAConnection, 
   }
 
   /**
-   * <p>Preconditions:
+   * <p>Preconditions:</p>
    * <ol>
    *     <li>xid is known to the RM or it's in prepared state</li>
    * </ol>
-   * </p>
    *
-   * <p>Implementation deficiency preconditions:
+   * <p>Implementation deficiency preconditions:</p>
    * <ol>
    *     <li>xid must be associated with this connection if it's not in prepared state.</li>
    * </ol>
-   * </p>
    *
-   * <p>Postconditions:
+   * <p>Postconditions:</p>
    * <ol>
    *     <li>Transaction is rolled back and disassociated from connection</li>
    * </ol>
-   * </p>
    */
   @Override
   public void rollback(Xid xid) throws XAException {
@@ -513,23 +499,20 @@ public class PGXAConnection extends PGPooledConnection implements XAConnection, 
   }
 
   /**
-   * <p>Preconditions:
+   * <p>Preconditions:</p>
    * <ol>
    *     <li>xid must in ended state.</li>
    * </ol>
-   * </p>
    *
-   * <p>Implementation deficiency preconditions:
+   * <p>Implementation deficiency preconditions:</p>
    * <ol>
    *     <li>this connection must have been used to run the transaction</li>
    * </ol>
-   * </p>
    *
-   * <p>Postconditions:
+   * <p>Postconditions:</p>
    * <ol>
    *     <li>Transaction is committed</li>
    * </ol>
-   * </p>
    */
   private void commitOnePhase(Xid xid) throws XAException {
     try {
@@ -567,23 +550,20 @@ public class PGXAConnection extends PGPooledConnection implements XAConnection, 
   }
 
   /**
-   * <p>Commits prepared transaction. Preconditions:
+   * <p>Commits prepared transaction. Preconditions:</p>
    * <ol>
    *     <li>xid must be in prepared state in the server</li>
    * </ol>
-   * </p>
    *
-   * <p>Implementation deficiency preconditions:
+   * <p>Implementation deficiency preconditions:</p>
    * <ol>
    *     <li>Connection must be in idle state</li>
    * </ol>
-   * </p>
    *
-   * <p>Postconditions:
+   * <p>Postconditions:</p>
    * <ol>
    *     <li>Transaction is committed</li>
    * </ol>
-   * </p>
    */
   private void commitPrepared(Xid xid) throws XAException {
     try {

--- a/pgjdbc/src/main/java/org/postgresql/xa/PGXAConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/xa/PGXAConnection.java
@@ -31,12 +31,12 @@ import javax.transaction.xa.XAResource;
 import javax.transaction.xa.Xid;
 
 /**
- * The PostgreSQL implementation of {@link XAResource}.
+ * <p>The PostgreSQL implementation of {@link XAResource}.</p>
  *
- * This implementation doesn't support transaction interleaving (see JTA specification, section
- * 3.4.4) and suspend/resume.
+ * <p>This implementation doesn't support transaction interleaving (see JTA specification, section
+ * 3.4.4) and suspend/resume.</p>
  *
- * Two-phase commit requires PostgreSQL server version 8.1 or higher.
+ * <p>Two-phase commit requires PostgreSQL server version 8.1 or higher.</p>
  *
  * @author Heikki Linnakangas (heikki.linnakangas@iki.fi)
  */
@@ -153,14 +153,29 @@ public class PGXAConnection extends PGPooledConnection implements XAConnection, 
   }
 
   /**
-   * Preconditions: 1. flags must be one of TMNOFLAGS, TMRESUME or TMJOIN 2. xid != null 3.
-   * connection must not be associated with a transaction 4. the TM hasn't seen the xid before
+   * <p>Preconditions:
+   * <ol>
+   *     <li>Flags must be one of TMNOFLAGS, TMRESUME or TMJOIN</li>
+   *     <li>xid != null</li>
+   *     <li>Connection must not be associated with a transaction</li>
+   *     <li>The TM hasn't seen the xid before</li>
+   * </ol>
+   * </p>
    *
-   * Implementation deficiency preconditions: 1. TMRESUME not supported. 2. if flags is TMJOIN, we
-   * must be in ended state, and xid must be the current transaction 3. unless flags is TMJOIN,
-   * previous transaction using the connection must be committed or prepared or rolled back
+   * <p>Implementation deficiency preconditions:
+   * <ol>
+   *     <li>TMRESUME not supported.</li>
+   *     <li>If flags is TMJOIN, we must be in ended state, and xid must be the current transaction</li>
+   *     <li>Unless flags is TMJOIN, previous transaction using the connection must be committed or prepared or rolled
+   *     back</li>
+   * </ol>
+   * </p>
    *
-   * Postconditions: 1. Connection is associated with the transaction
+   * <p>Postconditions:
+   * <ol>
+   *     <li>Connection is associated with the transaction</li>
+   * </ol>
+   * </p>
    */
   @Override
   public void start(Xid xid, int flags) throws XAException {
@@ -230,12 +245,25 @@ public class PGXAConnection extends PGPooledConnection implements XAConnection, 
   }
 
   /**
-   * Preconditions: 1. Flags is one of TMSUCCESS, TMFAIL, TMSUSPEND 2. xid != null 3. Connection is
-   * associated with transaction xid
+   * <p>Preconditions:
+   * <ol>
+   *     <li>Flags is one of TMSUCCESS, TMFAIL, TMSUSPEND</li>
+   *     <li>xid != null</li>
+   *     <li>Connection is associated with transaction xid</li>
+   * </ol>
+   * </p>
    *
-   * Implementation deficiency preconditions: 1. Flags is not TMSUSPEND
+   * <p>Implementation deficiency preconditions:
+   * <ol>
+   *     <li>Flags is not TMSUSPEND</li>
+   * </ol>
+   * </p>
    *
-   * Postconditions: 1. connection is disassociated from the transaction.
+   * <p>Postconditions:
+   * <ol>
+   *     <li>Connection is disassociated from the transaction.</li>
+   * </ol>
+   * </p>
    */
   @Override
   public void end(Xid xid, int flags) throws XAException {
@@ -272,11 +300,24 @@ public class PGXAConnection extends PGPooledConnection implements XAConnection, 
   }
 
   /**
-   * Preconditions: 1. xid != null 2. xid is in ended state
+   * <p>Prepares transaction. Preconditions:
+   * <ol>
+   *     <li>xid != null</li>
+   *     <li>xid is in ended state</li>
+   * </ol>
+   * </p>
    *
-   * Implementation deficiency preconditions: 1. xid was associated with this connection
+   * <p>Implementation deficiency preconditions:
+   * <ol>
+   *     <li>xid was associated with this connection</li>
+   * </ol>
+   * </p>
    *
-   * Postconditions: 1. Transaction is prepared
+   * <p>Postconditions:
+   * <ol>
+   *     <li>Transaction is prepared</li>
+   * </ol>
+   * </p>
    */
   @Override
   public int prepare(Xid xid) throws XAException {
@@ -330,11 +371,18 @@ public class PGXAConnection extends PGPooledConnection implements XAConnection, 
   }
 
   /**
-   * Preconditions: 1. flag must be one of TMSTARTRSCAN, TMENDRSCAN, TMNOFLAGS or TMSTARTTRSCAN |
-   * TMENDRSCAN 2. if flag isn't TMSTARTRSCAN or TMSTARTRSCAN | TMENDRSCAN, a recovery scan must be
-   * in progress
+   * <p>Recovers transaction. Preconditions:
+   * <ol>
+   *     <li>flag must be one of TMSTARTRSCAN, TMENDRSCAN, TMNOFLAGS or TMSTARTTRSCAN | TMENDRSCAN</li>
+   *     <li>If flag isn't TMSTARTRSCAN or TMSTARTRSCAN | TMENDRSCAN, a recovery scan must be in progress</li>
+   * </ol>
+   * </p>
    *
-   * Postconditions: 1. list of prepared xids is returned
+   * <p>Postconditions:
+   * <ol>
+   *     <li>list of prepared xids is returned</li>
+   * </ol>
+   * </p>
    */
   @Override
   public Xid[] recover(int flag) throws XAException {
@@ -382,12 +430,23 @@ public class PGXAConnection extends PGPooledConnection implements XAConnection, 
   }
 
   /**
-   * Preconditions: 1. xid is known to the RM or it's in prepared state
+   * <p>Preconditions:
+   * <ol>
+   *     <li>xid is known to the RM or it's in prepared state</li>
+   * </ol>
+   * </p>
    *
-   * Implementation deficiency preconditions: 1. xid must be associated with this connection if it's
-   * not in prepared state.
+   * <p>Implementation deficiency preconditions:
+   * <ol>
+   *     <li>xid must be associated with this connection if it's not in prepared state.</li>
+   * </ol>
+   * </p>
    *
-   * Postconditions: 1. Transaction is rolled back and disassociated from connection
+   * <p>Postconditions:
+   * <ol>
+   *     <li>Transaction is rolled back and disassociated from connection</li>
+   * </ol>
+   * </p>
    */
   @Override
   public void rollback(Xid xid) throws XAException {
@@ -454,12 +513,23 @@ public class PGXAConnection extends PGPooledConnection implements XAConnection, 
   }
 
   /**
-   * Preconditions: 1. xid must in ended state.
+   * <p>Preconditions:
+   * <ol>
+   *     <li>xid must in ended state.</li>
+   * </ol>
+   * </p>
    *
-   * Implementation deficiency preconditions: 1. this connection must have been used to run the
-   * transaction
+   * <p>Implementation deficiency preconditions:
+   * <ol>
+   *     <li>this connection must have been used to run the transaction</li>
+   * </ol>
+   * </p>
    *
-   * Postconditions: 1. Transaction is committed
+   * <p>Postconditions:
+   * <ol>
+   *     <li>Transaction is committed</li>
+   * </ol>
+   * </p>
    */
   private void commitOnePhase(Xid xid) throws XAException {
     try {
@@ -497,11 +567,23 @@ public class PGXAConnection extends PGPooledConnection implements XAConnection, 
   }
 
   /**
-   * Preconditions: 1. xid must be in prepared state in the server
+   * <p>Commits prepared transaction. Preconditions:
+   * <ol>
+   *     <li>xid must be in prepared state in the server</li>
+   * </ol>
+   * </p>
    *
-   * Implementation deficiency preconditions: 1. Connection must be in idle state
+   * <p>Implementation deficiency preconditions:
+   * <ol>
+   *     <li>Connection must be in idle state</li>
+   * </ol>
+   * </p>
    *
-   * Postconditions: 1. Transaction is committed
+   * <p>Postconditions:
+   * <ol>
+   *     <li>Transaction is committed</li>
+   * </ol>
+   * </p>
    */
   private void commitPrepared(Xid xid) throws XAException {
     try {

--- a/pgjdbc/src/main/java/org/postgresql/xa/PGXAConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/xa/PGXAConnection.java
@@ -76,7 +76,7 @@ public class PGXAConnection extends PGPooledConnection implements XAConnection, 
   }
 
   /**
-   * XAConnection interface
+   * XAConnection interface.
    */
   @Override
   public Connection getConnection() throws SQLException {
@@ -557,7 +557,7 @@ public class PGXAConnection extends PGPooledConnection implements XAConnection, 
   }
 
   /**
-   * Does nothing, since we don't do heuristics,
+   * Does nothing, since we don't do heuristics.
    */
   @Override
   public void forget(Xid xid) throws XAException {

--- a/pgjdbc/src/main/java/org/postgresql/xa/RecoveredXid.java
+++ b/pgjdbc/src/main/java/org/postgresql/xa/RecoveredXid.java
@@ -63,7 +63,7 @@ class RecoveredXid implements Xid {
   }
 
   /**
-   * This is for debugging purposes only
+   * This is for debugging purposes only.
    */
   public String toString() {
     return xidToString(this);

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/DeepBatchedInsertStatementTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/DeepBatchedInsertStatementTest.java
@@ -306,7 +306,7 @@ public class DeepBatchedInsertStatementTest extends BaseTest4 {
    * Again using reflection to gain access to a private field member
    * @param bqd BatchedQueryDecorator object on which field is present
    * @return byte[] array of bytes that represent the statement name
-   * when encoded
+   *     when encoded
    * @throws Exception fault raised if access to field not possible
    */
   private byte[] getEncodedStatementName(BatchedQuery bqd)

--- a/pgjdbc/src/test/java/org/postgresql/replication/LogicalReplicationStatusTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/replication/LogicalReplicationStatusTest.java
@@ -96,7 +96,7 @@ public class LogicalReplicationStatusTest {
   }
 
   /**
-   * Test fail on PG version 9.4.5 because postgresql have bug
+   * Test fail on PG version 9.4.5 because postgresql have bug.
    */
   @Test
   @HaveMinimalServerVersion("9.4.8")
@@ -304,7 +304,7 @@ public class LogicalReplicationStatusTest {
   }
 
   /**
-   * Test fail on PG version 9.4.5 because postgresql have bug
+   * Test fail on PG version 9.4.5 because postgresql have bug.
    */
   @Test
   @HaveMinimalServerVersion("9.4.8")

--- a/pgjdbc/src/test/java/org/postgresql/replication/LogicalReplicationTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/replication/LogicalReplicationTest.java
@@ -256,10 +256,10 @@ public class LogicalReplicationTest {
   /**
    * <p>Bug in postgreSQL that should be fixed in 10 version after code review patch <a
    * href="http://www.postgresql.org/message-id/CAFgjRd3hdYOa33m69TbeOfNNer2BZbwa8FFjt2V5VFzTBvUU3w@mail.gmail.com">
-   * Stopping logical replication protocol</a>.
+   * Stopping logical replication protocol</a>.</p>
    *
    * <p>If you try to run it test on version before 10 they fail with time out, because postgresql
-   * wait new changes and until waiting messages from client ignores.
+   * wait new changes and until waiting messages from client ignores.</p>
    */
   @Test(timeout = 1000)
   @HaveMinimalServerVersion("11.1")
@@ -327,10 +327,10 @@ public class LogicalReplicationTest {
   /**
    * <p>Bug in postgreSQL that should be fixed in 10 version after code review patch <a
    * href="http://www.postgresql.org/message-id/CAFgjRd3hdYOa33m69TbeOfNNer2BZbwa8FFjt2V5VFzTBvUU3w@mail.gmail.com">
-   * Stopping logical replication protocol</a>.
+   * Stopping logical replication protocol</a>.</p>
    *
    * <p>If you try to run it test on version before 10 they fail with time out, because postgresql
-   * wait new changes and until waiting messages from client ignores.
+   * wait new changes and until waiting messages from client ignores.</p>
    */
   @Test(timeout = 10000)
   @HaveMinimalServerVersion("11.1")
@@ -377,10 +377,10 @@ public class LogicalReplicationTest {
   /**
    * <p>Bug in postgreSQL that should be fixed in 10 version after code review patch <a
    * href="http://www.postgresql.org/message-id/CAFgjRd3hdYOa33m69TbeOfNNer2BZbwa8FFjt2V5VFzTBvUU3w@mail.gmail.com">
-   * Stopping logical replication protocol</a>.
+   * Stopping logical replication protocol</a>.</p>
    *
    * <p>If you try to run it test on version before 10 they fail with time out, because postgresql
-   * wait new changes and until waiting messages from client ignores.
+   * wait new changes and until waiting messages from client ignores.</p>
    */
   @Test(timeout = 60000)
   @HaveMinimalServerVersion("11.1")

--- a/pgjdbc/src/test/java/org/postgresql/test/TestUtil.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/TestUtil.java
@@ -29,7 +29,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 /**
- * Utility class for JDBC tests
+ * Utility class for JDBC tests.
  */
 public class TestUtil {
   /*
@@ -256,7 +256,7 @@ public class TestUtil {
 
   /**
    * Get a connection using a priviliged user mostly for tests that the ability to load C functions
-   * now as of 4/14
+   * now as of 4/14.
    *
    * @return connection using a priviliged user mostly for tests that the ability to load C
    *         functions now as of 4/14
@@ -393,7 +393,7 @@ public class TestUtil {
   }
 
   /**
-   * Helper creates a temporary table
+   * Helper creates a temporary table.
    *
    * @param con Connection
    * @param table String
@@ -415,7 +415,7 @@ public class TestUtil {
   }
 
   /**
-   * Helper creates an enum type
+   * Helper creates an enum type.
    *
    * @param con Connection
    * @param name String
@@ -437,7 +437,7 @@ public class TestUtil {
   }
 
   /**
-   * Helper creates an composite type
+   * Helper creates an composite type.
    *
    * @param con Connection
    * @param name String
@@ -459,7 +459,7 @@ public class TestUtil {
   }
 
   /**
-   * Drops a domain
+   * Drops a domain.
    *
    * @param con Connection
    * @param name String
@@ -479,7 +479,7 @@ public class TestUtil {
   }
 
   /**
-   * Helper creates a domain
+   * Helper creates a domain.
    *
    * @param con Connection
    * @param name String

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/AutoRollbackTestSuite.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/AutoRollbackTestSuite.java
@@ -44,12 +44,12 @@ public class AutoRollbackTestSuite extends BaseTest4 {
      */
     SELECT,
     /**
-     * Executes "alter table rollbacktest", thus it breaks a prepared select over that table
+     * Executes "alter table rollbacktest", thus it breaks a prepared select over that table.
      * Mitigation: "autosave in (always, conservative)"
      */
     ALTER,
     /**
-     * Executes DEALLOCATE ALL
+     * Executes DEALLOCATE ALL.
      * Mitigation:
      *  1) QueryExecutor tracks "DEALLOCATE ALL" responses ({@see org.postgresql.core.QueryExecutor#setFlushCacheOnDeallocate(boolean)}
      *  2) QueryExecutor tracks "prepared statement name is invalid" and unprepares relevant statements ({@link org.postgresql.core.v3.QueryExecutorImpl#processResults(ResultHandler, int)}
@@ -58,7 +58,7 @@ public class AutoRollbackTestSuite extends BaseTest4 {
      */
     DEALLOCATE,
     /**
-     * Executes DISCARD ALL
+     * Executes DISCARD ALL.
      * Mitigation: the same as for {@link #DEALLOCATE}
      */
     DISCARD,

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BaseTest4.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BaseTest4.java
@@ -110,14 +110,14 @@ public class BaseTest4 {
   }
 
   /**
-   * Shorthand for {@code Assume.assumeTrue(TestUtil.haveMinimumServerVersion(conn, version)}
+   * Shorthand for {@code Assume.assumeTrue(TestUtil.haveMinimumServerVersion(conn, version)}.
    */
   public void assumeMinimumServerVersion(String message, Version version) throws SQLException {
     Assume.assumeTrue(message, TestUtil.haveMinimumServerVersion(con, version));
   }
 
   /**
-   * Shorthand for {@code Assume.assumeTrue(TestUtil.haveMinimumServerVersion(conn, version)}
+   * Shorthand for {@code Assume.assumeTrue(TestUtil.haveMinimumServerVersion(conn, version)}.
    */
   public void assumeMinimumServerVersion(Version version) throws SQLException {
     Assume.assumeTrue(TestUtil.haveMinimumServerVersion(con, version));

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BatchExecuteTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BatchExecuteTest.java
@@ -589,7 +589,8 @@ public class BatchExecuteTest extends BaseTest4 {
   }
 
   /**
-   * This one is reproduced in regular (non-force binary) mode
+   * This one is reproduced in regular (non-force binary) mode.
+   *
    * As of 9.4.1208 the following tests fail:
    * BatchExecuteTest.testBatchWithAlternatingAndUnknownTypes3
    * BatchExecuteTest.testBatchWithAlternatingAndUnknownTypes4

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BatchExecuteTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BatchExecuteTest.java
@@ -589,13 +589,13 @@ public class BatchExecuteTest extends BaseTest4 {
   }
 
   /**
-   * This one is reproduced in regular (non-force binary) mode.
+   * <p>This one is reproduced in regular (non-force binary) mode.</p>
    *
-   * As of 9.4.1208 the following tests fail:
+   * <p>As of 9.4.1208 the following tests fail:
    * BatchExecuteTest.testBatchWithAlternatingAndUnknownTypes3
    * BatchExecuteTest.testBatchWithAlternatingAndUnknownTypes4
    * BatchExecuteTest.testBatchWithAlternatingAndUnknownTypes5
-   * BatchExecuteTest.testBatchWithAlternatingAndUnknownTypes6
+   * BatchExecuteTest.testBatchWithAlternatingAndUnknownTypes6</p>
    * @throws SQLException in case of failure
    * @param numPreliminaryInserts number of preliminary inserts to make so the statement gets
    *                              prepared

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BatchedInsertReWriteEnabledTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BatchedInsertReWriteEnabledTest.java
@@ -185,7 +185,7 @@ public class BatchedInsertReWriteEnabledTest extends BaseTest4 {
   }
 
   /**
-   * Test to make sure a statement with a semicolon is not broken
+   * Test to make sure a statement with a semicolon is not broken.
    */
   private void simpleRewriteBatch(String values, String suffix)
       throws SQLException {
@@ -216,7 +216,7 @@ public class BatchedInsertReWriteEnabledTest extends BaseTest4 {
   }
 
   /**
-   * Test to make sure a statement with a semicolon is not broken
+   * Test to make sure a statement with a semicolon is not broken.
    */
   @Test
   public void testBatchWithReWrittenBatchStatementWithSemiColon()
@@ -225,7 +225,7 @@ public class BatchedInsertReWriteEnabledTest extends BaseTest4 {
   }
 
   /**
-   * Test to make sure a statement with a semicolon is not broken
+   * Test to make sure a statement with a semicolon is not broken.
    */
   @Test
   public void testBatchWithReWrittenSpaceAfterValues()
@@ -247,7 +247,7 @@ public class BatchedInsertReWriteEnabledTest extends BaseTest4 {
   }
 
   /**
-   * Test to make sure a statement with a semicolon is not broken
+   * Test to make sure a statement with a semicolon is not broken.
    */
   @Test
   public void testBindsInNestedParens()
@@ -274,7 +274,7 @@ public class BatchedInsertReWriteEnabledTest extends BaseTest4 {
   }
 
   /**
-   * Test to make sure a statement with a semicolon is not broken
+   * Test to make sure a statement with a semicolon is not broken.
    */
   @Test
   public void testMultiValues1bind()

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BlobTransactionTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BlobTransactionTest.java
@@ -28,7 +28,7 @@ import java.util.Arrays;
 import javax.sql.rowset.serial.SerialBlob;
 
 /**
- * Test that oid/lob are accessible in concurrent connection, in presence of the lo_manage trigger
+ * Test that oid/lob are accessible in concurrent connection, in presence of the lo_manage trigger.
  * Require the lo module accessible in $libdir
  */
 public class BlobTransactionTest {

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/CopyBothResponseTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/CopyBothResponseTest.java
@@ -36,7 +36,7 @@ import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
 /**
- * CopyBothResponse use since 9.1 PostgreSQL version for replication protocol
+ * CopyBothResponse use since 9.1 PostgreSQL version for replication protocol.
  */
 @HaveMinimalServerVersion("9.4")
 public class CopyBothResponseTest {

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DriverTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DriverTest.java
@@ -96,7 +96,7 @@ public class DriverTest {
   }
 
   /**
-   * Tests the connect method by connecting to the test database
+   * Tests the connect method by connecting to the test database.
    */
   @Test
   public void testConnect() throws Exception {

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PGPropertyTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PGPropertyTest.java
@@ -55,7 +55,7 @@ public class PGPropertyTest {
   }
 
   /**
-   * Test that we can get and set all default values and all choices (if any)
+   * Test that we can get and set all default values and all choices (if any).
    */
   @Test
   public void testGetSetAllProperties() {
@@ -77,7 +77,7 @@ public class PGPropertyTest {
   }
 
   /**
-   * Test that the enum constant is common with the underlying property name
+   * Test that the enum constant is common with the underlying property name.
    */
   @Test
   public void testEnumConstantNaming() {
@@ -108,7 +108,7 @@ public class PGPropertyTest {
   }
 
   /**
-   * Test if the datasource has getter and setter for all properties
+   * Test if the datasource has getter and setter for all properties.
    */
   @Test
   public void testDataSourceProperties() throws Exception {
@@ -151,7 +151,7 @@ public class PGPropertyTest {
   }
 
   /**
-   * Test that {@link PGProperty#isPresent(Properties)} returns a correct result in all cases
+   * Test that {@link PGProperty#isPresent(Properties)} returns a correct result in all cases.
    */
   @Test
   public void testIsPresentWithParseURLResult() throws Exception {

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/SearchPathLookupTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/SearchPathLookupTest.java
@@ -34,7 +34,7 @@ public class SearchPathLookupTest {
 
   /**
    * This usecase is most common, here the object we are searching for is in the current_schema (the
-   * first schema in the search_path)
+   * first schema in the search_path).
    */
   @Test
   public void testSearchPathNormalLookup() throws Exception {

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/StatementTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/StatementTest.java
@@ -938,7 +938,7 @@ public class StatementTest {
 
   /**
    * Tests that calling {@code java.sql.Statement#close()} from a concurrent thread does not result
-   * in {@link java.util.ConcurrentModificationException}
+   * in {@link java.util.ConcurrentModificationException}.
    */
   @Test
   public void testSideStatementFinalizers() throws SQLException {

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/StatementTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/StatementTest.java
@@ -509,12 +509,12 @@ public class StatementTest {
 
 
   /**
-   * Demonstrates a safe approach to concurrently reading the latest
-   * warnings while periodically clearing them.
+   * <p>Demonstrates a safe approach to concurrently reading the latest
+   * warnings while periodically clearing them.</p>
    *
-   * One drawback of this approach is that it requires the reader to make it to the end of the
+   * <p>One drawback of this approach is that it requires the reader to make it to the end of the
    * warning chain before clearing it, so long as your warning processing step is not very slow,
-   * this should happen more or less instantaneously even if you receive a lot of warnings.
+   * this should happen more or less instantaneously even if you receive a lot of warnings.</p>
    */
   @Test
   public void testConcurrentWarningReadAndClear()

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/TimezoneTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/TimezoneTest.java
@@ -32,25 +32,24 @@ import java.util.Properties;
 import java.util.TimeZone;
 
 /**
- * Tests for time and date types with calendars involved. TimestampTest was melting my brain, so I
- * started afresh. -O
+ * <p>Tests for time and date types with calendars involved. TimestampTest was melting my brain, so I
+ * started afresh. -O</p>
  *
- * Conversions that this code tests:
- * <p>
- * setTimestamp -> timestamp, timestamptz, date, time, timetz
- * <p>
- * setDate -> timestamp, timestamptz, date
- * <p>
- * setTime -> time, timetz
+ * <p>Conversions that this code tests:</p>
  *
- * <p>
- * getTimestamp <- timestamp, timestamptz, date, time, timetz
- * <p>
- * getDate <- timestamp, timestamptz, date
- * <p>
- * getTime <- timestamp, timestamptz, time, timetz
+ * <p>setTimestamp -> timestamp, timestamptz, date, time, timetz</p>
  *
- * (this matches what we must support per JDBC 3.0, tables B-5 and B-6)
+ * <p>setDate -> timestamp, timestamptz, date</p>
+ *
+ * <p>setTime -> time, timetz</p>
+ *
+ * <p>getTimestamp <- timestamp, timestamptz, date, time, timetz</p>
+ *
+ * <p>getDate <- timestamp, timestamptz, date</p>
+ *
+ * <p>getTime <- timestamp, timestamptz, time, timetz</p>
+ *
+ * <p>(this matches what we must support per JDBC 3.0, tables B-5 and B-6)</p>
  */
 public class TimezoneTest {
   private static final int DAY = 24 * 3600 * 1000;

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/TimezoneTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/TimezoneTest.java
@@ -950,7 +950,7 @@ public class TimezoneTest {
   }
 
   /**
-   * Converts the given time
+   * Converts the given time.
    *
    * @param t The time of day. Must be within -24 and + 24 hours of epoc.
    * @param tz The timezone to normalize to.

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/optional/BaseDataSourceTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/optional/BaseDataSourceTest.java
@@ -57,7 +57,7 @@ public abstract class BaseDataSourceTest {
   }
 
   /**
-   * Removes the test table using a standard connection (not from a DataSource)
+   * Removes the test table using a standard connection (not from a DataSource).
    */
   @After
   public void tearDown() throws Exception {
@@ -68,7 +68,7 @@ public abstract class BaseDataSourceTest {
   }
 
   /**
-   * Gets a connection from the current BaseDataSource
+   * Gets a connection from the current BaseDataSource.
    */
   protected Connection getDataSourceConnection() throws SQLException {
     if (bds == null) {
@@ -96,7 +96,7 @@ public abstract class BaseDataSourceTest {
   }
 
   /**
-   * Test to make sure you can instantiate and configure the appropriate DataSource
+   * Test to make sure you can instantiate and configure the appropriate DataSource.
    */
   @Test
   public void testCreateDataSource() {
@@ -118,7 +118,7 @@ public abstract class BaseDataSourceTest {
   }
 
   /**
-   * A simple test to make sure you can execute SQL using the Connection from the DataSource
+   * A simple test to make sure you can execute SQL using the Connection from the DataSource.
    */
   @Test
   public void testUseConnection() {
@@ -218,7 +218,7 @@ public abstract class BaseDataSourceTest {
   }
 
   /**
-   * Uses the mini-JNDI implementation for testing purposes
+   * Uses the mini-JNDI implementation for testing purposes.
    */
   protected InitialContext getInitialContext() {
     Hashtable<String, Object> env = new Hashtable<String, Object>();

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/optional/CaseOptimiserDataSourceTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/optional/CaseOptimiserDataSourceTest.java
@@ -22,7 +22,7 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Statement;
 
-/*
+/**
  * DataSource test to ensure the BaseConnection is configured with column sanitiser disabled.
  */
 public class CaseOptimiserDataSourceTest {
@@ -73,7 +73,7 @@ public class CaseOptimiserDataSourceTest {
   }
 
   /**
-   * Gets a connection from the current BaseDataSource
+   * Gets a connection from the current BaseDataSource.
    */
   protected Connection getDataSourceConnection() throws SQLException {
     if (bds == null) {

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/optional/ConnectionPoolTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/optional/ConnectionPoolTest.java
@@ -44,7 +44,7 @@ public class ConnectionPoolTest extends BaseDataSourceTest {
   private ArrayList<PooledConnection> connections = new ArrayList<PooledConnection>();
 
   /**
-   * Creates and configures a ConnectionPool
+   * Creates and configures a ConnectionPool.
    */
   @Override
   protected void initializeDataSource() {

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc4/ClientInfoTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc4/ClientInfoTest.java
@@ -78,7 +78,7 @@ public class ClientInfoTest extends BaseTest4 {
   }
 
   /**
-   * Test that no exception is thrown when an unknown property is set
+   * Test that no exception is thrown when an unknown property is set.
    */
   @Test
   public void testWarningOnUnknownName() throws SQLException {
@@ -91,7 +91,7 @@ public class ClientInfoTest extends BaseTest4 {
   }
 
   /**
-   * Test that a name missing in the properties given to setClientInfo should be unset (spec)
+   * Test that a name missing in the properties given to setClientInfo should be unset (spec).
    */
   @Test
   public void testMissingName() throws SQLException {

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc4/IsValidTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc4/IsValidTest.java
@@ -36,7 +36,7 @@ public class IsValidTest extends BaseTest4 {
   }
 
   /**
-   * Test that the transaction state is left unchanged
+   * Test that the transaction state is left unchanged.
    */
   @Test
   public void testTransactionState() throws Exception {

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc4/WrapperTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc4/WrapperTest.java
@@ -41,7 +41,7 @@ public class WrapperTest {
   }
 
   /**
-   * This interface is private, and so cannot be supported by any wrapper
+   * This interface is private, and so cannot be supported by any wrapper.
    */
   private interface PrivateInterface {
   }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc4/jdbc41/CloseOnCompletionTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc4/jdbc41/CloseOnCompletionTest.java
@@ -35,7 +35,7 @@ public class CloseOnCompletionTest {
   }
 
   /**
-   * Test that the statement is not automatically closed if we do not ask for it
+   * Test that the statement is not automatically closed if we do not ask for it.
    */
   @Test
   public void testWithoutCloseOnCompletion() throws SQLException {
@@ -47,7 +47,7 @@ public class CloseOnCompletionTest {
   }
 
   /**
-   * Test the behavior of closeOnCompletion with a single result set
+   * Test the behavior of closeOnCompletion with a single result set.
    */
   @Test
   public void testSingleResultSet() throws SQLException {
@@ -60,7 +60,7 @@ public class CloseOnCompletionTest {
   }
 
   /**
-   * Test the behavior of closeOnCompletion with a multiple result sets
+   * Test the behavior of closeOnCompletion with a multiple result sets.
    */
   @Test
   public void testMultipleResultSet() throws SQLException {
@@ -79,7 +79,7 @@ public class CloseOnCompletionTest {
 
   /**
    * Test that when execution does not produce any result sets, closeOnCompletion has no effect
-   * (spec)
+   * (spec).
    */
   @Test
   public void testNoResultSet() throws SQLException {

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc4/jdbc41/GetObjectTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc4/jdbc41/GetObjectTest.java
@@ -214,7 +214,6 @@ public class GetObjectTest {
   }
 
   /**
-   *
    * Test the behavior getObject for timestamp columns.
    */
   @Test
@@ -717,9 +716,9 @@ public class GetObjectTest {
   }
 
   /**
-   * Test the behavior getObject for money columns.
+   * <p>Test the behavior getObject for money columns.</p>
    *
-   * The test is ignored as it is locale-dependent.
+   * <p>The test is ignored as it is locale-dependent.</p>
    */
   @Ignore
   @Test

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc4/jdbc41/SchemaTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc4/jdbc41/SchemaTest.java
@@ -70,7 +70,7 @@ public class SchemaTest {
   }
 
   /**
-   * Test that what you set is what you get
+   * Test that what you set is what you get.
    */
   @Test
   public void testGetSetSchema() throws SQLException {
@@ -138,7 +138,7 @@ public class SchemaTest {
   }
 
   /**
-   * Test that get schema returns the schema with the highest priority in the search path
+   * Test that get schema returns the schema with the highest priority in the search path.
    */
   @Test
   public void testMultipleSearchPath() throws SQLException {

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc4/jdbc41/SharedTimerClassLoaderLeakTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc4/jdbc41/SharedTimerClassLoaderLeakTest.java
@@ -15,11 +15,11 @@ import se.jiderhamn.classloader.leak.JUnitClassloaderRunner;
 import se.jiderhamn.classloader.leak.Leaks;
 
 /**
- * Test case that verifies that the use of {@link org.postgresql.util.SharedTimer} within
- * {@link org.postgresql.Driver} does not cause ClassLoader leaks.
+ * <p>Test case that verifies that the use of {@link org.postgresql.util.SharedTimer} within
+ * {@link org.postgresql.Driver} does not cause ClassLoader leaks.</p>
  *
- * The class is placed in {@code jdbc41} package so it won't be tested in JRE6 build.
- * {@link JUnitClassloaderRunner} does not support JRE6, so we have to skip the test there.
+ * <p>The class is placed in {@code jdbc41} package so it won't be tested in JRE6 build.
+ * {@link JUnitClassloaderRunner} does not support JRE6, so we have to skip the test there.</p>
  *
  * @author Mattias Jiderhamn
  */

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc4/jdbc41/SharedTimerClassLoaderLeakTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc4/jdbc41/SharedTimerClassLoaderLeakTest.java
@@ -16,7 +16,7 @@ import se.jiderhamn.classloader.leak.Leaks;
 
 /**
  * Test case that verifies that the use of {@link org.postgresql.util.SharedTimer} within
- * {@link org.postgresql.Driver} does not cause ClassLoader leaks
+ * {@link org.postgresql.Driver} does not cause ClassLoader leaks.
  *
  * The class is placed in {@code jdbc41} package so it won't be tested in JRE6 build.
  * {@link JUnitClassloaderRunner} does not support JRE6, so we have to skip the test there.
@@ -27,7 +27,7 @@ import se.jiderhamn.classloader.leak.Leaks;
 @PackagesLoadedOutsideClassLoader(packages = "org.postgresql", addToDefaults = true)
 public class SharedTimerClassLoaderLeakTest {
 
-  /** Starting a {@link org.postgresql.util.SharedTimer} should not cause ClassLoader leaks */
+  /** Starting a {@link org.postgresql.util.SharedTimer} should not cause ClassLoader leaks. */
   @Leaks(false)
   @Test
   public void sharedTimerDoesNotCauseLeak() {

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc42/SimpleJdbc42Test.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc42/SimpleJdbc42Test.java
@@ -12,12 +12,12 @@ import org.postgresql.test.jdbc2.BaseTest4;
 import org.junit.Test;
 
 /**
- * Most basic test to check that the right package is compiled
+ * Most basic test to check that the right package is compiled.
  */
 public class SimpleJdbc42Test extends BaseTest4 {
 
   /**
-   * Test presence of JDBC 4.2 specific methods
+   * Test presence of JDBC 4.2 specific methods.
    */
   @Test
   public void testSupportsRefCursors() throws Exception {

--- a/pgjdbc/src/test/java/org/postgresql/test/jre8/core/SocksProxyTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jre8/core/SocksProxyTest.java
@@ -29,7 +29,7 @@ public class SocksProxyTest {
   }
 
   /**
-   * Tests the connect method by connecting to the test database
+   * Tests the connect method by connecting to the test database.
    */
   @Test
   public void testConnectWithSocksNonProxyHost() throws Exception {

--- a/pgjdbc/src/test/java/org/postgresql/test/socketfactory/SocketFactoryTestSuite.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/socketfactory/SocketFactoryTestSuite.java
@@ -38,7 +38,7 @@ public class SocketFactoryTestSuite {
   }
 
   /**
-   * Test custom socket factory
+   * Test custom socket factory.
    */
   @Test
   public void testDatabaseMetaData() throws Exception {

--- a/pgjdbc/src/test/java/org/postgresql/test/ssl/SingleCertValidatingFactoryTestSuite.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/ssl/SingleCertValidatingFactoryTestSuite.java
@@ -347,7 +347,7 @@ public class SingleCertValidatingFactoryTestSuite {
   ///////////////////////////////////////////////////////////////////
 
   /**
-   * Utility function to load a file as a string
+   * Utility function to load a file as a string.
    */
   public static String loadFile(String path) {
     BufferedReader br = null;

--- a/pgjdbc/src/test/java/org/postgresql/test/ssl/SingleCertValidatingFactoryTestSuite.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/ssl/SingleCertValidatingFactoryTestSuite.java
@@ -33,15 +33,15 @@ public class SingleCertValidatingFactoryTestSuite {
   private static String IS_ENABLED_PROP_NAME = "testsinglecertfactory";
 
   /**
-   * This method returns the paramaters that JUnit will use when constructing this class for
+   * <p>This method returns the paramaters that JUnit will use when constructing this class for
    * testing. It returns a collection of arrays, each containing a single value for the JDBC URL to
-   * test against.
+   * test against.</p>
    *
-   * To point the test at a different set of test databases edit the JDBC URL list accordingly. By
-   * default it points to the test databases setup by the pgjdbc-test-vm virtual machine.
+   * <p>To point the test at a different set of test databases edit the JDBC URL list accordingly. By
+   * default it points to the test databases setup by the pgjdbc-test-vm virtual machine.</p>
    *
-   * Note: The test assumes that the username as password for all the test databases are the same
-   * (pulled from system properties).
+   * <p>Note: The test assumes that the username as password for all the test databases are the same
+   * (pulled from system properties).</p>
    */
   @Parameters
   public static Collection<Object[]> data() throws IOException {
@@ -187,15 +187,15 @@ public class SingleCertValidatingFactoryTestSuite {
   }
 
   /**
-   * Connect using SSL and attempt to validate the server's certificate against the wrong pre shared
+   * <p>Connect using SSL and attempt to validate the server's certificate against the wrong pre shared
    * certificate. This test uses a pre generated certificate that will *not* match the test
-   * PostgreSQL server (the certificate is for properssl.example.com).
+   * PostgreSQL server (the certificate is for properssl.example.com).</p>
    *
-   * This connection uses a custom SSLSocketFactory using a custom trust manager that validates the
-   * remote server's certificate against the pre shared certificate.
+   * <p>This connection uses a custom SSLSocketFactory using a custom trust manager that validates the
+   * remote server's certificate against the pre shared certificate.</p>
    *
-   * This test should throw an exception as the client should reject the server since the
-   * certificate does not match.
+   * <p>This test should throw an exception as the client should reject the server since the
+   * certificate does not match.</p>
    */
   @Test
   public void connectSSLWithValidationWrongCert() throws SQLException, IOException {
@@ -276,13 +276,13 @@ public class SingleCertValidatingFactoryTestSuite {
   }
 
   /**
-   * Connect using SSL and attempt to validate the server's certificate against the proper pre
-   * shared certificate. The certificate is specified as an environment variable.
+   * <p>Connect using SSL and attempt to validate the server's certificate against the proper pre
+   * shared certificate. The certificate is specified as an environment variable.</p>
    *
-   * Note: To execute this test succesfully you need to set the value of the environment variable
-   * DATASOURCE_SSL_CERT prior to running the test.
+   * <p>Note: To execute this test succesfully you need to set the value of the environment variable
+   * DATASOURCE_SSL_CERT prior to running the test.</p>
    *
-   * Here's one way to do it: $ DATASOURCE_SSL_CERT=$(cat certdir/goodroot.crt) ant clean test
+   * <p>Here's one way to do it: $ DATASOURCE_SSL_CERT=$(cat certdir/goodroot.crt) ant clean test</p>
    */
   @Test
   public void connectSSLWithValidationProperCertEnvVar() throws SQLException, IOException {

--- a/pgjdbc/src/test/java/org/postgresql/test/util/LruCacheTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/util/LruCacheTest.java
@@ -20,7 +20,7 @@ import java.util.Arrays;
 import java.util.Deque;
 
 /**
- * Tests {@link org.postgresql.util.LruCache}
+ * Tests {@link org.postgresql.util.LruCache}.
  */
 public class LruCacheTest {
 

--- a/pgjdbc/src/test/java/org/postgresql/test/util/rules/ServerVersionRule.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/util/rules/ServerVersionRule.java
@@ -19,8 +19,9 @@ import org.junit.runners.model.Statement;
 /**
  * <p>Rule for ignore test if current version postgresql to old to use. And it necessary because
  * without it test will fail. For use it method test class or test method should be annotate with
- * {@link HaveMinimalServerVersion} annotation.
- * Example use:
+ * {@link HaveMinimalServerVersion} annotation.</p>
+ *
+ * <p>Example use:
  * <pre>
  * &#064;HaveMinimalServerVersion("8.4")
  * public class CopyAPITest {
@@ -45,6 +46,7 @@ import org.junit.runners.model.Statement;
  *     }
  * }
  * </pre>
+ * </p>
  */
 public class ServerVersionRule implements TestRule {
   /**

--- a/pgjdbc/src/test/java/org/postgresql/test/xa/XADataSourceTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/xa/XADataSourceTest.java
@@ -350,13 +350,13 @@ public class XADataSourceTest {
   }
 
   /**
-   * Get the time the current transaction was started from the server.
+   * <p>Get the time the current transaction was started from the server.</p>
    *
-   * This can be used to check that transaction doesn't get committed/ rolled back inadvertently, by
+   * <p>This can be used to check that transaction doesn't get committed/ rolled back inadvertently, by
    * calling this once before and after the suspected piece of code, and check that they match. It's
    * a bit iffy, conceivably you might get the same timestamp anyway if the suspected piece of code
    * runs fast enough, and/or the server clock is very coarse grained. But it'll do for testing
-   * purposes.
+   * purposes.</p>
    */
   private static java.sql.Timestamp getTransactionTimestamp(Connection conn) throws SQLException {
     ResultSet rs = conn.createStatement().executeQuery("SELECT now()");


### PR DESCRIPTION
The attached PR contains the commits to enable the Checkstyle Javadoc rules on the codebase and the corresponding changes to make the existing Javadoc compliant.