### PR TITLE
chore: update parent versions to 1.1.4 to enforce Javadoc warnings as errors

### DIFF
--- a/pgjdbc/pom.xml
+++ b/pgjdbc/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.postgresql</groupId>
     <artifactId>pgjdbc-core-parent</artifactId>
-    <version>1.1.3</version>
+    <version>1.1.4</version>
     <relativePath />
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.postgresql</groupId>
     <artifactId>pgjdbc-versions</artifactId>
-    <version>1.1.3</version>
+    <version>1.1.4</version>
   </parent>
 
   <artifactId>pgjdbc-aggregate</artifactId>


### PR DESCRIPTION
This is a missing part of #1236 