### PR TITLE
docs: use "PR 42" references instead of "PR#42" in the changelog

### DIFF
--- a/docs/_posts/2017-02-20-42.0.0-release.md
+++ b/docs/_posts/2017-02-20-42.0.0-release.md
@@ -38,85 +38,85 @@ You may have noticed the change in the versioning of the driver, you can [read t
 
 AlexElin (6):
 
-* refactor: use varargs [PR#681](https://github.com/pgjdbc/pgjdbc/pull/681) [50b7fe0f](https://github.com/pgjdbc/pgjdbc/commit/50b7fe0fe901ee24160615bebd4b86603b960b86)
-* refactor: make HostChooser implement Iterable [PR#645](https://github.com/pgjdbc/pgjdbc/pull/645) [3d37db78](https://github.com/pgjdbc/pgjdbc/commit/3d37db78ae4a82cab8809bac86e3b55537e91d95)
-* refactor: migrate to Junit4 [PR#682](https://github.com/pgjdbc/pgjdbc/pull/682) [f4a067cc](https://github.com/pgjdbc/pgjdbc/commit/f4a067cc5d32dde2698a062d6f9855d50fa3127d)
-* refactor: remove deprecated Utils' methods [PR#678](https://github.com/pgjdbc/pgjdbc/pull/678) [0275d40f](https://github.com/pgjdbc/pgjdbc/commit/0275d40f6f2b8b30faef8aed31761e1ff7a0ed90)
-* refactor: migrate tests to junit4 [PR#685](https://github.com/pgjdbc/pgjdbc/pull/685) [faab4998](https://github.com/pgjdbc/pgjdbc/commit/faab499853c56f67cb70fb242f75b918452f2a6f)
-* refactor: remove checks for jdk version 1.4 (tests) [PR#737](https://github.com/pgjdbc/pgjdbc/pull/737) [ee51dfce](https://github.com/pgjdbc/pgjdbc/commit/ee51dfce99dcd922b66373cd0c69c83bf339dbdb)
+* refactor: use varargs [PR 681](https://github.com/pgjdbc/pgjdbc/pull/681) [50b7fe0f](https://github.com/pgjdbc/pgjdbc/commit/50b7fe0fe901ee24160615bebd4b86603b960b86)
+* refactor: make HostChooser implement Iterable [PR 645](https://github.com/pgjdbc/pgjdbc/pull/645) [3d37db78](https://github.com/pgjdbc/pgjdbc/commit/3d37db78ae4a82cab8809bac86e3b55537e91d95)
+* refactor: migrate to Junit4 [PR 682](https://github.com/pgjdbc/pgjdbc/pull/682) [f4a067cc](https://github.com/pgjdbc/pgjdbc/commit/f4a067cc5d32dde2698a062d6f9855d50fa3127d)
+* refactor: remove deprecated Utils' methods [PR 678](https://github.com/pgjdbc/pgjdbc/pull/678) [0275d40f](https://github.com/pgjdbc/pgjdbc/commit/0275d40f6f2b8b30faef8aed31761e1ff7a0ed90)
+* refactor: migrate tests to junit4 [PR 685](https://github.com/pgjdbc/pgjdbc/pull/685) [faab4998](https://github.com/pgjdbc/pgjdbc/commit/faab499853c56f67cb70fb242f75b918452f2a6f)
+* refactor: remove checks for jdk version 1.4 (tests) [PR 737](https://github.com/pgjdbc/pgjdbc/pull/737) [ee51dfce](https://github.com/pgjdbc/pgjdbc/commit/ee51dfce99dcd922b66373cd0c69c83bf339dbdb)
 
 Eric McCormack (1):
 
-* fix: accept server version with more than 3 parts [PR#741](https://github.com/pgjdbc/pgjdbc/pull/741) [8437f6c1](https://github.com/pgjdbc/pgjdbc/commit/8437f6c1c76c3560331d75c4332ab50959d57228)
+* fix: accept server version with more than 3 parts [PR 741](https://github.com/pgjdbc/pgjdbc/pull/741) [8437f6c1](https://github.com/pgjdbc/pgjdbc/commit/8437f6c1c76c3560331d75c4332ab50959d57228)
 
 Jordan Lewis (1):
 
-* feat: do not use pg_depend against PostgreSQL 9.0+ [PR#689](https://github.com/pgjdbc/pgjdbc/pull/689) [62e25fba](https://github.com/pgjdbc/pgjdbc/commit/62e25fba70002d7639472c5a1dcd9d1de5b7f872)
+* feat: do not use pg_depend against PostgreSQL 9.0+ [PR 689](https://github.com/pgjdbc/pgjdbc/pull/689) [62e25fba](https://github.com/pgjdbc/pgjdbc/commit/62e25fba70002d7639472c5a1dcd9d1de5b7f872)
 
 Jorge Solorzano (22):
 
-* refactor: remove support for postgresql < 8.2 [PR#661](https://github.com/pgjdbc/pgjdbc/pull/661) [14e64be7](https://github.com/pgjdbc/pgjdbc/commit/14e64be7dc43feaef210e82fcd9b6089e54e5e4f)
-* fix: add query to support postgresql 8.2 without t.typarray [PR#699](https://github.com/pgjdbc/pgjdbc/pull/699) [cb3995b5](https://github.com/pgjdbc/pgjdbc/commit/cb3995b5a0311a2f5f7737fdfe83457680305efb)
-* test: add CI tests against PostgreSQL 8.3 [PR#710](https://github.com/pgjdbc/pgjdbc/pull/710) [436365b0](https://github.com/pgjdbc/pgjdbc/commit/436365b095d0a276b876433fd00d9bbac72708cc)
-* fix: robust castToBoolean for setObject in PreparedStatement [PR#714](https://github.com/pgjdbc/pgjdbc/pull/714) [edc2a14a](https://github.com/pgjdbc/pgjdbc/commit/edc2a14af8837911a48bb322363bb8b70d2b173d)
-* refactor: remove unused V2ReplicationProtocol.java [PR#718](https://github.com/pgjdbc/pgjdbc/pull/718) [7881e41e](https://github.com/pgjdbc/pgjdbc/commit/7881e41ea93f3bd6a3f58e85cb4329f77b667db0)
-* test: ignore tests that don't apply to Pg8.2 and Pg8.3 [PR#703](https://github.com/pgjdbc/pgjdbc/pull/703) [3bc0951e](https://github.com/pgjdbc/pgjdbc/commit/3bc0951e84ad3b7af746e2dece04b4ea816605e2)
-* style: reorder checkstyle in travis [PR#721](https://github.com/pgjdbc/pgjdbc/pull/721) [ba812fb4](https://github.com/pgjdbc/pgjdbc/commit/ba812fb404852b73a304f7ccb068a2030b8604b3)
-* refactor: remove charset property not used [PR#709](https://github.com/pgjdbc/pgjdbc/pull/709) [f6fd5a5a](https://github.com/pgjdbc/pgjdbc/commit/f6fd5a5abea1efe9b987825b7874ffd962772197)
-* fix: huntbugs on PgDatabaseMetaData, String concatenation in a loop [PR#693](https://github.com/pgjdbc/pgjdbc/pull/693) [3a00ef94](https://github.com/pgjdbc/pgjdbc/commit/3a00ef9436c6b04c472330802a8adb22adaa9b63)
-* refactor: fix getDriverVersion, getDriverName and getJDBCMajor/MinorVersion methods [PR#668](https://github.com/pgjdbc/pgjdbc/pull/668) [aa974341](https://github.com/pgjdbc/pgjdbc/commit/aa9743417f18a10a1a7c7a4bc25ad2862155ddc8)
-* docs: reword supported versions, include datasources section, compare versions [PR#673](https://github.com/pgjdbc/pgjdbc/pull/673) [b2cdd057](https://github.com/pgjdbc/pgjdbc/commit/b2cdd057664a00928d97290ed7435fcf57f3a360)
-* test: fix test replication on PG_HEAD [PR#734](https://github.com/pgjdbc/pgjdbc/pull/734) [3b406a18](https://github.com/pgjdbc/pgjdbc/commit/3b406a18a7c1751aa477e8378ee8cad0a60efd1e)
-* refactor: deprecated PGPoolingDataSource [PR#739](https://github.com/pgjdbc/pgjdbc/pull/739) [55e2cd16](https://github.com/pgjdbc/pgjdbc/commit/55e2cd16cc7e30b1370e777d71556aa625bace9f)
-* fix: strict handling of getBoolean and setObject with postgres accepted values [PR#732](https://github.com/pgjdbc/pgjdbc/pull/732) [4942f7d1](https://github.com/pgjdbc/pgjdbc/commit/4942f7d1cc812feeeca331878334a3d4058615e4)
-* docs: move docs from www/documentation/head [PR#744](https://github.com/pgjdbc/pgjdbc/pull/744) [70e23c45](https://github.com/pgjdbc/pgjdbc/commit/70e23c45c904ebded42ab1b5efc10d66f34ab68c)
-* test: fix replication test in Pg10 [PR#746](https://github.com/pgjdbc/pgjdbc/pull/746) [63ed2129](https://github.com/pgjdbc/pgjdbc/commit/63ed2129f7aa4375d009f19c64dc2404e725aabb)
-* feat: use java.util.logging [PR#722](https://github.com/pgjdbc/pgjdbc/pull/722) [43e6505e](https://github.com/pgjdbc/pgjdbc/commit/43e6505e3aa16e6acdf08f02f2dd1e3cf131ac3e)
-* perf: short circuit Oid.BOOL in getBoolean [PR#745](https://github.com/pgjdbc/pgjdbc/pull/745) [e69e4a1d](https://github.com/pgjdbc/pgjdbc/commit/e69e4a1d5502319bc810e0e4529611ba52ea386c)
-* fix: add isLoggable around parameterized logger [PR#752](https://github.com/pgjdbc/pgjdbc/pull/752) [8b50cfe5](https://github.com/pgjdbc/pgjdbc/commit/8b50cfe58c47d19adc0c241488a24037f4a4416f)
+* refactor: remove support for postgresql < 8.2 [PR 661](https://github.com/pgjdbc/pgjdbc/pull/661) [14e64be7](https://github.com/pgjdbc/pgjdbc/commit/14e64be7dc43feaef210e82fcd9b6089e54e5e4f)
+* fix: add query to support postgresql 8.2 without t.typarray [PR 699](https://github.com/pgjdbc/pgjdbc/pull/699) [cb3995b5](https://github.com/pgjdbc/pgjdbc/commit/cb3995b5a0311a2f5f7737fdfe83457680305efb)
+* test: add CI tests against PostgreSQL 8.3 [PR 710](https://github.com/pgjdbc/pgjdbc/pull/710) [436365b0](https://github.com/pgjdbc/pgjdbc/commit/436365b095d0a276b876433fd00d9bbac72708cc)
+* fix: robust castToBoolean for setObject in PreparedStatement [PR 714](https://github.com/pgjdbc/pgjdbc/pull/714) [edc2a14a](https://github.com/pgjdbc/pgjdbc/commit/edc2a14af8837911a48bb322363bb8b70d2b173d)
+* refactor: remove unused V2ReplicationProtocol.java [PR 718](https://github.com/pgjdbc/pgjdbc/pull/718) [7881e41e](https://github.com/pgjdbc/pgjdbc/commit/7881e41ea93f3bd6a3f58e85cb4329f77b667db0)
+* test: ignore tests that don't apply to Pg8.2 and Pg8.3 [PR 703](https://github.com/pgjdbc/pgjdbc/pull/703) [3bc0951e](https://github.com/pgjdbc/pgjdbc/commit/3bc0951e84ad3b7af746e2dece04b4ea816605e2)
+* style: reorder checkstyle in travis [PR 721](https://github.com/pgjdbc/pgjdbc/pull/721) [ba812fb4](https://github.com/pgjdbc/pgjdbc/commit/ba812fb404852b73a304f7ccb068a2030b8604b3)
+* refactor: remove charset property not used [PR 709](https://github.com/pgjdbc/pgjdbc/pull/709) [f6fd5a5a](https://github.com/pgjdbc/pgjdbc/commit/f6fd5a5abea1efe9b987825b7874ffd962772197)
+* fix: huntbugs on PgDatabaseMetaData, String concatenation in a loop [PR 693](https://github.com/pgjdbc/pgjdbc/pull/693) [3a00ef94](https://github.com/pgjdbc/pgjdbc/commit/3a00ef9436c6b04c472330802a8adb22adaa9b63)
+* refactor: fix getDriverVersion, getDriverName and getJDBCMajor/MinorVersion methods [PR 668](https://github.com/pgjdbc/pgjdbc/pull/668) [aa974341](https://github.com/pgjdbc/pgjdbc/commit/aa9743417f18a10a1a7c7a4bc25ad2862155ddc8)
+* docs: reword supported versions, include datasources section, compare versions [PR 673](https://github.com/pgjdbc/pgjdbc/pull/673) [b2cdd057](https://github.com/pgjdbc/pgjdbc/commit/b2cdd057664a00928d97290ed7435fcf57f3a360)
+* test: fix test replication on PG_HEAD [PR 734](https://github.com/pgjdbc/pgjdbc/pull/734) [3b406a18](https://github.com/pgjdbc/pgjdbc/commit/3b406a18a7c1751aa477e8378ee8cad0a60efd1e)
+* refactor: deprecated PGPoolingDataSource [PR 739](https://github.com/pgjdbc/pgjdbc/pull/739) [55e2cd16](https://github.com/pgjdbc/pgjdbc/commit/55e2cd16cc7e30b1370e777d71556aa625bace9f)
+* fix: strict handling of getBoolean and setObject with postgres accepted values [PR 732](https://github.com/pgjdbc/pgjdbc/pull/732) [4942f7d1](https://github.com/pgjdbc/pgjdbc/commit/4942f7d1cc812feeeca331878334a3d4058615e4)
+* docs: move docs from www/documentation/head [PR 744](https://github.com/pgjdbc/pgjdbc/pull/744) [70e23c45](https://github.com/pgjdbc/pgjdbc/commit/70e23c45c904ebded42ab1b5efc10d66f34ab68c)
+* test: fix replication test in Pg10 [PR 746](https://github.com/pgjdbc/pgjdbc/pull/746) [63ed2129](https://github.com/pgjdbc/pgjdbc/commit/63ed2129f7aa4375d009f19c64dc2404e725aabb)
+* feat: use java.util.logging [PR 722](https://github.com/pgjdbc/pgjdbc/pull/722) [43e6505e](https://github.com/pgjdbc/pgjdbc/commit/43e6505e3aa16e6acdf08f02f2dd1e3cf131ac3e)
+* perf: short circuit Oid.BOOL in getBoolean [PR 745](https://github.com/pgjdbc/pgjdbc/pull/745) [e69e4a1d](https://github.com/pgjdbc/pgjdbc/commit/e69e4a1d5502319bc810e0e4529611ba52ea386c)
+* fix: add isLoggable around parameterized logger [PR 752](https://github.com/pgjdbc/pgjdbc/pull/752) [8b50cfe5](https://github.com/pgjdbc/pgjdbc/commit/8b50cfe58c47d19adc0c241488a24037f4a4416f)
 * docs: move www repository to pgjdbc/docs [d4e99198](https://github.com/pgjdbc/pgjdbc/commit/d4e99198336bf41fc7f3fe9c0746036d5477601c)
 * add syntax highlight to documentation [8c035ade](https://github.com/pgjdbc/pgjdbc/commit/8c035adeb820c8a19e372f0b76a70e511b657cad)
 * add more style [9c510e65](https://github.com/pgjdbc/pgjdbc/commit/9c510e65f573354a47b7e94553870231e8dc2935)
 
 Pavel Raiskup (3):
 
-* fix: sync with latest Fedora [PR#637](https://github.com/pgjdbc/pgjdbc/pull/637) [a29ad80b](https://github.com/pgjdbc/pgjdbc/commit/a29ad80bcfdd65d11257f6339eb6bf2512612eed)
+* fix: sync with latest Fedora [PR 637](https://github.com/pgjdbc/pgjdbc/pull/637) [a29ad80b](https://github.com/pgjdbc/pgjdbc/commit/a29ad80bcfdd65d11257f6339eb6bf2512612eed)
 * packaging: rpm: update srpm generator [5c3c9239](https://github.com/pgjdbc/pgjdbc/commit/5c3c92392d66608ed7d9d1f96eb5b380e2667cd9)
 * packaging: rpm_ci: use curl -L to download rawhide logs [c8125cff](https://github.com/pgjdbc/pgjdbc/commit/c8125cff3ae719675983185d49cd49e6c028d7b7)
 
 Philippe Marschall (3):
 
-* refactor: clean up PgDatabaseMetaData [PR#692](https://github.com/pgjdbc/pgjdbc/pull/692) [d32b077e](https://github.com/pgjdbc/pgjdbc/commit/d32b077e20b2afae9c4c80f704f7c8a26a8b8e11)
-* refactor: delete Keyword enum [PR#697](https://github.com/pgjdbc/pgjdbc/pull/697) [677e3c4c](https://github.com/pgjdbc/pgjdbc/commit/677e3c4cf2533ce283a2d444cee6da8a94a4ca82)
-* feat: support microsecond resolution for JSR-310 types [PR#691](https://github.com/pgjdbc/pgjdbc/pull/691) [6b3a1efb](https://github.com/pgjdbc/pgjdbc/commit/6b3a1efb36709e570caf0dc71a42a53e89f5a5e0)
+* refactor: clean up PgDatabaseMetaData [PR 692](https://github.com/pgjdbc/pgjdbc/pull/692) [d32b077e](https://github.com/pgjdbc/pgjdbc/commit/d32b077e20b2afae9c4c80f704f7c8a26a8b8e11)
+* refactor: delete Keyword enum [PR 697](https://github.com/pgjdbc/pgjdbc/pull/697) [677e3c4c](https://github.com/pgjdbc/pgjdbc/commit/677e3c4cf2533ce283a2d444cee6da8a94a4ca82)
+* feat: support microsecond resolution for JSR-310 types [PR 691](https://github.com/pgjdbc/pgjdbc/pull/691) [6b3a1efb](https://github.com/pgjdbc/pgjdbc/commit/6b3a1efb36709e570caf0dc71a42a53e89f5a5e0)
 
 Roman Ivanov (2):
 
-* config: move version of checkstyle to property [PR#723](https://github.com/pgjdbc/pgjdbc/pull/723) [9ef7d6f1](https://github.com/pgjdbc/pgjdbc/commit/9ef7d6f1f274a75a14b380c57f4c140b47b25888)
-* chore: upgrade checkstyle to 7.4, make checkstyle version configurable via property [PR#725](https://github.com/pgjdbc/pgjdbc/pull/725) [e1a25782](https://github.com/pgjdbc/pgjdbc/commit/e1a2578247684667a51bc34ee53449e4457755df)
+* config: move version of checkstyle to property [PR 723](https://github.com/pgjdbc/pgjdbc/pull/723) [9ef7d6f1](https://github.com/pgjdbc/pgjdbc/commit/9ef7d6f1f274a75a14b380c57f4c140b47b25888)
+* chore: upgrade checkstyle to 7.4, make checkstyle version configurable via property [PR 725](https://github.com/pgjdbc/pgjdbc/pull/725) [e1a25782](https://github.com/pgjdbc/pgjdbc/commit/e1a2578247684667a51bc34ee53449e4457755df)
 
 Steve Ungerer (1):
 
-* fix: ensure executeBatch() does not use server-side prepared statements when prepareThreshold=0 [PR#690](https://github.com/pgjdbc/pgjdbc/pull/690) [aca26a07](https://github.com/pgjdbc/pgjdbc/commit/aca26a07026e9b289a209799ab28131a33b296dd)
+* fix: ensure executeBatch() does not use server-side prepared statements when prepareThreshold=0 [PR 690](https://github.com/pgjdbc/pgjdbc/pull/690) [aca26a07](https://github.com/pgjdbc/pgjdbc/commit/aca26a07026e9b289a209799ab28131a33b296dd)
 
 Trygve Laugstøl (1):
 
-* feat: connect the socket only if the socket factory created an unconnected socket [PR#587](https://github.com/pgjdbc/pgjdbc/pull/587) [f75572be](https://github.com/pgjdbc/pgjdbc/commit/f75572beb8b59a7a73f6e1d12d692b483dc04c85)
+* feat: connect the socket only if the socket factory created an unconnected socket [PR 587](https://github.com/pgjdbc/pgjdbc/pull/587) [f75572be](https://github.com/pgjdbc/pgjdbc/commit/f75572beb8b59a7a73f6e1d12d692b483dc04c85)
 
 Vladimir Gordiychuk (4):
 
-* bug: fix not enscaped special symbol that fail build [PR#686](https://github.com/pgjdbc/pgjdbc/pull/686) [b4604cd7](https://github.com/pgjdbc/pgjdbc/commit/b4604cd7de0c297c8b56608642055ed6eb3645e0)
-* feat: add replication protocol API [PR#550](https://github.com/pgjdbc/pgjdbc/pull/550) [f48c6bb7](https://github.com/pgjdbc/pgjdbc/commit/f48c6bb7e726479bbf4be4ef95e4c138db5cac96)
-* test: fix drop replication slot on 9.4 for tests [PR#696](https://github.com/pgjdbc/pgjdbc/pull/696) [c1c48bd7](https://github.com/pgjdbc/pgjdbc/commit/c1c48bd705f04e8d1b1cb8b998dda0a6893f891d)
-* chore: Gather backtrace from core dump on CI [PR#736](https://github.com/pgjdbc/pgjdbc/pull/736) [da5e4ef1](https://github.com/pgjdbc/pgjdbc/commit/da5e4ef1cbc4a5c9f41e9aee8d183560ba679541)
+* bug: fix not enscaped special symbol that fail build [PR 686](https://github.com/pgjdbc/pgjdbc/pull/686) [b4604cd7](https://github.com/pgjdbc/pgjdbc/commit/b4604cd7de0c297c8b56608642055ed6eb3645e0)
+* feat: add replication protocol API [PR 550](https://github.com/pgjdbc/pgjdbc/pull/550) [f48c6bb7](https://github.com/pgjdbc/pgjdbc/commit/f48c6bb7e726479bbf4be4ef95e4c138db5cac96)
+* test: fix drop replication slot on 9.4 for tests [PR 696](https://github.com/pgjdbc/pgjdbc/pull/696) [c1c48bd7](https://github.com/pgjdbc/pgjdbc/commit/c1c48bd705f04e8d1b1cb8b998dda0a6893f891d)
+* chore: Gather backtrace from core dump on CI [PR 736](https://github.com/pgjdbc/pgjdbc/pull/736) [da5e4ef1](https://github.com/pgjdbc/pgjdbc/commit/da5e4ef1cbc4a5c9f41e9aee8d183560ba679541)
 
 Vladimir Sitnikov (12):
 
 * fedora: add BuildRequires: classloader-leak-test-framework [64b6750c](https://github.com/pgjdbc/pgjdbc/commit/64b6750cbd49ca8a9f0596bed1876132b64c34d4)
 * tests: remove Class.forName(..driver..) from test code [c99507b5](https://github.com/pgjdbc/pgjdbc/commit/c99507b5661804b5b1b2340ba747fe553dc37a68)
-* test: add CI tests against PostgreSQL 8.2 [PR#659](https://github.com/pgjdbc/pgjdbc/pull/659) [63ee60e2](https://github.com/pgjdbc/pgjdbc/commit/63ee60e2ad93441ff55dab08213cc09815b614e0)
-* feat: display error position when SQL has unterminated literals, comments, etc [PR#688](https://github.com/pgjdbc/pgjdbc/pull/688) [8a95d991](https://github.com/pgjdbc/pgjdbc/commit/8a95d991e2032cf0406be8e54e70cfafaad794b5)
-* feat: add support for PreparedStatement.setCharacterStream(int, Reader) [PR#671](https://github.com/pgjdbc/pgjdbc/pull/671) [ee4c4265](https://github.com/pgjdbc/pgjdbc/commit/ee4c4265aebc1c73a1d1fabac5ba259d1fbfd1e4)
+* test: add CI tests against PostgreSQL 8.2 [PR 659](https://github.com/pgjdbc/pgjdbc/pull/659) [63ee60e2](https://github.com/pgjdbc/pgjdbc/commit/63ee60e2ad93441ff55dab08213cc09815b614e0)
+* feat: display error position when SQL has unterminated literals, comments, etc [PR 688](https://github.com/pgjdbc/pgjdbc/pull/688) [8a95d991](https://github.com/pgjdbc/pgjdbc/commit/8a95d991e2032cf0406be8e54e70cfafaad794b5)
+* feat: add support for PreparedStatement.setCharacterStream(int, Reader) [PR 671](https://github.com/pgjdbc/pgjdbc/pull/671) [ee4c4265](https://github.com/pgjdbc/pgjdbc/commit/ee4c4265aebc1c73a1d1fabac5ba259d1fbfd1e4)
 * chore: update next version to 42.0.0-SNAPSHOT [46634923](https://github.com/pgjdbc/pgjdbc/commit/466349236622c6b03bb9cd8d7f517c3ce0586751)
 * refactor: add CallableQueryKey#equals override [401c51a1](https://github.com/pgjdbc/pgjdbc/commit/401c51a15d80d2f24cddbe5cd4b2ca7509a0a765)
 * doc: correct wording in readme regarding PostgreSQL versions used in pgjdbc regression testing [60391d75](https://github.com/pgjdbc/pgjdbc/commit/60391d7559d6ee4e579ec2e36d7aa8199a99189d)
@@ -127,7 +127,7 @@ Vladimir Sitnikov (12):
 
 bd-infor (1):
 
-* docs: clarify handling of loglevel [PR#711](https://github.com/pgjdbc/pgjdbc/pull/711) [6334bac0](https://github.com/pgjdbc/pgjdbc/commit/6334bac036efaa4a9f2a445f1cbdcc310f4c6263)
+* docs: clarify handling of loglevel [PR 711](https://github.com/pgjdbc/pgjdbc/pull/711) [6334bac0](https://github.com/pgjdbc/pgjdbc/commit/6334bac036efaa4a9f2a445f1cbdcc310f4c6263)
 
 <a name="contributors_{{ page.version }}"></a>
 ### Contributors to this release

--- a/docs/_posts/2017-05-04-42.1.0-release.md
+++ b/docs/_posts/2017-05-04-42.1.0-release.md
@@ -24,40 +24,40 @@ version: 42.1.0
 
 Alexander Kjäll (1):
 
-* documentation typo [PR#818](https://github.com/pgjdbc/pgjdbc/pull/818) [90f5556f](https://github.com/pgjdbc/pgjdbc/commit/90f5556fd3de2395971496fc4b0b4cacd5d5d562)
+* documentation typo [PR 818](https://github.com/pgjdbc/pgjdbc/pull/818) [90f5556f](https://github.com/pgjdbc/pgjdbc/commit/90f5556fd3de2395971496fc4b0b4cacd5d5d562)
 
 Daniel Migowski (1):
 
-* feat: improve waiting for notifications by providing a timeout option [PR#778](https://github.com/pgjdbc/pgjdbc/pull/778) [a7e0c83b](https://github.com/pgjdbc/pgjdbc/commit/a7e0c83be93600c6299ae99907942e2530cb5e30)
+* feat: improve waiting for notifications by providing a timeout option [PR 778](https://github.com/pgjdbc/pgjdbc/pull/778) [a7e0c83b](https://github.com/pgjdbc/pgjdbc/commit/a7e0c83be93600c6299ae99907942e2530cb5e30)
 
 Dave Cramer (4):
 
 * Update index.html [4d8b1b38](https://github.com/pgjdbc/pgjdbc/commit/4d8b1b381d8e2ae4ca19c2d84a195412bfc472ee)
-* Review the documentation for the replication API [PR#756](https://github.com/pgjdbc/pgjdbc/pull/756) [3e1eb34d](https://github.com/pgjdbc/pgjdbc/commit/3e1eb34d2500eae9fdf4938ebbced4cff886edef)
-* fix callproc escape documentation the specification [PR#785](https://github.com/pgjdbc/pgjdbc/pull/785) [95a3f41d](https://github.com/pgjdbc/pgjdbc/commit/95a3f41d6c0debbc6658312c484c6709e3da2225)
-* Honour setLogStream. If the logStream is set [PR#780](https://github.com/pgjdbc/pgjdbc/pull/780) [b97ad630](https://github.com/pgjdbc/pgjdbc/commit/b97ad63089a9042cfef0ce97d1eaacce0fe47d4e)
+* Review the documentation for the replication API [PR 756](https://github.com/pgjdbc/pgjdbc/pull/756) [3e1eb34d](https://github.com/pgjdbc/pgjdbc/commit/3e1eb34d2500eae9fdf4938ebbced4cff886edef)
+* fix callproc escape documentation the specification [PR 785](https://github.com/pgjdbc/pgjdbc/pull/785) [95a3f41d](https://github.com/pgjdbc/pgjdbc/commit/95a3f41d6c0debbc6658312c484c6709e3da2225)
+* Honour setLogStream. If the logStream is set [PR 780](https://github.com/pgjdbc/pgjdbc/pull/780) [b97ad630](https://github.com/pgjdbc/pgjdbc/commit/b97ad63089a9042cfef0ce97d1eaacce0fe47d4e)
 
 Jacques Fuentes (1):
 
-* Make replication docs use PREFER_QUERY_MODE [PR#761](https://github.com/pgjdbc/pgjdbc/pull/761) [bd0497de](https://github.com/pgjdbc/pgjdbc/commit/bd0497dee741e92de1cc3eeabb58a82608ed6070)
+* Make replication docs use PREFER_QUERY_MODE [PR 761](https://github.com/pgjdbc/pgjdbc/pull/761) [bd0497de](https://github.com/pgjdbc/pgjdbc/commit/bd0497dee741e92de1cc3eeabb58a82608ed6070)
 
 James (1):
 
-* fix: use SQLWarning(String reason) constructor for correct DriverManager [PR#751](https://github.com/pgjdbc/pgjdbc/pull/751) [74a426b9](https://github.com/pgjdbc/pgjdbc/commit/74a426b929f47a3f585dd6e535300d2ffe77a9da)
+* fix: use SQLWarning(String reason) constructor for correct DriverManager [PR 751](https://github.com/pgjdbc/pgjdbc/pull/751) [74a426b9](https://github.com/pgjdbc/pgjdbc/commit/74a426b929f47a3f585dd6e535300d2ffe77a9da)
 
 Joe Kutner (1):
 
-* fix: Only resolve hostname if not using a SOCKS proxy [PR#774](https://github.com/pgjdbc/pgjdbc/pull/774) [480b0cf1](https://github.com/pgjdbc/pgjdbc/commit/480b0cf1ffe266e41e259f1f7a016d3ea681cc3a)
+* fix: Only resolve hostname if not using a SOCKS proxy [PR 774](https://github.com/pgjdbc/pgjdbc/pull/774) [480b0cf1](https://github.com/pgjdbc/pgjdbc/commit/480b0cf1ffe266e41e259f1f7a016d3ea681cc3a)
 
 Jorge Solorzano (3):
 
-* fix: build site with jekyll 2.2.0 [PR#755](https://github.com/pgjdbc/pgjdbc/pull/755) [773ee679](https://github.com/pgjdbc/pgjdbc/commit/773ee679ae61ae48fed56c915bf4e19576cbb292)
-* test: check that new properties follow correct lower camel case [PR#740](https://github.com/pgjdbc/pgjdbc/pull/740) [3f2a02e1](https://github.com/pgjdbc/pgjdbc/commit/3f2a02e128367df6ae47b6f850203200cef223fe)
-* refactor: simplify Encoding class [PR#765](https://github.com/pgjdbc/pgjdbc/pull/765) [ef8c6f96](https://github.com/pgjdbc/pgjdbc/commit/ef8c6f9651f54a220f7231a2bc5b8ad0ca08d0c7)
+* fix: build site with jekyll 2.2.0 [PR 755](https://github.com/pgjdbc/pgjdbc/pull/755) [773ee679](https://github.com/pgjdbc/pgjdbc/commit/773ee679ae61ae48fed56c915bf4e19576cbb292)
+* test: check that new properties follow correct lower camel case [PR 740](https://github.com/pgjdbc/pgjdbc/pull/740) [3f2a02e1](https://github.com/pgjdbc/pgjdbc/commit/3f2a02e128367df6ae47b6f850203200cef223fe)
+* refactor: simplify Encoding class [PR 765](https://github.com/pgjdbc/pgjdbc/pull/765) [ef8c6f96](https://github.com/pgjdbc/pgjdbc/commit/ef8c6f9651f54a220f7231a2bc5b8ad0ca08d0c7)
 
 Philippe Marschall (1):
 
-* feat: support fetching a REF_CURSOR using getObject [PR#809](https://github.com/pgjdbc/pgjdbc/pull/809) [4ab5ccb7](https://github.com/pgjdbc/pgjdbc/commit/4ab5ccb7a299cfcec8a5b1cddf612d3f828fa157)
+* feat: support fetching a REF_CURSOR using getObject [PR 809](https://github.com/pgjdbc/pgjdbc/pull/809) [4ab5ccb7](https://github.com/pgjdbc/pgjdbc/commit/4ab5ccb7a299cfcec8a5b1cddf612d3f828fa157)
 
 Robert Zenz (1):
 
@@ -65,18 +65,18 @@ Robert Zenz (1):
 
 Vladimir Gordiychuk (2):
 
-* chore: fix false alarm on check coredump [PR#806](https://github.com/pgjdbc/pgjdbc/pull/806) [3883a846](https://github.com/pgjdbc/pgjdbc/commit/3883a846febfe92582be2785737da9460ece1176)
-* bug: fix calculation of lastReceiveLSN for logical replication [PR#801](https://github.com/pgjdbc/pgjdbc/pull/801) [170d9c27](https://github.com/pgjdbc/pgjdbc/commit/170d9c27810349456e56aff1c36a0ad6584b9e28)
+* chore: fix false alarm on check coredump [PR 806](https://github.com/pgjdbc/pgjdbc/pull/806) [3883a846](https://github.com/pgjdbc/pgjdbc/commit/3883a846febfe92582be2785737da9460ece1176)
+* bug: fix calculation of lastReceiveLSN for logical replication [PR 801](https://github.com/pgjdbc/pgjdbc/pull/801) [170d9c27](https://github.com/pgjdbc/pgjdbc/commit/170d9c27810349456e56aff1c36a0ad6584b9e28)
 
 Vladimir Sitnikov (3):
 
-* fix: make sure org.postgresql.Driver is loaded when accessing though DataSource interface [PR#768](https://github.com/pgjdbc/pgjdbc/pull/768) [9c80adc2](https://github.com/pgjdbc/pgjdbc/commit/9c80adc24776ae02e0aff419e1cddf26a28eeff0)
+* fix: make sure org.postgresql.Driver is loaded when accessing though DataSource interface [PR 768](https://github.com/pgjdbc/pgjdbc/pull/768) [9c80adc2](https://github.com/pgjdbc/pgjdbc/commit/9c80adc24776ae02e0aff419e1cddf26a28eeff0)
 * refactor: add encoding, fix expected/actual, use proper constructor [77cace40](https://github.com/pgjdbc/pgjdbc/commit/77cace40a4ce33fadafcb5f144b5238bff2854a3)
-* fix: infinity handling for java.time types [PR#789](https://github.com/pgjdbc/pgjdbc/pull/789) [f375701b](https://github.com/pgjdbc/pgjdbc/commit/f375701b571c308b7e389df49c1d958f416e4340)
+* fix: infinity handling for java.time types [PR 789](https://github.com/pgjdbc/pgjdbc/pull/789) [f375701b](https://github.com/pgjdbc/pgjdbc/commit/f375701b571c308b7e389df49c1d958f416e4340)
 
 slmsbrhgn (1):
 
-* bug: fix data being truncated in setCharacterStream (the bug introduced in 42.0.0) [PR#802](https://github.com/pgjdbc/pgjdbc/pull/802) [28c98418](https://github.com/pgjdbc/pgjdbc/commit/28c98418b576394b7a0a4a6415ae86ba47be40ae)
+* bug: fix data being truncated in setCharacterStream (the bug introduced in 42.0.0) [PR 802](https://github.com/pgjdbc/pgjdbc/pull/802) [28c98418](https://github.com/pgjdbc/pgjdbc/commit/28c98418b576394b7a0a4a6415ae86ba47be40ae)
 
 <a name="contributors_{{ page.version }}"></a>
 ### Contributors to this release

--- a/docs/_posts/2017-07-12-42.1.2-release.md
+++ b/docs/_posts/2017-07-12-42.1.2-release.md
@@ -23,39 +23,39 @@ version: 42.1.2
 
 AlexElin (1):
 
-* refactor: make PSQLState as enum [PR#837](https://github.com/pgjdbc/pgjdbc/pull/837) [fb5df7fe](https://github.com/pgjdbc/pgjdbc/commit/fb5df7fee1d3568356e680c6ac5a62336ec7bf6e)
+* refactor: make PSQLState as enum [PR 837](https://github.com/pgjdbc/pgjdbc/pull/837) [fb5df7fe](https://github.com/pgjdbc/pgjdbc/commit/fb5df7fee1d3568356e680c6ac5a62336ec7bf6e)
 
 Dave Cramer (8):
 
-* Initial support of partitioned tables via JDBC metadata API [PR#823](https://github.com/pgjdbc/pgjdbc/pull/823) [9c3471f2](https://github.com/pgjdbc/pgjdbc/commit/9c3471f21f6ac9cf1a5e5700115ac7d0d55e0ad9)
-* fix javadoc complaints and some small edits to replication comments [PR#832](https://github.com/pgjdbc/pgjdbc/pull/832) [2d0bfceb](https://github.com/pgjdbc/pgjdbc/commit/2d0bfcebb0641ddb73d9297e6211f75537238b15)
-* fix issue #834 setting statusIntervalUpdate causes high CPU load \ [PR#835](https://github.com/pgjdbc/pgjdbc/pull/835) [59236b74](https://github.com/pgjdbc/pgjdbc/commit/59236b74acdd400d9d91d3eb2bb07d70b15392e5)
-* fix issue #838 make sure we don't get columns that are dropped [PR#840](https://github.com/pgjdbc/pgjdbc/pull/840) [464a2d43](https://github.com/pgjdbc/pgjdbc/commit/464a2d43519004174f1b530a595ee0ad9ffda870)
-* add missing connection documentation, fix spelling [PR#846](https://github.com/pgjdbc/pgjdbc/pull/846) [cd400f6f](https://github.com/pgjdbc/pgjdbc/commit/cd400f6f39d3c062fc94fa97b33b4d272a829a24)
-* more spelling mistakes for preferQueryMode [PR#850](https://github.com/pgjdbc/pgjdbc/pull/850) [73bc3c1b](https://github.com/pgjdbc/pgjdbc/commit/73bc3c1b7acda676f366631ff7e28f09a3399f37)
-* fix formatting of section on failover, still not perfect but better [PR#852](https://github.com/pgjdbc/pgjdbc/pull/852) [9f722014](https://github.com/pgjdbc/pgjdbc/commit/9f72201458d1ce0837e9525d947dcea2828b9475)
-* small reformat to clarify read and write connections [PR#854](https://github.com/pgjdbc/pgjdbc/pull/854) [551d71b6](https://github.com/pgjdbc/pgjdbc/commit/551d71b6a513c223d8d8d8d75afbe8b5d42ce783)
+* Initial support of partitioned tables via JDBC metadata API [PR 823](https://github.com/pgjdbc/pgjdbc/pull/823) [9c3471f2](https://github.com/pgjdbc/pgjdbc/commit/9c3471f21f6ac9cf1a5e5700115ac7d0d55e0ad9)
+* fix javadoc complaints and some small edits to replication comments [PR 832](https://github.com/pgjdbc/pgjdbc/pull/832) [2d0bfceb](https://github.com/pgjdbc/pgjdbc/commit/2d0bfcebb0641ddb73d9297e6211f75537238b15)
+* fix issue #834 setting statusIntervalUpdate causes high CPU load \ [PR 835](https://github.com/pgjdbc/pgjdbc/pull/835) [59236b74](https://github.com/pgjdbc/pgjdbc/commit/59236b74acdd400d9d91d3eb2bb07d70b15392e5)
+* fix issue #838 make sure we don't get columns that are dropped [PR 840](https://github.com/pgjdbc/pgjdbc/pull/840) [464a2d43](https://github.com/pgjdbc/pgjdbc/commit/464a2d43519004174f1b530a595ee0ad9ffda870)
+* add missing connection documentation, fix spelling [PR 846](https://github.com/pgjdbc/pgjdbc/pull/846) [cd400f6f](https://github.com/pgjdbc/pgjdbc/commit/cd400f6f39d3c062fc94fa97b33b4d272a829a24)
+* more spelling mistakes for preferQueryMode [PR 850](https://github.com/pgjdbc/pgjdbc/pull/850) [73bc3c1b](https://github.com/pgjdbc/pgjdbc/commit/73bc3c1b7acda676f366631ff7e28f09a3399f37)
+* fix formatting of section on failover, still not perfect but better [PR 852](https://github.com/pgjdbc/pgjdbc/pull/852) [9f722014](https://github.com/pgjdbc/pgjdbc/commit/9f72201458d1ce0837e9525d947dcea2828b9475)
+* small reformat to clarify read and write connections [PR 854](https://github.com/pgjdbc/pgjdbc/pull/854) [551d71b6](https://github.com/pgjdbc/pgjdbc/commit/551d71b6a513c223d8d8d8d75afbe8b5d42ce783)
 
 Jorge Solorzano (3):
 
-* test: yet another rename to use "lsn" not "location" in Pg10. [PR#822](https://github.com/pgjdbc/pgjdbc/pull/822) [90228621](https://github.com/pgjdbc/pgjdbc/commit/902286212df19b1eda9310c4174756786ad249c7)
-* use zulu-9 [PR#828](https://github.com/pgjdbc/pgjdbc/pull/828) [4ac74886](https://github.com/pgjdbc/pgjdbc/commit/4ac74886e54e7689035be00c417a536717a45318)
-* fix: remove type name from cast exception of getBoolean and setObject [PR#781](https://github.com/pgjdbc/pgjdbc/pull/781) [394b3a2f](https://github.com/pgjdbc/pgjdbc/commit/394b3a2f4d93e9ca701d8c31b4b66fa25fca8945)
+* test: yet another rename to use "lsn" not "location" in Pg10. [PR 822](https://github.com/pgjdbc/pgjdbc/pull/822) [90228621](https://github.com/pgjdbc/pgjdbc/commit/902286212df19b1eda9310c4174756786ad249c7)
+* use zulu-9 [PR 828](https://github.com/pgjdbc/pgjdbc/pull/828) [4ac74886](https://github.com/pgjdbc/pgjdbc/commit/4ac74886e54e7689035be00c417a536717a45318)
+* fix: remove type name from cast exception of getBoolean and setObject [PR 781](https://github.com/pgjdbc/pgjdbc/pull/781) [394b3a2f](https://github.com/pgjdbc/pgjdbc/commit/394b3a2f4d93e9ca701d8c31b4b66fa25fca8945)
 
 Robert 'Bobby' Zenz (1):
 
-* fix: Add fallback to setObject(int, Object) for Number [PR#812](https://github.com/pgjdbc/pgjdbc/pull/812) [5b9edb7d](https://github.com/pgjdbc/pgjdbc/commit/5b9edb7dfb1b281bffedf7c9f2583f2df354c0ea)
+* fix: Add fallback to setObject(int, Object) for Number [PR 812](https://github.com/pgjdbc/pgjdbc/pull/812) [5b9edb7d](https://github.com/pgjdbc/pgjdbc/commit/5b9edb7dfb1b281bffedf7c9f2583f2df354c0ea)
 
 Vladimir Gordiychuk (1):
 
-* bug: floating logical replcation test [PR#829](https://github.com/pgjdbc/pgjdbc/pull/829) [2d3e8972](https://github.com/pgjdbc/pgjdbc/commit/2d3e8972a0b34106a8b7426619cabf852c38ddaa)
+* bug: floating logical replcation test [PR 829](https://github.com/pgjdbc/pgjdbc/pull/829) [2d3e8972](https://github.com/pgjdbc/pgjdbc/commit/2d3e8972a0b34106a8b7426619cabf852c38ddaa)
 
 Vladimir Sitnikov (7):
 
 * chore: implement a script to stage pgjdbc, pgdjbc-jre7, pgjdbc-jre6 artifacts [15d78839](https://github.com/pgjdbc/pgjdbc/commit/15d7883987d2de4b662aa8cd81c6de5be0257153)
-* doc: fix 42.1.0.jre8->jre6 typo [PR#42](https://github.com/pgjdbc/pgjdbc/pull/42) [88942b58](https://github.com/pgjdbc/pgjdbc/commit/88942b58637afbea16102a6a77d922914fd27562)
+* doc: fix 42.1.0.jre8->jre6 typo [PR 42](https://github.com/pgjdbc/pgjdbc/pull/42) [88942b58](https://github.com/pgjdbc/pgjdbc/commit/88942b58637afbea16102a6a77d922914fd27562)
 * fix: use server-prepared statements for batch inserts when prepareThreshold>0 [abc3d9d7](https://github.com/pgjdbc/pgjdbc/commit/abc3d9d7f34a001322fbbe53f25d5e77a33a667f)
-* fix: better parsing for returning keyword [PR#824](https://github.com/pgjdbc/pgjdbc/pull/824) [201daf1d](https://github.com/pgjdbc/pgjdbc/commit/201daf1dc916bbc35e2bbec961aebfd1b1e30bfc)
+* fix: better parsing for returning keyword [PR 824](https://github.com/pgjdbc/pgjdbc/pull/824) [201daf1d](https://github.com/pgjdbc/pgjdbc/commit/201daf1dc916bbc35e2bbec961aebfd1b1e30bfc)
 * docs: build index, changelog pages from _posts/... to reduce release overhead [d6fe07d7](https://github.com/pgjdbc/pgjdbc/commit/d6fe07d7bb613d7b8fb06ace64b9b37d3f23bbfe)
 * chore: make ./release_notes.sh create docs/_posts/$DATE_YMD-$VERS-release.md file [e00d4571](https://github.com/pgjdbc/pgjdbc/commit/e00d4571bb6ca24c8f93956b59fd1c9a14131394)
 * docs: add 42.1.2 release notes [6f127a61](https://github.com/pgjdbc/pgjdbc/commit/6f127a61eed5317133ea80f0a06f9441b170a17a)

--- a/docs/_posts/2017-07-14-42.1.3-release.md
+++ b/docs/_posts/2017-07-14-42.1.3-release.md
@@ -17,7 +17,7 @@ version: 42.1.3
 Vladimir Sitnikov (2):
 
 * doc: ensure changelog uses %Y-%m-%d format, not %Y-%d-%m [5d585aac](https://github.com/pgjdbc/pgjdbc/commit/5d585aac7e4f916d4b54dccd11c778143a1f7725)
-* fix: NPE in PreparedStatement.executeBatch in case of empty batch [PR#867](https://github.com/pgjdbc/pgjdbc/pull/867) [7514552d](https://github.com/pgjdbc/pgjdbc/commit/7514552d2d105cb8e637e70c8e14ab7e36000ed4)
+* fix: NPE in PreparedStatement.executeBatch in case of empty batch [PR 867](https://github.com/pgjdbc/pgjdbc/pull/867) [7514552d](https://github.com/pgjdbc/pgjdbc/commit/7514552d2d105cb8e637e70c8e14ab7e36000ed4)
 
 <a name="contributors_{{ page.version }}"></a>
 ### Contributors to this release

--- a/docs/_posts/2017-08-01-42.1.4-release.md
+++ b/docs/_posts/2017-08-01-42.1.4-release.md
@@ -16,22 +16,22 @@ version: 42.1.4
 
 AlexElin (4):
 
-* test: migrate tests to JUnit 4 [PR#738](https://github.com/pgjdbc/pgjdbc/pull/738) [5b65e2f4](https://github.com/pgjdbc/pgjdbc/commit/5b65e2f45b1cb130b4380b31ff6c0c73210d9fe0)
-* style: update checkstyle + turn on some rules [PR#847](https://github.com/pgjdbc/pgjdbc/pull/847) [246b759c](https://github.com/pgjdbc/pgjdbc/commit/246b759cdc264c2732717dbd6ff9f8f472024196)
-* test: migrate tests to Junit4 [PR#883](https://github.com/pgjdbc/pgjdbc/pull/883) [5c12da16](https://github.com/pgjdbc/pgjdbc/commit/5c12da16d3aa17d299e942c4a2b3647674422920)
+* test: migrate tests to JUnit 4 [PR 738](https://github.com/pgjdbc/pgjdbc/pull/738) [5b65e2f4](https://github.com/pgjdbc/pgjdbc/commit/5b65e2f45b1cb130b4380b31ff6c0c73210d9fe0)
+* style: update checkstyle + turn on some rules [PR 847](https://github.com/pgjdbc/pgjdbc/pull/847) [246b759c](https://github.com/pgjdbc/pgjdbc/commit/246b759cdc264c2732717dbd6ff9f8f472024196)
+* test: migrate tests to Junit4 [PR 883](https://github.com/pgjdbc/pgjdbc/pull/883) [5c12da16](https://github.com/pgjdbc/pgjdbc/commit/5c12da16d3aa17d299e942c4a2b3647674422920)
 * refactor: remove useless checks in the tests [0221f930](https://github.com/pgjdbc/pgjdbc/commit/0221f930b35a6f24e539ac4740886fafaebcaeac)
 
 Dave Cramer (2):
 
-* honour PGPORT, PGHOST, PGDBNAME in connection properties [PR#862](https://github.com/pgjdbc/pgjdbc/pull/862) [2951a958](https://github.com/pgjdbc/pgjdbc/commit/2951a9583b8ea1b1b0e933896ff4be95628f834e)
-* doc: fix spelling mistakes [PR#868](https://github.com/pgjdbc/pgjdbc/pull/868) [757db625](https://github.com/pgjdbc/pgjdbc/commit/757db62590f4f7b72cf565680ab79eda7880f2b3)
+* honour PGPORT, PGHOST, PGDBNAME in connection properties [PR 862](https://github.com/pgjdbc/pgjdbc/pull/862) [2951a958](https://github.com/pgjdbc/pgjdbc/commit/2951a9583b8ea1b1b0e933896ff4be95628f834e)
+* doc: fix spelling mistakes [PR 868](https://github.com/pgjdbc/pgjdbc/pull/868) [757db625](https://github.com/pgjdbc/pgjdbc/commit/757db62590f4f7b72cf565680ab79eda7880f2b3)
 
 Michael Glaesemann (4):
 
 * test: assume minimum server version 8.3 testing autosave with ALTER [77ee528d](https://github.com/pgjdbc/pgjdbc/commit/77ee528d021ccdf740b19f9ed48259ece5df7705)
 * test: assume minimum server version 8.3 when testing with uuid [ff2717e4](https://github.com/pgjdbc/pgjdbc/commit/ff2717e42a8c0394e6cde4527ed1f721ffa9fb84)
 * refactor: remove unused import [8afe856e](https://github.com/pgjdbc/pgjdbc/commit/8afe856e5ea22870cf1489ec1fd328efee6b7426)
-* test: assume integer datetimes for timestamp tests [PR#873](https://github.com/pgjdbc/pgjdbc/pull/873) [8287e7f9](https://github.com/pgjdbc/pgjdbc/commit/8287e7f92f890a41f8d2b51980157a92e1cd57e8)
+* test: assume integer datetimes for timestamp tests [PR 873](https://github.com/pgjdbc/pgjdbc/pull/873) [8287e7f9](https://github.com/pgjdbc/pgjdbc/commit/8287e7f92f890a41f8d2b51980157a92e1cd57e8)
 
 Vladimir Sitnikov (7):
 
@@ -39,9 +39,9 @@ Vladimir Sitnikov (7):
 * doc: fix anchors for "contributors to this release" [c1d743f2](https://github.com/pgjdbc/pgjdbc/commit/c1d743f2408df8b377bc9d8440717541a5b627e3)
 * test: fix StringTypeParameterTest to skip preferQueryMode=simple [beca1692](https://github.com/pgjdbc/pgjdbc/commit/beca16922b455a6a00c655df8a3b701d008aad6e)
 * chore: install PostgreSQL 9.1 to Trusty builds via apt, and use Precise for Java 6 [e960f237](https://github.com/pgjdbc/pgjdbc/commit/e960f2373a8de8b1b58fa199ee85a8b73ae684d2)
-* test: make StringTypeParameterTest 8.3+ since 8.2 misses enum types [PR#882](https://github.com/pgjdbc/pgjdbc/pull/882) [ed0014cc](https://github.com/pgjdbc/pgjdbc/commit/ed0014cc03cedde76003a84c06a4f7b95b823de0)
-* fix: named statements were used when fetchSize was non-zero and prepareThreshold=0 [PR#870](https://github.com/pgjdbc/pgjdbc/pull/870) [f0deabf7](https://github.com/pgjdbc/pgjdbc/commit/f0deabf7d87bb5bffeb84e9cd686eeb632aa9687)
-* test: skip ConcurrentStatementFetch for PostgreSQL < 8.4 [PR#884](https://github.com/pgjdbc/pgjdbc/pull/884) [5334cb6e](https://github.com/pgjdbc/pgjdbc/commit/5334cb6ef7554bba255f00baf4ff3220f16e31ea)
+* test: make StringTypeParameterTest 8.3+ since 8.2 misses enum types [PR 882](https://github.com/pgjdbc/pgjdbc/pull/882) [ed0014cc](https://github.com/pgjdbc/pgjdbc/commit/ed0014cc03cedde76003a84c06a4f7b95b823de0)
+* fix: named statements were used when fetchSize was non-zero and prepareThreshold=0 [PR 870](https://github.com/pgjdbc/pgjdbc/pull/870) [f0deabf7](https://github.com/pgjdbc/pgjdbc/commit/f0deabf7d87bb5bffeb84e9cd686eeb632aa9687)
+* test: skip ConcurrentStatementFetch for PostgreSQL < 8.4 [PR 884](https://github.com/pgjdbc/pgjdbc/pull/884) [5334cb6e](https://github.com/pgjdbc/pgjdbc/commit/5334cb6ef7554bba255f00baf4ff3220f16e31ea)
 
 <a name="contributors_{{ page.version }}"></a>
 ### Contributors to this release

--- a/docs/_posts/2018-01-17-42.2.0-release.md
+++ b/docs/_posts/2018-01-17-42.2.0-release.md
@@ -16,7 +16,7 @@ version: 42.2.0
 - Make SELECT INTO and CREATE TABLE AS return row counts to the client in their command tags. [Issue 958](https://github.com/pgjdbc/pgjdbc/issues/958) [PR 962](https://github.com/pgjdbc/pgjdbc/pull/962)
 - Support Subject Alternative Names for SSL connections. [PR 952](https://github.com/pgjdbc/pgjdbc/pull/952)
 - Support isAutoIncrement metadata for PostgreSQL 10 IDENTITY column. [PR 1004](https://github.com/pgjdbc/pgjdbc/pull/1004)
-- Support for primitive arrays [PR#887](https://github.com/pgjdbc/pgjdbc/pull/887) [3e0491a](https://github.com/pgjdbc/pgjdbc/commit/3e0491ac3833800721b98e7437635cf6ab338162)
+- Support for primitive arrays [PR 887](https://github.com/pgjdbc/pgjdbc/pull/887) [3e0491a](https://github.com/pgjdbc/pgjdbc/commit/3e0491ac3833800721b98e7437635cf6ab338162)
 - Implement support for get/setNetworkTimeout() in connections. [PR 849](https://github.com/pgjdbc/pgjdbc/pull/849)
 - Make GSS JAAS login optional, add an option "jaasLogin" [PR 922](https://github.com/pgjdbc/pgjdbc/pull/922) see [Connecting to the Database](https://jdbc.postgresql.org/documentation/head/connect.html)
 
@@ -47,93 +47,93 @@ version: 42.2.0
 
 AlexElin (9):
 
-* docs: fix header in CONTRIBUTING [PR#902](https://github.com/pgjdbc/pgjdbc/pull/902) [38ff0fe](https://github.com/pgjdbc/pgjdbc/commit/38ff0fe4728addf9a34d6fb0069ce4963aaae7ee)
-* refactor: remove dead code from PGStream, implement Closeable [PR#901](https://github.com/pgjdbc/pgjdbc/pull/901) [acff949](https://github.com/pgjdbc/pgjdbc/commit/acff9495b8745bce30d93d61e77caf81d9748b4b)
-* refactor: replace some usages of assertTrue [PR#957](https://github.com/pgjdbc/pgjdbc/pull/957) [c759a58](https://github.com/pgjdbc/pgjdbc/commit/c759a58313c4344924a311021e1c860580f3e318)
-* refactor: state of PGXAConnection as enum [PR#966](https://github.com/pgjdbc/pgjdbc/pull/966) [7618822](https://github.com/pgjdbc/pgjdbc/commit/76188228ddb412db74959fbe59b5c2d6ef5eddfc)
-* refactor: make PgStream implements Flushable [PR#1008](https://github.com/pgjdbc/pgjdbc/pull/1008) [0c3a2fc](https://github.com/pgjdbc/pgjdbc/commit/0c3a2fc132101f83dbb0990ac2c49c49b9c65ffe)
-* style: add MissingDeprecated into checkstyle [PR#1019](https://github.com/pgjdbc/pgjdbc/pull/1019) [d74386d](https://github.com/pgjdbc/pgjdbc/commit/d74386def0d39f450f5dcfdb21ff6171ba0a89f3)
-* chore: update checkstyle [PR#1025](https://github.com/pgjdbc/pgjdbc/pull/1025) [69e3b8b](https://github.com/pgjdbc/pgjdbc/commit/69e3b8b2ef7fb80ece8df23b55855fa4208e8a00)
-* refactor: simplify methods in ConnectionFactoryImpl [PR#1028](https://github.com/pgjdbc/pgjdbc/pull/1028) [ed27c5b](https://github.com/pgjdbc/pgjdbc/commit/ed27c5b464563448079189b1759ecf05d4726ea0)
-* refactor: replace some usages of initCause [PR#1037](https://github.com/pgjdbc/pgjdbc/pull/1037) [0c29823](https://github.com/pgjdbc/pgjdbc/commit/0c29823ad8eca86e3b8f27bcee5f116d41e367f9)
+* docs: fix header in CONTRIBUTING [PR 902](https://github.com/pgjdbc/pgjdbc/pull/902) [38ff0fe](https://github.com/pgjdbc/pgjdbc/commit/38ff0fe4728addf9a34d6fb0069ce4963aaae7ee)
+* refactor: remove dead code from PGStream, implement Closeable [PR 901](https://github.com/pgjdbc/pgjdbc/pull/901) [acff949](https://github.com/pgjdbc/pgjdbc/commit/acff9495b8745bce30d93d61e77caf81d9748b4b)
+* refactor: replace some usages of assertTrue [PR 957](https://github.com/pgjdbc/pgjdbc/pull/957) [c759a58](https://github.com/pgjdbc/pgjdbc/commit/c759a58313c4344924a311021e1c860580f3e318)
+* refactor: state of PGXAConnection as enum [PR 966](https://github.com/pgjdbc/pgjdbc/pull/966) [7618822](https://github.com/pgjdbc/pgjdbc/commit/76188228ddb412db74959fbe59b5c2d6ef5eddfc)
+* refactor: make PgStream implements Flushable [PR 1008](https://github.com/pgjdbc/pgjdbc/pull/1008) [0c3a2fc](https://github.com/pgjdbc/pgjdbc/commit/0c3a2fc132101f83dbb0990ac2c49c49b9c65ffe)
+* style: add MissingDeprecated into checkstyle [PR 1019](https://github.com/pgjdbc/pgjdbc/pull/1019) [d74386d](https://github.com/pgjdbc/pgjdbc/commit/d74386def0d39f450f5dcfdb21ff6171ba0a89f3)
+* chore: update checkstyle [PR 1025](https://github.com/pgjdbc/pgjdbc/pull/1025) [69e3b8b](https://github.com/pgjdbc/pgjdbc/commit/69e3b8b2ef7fb80ece8df23b55855fa4208e8a00)
+* refactor: simplify methods in ConnectionFactoryImpl [PR 1028](https://github.com/pgjdbc/pgjdbc/pull/1028) [ed27c5b](https://github.com/pgjdbc/pgjdbc/commit/ed27c5b464563448079189b1759ecf05d4726ea0)
+* refactor: replace some usages of initCause [PR 1037](https://github.com/pgjdbc/pgjdbc/pull/1037) [0c29823](https://github.com/pgjdbc/pgjdbc/commit/0c29823ad8eca86e3b8f27bcee5f116d41e367f9)
 
 Álvaro Hernández Tortosa (1):
 
-* Add SCRAM-SHA-256 support [PR#842](https://github.com/pgjdbc/pgjdbc/pull/842) [befea18](https://github.com/pgjdbc/pgjdbc/commit/befea18d153dda7814daef4e036d3f5daf8de1e5)
+* Add SCRAM-SHA-256 support [PR 842](https://github.com/pgjdbc/pgjdbc/pull/842) [befea18](https://github.com/pgjdbc/pgjdbc/commit/befea18d153dda7814daef4e036d3f5daf8de1e5)
 
 Barnabas Bodnar (1):
 
-* fix: don't attempt to read a SQLXML more than once [PR#965](https://github.com/pgjdbc/pgjdbc/pull/965) [8f5e245](https://github.com/pgjdbc/pgjdbc/commit/8f5e2454185a929f1bc6ef66813d6681bb38e736)
+* fix: don't attempt to read a SQLXML more than once [PR 965](https://github.com/pgjdbc/pgjdbc/pull/965) [8f5e245](https://github.com/pgjdbc/pgjdbc/commit/8f5e2454185a929f1bc6ef66813d6681bb38e736)
 
 Brett Okken (1):
 
-* feat: primitive arrays [PR#887](https://github.com/pgjdbc/pgjdbc/pull/887) [3e0491a](https://github.com/pgjdbc/pgjdbc/commit/3e0491ac3833800721b98e7437635cf6ab338162)
+* feat: primitive arrays [PR 887](https://github.com/pgjdbc/pgjdbc/pull/887) [3e0491a](https://github.com/pgjdbc/pgjdbc/commit/3e0491ac3833800721b98e7437635cf6ab338162)
 
 Brett Wooldridge (1):
 
-* Fixes #638 Implement support for get/setNetworkTimeout() [PR#849](https://github.com/pgjdbc/pgjdbc/pull/849) [8a30044](https://github.com/pgjdbc/pgjdbc/commit/8a30044d9e97c1038ee4401ae745d37a11f008db)
+* Fixes #638 Implement support for get/setNetworkTimeout() [PR 849](https://github.com/pgjdbc/pgjdbc/pull/849) [8a30044](https://github.com/pgjdbc/pgjdbc/commit/8a30044d9e97c1038ee4401ae745d37a11f008db)
 
 Chen Huajun (1):
 
-* fix: improve multihost connection for preferSlave case (verify expired hosts before connecting to cached master) [PR#844](https://github.com/pgjdbc/pgjdbc/pull/844) [c6fec34](https://github.com/pgjdbc/pgjdbc/commit/c6fec34661b51cd9cbee157d0c334a3ab29859e8)
+* fix: improve multihost connection for preferSlave case (verify expired hosts before connecting to cached master) [PR 844](https://github.com/pgjdbc/pgjdbc/pull/844) [c6fec34](https://github.com/pgjdbc/pgjdbc/commit/c6fec34661b51cd9cbee157d0c334a3ab29859e8)
 
 Dave Cramer (11):
 
-* Update thread safety status of the driver to reflect reality; that being that the driver is not thread safe [PR#928](https://github.com/pgjdbc/pgjdbc/pull/928) [ad47aba](https://github.com/pgjdbc/pgjdbc/commit/ad47abafa1754f8d0f2126ef1d26aa9b037b49e5)
-* fix: use 00:00:00 and 24:00:00 for LocalTime.MIN/MAX [PR#992](https://github.com/pgjdbc/pgjdbc/pull/992) [f2d8ec5](https://github.com/pgjdbc/pgjdbc/commit/f2d8ec5740aa26c417d666a7afedaaf0fdf62d37)
-* fix: support Subject Alternative Names for SSL connections [PR#952](https://github.com/pgjdbc/pgjdbc/pull/952) [2dcb91e](https://github.com/pgjdbc/pgjdbc/commit/2dcb91ef1fd8f0fe08f107c9c30cdc57d4c44b05)
-* test: Appveyor configuration [PR#1000](https://github.com/pgjdbc/pgjdbc/pull/1000) [059628f](https://github.com/pgjdbc/pgjdbc/commit/059628fcdf2058cfd05cb80eac64799ca26ad0d2)
-* add test for identity, fix isAutoincrement in postgresql 10 fixes #130 [PR#1004](https://github.com/pgjdbc/pgjdbc/pull/1004) [2f6633b](https://github.com/pgjdbc/pgjdbc/commit/2f6633bd9e1e9d7f313ea4dfec37f9671fc07453)
-* elaborate on sslmode options [PR#1054](https://github.com/pgjdbc/pgjdbc/pull/1054) [aa7a420](https://github.com/pgjdbc/pgjdbc/commit/aa7a4202e41bc58c4958e06161c5fd4daa36a7f9)
-* prefer the word secondary over slave [PR#1063](https://github.com/pgjdbc/pgjdbc/pull/1063) [2e8c2b6](https://github.com/pgjdbc/pgjdbc/commit/2e8c2b67e22ddaa38894be4b2578ccd4bf97a27d)
-* Revert "refactor: replace some usages of initCause [PR#1037](https://github.com/pgjdbc/pgjdbc/pull/1037)" (#1064) [e6a1ecc](https://github.com/pgjdbc/pgjdbc/commit/e6a1eccb148c3c59e8cf122e98ad01afc5bb555a)
-* prefer secondary over slave referring to standby or secondary servers [PR#1070](https://github.com/pgjdbc/pgjdbc/pull/1070) [32c53902](https://github.com/pgjdbc/pgjdbc/commit/32c539020db3c940bae9b2a42425b1f23e864c73)
-* first pass at release notes and some fixes to previous notes [PR#1041](https://github.com/pgjdbc/pgjdbc/pull/1041) [a8260f5](https://github.com/pgjdbc/pgjdbc/commit/a8260f5d0e31d00c1b44d2b94f62d86a72e2b2d5)
+* Update thread safety status of the driver to reflect reality; that being that the driver is not thread safe [PR 928](https://github.com/pgjdbc/pgjdbc/pull/928) [ad47aba](https://github.com/pgjdbc/pgjdbc/commit/ad47abafa1754f8d0f2126ef1d26aa9b037b49e5)
+* fix: use 00:00:00 and 24:00:00 for LocalTime.MIN/MAX [PR 992](https://github.com/pgjdbc/pgjdbc/pull/992) [f2d8ec5](https://github.com/pgjdbc/pgjdbc/commit/f2d8ec5740aa26c417d666a7afedaaf0fdf62d37)
+* fix: support Subject Alternative Names for SSL connections [PR 952](https://github.com/pgjdbc/pgjdbc/pull/952) [2dcb91e](https://github.com/pgjdbc/pgjdbc/commit/2dcb91ef1fd8f0fe08f107c9c30cdc57d4c44b05)
+* test: Appveyor configuration [PR 1000](https://github.com/pgjdbc/pgjdbc/pull/1000) [059628f](https://github.com/pgjdbc/pgjdbc/commit/059628fcdf2058cfd05cb80eac64799ca26ad0d2)
+* add test for identity, fix isAutoincrement in postgresql 10 fixes #130 [PR 1004](https://github.com/pgjdbc/pgjdbc/pull/1004) [2f6633b](https://github.com/pgjdbc/pgjdbc/commit/2f6633bd9e1e9d7f313ea4dfec37f9671fc07453)
+* elaborate on sslmode options [PR 1054](https://github.com/pgjdbc/pgjdbc/pull/1054) [aa7a420](https://github.com/pgjdbc/pgjdbc/commit/aa7a4202e41bc58c4958e06161c5fd4daa36a7f9)
+* prefer the word secondary over slave [PR 1063](https://github.com/pgjdbc/pgjdbc/pull/1063) [2e8c2b6](https://github.com/pgjdbc/pgjdbc/commit/2e8c2b67e22ddaa38894be4b2578ccd4bf97a27d)
+* Revert "refactor: replace some usages of initCause [PR 1037](https://github.com/pgjdbc/pgjdbc/pull/1037)" (#1064) [e6a1ecc](https://github.com/pgjdbc/pgjdbc/commit/e6a1eccb148c3c59e8cf122e98ad01afc5bb555a)
+* prefer secondary over slave referring to standby or secondary servers [PR 1070](https://github.com/pgjdbc/pgjdbc/pull/1070) [32c53902](https://github.com/pgjdbc/pgjdbc/commit/32c539020db3c940bae9b2a42425b1f23e864c73)
+* first pass at release notes and some fixes to previous notes [PR 1041](https://github.com/pgjdbc/pgjdbc/pull/1041) [a8260f5](https://github.com/pgjdbc/pgjdbc/commit/a8260f5d0e31d00c1b44d2b94f62d86a72e2b2d5)
 * Update 2018-01-16-42.2.0-release.md [b36867f](https://github.com/pgjdbc/pgjdbc/commit/b36867f34719d2af559b60b6f63b2df036798231)
 
 Hugh Cole-Baker (1):
 
-* Make GSS JAAS login optional [PR#922](https://github.com/pgjdbc/pgjdbc/pull/922) [d7f0f27](https://github.com/pgjdbc/pgjdbc/commit/d7f0f271b73adbf0ae22146beea122e014d9f9f2)
+* Make GSS JAAS login optional [PR 922](https://github.com/pgjdbc/pgjdbc/pull/922) [d7f0f27](https://github.com/pgjdbc/pgjdbc/commit/d7f0f271b73adbf0ae22146beea122e014d9f9f2)
 
 Jeff Klukas (1):
 
-* fix: advance lastReceiveLSN on keepalive messages [PR#1038](https://github.com/pgjdbc/pgjdbc/pull/1038) [1be8a9e](https://github.com/pgjdbc/pgjdbc/commit/1be8a9ebafbfbcff118385a61a350745addcaf3d)
+* fix: advance lastReceiveLSN on keepalive messages [PR 1038](https://github.com/pgjdbc/pgjdbc/pull/1038) [1be8a9e](https://github.com/pgjdbc/pgjdbc/commit/1be8a9ebafbfbcff118385a61a350745addcaf3d)
 
 Joe Kutner (1):
 
-* fix: Added support for socksNonProxyHosts property [PR#975](https://github.com/pgjdbc/pgjdbc/pull/975) (#985) [9813c68](https://github.com/pgjdbc/pgjdbc/commit/9813c685cae2cbfbc561a6220ba388cef08f34b0)
+* fix: Added support for socksNonProxyHosts property [PR 975](https://github.com/pgjdbc/pgjdbc/pull/975) (#985) [9813c68](https://github.com/pgjdbc/pgjdbc/commit/9813c685cae2cbfbc561a6220ba388cef08f34b0)
 
 Jorge Solorzano (13):
 
-* chore: use mainly Trusty in Travis, reorder CI jobs, and jdk tests [PR#939](https://github.com/pgjdbc/pgjdbc/pull/939) [646a868](https://github.com/pgjdbc/pgjdbc/commit/646a868c0bc80def5fa62374e83b71d65fef9a14)
-* fix: ignore replication test until 11.1 to avoid random failures [PR#949](https://github.com/pgjdbc/pgjdbc/pull/949) [ee6443d](https://github.com/pgjdbc/pgjdbc/commit/ee6443db167da735f5a9402d16f31c3ee6d719dc)
-* chore: streamlining jobs [PR#959](https://github.com/pgjdbc/pgjdbc/pull/959) [ed0a398](https://github.com/pgjdbc/pgjdbc/commit/ed0a398edb47d0eea62e7f53723e14d9ed278fbb)
-* docs: move changelog to separate file [PR#956](https://github.com/pgjdbc/pgjdbc/pull/956) [e67e8f9](https://github.com/pgjdbc/pgjdbc/commit/e67e8f9685e6c8235134baedeb790f39de39e77c)
-* docs: improve website front page [PR#968](https://github.com/pgjdbc/pgjdbc/pull/968) [65170f1](https://github.com/pgjdbc/pgjdbc/commit/65170f1690bb571c8dbe0425b205ba8498c8173f)
-* docs: fix test db password in docs [PR#984](https://github.com/pgjdbc/pgjdbc/pull/984) [7df56f8](https://github.com/pgjdbc/pgjdbc/commit/7df56f816770a7129cb56d150c6d556c64632a5c)
-* test: add openj9 to the matrix [PR#974](https://github.com/pgjdbc/pgjdbc/pull/974) [f187645](https://github.com/pgjdbc/pgjdbc/commit/f187645896e9f86a654390581163a7064b611404)
-* chore: remove testing of the latest Java updates [PR#993](https://github.com/pgjdbc/pgjdbc/pull/993) [0d8fde6](https://github.com/pgjdbc/pgjdbc/commit/0d8fde6da6dd28a14e12715a3b01d3787cac7fb8)
-* chore: updates to CHANGELOG.md in release_notes.sh [PR#981](https://github.com/pgjdbc/pgjdbc/pull/981) [bdfc1db](https://github.com/pgjdbc/pgjdbc/commit/bdfc1dbb45315d659a49c1ef7a831ca2d6326be4)
-* test: querymode extendedCacheEverything [PR#1007](https://github.com/pgjdbc/pgjdbc/pull/1007) [f574285](https://github.com/pgjdbc/pgjdbc/commit/f5742853b6d79cc20f718339855904c1384c59cd)
-* fix: first composite query not calling getNativeSql() [PR#1020](https://github.com/pgjdbc/pgjdbc/pull/1020) [2cae5a1](https://github.com/pgjdbc/pgjdbc/commit/2cae5a199c2d08768ea9f784ee3f60cef244c4b0)
-* drop old and unused crypt auth [PR#1026](https://github.com/pgjdbc/pgjdbc/pull/1026) [405f14e](https://github.com/pgjdbc/pgjdbc/commit/405f14eefc9d7e01bfaa1b526f1a6a0bac50d3c4)
-* chore: collect coverage for Java 7 [PR#1030](https://github.com/pgjdbc/pgjdbc/pull/1030) [b629934](https://github.com/pgjdbc/pgjdbc/commit/b6299347e15ea2a40c80de9907ae3f137caa4401)
+* chore: use mainly Trusty in Travis, reorder CI jobs, and jdk tests [PR 939](https://github.com/pgjdbc/pgjdbc/pull/939) [646a868](https://github.com/pgjdbc/pgjdbc/commit/646a868c0bc80def5fa62374e83b71d65fef9a14)
+* fix: ignore replication test until 11.1 to avoid random failures [PR 949](https://github.com/pgjdbc/pgjdbc/pull/949) [ee6443d](https://github.com/pgjdbc/pgjdbc/commit/ee6443db167da735f5a9402d16f31c3ee6d719dc)
+* chore: streamlining jobs [PR 959](https://github.com/pgjdbc/pgjdbc/pull/959) [ed0a398](https://github.com/pgjdbc/pgjdbc/commit/ed0a398edb47d0eea62e7f53723e14d9ed278fbb)
+* docs: move changelog to separate file [PR 956](https://github.com/pgjdbc/pgjdbc/pull/956) [e67e8f9](https://github.com/pgjdbc/pgjdbc/commit/e67e8f9685e6c8235134baedeb790f39de39e77c)
+* docs: improve website front page [PR 968](https://github.com/pgjdbc/pgjdbc/pull/968) [65170f1](https://github.com/pgjdbc/pgjdbc/commit/65170f1690bb571c8dbe0425b205ba8498c8173f)
+* docs: fix test db password in docs [PR 984](https://github.com/pgjdbc/pgjdbc/pull/984) [7df56f8](https://github.com/pgjdbc/pgjdbc/commit/7df56f816770a7129cb56d150c6d556c64632a5c)
+* test: add openj9 to the matrix [PR 974](https://github.com/pgjdbc/pgjdbc/pull/974) [f187645](https://github.com/pgjdbc/pgjdbc/commit/f187645896e9f86a654390581163a7064b611404)
+* chore: remove testing of the latest Java updates [PR 993](https://github.com/pgjdbc/pgjdbc/pull/993) [0d8fde6](https://github.com/pgjdbc/pgjdbc/commit/0d8fde6da6dd28a14e12715a3b01d3787cac7fb8)
+* chore: updates to CHANGELOG.md in release_notes.sh [PR 981](https://github.com/pgjdbc/pgjdbc/pull/981) [bdfc1db](https://github.com/pgjdbc/pgjdbc/commit/bdfc1dbb45315d659a49c1ef7a831ca2d6326be4)
+* test: querymode extendedCacheEverything [PR 1007](https://github.com/pgjdbc/pgjdbc/pull/1007) [f574285](https://github.com/pgjdbc/pgjdbc/commit/f5742853b6d79cc20f718339855904c1384c59cd)
+* fix: first composite query not calling getNativeSql() [PR 1020](https://github.com/pgjdbc/pgjdbc/pull/1020) [2cae5a1](https://github.com/pgjdbc/pgjdbc/commit/2cae5a199c2d08768ea9f784ee3f60cef244c4b0)
+* drop old and unused crypt auth [PR 1026](https://github.com/pgjdbc/pgjdbc/pull/1026) [405f14e](https://github.com/pgjdbc/pgjdbc/commit/405f14eefc9d7e01bfaa1b526f1a6a0bac50d3c4)
+* chore: collect coverage for Java 7 [PR 1030](https://github.com/pgjdbc/pgjdbc/pull/1030) [b629934](https://github.com/pgjdbc/pgjdbc/commit/b6299347e15ea2a40c80de9907ae3f137caa4401)
 
 Magnus (1):
 
-* fix: make warnings available as soon as they are received [PR#857](https://github.com/pgjdbc/pgjdbc/pull/857) [83dd5fe](https://github.com/pgjdbc/pgjdbc/commit/83dd5fea94928b349e05c1417e264797052f2bbe)
+* fix: make warnings available as soon as they are received [PR 857](https://github.com/pgjdbc/pgjdbc/pull/857) [83dd5fe](https://github.com/pgjdbc/pgjdbc/commit/83dd5fea94928b349e05c1417e264797052f2bbe)
 
 Magnus Hagander (1):
 
-* Fix documentation spelling of sslpasswordcallback [PR#1021](https://github.com/pgjdbc/pgjdbc/pull/1021) [8ba5841](https://github.com/pgjdbc/pgjdbc/commit/8ba58418ae10f80530f67f0c8628161011c5a228)
+* Fix documentation spelling of sslpasswordcallback [PR 1021](https://github.com/pgjdbc/pgjdbc/pull/1021) [8ba5841](https://github.com/pgjdbc/pgjdbc/commit/8ba58418ae10f80530f67f0c8628161011c5a228)
 
 MichaelZg (1):
 
-* fix: trim trailing zeros in timestamp strings returned in binary mode [PR#896](https://github.com/pgjdbc/pgjdbc/pull/896) [d28deff](https://github.com/pgjdbc/pgjdbc/commit/d28deff57684349707d2b2a357048f59b0861bb1)
+* fix: trim trailing zeros in timestamp strings returned in binary mode [PR 896](https://github.com/pgjdbc/pgjdbc/pull/896) [d28deff](https://github.com/pgjdbc/pgjdbc/commit/d28deff57684349707d2b2a357048f59b0861bb1)
 
 Michael Glaesemann (1):
 
-* refactor: use TypeInfo getPGArrayType instead of munging type name [PR#913](https://github.com/pgjdbc/pgjdbc/pull/913) [634e157](https://github.com/pgjdbc/pgjdbc/commit/634e157e4cdbc2f78f1a90ac4d9f538f39caf4f9)
+* refactor: use TypeInfo getPGArrayType instead of munging type name [PR 913](https://github.com/pgjdbc/pgjdbc/pull/913) [634e157](https://github.com/pgjdbc/pgjdbc/commit/634e157e4cdbc2f78f1a90ac4d9f538f39caf4f9)
 
 Pavel Raiskup (2):
 
@@ -142,82 +142,82 @@ Pavel Raiskup (2):
 
 Philippe Marschall (2):
 
-* feat: improve ResultSet#getObject(int, Class) [PR#932](https://github.com/pgjdbc/pgjdbc/pull/932) [fcb28c7](https://github.com/pgjdbc/pgjdbc/commit/fcb28c7c87a18ba6673b7fd3a48f3421410eb942)
-* test: add ubenchmark for UTF-8 decoding [PR#988](https://github.com/pgjdbc/pgjdbc/pull/988) [0d918c3](https://github.com/pgjdbc/pgjdbc/commit/0d918c3b21ba2a368da34bd30668908723dc4d36)
+* feat: improve ResultSet#getObject(int, Class) [PR 932](https://github.com/pgjdbc/pgjdbc/pull/932) [fcb28c7](https://github.com/pgjdbc/pgjdbc/commit/fcb28c7c87a18ba6673b7fd3a48f3421410eb942)
+* test: add ubenchmark for UTF-8 decoding [PR 988](https://github.com/pgjdbc/pgjdbc/pull/988) [0d918c3](https://github.com/pgjdbc/pgjdbc/commit/0d918c3b21ba2a368da34bd30668908723dc4d36)
 
 Piyush Sharma (1):
 
-* doc: Added quotes to URL in '@see' tag over org.postgresql.sspi.NTDSAPI#DsMakeSpnW for syntactic correctness [PR#926](https://github.com/pgjdbc/pgjdbc/pull/926) [29f574a](https://github.com/pgjdbc/pgjdbc/commit/29f574a0116ab93eade3c80e2db20573390a6a31)
+* doc: Added quotes to URL in '@see' tag over org.postgresql.sspi.NTDSAPI#DsMakeSpnW for syntactic correctness [PR 926](https://github.com/pgjdbc/pgjdbc/pull/926) [29f574a](https://github.com/pgjdbc/pgjdbc/commit/29f574a0116ab93eade3c80e2db20573390a6a31)
 
 Sehrope Sarkuni (1):
 
-* feat: parse command complete message via regex [PR#962](https://github.com/pgjdbc/pgjdbc/pull/962) [097db5e](https://github.com/pgjdbc/pgjdbc/commit/097db5e70ae8bf193c736b11603332feadb8d544)
+* feat: parse command complete message via regex [PR 962](https://github.com/pgjdbc/pgjdbc/pull/962) [097db5e](https://github.com/pgjdbc/pgjdbc/commit/097db5e70ae8bf193c736b11603332feadb8d544)
 
 Thach Hoang (2):
 
-* Update ServerVersionTest to actually compare versions [PR#1015](https://github.com/pgjdbc/pgjdbc/pull/1015) [cccd6cd](https://github.com/pgjdbc/pgjdbc/commit/cccd6cde4672de30ac0bbac6621b63e81aae9474)
-* fix: always return Short[] for java.sql.Array.getArray() on smallint[] [PR#1017](https://github.com/pgjdbc/pgjdbc/pull/1017) [279fb43](https://github.com/pgjdbc/pgjdbc/commit/279fb435b392114c45266ecef901bfd59470842a)
+* Update ServerVersionTest to actually compare versions [PR 1015](https://github.com/pgjdbc/pgjdbc/pull/1015) [cccd6cd](https://github.com/pgjdbc/pgjdbc/commit/cccd6cde4672de30ac0bbac6621b63e81aae9474)
+* fix: always return Short[] for java.sql.Array.getArray() on smallint[] [PR 1017](https://github.com/pgjdbc/pgjdbc/pull/1017) [279fb43](https://github.com/pgjdbc/pgjdbc/commit/279fb435b392114c45266ecef901bfd59470842a)
 
 Vladimir Sitnikov (23):
 
-* fix: reintroduce Driver.getVersion for backward compatibility reasons [PR#905](https://github.com/pgjdbc/pgjdbc/pull/905) [50d5dd3](https://github.com/pgjdbc/pgjdbc/commit/50d5dd3e708a92602e04d6b4aa0822ad3f110a78)
-* style: make PGReplicationStream, LargeObject implement AutoCloseable for Java 7+ [PR#1016](https://github.com/pgjdbc/pgjdbc/pull/1016) [9f07c9a](https://github.com/pgjdbc/pgjdbc/commit/9f07c9ae2eb0c1ec18455e3a3d66460dd264c790)
-* fix: prevent statement hang in case close() called when query is in progress [PR#1022](https://github.com/pgjdbc/pgjdbc/pull/1022) [04c5dbb](https://github.com/pgjdbc/pgjdbc/commit/04c5dbb5058008a8ddad0194156af9819595c315)
+* fix: reintroduce Driver.getVersion for backward compatibility reasons [PR 905](https://github.com/pgjdbc/pgjdbc/pull/905) [50d5dd3](https://github.com/pgjdbc/pgjdbc/commit/50d5dd3e708a92602e04d6b4aa0822ad3f110a78)
+* style: make PGReplicationStream, LargeObject implement AutoCloseable for Java 7+ [PR 1016](https://github.com/pgjdbc/pgjdbc/pull/1016) [9f07c9a](https://github.com/pgjdbc/pgjdbc/commit/9f07c9ae2eb0c1ec18455e3a3d66460dd264c790)
+* fix: prevent statement hang in case close() called when query is in progress [PR 1022](https://github.com/pgjdbc/pgjdbc/pull/1022) [04c5dbb](https://github.com/pgjdbc/pgjdbc/commit/04c5dbb5058008a8ddad0194156af9819595c315)
 * fix: synchronize Statement#result field access to make #close() more thread-safe [4139248](https://github.com/pgjdbc/pgjdbc/commit/41392481d5f2c7f89d783a535ade2d3afb565654)
-* fix: avoid reflective access to TimeZone.defaultTimeZone in Java 9+ [PR#1002](https://github.com/pgjdbc/pgjdbc/pull/1002) [fd0eeee](https://github.com/pgjdbc/pgjdbc/commit/fd0eeee8f123b1355b523425a1e11fdd59b057a5)
+* fix: avoid reflective access to TimeZone.defaultTimeZone in Java 9+ [PR 1002](https://github.com/pgjdbc/pgjdbc/pull/1002) [fd0eeee](https://github.com/pgjdbc/pgjdbc/commit/fd0eeee8f123b1355b523425a1e11fdd59b057a5)
 * fix: throw TOO_MANY_RESULTS (0100E) instead of "PgResultSet: tuples must be non-null" [0d31d46](https://github.com/pgjdbc/pgjdbc/commit/0d31d46adff4e9772db843195e1638531bc703e0)
-* fix: "Received resultset tuples, but no field structure for them" when bind failure happens on 5th execution of a statement [PR#811](https://github.com/pgjdbc/pgjdbc/pull/811) [082d009](https://github.com/pgjdbc/pgjdbc/commit/082d00941ad5f8abf44a0785a6f086c106b3c746)
+* fix: "Received resultset tuples, but no field structure for them" when bind failure happens on 5th execution of a statement [PR 811](https://github.com/pgjdbc/pgjdbc/pull/811) [082d009](https://github.com/pgjdbc/pgjdbc/commit/082d00941ad5f8abf44a0785a6f086c106b3c746)
 * tests: correct assertion to use proper column [63918eb](https://github.com/pgjdbc/pgjdbc/commit/63918eb9b1211e0115c8b55401e22c7a3f37e534)
 * fix: add type parameter so code is Java 6/7 compatible [1361c52](https://github.com/pgjdbc/pgjdbc/commit/1361c5208d6afc5d54e4df1053c48cdb31df9038)
 * chore: avoid non-blocking IO for stdout to workaround "stdout: write error" in Travis [12bb084](https://github.com/pgjdbc/pgjdbc/commit/12bb084035a13c4fb690df93837b37e85354ebc4)
 * test: run Travis tests with non-default time zone [a3982b4](https://github.com/pgjdbc/pgjdbc/commit/a3982b474dd92cd32c8fb1b7dafbd28c853c4177)
-* fix: execute autosave/rollback savepoint via simple queries always to prevent "statement S_xx not exists" when autosaving [PR#955](https://github.com/pgjdbc/pgjdbc/pull/955) [684a699](https://github.com/pgjdbc/pgjdbc/commit/684a69920e08017c74ab4194d1a77067f544a28b)
+* fix: execute autosave/rollback savepoint via simple queries always to prevent "statement S_xx not exists" when autosaving [PR 955](https://github.com/pgjdbc/pgjdbc/pull/955) [684a699](https://github.com/pgjdbc/pgjdbc/commit/684a69920e08017c74ab4194d1a77067f544a28b)
 * fix: use 'time with time zone' and 'timestamp with time zone' values as is and avoid computation with user-provided/default Calendars [e8c43f3](https://github.com/pgjdbc/pgjdbc/commit/e8c43f36ab2a6843f37d27e7417a5214f7142084)
 * test: refactor SetObject310Test to use proper assertion messages and use less statements (make it faster) [be06946](https://github.com/pgjdbc/pgjdbc/commit/be06946f8b908536f4d659aaf6fc660bed339f67)
 * refactor: factor out receiveParameterStatus so all the ParameterStatus messages are handled in the same way [a94cfea](https://github.com/pgjdbc/pgjdbc/commit/a94cfeace5d66b4fe8d8fa3b16986baebaec2a11)
-* fix: add Provide-Capability OSGi manifest [PR#1029](https://github.com/pgjdbc/pgjdbc/pull/1029) [236805b](https://github.com/pgjdbc/pgjdbc/commit/236805bcaf0dd1d9df3542c5865a15b24375a01c)
+* fix: add Provide-Capability OSGi manifest [PR 1029](https://github.com/pgjdbc/pgjdbc/pull/1029) [236805b](https://github.com/pgjdbc/pgjdbc/commit/236805bcaf0dd1d9df3542c5865a15b24375a01c)
 * chore: update version to 42.2.0-SNAPSHOT to reflect the next release version [e27ee74](https://github.com/pgjdbc/pgjdbc/commit/e27ee740535a4034084d450cddefda2fbcb1b2af)
 * packaging: add missing maven-clean-plugin dependency [a2ed9b5](https://github.com/pgjdbc/pgjdbc/commit/a2ed9b50e304a3437f92b945217c19197226d53f)
 * chore: introduce release via Travis [acb9bdd](https://github.com/pgjdbc/pgjdbc/commit/acb9bddf36a8af6d1dd09857a6a05014c3e8849a)
 * chore: skip CI builds for tags; skip Fedora and extendedCacheEverything jobs when building pull requests [3ba3b63](https://github.com/pgjdbc/pgjdbc/commit/3ba3b6334761909183334a3be3af0aa8dc4798da)
-* fix: avoid NPE from getObject(..., Date.class) and getObject(..., Calendar.class) on null timestamps [PR#1071](https://github.com/pgjdbc/pgjdbc/pull/1071) [eb33c4c](https://github.com/pgjdbc/pgjdbc/commit/eb33c4c8e27d6df6ccd9c0a81eb119edeb069d55)
+* fix: avoid NPE from getObject(..., Date.class) and getObject(..., Calendar.class) on null timestamps [PR 1071](https://github.com/pgjdbc/pgjdbc/pull/1071) [eb33c4c](https://github.com/pgjdbc/pgjdbc/commit/eb33c4c8e27d6df6ccd9c0a81eb119edeb069d55)
 * test: add "as" to test queries so they work with PostgreSQL 8.3 [71b3c11](https://github.com/pgjdbc/pgjdbc/commit/71b3c118f6a9e125c06e58faa50bf54b6a8f3400)
 * docs: make pgjdbc's javadocs to inherit base Java documentation [eb406dc](https://github.com/pgjdbc/pgjdbc/commit/eb406dcbee469a8724723f008f7dc5a515457cbe)
 
 Zemian Deng (3):
 
-* refactor: use PGProperty enum instead of text ref for targetServerType, hostRecheckSeconds, loadBalanceHosts [PR#912](https://github.com/pgjdbc/pgjdbc/pull/912) (#915) [b0cfc33](https://github.com/pgjdbc/pgjdbc/commit/b0cfc33483759ed3583b57cd845311d17670524f)
-* fix: correct javadoc on PGResultSetMetaData.getFormat [PR#917](https://github.com/pgjdbc/pgjdbc/pull/917) [cd77693](https://github.com/pgjdbc/pgjdbc/commit/cd77693ca22924479a39b8d925f276879023672a)
-* fix: Correct DatabaseMetaData.getFunctions() implementation [PR#918](https://github.com/pgjdbc/pgjdbc/pull/918) [8884202](https://github.com/pgjdbc/pgjdbc/commit/8884202b9e7785a1eaf67ddcd97f2ba689d0cf19)
+* refactor: use PGProperty enum instead of text ref for targetServerType, hostRecheckSeconds, loadBalanceHosts [PR 912](https://github.com/pgjdbc/pgjdbc/pull/912) (#915) [b0cfc33](https://github.com/pgjdbc/pgjdbc/commit/b0cfc33483759ed3583b57cd845311d17670524f)
+* fix: correct javadoc on PGResultSetMetaData.getFormat [PR 917](https://github.com/pgjdbc/pgjdbc/pull/917) [cd77693](https://github.com/pgjdbc/pgjdbc/commit/cd77693ca22924479a39b8d925f276879023672a)
+* fix: Correct DatabaseMetaData.getFunctions() implementation [PR 918](https://github.com/pgjdbc/pgjdbc/pull/918) [8884202](https://github.com/pgjdbc/pgjdbc/commit/8884202b9e7785a1eaf67ddcd97f2ba689d0cf19)
 
 bpd0018 (3):
 
-* docs - change load.md to reflect current practice [PR#1058](https://github.com/pgjdbc/pgjdbc/pull/1058) [90535d9](https://github.com/pgjdbc/pgjdbc/commit/90535d9289141c398b2e62f2ee7571617c5aecc3)
-* docs: fix the URL regex [PR#1057](https://github.com/pgjdbc/pgjdbc/pull/1057) [6c5490f](https://github.com/pgjdbc/pgjdbc/commit/6c5490f90da434f37abd0be0f7bbdc38169ec33f)
-* docs: fix no parameter connect string example [PR#1056](https://github.com/pgjdbc/pgjdbc/pull/1056) [bb8a315](https://github.com/pgjdbc/pgjdbc/commit/bb8a31508f3caef7532b87b50c19e092af2ec5f0)
+* docs - change load.md to reflect current practice [PR 1058](https://github.com/pgjdbc/pgjdbc/pull/1058) [90535d9](https://github.com/pgjdbc/pgjdbc/commit/90535d9289141c398b2e62f2ee7571617c5aecc3)
+* docs: fix the URL regex [PR 1057](https://github.com/pgjdbc/pgjdbc/pull/1057) [6c5490f](https://github.com/pgjdbc/pgjdbc/commit/6c5490f90da434f37abd0be0f7bbdc38169ec33f)
+* docs: fix no parameter connect string example [PR 1056](https://github.com/pgjdbc/pgjdbc/pull/1056) [bb8a315](https://github.com/pgjdbc/pgjdbc/commit/bb8a31508f3caef7532b87b50c19e092af2ec5f0)
 
 djydewang (1):
 
-* style: disallowing user to use incomplete fully qualified Check names in config file [PR#961](https://github.com/pgjdbc/pgjdbc/pull/961) [3286c8c](https://github.com/pgjdbc/pgjdbc/commit/3286c8caa16efe59307b2713784c348e603ee67d)
+* style: disallowing user to use incomplete fully qualified Check names in config file [PR 961](https://github.com/pgjdbc/pgjdbc/pull/961) [3286c8c](https://github.com/pgjdbc/pgjdbc/commit/3286c8caa16efe59307b2713784c348e603ee67d)
 
 eperez (1):
 
-* Someone forgot to get the next column [PR#973](https://github.com/pgjdbc/pgjdbc/pull/973) [15aec6a](https://github.com/pgjdbc/pgjdbc/commit/15aec6a99c5615cdf0c0adaf5fc47b5419c617d4)
+* Someone forgot to get the next column [PR 973](https://github.com/pgjdbc/pgjdbc/pull/973) [15aec6a](https://github.com/pgjdbc/pgjdbc/commit/15aec6a99c5615cdf0c0adaf5fc47b5419c617d4)
 
 mjanczykowski (1):
 
-* feat: add setURL method to BaseDataSource [PR#999](https://github.com/pgjdbc/pgjdbc/pull/999) [2277ffb](https://github.com/pgjdbc/pgjdbc/commit/2277ffb7b65d3cba9ef05be36408e2fdbef00ee7)
+* feat: add setURL method to BaseDataSource [PR 999](https://github.com/pgjdbc/pgjdbc/pull/999) [2277ffb](https://github.com/pgjdbc/pgjdbc/commit/2277ffb7b65d3cba9ef05be36408e2fdbef00ee7)
 
 rnveach (1):
 
-* style: remove deprecated maxLineLength from LeftCurlyCheck [PR#904](https://github.com/pgjdbc/pgjdbc/pull/904) [5f083d1](https://github.com/pgjdbc/pgjdbc/commit/5f083d118eea30e180500864d70f292b411c19af)
+* style: remove deprecated maxLineLength from LeftCurlyCheck [PR 904](https://github.com/pgjdbc/pgjdbc/pull/904) [5f083d1](https://github.com/pgjdbc/pgjdbc/commit/5f083d118eea30e180500864d70f292b411c19af)
 
 steinarb (1):
 * fix: add Provide-Capability org.osgi.service.jdbc.DataSourceFactory to OSGi manifest [Issue 1029](https://github.com/pgjdbc/pgjdbc/issues/1029)
 
 zapov (1):
 
-* fix: avoid integer overflow when sending large arguments [PR#946](https://github.com/pgjdbc/pgjdbc/pull/946) [266ed61](https://github.com/pgjdbc/pgjdbc/commit/266ed61b30e89c2840b7967a8af7ac8ab86407ff)
+* fix: avoid integer overflow when sending large arguments [PR 946](https://github.com/pgjdbc/pgjdbc/pull/946) [266ed61](https://github.com/pgjdbc/pgjdbc/commit/266ed61b30e89c2840b7967a8af7ac8ab86407ff)
 
 <a name="contributors_{{ page.version }}"></a>
 ### Contributors to this release

--- a/docs/_posts/2018-01-25-42.2.1-release.md
+++ b/docs/_posts/2018-01-25-42.2.1-release.md
@@ -15,7 +15,7 @@ version: 42.2.1
 
 ### Fixed
 - Avoid connection failure when `DateStyle` is set to `ISO` (~PgBouncer) [Issue 1080](https://github.com/pgjdbc/pgjdbc/issues/1080)
-- Package scram:client classes, so SCRAM works when using a shaded jar [PR#1091](https://github.com/pgjdbc/pgjdbc/pull/1091) [1a89290e](https://github.com/pgjdbc/pgjdbc/commit/1a89290e110d5863b35e0a2ccf79e4292c1056f8)
+- Package scram:client classes, so SCRAM works when using a shaded jar [PR 1091](https://github.com/pgjdbc/pgjdbc/pull/1091) [1a89290e](https://github.com/pgjdbc/pgjdbc/commit/1a89290e110d5863b35e0a2ccf79e4292c1056f8)
 - reWriteBatchedInserts=true causes syntax error with ON CONFLICT [Issue 1045](https://github.com/pgjdbc/pgjdbc/issues/1045) [PR 1082](https://github.com/pgjdbc/pgjdbc/pull/1082)
 - Avoid failure in getPGArrayType when stringType=unspecified [PR 1036](https://github.com/pgjdbc/pgjdbc/pull/1036)
 
@@ -26,32 +26,32 @@ version: 42.2.1
 
 AlexElin (1):
 
-* test: check if url is not for PostgreSQL [PR#1077](https://github.com/pgjdbc/pgjdbc/pull/1077) [fe463bce](https://github.com/pgjdbc/pgjdbc/commit/fe463bceb3d6449443bd5e6abf2929516effccff)
+* test: check if url is not for PostgreSQL [PR 1077](https://github.com/pgjdbc/pgjdbc/pull/1077) [fe463bce](https://github.com/pgjdbc/pgjdbc/commit/fe463bceb3d6449443bd5e6abf2929516effccff)
 
 Alexander Kjäll (1):
 
-* feat: add support for fetching 'TIMESTAMP(6) WITHOUT TIME ZONE' as LocalDate to getObject() [PR#1083](https://github.com/pgjdbc/pgjdbc/pull/1083) [09af4b23](https://github.com/pgjdbc/pgjdbc/commit/09af4b23ad589e3691314e955c130a8755436e2d)
+* feat: add support for fetching 'TIMESTAMP(6) WITHOUT TIME ZONE' as LocalDate to getObject() [PR 1083](https://github.com/pgjdbc/pgjdbc/pull/1083) [09af4b23](https://github.com/pgjdbc/pgjdbc/commit/09af4b23ad589e3691314e955c130a8755436e2d)
 
 Dave Cramer (1):
 
-* fix: package scram:client classes, so SCRAM works when using a shaded jar [PR#1091](https://github.com/pgjdbc/pgjdbc/pull/1091) [1a89290e](https://github.com/pgjdbc/pgjdbc/commit/1a89290e110d5863b35e0a2ccf79e4292c1056f8)
+* fix: package scram:client classes, so SCRAM works when using a shaded jar [PR 1091](https://github.com/pgjdbc/pgjdbc/pull/1091) [1a89290e](https://github.com/pgjdbc/pgjdbc/commit/1a89290e110d5863b35e0a2ccf79e4292c1056f8)
 
 Ivan (2):
 
-* chore: remove braces for LeftCurlyCheck checkstyle [PR#1075](https://github.com/pgjdbc/pgjdbc/pull/1075) [c2664b44](https://github.com/pgjdbc/pgjdbc/commit/c2664b444ffa1390d0dd5e4104d4200823d145ba)
-* chore: remove additional braces for LeftCurlyCheck checkstyle [PR#1076](https://github.com/pgjdbc/pgjdbc/pull/1076) [975aaf5a](https://github.com/pgjdbc/pgjdbc/commit/975aaf5ae489b3efeda3fd0241a4d39d260105cd)
+* chore: remove braces for LeftCurlyCheck checkstyle [PR 1075](https://github.com/pgjdbc/pgjdbc/pull/1075) [c2664b44](https://github.com/pgjdbc/pgjdbc/commit/c2664b444ffa1390d0dd5e4104d4200823d145ba)
+* chore: remove additional braces for LeftCurlyCheck checkstyle [PR 1076](https://github.com/pgjdbc/pgjdbc/pull/1076) [975aaf5a](https://github.com/pgjdbc/pgjdbc/commit/975aaf5ae489b3efeda3fd0241a4d39d260105cd)
 
 JCzogalla (1):
 
-* Fixes issue #1078 [PR#1079](https://github.com/pgjdbc/pgjdbc/pull/1079) [0d51370b](https://github.com/pgjdbc/pgjdbc/commit/0d51370b68cd26ccfa92b0bae4a66da1015cf9ee)
+* Fixes issue #1078 [PR 1079](https://github.com/pgjdbc/pgjdbc/pull/1079) [0d51370b](https://github.com/pgjdbc/pgjdbc/commit/0d51370b68cd26ccfa92b0bae4a66da1015cf9ee)
 
 Jamie Pullar (1):
 
-* fix: getPGArrayType fails in when stringType=unspecified [PR#1036](https://github.com/pgjdbc/pgjdbc/pull/1036) [d5f1cf7c](https://github.com/pgjdbc/pgjdbc/commit/d5f1cf7c35b05318947021d41e73b6953f623256)
+* fix: getPGArrayType fails in when stringType=unspecified [PR 1036](https://github.com/pgjdbc/pgjdbc/pull/1036) [d5f1cf7c](https://github.com/pgjdbc/pgjdbc/commit/d5f1cf7c35b05318947021d41e73b6953f623256)
 
 Jorge Solorzano (1):
 
-* Fix style changelog [PR#1089](https://github.com/pgjdbc/pgjdbc/pull/1089) [5ebd2090](https://github.com/pgjdbc/pgjdbc/commit/5ebd20900ebf7af5b55c56eac7f2fae6d40d9f5c)
+* Fix style changelog [PR 1089](https://github.com/pgjdbc/pgjdbc/pull/1089) [5ebd2090](https://github.com/pgjdbc/pgjdbc/commit/5ebd20900ebf7af5b55c56eac7f2fae6d40d9f5c)
 
 Pavel Raiskup (1):
 
@@ -60,8 +60,8 @@ Pavel Raiskup (1):
 Vladimir Sitnikov (3):
 
 * docs: reflect 42.2.0 release in readme.md [6d02e958](https://github.com/pgjdbc/pgjdbc/commit/6d02e9587e47921e66d8d029e5056bab72f15565)
-* fix: avoid connection failure when DateStyle is set to ISO [PR#1081](https://github.com/pgjdbc/pgjdbc/pull/1081) [e442db1f](https://github.com/pgjdbc/pgjdbc/commit/e442db1f064c78372f8312d65faee30842a68aea)
-* fix: reWriteBatchedInserts=true causes syntax error with ON CONFLICT [PR#1082](https://github.com/pgjdbc/pgjdbc/pull/1082) [e133510e](https://github.com/pgjdbc/pgjdbc/commit/e133510e70114db128784911b6790b5690d77320)
+* fix: avoid connection failure when DateStyle is set to ISO [PR 1081](https://github.com/pgjdbc/pgjdbc/pull/1081) [e442db1f](https://github.com/pgjdbc/pgjdbc/commit/e442db1f064c78372f8312d65faee30842a68aea)
+* fix: reWriteBatchedInserts=true causes syntax error with ON CONFLICT [PR 1082](https://github.com/pgjdbc/pgjdbc/pull/1082) [e133510e](https://github.com/pgjdbc/pgjdbc/commit/e133510e70114db128784911b6790b5690d77320)
 
 <a name="contributors_{{ page.version }}"></a>
 ### Contributors to this release

--- a/docs/_posts/2018-03-15-42.2.2-release.md
+++ b/docs/_posts/2018-03-15-42.2.2-release.md
@@ -30,54 +30,54 @@ Dave Cramer (5):
 * Update about.html [6fe76a3c](https://github.com/pgjdbc/pgjdbc/commit/6fe76a3c9289c78b2a8875e101020747584c36a7)
 * Update documentation.md [3b3fd8c9](https://github.com/pgjdbc/pgjdbc/commit/3b3fd8c90a4bdcde101f45ae255ca2fe30bac338)
 * Update documentation.md [a8ef9f96](https://github.com/pgjdbc/pgjdbc/commit/a8ef9f96feb02246a3d7967ada2ffe146778f7ed)
-* test: add Travis configuration to test SSL [PR#1095](https://github.com/pgjdbc/pgjdbc/pull/1095) [298683b1](https://github.com/pgjdbc/pgjdbc/commit/298683b1bd11a4b16cdba861c8ca93134cfb037b)
+* test: add Travis configuration to test SSL [PR 1095](https://github.com/pgjdbc/pgjdbc/pull/1095) [298683b1](https://github.com/pgjdbc/pgjdbc/commit/298683b1bd11a4b16cdba861c8ca93134cfb037b)
 
 Jorge Solorzano (1):
 
-* fix: improve DatabaseMetaData.getSQLKeywords() [PR#940](https://github.com/pgjdbc/pgjdbc/pull/940) [7a586b6e](https://github.com/pgjdbc/pgjdbc/commit/7a586b6e492e8911a928d50113a68569981fa731)
+* fix: improve DatabaseMetaData.getSQLKeywords() [PR 940](https://github.com/pgjdbc/pgjdbc/pull/940) [7a586b6e](https://github.com/pgjdbc/pgjdbc/commit/7a586b6e492e8911a928d50113a68569981fa731)
 
 Pawel (1):
 
-* Fixes #1096 [PR#1097](https://github.com/pgjdbc/pgjdbc/pull/1097) [df4e7fa0](https://github.com/pgjdbc/pgjdbc/commit/df4e7fa07c205e12f7fe5e3c80ab90ea63c1bc17)
+* Fixes #1096 [PR 1097](https://github.com/pgjdbc/pgjdbc/pull/1097) [df4e7fa0](https://github.com/pgjdbc/pgjdbc/commit/df4e7fa07c205e12f7fe5e3c80ab90ea63c1bc17)
 
 Selene Feigl (1):
 
-* fix: wrong data from Blob/Clob when mark/reset is used [PR#971](https://github.com/pgjdbc/pgjdbc/pull/971) [61e1c300](https://github.com/pgjdbc/pgjdbc/commit/61e1c300fb52237b05b7649d61603dd339fbdd9b)
+* fix: wrong data from Blob/Clob when mark/reset is used [PR 971](https://github.com/pgjdbc/pgjdbc/pull/971) [61e1c300](https://github.com/pgjdbc/pgjdbc/commit/61e1c300fb52237b05b7649d61603dd339fbdd9b)
 
 Simon Stelling (1):
 
-* fix: handle Timestamp values with fractional seconds < 1 microsecond correctly in PreparedStatement arguments [PR#1119](https://github.com/pgjdbc/pgjdbc/pull/1119) [8ff2a617](https://github.com/pgjdbc/pgjdbc/commit/8ff2a617c8a153eb364d8b762102b6b6b1cb53f8)
+* fix: handle Timestamp values with fractional seconds < 1 microsecond correctly in PreparedStatement arguments [PR 1119](https://github.com/pgjdbc/pgjdbc/pull/1119) [8ff2a617](https://github.com/pgjdbc/pgjdbc/commit/8ff2a617c8a153eb364d8b762102b6b6b1cb53f8)
 
 Vladimir Sitnikov (14):
 
 * docs: reflect 42.2.1 release in readme.md [1a4256b9](https://github.com/pgjdbc/pgjdbc/commit/1a4256b973da36c0fc42f0268e58e1535073247b)
 * chore: make sure TEST_CLIENTS performs regular tests as well [aa676bb3](https://github.com/pgjdbc/pgjdbc/commit/aa676bb39117dc47cbd51a236b232227e9128220)
 * chore: remove unused variable lastKnownTime in ConnectionFactoryImpl [48b98971](https://github.com/pgjdbc/pgjdbc/commit/48b98971d085a7988b67a31cf5ff9fb52c5534e5)
-* fix: ArrayIndexOutOfBoundsException when using the same SQL for regular and updateable resultset [PR#1123](https://github.com/pgjdbc/pgjdbc/pull/1123) [45c32bc6](https://github.com/pgjdbc/pgjdbc/commit/45c32bc6af2e140ff86dabd718344c74fc244394)
-* fix: support insert ... on conflict...update for reWriteBatchedInserts=true [PR#1130](https://github.com/pgjdbc/pgjdbc/pull/1130) [1ca0c586](https://github.com/pgjdbc/pgjdbc/commit/1ca0c5864a8b6c575b32aee03e2e1e8848fee143)
-* fix: allowEncodingChanges should allow set client_encoding=... [PR#1125](https://github.com/pgjdbc/pgjdbc/pull/1125) [af64ed2d](https://github.com/pgjdbc/pgjdbc/commit/af64ed2dac035c621b4aec4a0471730457725194)
-* tests: UUID vs setString test [PR#1133](https://github.com/pgjdbc/pgjdbc/pull/1133) [5827858b](https://github.com/pgjdbc/pgjdbc/commit/5827858ba5b72b519feb86fc65301a7bffa10c4d)
+* fix: ArrayIndexOutOfBoundsException when using the same SQL for regular and updateable resultset [PR 1123](https://github.com/pgjdbc/pgjdbc/pull/1123) [45c32bc6](https://github.com/pgjdbc/pgjdbc/commit/45c32bc6af2e140ff86dabd718344c74fc244394)
+* fix: support insert ... on conflict...update for reWriteBatchedInserts=true [PR 1130](https://github.com/pgjdbc/pgjdbc/pull/1130) [1ca0c586](https://github.com/pgjdbc/pgjdbc/commit/1ca0c5864a8b6c575b32aee03e2e1e8848fee143)
+* fix: allowEncodingChanges should allow set client_encoding=... [PR 1125](https://github.com/pgjdbc/pgjdbc/pull/1125) [af64ed2d](https://github.com/pgjdbc/pgjdbc/commit/af64ed2dac035c621b4aec4a0471730457725194)
+* tests: UUID vs setString test [PR 1133](https://github.com/pgjdbc/pgjdbc/pull/1133) [5827858b](https://github.com/pgjdbc/pgjdbc/commit/5827858ba5b72b519feb86fc65301a7bffa10c4d)
 * fix: UUID test for preferQueryMode=simple [44bb7f8d](https://github.com/pgjdbc/pgjdbc/commit/44bb7f8d66829705bf46a6cfcad8a179eb14e441)
-* fix: wrong results when a single statement is used with UNSPECIFIED types [PR#1137](https://github.com/pgjdbc/pgjdbc/pull/1137) [fcd1ea14](https://github.com/pgjdbc/pgjdbc/commit/fcd1ea14545a113fe4a124e17132824e279f572e)
+* fix: wrong results when a single statement is used with UNSPECIFIED types [PR 1137](https://github.com/pgjdbc/pgjdbc/pull/1137) [fcd1ea14](https://github.com/pgjdbc/pgjdbc/commit/fcd1ea14545a113fe4a124e17132824e279f572e)
 * test: workaround DST issue in StatementTest#testDateFunctions [af499625](https://github.com/pgjdbc/pgjdbc/commit/af499625fb99043fe0bf605ec4b23f3dd64c18d7)
-* docs: improve documentation and tests for server-side prepared statements [PR#1135](https://github.com/pgjdbc/pgjdbc/pull/1135) [4204f094](https://github.com/pgjdbc/pgjdbc/commit/4204f09446edbc7caaecb4c8cd7c8f78abd9344e)
-* test: make testAlternatingBindType Java 6-compatible [PR#1139](https://github.com/pgjdbc/pgjdbc/pull/1139) [bcdd4273](https://github.com/pgjdbc/pgjdbc/commit/bcdd4273bba7ae6b3348d47d4cdeb72e941d5acc)
-* fix: better support for RETURNING for WITH queries and queries with comments [PR#1138](https://github.com/pgjdbc/pgjdbc/pull/1138) [04e76661](https://github.com/pgjdbc/pgjdbc/commit/04e76661586b54157a1220552c005569231388a9)
+* docs: improve documentation and tests for server-side prepared statements [PR 1135](https://github.com/pgjdbc/pgjdbc/pull/1135) [4204f094](https://github.com/pgjdbc/pgjdbc/commit/4204f09446edbc7caaecb4c8cd7c8f78abd9344e)
+* test: make testAlternatingBindType Java 6-compatible [PR 1139](https://github.com/pgjdbc/pgjdbc/pull/1139) [bcdd4273](https://github.com/pgjdbc/pgjdbc/commit/bcdd4273bba7ae6b3348d47d4cdeb72e941d5acc)
+* fix: better support for RETURNING for WITH queries and queries with comments [PR 1138](https://github.com/pgjdbc/pgjdbc/pull/1138) [04e76661](https://github.com/pgjdbc/pgjdbc/commit/04e76661586b54157a1220552c005569231388a9)
 * chore: add contributor links to release script [2568d38e](https://github.com/pgjdbc/pgjdbc/commit/2568d38e5ff7c9b23f92011c7dc936c307f53008)
 
 bpd0018 (3):
 
-* docs: fix spelling and chapter, update sample code [PR#1098](https://github.com/pgjdbc/pgjdbc/pull/1098) [0cfffa84](https://github.com/pgjdbc/pgjdbc/commit/0cfffa841b9b8d2040fe6c576aa77edfd399bbc0)
-* style: spelling in comment [PR#1121](https://github.com/pgjdbc/pgjdbc/pull/1121) [cc219aa7](https://github.com/pgjdbc/pgjdbc/commit/cc219aa79b37f03432db4fe61e06b5f27fcb7f83)
-* docs: fix JavaDoc for getPreferQueryMode() [PR#1122](https://github.com/pgjdbc/pgjdbc/pull/1122) [43d80cd4](https://github.com/pgjdbc/pgjdbc/commit/43d80cd48a54ea91868d15bd2f3806b467519883)
+* docs: fix spelling and chapter, update sample code [PR 1098](https://github.com/pgjdbc/pgjdbc/pull/1098) [0cfffa84](https://github.com/pgjdbc/pgjdbc/commit/0cfffa841b9b8d2040fe6c576aa77edfd399bbc0)
+* style: spelling in comment [PR 1121](https://github.com/pgjdbc/pgjdbc/pull/1121) [cc219aa7](https://github.com/pgjdbc/pgjdbc/commit/cc219aa79b37f03432db4fe61e06b5f27fcb7f83)
+* docs: fix JavaDoc for getPreferQueryMode() [PR 1122](https://github.com/pgjdbc/pgjdbc/pull/1122) [43d80cd4](https://github.com/pgjdbc/pgjdbc/commit/43d80cd48a54ea91868d15bd2f3806b467519883)
 
 chalda (1):
 
-* Adjust XAException return codes for better compatibility with XA specification [PR#782](https://github.com/pgjdbc/pgjdbc/pull/782) [e5aab1cd](https://github.com/pgjdbc/pgjdbc/commit/e5aab1cd3e49051f46298d8f1fd9f66af1731299)
+* Adjust XAException return codes for better compatibility with XA specification [PR 782](https://github.com/pgjdbc/pgjdbc/pull/782) [e5aab1cd](https://github.com/pgjdbc/pgjdbc/commit/e5aab1cd3e49051f46298d8f1fd9f66af1731299)
 
 trtrmitya (1):
 
-* fix: use Locale.Category.DISPLAY (~lc_messages) when selecting resource bundle. [PR#1115](https://github.com/pgjdbc/pgjdbc/pull/1115) [0e9dfce4](https://github.com/pgjdbc/pgjdbc/commit/0e9dfce42c80391d0eefa830600e0ac4c1baae50)
+* fix: use Locale.Category.DISPLAY (~lc_messages) when selecting resource bundle. [PR 1115](https://github.com/pgjdbc/pgjdbc/pull/1115) [0e9dfce4](https://github.com/pgjdbc/pgjdbc/commit/0e9dfce42c80391d0eefa830600e0ac4c1baae50)
 
 <a name="contributors_{{ page.version }}"></a>
 ### Contributors to this release


### PR DESCRIPTION
This makes changelog consistent with "notable changes"