### PR TITLE
test: close of replication connection has not been fixed at backend side, so disable the test till 12.1

### DIFF
--- a/pgjdbc/src/test/java/org/postgresql/replication/LogicalReplicationTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/replication/LogicalReplicationTest.java
@@ -333,7 +333,7 @@ public class LogicalReplicationTest {
    * wait new changes and until waiting messages from client ignores.
    */
   @Test(timeout = 10000)
-  @HaveMinimalServerVersion("11.1")
+  @HaveMinimalServerVersion("12.1")
   public void testDuringSendBigTransactionConnectionCloseSlotStatusNotActive() throws Exception {
     PGConnection pgConnection = (PGConnection) replConnection;
 


### PR DESCRIPTION
See http://www.postgresql.org/message-id/CAFgjRd3hdYOa33m69TbeOfNNer2BZbwa8FFjt2V5VFzTBvUU3w@mail.gmail.com