### PR TITLE
perf: avoid autoboxing bind indexes

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/NativeQuery.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/NativeQuery.java
@@ -31,7 +31,7 @@ public class NativeQuery {
     this(nativeSql, NO_BINDS, true, dml);
   }
 
-  public NativeQuery(String nativeSql, int[] bindPositions, boolean multiStatement, SqlCommand dml) {
+  public NativeQuery(String nativeSql, int @Nullable [] bindPositions, boolean multiStatement, SqlCommand dml) {
     this.nativeSql = nativeSql;
     this.bindPositions =
         bindPositions == null || bindPositions.length == 0 ? NO_BINDS : bindPositions;

--- a/pgjdbc/src/main/java/org/postgresql/core/Parser.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/Parser.java
@@ -8,6 +8,7 @@ package org.postgresql.core;
 import org.postgresql.jdbc.EscapeSyntaxCallMode;
 import org.postgresql.jdbc.EscapedFunctions2;
 import org.postgresql.util.GT;
+import org.postgresql.util.IntList;
 import org.postgresql.util.PSQLException;
 import org.postgresql.util.PSQLState;
 
@@ -28,8 +29,6 @@ import java.util.List;
  * @author Christopher Deckers (chrriis@gmail.com)
  */
 public class Parser {
-  private static final int[] NO_BINDS = new int[0];
-
   /**
    * Parses JDBC query into PostgreSQL's native format. Several queries might be given if separated
    * by semicolon.
@@ -62,7 +61,7 @@ public class Parser {
     char[] aChars = query.toCharArray();
 
     StringBuilder nativeSql = new StringBuilder(query.length() + 10);
-    List<Integer> bindPositions = null; // initialized on demand
+    IntList bindPositions = null; // initialized on demand
     List<NativeQuery> nativeQueries = null;
     boolean isCurrentReWriteCompatible = false;
     boolean isValuesFound = false;
@@ -135,7 +134,7 @@ public class Parser {
               nativeSql.append('?');
             } else {
               if (bindPositions == null) {
-                bindPositions = new ArrayList<Integer>();
+                bindPositions = new IntList();
               }
               bindPositions.add(nativeSql.length());
               int bindIndex = bindPositions.size();
@@ -407,21 +406,17 @@ public class Parser {
   }
 
   /**
-   * Converts {@code List<Integer>} to {@code int[]}. Empty and {@code null} lists are converted to
-   * empty array.
+   * Converts {@link IntList} to {@code int[]}. A {@code null} collection is converted to
+   * {@code null} array.
    *
    * @param list input list
    * @return output array
    */
-  private static int[] toIntArray(@Nullable List<Integer> list) {
-    if (list == null || list.isEmpty()) {
-      return NO_BINDS;
+  private static int @Nullable [] toIntArray(@Nullable IntList list) {
+    if (list == null) {
+      return null;
     }
-    int[] res = new int[list.size()];
-    for (int i = 0; i < list.size(); i++) {
-      res[i] = list.get(i); // must not be null
-    }
-    return res;
+    return list.toArray();
   }
 
   /**

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -3055,28 +3055,28 @@ public class QueryExecutorImpl extends QueryExecutorBase {
 
   private final SimpleQuery beginTransactionQuery =
       new SimpleQuery(
-          new NativeQuery("BEGIN", new int[0], false, SqlCommand.BLANK),
+          new NativeQuery("BEGIN", null, false, SqlCommand.BLANK),
           null, false);
 
   private final SimpleQuery beginReadOnlyTransactionQuery =
       new SimpleQuery(
-          new NativeQuery("BEGIN READ ONLY", new int[0], false, SqlCommand.BLANK),
+          new NativeQuery("BEGIN READ ONLY", null, false, SqlCommand.BLANK),
           null, false);
 
   private final SimpleQuery emptyQuery =
       new SimpleQuery(
-          new NativeQuery("", new int[0], false,
+          new NativeQuery("", null, false,
               SqlCommand.createStatementTypeInfo(SqlCommandType.BLANK)
           ), null, false);
 
   private final SimpleQuery autoSaveQuery =
       new SimpleQuery(
-          new NativeQuery("SAVEPOINT PGJDBC_AUTOSAVE", new int[0], false, SqlCommand.BLANK),
+          new NativeQuery("SAVEPOINT PGJDBC_AUTOSAVE", null, false, SqlCommand.BLANK),
           null, false);
 
   private final SimpleQuery releaseAutoSave =
       new SimpleQuery(
-          new NativeQuery("RELEASE SAVEPOINT PGJDBC_AUTOSAVE", new int[0], false, SqlCommand.BLANK),
+          new NativeQuery("RELEASE SAVEPOINT PGJDBC_AUTOSAVE", null, false, SqlCommand.BLANK),
           null, false);
 
   /*
@@ -3084,6 +3084,6 @@ public class QueryExecutorImpl extends QueryExecutorBase {
    */
   private final SimpleQuery restoreToAutoSave =
       new SimpleQuery(
-          new NativeQuery("ROLLBACK TO SAVEPOINT PGJDBC_AUTOSAVE", new int[0], false, SqlCommand.BLANK),
+          new NativeQuery("ROLLBACK TO SAVEPOINT PGJDBC_AUTOSAVE", null, false, SqlCommand.BLANK),
           null, false);
 }

--- a/pgjdbc/src/main/java/org/postgresql/util/IntList.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/IntList.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2023, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.util;
+
+import java.util.Arrays;
+
+/**
+ * A specialized class to store a list of {@code int} values, so it does not need auto-boxing. Note:
+ * this is a driver-internal class, and it is not intended to be used outside the driver.
+ */
+public final class IntList {
+  private static final int[] EMPTY_INT_ARRAY = new int[0];
+  private int[] ints = EMPTY_INT_ARRAY;
+  private int index = 0;
+
+  public void add(int i) {
+    int index = this.index;
+    ensureSize(index);
+    ints[index] = i;
+    this.index = index + 1;
+  }
+
+  private void ensureSize(int size) {
+    int length = ints.length;
+    if (size >= length) {
+      // double in size until 1024 in size, then grow by 1.5x
+      final int newLength = length == 0 ? 8 :
+          length < 1024 ? length << 1 :
+              (length + (length >> 1));
+      ints = Arrays.copyOf(ints, newLength);
+    }
+  }
+
+  public int size() {
+    return index;
+  }
+
+  public int get(int i) {
+    if (i < 0 || i >= index) {
+      throw new ArrayIndexOutOfBoundsException("Index: " + i + ", Size: " + index);
+    }
+    return ints[i];
+  }
+
+  public void clear() {
+    index = 0;
+  }
+
+  /**
+   * Returns an array containing all the elements in this list. The modifications of the returned
+   * array will not affect this list.
+   *
+   * @return an array containing all the elements in this list
+   */
+  public int[] toArray() {
+    if (index == 0) {
+      return EMPTY_INT_ARRAY;
+    }
+    return Arrays.copyOf(ints, index);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder("[");
+    for (int i = 0; i < index; ++i) {
+      if (i > 0) {
+        sb.append(", ");
+      }
+      sb.append(ints[i]);
+    }
+    sb.append("]");
+    return sb.toString();
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/util/IntListTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/util/IntListTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2023, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.util;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests {@link IntList}.
+ */
+public class IntListTest {
+
+  @Test
+  public void testSize() {
+    final IntList list = new IntList();
+    assertEquals(0, list.size());
+    list.add(3);
+    assertEquals(1, list.size());
+
+    for (int i = 0; i < 48; ++i) {
+      list.add(i);
+    }
+    assertEquals(49, list.size());
+
+    list.clear();
+    assertEquals(0, list.size());
+  }
+
+  @Test
+  public void testGet_empty() {
+    final IntList list = new IntList();
+    assertThrows(ArrayIndexOutOfBoundsException.class, () -> list.get(0));
+  }
+
+  @Test
+  public void testGet_negative() {
+    final IntList list = new IntList();
+    list.add(3);
+    assertThrows(ArrayIndexOutOfBoundsException.class, () -> list.get(-1));
+  }
+
+  @Test
+  public void testGet_tooLarge() {
+    final IntList list = new IntList();
+    list.add(3);
+    assertThrows(ArrayIndexOutOfBoundsException.class, () -> list.get(1));
+  }
+
+  @Test
+  public void testGet() {
+    final IntList list = new IntList();
+    list.add(3);
+    assertEquals(3, list.get(0));
+
+    for (int i = 0; i < 1048; ++i) {
+      list.add(i);
+    }
+
+    assertEquals(3, list.get(0));
+
+    for (int i = 0; i < 1048; ++i) {
+      assertEquals(i, list.get(i + 1));
+    }
+
+    list.clear();
+    list.add(4);
+    assertEquals(4, list.get(0));
+  }
+
+  @Test
+  public void testToArray() {
+    int[] emptyArray = new IntList().toArray();
+    IntList list = new IntList();
+    assertSame(emptyArray, list.toArray(), "emptyList.toArray()");
+
+    list.add(45);
+    assertArrayEquals(new int[]{45}, list.toArray());
+
+    list.clear();
+    assertSame(emptyArray, list.toArray(), "emptyList.toArray() after clearing the list");
+
+    final int[] expected = new int[1048];
+    for (int i = 0; i < 1048; ++i) {
+      list.add(i);
+      expected[i] = i;
+    }
+    assertArrayEquals(expected, list.toArray());
+  }
+}


### PR DESCRIPTION
The parser currently builds a `List<Integer>` (requires boxing) to track bind variables. It then converts this to an `int[]` (requires unboxing) when creating the `NativeQuery`.
This change provides a simple collection backed by an `int[]`.