### PR TITLE
fix: remove POT-Creation-Date from generated .po and .pot files

### DIFF
--- a/pgjdbc/pom.xml
+++ b/pgjdbc/pom.xml
@@ -55,7 +55,7 @@
           <plugin>
             <groupId>com.github.vlsi.gettext</groupId>
             <artifactId>gettext-maven-plugin</artifactId>
-            <version>1.2.11</version>
+            <version>1.3.0</version>
             <executions>
               <execution>
                 <id>update_po_with_new_messages</id>

--- a/pgjdbc/src/main/java/org/postgresql/translation/bg.po
+++ b/pgjdbc/src/main/java/org/postgresql/translation/bg.po
@@ -6,7 +6,6 @@ msgid ""
 msgstr ""
 "Project-Id-Version: JDBC Driver for PostgreSQL 8.x\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-06-05 10:57+0300\n"
 "PO-Revision-Date: 2009-12-28 00:01+0100\n"
 "Last-Translator: <usun0v@mail.bg>\n"
 "Language-Team: <bg@li.org>\n"
@@ -17,17 +16,17 @@ msgstr ""
 "X-Poedit-Language: Bulgarian\n"
 "X-Poedit-Country: BULGARIA\n"
 
-#: org/postgresql/Driver.java:214
+#: org/postgresql/Driver.java:217
 msgid "Error loading default settings from driverconfig.properties"
 msgstr ""
 "Грешка при зареждане на настройките по подразбиране от файла driverconfig."
 "properties"
 
-#: org/postgresql/Driver.java:226
+#: org/postgresql/Driver.java:229
 msgid "Properties for the driver contains a non-string value for the key "
 msgstr ""
 
-#: org/postgresql/Driver.java:270
+#: org/postgresql/Driver.java:272
 msgid ""
 "Your security policy has prevented the connection from being attempted.  You "
 "probably need to grant the connect java.net.SocketPermission to the database "
@@ -37,42 +36,42 @@ msgstr ""
 "трябва да предоставите java.net.SocketPermission права на сървъра и порта с "
 "базата данни, към който искате да се свържете."
 
-#: org/postgresql/Driver.java:276 org/postgresql/Driver.java:408
+#: org/postgresql/Driver.java:278 org/postgresql/Driver.java:410
 msgid ""
 "Something unusual has occurred to cause the driver to fail. Please report "
 "this exception."
 msgstr ""
 "Възникна неочаквана грешка с драйвъра. Моля докадвайте това изключение. "
 
-#: org/postgresql/Driver.java:416
+#: org/postgresql/Driver.java:418
 msgid "Connection attempt timed out."
 msgstr "Времето за осъществяване на връзката изтече (таймаут)."
 
-#: org/postgresql/Driver.java:429
+#: org/postgresql/Driver.java:431
 msgid "Interrupted while attempting to connect."
 msgstr "Опита за осъществяване на връзка бе своевременно прекъснат. "
 
-#: org/postgresql/Driver.java:682
+#: org/postgresql/Driver.java:687
 #, java-format
 msgid "Method {0} is not yet implemented."
 msgstr "Методът {0} все още не е функционален."
 
-#: org/postgresql/PGProperty.java:535 org/postgresql/PGProperty.java:555
+#: org/postgresql/PGProperty.java:537 org/postgresql/PGProperty.java:557
 #, fuzzy, java-format
 msgid "{0} parameter value must be an integer but was: {1}"
 msgstr "Стойността на параметъра unknownLength трябва да бъде цяло число"
 
-#: org/postgresql/copy/CopyManager.java:53
+#: org/postgresql/copy/CopyManager.java:49
 #, java-format
 msgid "Requested CopyIn but got {0}"
 msgstr "Зададено CopyIn но получено {0}"
 
-#: org/postgresql/copy/CopyManager.java:64
+#: org/postgresql/copy/CopyManager.java:60
 #, java-format
 msgid "Requested CopyOut but got {0}"
 msgstr "Зададено CopyOut но получено {0}"
 
-#: org/postgresql/copy/CopyManager.java:75
+#: org/postgresql/copy/CopyManager.java:71
 #, fuzzy, java-format
 msgid "Requested CopyDual but got {0}"
 msgstr "Зададено CopyOut но получено {0}"
@@ -96,6 +95,12 @@ msgstr "Четене от копието неуспешно."
 msgid "Cannot write to copy a byte of value {0}"
 msgstr "Няма пишещи права, за да копира байтова стойност {0}"
 
+#: org/postgresql/core/CommandCompleteParser.java:71
+#, fuzzy, java-format
+msgid "Unable to parse the count in command completion tag: {0}."
+msgstr ""
+"Не може да осъществи актуализация на брояча при командно допълнение: {0}."
+
 #: org/postgresql/core/ConnectionFactory.java:57
 #, java-format
 msgid "A connection could not be made using the requested protocol {0}."
@@ -118,7 +123,7 @@ msgstr ""
 msgid "Expected an EOF from server, got: {0}"
 msgstr "Очакван край на файла от сървъра, но получено: {0}"
 
-#: org/postgresql/core/Parser.java:1006
+#: org/postgresql/core/Parser.java:1051
 #, java-format
 msgid "Malformed function or procedure escape syntax at offset {0}."
 msgstr "Непозволен синтаксис на функция или процедура при офсет {0}."
@@ -182,23 +187,23 @@ msgstr "Не може да има нула байта в идентификат�
 #: org/postgresql/core/v3/CompositeParameterList.java:33
 #: org/postgresql/core/v3/SimpleParameterList.java:54
 #: org/postgresql/core/v3/SimpleParameterList.java:65
-#: org/postgresql/jdbc/PgResultSet.java:2757
-#: org/postgresql/jdbc/PgResultSetMetaData.java:494
+#: org/postgresql/jdbc/PgResultSet.java:2755
+#: org/postgresql/jdbc/PgResultSetMetaData.java:388
 #, java-format
 msgid "The column index is out of range: {0}, number of columns: {1}."
 msgstr "Индексът на колоната е извън стойностен обхват: {0}, брой колони: {1}."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:109
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:103
 #, fuzzy, java-format
 msgid "Invalid sslmode value: {0}"
 msgstr "Невалидна дължина {0} на потока данни."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:124
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:118
 #, fuzzy, java-format
 msgid "Invalid targetServerType value: {0}"
 msgstr "Невалидна дължина {0} на потока данни."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:246
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:239
 #, fuzzy, java-format
 msgid ""
 "Connection to {0} refused. Check that the hostname and port are correct and "
@@ -207,39 +212,39 @@ msgstr ""
 "Връзката отказана. Проверете дали името на хоста и порта са верни и дали "
 "postmaster приема ТСР / IP връзки."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:257
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:250
 #: org/postgresql/core/v3/replication/V3ReplicationProtocol.java:133
 msgid "The connection attempt failed."
 msgstr "Опита за връзка бе неуспешен."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:272
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:265
 #, java-format
 msgid "Could not find a server with specified targetServerType: {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:368
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:381
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:361
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:374
 msgid "The server does not support SSL."
 msgstr "Сървърът не поддържа SSL."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:395
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:388
 msgid "An error occurred while setting up the SSL connection."
 msgstr "Възникна грешка при осъществяване на SSL връзката."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:496
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:523
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:484
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:511
 msgid ""
 "The server requested password-based authentication, but no password was "
 "provided."
 msgstr "Сървърът изисква идентифициране с парола, но парола не бе въведена."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:626
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:614
 msgid ""
 "SCRAM authentication is not supported by this driver. You need JDK >= 8 and "
 "pgjdbc >= 42.2.0 (not \".jre\" versions)"
 msgstr ""
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:650
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:638
 #, java-format
 msgid ""
 "The authentication type {0} is not supported. Check that you have configured "
@@ -250,16 +255,16 @@ msgstr ""
 "pg_hba.conf файла, да включва IP адреса на клиента или подмрежата, и че се "
 "използва схема за удостоверяване, поддържана от драйвъра."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:657
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2550
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2581
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2585
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2653
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:645
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2543
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2576
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2580
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2648
 #: org/postgresql/gss/GssAction.java:126
 msgid "Protocol error.  Session setup failed."
 msgstr "Грешка в протокола. Неуспешна настройка на сесията."
 
-#: org/postgresql/core/v3/CopyInImpl.java:47
+#: org/postgresql/core/v3/CopyInImpl.java:49
 msgid "CopyIn copy direction can't receive data"
 msgstr ""
 
@@ -267,148 +272,148 @@ msgstr ""
 msgid "CommandComplete expected COPY but got: "
 msgstr "Очаквано командно допълнение COPY но получено: "
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:161
+#: org/postgresql/core/v3/QueryExecutorImpl.java:163
 msgid "Tried to obtain lock while already holding it"
 msgstr "Опит за получаване на заключване/резервация докато вече е получено"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:177
+#: org/postgresql/core/v3/QueryExecutorImpl.java:179
 msgid "Tried to break lock on database connection"
 msgstr ""
 "Опит за премахване на заключването/резервацията при връзка към базата данни"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:195
+#: org/postgresql/core/v3/QueryExecutorImpl.java:197
 msgid "Interrupted while waiting to obtain lock on database connection"
 msgstr ""
 "Прекъсване при чакане да получи заключване/резервация при връзка към базата "
 "данни"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:327
+#: org/postgresql/core/v3/QueryExecutorImpl.java:329
 msgid "Unable to bind parameter values for statement."
 msgstr "Не може да подготви параметрите на командата."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:333
-#: org/postgresql/core/v3/QueryExecutorImpl.java:485
-#: org/postgresql/core/v3/QueryExecutorImpl.java:559
-#: org/postgresql/core/v3/QueryExecutorImpl.java:602
-#: org/postgresql/core/v3/QueryExecutorImpl.java:729
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2372
+#: org/postgresql/core/v3/QueryExecutorImpl.java:335
+#: org/postgresql/core/v3/QueryExecutorImpl.java:487
+#: org/postgresql/core/v3/QueryExecutorImpl.java:561
+#: org/postgresql/core/v3/QueryExecutorImpl.java:604
+#: org/postgresql/core/v3/QueryExecutorImpl.java:731
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2377
 #: org/postgresql/util/StreamWrapper.java:130
 #, fuzzy
 msgid "An I/O error occurred while sending to the backend."
 msgstr "Входно/изходна грешка при изпращане към backend."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:534
-#: org/postgresql/core/v3/QueryExecutorImpl.java:576
+#: org/postgresql/core/v3/QueryExecutorImpl.java:536
+#: org/postgresql/core/v3/QueryExecutorImpl.java:578
 #, java-format
 msgid "Expected command status BEGIN, got {0}."
 msgstr "Очаквана команда BEGIN, получена {0}."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:581
+#: org/postgresql/core/v3/QueryExecutorImpl.java:583
 #: org/postgresql/jdbc/PgResultSet.java:1778
 #, java-format
 msgid "Unexpected command status: {0}."
 msgstr "Неочакван статус на команда: {0}."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:687
+#: org/postgresql/core/v3/QueryExecutorImpl.java:689
 #, fuzzy
 msgid "An error occurred while trying to get the socket timeout."
 msgstr "Входно/изходна грешка при изпращане към backend."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:722
-#: org/postgresql/core/v3/QueryExecutorImpl.java:798
+#: org/postgresql/core/v3/QueryExecutorImpl.java:724
+#: org/postgresql/core/v3/QueryExecutorImpl.java:800
 #, java-format
 msgid "Unknown Response Type {0}."
 msgstr "Неизвестен тип на отговор {0}."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:745
+#: org/postgresql/core/v3/QueryExecutorImpl.java:747
 #, fuzzy
 msgid "An error occurred while trying to reset the socket timeout."
 msgstr "Входно/изходна грешка при изпращане към backend."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:843
+#: org/postgresql/core/v3/QueryExecutorImpl.java:845
 msgid "Database connection failed when starting copy"
 msgstr "Неосъществена връзка към базата данни при започване на копирането"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:878
+#: org/postgresql/core/v3/QueryExecutorImpl.java:880
 msgid "Tried to cancel an inactive copy operation"
 msgstr "Опит за прекъсване на неактивно копиране"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:917
+#: org/postgresql/core/v3/QueryExecutorImpl.java:919
 msgid "Database connection failed when canceling copy operation"
 msgstr "Неосъществена връзка към базата данни при прекъсване на копирането"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:933
+#: org/postgresql/core/v3/QueryExecutorImpl.java:935
 msgid "Missing expected error response to copy cancel request"
 msgstr "Липсва очакван отговор при грешка да прекъсне копирането"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:937
+#: org/postgresql/core/v3/QueryExecutorImpl.java:939
 #, java-format
 msgid "Got {0} error responses to single copy cancel request"
 msgstr ""
 "Получени {0} отговори за грешка при единствено искане да се прекъсне "
 "копирането"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:952
+#: org/postgresql/core/v3/QueryExecutorImpl.java:954
 msgid "Tried to end inactive copy"
 msgstr "Опит за прекъсване на неактивно копиране"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:967
+#: org/postgresql/core/v3/QueryExecutorImpl.java:969
 msgid "Database connection failed when ending copy"
 msgstr "Неосъществена връзка към базата данни при завършване на копирането"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:985
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1005
+#: org/postgresql/core/v3/QueryExecutorImpl.java:987
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1007
 msgid "Tried to write to an inactive copy operation"
 msgstr "Опит за писане при неактивна операция за копиране"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:998
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1013
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1000
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1015
 msgid "Database connection failed when writing to copy"
 msgstr "Неосъществена връзка към базата данни при опит за копиране"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1028
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1030
 msgid "Tried to read from inactive copy"
 msgstr "Опит за четене при неактивно копиране"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1035
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1037
 msgid "Database connection failed when reading from copy"
 msgstr "Неосъществена връзка към базата данни при четене от копие"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1101
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1103
 #, java-format
 msgid "Received CommandComplete ''{0}'' without an active copy operation"
 msgstr "Получено командно допълнение ''{0}'' без активна команда за копиране"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1126
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1128
 #, java-format
 msgid "Got CopyInResponse from server during an active {0}"
 msgstr "Получен CopyInResponse отговор от сървъра при активно {0}"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1140
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1142
 #, java-format
 msgid "Got CopyOutResponse from server during an active {0}"
 msgstr "Получен CopyOutResponse отговор от сървъра при активно {0}"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1154
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1156
 #, fuzzy, java-format
 msgid "Got CopyBothResponse from server during an active {0}"
 msgstr "Получен CopyOutResponse отговор от сървъра при активно {0}"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1170
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1172
 msgid "Got CopyData without an active copy operation"
 msgstr "Получено CopyData без наличие на активна операция за копиране"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1174
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1176
 #, java-format
 msgid "Unexpected copydata from server for {0}"
 msgstr "Неочаквано CopyData от сървъра за {0}"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1234
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1236
 #, java-format
 msgid "Unexpected packet type during copy: {0}"
 msgstr "Неочакван тип пакет при копиране: {0}"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1524
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1526
 #, java-format
 msgid ""
 "Bind message length {0} too long.  This can be caused by very large or "
@@ -417,21 +422,15 @@ msgstr ""
 "Прекалено голяма дължина {0} на съобщението. Това може да е причинено от "
 "прекалено голяма или неправилно зададена дължина на InputStream параметри."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2145
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2150
 msgid "Ran out of memory retrieving query results."
 msgstr "Недостатъчна памет при представяна на резултатите от заявката."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2313
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2318
 msgid "The driver currently does not support COPY operations."
 msgstr "За момента драйвъра не поддържа COPY команди."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2487
-#, fuzzy, java-format
-msgid "Unable to parse the count in command completion tag: {0}."
-msgstr ""
-"Не може да осъществи актуализация на брояча при командно допълнение: {0}."
-
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2610
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2605
 #, fuzzy, java-format
 msgid ""
 "The server''s client_encoding parameter was changed to {0}. The JDBC driver "
@@ -440,7 +439,7 @@ msgstr ""
 "Параметърът client_encoding при сървъра бе променен на {0}. JDBC драйвъра "
 "изисква client_encoding да бъде UNICODE за да функционира правилно."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2620
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2615
 #, java-format
 msgid ""
 "The server''s DateStyle parameter was changed to {0}. The JDBC driver "
@@ -449,7 +448,7 @@ msgstr ""
 "Параметърът DateStyle при сървъра бе променен на {0}. JDBC драйвъра изисква "
 "DateStyle започва с ISO за да функционира правилно."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2633
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2628
 #, java-format
 msgid ""
 "The server''s standard_conforming_strings parameter was reported as {0}. The "
@@ -512,36 +511,36 @@ msgstr "Източникът на данни е прекъснат."
 msgid "Unsupported property name: {0}"
 msgstr "Неподдържана стойност за тип: {0}"
 
-#: org/postgresql/fastpath/Fastpath.java:86
+#: org/postgresql/fastpath/Fastpath.java:84
 #, fuzzy, java-format
 msgid "Fastpath call {0} - No result was returned and we expected a numeric."
 msgstr "Извикване на {0} - няма резултати и а бе очаквано цяло число."
 
-#: org/postgresql/fastpath/Fastpath.java:163
+#: org/postgresql/fastpath/Fastpath.java:161
 #, java-format
 msgid "Fastpath call {0} - No result was returned and we expected an integer."
 msgstr "Извикване на {0} - няма резултати и а бе очаквано цяло число."
 
-#: org/postgresql/fastpath/Fastpath.java:171
+#: org/postgresql/fastpath/Fastpath.java:169
 #, fuzzy, java-format
 msgid ""
 "Fastpath call {0} - No result was returned or wrong size while expecting an "
 "integer."
 msgstr "Извикване на {0} - няма резултати и а бе очаквано цяло число."
 
-#: org/postgresql/fastpath/Fastpath.java:188
+#: org/postgresql/fastpath/Fastpath.java:186
 #, fuzzy, java-format
 msgid "Fastpath call {0} - No result was returned and we expected a long."
 msgstr "Извикване на {0} - няма резултати и а бе очаквано цяло число."
 
-#: org/postgresql/fastpath/Fastpath.java:196
+#: org/postgresql/fastpath/Fastpath.java:194
 #, fuzzy, java-format
 msgid ""
 "Fastpath call {0} - No result was returned or wrong size while expecting a "
 "long."
 msgstr "Извикване на {0} - няма резултати и а бе очаквано цяло число."
 
-#: org/postgresql/fastpath/Fastpath.java:308
+#: org/postgresql/fastpath/Fastpath.java:297
 #, java-format
 msgid "The fastpath function {0} is unknown."
 msgstr "Функцията {0} е неизвестна."
@@ -609,63 +608,70 @@ msgid "Cannot cast to boolean: \"{0}\""
 msgstr ""
 
 #: org/postgresql/jdbc/EscapedFunctions.java:240
+#: org/postgresql/jdbc/EscapedFunctions2.java:167
 #, java-format
 msgid "{0} function takes four and only four argument."
 msgstr "Функцията {0} може да приеме четири и само четири аргумента."
 
 #: org/postgresql/jdbc/EscapedFunctions.java:270
-#: org/postgresql/jdbc/EscapedFunctions.java:344
-#: org/postgresql/jdbc/EscapedFunctions.java:749
-#: org/postgresql/jdbc/EscapedFunctions.java:787
+#: org/postgresql/jdbc/EscapedFunctions.java:337
+#: org/postgresql/jdbc/EscapedFunctions.java:740
+#: org/postgresql/jdbc/EscapedFunctions2.java:196
+#: org/postgresql/jdbc/EscapedFunctions2.java:263
+#: org/postgresql/jdbc/EscapedFunctions2.java:665
 #, java-format
 msgid "{0} function takes two and only two arguments."
 msgstr "Функцията {0} може да приеме два и само два аргумента."
 
 #: org/postgresql/jdbc/EscapedFunctions.java:288
-#: org/postgresql/jdbc/EscapedFunctions.java:326
-#: org/postgresql/jdbc/EscapedFunctions.java:446
-#: org/postgresql/jdbc/EscapedFunctions.java:461
-#: org/postgresql/jdbc/EscapedFunctions.java:476
-#: org/postgresql/jdbc/EscapedFunctions.java:491
-#: org/postgresql/jdbc/EscapedFunctions.java:506
-#: org/postgresql/jdbc/EscapedFunctions.java:521
-#: org/postgresql/jdbc/EscapedFunctions.java:536
-#: org/postgresql/jdbc/EscapedFunctions.java:551
-#: org/postgresql/jdbc/EscapedFunctions.java:566
-#: org/postgresql/jdbc/EscapedFunctions.java:581
-#: org/postgresql/jdbc/EscapedFunctions.java:596
-#: org/postgresql/jdbc/EscapedFunctions.java:611
-#: org/postgresql/jdbc/EscapedFunctions.java:775
+#: org/postgresql/jdbc/EscapedFunctions.java:441
+#: org/postgresql/jdbc/EscapedFunctions.java:467
+#: org/postgresql/jdbc/EscapedFunctions.java:526
+#: org/postgresql/jdbc/EscapedFunctions.java:728
+#: org/postgresql/jdbc/EscapedFunctions2.java:211
+#: org/postgresql/jdbc/EscapedFunctions2.java:355
+#: org/postgresql/jdbc/EscapedFunctions2.java:381
+#: org/postgresql/jdbc/EscapedFunctions2.java:440
+#: org/postgresql/jdbc/EscapedFunctions2.java:654
 #, java-format
 msgid "{0} function takes one and only one argument."
 msgstr "Функцията {0} може да приеме само един единствен аргумент."
 
-#: org/postgresql/jdbc/EscapedFunctions.java:310
-#: org/postgresql/jdbc/EscapedFunctions.java:391
+#: org/postgresql/jdbc/EscapedFunctions.java:312
+#: org/postgresql/jdbc/EscapedFunctions.java:386
+#: org/postgresql/jdbc/EscapedFunctions2.java:238
+#: org/postgresql/jdbc/EscapedFunctions2.java:307
 #, java-format
 msgid "{0} function takes two or three arguments."
 msgstr "Функцията {0} може да приеме два или три аргумента."
 
-#: org/postgresql/jdbc/EscapedFunctions.java:416
-#: org/postgresql/jdbc/EscapedFunctions.java:431
-#: org/postgresql/jdbc/EscapedFunctions.java:734
-#: org/postgresql/jdbc/EscapedFunctions.java:764
+#: org/postgresql/jdbc/EscapedFunctions.java:411
+#: org/postgresql/jdbc/EscapedFunctions.java:426
+#: org/postgresql/jdbc/EscapedFunctions.java:693
+#: org/postgresql/jdbc/EscapedFunctions.java:719
+#: org/postgresql/jdbc/EscapedFunctions2.java:645
 #, java-format
 msgid "{0} function doesn''t take any argument."
 msgstr "Функцията {0} не може да приема аргументи."
 
-#: org/postgresql/jdbc/EscapedFunctions.java:627
-#: org/postgresql/jdbc/EscapedFunctions.java:680
+#: org/postgresql/jdbc/EscapedFunctions.java:586
+#: org/postgresql/jdbc/EscapedFunctions.java:639
+#: org/postgresql/jdbc/EscapedFunctions2.java:500
+#: org/postgresql/jdbc/EscapedFunctions2.java:571
 #, java-format
 msgid "{0} function takes three and only three arguments."
 msgstr "Функцията {0} може да приеме три и само три аргумента."
 
-#: org/postgresql/jdbc/EscapedFunctions.java:640
-#: org/postgresql/jdbc/EscapedFunctions.java:661
-#: org/postgresql/jdbc/EscapedFunctions.java:664
-#: org/postgresql/jdbc/EscapedFunctions.java:697
-#: org/postgresql/jdbc/EscapedFunctions.java:710
-#: org/postgresql/jdbc/EscapedFunctions.java:713
+#: org/postgresql/jdbc/EscapedFunctions.java:599
+#: org/postgresql/jdbc/EscapedFunctions.java:620
+#: org/postgresql/jdbc/EscapedFunctions.java:623
+#: org/postgresql/jdbc/EscapedFunctions.java:656
+#: org/postgresql/jdbc/EscapedFunctions.java:669
+#: org/postgresql/jdbc/EscapedFunctions.java:672
+#: org/postgresql/jdbc/EscapedFunctions2.java:510
+#: org/postgresql/jdbc/EscapedFunctions2.java:527
+#: org/postgresql/jdbc/EscapedFunctions2.java:585
+#: org/postgresql/jdbc/EscapedFunctions2.java:597
 #, java-format
 msgid "Interval {0} not yet implemented"
 msgstr "Интервалът {0} не е валиден все още."
@@ -684,17 +690,17 @@ msgstr "Не може да определи ID на спомената savepoint
 msgid "Cannot retrieve the name of an unnamed savepoint."
 msgstr "Не може да определи името на неупомената savepoint."
 
-#: org/postgresql/jdbc/PgArray.java:157 org/postgresql/jdbc/PgArray.java:844
+#: org/postgresql/jdbc/PgArray.java:155 org/postgresql/jdbc/PgArray.java:842
 #, java-format
 msgid "The array index is out of range: {0}"
 msgstr "Индексът на масив е извън обхвата: {0}"
 
-#: org/postgresql/jdbc/PgArray.java:178 org/postgresql/jdbc/PgArray.java:861
+#: org/postgresql/jdbc/PgArray.java:176 org/postgresql/jdbc/PgArray.java:859
 #, java-format
 msgid "The array index is out of range: {0}, number of elements: {1}."
 msgstr "Индексът на масив е извън обхвата: {0}, брой елементи: {1}."
 
-#: org/postgresql/jdbc/PgArray.java:210
+#: org/postgresql/jdbc/PgArray.java:208
 #: org/postgresql/jdbc/PgResultSet.java:1930
 #: org/postgresql/util/HStoreConverter.java:43
 #: org/postgresql/util/HStoreConverter.java:74
@@ -709,17 +715,17 @@ msgstr ""
 "създаване на базата данни. Чест пример за това е съхраняване на 8bit данни в "
 "SQL_ASCII бази данни."
 
-#: org/postgresql/jdbc/PgCallableStatement.java:86
-#: org/postgresql/jdbc/PgCallableStatement.java:96
+#: org/postgresql/jdbc/PgCallableStatement.java:85
+#: org/postgresql/jdbc/PgCallableStatement.java:95
 msgid "A CallableStatement was executed with nothing returned."
 msgstr "CallableStatement функция бе обработена, но няма резултати."
 
-#: org/postgresql/jdbc/PgCallableStatement.java:107
+#: org/postgresql/jdbc/PgCallableStatement.java:106
 msgid "A CallableStatement was executed with an invalid number of parameters"
 msgstr ""
 "CallableStatement функция бе обработена, но с непозволен брой параметри."
 
-#: org/postgresql/jdbc/PgCallableStatement.java:145
+#: org/postgresql/jdbc/PgCallableStatement.java:144
 #, java-format
 msgid ""
 "A CallableStatement function was executed and the out parameter {0} was of "
@@ -728,7 +734,7 @@ msgstr ""
 "CallableStatement функция бе обработена и изходния параметър {0} бе от тип "
 "{1}, обаче тип {2} бе използван."
 
-#: org/postgresql/jdbc/PgCallableStatement.java:202
+#: org/postgresql/jdbc/PgCallableStatement.java:206
 msgid ""
 "This statement does not declare an OUT parameter.  Use '{' ?= call ... '}' "
 "to declare one."
@@ -736,12 +742,12 @@ msgstr ""
 "Тази заявка не декларира изходен параметър. Ползвайте '{' ?= call ... '}' за "
 "да декларирате такъв."
 
-#: org/postgresql/jdbc/PgCallableStatement.java:246
+#: org/postgresql/jdbc/PgCallableStatement.java:229
 msgid "wasNull cannot be call before fetching a result."
 msgstr "wasNull не може да бьде изпълнен, преди наличието на резултата."
 
-#: org/postgresql/jdbc/PgCallableStatement.java:384
-#: org/postgresql/jdbc/PgCallableStatement.java:403
+#: org/postgresql/jdbc/PgCallableStatement.java:367
+#: org/postgresql/jdbc/PgCallableStatement.java:386
 #, java-format
 msgid ""
 "Parameter of type {0} was registered, but call to get{1} (sqltype={2}) was "
@@ -749,7 +755,7 @@ msgid ""
 msgstr ""
 "Отчетен параметър от тип {0}, но обработено като get{1} (sqltype={2}). "
 
-#: org/postgresql/jdbc/PgCallableStatement.java:424
+#: org/postgresql/jdbc/PgCallableStatement.java:407
 msgid ""
 "A CallableStatement was declared, but no call to registerOutParameter(1, "
 "<some type>) was made."
@@ -757,29 +763,29 @@ msgstr ""
 "CallableStatement функция бе декларирана, но обработена като "
 "registerOutParameter(1, <some type>) "
 
-#: org/postgresql/jdbc/PgCallableStatement.java:430
+#: org/postgresql/jdbc/PgCallableStatement.java:413
 msgid "No function outputs were registered."
 msgstr "Резултати от функцията не бяха регистрирани."
 
-#: org/postgresql/jdbc/PgCallableStatement.java:436
+#: org/postgresql/jdbc/PgCallableStatement.java:419
 msgid ""
 "Results cannot be retrieved from a CallableStatement before it is executed."
 msgstr ""
 "Резултати от CallableStatement функция не могат да бъдат получени, преди тя "
 "да бъде обработена."
 
-#: org/postgresql/jdbc/PgCallableStatement.java:703
+#: org/postgresql/jdbc/PgCallableStatement.java:686
 #, fuzzy, java-format
 msgid "Unsupported type conversion to {1}."
 msgstr "Неподдържана стойност за тип: {0}"
 
-#: org/postgresql/jdbc/PgConnection.java:272
+#: org/postgresql/jdbc/PgConnection.java:241
 #, java-format
 msgid "Unsupported value for stringtype parameter: {0}"
 msgstr "Непозволена стойност за StringType параметър: {0}"
 
 #: org/postgresql/jdbc/PgConnection.java:424
-#: org/postgresql/jdbc/PgPreparedStatement.java:119
+#: org/postgresql/jdbc/PgPreparedStatement.java:107
 #: org/postgresql/jdbc/PgStatement.java:225
 #: org/postgresql/jdbc/TypeInfoCache.java:226
 #: org/postgresql/jdbc/TypeInfoCache.java:371
@@ -791,131 +797,131 @@ msgstr "Непозволена стойност за StringType параметъ
 msgid "No results were returned by the query."
 msgstr "Няма намерени резултати за заявката."
 
-#: org/postgresql/jdbc/PgConnection.java:441
+#: org/postgresql/jdbc/PgConnection.java:442
 #: org/postgresql/jdbc/PgStatement.java:254
 msgid "A result was returned when none was expected."
 msgstr "Бе получен резултат, когато такъв не бе очакван."
 
-#: org/postgresql/jdbc/PgConnection.java:545
+#: org/postgresql/jdbc/PgConnection.java:547
 msgid "Custom type maps are not supported."
 msgstr "Специфични типови съответствия не се поддържат."
 
-#: org/postgresql/jdbc/PgConnection.java:587
+#: org/postgresql/jdbc/PgConnection.java:589
 #, java-format
 msgid "Failed to create object for: {0}."
 msgstr "Неуспешно създаване на обект за: {0}."
 
-#: org/postgresql/jdbc/PgConnection.java:641
+#: org/postgresql/jdbc/PgConnection.java:643
 #, java-format
 msgid "Unable to load the class {0} responsible for the datatype {1}"
 msgstr "Невъзможно е зареждането на клас {0}, отговарящ за типа данни {1}"
 
-#: org/postgresql/jdbc/PgConnection.java:693
+#: org/postgresql/jdbc/PgConnection.java:705
 msgid ""
 "Cannot change transaction read-only property in the middle of a transaction."
 msgstr ""
 "Не може да променяте правата на транзакцията по време на нейното извършване."
 
-#: org/postgresql/jdbc/PgConnection.java:756
+#: org/postgresql/jdbc/PgConnection.java:772
 msgid "Cannot commit when autoCommit is enabled."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:767
-#: org/postgresql/jdbc/PgConnection.java:1384
-#: org/postgresql/jdbc/PgConnection.java:1428
+#: org/postgresql/jdbc/PgConnection.java:783
+#: org/postgresql/jdbc/PgConnection.java:1401
+#: org/postgresql/jdbc/PgConnection.java:1445
 #, fuzzy
 msgid "This connection has been closed."
 msgstr "Връзката бе прекъсната."
 
-#: org/postgresql/jdbc/PgConnection.java:777
+#: org/postgresql/jdbc/PgConnection.java:794
 msgid "Cannot rollback when autoCommit is enabled."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:827
+#: org/postgresql/jdbc/PgConnection.java:844
 msgid ""
 "Cannot change transaction isolation level in the middle of a transaction."
 msgstr ""
 "Не може да променяте изолационното ниво на транзакцията по време на нейното "
 "извършване."
 
-#: org/postgresql/jdbc/PgConnection.java:833
+#: org/postgresql/jdbc/PgConnection.java:850
 #, java-format
 msgid "Transaction isolation level {0} not supported."
 msgstr "Изолационно ниво на транзакциите {0} не се поддържа."
 
-#: org/postgresql/jdbc/PgConnection.java:878
+#: org/postgresql/jdbc/PgConnection.java:895
 msgid "Finalizing a Connection that was never closed:"
 msgstr "Приключване на връзка, която не бе прекъсната:"
 
-#: org/postgresql/jdbc/PgConnection.java:945
+#: org/postgresql/jdbc/PgConnection.java:962
 msgid "Unable to translate data into the desired encoding."
 msgstr "Невъзможно преобразуване на данни в желаното кодиране."
 
-#: org/postgresql/jdbc/PgConnection.java:1008
+#: org/postgresql/jdbc/PgConnection.java:1025
 #: org/postgresql/jdbc/PgResultSet.java:1817
-#: org/postgresql/jdbc/PgStatement.java:903
+#: org/postgresql/jdbc/PgStatement.java:908
 msgid "Fetch size must be a value greater to or equal to 0."
 msgstr "Размера за fetch size трябва да бъде по-голям или равен на 0."
 
-#: org/postgresql/jdbc/PgConnection.java:1289
-#: org/postgresql/jdbc/PgConnection.java:1330
+#: org/postgresql/jdbc/PgConnection.java:1306
+#: org/postgresql/jdbc/PgConnection.java:1347
 #, java-format
 msgid "Unable to find server array type for provided name {0}."
 msgstr "Не може да се намери типа на сървърен масив за зададеното име {0}."
 
-#: org/postgresql/jdbc/PgConnection.java:1312
+#: org/postgresql/jdbc/PgConnection.java:1329
 #, fuzzy, java-format
 msgid "Invalid elements {0}"
 msgstr "Невалидни флагове {0}"
 
-#: org/postgresql/jdbc/PgConnection.java:1348
+#: org/postgresql/jdbc/PgConnection.java:1365
 #, fuzzy, java-format
 msgid "Invalid timeout ({0}<0)."
 msgstr "Невалидна дължина {0} на потока данни."
 
-#: org/postgresql/jdbc/PgConnection.java:1372
+#: org/postgresql/jdbc/PgConnection.java:1389
 msgid "Validating connection."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1405
+#: org/postgresql/jdbc/PgConnection.java:1422
 #, fuzzy, java-format
 msgid "Failed to set ClientInfo property: {0}"
 msgstr "Неуспешно създаване на обект за: {0}."
 
-#: org/postgresql/jdbc/PgConnection.java:1415
+#: org/postgresql/jdbc/PgConnection.java:1432
 msgid "ClientInfo property not supported."
 msgstr "Информацията за ClientInfo не се поддържа."
 
-#: org/postgresql/jdbc/PgConnection.java:1441
+#: org/postgresql/jdbc/PgConnection.java:1458
 msgid "One ore more ClientInfo failed."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1540
+#: org/postgresql/jdbc/PgConnection.java:1559
 #, fuzzy
 msgid "Network timeout must be a value greater than or equal to 0."
 msgstr ""
 "Времето за изпълнение на заявката трябва да бъде стойност по-голяма или "
 "равна на 0."
 
-#: org/postgresql/jdbc/PgConnection.java:1552
+#: org/postgresql/jdbc/PgConnection.java:1571
 msgid "Unable to set network timeout."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1563
+#: org/postgresql/jdbc/PgConnection.java:1582
 msgid "Unable to get network timeout."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1580
+#: org/postgresql/jdbc/PgConnection.java:1599
 #, java-format
 msgid "Unknown ResultSet holdability setting: {0}."
 msgstr "Неизвестна ResultSet holdability настройка: {0}."
 
-#: org/postgresql/jdbc/PgConnection.java:1598
-#: org/postgresql/jdbc/PgConnection.java:1619
+#: org/postgresql/jdbc/PgConnection.java:1617
+#: org/postgresql/jdbc/PgConnection.java:1638
 msgid "Cannot establish a savepoint in auto-commit mode."
 msgstr "Не може да се установи savepoint в auto-commit модус."
 
-#: org/postgresql/jdbc/PgConnection.java:1685
+#: org/postgresql/jdbc/PgConnection.java:1707
 msgid "Returning autogenerated keys is not supported."
 msgstr "Автоматично генерирани ключове не се поддържат."
 
@@ -931,47 +937,47 @@ msgstr ""
 msgid "Unable to find name datatype in the system catalogs."
 msgstr "Не може да се намери името на типа данни в системните каталози."
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:323
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:322
 #, fuzzy
 msgid "Unable to find keywords in the system catalogs."
 msgstr "Не може да се намери името на типа данни в системните каталози."
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1105
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1095
 msgid "oid"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1105
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1095
 msgid "proname"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1107
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1558
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1097
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1548
 msgid "typtype"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1110
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1100
 msgid "proargtypes"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1576
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1566
 msgid "adsrc"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1589
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1579
 msgid "attidentity"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1685
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1761
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1675
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1751
 msgid "rolname"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1686
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1762
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1676
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1752
 msgid "relacl"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1692
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1682
 msgid "attacl"
 msgstr ""
 
@@ -980,68 +986,68 @@ msgstr ""
 msgid "The parameter index is out of range: {0}, number of parameters: {1}."
 msgstr "Параметърният индекс е извън обхват: {0}, брой параметри: {1}."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:106
+#: org/postgresql/jdbc/PgPreparedStatement.java:94
+#: org/postgresql/jdbc/PgPreparedStatement.java:115
 #: org/postgresql/jdbc/PgPreparedStatement.java:127
-#: org/postgresql/jdbc/PgPreparedStatement.java:139
-#: org/postgresql/jdbc/PgPreparedStatement.java:1035
+#: org/postgresql/jdbc/PgPreparedStatement.java:1008
 msgid ""
 "Can''t use query methods that take a query string on a PreparedStatement."
 msgstr ""
 "Не може да се употребяват методи за заявка, които ползват низове на "
 "PreparedStatement."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:249
+#: org/postgresql/jdbc/PgPreparedStatement.java:237
 msgid "Unknown Types value."
 msgstr "Стойност от неизвестен тип."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:382
-#: org/postgresql/jdbc/PgPreparedStatement.java:439
-#: org/postgresql/jdbc/PgPreparedStatement.java:1191
-#: org/postgresql/jdbc/PgPreparedStatement.java:1490
+#: org/postgresql/jdbc/PgPreparedStatement.java:364
+#: org/postgresql/jdbc/PgPreparedStatement.java:421
+#: org/postgresql/jdbc/PgPreparedStatement.java:1164
+#: org/postgresql/jdbc/PgPreparedStatement.java:1472
 #, java-format
 msgid "Invalid stream length {0}."
 msgstr "Невалидна дължина {0} на потока данни."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:411
+#: org/postgresql/jdbc/PgPreparedStatement.java:393
 #, java-format
 msgid "The JVM claims not to support the {0} encoding."
 msgstr "JVM не поддържа за момента {0} кодовата таблица."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:414
+#: org/postgresql/jdbc/PgPreparedStatement.java:396
 #: org/postgresql/jdbc/PgResultSet.java:1122
 #: org/postgresql/jdbc/PgResultSet.java:1156
 msgid "Provided InputStream failed."
 msgstr "Зададения InputStream поток е неуспешен."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:460
-#: org/postgresql/jdbc/PgPreparedStatement.java:1096
+#: org/postgresql/jdbc/PgPreparedStatement.java:442
+#: org/postgresql/jdbc/PgPreparedStatement.java:1069
 #, java-format
 msgid "Unknown type {0}."
 msgstr "Неизвестен тип {0}."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:477
+#: org/postgresql/jdbc/PgPreparedStatement.java:459
 msgid "No hstore extension installed."
 msgstr ""
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:619
-#: org/postgresql/jdbc/PgPreparedStatement.java:642
-#: org/postgresql/jdbc/PgPreparedStatement.java:652
-#: org/postgresql/jdbc/PgPreparedStatement.java:664
+#: org/postgresql/jdbc/PgPreparedStatement.java:601
+#: org/postgresql/jdbc/PgPreparedStatement.java:624
+#: org/postgresql/jdbc/PgPreparedStatement.java:634
+#: org/postgresql/jdbc/PgPreparedStatement.java:646
 #, java-format
 msgid "Cannot cast an instance of {0} to type {1}"
 msgstr "Не може да преобразува инстанция на {0} към тип {1}"
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:682
+#: org/postgresql/jdbc/PgPreparedStatement.java:664
 #, java-format
 msgid "Unsupported Types value: {0}"
 msgstr "Неподдържана стойност за тип: {0}"
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:894
+#: org/postgresql/jdbc/PgPreparedStatement.java:876
 #, java-format
 msgid "Cannot convert an instance of {0} to type {1}"
 msgstr "Не може да преобразува инстанцията на {0} във вида {1}"
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:968
+#: org/postgresql/jdbc/PgPreparedStatement.java:950
 #, java-format
 msgid ""
 "Can''t infer the SQL type to use for an instance of {0}. Use setObject() "
@@ -1050,17 +1056,17 @@ msgstr ""
 "Не може да се определи SQL тип, който да се използва за инстанцията на {0}. "
 "Ползвайте метода setObject() с точни стойности, за да определите типа."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:1133
-#: org/postgresql/jdbc/PgPreparedStatement.java:1233
+#: org/postgresql/jdbc/PgPreparedStatement.java:1106
+#: org/postgresql/jdbc/PgPreparedStatement.java:1206
 msgid "Unexpected error writing large object to database."
 msgstr "Неочаквана грешка при записване на голям обект LOB в базата данни."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:1178
+#: org/postgresql/jdbc/PgPreparedStatement.java:1151
 #: org/postgresql/jdbc/PgResultSet.java:1210
 msgid "Provided Reader failed."
 msgstr "Грешка с ползвания четец."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:1449
+#: org/postgresql/jdbc/PgPreparedStatement.java:1431
 #: org/postgresql/util/StreamWrapper.java:56
 msgid "Object is too large to send over the protocol."
 msgstr ""
@@ -1078,8 +1084,8 @@ msgstr ""
 #: org/postgresql/jdbc/PgResultSet.java:556
 #: org/postgresql/jdbc/PgResultSet.java:594
 #: org/postgresql/jdbc/PgResultSet.java:624
-#: org/postgresql/jdbc/PgResultSet.java:3014
-#: org/postgresql/jdbc/PgResultSet.java:3058
+#: org/postgresql/jdbc/PgResultSet.java:3012
+#: org/postgresql/jdbc/PgResultSet.java:3057
 #, fuzzy, java-format
 msgid "Cannot convert the column of type {0} to requested type {1}."
 msgstr "Не може да преобразува инстанцията на {0} във вида {1}"
@@ -1093,7 +1099,7 @@ msgstr ""
 "при редицата на въвеждане."
 
 #: org/postgresql/jdbc/PgResultSet.java:878
-#: org/postgresql/jdbc/PgStatement.java:895
+#: org/postgresql/jdbc/PgStatement.java:900
 #, java-format
 msgid "Invalid fetch direction constant: {0}."
 msgstr "Невалидна константа за fetch посоката: {0}."
@@ -1140,8 +1146,8 @@ msgstr "Трябва да посочите поне една стойност з
 
 #: org/postgresql/jdbc/PgResultSet.java:1119
 #: org/postgresql/jdbc/PgResultSet.java:1754
-#: org/postgresql/jdbc/PgResultSet.java:2422
-#: org/postgresql/jdbc/PgResultSet.java:2443
+#: org/postgresql/jdbc/PgResultSet.java:2420
+#: org/postgresql/jdbc/PgResultSet.java:2441
 #, java-format
 msgid "The JVM claims not to support the encoding: {0}"
 msgstr "JVM не поддържа тази кодова таблица за момента: {0}"
@@ -1157,7 +1163,7 @@ msgstr ""
 "въвеждане."
 
 #: org/postgresql/jdbc/PgResultSet.java:1335
-#: org/postgresql/jdbc/PgResultSet.java:3075
+#: org/postgresql/jdbc/PgResultSet.java:3074
 msgid ""
 "Cannot update the ResultSet because it is either before the start or after "
 "the end of the results."
@@ -1177,27 +1183,27 @@ msgstr "Няма първичен ключ за таблица {0}."
 
 #: org/postgresql/jdbc/PgResultSet.java:2017
 #: org/postgresql/jdbc/PgResultSet.java:2022
-#: org/postgresql/jdbc/PgResultSet.java:2809
-#: org/postgresql/jdbc/PgResultSet.java:2815
-#: org/postgresql/jdbc/PgResultSet.java:2840
-#: org/postgresql/jdbc/PgResultSet.java:2846
-#: org/postgresql/jdbc/PgResultSet.java:2870
-#: org/postgresql/jdbc/PgResultSet.java:2875
-#: org/postgresql/jdbc/PgResultSet.java:2891
-#: org/postgresql/jdbc/PgResultSet.java:2912
-#: org/postgresql/jdbc/PgResultSet.java:2923
-#: org/postgresql/jdbc/PgResultSet.java:2936
-#: org/postgresql/jdbc/PgResultSet.java:3063
+#: org/postgresql/jdbc/PgResultSet.java:2807
+#: org/postgresql/jdbc/PgResultSet.java:2813
+#: org/postgresql/jdbc/PgResultSet.java:2838
+#: org/postgresql/jdbc/PgResultSet.java:2844
+#: org/postgresql/jdbc/PgResultSet.java:2868
+#: org/postgresql/jdbc/PgResultSet.java:2873
+#: org/postgresql/jdbc/PgResultSet.java:2889
+#: org/postgresql/jdbc/PgResultSet.java:2910
+#: org/postgresql/jdbc/PgResultSet.java:2921
+#: org/postgresql/jdbc/PgResultSet.java:2934
+#: org/postgresql/jdbc/PgResultSet.java:3062
 #, java-format
 msgid "Bad value for type {0} : {1}"
 msgstr "Невалидна стойност за тип {0} : {1}"
 
-#: org/postgresql/jdbc/PgResultSet.java:2595
+#: org/postgresql/jdbc/PgResultSet.java:2593
 #, java-format
 msgid "The column name {0} was not found in this ResultSet."
 msgstr "Името на колоната {0} не бе намерено в този ResultSet."
 
-#: org/postgresql/jdbc/PgResultSet.java:2731
+#: org/postgresql/jdbc/PgResultSet.java:2729
 msgid ""
 "ResultSet is not updateable.  The query that generated this result set must "
 "select only one table, and must select all primary keys from that table. See "
@@ -1207,43 +1213,43 @@ msgstr ""
 "да селектира само една таблица, както и всички първични ключове в нея. За "
 "повече информация, вижте раздел 5.6 на JDBC 2.1 API Specification."
 
-#: org/postgresql/jdbc/PgResultSet.java:2743
+#: org/postgresql/jdbc/PgResultSet.java:2741
 msgid "This ResultSet is closed."
 msgstr "Операциите по този ResultSet са били прекратени."
 
-#: org/postgresql/jdbc/PgResultSet.java:2774
+#: org/postgresql/jdbc/PgResultSet.java:2772
 msgid "ResultSet not positioned properly, perhaps you need to call next."
 msgstr ""
 "ResultSet не е референциран правилно. Вероятно трябва да придвижите курсора "
 "посредством next."
 
-#: org/postgresql/jdbc/PgResultSet.java:3095
+#: org/postgresql/jdbc/PgResultSet.java:3094
 msgid "Invalid UUID data."
 msgstr "Невалидни UUID данни."
 
-#: org/postgresql/jdbc/PgResultSet.java:3184
-#: org/postgresql/jdbc/PgResultSet.java:3191
-#: org/postgresql/jdbc/PgResultSet.java:3202
-#: org/postgresql/jdbc/PgResultSet.java:3213
-#: org/postgresql/jdbc/PgResultSet.java:3224
-#: org/postgresql/jdbc/PgResultSet.java:3235
-#: org/postgresql/jdbc/PgResultSet.java:3246
-#: org/postgresql/jdbc/PgResultSet.java:3257
-#: org/postgresql/jdbc/PgResultSet.java:3268
-#: org/postgresql/jdbc/PgResultSet.java:3275
-#: org/postgresql/jdbc/PgResultSet.java:3282
-#: org/postgresql/jdbc/PgResultSet.java:3293
-#: org/postgresql/jdbc/PgResultSet.java:3310
-#: org/postgresql/jdbc/PgResultSet.java:3317
-#: org/postgresql/jdbc/PgResultSet.java:3324
-#: org/postgresql/jdbc/PgResultSet.java:3335
-#: org/postgresql/jdbc/PgResultSet.java:3342
-#: org/postgresql/jdbc/PgResultSet.java:3349
-#: org/postgresql/jdbc/PgResultSet.java:3387
-#: org/postgresql/jdbc/PgResultSet.java:3394
-#: org/postgresql/jdbc/PgResultSet.java:3401
-#: org/postgresql/jdbc/PgResultSet.java:3421
-#: org/postgresql/jdbc/PgResultSet.java:3434
+#: org/postgresql/jdbc/PgResultSet.java:3183
+#: org/postgresql/jdbc/PgResultSet.java:3190
+#: org/postgresql/jdbc/PgResultSet.java:3201
+#: org/postgresql/jdbc/PgResultSet.java:3212
+#: org/postgresql/jdbc/PgResultSet.java:3223
+#: org/postgresql/jdbc/PgResultSet.java:3234
+#: org/postgresql/jdbc/PgResultSet.java:3245
+#: org/postgresql/jdbc/PgResultSet.java:3256
+#: org/postgresql/jdbc/PgResultSet.java:3267
+#: org/postgresql/jdbc/PgResultSet.java:3274
+#: org/postgresql/jdbc/PgResultSet.java:3281
+#: org/postgresql/jdbc/PgResultSet.java:3292
+#: org/postgresql/jdbc/PgResultSet.java:3309
+#: org/postgresql/jdbc/PgResultSet.java:3316
+#: org/postgresql/jdbc/PgResultSet.java:3323
+#: org/postgresql/jdbc/PgResultSet.java:3334
+#: org/postgresql/jdbc/PgResultSet.java:3341
+#: org/postgresql/jdbc/PgResultSet.java:3348
+#: org/postgresql/jdbc/PgResultSet.java:3386
+#: org/postgresql/jdbc/PgResultSet.java:3393
+#: org/postgresql/jdbc/PgResultSet.java:3400
+#: org/postgresql/jdbc/PgResultSet.java:3420
+#: org/postgresql/jdbc/PgResultSet.java:3433
 #, fuzzy, java-format
 msgid "conversion to {0} from {1} not supported"
 msgstr "Изолационно ниво на транзакциите {0} не се поддържа."
@@ -1311,38 +1317,38 @@ msgid "Maximum number of rows must be a value grater than or equal to 0."
 msgstr ""
 "Максималният брой редове трябва да бъде стойност по-голяма или равна на 0."
 
-#: org/postgresql/jdbc/PgStatement.java:550
+#: org/postgresql/jdbc/PgStatement.java:555
 msgid "Query timeout must be a value greater than or equals to 0."
 msgstr ""
 "Времето за изпълнение на заявката трябва да бъде стойност по-голяма или "
 "равна на 0."
 
-#: org/postgresql/jdbc/PgStatement.java:590
+#: org/postgresql/jdbc/PgStatement.java:595
 msgid "The maximum field size must be a value greater than or equal to 0."
 msgstr ""
 "Максималният размер на полето трябва да бъде стойност по-голяма или равна на "
 "0."
 
-#: org/postgresql/jdbc/PgStatement.java:689
+#: org/postgresql/jdbc/PgStatement.java:694
 msgid "This statement has been closed."
 msgstr "Командата е извършена."
 
-#: org/postgresql/jdbc/PgStatement.java:1145
-#: org/postgresql/jdbc/PgStatement.java:1173
+#: org/postgresql/jdbc/PgStatement.java:1150
+#: org/postgresql/jdbc/PgStatement.java:1178
 msgid "Returning autogenerated keys by column index is not supported."
 msgstr ""
 "Автоматично генерирани ключове спрямо индекс на колона не се поддържат."
 
-#: org/postgresql/jdbc/TimestampUtils.java:355
-#: org/postgresql/jdbc/TimestampUtils.java:423
+#: org/postgresql/jdbc/TimestampUtils.java:365
+#: org/postgresql/jdbc/TimestampUtils.java:433
 #, fuzzy, java-format
 msgid "Bad value for type timestamp/date/time: {1}"
 msgstr "Невалидна стойност за тип {0} : {1}"
 
-#: org/postgresql/jdbc/TimestampUtils.java:858
-#: org/postgresql/jdbc/TimestampUtils.java:915
-#: org/postgresql/jdbc/TimestampUtils.java:961
-#: org/postgresql/jdbc/TimestampUtils.java:1010
+#: org/postgresql/jdbc/TimestampUtils.java:914
+#: org/postgresql/jdbc/TimestampUtils.java:971
+#: org/postgresql/jdbc/TimestampUtils.java:1017
+#: org/postgresql/jdbc/TimestampUtils.java:1066
 #, fuzzy, java-format
 msgid "Unsupported binary encoding of {0}."
 msgstr "Неподдържана стойност за тип: {0}"
@@ -1355,31 +1361,31 @@ msgstr ""
 msgid "Invalid or unsupported by client SCRAM mechanisms"
 msgstr ""
 
-#: org/postgresql/jre8/sasl/ScramAuthenticator.java:117
+#: org/postgresql/jre8/sasl/ScramAuthenticator.java:119
 #, fuzzy, java-format
 msgid "Invalid server-first-message: {0}"
 msgstr "Невалидна дължина {0} на потока данни."
 
-#: org/postgresql/jre8/sasl/ScramAuthenticator.java:147
+#: org/postgresql/jre8/sasl/ScramAuthenticator.java:151
 #, fuzzy, java-format
 msgid "Invalid server-final-message: {0}"
 msgstr "Невалидна дължина {0} на потока данни."
 
-#: org/postgresql/jre8/sasl/ScramAuthenticator.java:153
+#: org/postgresql/jre8/sasl/ScramAuthenticator.java:157
 #, java-format
 msgid "SCRAM authentication failed, server returned error: {0}"
 msgstr ""
 
-#: org/postgresql/jre8/sasl/ScramAuthenticator.java:160
+#: org/postgresql/jre8/sasl/ScramAuthenticator.java:164
 msgid "Invalid server SCRAM signature"
 msgstr ""
 
-#: org/postgresql/largeobject/LargeObjectManager.java:144
+#: org/postgresql/largeobject/LargeObjectManager.java:136
 msgid "Failed to initialize LargeObject API"
 msgstr "Не може да инициализира LargeObject API"
 
-#: org/postgresql/largeobject/LargeObjectManager.java:262
-#: org/postgresql/largeobject/LargeObjectManager.java:305
+#: org/postgresql/largeobject/LargeObjectManager.java:254
+#: org/postgresql/largeobject/LargeObjectManager.java:295
 msgid "Large Objects may not be used in auto-commit mode."
 msgstr "Големи обекти LOB не могат да се използват в auto-commit модус."
 
@@ -1413,34 +1419,34 @@ msgstr ""
 msgid "The hostname {0} could not be verified."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:164
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:90
 msgid "The sslfactoryarg property may not be empty."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:180
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:106
 msgid ""
 "The environment variable containing the server's SSL certificate must not be "
 "empty."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:188
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:114
 msgid ""
 "The system property containing the server's SSL certificate must not be "
 "empty."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:195
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:121
 msgid ""
 "The sslfactoryarg property must start with the prefix file:, classpath:, "
 "env:, sys:, or -----BEGIN CERTIFICATE-----."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:207
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:133
 #, fuzzy
 msgid "An error occurred reading the certificate"
 msgstr "Възникна грешка при осъществяване на SSL връзката."
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:240
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:166
 msgid "No X509TrustManager found"
 msgstr ""
 
@@ -1575,31 +1581,31 @@ msgid ""
 "setSavePoint not allowed while an XA transaction is active."
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:177
-#: org/postgresql/xa/PGXAConnection.java:253
-#: org/postgresql/xa/PGXAConnection.java:347
+#: org/postgresql/xa/PGXAConnection.java:186
+#: org/postgresql/xa/PGXAConnection.java:272
+#: org/postgresql/xa/PGXAConnection.java:381
 #, java-format
 msgid "Invalid flags {0}"
 msgstr "Невалидни флагове {0}"
 
-#: org/postgresql/xa/PGXAConnection.java:181
-#: org/postgresql/xa/PGXAConnection.java:257
-#: org/postgresql/xa/PGXAConnection.java:449
+#: org/postgresql/xa/PGXAConnection.java:190
+#: org/postgresql/xa/PGXAConnection.java:276
+#: org/postgresql/xa/PGXAConnection.java:491
 msgid "xid must not be null"
 msgstr "xid не може да бъде null"
 
-#: org/postgresql/xa/PGXAConnection.java:185
+#: org/postgresql/xa/PGXAConnection.java:194
 msgid "Connection is busy with another transaction"
 msgstr "Връзката е заета с друга транзакция"
 
-#: org/postgresql/xa/PGXAConnection.java:194
-#: org/postgresql/xa/PGXAConnection.java:267
+#: org/postgresql/xa/PGXAConnection.java:203
+#: org/postgresql/xa/PGXAConnection.java:286
 msgid "suspend/resume not implemented"
 msgstr "спиране / започване не се поддържа за момента"
 
-#: org/postgresql/xa/PGXAConnection.java:202
-#: org/postgresql/xa/PGXAConnection.java:209
-#: org/postgresql/xa/PGXAConnection.java:213
+#: org/postgresql/xa/PGXAConnection.java:211
+#: org/postgresql/xa/PGXAConnection.java:218
+#: org/postgresql/xa/PGXAConnection.java:222
 #, java-format
 msgid ""
 "Invalid protocol state requested. Attempted transaction interleaving is not "
@@ -1608,11 +1614,11 @@ msgstr ""
 "Транзакция в транзакция не се поддържа за момента. xid={0}, currentXid={1}, "
 "state={2}, flags={3}"
 
-#: org/postgresql/xa/PGXAConnection.java:224
+#: org/postgresql/xa/PGXAConnection.java:233
 msgid "Error disabling autocommit"
 msgstr "Грешка при изключване на autocommit"
 
-#: org/postgresql/xa/PGXAConnection.java:261
+#: org/postgresql/xa/PGXAConnection.java:280
 #, java-format
 msgid ""
 "tried to call end without corresponding start call. state={0}, start "
@@ -1621,7 +1627,7 @@ msgstr ""
 "опита да извика end без съответстващо извикване на start. state={0}, start "
 "xid={1}, currentXid={2}, preparedXid={3}"
 
-#: org/postgresql/xa/PGXAConnection.java:297
+#: org/postgresql/xa/PGXAConnection.java:326
 #, fuzzy, java-format
 msgid ""
 "Preparing already prepared transaction, the prepared xid {0}, prepare xid={1}"
@@ -1629,12 +1635,12 @@ msgstr ""
 "Грешка при възстановяване на състоянието преди подготвена транзакция. "
 "rollback xid={0}, preparedXid={1}, currentXid={2}"
 
-#: org/postgresql/xa/PGXAConnection.java:300
+#: org/postgresql/xa/PGXAConnection.java:329
 #, java-format
 msgid "Current connection does not have an associated xid. prepare xid={0}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:307
+#: org/postgresql/xa/PGXAConnection.java:336
 #, java-format
 msgid ""
 "Not implemented: Prepare must be issued using the same connection that "
@@ -1644,21 +1650,21 @@ msgstr ""
 "същата връзка, при която е започната транзакцията. currentXid={0}, prepare "
 "xid={1}"
 
-#: org/postgresql/xa/PGXAConnection.java:311
+#: org/postgresql/xa/PGXAConnection.java:340
 #, java-format
 msgid "Prepare called before end. prepare xid={0}, state={1}"
 msgstr "Prepare извикано преди края. prepare xid={0}, state={1}"
 
-#: org/postgresql/xa/PGXAConnection.java:331
+#: org/postgresql/xa/PGXAConnection.java:360
 #, java-format
 msgid "Error preparing transaction. prepare xid={0}"
 msgstr "Грешка при подготвяне на транзакция. prepare xid={0}"
 
-#: org/postgresql/xa/PGXAConnection.java:382
+#: org/postgresql/xa/PGXAConnection.java:416
 msgid "Error during recover"
 msgstr "Грешка при възстановяване"
 
-#: org/postgresql/xa/PGXAConnection.java:438
+#: org/postgresql/xa/PGXAConnection.java:480
 #, java-format
 msgid ""
 "Error rolling back prepared transaction. rollback xid={0}, preparedXid={1}, "
@@ -1667,13 +1673,13 @@ msgstr ""
 "Грешка при възстановяване на състоянието преди подготвена транзакция. "
 "rollback xid={0}, preparedXid={1}, currentXid={2}"
 
-#: org/postgresql/xa/PGXAConnection.java:471
+#: org/postgresql/xa/PGXAConnection.java:521
 #, java-format
 msgid ""
 "One-phase commit called for xid {0} but connection was prepared with xid {1}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:479
+#: org/postgresql/xa/PGXAConnection.java:529
 msgid ""
 "Not implemented: one-phase commit must be issued using the same connection "
 "that was used to start it"
@@ -1681,22 +1687,22 @@ msgstr ""
 "Невъзможна комбинация: едно-фазов commit трябва да бъде издаден чрез "
 "използване на същата връзка, при която е започнал"
 
-#: org/postgresql/xa/PGXAConnection.java:483
+#: org/postgresql/xa/PGXAConnection.java:533
 #, java-format
 msgid "One-phase commit with unknown xid. commit xid={0}, currentXid={1}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:487
+#: org/postgresql/xa/PGXAConnection.java:537
 #, java-format
 msgid "commit called before end. commit xid={0}, state={1}"
 msgstr "commit извикан преди end. commit xid={0}, state={1}"
 
-#: org/postgresql/xa/PGXAConnection.java:498
+#: org/postgresql/xa/PGXAConnection.java:548
 #, java-format
 msgid "Error during one-phase commit. commit xid={0}"
 msgstr "Грешка при едно-фазов commit. commit xid={0}"
 
-#: org/postgresql/xa/PGXAConnection.java:517
+#: org/postgresql/xa/PGXAConnection.java:576
 msgid ""
 "Not implemented: 2nd phase commit must be issued using an idle connection. "
 "commit xid={0}, currentXid={1}, state={2], transactionState={3}"
@@ -1705,7 +1711,7 @@ msgstr ""
 "издадена при свободна връзка. commit xid={0}, currentXid={1}, state={2], "
 "transactionState={3}"
 
-#: org/postgresql/xa/PGXAConnection.java:550
+#: org/postgresql/xa/PGXAConnection.java:609
 #, fuzzy, java-format
 msgid ""
 "Error committing prepared transaction. commit xid={0}, preparedXid={1}, "
@@ -1714,7 +1720,7 @@ msgstr ""
 "Грешка при възстановяване на състоянието преди подготвена транзакция. commit "
 "xid={0}, preparedXid={1}, currentXid={2}"
 
-#: org/postgresql/xa/PGXAConnection.java:567
+#: org/postgresql/xa/PGXAConnection.java:626
 #, java-format
 msgid "Heuristic commit/rollback not supported. forget xid={0}"
 msgstr "Евристичен commit или rollback не се поддържа. forget xid={0}"

--- a/pgjdbc/src/main/java/org/postgresql/translation/cs.po
+++ b/pgjdbc/src/main/java/org/postgresql/translation/cs.po
@@ -7,7 +7,6 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PostgreSQL JDBC Driver 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-06-05 10:57+0300\n"
 "PO-Revision-Date: 2005-08-21 20:00+0200\n"
 "Last-Translator: Petr Dittrich <bodyn@medoro.org>\n"
 "Language-Team: \n"
@@ -16,59 +15,59 @@ msgstr ""
 "Content-Type: text/plain; charset=ISO-8859-2\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: org/postgresql/Driver.java:214
+#: org/postgresql/Driver.java:217
 msgid "Error loading default settings from driverconfig.properties"
 msgstr "Chyba naèítání standardního nastavení z driverconfig.properties"
 
-#: org/postgresql/Driver.java:226
+#: org/postgresql/Driver.java:229
 msgid "Properties for the driver contains a non-string value for the key "
 msgstr ""
 
-#: org/postgresql/Driver.java:270
+#: org/postgresql/Driver.java:272
 msgid ""
 "Your security policy has prevented the connection from being attempted.  You "
 "probably need to grant the connect java.net.SocketPermission to the database "
 "server host and port that you wish to connect to."
 msgstr ""
 
-#: org/postgresql/Driver.java:276 org/postgresql/Driver.java:408
+#: org/postgresql/Driver.java:278 org/postgresql/Driver.java:410
 msgid ""
 "Something unusual has occurred to cause the driver to fail. Please report "
 "this exception."
 msgstr ""
 "Nìco neobvyklého pøinutilo ovladaè selhat. Prosím nahlaste tuto vyjímku."
 
-#: org/postgresql/Driver.java:416
+#: org/postgresql/Driver.java:418
 #, fuzzy
 msgid "Connection attempt timed out."
 msgstr "Pokus o pøipojení selhal."
 
-#: org/postgresql/Driver.java:429
+#: org/postgresql/Driver.java:431
 #, fuzzy
 msgid "Interrupted while attempting to connect."
 msgstr "Nastala chyba pøi nastavení SSL spojení."
 
-#: org/postgresql/Driver.java:682
+#: org/postgresql/Driver.java:687
 #, java-format
 msgid "Method {0} is not yet implemented."
 msgstr "Metoda {0} není implementována."
 
-#: org/postgresql/PGProperty.java:535 org/postgresql/PGProperty.java:555
+#: org/postgresql/PGProperty.java:537 org/postgresql/PGProperty.java:557
 #, java-format
 msgid "{0} parameter value must be an integer but was: {1}"
 msgstr ""
 
-#: org/postgresql/copy/CopyManager.java:53
+#: org/postgresql/copy/CopyManager.java:49
 #, java-format
 msgid "Requested CopyIn but got {0}"
 msgstr ""
 
-#: org/postgresql/copy/CopyManager.java:64
+#: org/postgresql/copy/CopyManager.java:60
 #, java-format
 msgid "Requested CopyOut but got {0}"
 msgstr ""
 
-#: org/postgresql/copy/CopyManager.java:75
+#: org/postgresql/copy/CopyManager.java:71
 #, java-format
 msgid "Requested CopyDual but got {0}"
 msgstr ""
@@ -93,6 +92,11 @@ msgstr ""
 msgid "Cannot write to copy a byte of value {0}"
 msgstr ""
 
+#: org/postgresql/core/CommandCompleteParser.java:71
+#, java-format
+msgid "Unable to parse the count in command completion tag: {0}."
+msgstr ""
+
 #: org/postgresql/core/ConnectionFactory.java:57
 #, java-format
 msgid "A connection could not be made using the requested protocol {0}."
@@ -113,7 +117,7 @@ msgstr ""
 msgid "Expected an EOF from server, got: {0}"
 msgstr ""
 
-#: org/postgresql/core/Parser.java:1006
+#: org/postgresql/core/Parser.java:1051
 #, java-format
 msgid "Malformed function or procedure escape syntax at offset {0}."
 msgstr "Po¹kozená funkce nebo opu¹tìní procedury na pozici {0}."
@@ -169,23 +173,23 @@ msgstr ""
 #: org/postgresql/core/v3/CompositeParameterList.java:33
 #: org/postgresql/core/v3/SimpleParameterList.java:54
 #: org/postgresql/core/v3/SimpleParameterList.java:65
-#: org/postgresql/jdbc/PgResultSet.java:2757
-#: org/postgresql/jdbc/PgResultSetMetaData.java:494
+#: org/postgresql/jdbc/PgResultSet.java:2755
+#: org/postgresql/jdbc/PgResultSetMetaData.java:388
 #, java-format
 msgid "The column index is out of range: {0}, number of columns: {1}."
 msgstr "Index sloupece je mimo rozsah: {0}, poèet sloupcù: {1}."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:109
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:103
 #, fuzzy, java-format
 msgid "Invalid sslmode value: {0}"
 msgstr "Vadná délka proudu {0}."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:124
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:118
 #, fuzzy, java-format
 msgid "Invalid targetServerType value: {0}"
 msgstr "Vadná délka proudu {0}."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:246
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:239
 #, fuzzy, java-format
 msgid ""
 "Connection to {0} refused. Check that the hostname and port are correct and "
@@ -194,39 +198,39 @@ msgstr ""
 "Spojení odmítnuto. Zkontrolujte zda je jméno hosta a port správné a zda "
 "postmaster pøijímá TCP/IP spojení."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:257
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:250
 #: org/postgresql/core/v3/replication/V3ReplicationProtocol.java:133
 msgid "The connection attempt failed."
 msgstr "Pokus o pøipojení selhal."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:272
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:265
 #, java-format
 msgid "Could not find a server with specified targetServerType: {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:368
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:381
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:361
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:374
 msgid "The server does not support SSL."
 msgstr "Server nepodporuje SSL."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:395
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:388
 msgid "An error occurred while setting up the SSL connection."
 msgstr "Nastala chyba pøi nastavení SSL spojení."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:496
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:523
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:484
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:511
 msgid ""
 "The server requested password-based authentication, but no password was "
 "provided."
 msgstr "Server vy¾aduje ovìøení heslem, ale ¾ádné nebylo posláno."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:626
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:614
 msgid ""
 "SCRAM authentication is not supported by this driver. You need JDK >= 8 and "
 "pgjdbc >= 42.2.0 (not \".jre\" versions)"
 msgstr ""
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:650
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:638
 #, java-format
 msgid ""
 "The authentication type {0} is not supported. Check that you have configured "
@@ -237,16 +241,16 @@ msgstr ""
 "pg_hba.conf obsahuje klientskou IP adresu èi podsí» a zda je pou¾ité "
 "ovìøenovací schéma podporováno ovladaèem."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:657
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2550
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2581
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2585
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2653
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:645
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2543
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2576
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2580
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2648
 #: org/postgresql/gss/GssAction.java:126
 msgid "Protocol error.  Session setup failed."
 msgstr "Chyba protokolu. Nastavení relace selhalo."
 
-#: org/postgresql/core/v3/CopyInImpl.java:47
+#: org/postgresql/core/v3/CopyInImpl.java:49
 msgid "CopyIn copy direction can't receive data"
 msgstr ""
 
@@ -254,177 +258,172 @@ msgstr ""
 msgid "CommandComplete expected COPY but got: "
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:161
+#: org/postgresql/core/v3/QueryExecutorImpl.java:163
 msgid "Tried to obtain lock while already holding it"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:177
+#: org/postgresql/core/v3/QueryExecutorImpl.java:179
 msgid "Tried to break lock on database connection"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:195
+#: org/postgresql/core/v3/QueryExecutorImpl.java:197
 #, fuzzy
 msgid "Interrupted while waiting to obtain lock on database connection"
 msgstr "Nastala chyba pøi nastavení SSL spojení."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:327
+#: org/postgresql/core/v3/QueryExecutorImpl.java:329
 msgid "Unable to bind parameter values for statement."
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:333
-#: org/postgresql/core/v3/QueryExecutorImpl.java:485
-#: org/postgresql/core/v3/QueryExecutorImpl.java:559
-#: org/postgresql/core/v3/QueryExecutorImpl.java:602
-#: org/postgresql/core/v3/QueryExecutorImpl.java:729
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2372
+#: org/postgresql/core/v3/QueryExecutorImpl.java:335
+#: org/postgresql/core/v3/QueryExecutorImpl.java:487
+#: org/postgresql/core/v3/QueryExecutorImpl.java:561
+#: org/postgresql/core/v3/QueryExecutorImpl.java:604
+#: org/postgresql/core/v3/QueryExecutorImpl.java:731
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2377
 #: org/postgresql/util/StreamWrapper.java:130
 msgid "An I/O error occurred while sending to the backend."
 msgstr "Vystupnì/výstupní chyba pøi odesílání k backend."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:534
-#: org/postgresql/core/v3/QueryExecutorImpl.java:576
+#: org/postgresql/core/v3/QueryExecutorImpl.java:536
+#: org/postgresql/core/v3/QueryExecutorImpl.java:578
 #, java-format
 msgid "Expected command status BEGIN, got {0}."
 msgstr "Oèekáván pøíkaz BEGIN, obdr¾en {0}."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:581
+#: org/postgresql/core/v3/QueryExecutorImpl.java:583
 #: org/postgresql/jdbc/PgResultSet.java:1778
 #, java-format
 msgid "Unexpected command status: {0}."
 msgstr "Neoèekávaný stav pøíkazu: {0}."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:687
+#: org/postgresql/core/v3/QueryExecutorImpl.java:689
 #, fuzzy
 msgid "An error occurred while trying to get the socket timeout."
 msgstr "Vystupnì/výstupní chyba pøi odesílání k backend."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:722
-#: org/postgresql/core/v3/QueryExecutorImpl.java:798
+#: org/postgresql/core/v3/QueryExecutorImpl.java:724
+#: org/postgresql/core/v3/QueryExecutorImpl.java:800
 #, java-format
 msgid "Unknown Response Type {0}."
 msgstr "Neznámý typ odpovìdi {0}."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:745
+#: org/postgresql/core/v3/QueryExecutorImpl.java:747
 #, fuzzy
 msgid "An error occurred while trying to reset the socket timeout."
 msgstr "Vystupnì/výstupní chyba pøi odesílání k backend."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:843
+#: org/postgresql/core/v3/QueryExecutorImpl.java:845
 msgid "Database connection failed when starting copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:878
+#: org/postgresql/core/v3/QueryExecutorImpl.java:880
 msgid "Tried to cancel an inactive copy operation"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:917
+#: org/postgresql/core/v3/QueryExecutorImpl.java:919
 msgid "Database connection failed when canceling copy operation"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:933
+#: org/postgresql/core/v3/QueryExecutorImpl.java:935
 msgid "Missing expected error response to copy cancel request"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:937
+#: org/postgresql/core/v3/QueryExecutorImpl.java:939
 #, java-format
 msgid "Got {0} error responses to single copy cancel request"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:952
+#: org/postgresql/core/v3/QueryExecutorImpl.java:954
 msgid "Tried to end inactive copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:967
+#: org/postgresql/core/v3/QueryExecutorImpl.java:969
 msgid "Database connection failed when ending copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:985
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1005
+#: org/postgresql/core/v3/QueryExecutorImpl.java:987
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1007
 msgid "Tried to write to an inactive copy operation"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:998
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1013
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1000
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1015
 msgid "Database connection failed when writing to copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1028
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1030
 msgid "Tried to read from inactive copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1035
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1037
 msgid "Database connection failed when reading from copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1101
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1103
 #, java-format
 msgid "Received CommandComplete ''{0}'' without an active copy operation"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1126
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1128
 #, java-format
 msgid "Got CopyInResponse from server during an active {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1140
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1142
 #, java-format
 msgid "Got CopyOutResponse from server during an active {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1154
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1156
 #, java-format
 msgid "Got CopyBothResponse from server during an active {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1170
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1172
 msgid "Got CopyData without an active copy operation"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1174
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1176
 #, fuzzy, java-format
 msgid "Unexpected copydata from server for {0}"
 msgstr "Neoèekávaný stav pøíkazu: {0}."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1234
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1236
 #, java-format
 msgid "Unexpected packet type during copy: {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1524
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1526
 #, java-format
 msgid ""
 "Bind message length {0} too long.  This can be caused by very large or "
 "incorrect length specifications on InputStream parameters."
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2145
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2150
 msgid "Ran out of memory retrieving query results."
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2313
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2318
 msgid "The driver currently does not support COPY operations."
 msgstr "Ovladaè nyní nepodporuje pøíkaz COPY."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2487
-#, java-format
-msgid "Unable to parse the count in command completion tag: {0}."
-msgstr ""
-
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2610
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2605
 #, java-format
 msgid ""
 "The server''s client_encoding parameter was changed to {0}. The JDBC driver "
 "requires client_encoding to be UTF8 for correct operation."
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2620
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2615
 #, java-format
 msgid ""
 "The server''s DateStyle parameter was changed to {0}. The JDBC driver "
 "requires DateStyle to begin with ISO for correct operation."
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2633
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2628
 #, java-format
 msgid ""
 "The server''s standard_conforming_strings parameter was reported as {0}. The "
@@ -483,36 +482,36 @@ msgstr "DataSource byl uzavøen."
 msgid "Unsupported property name: {0}"
 msgstr "Nepodporovaná hodnota typu: {0}"
 
-#: org/postgresql/fastpath/Fastpath.java:86
+#: org/postgresql/fastpath/Fastpath.java:84
 #, java-format
 msgid "Fastpath call {0} - No result was returned and we expected a numeric."
 msgstr ""
 
-#: org/postgresql/fastpath/Fastpath.java:163
+#: org/postgresql/fastpath/Fastpath.java:161
 #, java-format
 msgid "Fastpath call {0} - No result was returned and we expected an integer."
 msgstr ""
 
-#: org/postgresql/fastpath/Fastpath.java:171
+#: org/postgresql/fastpath/Fastpath.java:169
 #, java-format
 msgid ""
 "Fastpath call {0} - No result was returned or wrong size while expecting an "
 "integer."
 msgstr ""
 
-#: org/postgresql/fastpath/Fastpath.java:188
+#: org/postgresql/fastpath/Fastpath.java:186
 #, fuzzy, java-format
 msgid "Fastpath call {0} - No result was returned and we expected a long."
 msgstr "Obdr¾en výsledek, ikdy¾ ¾ádný nebyl oèekáván."
 
-#: org/postgresql/fastpath/Fastpath.java:196
+#: org/postgresql/fastpath/Fastpath.java:194
 #, java-format
 msgid ""
 "Fastpath call {0} - No result was returned or wrong size while expecting a "
 "long."
 msgstr ""
 
-#: org/postgresql/fastpath/Fastpath.java:308
+#: org/postgresql/fastpath/Fastpath.java:297
 #, java-format
 msgid "The fastpath function {0} is unknown."
 msgstr ""
@@ -578,63 +577,70 @@ msgid "Cannot cast to boolean: \"{0}\""
 msgstr ""
 
 #: org/postgresql/jdbc/EscapedFunctions.java:240
+#: org/postgresql/jdbc/EscapedFunctions2.java:167
 #, java-format
 msgid "{0} function takes four and only four argument."
 msgstr "Funkce {0} bere pøesnì ètyøi argumenty."
 
 #: org/postgresql/jdbc/EscapedFunctions.java:270
-#: org/postgresql/jdbc/EscapedFunctions.java:344
-#: org/postgresql/jdbc/EscapedFunctions.java:749
-#: org/postgresql/jdbc/EscapedFunctions.java:787
+#: org/postgresql/jdbc/EscapedFunctions.java:337
+#: org/postgresql/jdbc/EscapedFunctions.java:740
+#: org/postgresql/jdbc/EscapedFunctions2.java:196
+#: org/postgresql/jdbc/EscapedFunctions2.java:263
+#: org/postgresql/jdbc/EscapedFunctions2.java:665
 #, java-format
 msgid "{0} function takes two and only two arguments."
 msgstr "Funkce {0} bere právì dva argumenty."
 
 #: org/postgresql/jdbc/EscapedFunctions.java:288
-#: org/postgresql/jdbc/EscapedFunctions.java:326
-#: org/postgresql/jdbc/EscapedFunctions.java:446
-#: org/postgresql/jdbc/EscapedFunctions.java:461
-#: org/postgresql/jdbc/EscapedFunctions.java:476
-#: org/postgresql/jdbc/EscapedFunctions.java:491
-#: org/postgresql/jdbc/EscapedFunctions.java:506
-#: org/postgresql/jdbc/EscapedFunctions.java:521
-#: org/postgresql/jdbc/EscapedFunctions.java:536
-#: org/postgresql/jdbc/EscapedFunctions.java:551
-#: org/postgresql/jdbc/EscapedFunctions.java:566
-#: org/postgresql/jdbc/EscapedFunctions.java:581
-#: org/postgresql/jdbc/EscapedFunctions.java:596
-#: org/postgresql/jdbc/EscapedFunctions.java:611
-#: org/postgresql/jdbc/EscapedFunctions.java:775
+#: org/postgresql/jdbc/EscapedFunctions.java:441
+#: org/postgresql/jdbc/EscapedFunctions.java:467
+#: org/postgresql/jdbc/EscapedFunctions.java:526
+#: org/postgresql/jdbc/EscapedFunctions.java:728
+#: org/postgresql/jdbc/EscapedFunctions2.java:211
+#: org/postgresql/jdbc/EscapedFunctions2.java:355
+#: org/postgresql/jdbc/EscapedFunctions2.java:381
+#: org/postgresql/jdbc/EscapedFunctions2.java:440
+#: org/postgresql/jdbc/EscapedFunctions2.java:654
 #, java-format
 msgid "{0} function takes one and only one argument."
 msgstr "Funkce {0} bere jeden argument."
 
-#: org/postgresql/jdbc/EscapedFunctions.java:310
-#: org/postgresql/jdbc/EscapedFunctions.java:391
+#: org/postgresql/jdbc/EscapedFunctions.java:312
+#: org/postgresql/jdbc/EscapedFunctions.java:386
+#: org/postgresql/jdbc/EscapedFunctions2.java:238
+#: org/postgresql/jdbc/EscapedFunctions2.java:307
 #, java-format
 msgid "{0} function takes two or three arguments."
 msgstr "Funkce {0} bere dva nebo tøi argumenty."
 
-#: org/postgresql/jdbc/EscapedFunctions.java:416
-#: org/postgresql/jdbc/EscapedFunctions.java:431
-#: org/postgresql/jdbc/EscapedFunctions.java:734
-#: org/postgresql/jdbc/EscapedFunctions.java:764
+#: org/postgresql/jdbc/EscapedFunctions.java:411
+#: org/postgresql/jdbc/EscapedFunctions.java:426
+#: org/postgresql/jdbc/EscapedFunctions.java:693
+#: org/postgresql/jdbc/EscapedFunctions.java:719
+#: org/postgresql/jdbc/EscapedFunctions2.java:645
 #, java-format
 msgid "{0} function doesn''t take any argument."
 msgstr "Funkce {0} nebere ¾ádný argument."
 
-#: org/postgresql/jdbc/EscapedFunctions.java:627
-#: org/postgresql/jdbc/EscapedFunctions.java:680
+#: org/postgresql/jdbc/EscapedFunctions.java:586
+#: org/postgresql/jdbc/EscapedFunctions.java:639
+#: org/postgresql/jdbc/EscapedFunctions2.java:500
+#: org/postgresql/jdbc/EscapedFunctions2.java:571
 #, fuzzy, java-format
 msgid "{0} function takes three and only three arguments."
 msgstr "Funkce {0} bere právì dva argumenty."
 
-#: org/postgresql/jdbc/EscapedFunctions.java:640
-#: org/postgresql/jdbc/EscapedFunctions.java:661
-#: org/postgresql/jdbc/EscapedFunctions.java:664
-#: org/postgresql/jdbc/EscapedFunctions.java:697
-#: org/postgresql/jdbc/EscapedFunctions.java:710
-#: org/postgresql/jdbc/EscapedFunctions.java:713
+#: org/postgresql/jdbc/EscapedFunctions.java:599
+#: org/postgresql/jdbc/EscapedFunctions.java:620
+#: org/postgresql/jdbc/EscapedFunctions.java:623
+#: org/postgresql/jdbc/EscapedFunctions.java:656
+#: org/postgresql/jdbc/EscapedFunctions.java:669
+#: org/postgresql/jdbc/EscapedFunctions.java:672
+#: org/postgresql/jdbc/EscapedFunctions2.java:510
+#: org/postgresql/jdbc/EscapedFunctions2.java:527
+#: org/postgresql/jdbc/EscapedFunctions2.java:585
+#: org/postgresql/jdbc/EscapedFunctions2.java:597
 #, fuzzy, java-format
 msgid "Interval {0} not yet implemented"
 msgstr "Metoda {0} není implementována."
@@ -653,17 +659,17 @@ msgstr "Nemohu získat id nepojmenovaného savepointu."
 msgid "Cannot retrieve the name of an unnamed savepoint."
 msgstr "Nemohu získat název nepojmenovaného savepointu."
 
-#: org/postgresql/jdbc/PgArray.java:157 org/postgresql/jdbc/PgArray.java:844
+#: org/postgresql/jdbc/PgArray.java:155 org/postgresql/jdbc/PgArray.java:842
 #, java-format
 msgid "The array index is out of range: {0}"
 msgstr "Index pole mimo rozsah: {0}"
 
-#: org/postgresql/jdbc/PgArray.java:178 org/postgresql/jdbc/PgArray.java:861
+#: org/postgresql/jdbc/PgArray.java:176 org/postgresql/jdbc/PgArray.java:859
 #, java-format
 msgid "The array index is out of range: {0}, number of elements: {1}."
 msgstr "Index pole mimo rozsah: {0}, poèet prvkù: {1}."
 
-#: org/postgresql/jdbc/PgArray.java:210
+#: org/postgresql/jdbc/PgArray.java:208
 #: org/postgresql/jdbc/PgResultSet.java:1930
 #: org/postgresql/util/HStoreConverter.java:43
 #: org/postgresql/util/HStoreConverter.java:74
@@ -678,68 +684,68 @@ msgstr ""
 "zakládání databáze. Nejznámej¹í pøíklad je ukládání 8bitových dat vSQL_ASCII "
 "databázi."
 
-#: org/postgresql/jdbc/PgCallableStatement.java:86
-#: org/postgresql/jdbc/PgCallableStatement.java:96
+#: org/postgresql/jdbc/PgCallableStatement.java:85
+#: org/postgresql/jdbc/PgCallableStatement.java:95
 msgid "A CallableStatement was executed with nothing returned."
 msgstr "CallableStatement byl spu¹tìn, leè nic nebylo vráceno."
 
-#: org/postgresql/jdbc/PgCallableStatement.java:107
+#: org/postgresql/jdbc/PgCallableStatement.java:106
 #, fuzzy
 msgid "A CallableStatement was executed with an invalid number of parameters"
 msgstr "CallableStatement byl spu¹tìn, leè nic nebylo vráceno."
 
-#: org/postgresql/jdbc/PgCallableStatement.java:145
+#: org/postgresql/jdbc/PgCallableStatement.java:144
 #, java-format
 msgid ""
 "A CallableStatement function was executed and the out parameter {0} was of "
 "type {1} however type {2} was registered."
 msgstr ""
 
-#: org/postgresql/jdbc/PgCallableStatement.java:202
+#: org/postgresql/jdbc/PgCallableStatement.java:206
 msgid ""
 "This statement does not declare an OUT parameter.  Use '{' ?= call ... '}' "
 "to declare one."
 msgstr ""
 
-#: org/postgresql/jdbc/PgCallableStatement.java:246
+#: org/postgresql/jdbc/PgCallableStatement.java:229
 msgid "wasNull cannot be call before fetching a result."
 msgstr ""
 
-#: org/postgresql/jdbc/PgCallableStatement.java:384
-#: org/postgresql/jdbc/PgCallableStatement.java:403
+#: org/postgresql/jdbc/PgCallableStatement.java:367
+#: org/postgresql/jdbc/PgCallableStatement.java:386
 #, java-format
 msgid ""
 "Parameter of type {0} was registered, but call to get{1} (sqltype={2}) was "
 "made."
 msgstr ""
 
-#: org/postgresql/jdbc/PgCallableStatement.java:424
+#: org/postgresql/jdbc/PgCallableStatement.java:407
 msgid ""
 "A CallableStatement was declared, but no call to registerOutParameter(1, "
 "<some type>) was made."
 msgstr ""
 
-#: org/postgresql/jdbc/PgCallableStatement.java:430
+#: org/postgresql/jdbc/PgCallableStatement.java:413
 msgid "No function outputs were registered."
 msgstr ""
 
-#: org/postgresql/jdbc/PgCallableStatement.java:436
+#: org/postgresql/jdbc/PgCallableStatement.java:419
 msgid ""
 "Results cannot be retrieved from a CallableStatement before it is executed."
 msgstr ""
 
-#: org/postgresql/jdbc/PgCallableStatement.java:703
+#: org/postgresql/jdbc/PgCallableStatement.java:686
 #, fuzzy, java-format
 msgid "Unsupported type conversion to {1}."
 msgstr "Nepodporovaná hodnota typu: {0}"
 
-#: org/postgresql/jdbc/PgConnection.java:272
+#: org/postgresql/jdbc/PgConnection.java:241
 #, fuzzy, java-format
 msgid "Unsupported value for stringtype parameter: {0}"
 msgstr "Nepodporovaná hodnota typu: {0}"
 
 #: org/postgresql/jdbc/PgConnection.java:424
-#: org/postgresql/jdbc/PgPreparedStatement.java:119
+#: org/postgresql/jdbc/PgPreparedStatement.java:107
 #: org/postgresql/jdbc/PgStatement.java:225
 #: org/postgresql/jdbc/TypeInfoCache.java:226
 #: org/postgresql/jdbc/TypeInfoCache.java:371
@@ -751,128 +757,128 @@ msgstr "Nepodporovaná hodnota typu: {0}"
 msgid "No results were returned by the query."
 msgstr "Neobdr¾en ¾ádný výsledek dotazu."
 
-#: org/postgresql/jdbc/PgConnection.java:441
+#: org/postgresql/jdbc/PgConnection.java:442
 #: org/postgresql/jdbc/PgStatement.java:254
 msgid "A result was returned when none was expected."
 msgstr "Obdr¾en výsledek, ikdy¾ ¾ádný nebyl oèekáván."
 
-#: org/postgresql/jdbc/PgConnection.java:545
+#: org/postgresql/jdbc/PgConnection.java:547
 msgid "Custom type maps are not supported."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:587
+#: org/postgresql/jdbc/PgConnection.java:589
 #, java-format
 msgid "Failed to create object for: {0}."
 msgstr "Selhalo vytvoøení objektu: {0}."
 
-#: org/postgresql/jdbc/PgConnection.java:641
+#: org/postgresql/jdbc/PgConnection.java:643
 #, java-format
 msgid "Unable to load the class {0} responsible for the datatype {1}"
 msgstr "Nemohu naèíst tøídu {0} odpovìdnou za typ {1}"
 
-#: org/postgresql/jdbc/PgConnection.java:693
+#: org/postgresql/jdbc/PgConnection.java:705
 msgid ""
 "Cannot change transaction read-only property in the middle of a transaction."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:756
+#: org/postgresql/jdbc/PgConnection.java:772
 msgid "Cannot commit when autoCommit is enabled."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:767
-#: org/postgresql/jdbc/PgConnection.java:1384
-#: org/postgresql/jdbc/PgConnection.java:1428
+#: org/postgresql/jdbc/PgConnection.java:783
+#: org/postgresql/jdbc/PgConnection.java:1401
+#: org/postgresql/jdbc/PgConnection.java:1445
 #, fuzzy
 msgid "This connection has been closed."
 msgstr "Spojeni bylo uzavøeno."
 
-#: org/postgresql/jdbc/PgConnection.java:777
+#: org/postgresql/jdbc/PgConnection.java:794
 msgid "Cannot rollback when autoCommit is enabled."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:827
+#: org/postgresql/jdbc/PgConnection.java:844
 msgid ""
 "Cannot change transaction isolation level in the middle of a transaction."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:833
+#: org/postgresql/jdbc/PgConnection.java:850
 #, java-format
 msgid "Transaction isolation level {0} not supported."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:878
+#: org/postgresql/jdbc/PgConnection.java:895
 #, fuzzy
 msgid "Finalizing a Connection that was never closed:"
 msgstr "Spojeni bylo uzavøeno."
 
-#: org/postgresql/jdbc/PgConnection.java:945
+#: org/postgresql/jdbc/PgConnection.java:962
 msgid "Unable to translate data into the desired encoding."
 msgstr "Nemohu pøelo¾it data do po¾adovaného kódování."
 
-#: org/postgresql/jdbc/PgConnection.java:1008
+#: org/postgresql/jdbc/PgConnection.java:1025
 #: org/postgresql/jdbc/PgResultSet.java:1817
-#: org/postgresql/jdbc/PgStatement.java:903
+#: org/postgresql/jdbc/PgStatement.java:908
 msgid "Fetch size must be a value greater to or equal to 0."
 msgstr "Nabraná velikost musí být nezáporná."
 
-#: org/postgresql/jdbc/PgConnection.java:1289
-#: org/postgresql/jdbc/PgConnection.java:1330
+#: org/postgresql/jdbc/PgConnection.java:1306
+#: org/postgresql/jdbc/PgConnection.java:1347
 #, java-format
 msgid "Unable to find server array type for provided name {0}."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1312
+#: org/postgresql/jdbc/PgConnection.java:1329
 #, fuzzy, java-format
 msgid "Invalid elements {0}"
 msgstr "Vadná délka proudu {0}."
 
-#: org/postgresql/jdbc/PgConnection.java:1348
+#: org/postgresql/jdbc/PgConnection.java:1365
 #, fuzzy, java-format
 msgid "Invalid timeout ({0}<0)."
 msgstr "Vadná délka proudu {0}."
 
-#: org/postgresql/jdbc/PgConnection.java:1372
+#: org/postgresql/jdbc/PgConnection.java:1389
 msgid "Validating connection."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1405
+#: org/postgresql/jdbc/PgConnection.java:1422
 #, fuzzy, java-format
 msgid "Failed to set ClientInfo property: {0}"
 msgstr "Selhalo vytvoøení objektu: {0}."
 
-#: org/postgresql/jdbc/PgConnection.java:1415
+#: org/postgresql/jdbc/PgConnection.java:1432
 #, fuzzy
 msgid "ClientInfo property not supported."
 msgstr "Vrácení automaticky generovaných klíèù není podporováno."
 
-#: org/postgresql/jdbc/PgConnection.java:1441
+#: org/postgresql/jdbc/PgConnection.java:1458
 msgid "One ore more ClientInfo failed."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1540
+#: org/postgresql/jdbc/PgConnection.java:1559
 #, fuzzy
 msgid "Network timeout must be a value greater than or equal to 0."
 msgstr "Èasový limit dotazu musí být nezáporné èíslo."
 
-#: org/postgresql/jdbc/PgConnection.java:1552
+#: org/postgresql/jdbc/PgConnection.java:1571
 msgid "Unable to set network timeout."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1563
+#: org/postgresql/jdbc/PgConnection.java:1582
 msgid "Unable to get network timeout."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1580
+#: org/postgresql/jdbc/PgConnection.java:1599
 #, java-format
 msgid "Unknown ResultSet holdability setting: {0}."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1598
-#: org/postgresql/jdbc/PgConnection.java:1619
+#: org/postgresql/jdbc/PgConnection.java:1617
+#: org/postgresql/jdbc/PgConnection.java:1638
 msgid "Cannot establish a savepoint in auto-commit mode."
 msgstr "Nemohu vytvoøit savepoint v auto-commit modu."
 
-#: org/postgresql/jdbc/PgConnection.java:1685
+#: org/postgresql/jdbc/PgConnection.java:1707
 msgid "Returning autogenerated keys is not supported."
 msgstr "Vrácení automaticky generovaných klíèù není podporováno."
 
@@ -887,47 +893,47 @@ msgstr "Nemohu najít oid a oidvector typu v systémovém katalogu."
 msgid "Unable to find name datatype in the system catalogs."
 msgstr "Nemohu najít název typu v systémovém katalogu."
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:323
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:322
 #, fuzzy
 msgid "Unable to find keywords in the system catalogs."
 msgstr "Nemohu najít název typu v systémovém katalogu."
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1105
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1095
 msgid "oid"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1105
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1095
 msgid "proname"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1107
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1558
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1097
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1548
 msgid "typtype"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1110
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1100
 msgid "proargtypes"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1576
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1566
 msgid "adsrc"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1589
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1579
 msgid "attidentity"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1685
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1761
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1675
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1751
 msgid "rolname"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1686
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1762
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1676
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1752
 msgid "relacl"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1692
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1682
 msgid "attacl"
 msgstr ""
 
@@ -936,83 +942,83 @@ msgstr ""
 msgid "The parameter index is out of range: {0}, number of parameters: {1}."
 msgstr "Index parametru mimo rozsah: {0}, poèet parametrù {1}."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:106
+#: org/postgresql/jdbc/PgPreparedStatement.java:94
+#: org/postgresql/jdbc/PgPreparedStatement.java:115
 #: org/postgresql/jdbc/PgPreparedStatement.java:127
-#: org/postgresql/jdbc/PgPreparedStatement.java:139
-#: org/postgresql/jdbc/PgPreparedStatement.java:1035
+#: org/postgresql/jdbc/PgPreparedStatement.java:1008
 msgid ""
 "Can''t use query methods that take a query string on a PreparedStatement."
 msgstr ""
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:249
+#: org/postgresql/jdbc/PgPreparedStatement.java:237
 msgid "Unknown Types value."
 msgstr "Neznámá hodnota typu."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:382
-#: org/postgresql/jdbc/PgPreparedStatement.java:439
-#: org/postgresql/jdbc/PgPreparedStatement.java:1191
-#: org/postgresql/jdbc/PgPreparedStatement.java:1490
+#: org/postgresql/jdbc/PgPreparedStatement.java:364
+#: org/postgresql/jdbc/PgPreparedStatement.java:421
+#: org/postgresql/jdbc/PgPreparedStatement.java:1164
+#: org/postgresql/jdbc/PgPreparedStatement.java:1472
 #, java-format
 msgid "Invalid stream length {0}."
 msgstr "Vadná délka proudu {0}."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:411
+#: org/postgresql/jdbc/PgPreparedStatement.java:393
 #, java-format
 msgid "The JVM claims not to support the {0} encoding."
 msgstr "JVM tvrdí, ¾e nepodporuje kodování {0}."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:414
+#: org/postgresql/jdbc/PgPreparedStatement.java:396
 #: org/postgresql/jdbc/PgResultSet.java:1122
 #: org/postgresql/jdbc/PgResultSet.java:1156
 msgid "Provided InputStream failed."
 msgstr "Selhal poskytnutý InputStream."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:460
-#: org/postgresql/jdbc/PgPreparedStatement.java:1096
+#: org/postgresql/jdbc/PgPreparedStatement.java:442
+#: org/postgresql/jdbc/PgPreparedStatement.java:1069
 #, java-format
 msgid "Unknown type {0}."
 msgstr "Neznámý typ {0}."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:477
+#: org/postgresql/jdbc/PgPreparedStatement.java:459
 msgid "No hstore extension installed."
 msgstr ""
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:619
-#: org/postgresql/jdbc/PgPreparedStatement.java:642
-#: org/postgresql/jdbc/PgPreparedStatement.java:652
-#: org/postgresql/jdbc/PgPreparedStatement.java:664
+#: org/postgresql/jdbc/PgPreparedStatement.java:601
+#: org/postgresql/jdbc/PgPreparedStatement.java:624
+#: org/postgresql/jdbc/PgPreparedStatement.java:634
+#: org/postgresql/jdbc/PgPreparedStatement.java:646
 #, java-format
 msgid "Cannot cast an instance of {0} to type {1}"
 msgstr "Nemohu pøetypovat instanci {0} na typ {1}"
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:682
+#: org/postgresql/jdbc/PgPreparedStatement.java:664
 #, java-format
 msgid "Unsupported Types value: {0}"
 msgstr "Nepodporovaná hodnota typu: {0}"
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:894
+#: org/postgresql/jdbc/PgPreparedStatement.java:876
 #, fuzzy, java-format
 msgid "Cannot convert an instance of {0} to type {1}"
 msgstr "Nemohu pøetypovat instanci {0} na typ {1}"
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:968
+#: org/postgresql/jdbc/PgPreparedStatement.java:950
 #, java-format
 msgid ""
 "Can''t infer the SQL type to use for an instance of {0}. Use setObject() "
 "with an explicit Types value to specify the type to use."
 msgstr ""
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:1133
-#: org/postgresql/jdbc/PgPreparedStatement.java:1233
+#: org/postgresql/jdbc/PgPreparedStatement.java:1106
+#: org/postgresql/jdbc/PgPreparedStatement.java:1206
 msgid "Unexpected error writing large object to database."
 msgstr "Neoèekávaná chyba pøi zapisování velkého objektu do databáze."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:1178
+#: org/postgresql/jdbc/PgPreparedStatement.java:1151
 #: org/postgresql/jdbc/PgResultSet.java:1210
 msgid "Provided Reader failed."
 msgstr "Selhal poskytnutý Reader."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:1449
+#: org/postgresql/jdbc/PgPreparedStatement.java:1431
 #: org/postgresql/util/StreamWrapper.java:56
 msgid "Object is too large to send over the protocol."
 msgstr ""
@@ -1028,8 +1034,8 @@ msgstr ""
 #: org/postgresql/jdbc/PgResultSet.java:556
 #: org/postgresql/jdbc/PgResultSet.java:594
 #: org/postgresql/jdbc/PgResultSet.java:624
-#: org/postgresql/jdbc/PgResultSet.java:3014
-#: org/postgresql/jdbc/PgResultSet.java:3058
+#: org/postgresql/jdbc/PgResultSet.java:3012
+#: org/postgresql/jdbc/PgResultSet.java:3057
 #, fuzzy, java-format
 msgid "Cannot convert the column of type {0} to requested type {1}."
 msgstr "Nemohu pøetypovat instanci {0} na typ {1}"
@@ -1041,7 +1047,7 @@ msgid "Can''t use relative move methods while on the insert row."
 msgstr "Nemù¾ete pou¾ívat relativní pøesuny pøi vkládání øádku."
 
 #: org/postgresql/jdbc/PgResultSet.java:878
-#: org/postgresql/jdbc/PgStatement.java:895
+#: org/postgresql/jdbc/PgStatement.java:900
 #, java-format
 msgid "Invalid fetch direction constant: {0}."
 msgstr "©patný smìr ètení: {0}."
@@ -1081,8 +1087,8 @@ msgstr "Musíte vyplnit alespoò jeden sloupec pro vlo¾ení øádku."
 
 #: org/postgresql/jdbc/PgResultSet.java:1119
 #: org/postgresql/jdbc/PgResultSet.java:1754
-#: org/postgresql/jdbc/PgResultSet.java:2422
-#: org/postgresql/jdbc/PgResultSet.java:2443
+#: org/postgresql/jdbc/PgResultSet.java:2420
+#: org/postgresql/jdbc/PgResultSet.java:2441
 #, java-format
 msgid "The JVM claims not to support the encoding: {0}"
 msgstr "JVM tvrdí, ¾e nepodporuje kodování: {0}"
@@ -1096,7 +1102,7 @@ msgid "Cannot call updateRow() when on the insert row."
 msgstr "Nemohu volat updateRow() na vlkádaném øádku."
 
 #: org/postgresql/jdbc/PgResultSet.java:1335
-#: org/postgresql/jdbc/PgResultSet.java:3075
+#: org/postgresql/jdbc/PgResultSet.java:3074
 msgid ""
 "Cannot update the ResultSet because it is either before the start or after "
 "the end of the results."
@@ -1113,27 +1119,27 @@ msgstr "Nenalezen primární klíè pro tabulku {0}."
 
 #: org/postgresql/jdbc/PgResultSet.java:2017
 #: org/postgresql/jdbc/PgResultSet.java:2022
-#: org/postgresql/jdbc/PgResultSet.java:2809
-#: org/postgresql/jdbc/PgResultSet.java:2815
-#: org/postgresql/jdbc/PgResultSet.java:2840
-#: org/postgresql/jdbc/PgResultSet.java:2846
-#: org/postgresql/jdbc/PgResultSet.java:2870
-#: org/postgresql/jdbc/PgResultSet.java:2875
-#: org/postgresql/jdbc/PgResultSet.java:2891
-#: org/postgresql/jdbc/PgResultSet.java:2912
-#: org/postgresql/jdbc/PgResultSet.java:2923
-#: org/postgresql/jdbc/PgResultSet.java:2936
-#: org/postgresql/jdbc/PgResultSet.java:3063
+#: org/postgresql/jdbc/PgResultSet.java:2807
+#: org/postgresql/jdbc/PgResultSet.java:2813
+#: org/postgresql/jdbc/PgResultSet.java:2838
+#: org/postgresql/jdbc/PgResultSet.java:2844
+#: org/postgresql/jdbc/PgResultSet.java:2868
+#: org/postgresql/jdbc/PgResultSet.java:2873
+#: org/postgresql/jdbc/PgResultSet.java:2889
+#: org/postgresql/jdbc/PgResultSet.java:2910
+#: org/postgresql/jdbc/PgResultSet.java:2921
+#: org/postgresql/jdbc/PgResultSet.java:2934
+#: org/postgresql/jdbc/PgResultSet.java:3062
 #, java-format
 msgid "Bad value for type {0} : {1}"
 msgstr "©patná hodnota pro typ {0} : {1}"
 
-#: org/postgresql/jdbc/PgResultSet.java:2595
+#: org/postgresql/jdbc/PgResultSet.java:2593
 #, java-format
 msgid "The column name {0} was not found in this ResultSet."
 msgstr "Sloupec pojmenovaný {0} nebyl nalezen v ResultSet."
 
-#: org/postgresql/jdbc/PgResultSet.java:2731
+#: org/postgresql/jdbc/PgResultSet.java:2729
 msgid ""
 "ResultSet is not updateable.  The query that generated this result set must "
 "select only one table, and must select all primary keys from that table. See "
@@ -1143,41 +1149,41 @@ msgstr ""
 "musí obsahovat v¹echny primární klíèe tabulky. Koukni do JDBC 2.1 API "
 "Specifikace, sekce 5.6 pro více podrobností."
 
-#: org/postgresql/jdbc/PgResultSet.java:2743
+#: org/postgresql/jdbc/PgResultSet.java:2741
 msgid "This ResultSet is closed."
 msgstr "Tento ResultSet je uzavøený."
 
-#: org/postgresql/jdbc/PgResultSet.java:2774
+#: org/postgresql/jdbc/PgResultSet.java:2772
 msgid "ResultSet not positioned properly, perhaps you need to call next."
 msgstr ""
 
-#: org/postgresql/jdbc/PgResultSet.java:3095
+#: org/postgresql/jdbc/PgResultSet.java:3094
 msgid "Invalid UUID data."
 msgstr ""
 
-#: org/postgresql/jdbc/PgResultSet.java:3184
-#: org/postgresql/jdbc/PgResultSet.java:3191
-#: org/postgresql/jdbc/PgResultSet.java:3202
-#: org/postgresql/jdbc/PgResultSet.java:3213
-#: org/postgresql/jdbc/PgResultSet.java:3224
-#: org/postgresql/jdbc/PgResultSet.java:3235
-#: org/postgresql/jdbc/PgResultSet.java:3246
-#: org/postgresql/jdbc/PgResultSet.java:3257
-#: org/postgresql/jdbc/PgResultSet.java:3268
-#: org/postgresql/jdbc/PgResultSet.java:3275
-#: org/postgresql/jdbc/PgResultSet.java:3282
-#: org/postgresql/jdbc/PgResultSet.java:3293
-#: org/postgresql/jdbc/PgResultSet.java:3310
-#: org/postgresql/jdbc/PgResultSet.java:3317
-#: org/postgresql/jdbc/PgResultSet.java:3324
-#: org/postgresql/jdbc/PgResultSet.java:3335
-#: org/postgresql/jdbc/PgResultSet.java:3342
-#: org/postgresql/jdbc/PgResultSet.java:3349
-#: org/postgresql/jdbc/PgResultSet.java:3387
-#: org/postgresql/jdbc/PgResultSet.java:3394
-#: org/postgresql/jdbc/PgResultSet.java:3401
-#: org/postgresql/jdbc/PgResultSet.java:3421
-#: org/postgresql/jdbc/PgResultSet.java:3434
+#: org/postgresql/jdbc/PgResultSet.java:3183
+#: org/postgresql/jdbc/PgResultSet.java:3190
+#: org/postgresql/jdbc/PgResultSet.java:3201
+#: org/postgresql/jdbc/PgResultSet.java:3212
+#: org/postgresql/jdbc/PgResultSet.java:3223
+#: org/postgresql/jdbc/PgResultSet.java:3234
+#: org/postgresql/jdbc/PgResultSet.java:3245
+#: org/postgresql/jdbc/PgResultSet.java:3256
+#: org/postgresql/jdbc/PgResultSet.java:3267
+#: org/postgresql/jdbc/PgResultSet.java:3274
+#: org/postgresql/jdbc/PgResultSet.java:3281
+#: org/postgresql/jdbc/PgResultSet.java:3292
+#: org/postgresql/jdbc/PgResultSet.java:3309
+#: org/postgresql/jdbc/PgResultSet.java:3316
+#: org/postgresql/jdbc/PgResultSet.java:3323
+#: org/postgresql/jdbc/PgResultSet.java:3334
+#: org/postgresql/jdbc/PgResultSet.java:3341
+#: org/postgresql/jdbc/PgResultSet.java:3348
+#: org/postgresql/jdbc/PgResultSet.java:3386
+#: org/postgresql/jdbc/PgResultSet.java:3393
+#: org/postgresql/jdbc/PgResultSet.java:3400
+#: org/postgresql/jdbc/PgResultSet.java:3420
+#: org/postgresql/jdbc/PgResultSet.java:3433
 #, java-format
 msgid "conversion to {0} from {1} not supported"
 msgstr ""
@@ -1243,34 +1249,34 @@ msgstr ""
 msgid "Maximum number of rows must be a value grater than or equal to 0."
 msgstr "Maximální poèet øádek musí být nezáporné èíslo."
 
-#: org/postgresql/jdbc/PgStatement.java:550
+#: org/postgresql/jdbc/PgStatement.java:555
 msgid "Query timeout must be a value greater than or equals to 0."
 msgstr "Èasový limit dotazu musí být nezáporné èíslo."
 
-#: org/postgresql/jdbc/PgStatement.java:590
+#: org/postgresql/jdbc/PgStatement.java:595
 msgid "The maximum field size must be a value greater than or equal to 0."
 msgstr "Maximální velikost pole musí být nezáporné èíslo."
 
-#: org/postgresql/jdbc/PgStatement.java:689
+#: org/postgresql/jdbc/PgStatement.java:694
 msgid "This statement has been closed."
 msgstr "Pøíkaz byl uzavøen."
 
-#: org/postgresql/jdbc/PgStatement.java:1145
-#: org/postgresql/jdbc/PgStatement.java:1173
+#: org/postgresql/jdbc/PgStatement.java:1150
+#: org/postgresql/jdbc/PgStatement.java:1178
 #, fuzzy
 msgid "Returning autogenerated keys by column index is not supported."
 msgstr "Vrácení automaticky generovaných klíèù není podporováno."
 
-#: org/postgresql/jdbc/TimestampUtils.java:355
-#: org/postgresql/jdbc/TimestampUtils.java:423
+#: org/postgresql/jdbc/TimestampUtils.java:365
+#: org/postgresql/jdbc/TimestampUtils.java:433
 #, fuzzy, java-format
 msgid "Bad value for type timestamp/date/time: {1}"
 msgstr "©patná hodnota pro typ {0} : {1}"
 
-#: org/postgresql/jdbc/TimestampUtils.java:858
-#: org/postgresql/jdbc/TimestampUtils.java:915
-#: org/postgresql/jdbc/TimestampUtils.java:961
-#: org/postgresql/jdbc/TimestampUtils.java:1010
+#: org/postgresql/jdbc/TimestampUtils.java:914
+#: org/postgresql/jdbc/TimestampUtils.java:971
+#: org/postgresql/jdbc/TimestampUtils.java:1017
+#: org/postgresql/jdbc/TimestampUtils.java:1066
 #, fuzzy, java-format
 msgid "Unsupported binary encoding of {0}."
 msgstr "Nepodporovaná hodnota typu: {0}"
@@ -1283,31 +1289,31 @@ msgstr ""
 msgid "Invalid or unsupported by client SCRAM mechanisms"
 msgstr ""
 
-#: org/postgresql/jre8/sasl/ScramAuthenticator.java:117
+#: org/postgresql/jre8/sasl/ScramAuthenticator.java:119
 #, fuzzy, java-format
 msgid "Invalid server-first-message: {0}"
 msgstr "Vadná délka proudu {0}."
 
-#: org/postgresql/jre8/sasl/ScramAuthenticator.java:147
+#: org/postgresql/jre8/sasl/ScramAuthenticator.java:151
 #, fuzzy, java-format
 msgid "Invalid server-final-message: {0}"
 msgstr "Vadná délka proudu {0}."
 
-#: org/postgresql/jre8/sasl/ScramAuthenticator.java:153
+#: org/postgresql/jre8/sasl/ScramAuthenticator.java:157
 #, java-format
 msgid "SCRAM authentication failed, server returned error: {0}"
 msgstr ""
 
-#: org/postgresql/jre8/sasl/ScramAuthenticator.java:160
+#: org/postgresql/jre8/sasl/ScramAuthenticator.java:164
 msgid "Invalid server SCRAM signature"
 msgstr ""
 
-#: org/postgresql/largeobject/LargeObjectManager.java:144
+#: org/postgresql/largeobject/LargeObjectManager.java:136
 msgid "Failed to initialize LargeObject API"
 msgstr "Selhala inicializace LargeObject API"
 
-#: org/postgresql/largeobject/LargeObjectManager.java:262
-#: org/postgresql/largeobject/LargeObjectManager.java:305
+#: org/postgresql/largeobject/LargeObjectManager.java:254
+#: org/postgresql/largeobject/LargeObjectManager.java:295
 msgid "Large Objects may not be used in auto-commit mode."
 msgstr "Velké objecky nemohou být pou¾ity v auto-commit modu."
 
@@ -1341,34 +1347,34 @@ msgstr ""
 msgid "The hostname {0} could not be verified."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:164
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:90
 msgid "The sslfactoryarg property may not be empty."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:180
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:106
 msgid ""
 "The environment variable containing the server's SSL certificate must not be "
 "empty."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:188
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:114
 msgid ""
 "The system property containing the server's SSL certificate must not be "
 "empty."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:195
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:121
 msgid ""
 "The sslfactoryarg property must start with the prefix file:, classpath:, "
 "env:, sys:, or -----BEGIN CERTIFICATE-----."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:207
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:133
 #, fuzzy
 msgid "An error occurred reading the certificate"
 msgstr "Nastala chyba pøi nastavení SSL spojení."
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:240
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:166
 msgid "No X509TrustManager found"
 msgstr ""
 
@@ -1504,128 +1510,128 @@ msgid ""
 "setSavePoint not allowed while an XA transaction is active."
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:177
-#: org/postgresql/xa/PGXAConnection.java:253
-#: org/postgresql/xa/PGXAConnection.java:347
+#: org/postgresql/xa/PGXAConnection.java:186
+#: org/postgresql/xa/PGXAConnection.java:272
+#: org/postgresql/xa/PGXAConnection.java:381
 #, fuzzy, java-format
 msgid "Invalid flags {0}"
 msgstr "Vadná délka proudu {0}."
 
-#: org/postgresql/xa/PGXAConnection.java:181
-#: org/postgresql/xa/PGXAConnection.java:257
-#: org/postgresql/xa/PGXAConnection.java:449
+#: org/postgresql/xa/PGXAConnection.java:190
+#: org/postgresql/xa/PGXAConnection.java:276
+#: org/postgresql/xa/PGXAConnection.java:491
 msgid "xid must not be null"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:185
+#: org/postgresql/xa/PGXAConnection.java:194
 msgid "Connection is busy with another transaction"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:194
-#: org/postgresql/xa/PGXAConnection.java:267
+#: org/postgresql/xa/PGXAConnection.java:203
+#: org/postgresql/xa/PGXAConnection.java:286
 msgid "suspend/resume not implemented"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:202
-#: org/postgresql/xa/PGXAConnection.java:209
-#: org/postgresql/xa/PGXAConnection.java:213
+#: org/postgresql/xa/PGXAConnection.java:211
+#: org/postgresql/xa/PGXAConnection.java:218
+#: org/postgresql/xa/PGXAConnection.java:222
 #, java-format
 msgid ""
 "Invalid protocol state requested. Attempted transaction interleaving is not "
 "supported. xid={0}, currentXid={1}, state={2}, flags={3}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:224
+#: org/postgresql/xa/PGXAConnection.java:233
 msgid "Error disabling autocommit"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:261
+#: org/postgresql/xa/PGXAConnection.java:280
 #, java-format
 msgid ""
 "tried to call end without corresponding start call. state={0}, start "
 "xid={1}, currentXid={2}, preparedXid={3}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:297
+#: org/postgresql/xa/PGXAConnection.java:326
 #, java-format
 msgid ""
 "Preparing already prepared transaction, the prepared xid {0}, prepare xid={1}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:300
+#: org/postgresql/xa/PGXAConnection.java:329
 #, java-format
 msgid "Current connection does not have an associated xid. prepare xid={0}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:307
+#: org/postgresql/xa/PGXAConnection.java:336
 #, java-format
 msgid ""
 "Not implemented: Prepare must be issued using the same connection that "
 "started the transaction. currentXid={0}, prepare xid={1}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:311
+#: org/postgresql/xa/PGXAConnection.java:340
 #, java-format
 msgid "Prepare called before end. prepare xid={0}, state={1}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:331
+#: org/postgresql/xa/PGXAConnection.java:360
 #, java-format
 msgid "Error preparing transaction. prepare xid={0}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:382
+#: org/postgresql/xa/PGXAConnection.java:416
 msgid "Error during recover"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:438
+#: org/postgresql/xa/PGXAConnection.java:480
 #, java-format
 msgid ""
 "Error rolling back prepared transaction. rollback xid={0}, preparedXid={1}, "
 "currentXid={2}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:471
+#: org/postgresql/xa/PGXAConnection.java:521
 #, java-format
 msgid ""
 "One-phase commit called for xid {0} but connection was prepared with xid {1}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:479
+#: org/postgresql/xa/PGXAConnection.java:529
 msgid ""
 "Not implemented: one-phase commit must be issued using the same connection "
 "that was used to start it"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:483
+#: org/postgresql/xa/PGXAConnection.java:533
 #, java-format
 msgid "One-phase commit with unknown xid. commit xid={0}, currentXid={1}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:487
+#: org/postgresql/xa/PGXAConnection.java:537
 #, java-format
 msgid "commit called before end. commit xid={0}, state={1}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:498
+#: org/postgresql/xa/PGXAConnection.java:548
 #, java-format
 msgid "Error during one-phase commit. commit xid={0}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:517
+#: org/postgresql/xa/PGXAConnection.java:576
 msgid ""
 "Not implemented: 2nd phase commit must be issued using an idle connection. "
 "commit xid={0}, currentXid={1}, state={2], transactionState={3}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:550
+#: org/postgresql/xa/PGXAConnection.java:609
 #, java-format
 msgid ""
 "Error committing prepared transaction. commit xid={0}, preparedXid={1}, "
 "currentXid={2}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:567
+#: org/postgresql/xa/PGXAConnection.java:626
 #, java-format
 msgid "Heuristic commit/rollback not supported. forget xid={0}"
 msgstr ""

--- a/pgjdbc/src/main/java/org/postgresql/translation/de.po
+++ b/pgjdbc/src/main/java/org/postgresql/translation/de.po
@@ -8,7 +8,6 @@ msgid ""
 msgstr ""
 "Project-Id-Version: head-de\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-06-05 10:57+0300\n"
 "PO-Revision-Date: 2008-09-12 14:22+0200\n"
 "Last-Translator: Andre Bialojahn <ab.spamnews@freenet.de>\n"
 "Language-Team: Deutsch\n"
@@ -20,15 +19,15 @@ msgstr ""
 "X-Poedit-Language: German\n"
 "X-Poedit-Country: GERMANY\n"
 
-#: org/postgresql/Driver.java:214
+#: org/postgresql/Driver.java:217
 msgid "Error loading default settings from driverconfig.properties"
 msgstr "Fehler beim Laden der Voreinstellungen aus driverconfig.properties"
 
-#: org/postgresql/Driver.java:226
+#: org/postgresql/Driver.java:229
 msgid "Properties for the driver contains a non-string value for the key "
 msgstr ""
 
-#: org/postgresql/Driver.java:270
+#: org/postgresql/Driver.java:272
 msgid ""
 "Your security policy has prevented the connection from being attempted.  You "
 "probably need to grant the connect java.net.SocketPermission to the database "
@@ -39,7 +38,7 @@ msgstr ""
 "java.net.SocketPermission gewähren, um den Rechner auf dem gewählten Port zu "
 "erreichen."
 
-#: org/postgresql/Driver.java:276 org/postgresql/Driver.java:408
+#: org/postgresql/Driver.java:278 org/postgresql/Driver.java:410
 msgid ""
 "Something unusual has occurred to cause the driver to fail. Please report "
 "this exception."
@@ -47,35 +46,35 @@ msgstr ""
 "Etwas Ungewöhnliches ist passiert, das den Treiber fehlschlagen ließ. Bitte "
 "teilen Sie diesen Fehler mit."
 
-#: org/postgresql/Driver.java:416
+#: org/postgresql/Driver.java:418
 msgid "Connection attempt timed out."
 msgstr "Keine Verbindung innerhalb des Zeitintervalls möglich."
 
-#: org/postgresql/Driver.java:429
+#: org/postgresql/Driver.java:431
 msgid "Interrupted while attempting to connect."
 msgstr "Beim Verbindungsversuch trat eine Unterbrechung auf."
 
-#: org/postgresql/Driver.java:682
+#: org/postgresql/Driver.java:687
 #, java-format
 msgid "Method {0} is not yet implemented."
 msgstr "Die Methode {0} ist noch nicht implementiert."
 
-#: org/postgresql/PGProperty.java:535 org/postgresql/PGProperty.java:555
+#: org/postgresql/PGProperty.java:537 org/postgresql/PGProperty.java:557
 #, java-format
 msgid "{0} parameter value must be an integer but was: {1}"
 msgstr ""
 
-#: org/postgresql/copy/CopyManager.java:53
+#: org/postgresql/copy/CopyManager.java:49
 #, java-format
 msgid "Requested CopyIn but got {0}"
 msgstr ""
 
-#: org/postgresql/copy/CopyManager.java:64
+#: org/postgresql/copy/CopyManager.java:60
 #, java-format
 msgid "Requested CopyOut but got {0}"
 msgstr ""
 
-#: org/postgresql/copy/CopyManager.java:75
+#: org/postgresql/copy/CopyManager.java:71
 #, java-format
 msgid "Requested CopyDual but got {0}"
 msgstr ""
@@ -99,6 +98,13 @@ msgstr ""
 #, java-format
 msgid "Cannot write to copy a byte of value {0}"
 msgstr ""
+
+#: org/postgresql/core/CommandCompleteParser.java:71
+#, fuzzy, java-format
+msgid "Unable to parse the count in command completion tag: {0}."
+msgstr ""
+"Der Updatecount aus der Kommandovervollständigungsmarkierung(?) {0} konnte "
+"nicht interpretiert werden."
 
 #: org/postgresql/core/ConnectionFactory.java:57
 #, java-format
@@ -124,7 +130,7 @@ msgstr ""
 msgid "Expected an EOF from server, got: {0}"
 msgstr "Vom Server wurde ein EOF erwartet, jedoch {0} gelesen."
 
-#: org/postgresql/core/Parser.java:1006
+#: org/postgresql/core/Parser.java:1051
 #, java-format
 msgid "Malformed function or procedure escape syntax at offset {0}."
 msgstr ""
@@ -188,25 +194,25 @@ msgstr "Nullbytes dürfen in Bezeichnern nicht vorkommen."
 #: org/postgresql/core/v3/CompositeParameterList.java:33
 #: org/postgresql/core/v3/SimpleParameterList.java:54
 #: org/postgresql/core/v3/SimpleParameterList.java:65
-#: org/postgresql/jdbc/PgResultSet.java:2757
-#: org/postgresql/jdbc/PgResultSetMetaData.java:494
+#: org/postgresql/jdbc/PgResultSet.java:2755
+#: org/postgresql/jdbc/PgResultSetMetaData.java:388
 #, java-format
 msgid "The column index is out of range: {0}, number of columns: {1}."
 msgstr ""
 "Der Spaltenindex {0} ist außerhalb des gültigen Bereichs. Anzahl Spalten: "
 "{1}."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:109
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:103
 #, fuzzy, java-format
 msgid "Invalid sslmode value: {0}"
 msgstr "Ungültige Länge des Datenstroms: {0}."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:124
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:118
 #, fuzzy, java-format
 msgid "Invalid targetServerType value: {0}"
 msgstr "Ungültige Länge des Datenstroms: {0}."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:246
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:239
 #, fuzzy, java-format
 msgid ""
 "Connection to {0} refused. Check that the hostname and port are correct and "
@@ -215,27 +221,27 @@ msgstr ""
 "Verbindung verweigert. Überprüfen Sie die Korrektheit von Hostnamen und der "
 "Portnummer und dass der Datenbankserver TCP/IP-Verbindungen annimmt."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:257
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:250
 #: org/postgresql/core/v3/replication/V3ReplicationProtocol.java:133
 msgid "The connection attempt failed."
 msgstr "Der Verbindungsversuch schlug fehl."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:272
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:265
 #, java-format
 msgid "Could not find a server with specified targetServerType: {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:368
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:381
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:361
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:374
 msgid "The server does not support SSL."
 msgstr "Der Server unterstützt SSL nicht."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:395
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:388
 msgid "An error occurred while setting up the SSL connection."
 msgstr "Beim Aufbau der SSL-Verbindung trat ein Fehler auf."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:496
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:523
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:484
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:511
 msgid ""
 "The server requested password-based authentication, but no password was "
 "provided."
@@ -243,13 +249,13 @@ msgstr ""
 "Der Server verlangt passwortbasierte Authentifizierung, jedoch wurde kein "
 "Passwort angegeben."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:626
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:614
 msgid ""
 "SCRAM authentication is not supported by this driver. You need JDK >= 8 and "
 "pgjdbc >= 42.2.0 (not \".jre\" versions)"
 msgstr ""
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:650
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:638
 #, java-format
 msgid ""
 "The authentication type {0} is not supported. Check that you have configured "
@@ -261,16 +267,16 @@ msgstr ""
 "enthält und dass der Client ein Authentifizierungsschema nutzt, das vom "
 "Treiber unterstützt wird."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:657
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2550
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2581
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2585
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2653
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:645
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2543
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2576
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2580
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2648
 #: org/postgresql/gss/GssAction.java:126
 msgid "Protocol error.  Session setup failed."
 msgstr "Protokollfehler.  Die Sitzung konnte nicht gestartet werden."
 
-#: org/postgresql/core/v3/CopyInImpl.java:47
+#: org/postgresql/core/v3/CopyInImpl.java:49
 msgid "CopyIn copy direction can't receive data"
 msgstr ""
 
@@ -278,144 +284,144 @@ msgstr ""
 msgid "CommandComplete expected COPY but got: "
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:161
+#: org/postgresql/core/v3/QueryExecutorImpl.java:163
 msgid "Tried to obtain lock while already holding it"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:177
+#: org/postgresql/core/v3/QueryExecutorImpl.java:179
 msgid "Tried to break lock on database connection"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:195
+#: org/postgresql/core/v3/QueryExecutorImpl.java:197
 #, fuzzy
 msgid "Interrupted while waiting to obtain lock on database connection"
 msgstr "Beim Verbindungsversuch trat eine Unterbrechung auf."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:327
+#: org/postgresql/core/v3/QueryExecutorImpl.java:329
 msgid "Unable to bind parameter values for statement."
 msgstr "Der Anweisung konnten keine Parameterwerte zugewiesen werden."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:333
-#: org/postgresql/core/v3/QueryExecutorImpl.java:485
-#: org/postgresql/core/v3/QueryExecutorImpl.java:559
-#: org/postgresql/core/v3/QueryExecutorImpl.java:602
-#: org/postgresql/core/v3/QueryExecutorImpl.java:729
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2372
+#: org/postgresql/core/v3/QueryExecutorImpl.java:335
+#: org/postgresql/core/v3/QueryExecutorImpl.java:487
+#: org/postgresql/core/v3/QueryExecutorImpl.java:561
+#: org/postgresql/core/v3/QueryExecutorImpl.java:604
+#: org/postgresql/core/v3/QueryExecutorImpl.java:731
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2377
 #: org/postgresql/util/StreamWrapper.java:130
 #, fuzzy
 msgid "An I/O error occurred while sending to the backend."
 msgstr "Eingabe/Ausgabe-Fehler {0} beim Senden an das Backend."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:534
-#: org/postgresql/core/v3/QueryExecutorImpl.java:576
+#: org/postgresql/core/v3/QueryExecutorImpl.java:536
+#: org/postgresql/core/v3/QueryExecutorImpl.java:578
 #, java-format
 msgid "Expected command status BEGIN, got {0}."
 msgstr "Statt des erwarteten Befehlsstatus BEGIN, wurde {0} empfangen."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:581
+#: org/postgresql/core/v3/QueryExecutorImpl.java:583
 #: org/postgresql/jdbc/PgResultSet.java:1778
 #, java-format
 msgid "Unexpected command status: {0}."
 msgstr "Unerwarteter Befehlsstatus: {0}."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:687
+#: org/postgresql/core/v3/QueryExecutorImpl.java:689
 #, fuzzy
 msgid "An error occurred while trying to get the socket timeout."
 msgstr "Eingabe/Ausgabe-Fehler {0} beim Senden an das Backend."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:722
-#: org/postgresql/core/v3/QueryExecutorImpl.java:798
+#: org/postgresql/core/v3/QueryExecutorImpl.java:724
+#: org/postgresql/core/v3/QueryExecutorImpl.java:800
 #, java-format
 msgid "Unknown Response Type {0}."
 msgstr "Die Antwort weist einen unbekannten Typ auf: {0}."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:745
+#: org/postgresql/core/v3/QueryExecutorImpl.java:747
 #, fuzzy
 msgid "An error occurred while trying to reset the socket timeout."
 msgstr "Eingabe/Ausgabe-Fehler {0} beim Senden an das Backend."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:843
+#: org/postgresql/core/v3/QueryExecutorImpl.java:845
 msgid "Database connection failed when starting copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:878
+#: org/postgresql/core/v3/QueryExecutorImpl.java:880
 msgid "Tried to cancel an inactive copy operation"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:917
+#: org/postgresql/core/v3/QueryExecutorImpl.java:919
 msgid "Database connection failed when canceling copy operation"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:933
+#: org/postgresql/core/v3/QueryExecutorImpl.java:935
 msgid "Missing expected error response to copy cancel request"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:937
+#: org/postgresql/core/v3/QueryExecutorImpl.java:939
 #, java-format
 msgid "Got {0} error responses to single copy cancel request"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:952
+#: org/postgresql/core/v3/QueryExecutorImpl.java:954
 msgid "Tried to end inactive copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:967
+#: org/postgresql/core/v3/QueryExecutorImpl.java:969
 msgid "Database connection failed when ending copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:985
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1005
+#: org/postgresql/core/v3/QueryExecutorImpl.java:987
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1007
 msgid "Tried to write to an inactive copy operation"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:998
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1013
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1000
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1015
 msgid "Database connection failed when writing to copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1028
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1030
 msgid "Tried to read from inactive copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1035
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1037
 msgid "Database connection failed when reading from copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1101
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1103
 #, java-format
 msgid "Received CommandComplete ''{0}'' without an active copy operation"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1126
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1128
 #, java-format
 msgid "Got CopyInResponse from server during an active {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1140
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1142
 #, java-format
 msgid "Got CopyOutResponse from server during an active {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1154
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1156
 #, java-format
 msgid "Got CopyBothResponse from server during an active {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1170
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1172
 msgid "Got CopyData without an active copy operation"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1174
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1176
 #, fuzzy, java-format
 msgid "Unexpected copydata from server for {0}"
 msgstr "Vom Server wurde ein EOF erwartet, jedoch {0} gelesen."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1234
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1236
 #, java-format
 msgid "Unexpected packet type during copy: {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1524
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1526
 #, java-format
 msgid ""
 "Bind message length {0} too long.  This can be caused by very large or "
@@ -424,22 +430,15 @@ msgstr ""
 "Die Nachrichtenlänge {0} ist zu groß. Das kann von sehr großen oder "
 "inkorrekten Längenangaben eines InputStream-Parameters herrühren."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2145
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2150
 msgid "Ran out of memory retrieving query results."
 msgstr "Nicht genügend Speicher beim Abholen der Abfrageergebnisse."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2313
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2318
 msgid "The driver currently does not support COPY operations."
 msgstr "Der Treiber unterstützt derzeit keine COPY-Operationen."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2487
-#, fuzzy, java-format
-msgid "Unable to parse the count in command completion tag: {0}."
-msgstr ""
-"Der Updatecount aus der Kommandovervollständigungsmarkierung(?) {0} konnte "
-"nicht interpretiert werden."
-
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2610
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2605
 #, fuzzy, java-format
 msgid ""
 "The server''s client_encoding parameter was changed to {0}. The JDBC driver "
@@ -449,7 +448,7 @@ msgstr ""
 "Der JDBC-Treiber setzt für korrektes Funktionieren die Einstellung UNICODE "
 "voraus."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2620
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2615
 #, java-format
 msgid ""
 "The server''s DateStyle parameter was changed to {0}. The JDBC driver "
@@ -459,7 +458,7 @@ msgstr ""
 "JDBC-Treiber setzt für korrekte Funktion voraus, dass ''Date Style'' mit "
 "''ISO'' beginnt."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2633
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2628
 #, java-format
 msgid ""
 "The server''s standard_conforming_strings parameter was reported as {0}. The "
@@ -525,21 +524,21 @@ msgstr "Die Datenquelle wurde geschlossen."
 msgid "Unsupported property name: {0}"
 msgstr "Unbekannter Typ: {0}."
 
-#: org/postgresql/fastpath/Fastpath.java:86
+#: org/postgresql/fastpath/Fastpath.java:84
 #, fuzzy, java-format
 msgid "Fastpath call {0} - No result was returned and we expected a numeric."
 msgstr ""
 "Der Fastpath-Aufruf {0} gab kein Ergebnis zurück, jedoch wurde ein Integer "
 "erwartet."
 
-#: org/postgresql/fastpath/Fastpath.java:163
+#: org/postgresql/fastpath/Fastpath.java:161
 #, java-format
 msgid "Fastpath call {0} - No result was returned and we expected an integer."
 msgstr ""
 "Der Fastpath-Aufruf {0} gab kein Ergebnis zurück, jedoch wurde ein Integer "
 "erwartet."
 
-#: org/postgresql/fastpath/Fastpath.java:171
+#: org/postgresql/fastpath/Fastpath.java:169
 #, fuzzy, java-format
 msgid ""
 "Fastpath call {0} - No result was returned or wrong size while expecting an "
@@ -548,14 +547,14 @@ msgstr ""
 "Der Fastpath-Aufruf {0} gab kein Ergebnis zurück, jedoch wurde ein Integer "
 "erwartet."
 
-#: org/postgresql/fastpath/Fastpath.java:188
+#: org/postgresql/fastpath/Fastpath.java:186
 #, fuzzy, java-format
 msgid "Fastpath call {0} - No result was returned and we expected a long."
 msgstr ""
 "Der Fastpath-Aufruf {0} gab kein Ergebnis zurück, jedoch wurde ein Integer "
 "erwartet."
 
-#: org/postgresql/fastpath/Fastpath.java:196
+#: org/postgresql/fastpath/Fastpath.java:194
 #, fuzzy, java-format
 msgid ""
 "Fastpath call {0} - No result was returned or wrong size while expecting a "
@@ -564,7 +563,7 @@ msgstr ""
 "Der Fastpath-Aufruf {0} gab kein Ergebnis zurück, jedoch wurde ein Integer "
 "erwartet."
 
-#: org/postgresql/fastpath/Fastpath.java:308
+#: org/postgresql/fastpath/Fastpath.java:297
 #, java-format
 msgid "The fastpath function {0} is unknown."
 msgstr "Die Fastpath-Funktion {0} ist unbekannt."
@@ -635,63 +634,70 @@ msgid "Cannot cast to boolean: \"{0}\""
 msgstr ""
 
 #: org/postgresql/jdbc/EscapedFunctions.java:240
+#: org/postgresql/jdbc/EscapedFunctions2.java:167
 #, java-format
 msgid "{0} function takes four and only four argument."
 msgstr "Die {0}-Funktion erwartet genau vier Argumente."
 
 #: org/postgresql/jdbc/EscapedFunctions.java:270
-#: org/postgresql/jdbc/EscapedFunctions.java:344
-#: org/postgresql/jdbc/EscapedFunctions.java:749
-#: org/postgresql/jdbc/EscapedFunctions.java:787
+#: org/postgresql/jdbc/EscapedFunctions.java:337
+#: org/postgresql/jdbc/EscapedFunctions.java:740
+#: org/postgresql/jdbc/EscapedFunctions2.java:196
+#: org/postgresql/jdbc/EscapedFunctions2.java:263
+#: org/postgresql/jdbc/EscapedFunctions2.java:665
 #, java-format
 msgid "{0} function takes two and only two arguments."
 msgstr "Die {0}-Funktion erwartet genau zwei Argumente."
 
 #: org/postgresql/jdbc/EscapedFunctions.java:288
-#: org/postgresql/jdbc/EscapedFunctions.java:326
-#: org/postgresql/jdbc/EscapedFunctions.java:446
-#: org/postgresql/jdbc/EscapedFunctions.java:461
-#: org/postgresql/jdbc/EscapedFunctions.java:476
-#: org/postgresql/jdbc/EscapedFunctions.java:491
-#: org/postgresql/jdbc/EscapedFunctions.java:506
-#: org/postgresql/jdbc/EscapedFunctions.java:521
-#: org/postgresql/jdbc/EscapedFunctions.java:536
-#: org/postgresql/jdbc/EscapedFunctions.java:551
-#: org/postgresql/jdbc/EscapedFunctions.java:566
-#: org/postgresql/jdbc/EscapedFunctions.java:581
-#: org/postgresql/jdbc/EscapedFunctions.java:596
-#: org/postgresql/jdbc/EscapedFunctions.java:611
-#: org/postgresql/jdbc/EscapedFunctions.java:775
+#: org/postgresql/jdbc/EscapedFunctions.java:441
+#: org/postgresql/jdbc/EscapedFunctions.java:467
+#: org/postgresql/jdbc/EscapedFunctions.java:526
+#: org/postgresql/jdbc/EscapedFunctions.java:728
+#: org/postgresql/jdbc/EscapedFunctions2.java:211
+#: org/postgresql/jdbc/EscapedFunctions2.java:355
+#: org/postgresql/jdbc/EscapedFunctions2.java:381
+#: org/postgresql/jdbc/EscapedFunctions2.java:440
+#: org/postgresql/jdbc/EscapedFunctions2.java:654
 #, java-format
 msgid "{0} function takes one and only one argument."
 msgstr "Die {0}-Funktion erwartet nur genau ein Argument."
 
-#: org/postgresql/jdbc/EscapedFunctions.java:310
-#: org/postgresql/jdbc/EscapedFunctions.java:391
+#: org/postgresql/jdbc/EscapedFunctions.java:312
+#: org/postgresql/jdbc/EscapedFunctions.java:386
+#: org/postgresql/jdbc/EscapedFunctions2.java:238
+#: org/postgresql/jdbc/EscapedFunctions2.java:307
 #, java-format
 msgid "{0} function takes two or three arguments."
 msgstr "Die {0}-Funktion erwartet zwei oder drei Argumente."
 
-#: org/postgresql/jdbc/EscapedFunctions.java:416
-#: org/postgresql/jdbc/EscapedFunctions.java:431
-#: org/postgresql/jdbc/EscapedFunctions.java:734
-#: org/postgresql/jdbc/EscapedFunctions.java:764
+#: org/postgresql/jdbc/EscapedFunctions.java:411
+#: org/postgresql/jdbc/EscapedFunctions.java:426
+#: org/postgresql/jdbc/EscapedFunctions.java:693
+#: org/postgresql/jdbc/EscapedFunctions.java:719
+#: org/postgresql/jdbc/EscapedFunctions2.java:645
 #, java-format
 msgid "{0} function doesn''t take any argument."
 msgstr "Die {0}-Funktion akzeptiert kein Argument."
 
-#: org/postgresql/jdbc/EscapedFunctions.java:627
-#: org/postgresql/jdbc/EscapedFunctions.java:680
+#: org/postgresql/jdbc/EscapedFunctions.java:586
+#: org/postgresql/jdbc/EscapedFunctions.java:639
+#: org/postgresql/jdbc/EscapedFunctions2.java:500
+#: org/postgresql/jdbc/EscapedFunctions2.java:571
 #, java-format
 msgid "{0} function takes three and only three arguments."
 msgstr "Die {0}-Funktion erwartet genau drei Argumente."
 
-#: org/postgresql/jdbc/EscapedFunctions.java:640
-#: org/postgresql/jdbc/EscapedFunctions.java:661
-#: org/postgresql/jdbc/EscapedFunctions.java:664
-#: org/postgresql/jdbc/EscapedFunctions.java:697
-#: org/postgresql/jdbc/EscapedFunctions.java:710
-#: org/postgresql/jdbc/EscapedFunctions.java:713
+#: org/postgresql/jdbc/EscapedFunctions.java:599
+#: org/postgresql/jdbc/EscapedFunctions.java:620
+#: org/postgresql/jdbc/EscapedFunctions.java:623
+#: org/postgresql/jdbc/EscapedFunctions.java:656
+#: org/postgresql/jdbc/EscapedFunctions.java:669
+#: org/postgresql/jdbc/EscapedFunctions.java:672
+#: org/postgresql/jdbc/EscapedFunctions2.java:510
+#: org/postgresql/jdbc/EscapedFunctions2.java:527
+#: org/postgresql/jdbc/EscapedFunctions2.java:585
+#: org/postgresql/jdbc/EscapedFunctions2.java:597
 #, java-format
 msgid "Interval {0} not yet implemented"
 msgstr "Intervall {0} ist noch nicht implementiert."
@@ -711,19 +717,19 @@ msgstr "Die ID eines benamten Rettungspunktes kann nicht ermittelt werden."
 msgid "Cannot retrieve the name of an unnamed savepoint."
 msgstr "Der Name eines namenlosen Rettungpunktes kann nicht ermittelt werden."
 
-#: org/postgresql/jdbc/PgArray.java:157 org/postgresql/jdbc/PgArray.java:844
+#: org/postgresql/jdbc/PgArray.java:155 org/postgresql/jdbc/PgArray.java:842
 #, java-format
 msgid "The array index is out of range: {0}"
 msgstr "Der Arrayindex ist außerhalb des gültigen Bereichs: {0}."
 
-#: org/postgresql/jdbc/PgArray.java:178 org/postgresql/jdbc/PgArray.java:861
+#: org/postgresql/jdbc/PgArray.java:176 org/postgresql/jdbc/PgArray.java:859
 #, java-format
 msgid "The array index is out of range: {0}, number of elements: {1}."
 msgstr ""
 "Der Arrayindex {0} ist außerhalb des gültigen Bereichs. Vorhandene Elemente: "
 "{1}."
 
-#: org/postgresql/jdbc/PgArray.java:210
+#: org/postgresql/jdbc/PgArray.java:208
 #: org/postgresql/jdbc/PgResultSet.java:1930
 #: org/postgresql/util/HStoreConverter.java:43
 #: org/postgresql/util/HStoreConverter.java:74
@@ -738,17 +744,17 @@ msgstr ""
 "vorliegen, als die, in der die Datenbank erstellt wurde.  Das häufigste "
 "Beispiel dafür ist es, 8Bit-Daten in SQL_ASCII-Datenbanken abzulegen."
 
-#: org/postgresql/jdbc/PgCallableStatement.java:86
-#: org/postgresql/jdbc/PgCallableStatement.java:96
+#: org/postgresql/jdbc/PgCallableStatement.java:85
+#: org/postgresql/jdbc/PgCallableStatement.java:95
 msgid "A CallableStatement was executed with nothing returned."
 msgstr "Ein CallableStatement wurde ausgeführt ohne etwas zurückzugeben."
 
-#: org/postgresql/jdbc/PgCallableStatement.java:107
+#: org/postgresql/jdbc/PgCallableStatement.java:106
 msgid "A CallableStatement was executed with an invalid number of parameters"
 msgstr ""
 "Ein CallableStatement wurde mit einer falschen Anzahl Parameter ausgeführt."
 
-#: org/postgresql/jdbc/PgCallableStatement.java:145
+#: org/postgresql/jdbc/PgCallableStatement.java:144
 #, java-format
 msgid ""
 "A CallableStatement function was executed and the out parameter {0} was of "
@@ -757,7 +763,7 @@ msgstr ""
 "Eine CallableStatement-Funktion wurde ausgeführt und der Rückgabewert {0} "
 "war vom Typ {1}. Jedoch wurde der Typ {2} dafür registriert."
 
-#: org/postgresql/jdbc/PgCallableStatement.java:202
+#: org/postgresql/jdbc/PgCallableStatement.java:206
 msgid ""
 "This statement does not declare an OUT parameter.  Use '{' ?= call ... '}' "
 "to declare one."
@@ -765,13 +771,13 @@ msgstr ""
 "Diese Anweisung deklariert keinen OUT-Parameter. Benutzen Sie '{' ?= "
 "call ... '}' um das zu tun."
 
-#: org/postgresql/jdbc/PgCallableStatement.java:246
+#: org/postgresql/jdbc/PgCallableStatement.java:229
 msgid "wasNull cannot be call before fetching a result."
 msgstr ""
 "wasNull kann nicht aufgerufen werden, bevor ein Ergebnis abgefragt wurde."
 
-#: org/postgresql/jdbc/PgCallableStatement.java:384
-#: org/postgresql/jdbc/PgCallableStatement.java:403
+#: org/postgresql/jdbc/PgCallableStatement.java:367
+#: org/postgresql/jdbc/PgCallableStatement.java:386
 #, java-format
 msgid ""
 "Parameter of type {0} was registered, but call to get{1} (sqltype={2}) was "
@@ -780,7 +786,7 @@ msgstr ""
 "Ein Parameter des Typs {0} wurde registriert, jedoch erfolgte ein Aufruf "
 "get{1} (sqltype={2})."
 
-#: org/postgresql/jdbc/PgCallableStatement.java:424
+#: org/postgresql/jdbc/PgCallableStatement.java:407
 msgid ""
 "A CallableStatement was declared, but no call to registerOutParameter(1, "
 "<some type>) was made."
@@ -788,30 +794,30 @@ msgstr ""
 "Ein CallableStatement wurde deklariert, aber kein Aufruf von "
 "''registerOutParameter(1, <some type>)'' erfolgte."
 
-#: org/postgresql/jdbc/PgCallableStatement.java:430
+#: org/postgresql/jdbc/PgCallableStatement.java:413
 #, fuzzy
 msgid "No function outputs were registered."
 msgstr "Es wurden keine Funktionsausgaben registriert."
 
-#: org/postgresql/jdbc/PgCallableStatement.java:436
+#: org/postgresql/jdbc/PgCallableStatement.java:419
 msgid ""
 "Results cannot be retrieved from a CallableStatement before it is executed."
 msgstr ""
 "Ergebnisse können nicht von einem CallableStatement abgerufen werden, bevor "
 "es ausgeführt wurde."
 
-#: org/postgresql/jdbc/PgCallableStatement.java:703
+#: org/postgresql/jdbc/PgCallableStatement.java:686
 #, fuzzy, java-format
 msgid "Unsupported type conversion to {1}."
 msgstr "Unbekannter Typ: {0}."
 
-#: org/postgresql/jdbc/PgConnection.java:272
+#: org/postgresql/jdbc/PgConnection.java:241
 #, java-format
 msgid "Unsupported value for stringtype parameter: {0}"
 msgstr "Nichtunterstützter Wert für den Stringparameter: {0}"
 
 #: org/postgresql/jdbc/PgConnection.java:424
-#: org/postgresql/jdbc/PgPreparedStatement.java:119
+#: org/postgresql/jdbc/PgPreparedStatement.java:107
 #: org/postgresql/jdbc/PgStatement.java:225
 #: org/postgresql/jdbc/TypeInfoCache.java:226
 #: org/postgresql/jdbc/TypeInfoCache.java:371
@@ -823,134 +829,134 @@ msgstr "Nichtunterstützter Wert für den Stringparameter: {0}"
 msgid "No results were returned by the query."
 msgstr "Die Abfrage lieferte kein Ergebnis."
 
-#: org/postgresql/jdbc/PgConnection.java:441
+#: org/postgresql/jdbc/PgConnection.java:442
 #: org/postgresql/jdbc/PgStatement.java:254
 msgid "A result was returned when none was expected."
 msgstr "Die Anweisung lieferte ein Ergebnis obwohl keines erwartet wurde."
 
-#: org/postgresql/jdbc/PgConnection.java:545
+#: org/postgresql/jdbc/PgConnection.java:547
 #, fuzzy
 msgid "Custom type maps are not supported."
 msgstr "Selbstdefinierte Typabbildungen werden nicht unterstützt."
 
-#: org/postgresql/jdbc/PgConnection.java:587
+#: org/postgresql/jdbc/PgConnection.java:589
 #, java-format
 msgid "Failed to create object for: {0}."
 msgstr "Erstellung des Objektes schlug fehl für: {0}."
 
-#: org/postgresql/jdbc/PgConnection.java:641
+#: org/postgresql/jdbc/PgConnection.java:643
 #, java-format
 msgid "Unable to load the class {0} responsible for the datatype {1}"
 msgstr ""
 "Die für den Datentyp {1} verantwortliche Klasse {0} konnte nicht geladen "
 "werden."
 
-#: org/postgresql/jdbc/PgConnection.java:693
+#: org/postgresql/jdbc/PgConnection.java:705
 msgid ""
 "Cannot change transaction read-only property in the middle of a transaction."
 msgstr ""
 "Die Nur-Lesen-Eigenschaft einer Transaktion kann nicht während der "
 "Transaktion verändert werden."
 
-#: org/postgresql/jdbc/PgConnection.java:756
+#: org/postgresql/jdbc/PgConnection.java:772
 msgid "Cannot commit when autoCommit is enabled."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:767
-#: org/postgresql/jdbc/PgConnection.java:1384
-#: org/postgresql/jdbc/PgConnection.java:1428
+#: org/postgresql/jdbc/PgConnection.java:783
+#: org/postgresql/jdbc/PgConnection.java:1401
+#: org/postgresql/jdbc/PgConnection.java:1445
 #, fuzzy
 msgid "This connection has been closed."
 msgstr "Die Verbindung wurde geschlossen."
 
-#: org/postgresql/jdbc/PgConnection.java:777
+#: org/postgresql/jdbc/PgConnection.java:794
 msgid "Cannot rollback when autoCommit is enabled."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:827
+#: org/postgresql/jdbc/PgConnection.java:844
 msgid ""
 "Cannot change transaction isolation level in the middle of a transaction."
 msgstr ""
 "Die Transaktions-Trennungsstufe kann nicht während einer Transaktion "
 "verändert werden."
 
-#: org/postgresql/jdbc/PgConnection.java:833
+#: org/postgresql/jdbc/PgConnection.java:850
 #, java-format
 msgid "Transaction isolation level {0} not supported."
 msgstr "Die Transaktions-Trennungsstufe {0} ist nicht unterstützt."
 
-#: org/postgresql/jdbc/PgConnection.java:878
+#: org/postgresql/jdbc/PgConnection.java:895
 msgid "Finalizing a Connection that was never closed:"
 msgstr "Eine Connection wurde finalisiert, die nie geschlossen wurde:"
 
-#: org/postgresql/jdbc/PgConnection.java:945
+#: org/postgresql/jdbc/PgConnection.java:962
 msgid "Unable to translate data into the desired encoding."
 msgstr "Die Daten konnten nicht in die gewünschte Kodierung gewandelt werden."
 
-#: org/postgresql/jdbc/PgConnection.java:1008
+#: org/postgresql/jdbc/PgConnection.java:1025
 #: org/postgresql/jdbc/PgResultSet.java:1817
-#: org/postgresql/jdbc/PgStatement.java:903
+#: org/postgresql/jdbc/PgStatement.java:908
 msgid "Fetch size must be a value greater to or equal to 0."
 msgstr "Die Fetch-Größe muss ein Wert größer oder gleich Null sein."
 
-#: org/postgresql/jdbc/PgConnection.java:1289
-#: org/postgresql/jdbc/PgConnection.java:1330
+#: org/postgresql/jdbc/PgConnection.java:1306
+#: org/postgresql/jdbc/PgConnection.java:1347
 #, fuzzy, java-format
 msgid "Unable to find server array type for provided name {0}."
 msgstr ""
 "Für den angegebenen Namen {0} konnte kein Serverarraytyp gefunden werden."
 
-#: org/postgresql/jdbc/PgConnection.java:1312
+#: org/postgresql/jdbc/PgConnection.java:1329
 #, fuzzy, java-format
 msgid "Invalid elements {0}"
 msgstr "Ungültige Länge des Datenstroms: {0}."
 
-#: org/postgresql/jdbc/PgConnection.java:1348
+#: org/postgresql/jdbc/PgConnection.java:1365
 #, fuzzy, java-format
 msgid "Invalid timeout ({0}<0)."
 msgstr "Ungültige Länge des Datenstroms: {0}."
 
-#: org/postgresql/jdbc/PgConnection.java:1372
+#: org/postgresql/jdbc/PgConnection.java:1389
 msgid "Validating connection."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1405
+#: org/postgresql/jdbc/PgConnection.java:1422
 #, fuzzy, java-format
 msgid "Failed to set ClientInfo property: {0}"
 msgstr "Erstellung des Objektes schlug fehl für: {0}."
 
-#: org/postgresql/jdbc/PgConnection.java:1415
+#: org/postgresql/jdbc/PgConnection.java:1432
 msgid "ClientInfo property not supported."
 msgstr "Die ClientInfo-Eigenschaft ist nicht unterstützt."
 
-#: org/postgresql/jdbc/PgConnection.java:1441
+#: org/postgresql/jdbc/PgConnection.java:1458
 msgid "One ore more ClientInfo failed."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1540
+#: org/postgresql/jdbc/PgConnection.java:1559
 #, fuzzy
 msgid "Network timeout must be a value greater than or equal to 0."
 msgstr "Das Abfragetimeout muss ein Wert größer oder gleich Null sein."
 
-#: org/postgresql/jdbc/PgConnection.java:1552
+#: org/postgresql/jdbc/PgConnection.java:1571
 msgid "Unable to set network timeout."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1563
+#: org/postgresql/jdbc/PgConnection.java:1582
 msgid "Unable to get network timeout."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1580
+#: org/postgresql/jdbc/PgConnection.java:1599
 #, java-format
 msgid "Unknown ResultSet holdability setting: {0}."
 msgstr "Unbekannte Einstellung für die Haltbarkeit des ResultSets: {0}."
 
-#: org/postgresql/jdbc/PgConnection.java:1598
-#: org/postgresql/jdbc/PgConnection.java:1619
+#: org/postgresql/jdbc/PgConnection.java:1617
+#: org/postgresql/jdbc/PgConnection.java:1638
 msgid "Cannot establish a savepoint in auto-commit mode."
 msgstr "Ein Rettungspunkt kann im Modus ''auto-commit'' nicht erstellt werden."
 
-#: org/postgresql/jdbc/PgConnection.java:1685
+#: org/postgresql/jdbc/PgConnection.java:1707
 msgid "Returning autogenerated keys is not supported."
 msgstr "Die Rückgabe automatisch generierter Schlüssel wird nicht unterstützt,"
 
@@ -967,48 +973,48 @@ msgid "Unable to find name datatype in the system catalogs."
 msgstr ""
 "In den Systemkatalogen konnte der Namensdatentyp nicht gefunden werden."
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:323
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:322
 #, fuzzy
 msgid "Unable to find keywords in the system catalogs."
 msgstr ""
 "In den Systemkatalogen konnte der Namensdatentyp nicht gefunden werden."
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1105
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1095
 msgid "oid"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1105
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1095
 msgid "proname"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1107
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1558
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1097
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1548
 msgid "typtype"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1110
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1100
 msgid "proargtypes"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1576
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1566
 msgid "adsrc"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1589
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1579
 msgid "attidentity"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1685
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1761
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1675
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1751
 msgid "rolname"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1686
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1762
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1676
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1752
 msgid "relacl"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1692
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1682
 msgid "attacl"
 msgstr ""
 
@@ -1019,10 +1025,10 @@ msgstr ""
 "Der Parameterindex {0} ist außerhalb des gültigen Bereichs. Es gibt {1} "
 "Parameter."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:106
+#: org/postgresql/jdbc/PgPreparedStatement.java:94
+#: org/postgresql/jdbc/PgPreparedStatement.java:115
 #: org/postgresql/jdbc/PgPreparedStatement.java:127
-#: org/postgresql/jdbc/PgPreparedStatement.java:139
-#: org/postgresql/jdbc/PgPreparedStatement.java:1035
+#: org/postgresql/jdbc/PgPreparedStatement.java:1008
 #, fuzzy
 msgid ""
 "Can''t use query methods that take a query string on a PreparedStatement."
@@ -1030,58 +1036,58 @@ msgstr ""
 "Abfragemethoden, die einen Abfragestring annehmen, können nicht auf ein "
 "PreparedStatement angewandt werden."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:249
+#: org/postgresql/jdbc/PgPreparedStatement.java:237
 msgid "Unknown Types value."
 msgstr "Unbekannter Typ."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:382
-#: org/postgresql/jdbc/PgPreparedStatement.java:439
-#: org/postgresql/jdbc/PgPreparedStatement.java:1191
-#: org/postgresql/jdbc/PgPreparedStatement.java:1490
+#: org/postgresql/jdbc/PgPreparedStatement.java:364
+#: org/postgresql/jdbc/PgPreparedStatement.java:421
+#: org/postgresql/jdbc/PgPreparedStatement.java:1164
+#: org/postgresql/jdbc/PgPreparedStatement.java:1472
 #, java-format
 msgid "Invalid stream length {0}."
 msgstr "Ungültige Länge des Datenstroms: {0}."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:411
+#: org/postgresql/jdbc/PgPreparedStatement.java:393
 #, java-format
 msgid "The JVM claims not to support the {0} encoding."
 msgstr "Die JVM behauptet, die Zeichenkodierung {0} nicht zu unterstützen."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:414
+#: org/postgresql/jdbc/PgPreparedStatement.java:396
 #: org/postgresql/jdbc/PgResultSet.java:1122
 #: org/postgresql/jdbc/PgResultSet.java:1156
 msgid "Provided InputStream failed."
 msgstr "Der bereitgestellte InputStream scheiterte."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:460
-#: org/postgresql/jdbc/PgPreparedStatement.java:1096
+#: org/postgresql/jdbc/PgPreparedStatement.java:442
+#: org/postgresql/jdbc/PgPreparedStatement.java:1069
 #, java-format
 msgid "Unknown type {0}."
 msgstr "Unbekannter Typ {0}."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:477
+#: org/postgresql/jdbc/PgPreparedStatement.java:459
 msgid "No hstore extension installed."
 msgstr ""
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:619
-#: org/postgresql/jdbc/PgPreparedStatement.java:642
-#: org/postgresql/jdbc/PgPreparedStatement.java:652
-#: org/postgresql/jdbc/PgPreparedStatement.java:664
+#: org/postgresql/jdbc/PgPreparedStatement.java:601
+#: org/postgresql/jdbc/PgPreparedStatement.java:624
+#: org/postgresql/jdbc/PgPreparedStatement.java:634
+#: org/postgresql/jdbc/PgPreparedStatement.java:646
 #, java-format
 msgid "Cannot cast an instance of {0} to type {1}"
 msgstr "Die Typwandlung für eine Instanz von {0} nach {1} ist nicht möglich."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:682
+#: org/postgresql/jdbc/PgPreparedStatement.java:664
 #, java-format
 msgid "Unsupported Types value: {0}"
 msgstr "Unbekannter Typ: {0}."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:894
+#: org/postgresql/jdbc/PgPreparedStatement.java:876
 #, java-format
 msgid "Cannot convert an instance of {0} to type {1}"
 msgstr "Die Typwandlung für eine Instanz von {0} nach {1} ist nicht möglich."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:968
+#: org/postgresql/jdbc/PgPreparedStatement.java:950
 #, java-format
 msgid ""
 "Can''t infer the SQL type to use for an instance of {0}. Use setObject() "
@@ -1091,19 +1097,19 @@ msgstr ""
 "abgeleitet werden. Benutzen Sie ''setObject()'' mit einem expliziten Typ, um "
 "ihn festzulegen."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:1133
-#: org/postgresql/jdbc/PgPreparedStatement.java:1233
+#: org/postgresql/jdbc/PgPreparedStatement.java:1106
+#: org/postgresql/jdbc/PgPreparedStatement.java:1206
 msgid "Unexpected error writing large object to database."
 msgstr ""
 "Beim Schreiben eines LargeObjects (LOB) in die Datenbank trat ein "
 "unerwarteter Fehler auf."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:1178
+#: org/postgresql/jdbc/PgPreparedStatement.java:1151
 #: org/postgresql/jdbc/PgResultSet.java:1210
 msgid "Provided Reader failed."
 msgstr "Der bereitgestellte Reader scheiterte."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:1449
+#: org/postgresql/jdbc/PgPreparedStatement.java:1431
 #: org/postgresql/util/StreamWrapper.java:56
 msgid "Object is too large to send over the protocol."
 msgstr ""
@@ -1121,8 +1127,8 @@ msgstr ""
 #: org/postgresql/jdbc/PgResultSet.java:556
 #: org/postgresql/jdbc/PgResultSet.java:594
 #: org/postgresql/jdbc/PgResultSet.java:624
-#: org/postgresql/jdbc/PgResultSet.java:3014
-#: org/postgresql/jdbc/PgResultSet.java:3058
+#: org/postgresql/jdbc/PgResultSet.java:3012
+#: org/postgresql/jdbc/PgResultSet.java:3057
 #, fuzzy, java-format
 msgid "Cannot convert the column of type {0} to requested type {1}."
 msgstr "Die Typwandlung für eine Instanz von {0} nach {1} ist nicht möglich."
@@ -1135,7 +1141,7 @@ msgstr ""
 "Relative Bewegungen können in der Einfügezeile nicht durchgeführt werden."
 
 #: org/postgresql/jdbc/PgResultSet.java:878
-#: org/postgresql/jdbc/PgStatement.java:895
+#: org/postgresql/jdbc/PgStatement.java:900
 #, java-format
 msgid "Invalid fetch direction constant: {0}."
 msgstr "Unzulässige Richtungskonstante bei fetch: {0}."
@@ -1180,8 +1186,8 @@ msgstr ""
 
 #: org/postgresql/jdbc/PgResultSet.java:1119
 #: org/postgresql/jdbc/PgResultSet.java:1754
-#: org/postgresql/jdbc/PgResultSet.java:2422
-#: org/postgresql/jdbc/PgResultSet.java:2443
+#: org/postgresql/jdbc/PgResultSet.java:2420
+#: org/postgresql/jdbc/PgResultSet.java:2441
 #, java-format
 msgid "The JVM claims not to support the encoding: {0}"
 msgstr "Die JVM behauptet, die Zeichenkodierung {0} nicht zu unterstützen."
@@ -1195,7 +1201,7 @@ msgid "Cannot call updateRow() when on the insert row."
 msgstr "''updateRow()'' kann in der Einfügezeile nicht aufgerufen werden."
 
 #: org/postgresql/jdbc/PgResultSet.java:1335
-#: org/postgresql/jdbc/PgResultSet.java:3075
+#: org/postgresql/jdbc/PgResultSet.java:3074
 msgid ""
 "Cannot update the ResultSet because it is either before the start or after "
 "the end of the results."
@@ -1216,27 +1222,27 @@ msgstr "Für die Tabelle {0} konnte kein Primärschlüssel gefunden werden."
 
 #: org/postgresql/jdbc/PgResultSet.java:2017
 #: org/postgresql/jdbc/PgResultSet.java:2022
-#: org/postgresql/jdbc/PgResultSet.java:2809
-#: org/postgresql/jdbc/PgResultSet.java:2815
-#: org/postgresql/jdbc/PgResultSet.java:2840
-#: org/postgresql/jdbc/PgResultSet.java:2846
-#: org/postgresql/jdbc/PgResultSet.java:2870
-#: org/postgresql/jdbc/PgResultSet.java:2875
-#: org/postgresql/jdbc/PgResultSet.java:2891
-#: org/postgresql/jdbc/PgResultSet.java:2912
-#: org/postgresql/jdbc/PgResultSet.java:2923
-#: org/postgresql/jdbc/PgResultSet.java:2936
-#: org/postgresql/jdbc/PgResultSet.java:3063
+#: org/postgresql/jdbc/PgResultSet.java:2807
+#: org/postgresql/jdbc/PgResultSet.java:2813
+#: org/postgresql/jdbc/PgResultSet.java:2838
+#: org/postgresql/jdbc/PgResultSet.java:2844
+#: org/postgresql/jdbc/PgResultSet.java:2868
+#: org/postgresql/jdbc/PgResultSet.java:2873
+#: org/postgresql/jdbc/PgResultSet.java:2889
+#: org/postgresql/jdbc/PgResultSet.java:2910
+#: org/postgresql/jdbc/PgResultSet.java:2921
+#: org/postgresql/jdbc/PgResultSet.java:2934
+#: org/postgresql/jdbc/PgResultSet.java:3062
 #, java-format
 msgid "Bad value for type {0} : {1}"
 msgstr "Unzulässiger Wert für den Typ {0} : {1}."
 
-#: org/postgresql/jdbc/PgResultSet.java:2595
+#: org/postgresql/jdbc/PgResultSet.java:2593
 #, java-format
 msgid "The column name {0} was not found in this ResultSet."
 msgstr "Der Spaltenname {0} wurde in diesem ResultSet nicht gefunden."
 
-#: org/postgresql/jdbc/PgResultSet.java:2731
+#: org/postgresql/jdbc/PgResultSet.java:2729
 msgid ""
 "ResultSet is not updateable.  The query that generated this result set must "
 "select only one table, and must select all primary keys from that table. See "
@@ -1246,44 +1252,44 @@ msgstr ""
 "darf nur eine Tabelle und muss darin alle Primärschlüssel auswählen. Siehe "
 "JDBC 2.1 API-Spezifikation, Abschnitt 5.6 für mehr Details."
 
-#: org/postgresql/jdbc/PgResultSet.java:2743
+#: org/postgresql/jdbc/PgResultSet.java:2741
 msgid "This ResultSet is closed."
 msgstr "Dieses ResultSet ist geschlossen."
 
-#: org/postgresql/jdbc/PgResultSet.java:2774
+#: org/postgresql/jdbc/PgResultSet.java:2772
 msgid "ResultSet not positioned properly, perhaps you need to call next."
 msgstr ""
 "Das ResultSet ist nicht richtig positioniert. Eventuell muss ''next'' "
 "aufgerufen werden."
 
-#: org/postgresql/jdbc/PgResultSet.java:3095
+#: org/postgresql/jdbc/PgResultSet.java:3094
 #, fuzzy
 msgid "Invalid UUID data."
 msgstr "Ungültiges Flag."
 
-#: org/postgresql/jdbc/PgResultSet.java:3184
-#: org/postgresql/jdbc/PgResultSet.java:3191
-#: org/postgresql/jdbc/PgResultSet.java:3202
-#: org/postgresql/jdbc/PgResultSet.java:3213
-#: org/postgresql/jdbc/PgResultSet.java:3224
-#: org/postgresql/jdbc/PgResultSet.java:3235
-#: org/postgresql/jdbc/PgResultSet.java:3246
-#: org/postgresql/jdbc/PgResultSet.java:3257
-#: org/postgresql/jdbc/PgResultSet.java:3268
-#: org/postgresql/jdbc/PgResultSet.java:3275
-#: org/postgresql/jdbc/PgResultSet.java:3282
-#: org/postgresql/jdbc/PgResultSet.java:3293
-#: org/postgresql/jdbc/PgResultSet.java:3310
-#: org/postgresql/jdbc/PgResultSet.java:3317
-#: org/postgresql/jdbc/PgResultSet.java:3324
-#: org/postgresql/jdbc/PgResultSet.java:3335
-#: org/postgresql/jdbc/PgResultSet.java:3342
-#: org/postgresql/jdbc/PgResultSet.java:3349
-#: org/postgresql/jdbc/PgResultSet.java:3387
-#: org/postgresql/jdbc/PgResultSet.java:3394
-#: org/postgresql/jdbc/PgResultSet.java:3401
-#: org/postgresql/jdbc/PgResultSet.java:3421
-#: org/postgresql/jdbc/PgResultSet.java:3434
+#: org/postgresql/jdbc/PgResultSet.java:3183
+#: org/postgresql/jdbc/PgResultSet.java:3190
+#: org/postgresql/jdbc/PgResultSet.java:3201
+#: org/postgresql/jdbc/PgResultSet.java:3212
+#: org/postgresql/jdbc/PgResultSet.java:3223
+#: org/postgresql/jdbc/PgResultSet.java:3234
+#: org/postgresql/jdbc/PgResultSet.java:3245
+#: org/postgresql/jdbc/PgResultSet.java:3256
+#: org/postgresql/jdbc/PgResultSet.java:3267
+#: org/postgresql/jdbc/PgResultSet.java:3274
+#: org/postgresql/jdbc/PgResultSet.java:3281
+#: org/postgresql/jdbc/PgResultSet.java:3292
+#: org/postgresql/jdbc/PgResultSet.java:3309
+#: org/postgresql/jdbc/PgResultSet.java:3316
+#: org/postgresql/jdbc/PgResultSet.java:3323
+#: org/postgresql/jdbc/PgResultSet.java:3334
+#: org/postgresql/jdbc/PgResultSet.java:3341
+#: org/postgresql/jdbc/PgResultSet.java:3348
+#: org/postgresql/jdbc/PgResultSet.java:3386
+#: org/postgresql/jdbc/PgResultSet.java:3393
+#: org/postgresql/jdbc/PgResultSet.java:3400
+#: org/postgresql/jdbc/PgResultSet.java:3420
+#: org/postgresql/jdbc/PgResultSet.java:3433
 #, fuzzy, java-format
 msgid "conversion to {0} from {1} not supported"
 msgstr "Die Transaktions-Trennungsstufe {0} ist nicht unterstützt."
@@ -1349,34 +1355,34 @@ msgstr ""
 msgid "Maximum number of rows must be a value grater than or equal to 0."
 msgstr "Die maximale Zeilenzahl muss ein Wert größer oder gleich Null sein."
 
-#: org/postgresql/jdbc/PgStatement.java:550
+#: org/postgresql/jdbc/PgStatement.java:555
 msgid "Query timeout must be a value greater than or equals to 0."
 msgstr "Das Abfragetimeout muss ein Wert größer oder gleich Null sein."
 
-#: org/postgresql/jdbc/PgStatement.java:590
+#: org/postgresql/jdbc/PgStatement.java:595
 msgid "The maximum field size must be a value greater than or equal to 0."
 msgstr "Die maximale Feldgröße muss ein Wert größer oder gleich Null sein."
 
-#: org/postgresql/jdbc/PgStatement.java:689
+#: org/postgresql/jdbc/PgStatement.java:694
 msgid "This statement has been closed."
 msgstr "Die Anweisung wurde geschlossen."
 
-#: org/postgresql/jdbc/PgStatement.java:1145
-#: org/postgresql/jdbc/PgStatement.java:1173
+#: org/postgresql/jdbc/PgStatement.java:1150
+#: org/postgresql/jdbc/PgStatement.java:1178
 #, fuzzy
 msgid "Returning autogenerated keys by column index is not supported."
 msgstr "Die Rückgabe automatisch generierter Schlüssel wird nicht unterstützt,"
 
-#: org/postgresql/jdbc/TimestampUtils.java:355
-#: org/postgresql/jdbc/TimestampUtils.java:423
+#: org/postgresql/jdbc/TimestampUtils.java:365
+#: org/postgresql/jdbc/TimestampUtils.java:433
 #, fuzzy, java-format
 msgid "Bad value for type timestamp/date/time: {1}"
 msgstr "Unzulässiger Wert für den Typ {0} : {1}."
 
-#: org/postgresql/jdbc/TimestampUtils.java:858
-#: org/postgresql/jdbc/TimestampUtils.java:915
-#: org/postgresql/jdbc/TimestampUtils.java:961
-#: org/postgresql/jdbc/TimestampUtils.java:1010
+#: org/postgresql/jdbc/TimestampUtils.java:914
+#: org/postgresql/jdbc/TimestampUtils.java:971
+#: org/postgresql/jdbc/TimestampUtils.java:1017
+#: org/postgresql/jdbc/TimestampUtils.java:1066
 #, fuzzy, java-format
 msgid "Unsupported binary encoding of {0}."
 msgstr "Unbekannter Typ: {0}."
@@ -1389,31 +1395,31 @@ msgstr ""
 msgid "Invalid or unsupported by client SCRAM mechanisms"
 msgstr ""
 
-#: org/postgresql/jre8/sasl/ScramAuthenticator.java:117
+#: org/postgresql/jre8/sasl/ScramAuthenticator.java:119
 #, fuzzy, java-format
 msgid "Invalid server-first-message: {0}"
 msgstr "Ungültige Länge des Datenstroms: {0}."
 
-#: org/postgresql/jre8/sasl/ScramAuthenticator.java:147
+#: org/postgresql/jre8/sasl/ScramAuthenticator.java:151
 #, fuzzy, java-format
 msgid "Invalid server-final-message: {0}"
 msgstr "Ungültige Länge des Datenstroms: {0}."
 
-#: org/postgresql/jre8/sasl/ScramAuthenticator.java:153
+#: org/postgresql/jre8/sasl/ScramAuthenticator.java:157
 #, java-format
 msgid "SCRAM authentication failed, server returned error: {0}"
 msgstr ""
 
-#: org/postgresql/jre8/sasl/ScramAuthenticator.java:160
+#: org/postgresql/jre8/sasl/ScramAuthenticator.java:164
 msgid "Invalid server SCRAM signature"
 msgstr ""
 
-#: org/postgresql/largeobject/LargeObjectManager.java:144
+#: org/postgresql/largeobject/LargeObjectManager.java:136
 msgid "Failed to initialize LargeObject API"
 msgstr "Die LargeObject-API konnte nicht initialisiert werden."
 
-#: org/postgresql/largeobject/LargeObjectManager.java:262
-#: org/postgresql/largeobject/LargeObjectManager.java:305
+#: org/postgresql/largeobject/LargeObjectManager.java:254
+#: org/postgresql/largeobject/LargeObjectManager.java:295
 msgid "Large Objects may not be used in auto-commit mode."
 msgstr ""
 "LargeObjects (LOB) dürfen im Modus ''auto-commit'' nicht verwendet werden."
@@ -1452,34 +1458,34 @@ msgstr ""
 msgid "The hostname {0} could not be verified."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:164
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:90
 msgid "The sslfactoryarg property may not be empty."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:180
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:106
 msgid ""
 "The environment variable containing the server's SSL certificate must not be "
 "empty."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:188
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:114
 msgid ""
 "The system property containing the server's SSL certificate must not be "
 "empty."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:195
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:121
 msgid ""
 "The sslfactoryarg property must start with the prefix file:, classpath:, "
 "env:, sys:, or -----BEGIN CERTIFICATE-----."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:207
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:133
 #, fuzzy
 msgid "An error occurred reading the certificate"
 msgstr "Beim Aufbau der SSL-Verbindung trat ein Fehler auf."
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:240
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:166
 msgid "No X509TrustManager found"
 msgstr ""
 
@@ -1616,42 +1622,42 @@ msgid ""
 "setSavePoint not allowed while an XA transaction is active."
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:177
-#: org/postgresql/xa/PGXAConnection.java:253
-#: org/postgresql/xa/PGXAConnection.java:347
+#: org/postgresql/xa/PGXAConnection.java:186
+#: org/postgresql/xa/PGXAConnection.java:272
+#: org/postgresql/xa/PGXAConnection.java:381
 #, fuzzy, java-format
 msgid "Invalid flags {0}"
 msgstr "Ungültige Flags"
 
-#: org/postgresql/xa/PGXAConnection.java:181
-#: org/postgresql/xa/PGXAConnection.java:257
-#: org/postgresql/xa/PGXAConnection.java:449
+#: org/postgresql/xa/PGXAConnection.java:190
+#: org/postgresql/xa/PGXAConnection.java:276
+#: org/postgresql/xa/PGXAConnection.java:491
 msgid "xid must not be null"
 msgstr "Die xid darf nicht null sein."
 
-#: org/postgresql/xa/PGXAConnection.java:185
+#: org/postgresql/xa/PGXAConnection.java:194
 msgid "Connection is busy with another transaction"
 msgstr "Die Verbindung ist derzeit mit einer anderen Transaktion beschäftigt."
 
-#: org/postgresql/xa/PGXAConnection.java:194
-#: org/postgresql/xa/PGXAConnection.java:267
+#: org/postgresql/xa/PGXAConnection.java:203
+#: org/postgresql/xa/PGXAConnection.java:286
 msgid "suspend/resume not implemented"
 msgstr "Anhalten/Fortsetzen ist nicht implementiert."
 
-#: org/postgresql/xa/PGXAConnection.java:202
-#: org/postgresql/xa/PGXAConnection.java:209
-#: org/postgresql/xa/PGXAConnection.java:213
+#: org/postgresql/xa/PGXAConnection.java:211
+#: org/postgresql/xa/PGXAConnection.java:218
+#: org/postgresql/xa/PGXAConnection.java:222
 #, java-format
 msgid ""
 "Invalid protocol state requested. Attempted transaction interleaving is not "
 "supported. xid={0}, currentXid={1}, state={2}, flags={3}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:224
+#: org/postgresql/xa/PGXAConnection.java:233
 msgid "Error disabling autocommit"
 msgstr "Fehler beim Abschalten von Autocommit."
 
-#: org/postgresql/xa/PGXAConnection.java:261
+#: org/postgresql/xa/PGXAConnection.java:280
 #, fuzzy, java-format
 msgid ""
 "tried to call end without corresponding start call. state={0}, start "
@@ -1659,18 +1665,18 @@ msgid ""
 msgstr ""
 "Es wurde versucht, ohne dazugehörigen ''start''-Aufruf ''end'' aufzurufen."
 
-#: org/postgresql/xa/PGXAConnection.java:297
+#: org/postgresql/xa/PGXAConnection.java:326
 #, java-format
 msgid ""
 "Preparing already prepared transaction, the prepared xid {0}, prepare xid={1}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:300
+#: org/postgresql/xa/PGXAConnection.java:329
 #, java-format
 msgid "Current connection does not have an associated xid. prepare xid={0}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:307
+#: org/postgresql/xa/PGXAConnection.java:336
 #, fuzzy, java-format
 msgid ""
 "Not implemented: Prepare must be issued using the same connection that "
@@ -1679,34 +1685,34 @@ msgstr ""
 "Nicht implementiert: ''Prepare'' muss über die selbe Verbindung abgesetzt "
 "werden, die die Transaktion startete."
 
-#: org/postgresql/xa/PGXAConnection.java:311
+#: org/postgresql/xa/PGXAConnection.java:340
 #, fuzzy, java-format
 msgid "Prepare called before end. prepare xid={0}, state={1}"
 msgstr "''Prepare'' wurde vor ''end'' aufgerufen."
 
-#: org/postgresql/xa/PGXAConnection.java:331
+#: org/postgresql/xa/PGXAConnection.java:360
 #, fuzzy, java-format
 msgid "Error preparing transaction. prepare xid={0}"
 msgstr "Beim Vorbereiten der Transaktion trat ein Fehler auf."
 
-#: org/postgresql/xa/PGXAConnection.java:382
+#: org/postgresql/xa/PGXAConnection.java:416
 msgid "Error during recover"
 msgstr "Beim Wiederherstellen trat ein Fehler auf."
 
-#: org/postgresql/xa/PGXAConnection.java:438
+#: org/postgresql/xa/PGXAConnection.java:480
 #, fuzzy, java-format
 msgid ""
 "Error rolling back prepared transaction. rollback xid={0}, preparedXid={1}, "
 "currentXid={2}"
 msgstr "Fehler beim Rollback einer vorbereiteten Transaktion."
 
-#: org/postgresql/xa/PGXAConnection.java:471
+#: org/postgresql/xa/PGXAConnection.java:521
 #, java-format
 msgid ""
 "One-phase commit called for xid {0} but connection was prepared with xid {1}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:479
+#: org/postgresql/xa/PGXAConnection.java:529
 msgid ""
 "Not implemented: one-phase commit must be issued using the same connection "
 "that was used to start it"
@@ -1714,22 +1720,22 @@ msgstr ""
 "Nicht implementiert: Die einphasige Bestätigung muss über die selbe "
 "Verbindung abgewickelt werden, die verwendet wurde, um sie zu beginnen."
 
-#: org/postgresql/xa/PGXAConnection.java:483
+#: org/postgresql/xa/PGXAConnection.java:533
 #, java-format
 msgid "One-phase commit with unknown xid. commit xid={0}, currentXid={1}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:487
+#: org/postgresql/xa/PGXAConnection.java:537
 #, fuzzy, java-format
 msgid "commit called before end. commit xid={0}, state={1}"
 msgstr "''Commit'' wurde vor ''end'' aufgerufen."
 
-#: org/postgresql/xa/PGXAConnection.java:498
+#: org/postgresql/xa/PGXAConnection.java:548
 #, fuzzy, java-format
 msgid "Error during one-phase commit. commit xid={0}"
 msgstr "Bei der einphasigen Bestätigung trat ein Fehler auf."
 
-#: org/postgresql/xa/PGXAConnection.java:517
+#: org/postgresql/xa/PGXAConnection.java:576
 #, fuzzy
 msgid ""
 "Not implemented: 2nd phase commit must be issued using an idle connection. "
@@ -1738,14 +1744,14 @@ msgstr ""
 "Nicht implementiert: Die zweite Bestätigungsphase muss über eine im Leerlauf "
 "befindliche Verbindung abgewickelt werden."
 
-#: org/postgresql/xa/PGXAConnection.java:550
+#: org/postgresql/xa/PGXAConnection.java:609
 #, fuzzy, java-format
 msgid ""
 "Error committing prepared transaction. commit xid={0}, preparedXid={1}, "
 "currentXid={2}"
 msgstr "Fehler beim Rollback einer vorbereiteten Transaktion."
 
-#: org/postgresql/xa/PGXAConnection.java:567
+#: org/postgresql/xa/PGXAConnection.java:626
 #, fuzzy, java-format
 msgid "Heuristic commit/rollback not supported. forget xid={0}"
 msgstr "Heuristisches Commit/Rollback wird nicht unterstützt."

--- a/pgjdbc/src/main/java/org/postgresql/translation/es.po
+++ b/pgjdbc/src/main/java/org/postgresql/translation/es.po
@@ -5,7 +5,6 @@ msgid ""
 msgstr ""
 "Project-Id-Version: JDBC PostgreSQL Driver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-06-05 10:57+0300\n"
 "PO-Revision-Date: 2004-10-22 16:51-0300\n"
 "Last-Translator: Diego Gil <diego@adminsa.com>\n"
 "Language-Team: \n"
@@ -15,22 +14,22 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Poedit-Language: Spanish\n"
 
-#: org/postgresql/Driver.java:214
+#: org/postgresql/Driver.java:217
 msgid "Error loading default settings from driverconfig.properties"
 msgstr ""
 
-#: org/postgresql/Driver.java:226
+#: org/postgresql/Driver.java:229
 msgid "Properties for the driver contains a non-string value for the key "
 msgstr ""
 
-#: org/postgresql/Driver.java:270
+#: org/postgresql/Driver.java:272
 msgid ""
 "Your security policy has prevented the connection from being attempted.  You "
 "probably need to grant the connect java.net.SocketPermission to the database "
 "server host and port that you wish to connect to."
 msgstr ""
 
-#: org/postgresql/Driver.java:276 org/postgresql/Driver.java:408
+#: org/postgresql/Driver.java:278 org/postgresql/Driver.java:410
 msgid ""
 "Something unusual has occurred to cause the driver to fail. Please report "
 "this exception."
@@ -38,37 +37,37 @@ msgstr ""
 "Algo inusual ha ocurrido que provocó un fallo en el controlador. Por favor "
 "reporte esta excepción."
 
-#: org/postgresql/Driver.java:416
+#: org/postgresql/Driver.java:418
 #, fuzzy
 msgid "Connection attempt timed out."
 msgstr "El intento de conexión falló."
 
-#: org/postgresql/Driver.java:429
+#: org/postgresql/Driver.java:431
 #, fuzzy
 msgid "Interrupted while attempting to connect."
 msgstr "Ha ocorrido un error mientras se establecía la conexión SSL."
 
-#: org/postgresql/Driver.java:682
+#: org/postgresql/Driver.java:687
 #, fuzzy, java-format
 msgid "Method {0} is not yet implemented."
 msgstr "Este método aún no ha sido implementado."
 
-#: org/postgresql/PGProperty.java:535 org/postgresql/PGProperty.java:555
+#: org/postgresql/PGProperty.java:537 org/postgresql/PGProperty.java:557
 #, java-format
 msgid "{0} parameter value must be an integer but was: {1}"
 msgstr ""
 
-#: org/postgresql/copy/CopyManager.java:53
+#: org/postgresql/copy/CopyManager.java:49
 #, java-format
 msgid "Requested CopyIn but got {0}"
 msgstr ""
 
-#: org/postgresql/copy/CopyManager.java:64
+#: org/postgresql/copy/CopyManager.java:60
 #, java-format
 msgid "Requested CopyOut but got {0}"
 msgstr ""
 
-#: org/postgresql/copy/CopyManager.java:75
+#: org/postgresql/copy/CopyManager.java:71
 #, java-format
 msgid "Requested CopyDual but got {0}"
 msgstr ""
@@ -90,6 +89,11 @@ msgstr ""
 #: org/postgresql/copy/PGCopyOutputStream.java:71
 #, java-format
 msgid "Cannot write to copy a byte of value {0}"
+msgstr ""
+
+#: org/postgresql/core/CommandCompleteParser.java:71
+#, java-format
+msgid "Unable to parse the count in command completion tag: {0}."
 msgstr ""
 
 #: org/postgresql/core/ConnectionFactory.java:57
@@ -114,7 +118,7 @@ msgstr ""
 msgid "Expected an EOF from server, got: {0}"
 msgstr ""
 
-#: org/postgresql/core/Parser.java:1006
+#: org/postgresql/core/Parser.java:1051
 #, java-format
 msgid "Malformed function or procedure escape syntax at offset {0}."
 msgstr ""
@@ -170,24 +174,24 @@ msgstr ""
 #: org/postgresql/core/v3/CompositeParameterList.java:33
 #: org/postgresql/core/v3/SimpleParameterList.java:54
 #: org/postgresql/core/v3/SimpleParameterList.java:65
-#: org/postgresql/jdbc/PgResultSet.java:2757
-#: org/postgresql/jdbc/PgResultSetMetaData.java:494
+#: org/postgresql/jdbc/PgResultSet.java:2755
+#: org/postgresql/jdbc/PgResultSetMetaData.java:388
 #, java-format
 msgid "The column index is out of range: {0}, number of columns: {1}."
 msgstr ""
 "El índice de la columna está fuera de rango: {0}, número de columnas: {1}."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:109
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:103
 #, java-format
 msgid "Invalid sslmode value: {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:124
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:118
 #, java-format
 msgid "Invalid targetServerType value: {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:246
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:239
 #, fuzzy, java-format
 msgid ""
 "Connection to {0} refused. Check that the hostname and port are correct and "
@@ -196,27 +200,27 @@ msgstr ""
 "Conexión rechazada. Verifique que el nombre del Host y el puerto sean "
 "correctos y que postmaster este aceptando conexiones TCP/IP."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:257
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:250
 #: org/postgresql/core/v3/replication/V3ReplicationProtocol.java:133
 msgid "The connection attempt failed."
 msgstr "El intento de conexión falló."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:272
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:265
 #, java-format
 msgid "Could not find a server with specified targetServerType: {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:368
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:381
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:361
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:374
 msgid "The server does not support SSL."
 msgstr "Este servidor no soporta SSL."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:395
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:388
 msgid "An error occurred while setting up the SSL connection."
 msgstr "Ha ocorrido un error mientras se establecía la conexión SSL."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:496
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:523
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:484
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:511
 msgid ""
 "The server requested password-based authentication, but no password was "
 "provided."
@@ -224,13 +228,13 @@ msgstr ""
 "El servidor requiere autenticación basada en contraseña, pero no se ha "
 "provisto ninguna contraseña."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:626
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:614
 msgid ""
 "SCRAM authentication is not supported by this driver. You need JDK >= 8 and "
 "pgjdbc >= 42.2.0 (not \".jre\" versions)"
 msgstr ""
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:650
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:638
 #, fuzzy, java-format
 msgid ""
 "The authentication type {0} is not supported. Check that you have configured "
@@ -242,16 +246,16 @@ msgstr ""
 "subred, y que está usando un esquema de autenticación soportado por el "
 "driver."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:657
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2550
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2581
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2585
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2653
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:645
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2543
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2576
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2580
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2648
 #: org/postgresql/gss/GssAction.java:126
 msgid "Protocol error.  Session setup failed."
 msgstr "Error de protocolo. Falló el inicio de la sesión."
 
-#: org/postgresql/core/v3/CopyInImpl.java:47
+#: org/postgresql/core/v3/CopyInImpl.java:49
 msgid "CopyIn copy direction can't receive data"
 msgstr ""
 
@@ -259,177 +263,172 @@ msgstr ""
 msgid "CommandComplete expected COPY but got: "
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:161
+#: org/postgresql/core/v3/QueryExecutorImpl.java:163
 msgid "Tried to obtain lock while already holding it"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:177
+#: org/postgresql/core/v3/QueryExecutorImpl.java:179
 msgid "Tried to break lock on database connection"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:195
+#: org/postgresql/core/v3/QueryExecutorImpl.java:197
 msgid "Interrupted while waiting to obtain lock on database connection"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:327
+#: org/postgresql/core/v3/QueryExecutorImpl.java:329
 msgid "Unable to bind parameter values for statement."
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:333
-#: org/postgresql/core/v3/QueryExecutorImpl.java:485
-#: org/postgresql/core/v3/QueryExecutorImpl.java:559
-#: org/postgresql/core/v3/QueryExecutorImpl.java:602
-#: org/postgresql/core/v3/QueryExecutorImpl.java:729
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2372
+#: org/postgresql/core/v3/QueryExecutorImpl.java:335
+#: org/postgresql/core/v3/QueryExecutorImpl.java:487
+#: org/postgresql/core/v3/QueryExecutorImpl.java:561
+#: org/postgresql/core/v3/QueryExecutorImpl.java:604
+#: org/postgresql/core/v3/QueryExecutorImpl.java:731
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2377
 #: org/postgresql/util/StreamWrapper.java:130
 #, fuzzy
 msgid "An I/O error occurred while sending to the backend."
 msgstr "Un error de E/S ha ocurrido mientras se enviaba al backend."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:534
-#: org/postgresql/core/v3/QueryExecutorImpl.java:576
+#: org/postgresql/core/v3/QueryExecutorImpl.java:536
+#: org/postgresql/core/v3/QueryExecutorImpl.java:578
 #, java-format
 msgid "Expected command status BEGIN, got {0}."
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:581
+#: org/postgresql/core/v3/QueryExecutorImpl.java:583
 #: org/postgresql/jdbc/PgResultSet.java:1778
 #, java-format
 msgid "Unexpected command status: {0}."
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:687
+#: org/postgresql/core/v3/QueryExecutorImpl.java:689
 #, fuzzy
 msgid "An error occurred while trying to get the socket timeout."
 msgstr "Un error de E/S ha ocurrido mientras se enviaba al backend."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:722
-#: org/postgresql/core/v3/QueryExecutorImpl.java:798
+#: org/postgresql/core/v3/QueryExecutorImpl.java:724
+#: org/postgresql/core/v3/QueryExecutorImpl.java:800
 #, java-format
 msgid "Unknown Response Type {0}."
 msgstr "Tipo de respuesta desconocida {0}."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:745
+#: org/postgresql/core/v3/QueryExecutorImpl.java:747
 #, fuzzy
 msgid "An error occurred while trying to reset the socket timeout."
 msgstr "Un error de E/S ha ocurrido mientras se enviaba al backend."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:843
+#: org/postgresql/core/v3/QueryExecutorImpl.java:845
 msgid "Database connection failed when starting copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:878
+#: org/postgresql/core/v3/QueryExecutorImpl.java:880
 msgid "Tried to cancel an inactive copy operation"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:917
+#: org/postgresql/core/v3/QueryExecutorImpl.java:919
 msgid "Database connection failed when canceling copy operation"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:933
+#: org/postgresql/core/v3/QueryExecutorImpl.java:935
 msgid "Missing expected error response to copy cancel request"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:937
+#: org/postgresql/core/v3/QueryExecutorImpl.java:939
 #, java-format
 msgid "Got {0} error responses to single copy cancel request"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:952
+#: org/postgresql/core/v3/QueryExecutorImpl.java:954
 msgid "Tried to end inactive copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:967
+#: org/postgresql/core/v3/QueryExecutorImpl.java:969
 msgid "Database connection failed when ending copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:985
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1005
+#: org/postgresql/core/v3/QueryExecutorImpl.java:987
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1007
 msgid "Tried to write to an inactive copy operation"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:998
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1013
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1000
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1015
 msgid "Database connection failed when writing to copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1028
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1030
 msgid "Tried to read from inactive copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1035
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1037
 msgid "Database connection failed when reading from copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1101
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1103
 #, java-format
 msgid "Received CommandComplete ''{0}'' without an active copy operation"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1126
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1128
 #, java-format
 msgid "Got CopyInResponse from server during an active {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1140
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1142
 #, java-format
 msgid "Got CopyOutResponse from server during an active {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1154
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1156
 #, java-format
 msgid "Got CopyBothResponse from server during an active {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1170
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1172
 msgid "Got CopyData without an active copy operation"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1174
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1176
 #, java-format
 msgid "Unexpected copydata from server for {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1234
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1236
 #, java-format
 msgid "Unexpected packet type during copy: {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1524
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1526
 #, java-format
 msgid ""
 "Bind message length {0} too long.  This can be caused by very large or "
 "incorrect length specifications on InputStream parameters."
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2145
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2150
 msgid "Ran out of memory retrieving query results."
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2313
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2318
 msgid "The driver currently does not support COPY operations."
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2487
-#, java-format
-msgid "Unable to parse the count in command completion tag: {0}."
-msgstr ""
-
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2610
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2605
 #, java-format
 msgid ""
 "The server''s client_encoding parameter was changed to {0}. The JDBC driver "
 "requires client_encoding to be UTF8 for correct operation."
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2620
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2615
 #, java-format
 msgid ""
 "The server''s DateStyle parameter was changed to {0}. The JDBC driver "
 "requires DateStyle to begin with ISO for correct operation."
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2633
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2628
 #, java-format
 msgid ""
 "The server''s standard_conforming_strings parameter was reported as {0}. The "
@@ -490,36 +489,36 @@ msgstr ""
 msgid "Unsupported property name: {0}"
 msgstr ""
 
-#: org/postgresql/fastpath/Fastpath.java:86
+#: org/postgresql/fastpath/Fastpath.java:84
 #, java-format
 msgid "Fastpath call {0} - No result was returned and we expected a numeric."
 msgstr ""
 
-#: org/postgresql/fastpath/Fastpath.java:163
+#: org/postgresql/fastpath/Fastpath.java:161
 #, java-format
 msgid "Fastpath call {0} - No result was returned and we expected an integer."
 msgstr ""
 
-#: org/postgresql/fastpath/Fastpath.java:171
+#: org/postgresql/fastpath/Fastpath.java:169
 #, java-format
 msgid ""
 "Fastpath call {0} - No result was returned or wrong size while expecting an "
 "integer."
 msgstr ""
 
-#: org/postgresql/fastpath/Fastpath.java:188
+#: org/postgresql/fastpath/Fastpath.java:186
 #, fuzzy, java-format
 msgid "Fastpath call {0} - No result was returned and we expected a long."
 msgstr "Se retornó un resultado cuando no se esperaba ninguno."
 
-#: org/postgresql/fastpath/Fastpath.java:196
+#: org/postgresql/fastpath/Fastpath.java:194
 #, java-format
 msgid ""
 "Fastpath call {0} - No result was returned or wrong size while expecting a "
 "long."
 msgstr ""
 
-#: org/postgresql/fastpath/Fastpath.java:308
+#: org/postgresql/fastpath/Fastpath.java:297
 #, java-format
 msgid "The fastpath function {0} is unknown."
 msgstr ""
@@ -586,63 +585,70 @@ msgid "Cannot cast to boolean: \"{0}\""
 msgstr ""
 
 #: org/postgresql/jdbc/EscapedFunctions.java:240
+#: org/postgresql/jdbc/EscapedFunctions2.java:167
 #, java-format
 msgid "{0} function takes four and only four argument."
 msgstr ""
 
 #: org/postgresql/jdbc/EscapedFunctions.java:270
-#: org/postgresql/jdbc/EscapedFunctions.java:344
-#: org/postgresql/jdbc/EscapedFunctions.java:749
-#: org/postgresql/jdbc/EscapedFunctions.java:787
+#: org/postgresql/jdbc/EscapedFunctions.java:337
+#: org/postgresql/jdbc/EscapedFunctions.java:740
+#: org/postgresql/jdbc/EscapedFunctions2.java:196
+#: org/postgresql/jdbc/EscapedFunctions2.java:263
+#: org/postgresql/jdbc/EscapedFunctions2.java:665
 #, java-format
 msgid "{0} function takes two and only two arguments."
 msgstr ""
 
 #: org/postgresql/jdbc/EscapedFunctions.java:288
-#: org/postgresql/jdbc/EscapedFunctions.java:326
-#: org/postgresql/jdbc/EscapedFunctions.java:446
-#: org/postgresql/jdbc/EscapedFunctions.java:461
-#: org/postgresql/jdbc/EscapedFunctions.java:476
-#: org/postgresql/jdbc/EscapedFunctions.java:491
-#: org/postgresql/jdbc/EscapedFunctions.java:506
-#: org/postgresql/jdbc/EscapedFunctions.java:521
-#: org/postgresql/jdbc/EscapedFunctions.java:536
-#: org/postgresql/jdbc/EscapedFunctions.java:551
-#: org/postgresql/jdbc/EscapedFunctions.java:566
-#: org/postgresql/jdbc/EscapedFunctions.java:581
-#: org/postgresql/jdbc/EscapedFunctions.java:596
-#: org/postgresql/jdbc/EscapedFunctions.java:611
-#: org/postgresql/jdbc/EscapedFunctions.java:775
+#: org/postgresql/jdbc/EscapedFunctions.java:441
+#: org/postgresql/jdbc/EscapedFunctions.java:467
+#: org/postgresql/jdbc/EscapedFunctions.java:526
+#: org/postgresql/jdbc/EscapedFunctions.java:728
+#: org/postgresql/jdbc/EscapedFunctions2.java:211
+#: org/postgresql/jdbc/EscapedFunctions2.java:355
+#: org/postgresql/jdbc/EscapedFunctions2.java:381
+#: org/postgresql/jdbc/EscapedFunctions2.java:440
+#: org/postgresql/jdbc/EscapedFunctions2.java:654
 #, java-format
 msgid "{0} function takes one and only one argument."
 msgstr ""
 
-#: org/postgresql/jdbc/EscapedFunctions.java:310
-#: org/postgresql/jdbc/EscapedFunctions.java:391
+#: org/postgresql/jdbc/EscapedFunctions.java:312
+#: org/postgresql/jdbc/EscapedFunctions.java:386
+#: org/postgresql/jdbc/EscapedFunctions2.java:238
+#: org/postgresql/jdbc/EscapedFunctions2.java:307
 #, java-format
 msgid "{0} function takes two or three arguments."
 msgstr ""
 
-#: org/postgresql/jdbc/EscapedFunctions.java:416
-#: org/postgresql/jdbc/EscapedFunctions.java:431
-#: org/postgresql/jdbc/EscapedFunctions.java:734
-#: org/postgresql/jdbc/EscapedFunctions.java:764
+#: org/postgresql/jdbc/EscapedFunctions.java:411
+#: org/postgresql/jdbc/EscapedFunctions.java:426
+#: org/postgresql/jdbc/EscapedFunctions.java:693
+#: org/postgresql/jdbc/EscapedFunctions.java:719
+#: org/postgresql/jdbc/EscapedFunctions2.java:645
 #, java-format
 msgid "{0} function doesn''t take any argument."
 msgstr ""
 
-#: org/postgresql/jdbc/EscapedFunctions.java:627
-#: org/postgresql/jdbc/EscapedFunctions.java:680
+#: org/postgresql/jdbc/EscapedFunctions.java:586
+#: org/postgresql/jdbc/EscapedFunctions.java:639
+#: org/postgresql/jdbc/EscapedFunctions2.java:500
+#: org/postgresql/jdbc/EscapedFunctions2.java:571
 #, java-format
 msgid "{0} function takes three and only three arguments."
 msgstr ""
 
-#: org/postgresql/jdbc/EscapedFunctions.java:640
-#: org/postgresql/jdbc/EscapedFunctions.java:661
-#: org/postgresql/jdbc/EscapedFunctions.java:664
-#: org/postgresql/jdbc/EscapedFunctions.java:697
-#: org/postgresql/jdbc/EscapedFunctions.java:710
-#: org/postgresql/jdbc/EscapedFunctions.java:713
+#: org/postgresql/jdbc/EscapedFunctions.java:599
+#: org/postgresql/jdbc/EscapedFunctions.java:620
+#: org/postgresql/jdbc/EscapedFunctions.java:623
+#: org/postgresql/jdbc/EscapedFunctions.java:656
+#: org/postgresql/jdbc/EscapedFunctions.java:669
+#: org/postgresql/jdbc/EscapedFunctions.java:672
+#: org/postgresql/jdbc/EscapedFunctions2.java:510
+#: org/postgresql/jdbc/EscapedFunctions2.java:527
+#: org/postgresql/jdbc/EscapedFunctions2.java:585
+#: org/postgresql/jdbc/EscapedFunctions2.java:597
 #, fuzzy, java-format
 msgid "Interval {0} not yet implemented"
 msgstr "Este método aún no ha sido implementado."
@@ -661,18 +667,18 @@ msgstr ""
 msgid "Cannot retrieve the name of an unnamed savepoint."
 msgstr ""
 
-#: org/postgresql/jdbc/PgArray.java:157 org/postgresql/jdbc/PgArray.java:844
+#: org/postgresql/jdbc/PgArray.java:155 org/postgresql/jdbc/PgArray.java:842
 #, java-format
 msgid "The array index is out of range: {0}"
 msgstr ""
 
-#: org/postgresql/jdbc/PgArray.java:178 org/postgresql/jdbc/PgArray.java:861
+#: org/postgresql/jdbc/PgArray.java:176 org/postgresql/jdbc/PgArray.java:859
 #, java-format
 msgid "The array index is out of range: {0}, number of elements: {1}."
 msgstr ""
 "El índice del arreglo esta fuera de rango: {0}, número de elementos: {1}."
 
-#: org/postgresql/jdbc/PgArray.java:210
+#: org/postgresql/jdbc/PgArray.java:208
 #: org/postgresql/jdbc/PgResultSet.java:1930
 #: org/postgresql/util/HStoreConverter.java:43
 #: org/postgresql/util/HStoreConverter.java:74
@@ -683,67 +689,67 @@ msgid ""
 "SQL_ASCII database."
 msgstr ""
 
-#: org/postgresql/jdbc/PgCallableStatement.java:86
-#: org/postgresql/jdbc/PgCallableStatement.java:96
+#: org/postgresql/jdbc/PgCallableStatement.java:85
+#: org/postgresql/jdbc/PgCallableStatement.java:95
 msgid "A CallableStatement was executed with nothing returned."
 msgstr ""
 
-#: org/postgresql/jdbc/PgCallableStatement.java:107
+#: org/postgresql/jdbc/PgCallableStatement.java:106
 msgid "A CallableStatement was executed with an invalid number of parameters"
 msgstr ""
 
-#: org/postgresql/jdbc/PgCallableStatement.java:145
+#: org/postgresql/jdbc/PgCallableStatement.java:144
 #, java-format
 msgid ""
 "A CallableStatement function was executed and the out parameter {0} was of "
 "type {1} however type {2} was registered."
 msgstr ""
 
-#: org/postgresql/jdbc/PgCallableStatement.java:202
+#: org/postgresql/jdbc/PgCallableStatement.java:206
 msgid ""
 "This statement does not declare an OUT parameter.  Use '{' ?= call ... '}' "
 "to declare one."
 msgstr ""
 
-#: org/postgresql/jdbc/PgCallableStatement.java:246
+#: org/postgresql/jdbc/PgCallableStatement.java:229
 msgid "wasNull cannot be call before fetching a result."
 msgstr ""
 
-#: org/postgresql/jdbc/PgCallableStatement.java:384
-#: org/postgresql/jdbc/PgCallableStatement.java:403
+#: org/postgresql/jdbc/PgCallableStatement.java:367
+#: org/postgresql/jdbc/PgCallableStatement.java:386
 #, java-format
 msgid ""
 "Parameter of type {0} was registered, but call to get{1} (sqltype={2}) was "
 "made."
 msgstr ""
 
-#: org/postgresql/jdbc/PgCallableStatement.java:424
+#: org/postgresql/jdbc/PgCallableStatement.java:407
 msgid ""
 "A CallableStatement was declared, but no call to registerOutParameter(1, "
 "<some type>) was made."
 msgstr ""
 
-#: org/postgresql/jdbc/PgCallableStatement.java:430
+#: org/postgresql/jdbc/PgCallableStatement.java:413
 msgid "No function outputs were registered."
 msgstr ""
 
-#: org/postgresql/jdbc/PgCallableStatement.java:436
+#: org/postgresql/jdbc/PgCallableStatement.java:419
 msgid ""
 "Results cannot be retrieved from a CallableStatement before it is executed."
 msgstr ""
 
-#: org/postgresql/jdbc/PgCallableStatement.java:703
+#: org/postgresql/jdbc/PgCallableStatement.java:686
 #, java-format
 msgid "Unsupported type conversion to {1}."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:272
+#: org/postgresql/jdbc/PgConnection.java:241
 #, java-format
 msgid "Unsupported value for stringtype parameter: {0}"
 msgstr ""
 
 #: org/postgresql/jdbc/PgConnection.java:424
-#: org/postgresql/jdbc/PgPreparedStatement.java:119
+#: org/postgresql/jdbc/PgPreparedStatement.java:107
 #: org/postgresql/jdbc/PgStatement.java:225
 #: org/postgresql/jdbc/TypeInfoCache.java:226
 #: org/postgresql/jdbc/TypeInfoCache.java:371
@@ -755,125 +761,125 @@ msgstr ""
 msgid "No results were returned by the query."
 msgstr "La consulta no retornó ningún resultado."
 
-#: org/postgresql/jdbc/PgConnection.java:441
+#: org/postgresql/jdbc/PgConnection.java:442
 #: org/postgresql/jdbc/PgStatement.java:254
 msgid "A result was returned when none was expected."
 msgstr "Se retornó un resultado cuando no se esperaba ninguno."
 
-#: org/postgresql/jdbc/PgConnection.java:545
+#: org/postgresql/jdbc/PgConnection.java:547
 msgid "Custom type maps are not supported."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:587
+#: org/postgresql/jdbc/PgConnection.java:589
 #, java-format
 msgid "Failed to create object for: {0}."
 msgstr "Fallo al crear objeto: {0}."
 
-#: org/postgresql/jdbc/PgConnection.java:641
+#: org/postgresql/jdbc/PgConnection.java:643
 #, java-format
 msgid "Unable to load the class {0} responsible for the datatype {1}"
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:693
+#: org/postgresql/jdbc/PgConnection.java:705
 msgid ""
 "Cannot change transaction read-only property in the middle of a transaction."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:756
+#: org/postgresql/jdbc/PgConnection.java:772
 msgid "Cannot commit when autoCommit is enabled."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:767
-#: org/postgresql/jdbc/PgConnection.java:1384
-#: org/postgresql/jdbc/PgConnection.java:1428
+#: org/postgresql/jdbc/PgConnection.java:783
+#: org/postgresql/jdbc/PgConnection.java:1401
+#: org/postgresql/jdbc/PgConnection.java:1445
 #, fuzzy
 msgid "This connection has been closed."
 msgstr "El intento de conexión falló."
 
-#: org/postgresql/jdbc/PgConnection.java:777
+#: org/postgresql/jdbc/PgConnection.java:794
 msgid "Cannot rollback when autoCommit is enabled."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:827
+#: org/postgresql/jdbc/PgConnection.java:844
 msgid ""
 "Cannot change transaction isolation level in the middle of a transaction."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:833
+#: org/postgresql/jdbc/PgConnection.java:850
 #, java-format
 msgid "Transaction isolation level {0} not supported."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:878
+#: org/postgresql/jdbc/PgConnection.java:895
 msgid "Finalizing a Connection that was never closed:"
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:945
+#: org/postgresql/jdbc/PgConnection.java:962
 msgid "Unable to translate data into the desired encoding."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1008
+#: org/postgresql/jdbc/PgConnection.java:1025
 #: org/postgresql/jdbc/PgResultSet.java:1817
-#: org/postgresql/jdbc/PgStatement.java:903
+#: org/postgresql/jdbc/PgStatement.java:908
 msgid "Fetch size must be a value greater to or equal to 0."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1289
-#: org/postgresql/jdbc/PgConnection.java:1330
+#: org/postgresql/jdbc/PgConnection.java:1306
+#: org/postgresql/jdbc/PgConnection.java:1347
 #, java-format
 msgid "Unable to find server array type for provided name {0}."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1312
+#: org/postgresql/jdbc/PgConnection.java:1329
 #, java-format
 msgid "Invalid elements {0}"
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1348
+#: org/postgresql/jdbc/PgConnection.java:1365
 #, java-format
 msgid "Invalid timeout ({0}<0)."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1372
+#: org/postgresql/jdbc/PgConnection.java:1389
 msgid "Validating connection."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1405
+#: org/postgresql/jdbc/PgConnection.java:1422
 #, fuzzy, java-format
 msgid "Failed to set ClientInfo property: {0}"
 msgstr "Fallo al crear objeto: {0}."
 
-#: org/postgresql/jdbc/PgConnection.java:1415
+#: org/postgresql/jdbc/PgConnection.java:1432
 msgid "ClientInfo property not supported."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1441
+#: org/postgresql/jdbc/PgConnection.java:1458
 msgid "One ore more ClientInfo failed."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1540
+#: org/postgresql/jdbc/PgConnection.java:1559
 msgid "Network timeout must be a value greater than or equal to 0."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1552
+#: org/postgresql/jdbc/PgConnection.java:1571
 msgid "Unable to set network timeout."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1563
+#: org/postgresql/jdbc/PgConnection.java:1582
 msgid "Unable to get network timeout."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1580
+#: org/postgresql/jdbc/PgConnection.java:1599
 #, java-format
 msgid "Unknown ResultSet holdability setting: {0}."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1598
-#: org/postgresql/jdbc/PgConnection.java:1619
+#: org/postgresql/jdbc/PgConnection.java:1617
+#: org/postgresql/jdbc/PgConnection.java:1638
 msgid "Cannot establish a savepoint in auto-commit mode."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1685
+#: org/postgresql/jdbc/PgConnection.java:1707
 msgid "Returning autogenerated keys is not supported."
 msgstr ""
 
@@ -887,46 +893,46 @@ msgstr ""
 msgid "Unable to find name datatype in the system catalogs."
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:323
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:322
 msgid "Unable to find keywords in the system catalogs."
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1105
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1095
 msgid "oid"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1105
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1095
 msgid "proname"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1107
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1558
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1097
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1548
 msgid "typtype"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1110
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1100
 msgid "proargtypes"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1576
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1566
 msgid "adsrc"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1589
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1579
 msgid "attidentity"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1685
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1761
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1675
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1751
 msgid "rolname"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1686
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1762
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1676
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1752
 msgid "relacl"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1692
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1682
 msgid "attacl"
 msgstr ""
 
@@ -936,83 +942,83 @@ msgid "The parameter index is out of range: {0}, number of parameters: {1}."
 msgstr ""
 "El índice del arreglo esta fuera de rango: {0}, número de elementos: {1}."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:106
+#: org/postgresql/jdbc/PgPreparedStatement.java:94
+#: org/postgresql/jdbc/PgPreparedStatement.java:115
 #: org/postgresql/jdbc/PgPreparedStatement.java:127
-#: org/postgresql/jdbc/PgPreparedStatement.java:139
-#: org/postgresql/jdbc/PgPreparedStatement.java:1035
+#: org/postgresql/jdbc/PgPreparedStatement.java:1008
 msgid ""
 "Can''t use query methods that take a query string on a PreparedStatement."
 msgstr ""
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:249
+#: org/postgresql/jdbc/PgPreparedStatement.java:237
 msgid "Unknown Types value."
 msgstr ""
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:382
-#: org/postgresql/jdbc/PgPreparedStatement.java:439
-#: org/postgresql/jdbc/PgPreparedStatement.java:1191
-#: org/postgresql/jdbc/PgPreparedStatement.java:1490
+#: org/postgresql/jdbc/PgPreparedStatement.java:364
+#: org/postgresql/jdbc/PgPreparedStatement.java:421
+#: org/postgresql/jdbc/PgPreparedStatement.java:1164
+#: org/postgresql/jdbc/PgPreparedStatement.java:1472
 #, java-format
 msgid "Invalid stream length {0}."
 msgstr ""
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:411
+#: org/postgresql/jdbc/PgPreparedStatement.java:393
 #, java-format
 msgid "The JVM claims not to support the {0} encoding."
 msgstr ""
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:414
+#: org/postgresql/jdbc/PgPreparedStatement.java:396
 #: org/postgresql/jdbc/PgResultSet.java:1122
 #: org/postgresql/jdbc/PgResultSet.java:1156
 msgid "Provided InputStream failed."
 msgstr ""
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:460
-#: org/postgresql/jdbc/PgPreparedStatement.java:1096
+#: org/postgresql/jdbc/PgPreparedStatement.java:442
+#: org/postgresql/jdbc/PgPreparedStatement.java:1069
 #, java-format
 msgid "Unknown type {0}."
 msgstr ""
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:477
+#: org/postgresql/jdbc/PgPreparedStatement.java:459
 msgid "No hstore extension installed."
 msgstr ""
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:619
-#: org/postgresql/jdbc/PgPreparedStatement.java:642
-#: org/postgresql/jdbc/PgPreparedStatement.java:652
-#: org/postgresql/jdbc/PgPreparedStatement.java:664
+#: org/postgresql/jdbc/PgPreparedStatement.java:601
+#: org/postgresql/jdbc/PgPreparedStatement.java:624
+#: org/postgresql/jdbc/PgPreparedStatement.java:634
+#: org/postgresql/jdbc/PgPreparedStatement.java:646
 #, java-format
 msgid "Cannot cast an instance of {0} to type {1}"
 msgstr ""
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:682
+#: org/postgresql/jdbc/PgPreparedStatement.java:664
 #, java-format
 msgid "Unsupported Types value: {0}"
 msgstr ""
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:894
+#: org/postgresql/jdbc/PgPreparedStatement.java:876
 #, java-format
 msgid "Cannot convert an instance of {0} to type {1}"
 msgstr ""
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:968
+#: org/postgresql/jdbc/PgPreparedStatement.java:950
 #, java-format
 msgid ""
 "Can''t infer the SQL type to use for an instance of {0}. Use setObject() "
 "with an explicit Types value to specify the type to use."
 msgstr ""
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:1133
-#: org/postgresql/jdbc/PgPreparedStatement.java:1233
+#: org/postgresql/jdbc/PgPreparedStatement.java:1106
+#: org/postgresql/jdbc/PgPreparedStatement.java:1206
 msgid "Unexpected error writing large object to database."
 msgstr ""
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:1178
+#: org/postgresql/jdbc/PgPreparedStatement.java:1151
 #: org/postgresql/jdbc/PgResultSet.java:1210
 msgid "Provided Reader failed."
 msgstr ""
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:1449
+#: org/postgresql/jdbc/PgPreparedStatement.java:1431
 #: org/postgresql/util/StreamWrapper.java:56
 msgid "Object is too large to send over the protocol."
 msgstr ""
@@ -1028,8 +1034,8 @@ msgstr ""
 #: org/postgresql/jdbc/PgResultSet.java:556
 #: org/postgresql/jdbc/PgResultSet.java:594
 #: org/postgresql/jdbc/PgResultSet.java:624
-#: org/postgresql/jdbc/PgResultSet.java:3014
-#: org/postgresql/jdbc/PgResultSet.java:3058
+#: org/postgresql/jdbc/PgResultSet.java:3012
+#: org/postgresql/jdbc/PgResultSet.java:3057
 #, java-format
 msgid "Cannot convert the column of type {0} to requested type {1}."
 msgstr ""
@@ -1041,7 +1047,7 @@ msgid "Can''t use relative move methods while on the insert row."
 msgstr ""
 
 #: org/postgresql/jdbc/PgResultSet.java:878
-#: org/postgresql/jdbc/PgStatement.java:895
+#: org/postgresql/jdbc/PgStatement.java:900
 #, java-format
 msgid "Invalid fetch direction constant: {0}."
 msgstr ""
@@ -1080,8 +1086,8 @@ msgstr ""
 
 #: org/postgresql/jdbc/PgResultSet.java:1119
 #: org/postgresql/jdbc/PgResultSet.java:1754
-#: org/postgresql/jdbc/PgResultSet.java:2422
-#: org/postgresql/jdbc/PgResultSet.java:2443
+#: org/postgresql/jdbc/PgResultSet.java:2420
+#: org/postgresql/jdbc/PgResultSet.java:2441
 #, java-format
 msgid "The JVM claims not to support the encoding: {0}"
 msgstr ""
@@ -1095,7 +1101,7 @@ msgid "Cannot call updateRow() when on the insert row."
 msgstr ""
 
 #: org/postgresql/jdbc/PgResultSet.java:1335
-#: org/postgresql/jdbc/PgResultSet.java:3075
+#: org/postgresql/jdbc/PgResultSet.java:3074
 msgid ""
 "Cannot update the ResultSet because it is either before the start or after "
 "the end of the results."
@@ -1112,68 +1118,68 @@ msgstr ""
 
 #: org/postgresql/jdbc/PgResultSet.java:2017
 #: org/postgresql/jdbc/PgResultSet.java:2022
-#: org/postgresql/jdbc/PgResultSet.java:2809
-#: org/postgresql/jdbc/PgResultSet.java:2815
-#: org/postgresql/jdbc/PgResultSet.java:2840
-#: org/postgresql/jdbc/PgResultSet.java:2846
-#: org/postgresql/jdbc/PgResultSet.java:2870
-#: org/postgresql/jdbc/PgResultSet.java:2875
-#: org/postgresql/jdbc/PgResultSet.java:2891
-#: org/postgresql/jdbc/PgResultSet.java:2912
-#: org/postgresql/jdbc/PgResultSet.java:2923
-#: org/postgresql/jdbc/PgResultSet.java:2936
-#: org/postgresql/jdbc/PgResultSet.java:3063
+#: org/postgresql/jdbc/PgResultSet.java:2807
+#: org/postgresql/jdbc/PgResultSet.java:2813
+#: org/postgresql/jdbc/PgResultSet.java:2838
+#: org/postgresql/jdbc/PgResultSet.java:2844
+#: org/postgresql/jdbc/PgResultSet.java:2868
+#: org/postgresql/jdbc/PgResultSet.java:2873
+#: org/postgresql/jdbc/PgResultSet.java:2889
+#: org/postgresql/jdbc/PgResultSet.java:2910
+#: org/postgresql/jdbc/PgResultSet.java:2921
+#: org/postgresql/jdbc/PgResultSet.java:2934
+#: org/postgresql/jdbc/PgResultSet.java:3062
 #, java-format
 msgid "Bad value for type {0} : {1}"
 msgstr ""
 
-#: org/postgresql/jdbc/PgResultSet.java:2595
+#: org/postgresql/jdbc/PgResultSet.java:2593
 #, java-format
 msgid "The column name {0} was not found in this ResultSet."
 msgstr ""
 
-#: org/postgresql/jdbc/PgResultSet.java:2731
+#: org/postgresql/jdbc/PgResultSet.java:2729
 msgid ""
 "ResultSet is not updateable.  The query that generated this result set must "
 "select only one table, and must select all primary keys from that table. See "
 "the JDBC 2.1 API Specification, section 5.6 for more details."
 msgstr ""
 
-#: org/postgresql/jdbc/PgResultSet.java:2743
+#: org/postgresql/jdbc/PgResultSet.java:2741
 msgid "This ResultSet is closed."
 msgstr ""
 
-#: org/postgresql/jdbc/PgResultSet.java:2774
+#: org/postgresql/jdbc/PgResultSet.java:2772
 msgid "ResultSet not positioned properly, perhaps you need to call next."
 msgstr ""
 
-#: org/postgresql/jdbc/PgResultSet.java:3095
+#: org/postgresql/jdbc/PgResultSet.java:3094
 msgid "Invalid UUID data."
 msgstr ""
 
-#: org/postgresql/jdbc/PgResultSet.java:3184
-#: org/postgresql/jdbc/PgResultSet.java:3191
-#: org/postgresql/jdbc/PgResultSet.java:3202
-#: org/postgresql/jdbc/PgResultSet.java:3213
-#: org/postgresql/jdbc/PgResultSet.java:3224
-#: org/postgresql/jdbc/PgResultSet.java:3235
-#: org/postgresql/jdbc/PgResultSet.java:3246
-#: org/postgresql/jdbc/PgResultSet.java:3257
-#: org/postgresql/jdbc/PgResultSet.java:3268
-#: org/postgresql/jdbc/PgResultSet.java:3275
-#: org/postgresql/jdbc/PgResultSet.java:3282
-#: org/postgresql/jdbc/PgResultSet.java:3293
-#: org/postgresql/jdbc/PgResultSet.java:3310
-#: org/postgresql/jdbc/PgResultSet.java:3317
-#: org/postgresql/jdbc/PgResultSet.java:3324
-#: org/postgresql/jdbc/PgResultSet.java:3335
-#: org/postgresql/jdbc/PgResultSet.java:3342
-#: org/postgresql/jdbc/PgResultSet.java:3349
-#: org/postgresql/jdbc/PgResultSet.java:3387
-#: org/postgresql/jdbc/PgResultSet.java:3394
-#: org/postgresql/jdbc/PgResultSet.java:3401
-#: org/postgresql/jdbc/PgResultSet.java:3421
-#: org/postgresql/jdbc/PgResultSet.java:3434
+#: org/postgresql/jdbc/PgResultSet.java:3183
+#: org/postgresql/jdbc/PgResultSet.java:3190
+#: org/postgresql/jdbc/PgResultSet.java:3201
+#: org/postgresql/jdbc/PgResultSet.java:3212
+#: org/postgresql/jdbc/PgResultSet.java:3223
+#: org/postgresql/jdbc/PgResultSet.java:3234
+#: org/postgresql/jdbc/PgResultSet.java:3245
+#: org/postgresql/jdbc/PgResultSet.java:3256
+#: org/postgresql/jdbc/PgResultSet.java:3267
+#: org/postgresql/jdbc/PgResultSet.java:3274
+#: org/postgresql/jdbc/PgResultSet.java:3281
+#: org/postgresql/jdbc/PgResultSet.java:3292
+#: org/postgresql/jdbc/PgResultSet.java:3309
+#: org/postgresql/jdbc/PgResultSet.java:3316
+#: org/postgresql/jdbc/PgResultSet.java:3323
+#: org/postgresql/jdbc/PgResultSet.java:3334
+#: org/postgresql/jdbc/PgResultSet.java:3341
+#: org/postgresql/jdbc/PgResultSet.java:3348
+#: org/postgresql/jdbc/PgResultSet.java:3386
+#: org/postgresql/jdbc/PgResultSet.java:3393
+#: org/postgresql/jdbc/PgResultSet.java:3400
+#: org/postgresql/jdbc/PgResultSet.java:3420
+#: org/postgresql/jdbc/PgResultSet.java:3433
 #, java-format
 msgid "conversion to {0} from {1} not supported"
 msgstr ""
@@ -1238,33 +1244,33 @@ msgstr ""
 msgid "Maximum number of rows must be a value grater than or equal to 0."
 msgstr ""
 
-#: org/postgresql/jdbc/PgStatement.java:550
+#: org/postgresql/jdbc/PgStatement.java:555
 msgid "Query timeout must be a value greater than or equals to 0."
 msgstr ""
 
-#: org/postgresql/jdbc/PgStatement.java:590
+#: org/postgresql/jdbc/PgStatement.java:595
 msgid "The maximum field size must be a value greater than or equal to 0."
 msgstr ""
 
-#: org/postgresql/jdbc/PgStatement.java:689
+#: org/postgresql/jdbc/PgStatement.java:694
 msgid "This statement has been closed."
 msgstr ""
 
-#: org/postgresql/jdbc/PgStatement.java:1145
-#: org/postgresql/jdbc/PgStatement.java:1173
+#: org/postgresql/jdbc/PgStatement.java:1150
+#: org/postgresql/jdbc/PgStatement.java:1178
 msgid "Returning autogenerated keys by column index is not supported."
 msgstr ""
 
-#: org/postgresql/jdbc/TimestampUtils.java:355
-#: org/postgresql/jdbc/TimestampUtils.java:423
+#: org/postgresql/jdbc/TimestampUtils.java:365
+#: org/postgresql/jdbc/TimestampUtils.java:433
 #, java-format
 msgid "Bad value for type timestamp/date/time: {1}"
 msgstr ""
 
-#: org/postgresql/jdbc/TimestampUtils.java:858
-#: org/postgresql/jdbc/TimestampUtils.java:915
-#: org/postgresql/jdbc/TimestampUtils.java:961
-#: org/postgresql/jdbc/TimestampUtils.java:1010
+#: org/postgresql/jdbc/TimestampUtils.java:914
+#: org/postgresql/jdbc/TimestampUtils.java:971
+#: org/postgresql/jdbc/TimestampUtils.java:1017
+#: org/postgresql/jdbc/TimestampUtils.java:1066
 #, java-format
 msgid "Unsupported binary encoding of {0}."
 msgstr ""
@@ -1277,31 +1283,31 @@ msgstr ""
 msgid "Invalid or unsupported by client SCRAM mechanisms"
 msgstr ""
 
-#: org/postgresql/jre8/sasl/ScramAuthenticator.java:117
+#: org/postgresql/jre8/sasl/ScramAuthenticator.java:119
 #, java-format
 msgid "Invalid server-first-message: {0}"
 msgstr ""
 
-#: org/postgresql/jre8/sasl/ScramAuthenticator.java:147
+#: org/postgresql/jre8/sasl/ScramAuthenticator.java:151
 #, java-format
 msgid "Invalid server-final-message: {0}"
 msgstr ""
 
-#: org/postgresql/jre8/sasl/ScramAuthenticator.java:153
+#: org/postgresql/jre8/sasl/ScramAuthenticator.java:157
 #, java-format
 msgid "SCRAM authentication failed, server returned error: {0}"
 msgstr ""
 
-#: org/postgresql/jre8/sasl/ScramAuthenticator.java:160
+#: org/postgresql/jre8/sasl/ScramAuthenticator.java:164
 msgid "Invalid server SCRAM signature"
 msgstr ""
 
-#: org/postgresql/largeobject/LargeObjectManager.java:144
+#: org/postgresql/largeobject/LargeObjectManager.java:136
 msgid "Failed to initialize LargeObject API"
 msgstr ""
 
-#: org/postgresql/largeobject/LargeObjectManager.java:262
-#: org/postgresql/largeobject/LargeObjectManager.java:305
+#: org/postgresql/largeobject/LargeObjectManager.java:254
+#: org/postgresql/largeobject/LargeObjectManager.java:295
 msgid "Large Objects may not be used in auto-commit mode."
 msgstr ""
 
@@ -1335,34 +1341,34 @@ msgstr ""
 msgid "The hostname {0} could not be verified."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:164
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:90
 msgid "The sslfactoryarg property may not be empty."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:180
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:106
 msgid ""
 "The environment variable containing the server's SSL certificate must not be "
 "empty."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:188
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:114
 msgid ""
 "The system property containing the server's SSL certificate must not be "
 "empty."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:195
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:121
 msgid ""
 "The sslfactoryarg property must start with the prefix file:, classpath:, "
 "env:, sys:, or -----BEGIN CERTIFICATE-----."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:207
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:133
 #, fuzzy
 msgid "An error occurred reading the certificate"
 msgstr "Ha ocorrido un error mientras se establecía la conexión SSL."
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:240
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:166
 msgid "No X509TrustManager found"
 msgstr ""
 
@@ -1497,129 +1503,129 @@ msgid ""
 "setSavePoint not allowed while an XA transaction is active."
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:177
-#: org/postgresql/xa/PGXAConnection.java:253
-#: org/postgresql/xa/PGXAConnection.java:347
+#: org/postgresql/xa/PGXAConnection.java:186
+#: org/postgresql/xa/PGXAConnection.java:272
+#: org/postgresql/xa/PGXAConnection.java:381
 #, java-format
 msgid "Invalid flags {0}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:181
-#: org/postgresql/xa/PGXAConnection.java:257
-#: org/postgresql/xa/PGXAConnection.java:449
+#: org/postgresql/xa/PGXAConnection.java:190
+#: org/postgresql/xa/PGXAConnection.java:276
+#: org/postgresql/xa/PGXAConnection.java:491
 msgid "xid must not be null"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:185
+#: org/postgresql/xa/PGXAConnection.java:194
 msgid "Connection is busy with another transaction"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:194
-#: org/postgresql/xa/PGXAConnection.java:267
+#: org/postgresql/xa/PGXAConnection.java:203
+#: org/postgresql/xa/PGXAConnection.java:286
 #, fuzzy
 msgid "suspend/resume not implemented"
 msgstr "Este método aún no ha sido implementado."
 
-#: org/postgresql/xa/PGXAConnection.java:202
-#: org/postgresql/xa/PGXAConnection.java:209
-#: org/postgresql/xa/PGXAConnection.java:213
+#: org/postgresql/xa/PGXAConnection.java:211
+#: org/postgresql/xa/PGXAConnection.java:218
+#: org/postgresql/xa/PGXAConnection.java:222
 #, java-format
 msgid ""
 "Invalid protocol state requested. Attempted transaction interleaving is not "
 "supported. xid={0}, currentXid={1}, state={2}, flags={3}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:224
+#: org/postgresql/xa/PGXAConnection.java:233
 msgid "Error disabling autocommit"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:261
+#: org/postgresql/xa/PGXAConnection.java:280
 #, java-format
 msgid ""
 "tried to call end without corresponding start call. state={0}, start "
 "xid={1}, currentXid={2}, preparedXid={3}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:297
+#: org/postgresql/xa/PGXAConnection.java:326
 #, java-format
 msgid ""
 "Preparing already prepared transaction, the prepared xid {0}, prepare xid={1}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:300
+#: org/postgresql/xa/PGXAConnection.java:329
 #, java-format
 msgid "Current connection does not have an associated xid. prepare xid={0}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:307
+#: org/postgresql/xa/PGXAConnection.java:336
 #, java-format
 msgid ""
 "Not implemented: Prepare must be issued using the same connection that "
 "started the transaction. currentXid={0}, prepare xid={1}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:311
+#: org/postgresql/xa/PGXAConnection.java:340
 #, java-format
 msgid "Prepare called before end. prepare xid={0}, state={1}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:331
+#: org/postgresql/xa/PGXAConnection.java:360
 #, java-format
 msgid "Error preparing transaction. prepare xid={0}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:382
+#: org/postgresql/xa/PGXAConnection.java:416
 msgid "Error during recover"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:438
+#: org/postgresql/xa/PGXAConnection.java:480
 #, java-format
 msgid ""
 "Error rolling back prepared transaction. rollback xid={0}, preparedXid={1}, "
 "currentXid={2}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:471
+#: org/postgresql/xa/PGXAConnection.java:521
 #, java-format
 msgid ""
 "One-phase commit called for xid {0} but connection was prepared with xid {1}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:479
+#: org/postgresql/xa/PGXAConnection.java:529
 msgid ""
 "Not implemented: one-phase commit must be issued using the same connection "
 "that was used to start it"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:483
+#: org/postgresql/xa/PGXAConnection.java:533
 #, java-format
 msgid "One-phase commit with unknown xid. commit xid={0}, currentXid={1}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:487
+#: org/postgresql/xa/PGXAConnection.java:537
 #, java-format
 msgid "commit called before end. commit xid={0}, state={1}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:498
+#: org/postgresql/xa/PGXAConnection.java:548
 #, java-format
 msgid "Error during one-phase commit. commit xid={0}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:517
+#: org/postgresql/xa/PGXAConnection.java:576
 msgid ""
 "Not implemented: 2nd phase commit must be issued using an idle connection. "
 "commit xid={0}, currentXid={1}, state={2], transactionState={3}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:550
+#: org/postgresql/xa/PGXAConnection.java:609
 #, java-format
 msgid ""
 "Error committing prepared transaction. commit xid={0}, preparedXid={1}, "
 "currentXid={2}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:567
+#: org/postgresql/xa/PGXAConnection.java:626
 #, java-format
 msgid "Heuristic commit/rollback not supported. forget xid={0}"
 msgstr ""

--- a/pgjdbc/src/main/java/org/postgresql/translation/fr.po
+++ b/pgjdbc/src/main/java/org/postgresql/translation/fr.po
@@ -8,7 +8,6 @@ msgid ""
 msgstr ""
 "Project-Id-Version: head-fr\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-06-05 10:57+0300\n"
 "PO-Revision-Date: 2007-07-27 12:27+0200\n"
 "Last-Translator: \n"
 "Language-Team:  <en@li.org>\n"
@@ -19,23 +18,23 @@ msgstr ""
 "X-Generator: KBabel 1.11.4\n"
 "Plural-Forms:  nplurals=2; plural=(n > 1);\n"
 
-#: org/postgresql/Driver.java:214
+#: org/postgresql/Driver.java:217
 msgid "Error loading default settings from driverconfig.properties"
 msgstr ""
 "Erreur de chargement des valeurs par défaut depuis driverconfig.properties"
 
-#: org/postgresql/Driver.java:226
+#: org/postgresql/Driver.java:229
 msgid "Properties for the driver contains a non-string value for the key "
 msgstr ""
 
-#: org/postgresql/Driver.java:270
+#: org/postgresql/Driver.java:272
 msgid ""
 "Your security policy has prevented the connection from being attempted.  You "
 "probably need to grant the connect java.net.SocketPermission to the database "
 "server host and port that you wish to connect to."
 msgstr ""
 
-#: org/postgresql/Driver.java:276 org/postgresql/Driver.java:408
+#: org/postgresql/Driver.java:278 org/postgresql/Driver.java:410
 msgid ""
 "Something unusual has occurred to cause the driver to fail. Please report "
 "this exception."
@@ -43,35 +42,35 @@ msgstr ""
 "Quelque chose d''inhabituel a provoqué l''échec du pilote. Veuillez faire un "
 "rapport sur cette erreur."
 
-#: org/postgresql/Driver.java:416
+#: org/postgresql/Driver.java:418
 msgid "Connection attempt timed out."
 msgstr "La tentative de connexion a échoué dans le délai imparti."
 
-#: org/postgresql/Driver.java:429
+#: org/postgresql/Driver.java:431
 msgid "Interrupted while attempting to connect."
 msgstr "Interrompu pendant l''établissement de la connexion."
 
-#: org/postgresql/Driver.java:682
+#: org/postgresql/Driver.java:687
 #, java-format
 msgid "Method {0} is not yet implemented."
 msgstr "La fonction {0} n''est pas encore implémentée."
 
-#: org/postgresql/PGProperty.java:535 org/postgresql/PGProperty.java:555
+#: org/postgresql/PGProperty.java:537 org/postgresql/PGProperty.java:557
 #, java-format
 msgid "{0} parameter value must be an integer but was: {1}"
 msgstr ""
 
-#: org/postgresql/copy/CopyManager.java:53
+#: org/postgresql/copy/CopyManager.java:49
 #, java-format
 msgid "Requested CopyIn but got {0}"
 msgstr ""
 
-#: org/postgresql/copy/CopyManager.java:64
+#: org/postgresql/copy/CopyManager.java:60
 #, java-format
 msgid "Requested CopyOut but got {0}"
 msgstr ""
 
-#: org/postgresql/copy/CopyManager.java:75
+#: org/postgresql/copy/CopyManager.java:71
 #, java-format
 msgid "Requested CopyDual but got {0}"
 msgstr ""
@@ -96,6 +95,13 @@ msgstr ""
 msgid "Cannot write to copy a byte of value {0}"
 msgstr ""
 
+#: org/postgresql/core/CommandCompleteParser.java:71
+#, fuzzy, java-format
+msgid "Unable to parse the count in command completion tag: {0}."
+msgstr ""
+"Incapable d''interpréter le nombre de mise à jour dans la balise de "
+"complétion de commande : {0}."
+
 #: org/postgresql/core/ConnectionFactory.java:57
 #, java-format
 msgid "A connection could not be made using the requested protocol {0}."
@@ -119,7 +125,7 @@ msgstr ""
 msgid "Expected an EOF from server, got: {0}"
 msgstr "Attendait une fin de fichier du serveur, reçu: {0}"
 
-#: org/postgresql/core/Parser.java:1006
+#: org/postgresql/core/Parser.java:1051
 #, java-format
 msgid "Malformed function or procedure escape syntax at offset {0}."
 msgstr ""
@@ -184,24 +190,24 @@ msgstr "Des octects à 0 ne devraient pas apparaître dans les identifiants."
 #: org/postgresql/core/v3/CompositeParameterList.java:33
 #: org/postgresql/core/v3/SimpleParameterList.java:54
 #: org/postgresql/core/v3/SimpleParameterList.java:65
-#: org/postgresql/jdbc/PgResultSet.java:2757
-#: org/postgresql/jdbc/PgResultSetMetaData.java:494
+#: org/postgresql/jdbc/PgResultSet.java:2755
+#: org/postgresql/jdbc/PgResultSetMetaData.java:388
 #, java-format
 msgid "The column index is out of range: {0}, number of columns: {1}."
 msgstr ""
 "L''indice de la colonne est hors limite : {0}, nombre de colonnes : {1}."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:109
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:103
 #, fuzzy, java-format
 msgid "Invalid sslmode value: {0}"
 msgstr "Longueur de flux invalide {0}."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:124
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:118
 #, fuzzy, java-format
 msgid "Invalid targetServerType value: {0}"
 msgstr "Longueur de flux invalide {0}."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:246
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:239
 #, fuzzy, java-format
 msgid ""
 "Connection to {0} refused. Check that the hostname and port are correct and "
@@ -210,28 +216,28 @@ msgstr ""
 "Connexion refusée. Vérifiez que le nom de machine et le port sont corrects "
 "et que postmaster accepte les connexions TCP/IP."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:257
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:250
 #: org/postgresql/core/v3/replication/V3ReplicationProtocol.java:133
 msgid "The connection attempt failed."
 msgstr "La tentative de connexion a échoué."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:272
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:265
 #, java-format
 msgid "Could not find a server with specified targetServerType: {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:368
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:381
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:361
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:374
 msgid "The server does not support SSL."
 msgstr "Le serveur ne supporte pas SSL."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:395
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:388
 msgid "An error occurred while setting up the SSL connection."
 msgstr ""
 "Une erreur s''est produite pendant l''établissement de la connexion SSL."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:496
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:523
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:484
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:511
 msgid ""
 "The server requested password-based authentication, but no password was "
 "provided."
@@ -239,13 +245,13 @@ msgstr ""
 "Le serveur a demandé une authentification par mots de passe, mais aucun mot "
 "de passe n''a été fourni."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:626
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:614
 msgid ""
 "SCRAM authentication is not supported by this driver. You need JDK >= 8 and "
 "pgjdbc >= 42.2.0 (not \".jre\" versions)"
 msgstr ""
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:650
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:638
 #, java-format
 msgid ""
 "The authentication type {0} is not supported. Check that you have configured "
@@ -257,16 +263,16 @@ msgstr ""
 "sous-réseau et qu''il utilise un schéma d''authentification supporté par le "
 "pilote."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:657
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2550
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2581
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2585
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2653
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:645
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2543
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2576
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2580
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2648
 #: org/postgresql/gss/GssAction.java:126
 msgid "Protocol error.  Session setup failed."
 msgstr "Erreur de protocole. Ouverture de la session en échec."
 
-#: org/postgresql/core/v3/CopyInImpl.java:47
+#: org/postgresql/core/v3/CopyInImpl.java:49
 msgid "CopyIn copy direction can't receive data"
 msgstr ""
 
@@ -274,143 +280,143 @@ msgstr ""
 msgid "CommandComplete expected COPY but got: "
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:161
+#: org/postgresql/core/v3/QueryExecutorImpl.java:163
 msgid "Tried to obtain lock while already holding it"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:177
+#: org/postgresql/core/v3/QueryExecutorImpl.java:179
 msgid "Tried to break lock on database connection"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:195
+#: org/postgresql/core/v3/QueryExecutorImpl.java:197
 #, fuzzy
 msgid "Interrupted while waiting to obtain lock on database connection"
 msgstr "Interrompu pendant l''établissement de la connexion."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:327
+#: org/postgresql/core/v3/QueryExecutorImpl.java:329
 msgid "Unable to bind parameter values for statement."
 msgstr "Incapable de lier les valeurs des paramètres pour la commande."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:333
-#: org/postgresql/core/v3/QueryExecutorImpl.java:485
-#: org/postgresql/core/v3/QueryExecutorImpl.java:559
-#: org/postgresql/core/v3/QueryExecutorImpl.java:602
-#: org/postgresql/core/v3/QueryExecutorImpl.java:729
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2372
+#: org/postgresql/core/v3/QueryExecutorImpl.java:335
+#: org/postgresql/core/v3/QueryExecutorImpl.java:487
+#: org/postgresql/core/v3/QueryExecutorImpl.java:561
+#: org/postgresql/core/v3/QueryExecutorImpl.java:604
+#: org/postgresql/core/v3/QueryExecutorImpl.java:731
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2377
 #: org/postgresql/util/StreamWrapper.java:130
 msgid "An I/O error occurred while sending to the backend."
 msgstr "Une erreur d''entrée/sortie a eu lieu lors d''envoi vers le serveur."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:534
-#: org/postgresql/core/v3/QueryExecutorImpl.java:576
+#: org/postgresql/core/v3/QueryExecutorImpl.java:536
+#: org/postgresql/core/v3/QueryExecutorImpl.java:578
 #, java-format
 msgid "Expected command status BEGIN, got {0}."
 msgstr "Attendait le statut de commande BEGIN, obtenu {0}."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:581
+#: org/postgresql/core/v3/QueryExecutorImpl.java:583
 #: org/postgresql/jdbc/PgResultSet.java:1778
 #, java-format
 msgid "Unexpected command status: {0}."
 msgstr "Statut de commande inattendu : {0}."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:687
+#: org/postgresql/core/v3/QueryExecutorImpl.java:689
 #, fuzzy
 msgid "An error occurred while trying to get the socket timeout."
 msgstr "Une erreur d''entrée/sortie a eu lieu lors d''envoi vers le serveur."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:722
-#: org/postgresql/core/v3/QueryExecutorImpl.java:798
+#: org/postgresql/core/v3/QueryExecutorImpl.java:724
+#: org/postgresql/core/v3/QueryExecutorImpl.java:800
 #, java-format
 msgid "Unknown Response Type {0}."
 msgstr "Type de réponse inconnu {0}."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:745
+#: org/postgresql/core/v3/QueryExecutorImpl.java:747
 #, fuzzy
 msgid "An error occurred while trying to reset the socket timeout."
 msgstr "Une erreur d''entrée/sortie a eu lieu lors d''envoi vers le serveur."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:843
+#: org/postgresql/core/v3/QueryExecutorImpl.java:845
 msgid "Database connection failed when starting copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:878
+#: org/postgresql/core/v3/QueryExecutorImpl.java:880
 msgid "Tried to cancel an inactive copy operation"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:917
+#: org/postgresql/core/v3/QueryExecutorImpl.java:919
 msgid "Database connection failed when canceling copy operation"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:933
+#: org/postgresql/core/v3/QueryExecutorImpl.java:935
 msgid "Missing expected error response to copy cancel request"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:937
+#: org/postgresql/core/v3/QueryExecutorImpl.java:939
 #, java-format
 msgid "Got {0} error responses to single copy cancel request"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:952
+#: org/postgresql/core/v3/QueryExecutorImpl.java:954
 msgid "Tried to end inactive copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:967
+#: org/postgresql/core/v3/QueryExecutorImpl.java:969
 msgid "Database connection failed when ending copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:985
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1005
+#: org/postgresql/core/v3/QueryExecutorImpl.java:987
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1007
 msgid "Tried to write to an inactive copy operation"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:998
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1013
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1000
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1015
 msgid "Database connection failed when writing to copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1028
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1030
 msgid "Tried to read from inactive copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1035
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1037
 msgid "Database connection failed when reading from copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1101
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1103
 #, java-format
 msgid "Received CommandComplete ''{0}'' without an active copy operation"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1126
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1128
 #, java-format
 msgid "Got CopyInResponse from server during an active {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1140
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1142
 #, java-format
 msgid "Got CopyOutResponse from server during an active {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1154
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1156
 #, java-format
 msgid "Got CopyBothResponse from server during an active {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1170
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1172
 msgid "Got CopyData without an active copy operation"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1174
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1176
 #, fuzzy, java-format
 msgid "Unexpected copydata from server for {0}"
 msgstr "Attendait une fin de fichier du serveur, reçu: {0}"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1234
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1236
 #, java-format
 msgid "Unexpected packet type during copy: {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1524
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1526
 #, java-format
 msgid ""
 "Bind message length {0} too long.  This can be caused by very large or "
@@ -420,22 +426,15 @@ msgstr ""
 "par des spécification de longueur très grandes ou incorrectes pour les "
 "paramètres de type InputStream."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2145
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2150
 msgid "Ran out of memory retrieving query results."
 msgstr "Ai manqué de mémoire en récupérant les résultats de la requête."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2313
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2318
 msgid "The driver currently does not support COPY operations."
 msgstr "Le pilote ne supporte pas actuellement les opérations COPY."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2487
-#, fuzzy, java-format
-msgid "Unable to parse the count in command completion tag: {0}."
-msgstr ""
-"Incapable d''interpréter le nombre de mise à jour dans la balise de "
-"complétion de commande : {0}."
-
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2610
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2605
 #, fuzzy, java-format
 msgid ""
 "The server''s client_encoding parameter was changed to {0}. The JDBC driver "
@@ -445,7 +444,7 @@ msgstr ""
 "JDBC nécessite l''affectation de la valeur UNICODE à client_encoding pour un "
 "fonctionnement correct."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2620
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2615
 #, java-format
 msgid ""
 "The server''s DateStyle parameter was changed to {0}. The JDBC driver "
@@ -454,7 +453,7 @@ msgstr ""
 "Le paramètre DateStyle du serveur a été changé pour {0}. Le pilote JDBC "
 "nécessite que DateStyle commence par ISO pour un fonctionnement correct."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2633
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2628
 #, java-format
 msgid ""
 "The server''s standard_conforming_strings parameter was reported as {0}. The "
@@ -518,21 +517,21 @@ msgstr "DataSource a été fermée."
 msgid "Unsupported property name: {0}"
 msgstr "Valeur de type non supportée : {0}"
 
-#: org/postgresql/fastpath/Fastpath.java:86
+#: org/postgresql/fastpath/Fastpath.java:84
 #, fuzzy, java-format
 msgid "Fastpath call {0} - No result was returned and we expected a numeric."
 msgstr ""
 "Appel Fastpath {0} - Aucun résultat n''a été retourné et nous attendions un "
 "entier."
 
-#: org/postgresql/fastpath/Fastpath.java:163
+#: org/postgresql/fastpath/Fastpath.java:161
 #, java-format
 msgid "Fastpath call {0} - No result was returned and we expected an integer."
 msgstr ""
 "Appel Fastpath {0} - Aucun résultat n''a été retourné et nous attendions un "
 "entier."
 
-#: org/postgresql/fastpath/Fastpath.java:171
+#: org/postgresql/fastpath/Fastpath.java:169
 #, fuzzy, java-format
 msgid ""
 "Fastpath call {0} - No result was returned or wrong size while expecting an "
@@ -541,14 +540,14 @@ msgstr ""
 "Appel Fastpath {0} - Aucun résultat n''a été retourné et nous attendions un "
 "entier."
 
-#: org/postgresql/fastpath/Fastpath.java:188
+#: org/postgresql/fastpath/Fastpath.java:186
 #, fuzzy, java-format
 msgid "Fastpath call {0} - No result was returned and we expected a long."
 msgstr ""
 "Appel Fastpath {0} - Aucun résultat n''a été retourné et nous attendions un "
 "entier."
 
-#: org/postgresql/fastpath/Fastpath.java:196
+#: org/postgresql/fastpath/Fastpath.java:194
 #, fuzzy, java-format
 msgid ""
 "Fastpath call {0} - No result was returned or wrong size while expecting a "
@@ -557,7 +556,7 @@ msgstr ""
 "Appel Fastpath {0} - Aucun résultat n''a été retourné et nous attendions un "
 "entier."
 
-#: org/postgresql/fastpath/Fastpath.java:308
+#: org/postgresql/fastpath/Fastpath.java:297
 #, java-format
 msgid "The fastpath function {0} is unknown."
 msgstr "La fonction fastpath {0} est inconnue."
@@ -627,63 +626,70 @@ msgid "Cannot cast to boolean: \"{0}\""
 msgstr ""
 
 #: org/postgresql/jdbc/EscapedFunctions.java:240
+#: org/postgresql/jdbc/EscapedFunctions2.java:167
 #, java-format
 msgid "{0} function takes four and only four argument."
 msgstr "La fonction {0} n''accepte que quatre et seulement quatre arguments."
 
 #: org/postgresql/jdbc/EscapedFunctions.java:270
-#: org/postgresql/jdbc/EscapedFunctions.java:344
-#: org/postgresql/jdbc/EscapedFunctions.java:749
-#: org/postgresql/jdbc/EscapedFunctions.java:787
+#: org/postgresql/jdbc/EscapedFunctions.java:337
+#: org/postgresql/jdbc/EscapedFunctions.java:740
+#: org/postgresql/jdbc/EscapedFunctions2.java:196
+#: org/postgresql/jdbc/EscapedFunctions2.java:263
+#: org/postgresql/jdbc/EscapedFunctions2.java:665
 #, java-format
 msgid "{0} function takes two and only two arguments."
 msgstr "La fonction {0} n''accepte que deux et seulement deux arguments."
 
 #: org/postgresql/jdbc/EscapedFunctions.java:288
-#: org/postgresql/jdbc/EscapedFunctions.java:326
-#: org/postgresql/jdbc/EscapedFunctions.java:446
-#: org/postgresql/jdbc/EscapedFunctions.java:461
-#: org/postgresql/jdbc/EscapedFunctions.java:476
-#: org/postgresql/jdbc/EscapedFunctions.java:491
-#: org/postgresql/jdbc/EscapedFunctions.java:506
-#: org/postgresql/jdbc/EscapedFunctions.java:521
-#: org/postgresql/jdbc/EscapedFunctions.java:536
-#: org/postgresql/jdbc/EscapedFunctions.java:551
-#: org/postgresql/jdbc/EscapedFunctions.java:566
-#: org/postgresql/jdbc/EscapedFunctions.java:581
-#: org/postgresql/jdbc/EscapedFunctions.java:596
-#: org/postgresql/jdbc/EscapedFunctions.java:611
-#: org/postgresql/jdbc/EscapedFunctions.java:775
+#: org/postgresql/jdbc/EscapedFunctions.java:441
+#: org/postgresql/jdbc/EscapedFunctions.java:467
+#: org/postgresql/jdbc/EscapedFunctions.java:526
+#: org/postgresql/jdbc/EscapedFunctions.java:728
+#: org/postgresql/jdbc/EscapedFunctions2.java:211
+#: org/postgresql/jdbc/EscapedFunctions2.java:355
+#: org/postgresql/jdbc/EscapedFunctions2.java:381
+#: org/postgresql/jdbc/EscapedFunctions2.java:440
+#: org/postgresql/jdbc/EscapedFunctions2.java:654
 #, java-format
 msgid "{0} function takes one and only one argument."
 msgstr "La fonction {0} n''accepte qu''un et un seul argument."
 
-#: org/postgresql/jdbc/EscapedFunctions.java:310
-#: org/postgresql/jdbc/EscapedFunctions.java:391
+#: org/postgresql/jdbc/EscapedFunctions.java:312
+#: org/postgresql/jdbc/EscapedFunctions.java:386
+#: org/postgresql/jdbc/EscapedFunctions2.java:238
+#: org/postgresql/jdbc/EscapedFunctions2.java:307
 #, java-format
 msgid "{0} function takes two or three arguments."
 msgstr "La fonction {0} n''accepte que deux ou trois arguments."
 
-#: org/postgresql/jdbc/EscapedFunctions.java:416
-#: org/postgresql/jdbc/EscapedFunctions.java:431
-#: org/postgresql/jdbc/EscapedFunctions.java:734
-#: org/postgresql/jdbc/EscapedFunctions.java:764
+#: org/postgresql/jdbc/EscapedFunctions.java:411
+#: org/postgresql/jdbc/EscapedFunctions.java:426
+#: org/postgresql/jdbc/EscapedFunctions.java:693
+#: org/postgresql/jdbc/EscapedFunctions.java:719
+#: org/postgresql/jdbc/EscapedFunctions2.java:645
 #, java-format
 msgid "{0} function doesn''t take any argument."
 msgstr "La fonction {0} n''accepte aucun argument."
 
-#: org/postgresql/jdbc/EscapedFunctions.java:627
-#: org/postgresql/jdbc/EscapedFunctions.java:680
+#: org/postgresql/jdbc/EscapedFunctions.java:586
+#: org/postgresql/jdbc/EscapedFunctions.java:639
+#: org/postgresql/jdbc/EscapedFunctions2.java:500
+#: org/postgresql/jdbc/EscapedFunctions2.java:571
 #, java-format
 msgid "{0} function takes three and only three arguments."
 msgstr "La fonction {0} n''accepte que trois et seulement trois arguments."
 
-#: org/postgresql/jdbc/EscapedFunctions.java:640
-#: org/postgresql/jdbc/EscapedFunctions.java:661
-#: org/postgresql/jdbc/EscapedFunctions.java:664
-#: org/postgresql/jdbc/EscapedFunctions.java:697
-#: org/postgresql/jdbc/EscapedFunctions.java:710
-#: org/postgresql/jdbc/EscapedFunctions.java:713
+#: org/postgresql/jdbc/EscapedFunctions.java:599
+#: org/postgresql/jdbc/EscapedFunctions.java:620
+#: org/postgresql/jdbc/EscapedFunctions.java:623
+#: org/postgresql/jdbc/EscapedFunctions.java:656
+#: org/postgresql/jdbc/EscapedFunctions.java:669
+#: org/postgresql/jdbc/EscapedFunctions.java:672
+#: org/postgresql/jdbc/EscapedFunctions2.java:510
+#: org/postgresql/jdbc/EscapedFunctions2.java:527
+#: org/postgresql/jdbc/EscapedFunctions2.java:585
+#: org/postgresql/jdbc/EscapedFunctions2.java:597
 #, java-format
 msgid "Interval {0} not yet implemented"
 msgstr "L''interval {0} n''est pas encore implémenté"
@@ -702,17 +708,17 @@ msgstr "Impossible de retrouver l''identifiant d''un savepoint nommé."
 msgid "Cannot retrieve the name of an unnamed savepoint."
 msgstr "Impossible de retrouver le nom d''un savepoint sans nom."
 
-#: org/postgresql/jdbc/PgArray.java:157 org/postgresql/jdbc/PgArray.java:844
+#: org/postgresql/jdbc/PgArray.java:155 org/postgresql/jdbc/PgArray.java:842
 #, java-format
 msgid "The array index is out of range: {0}"
 msgstr "L''indice du tableau est hors limites : {0}"
 
-#: org/postgresql/jdbc/PgArray.java:178 org/postgresql/jdbc/PgArray.java:861
+#: org/postgresql/jdbc/PgArray.java:176 org/postgresql/jdbc/PgArray.java:859
 #, java-format
 msgid "The array index is out of range: {0}, number of elements: {1}."
 msgstr "L''indice du tableau est hors limites : {0}, nombre d''éléments : {1}."
 
-#: org/postgresql/jdbc/PgArray.java:210
+#: org/postgresql/jdbc/PgArray.java:208
 #: org/postgresql/jdbc/PgResultSet.java:1930
 #: org/postgresql/util/HStoreConverter.java:43
 #: org/postgresql/util/HStoreConverter.java:74
@@ -727,18 +733,18 @@ msgstr ""
 "création de la base. L''exemple le plus courant est le stockage de données "
 "8bit dans une base SQL_ASCII."
 
-#: org/postgresql/jdbc/PgCallableStatement.java:86
-#: org/postgresql/jdbc/PgCallableStatement.java:96
+#: org/postgresql/jdbc/PgCallableStatement.java:85
+#: org/postgresql/jdbc/PgCallableStatement.java:95
 msgid "A CallableStatement was executed with nothing returned."
 msgstr "Un CallableStatement a été exécuté mais n''a rien retourné."
 
-#: org/postgresql/jdbc/PgCallableStatement.java:107
+#: org/postgresql/jdbc/PgCallableStatement.java:106
 #, fuzzy
 msgid "A CallableStatement was executed with an invalid number of parameters"
 msgstr ""
 "Un CallableStatement a été exécuté avec un nombre de paramètres incorrect"
 
-#: org/postgresql/jdbc/PgCallableStatement.java:145
+#: org/postgresql/jdbc/PgCallableStatement.java:144
 #, java-format
 msgid ""
 "A CallableStatement function was executed and the out parameter {0} was of "
@@ -747,7 +753,7 @@ msgstr ""
 "Une fonction CallableStatement a été exécutée et le paramètre en sortie {0} "
 "était du type {1} alors que le type {2} était prévu."
 
-#: org/postgresql/jdbc/PgCallableStatement.java:202
+#: org/postgresql/jdbc/PgCallableStatement.java:206
 msgid ""
 "This statement does not declare an OUT parameter.  Use '{' ?= call ... '}' "
 "to declare one."
@@ -755,12 +761,12 @@ msgstr ""
 "Cette requête ne déclare pas de paramètre OUT. Utilisez '{' ?= call ... '}' "
 "pour en déclarer un."
 
-#: org/postgresql/jdbc/PgCallableStatement.java:246
+#: org/postgresql/jdbc/PgCallableStatement.java:229
 msgid "wasNull cannot be call before fetching a result."
 msgstr "wasNull ne peut pas être appelé avant la récupération d''un résultat."
 
-#: org/postgresql/jdbc/PgCallableStatement.java:384
-#: org/postgresql/jdbc/PgCallableStatement.java:403
+#: org/postgresql/jdbc/PgCallableStatement.java:367
+#: org/postgresql/jdbc/PgCallableStatement.java:386
 #, java-format
 msgid ""
 "Parameter of type {0} was registered, but call to get{1} (sqltype={2}) was "
@@ -769,7 +775,7 @@ msgstr ""
 "Un paramètre de type {0} a été enregistré, mais un appel à get{1} "
 "(sqltype={2}) a été fait."
 
-#: org/postgresql/jdbc/PgCallableStatement.java:424
+#: org/postgresql/jdbc/PgCallableStatement.java:407
 msgid ""
 "A CallableStatement was declared, but no call to registerOutParameter(1, "
 "<some type>) was made."
@@ -777,30 +783,30 @@ msgstr ""
 "Un CallableStatement a été déclaré, mais aucun appel à "
 "registerOutParameter(1, <un type>) n''a été fait."
 
-#: org/postgresql/jdbc/PgCallableStatement.java:430
+#: org/postgresql/jdbc/PgCallableStatement.java:413
 msgid "No function outputs were registered."
 msgstr "Aucune fonction outputs n''a été enregistrée."
 
-#: org/postgresql/jdbc/PgCallableStatement.java:436
+#: org/postgresql/jdbc/PgCallableStatement.java:419
 msgid ""
 "Results cannot be retrieved from a CallableStatement before it is executed."
 msgstr ""
 "Les résultats ne peuvent être récupérés à partir d''un CallableStatement "
 "avant qu''il ne soit exécuté."
 
-#: org/postgresql/jdbc/PgCallableStatement.java:703
+#: org/postgresql/jdbc/PgCallableStatement.java:686
 #, fuzzy, java-format
 msgid "Unsupported type conversion to {1}."
 msgstr "Valeur de type non supportée : {0}"
 
-#: org/postgresql/jdbc/PgConnection.java:272
+#: org/postgresql/jdbc/PgConnection.java:241
 #, java-format
 msgid "Unsupported value for stringtype parameter: {0}"
 msgstr ""
 "Valeur non supportée pour les paramètre de type chaîne de caractères : {0}"
 
 #: org/postgresql/jdbc/PgConnection.java:424
-#: org/postgresql/jdbc/PgPreparedStatement.java:119
+#: org/postgresql/jdbc/PgPreparedStatement.java:107
 #: org/postgresql/jdbc/PgStatement.java:225
 #: org/postgresql/jdbc/TypeInfoCache.java:226
 #: org/postgresql/jdbc/TypeInfoCache.java:371
@@ -812,131 +818,131 @@ msgstr ""
 msgid "No results were returned by the query."
 msgstr "Aucun résultat retourné par la requête."
 
-#: org/postgresql/jdbc/PgConnection.java:441
+#: org/postgresql/jdbc/PgConnection.java:442
 #: org/postgresql/jdbc/PgStatement.java:254
 msgid "A result was returned when none was expected."
 msgstr "Un résultat a été retourné alors qu''aucun n''était attendu."
 
-#: org/postgresql/jdbc/PgConnection.java:545
+#: org/postgresql/jdbc/PgConnection.java:547
 msgid "Custom type maps are not supported."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:587
+#: org/postgresql/jdbc/PgConnection.java:589
 #, java-format
 msgid "Failed to create object for: {0}."
 msgstr "Échec à la création de l''objet pour : {0}."
 
-#: org/postgresql/jdbc/PgConnection.java:641
+#: org/postgresql/jdbc/PgConnection.java:643
 #, java-format
 msgid "Unable to load the class {0} responsible for the datatype {1}"
 msgstr "Incapable de charger la classe {0} responsable du type de données {1}"
 
-#: org/postgresql/jdbc/PgConnection.java:693
+#: org/postgresql/jdbc/PgConnection.java:705
 msgid ""
 "Cannot change transaction read-only property in the middle of a transaction."
 msgstr ""
 "Impossible de changer la propriété read-only d''une transaction au milieu "
 "d''une transaction."
 
-#: org/postgresql/jdbc/PgConnection.java:756
+#: org/postgresql/jdbc/PgConnection.java:772
 msgid "Cannot commit when autoCommit is enabled."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:767
-#: org/postgresql/jdbc/PgConnection.java:1384
-#: org/postgresql/jdbc/PgConnection.java:1428
+#: org/postgresql/jdbc/PgConnection.java:783
+#: org/postgresql/jdbc/PgConnection.java:1401
+#: org/postgresql/jdbc/PgConnection.java:1445
 #, fuzzy
 msgid "This connection has been closed."
 msgstr "La connexion a été fermée."
 
-#: org/postgresql/jdbc/PgConnection.java:777
+#: org/postgresql/jdbc/PgConnection.java:794
 msgid "Cannot rollback when autoCommit is enabled."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:827
+#: org/postgresql/jdbc/PgConnection.java:844
 msgid ""
 "Cannot change transaction isolation level in the middle of a transaction."
 msgstr ""
 "Impossible de changer le niveau d''isolation des transactions au milieu "
 "d''une transaction."
 
-#: org/postgresql/jdbc/PgConnection.java:833
+#: org/postgresql/jdbc/PgConnection.java:850
 #, java-format
 msgid "Transaction isolation level {0} not supported."
 msgstr "Le niveau d''isolation de transaction {0} n''est pas supporté."
 
-#: org/postgresql/jdbc/PgConnection.java:878
+#: org/postgresql/jdbc/PgConnection.java:895
 msgid "Finalizing a Connection that was never closed:"
 msgstr "Destruction d''une connection qui n''a jamais été fermée:"
 
-#: org/postgresql/jdbc/PgConnection.java:945
+#: org/postgresql/jdbc/PgConnection.java:962
 msgid "Unable to translate data into the desired encoding."
 msgstr "Impossible de traduire les données dans l''encodage désiré."
 
-#: org/postgresql/jdbc/PgConnection.java:1008
+#: org/postgresql/jdbc/PgConnection.java:1025
 #: org/postgresql/jdbc/PgResultSet.java:1817
-#: org/postgresql/jdbc/PgStatement.java:903
+#: org/postgresql/jdbc/PgStatement.java:908
 msgid "Fetch size must be a value greater to or equal to 0."
 msgstr "Fetch size doit être une valeur supérieur ou égal à 0."
 
-#: org/postgresql/jdbc/PgConnection.java:1289
-#: org/postgresql/jdbc/PgConnection.java:1330
+#: org/postgresql/jdbc/PgConnection.java:1306
+#: org/postgresql/jdbc/PgConnection.java:1347
 #, java-format
 msgid "Unable to find server array type for provided name {0}."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1312
+#: org/postgresql/jdbc/PgConnection.java:1329
 #, fuzzy, java-format
 msgid "Invalid elements {0}"
 msgstr "Longueur de flux invalide {0}."
 
-#: org/postgresql/jdbc/PgConnection.java:1348
+#: org/postgresql/jdbc/PgConnection.java:1365
 #, fuzzy, java-format
 msgid "Invalid timeout ({0}<0)."
 msgstr "Longueur de flux invalide {0}."
 
-#: org/postgresql/jdbc/PgConnection.java:1372
+#: org/postgresql/jdbc/PgConnection.java:1389
 msgid "Validating connection."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1405
+#: org/postgresql/jdbc/PgConnection.java:1422
 #, fuzzy, java-format
 msgid "Failed to set ClientInfo property: {0}"
 msgstr "Échec à la création de l''objet pour : {0}."
 
-#: org/postgresql/jdbc/PgConnection.java:1415
+#: org/postgresql/jdbc/PgConnection.java:1432
 #, fuzzy
 msgid "ClientInfo property not supported."
 msgstr "Le renvoi des clés automatiquement générées n''est pas supporté."
 
-#: org/postgresql/jdbc/PgConnection.java:1441
+#: org/postgresql/jdbc/PgConnection.java:1458
 msgid "One ore more ClientInfo failed."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1540
+#: org/postgresql/jdbc/PgConnection.java:1559
 #, fuzzy
 msgid "Network timeout must be a value greater than or equal to 0."
 msgstr "Query timeout doit être une valeur supérieure ou égale à 0."
 
-#: org/postgresql/jdbc/PgConnection.java:1552
+#: org/postgresql/jdbc/PgConnection.java:1571
 msgid "Unable to set network timeout."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1563
+#: org/postgresql/jdbc/PgConnection.java:1582
 msgid "Unable to get network timeout."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1580
+#: org/postgresql/jdbc/PgConnection.java:1599
 #, java-format
 msgid "Unknown ResultSet holdability setting: {0}."
 msgstr "Paramètre holdability du ResultSet inconnu : {0}."
 
-#: org/postgresql/jdbc/PgConnection.java:1598
-#: org/postgresql/jdbc/PgConnection.java:1619
+#: org/postgresql/jdbc/PgConnection.java:1617
+#: org/postgresql/jdbc/PgConnection.java:1638
 msgid "Cannot establish a savepoint in auto-commit mode."
 msgstr "Impossible d''établir un savepoint en mode auto-commit."
 
-#: org/postgresql/jdbc/PgConnection.java:1685
+#: org/postgresql/jdbc/PgConnection.java:1707
 msgid "Returning autogenerated keys is not supported."
 msgstr "Le renvoi des clés automatiquement générées n''est pas supporté."
 
@@ -953,48 +959,48 @@ msgid "Unable to find name datatype in the system catalogs."
 msgstr ""
 "Incapable de trouver le type de donnée name dans les catalogues systèmes."
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:323
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:322
 #, fuzzy
 msgid "Unable to find keywords in the system catalogs."
 msgstr ""
 "Incapable de trouver le type de donnée name dans les catalogues systèmes."
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1105
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1095
 msgid "oid"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1105
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1095
 msgid "proname"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1107
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1558
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1097
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1548
 msgid "typtype"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1110
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1100
 msgid "proargtypes"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1576
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1566
 msgid "adsrc"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1589
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1579
 msgid "attidentity"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1685
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1761
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1675
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1751
 msgid "rolname"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1686
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1762
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1676
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1752
 msgid "relacl"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1692
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1682
 msgid "attacl"
 msgstr ""
 
@@ -1004,68 +1010,68 @@ msgid "The parameter index is out of range: {0}, number of parameters: {1}."
 msgstr ""
 "L''indice du paramètre est hors limites : {0}, nombre de paramètres : {1}."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:106
+#: org/postgresql/jdbc/PgPreparedStatement.java:94
+#: org/postgresql/jdbc/PgPreparedStatement.java:115
 #: org/postgresql/jdbc/PgPreparedStatement.java:127
-#: org/postgresql/jdbc/PgPreparedStatement.java:139
-#: org/postgresql/jdbc/PgPreparedStatement.java:1035
+#: org/postgresql/jdbc/PgPreparedStatement.java:1008
 msgid ""
 "Can''t use query methods that take a query string on a PreparedStatement."
 msgstr ""
 "Impossible d''utiliser les fonctions de requête qui utilisent une chaîne de "
 "caractères sur un PreparedStatement."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:249
+#: org/postgresql/jdbc/PgPreparedStatement.java:237
 msgid "Unknown Types value."
 msgstr "Valeur de Types inconnue."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:382
-#: org/postgresql/jdbc/PgPreparedStatement.java:439
-#: org/postgresql/jdbc/PgPreparedStatement.java:1191
-#: org/postgresql/jdbc/PgPreparedStatement.java:1490
+#: org/postgresql/jdbc/PgPreparedStatement.java:364
+#: org/postgresql/jdbc/PgPreparedStatement.java:421
+#: org/postgresql/jdbc/PgPreparedStatement.java:1164
+#: org/postgresql/jdbc/PgPreparedStatement.java:1472
 #, java-format
 msgid "Invalid stream length {0}."
 msgstr "Longueur de flux invalide {0}."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:411
+#: org/postgresql/jdbc/PgPreparedStatement.java:393
 #, java-format
 msgid "The JVM claims not to support the {0} encoding."
 msgstr "La JVM prétend ne pas supporter l''encodage {0}."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:414
+#: org/postgresql/jdbc/PgPreparedStatement.java:396
 #: org/postgresql/jdbc/PgResultSet.java:1122
 #: org/postgresql/jdbc/PgResultSet.java:1156
 msgid "Provided InputStream failed."
 msgstr "L''InputStream fourni a échoué."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:460
-#: org/postgresql/jdbc/PgPreparedStatement.java:1096
+#: org/postgresql/jdbc/PgPreparedStatement.java:442
+#: org/postgresql/jdbc/PgPreparedStatement.java:1069
 #, java-format
 msgid "Unknown type {0}."
 msgstr "Type inconnu : {0}."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:477
+#: org/postgresql/jdbc/PgPreparedStatement.java:459
 msgid "No hstore extension installed."
 msgstr ""
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:619
-#: org/postgresql/jdbc/PgPreparedStatement.java:642
-#: org/postgresql/jdbc/PgPreparedStatement.java:652
-#: org/postgresql/jdbc/PgPreparedStatement.java:664
+#: org/postgresql/jdbc/PgPreparedStatement.java:601
+#: org/postgresql/jdbc/PgPreparedStatement.java:624
+#: org/postgresql/jdbc/PgPreparedStatement.java:634
+#: org/postgresql/jdbc/PgPreparedStatement.java:646
 #, java-format
 msgid "Cannot cast an instance of {0} to type {1}"
 msgstr "Impossible de convertir une instance de {0} vers le type {1}"
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:682
+#: org/postgresql/jdbc/PgPreparedStatement.java:664
 #, java-format
 msgid "Unsupported Types value: {0}"
 msgstr "Valeur de type non supportée : {0}"
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:894
+#: org/postgresql/jdbc/PgPreparedStatement.java:876
 #, java-format
 msgid "Cannot convert an instance of {0} to type {1}"
 msgstr "Impossible de convertir une instance de type {0} vers le type {1}"
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:968
+#: org/postgresql/jdbc/PgPreparedStatement.java:950
 #, java-format
 msgid ""
 "Can''t infer the SQL type to use for an instance of {0}. Use setObject() "
@@ -1075,17 +1081,17 @@ msgstr ""
 "Utilisez setObject() avec une valeur de type explicite pour spécifier le "
 "type à utiliser."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:1133
-#: org/postgresql/jdbc/PgPreparedStatement.java:1233
+#: org/postgresql/jdbc/PgPreparedStatement.java:1106
+#: org/postgresql/jdbc/PgPreparedStatement.java:1206
 msgid "Unexpected error writing large object to database."
 msgstr "Erreur inattendue pendant l''écriture de large object dans la base."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:1178
+#: org/postgresql/jdbc/PgPreparedStatement.java:1151
 #: org/postgresql/jdbc/PgResultSet.java:1210
 msgid "Provided Reader failed."
 msgstr "Le Reader fourni a échoué."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:1449
+#: org/postgresql/jdbc/PgPreparedStatement.java:1431
 #: org/postgresql/util/StreamWrapper.java:56
 msgid "Object is too large to send over the protocol."
 msgstr ""
@@ -1103,8 +1109,8 @@ msgstr ""
 #: org/postgresql/jdbc/PgResultSet.java:556
 #: org/postgresql/jdbc/PgResultSet.java:594
 #: org/postgresql/jdbc/PgResultSet.java:624
-#: org/postgresql/jdbc/PgResultSet.java:3014
-#: org/postgresql/jdbc/PgResultSet.java:3058
+#: org/postgresql/jdbc/PgResultSet.java:3012
+#: org/postgresql/jdbc/PgResultSet.java:3057
 #, fuzzy, java-format
 msgid "Cannot convert the column of type {0} to requested type {1}."
 msgstr "Impossible de convertir une instance de type {0} vers le type {1}"
@@ -1118,7 +1124,7 @@ msgstr ""
 "l''insertion d''une ligne."
 
 #: org/postgresql/jdbc/PgResultSet.java:878
-#: org/postgresql/jdbc/PgStatement.java:895
+#: org/postgresql/jdbc/PgStatement.java:900
 #, java-format
 msgid "Invalid fetch direction constant: {0}."
 msgstr "Constante de direction pour la récupération invalide : {0}."
@@ -1163,8 +1169,8 @@ msgstr ""
 
 #: org/postgresql/jdbc/PgResultSet.java:1119
 #: org/postgresql/jdbc/PgResultSet.java:1754
-#: org/postgresql/jdbc/PgResultSet.java:2422
-#: org/postgresql/jdbc/PgResultSet.java:2443
+#: org/postgresql/jdbc/PgResultSet.java:2420
+#: org/postgresql/jdbc/PgResultSet.java:2441
 #, java-format
 msgid "The JVM claims not to support the encoding: {0}"
 msgstr "La JVM prétend ne pas supporter l''encodage: {0}"
@@ -1179,7 +1185,7 @@ msgstr ""
 "Impossible d''appeler updateRow() tant que l''on est sur la ligne insérée."
 
 #: org/postgresql/jdbc/PgResultSet.java:1335
-#: org/postgresql/jdbc/PgResultSet.java:3075
+#: org/postgresql/jdbc/PgResultSet.java:3074
 msgid ""
 "Cannot update the ResultSet because it is either before the start or after "
 "the end of the results."
@@ -1200,27 +1206,27 @@ msgstr "Pas de clé primaire trouvée pour la table {0}."
 
 #: org/postgresql/jdbc/PgResultSet.java:2017
 #: org/postgresql/jdbc/PgResultSet.java:2022
-#: org/postgresql/jdbc/PgResultSet.java:2809
-#: org/postgresql/jdbc/PgResultSet.java:2815
-#: org/postgresql/jdbc/PgResultSet.java:2840
-#: org/postgresql/jdbc/PgResultSet.java:2846
-#: org/postgresql/jdbc/PgResultSet.java:2870
-#: org/postgresql/jdbc/PgResultSet.java:2875
-#: org/postgresql/jdbc/PgResultSet.java:2891
-#: org/postgresql/jdbc/PgResultSet.java:2912
-#: org/postgresql/jdbc/PgResultSet.java:2923
-#: org/postgresql/jdbc/PgResultSet.java:2936
-#: org/postgresql/jdbc/PgResultSet.java:3063
+#: org/postgresql/jdbc/PgResultSet.java:2807
+#: org/postgresql/jdbc/PgResultSet.java:2813
+#: org/postgresql/jdbc/PgResultSet.java:2838
+#: org/postgresql/jdbc/PgResultSet.java:2844
+#: org/postgresql/jdbc/PgResultSet.java:2868
+#: org/postgresql/jdbc/PgResultSet.java:2873
+#: org/postgresql/jdbc/PgResultSet.java:2889
+#: org/postgresql/jdbc/PgResultSet.java:2910
+#: org/postgresql/jdbc/PgResultSet.java:2921
+#: org/postgresql/jdbc/PgResultSet.java:2934
+#: org/postgresql/jdbc/PgResultSet.java:3062
 #, java-format
 msgid "Bad value for type {0} : {1}"
 msgstr "Mauvaise valeur pour le type {0} : {1}"
 
-#: org/postgresql/jdbc/PgResultSet.java:2595
+#: org/postgresql/jdbc/PgResultSet.java:2593
 #, java-format
 msgid "The column name {0} was not found in this ResultSet."
 msgstr "Le nom de colonne {0} n''a pas été trouvé dans ce ResultSet."
 
-#: org/postgresql/jdbc/PgResultSet.java:2731
+#: org/postgresql/jdbc/PgResultSet.java:2729
 msgid ""
 "ResultSet is not updateable.  The query that generated this result set must "
 "select only one table, and must select all primary keys from that table. See "
@@ -1231,44 +1237,44 @@ msgstr ""
 "primaires de cette table. Voir la spécification de l''API JDBC 2.1, section "
 "5.6 pour plus de détails."
 
-#: org/postgresql/jdbc/PgResultSet.java:2743
+#: org/postgresql/jdbc/PgResultSet.java:2741
 msgid "This ResultSet is closed."
 msgstr "Ce ResultSet est fermé."
 
-#: org/postgresql/jdbc/PgResultSet.java:2774
+#: org/postgresql/jdbc/PgResultSet.java:2772
 msgid "ResultSet not positioned properly, perhaps you need to call next."
 msgstr ""
 "Le ResultSet n''est pas positionné correctement, vous devez peut-être "
 "appeler next()."
 
-#: org/postgresql/jdbc/PgResultSet.java:3095
+#: org/postgresql/jdbc/PgResultSet.java:3094
 #, fuzzy
 msgid "Invalid UUID data."
 msgstr "Drapeau invalide"
 
-#: org/postgresql/jdbc/PgResultSet.java:3184
-#: org/postgresql/jdbc/PgResultSet.java:3191
-#: org/postgresql/jdbc/PgResultSet.java:3202
-#: org/postgresql/jdbc/PgResultSet.java:3213
-#: org/postgresql/jdbc/PgResultSet.java:3224
-#: org/postgresql/jdbc/PgResultSet.java:3235
-#: org/postgresql/jdbc/PgResultSet.java:3246
-#: org/postgresql/jdbc/PgResultSet.java:3257
-#: org/postgresql/jdbc/PgResultSet.java:3268
-#: org/postgresql/jdbc/PgResultSet.java:3275
-#: org/postgresql/jdbc/PgResultSet.java:3282
-#: org/postgresql/jdbc/PgResultSet.java:3293
-#: org/postgresql/jdbc/PgResultSet.java:3310
-#: org/postgresql/jdbc/PgResultSet.java:3317
-#: org/postgresql/jdbc/PgResultSet.java:3324
-#: org/postgresql/jdbc/PgResultSet.java:3335
-#: org/postgresql/jdbc/PgResultSet.java:3342
-#: org/postgresql/jdbc/PgResultSet.java:3349
-#: org/postgresql/jdbc/PgResultSet.java:3387
-#: org/postgresql/jdbc/PgResultSet.java:3394
-#: org/postgresql/jdbc/PgResultSet.java:3401
-#: org/postgresql/jdbc/PgResultSet.java:3421
-#: org/postgresql/jdbc/PgResultSet.java:3434
+#: org/postgresql/jdbc/PgResultSet.java:3183
+#: org/postgresql/jdbc/PgResultSet.java:3190
+#: org/postgresql/jdbc/PgResultSet.java:3201
+#: org/postgresql/jdbc/PgResultSet.java:3212
+#: org/postgresql/jdbc/PgResultSet.java:3223
+#: org/postgresql/jdbc/PgResultSet.java:3234
+#: org/postgresql/jdbc/PgResultSet.java:3245
+#: org/postgresql/jdbc/PgResultSet.java:3256
+#: org/postgresql/jdbc/PgResultSet.java:3267
+#: org/postgresql/jdbc/PgResultSet.java:3274
+#: org/postgresql/jdbc/PgResultSet.java:3281
+#: org/postgresql/jdbc/PgResultSet.java:3292
+#: org/postgresql/jdbc/PgResultSet.java:3309
+#: org/postgresql/jdbc/PgResultSet.java:3316
+#: org/postgresql/jdbc/PgResultSet.java:3323
+#: org/postgresql/jdbc/PgResultSet.java:3334
+#: org/postgresql/jdbc/PgResultSet.java:3341
+#: org/postgresql/jdbc/PgResultSet.java:3348
+#: org/postgresql/jdbc/PgResultSet.java:3386
+#: org/postgresql/jdbc/PgResultSet.java:3393
+#: org/postgresql/jdbc/PgResultSet.java:3400
+#: org/postgresql/jdbc/PgResultSet.java:3420
+#: org/postgresql/jdbc/PgResultSet.java:3433
 #, fuzzy, java-format
 msgid "conversion to {0} from {1} not supported"
 msgstr "Le niveau d''isolation de transaction {0} n''est pas supporté."
@@ -1335,35 +1341,35 @@ msgid "Maximum number of rows must be a value grater than or equal to 0."
 msgstr ""
 "Le nombre maximum de lignes doit être une valeur supérieure ou égale à 0."
 
-#: org/postgresql/jdbc/PgStatement.java:550
+#: org/postgresql/jdbc/PgStatement.java:555
 msgid "Query timeout must be a value greater than or equals to 0."
 msgstr "Query timeout doit être une valeur supérieure ou égale à 0."
 
-#: org/postgresql/jdbc/PgStatement.java:590
+#: org/postgresql/jdbc/PgStatement.java:595
 msgid "The maximum field size must be a value greater than or equal to 0."
 msgstr ""
 "La taille maximum des champs doit être une valeur supérieure ou égale à 0."
 
-#: org/postgresql/jdbc/PgStatement.java:689
+#: org/postgresql/jdbc/PgStatement.java:694
 msgid "This statement has been closed."
 msgstr "Ce statement a été fermé."
 
-#: org/postgresql/jdbc/PgStatement.java:1145
-#: org/postgresql/jdbc/PgStatement.java:1173
+#: org/postgresql/jdbc/PgStatement.java:1150
+#: org/postgresql/jdbc/PgStatement.java:1178
 #, fuzzy
 msgid "Returning autogenerated keys by column index is not supported."
 msgstr "Le renvoi des clés automatiquement générées n''est pas supporté."
 
-#: org/postgresql/jdbc/TimestampUtils.java:355
-#: org/postgresql/jdbc/TimestampUtils.java:423
+#: org/postgresql/jdbc/TimestampUtils.java:365
+#: org/postgresql/jdbc/TimestampUtils.java:433
 #, fuzzy, java-format
 msgid "Bad value for type timestamp/date/time: {1}"
 msgstr "Mauvaise valeur pour le type {0} : {1}"
 
-#: org/postgresql/jdbc/TimestampUtils.java:858
-#: org/postgresql/jdbc/TimestampUtils.java:915
-#: org/postgresql/jdbc/TimestampUtils.java:961
-#: org/postgresql/jdbc/TimestampUtils.java:1010
+#: org/postgresql/jdbc/TimestampUtils.java:914
+#: org/postgresql/jdbc/TimestampUtils.java:971
+#: org/postgresql/jdbc/TimestampUtils.java:1017
+#: org/postgresql/jdbc/TimestampUtils.java:1066
 #, fuzzy, java-format
 msgid "Unsupported binary encoding of {0}."
 msgstr "Valeur de type non supportée : {0}"
@@ -1376,31 +1382,31 @@ msgstr ""
 msgid "Invalid or unsupported by client SCRAM mechanisms"
 msgstr ""
 
-#: org/postgresql/jre8/sasl/ScramAuthenticator.java:117
+#: org/postgresql/jre8/sasl/ScramAuthenticator.java:119
 #, fuzzy, java-format
 msgid "Invalid server-first-message: {0}"
 msgstr "Longueur de flux invalide {0}."
 
-#: org/postgresql/jre8/sasl/ScramAuthenticator.java:147
+#: org/postgresql/jre8/sasl/ScramAuthenticator.java:151
 #, fuzzy, java-format
 msgid "Invalid server-final-message: {0}"
 msgstr "Longueur de flux invalide {0}."
 
-#: org/postgresql/jre8/sasl/ScramAuthenticator.java:153
+#: org/postgresql/jre8/sasl/ScramAuthenticator.java:157
 #, java-format
 msgid "SCRAM authentication failed, server returned error: {0}"
 msgstr ""
 
-#: org/postgresql/jre8/sasl/ScramAuthenticator.java:160
+#: org/postgresql/jre8/sasl/ScramAuthenticator.java:164
 msgid "Invalid server SCRAM signature"
 msgstr ""
 
-#: org/postgresql/largeobject/LargeObjectManager.java:144
+#: org/postgresql/largeobject/LargeObjectManager.java:136
 msgid "Failed to initialize LargeObject API"
 msgstr "Échec à l''initialisation de l''API LargeObject"
 
-#: org/postgresql/largeobject/LargeObjectManager.java:262
-#: org/postgresql/largeobject/LargeObjectManager.java:305
+#: org/postgresql/largeobject/LargeObjectManager.java:254
+#: org/postgresql/largeobject/LargeObjectManager.java:295
 msgid "Large Objects may not be used in auto-commit mode."
 msgstr "Les Large Objects ne devraient pas être utilisés en mode auto-commit."
 
@@ -1434,35 +1440,35 @@ msgstr ""
 msgid "The hostname {0} could not be verified."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:164
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:90
 msgid "The sslfactoryarg property may not be empty."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:180
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:106
 msgid ""
 "The environment variable containing the server's SSL certificate must not be "
 "empty."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:188
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:114
 msgid ""
 "The system property containing the server's SSL certificate must not be "
 "empty."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:195
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:121
 msgid ""
 "The sslfactoryarg property must start with the prefix file:, classpath:, "
 "env:, sys:, or -----BEGIN CERTIFICATE-----."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:207
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:133
 #, fuzzy
 msgid "An error occurred reading the certificate"
 msgstr ""
 "Une erreur s''est produite pendant l''établissement de la connexion SSL."
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:240
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:166
 msgid "No X509TrustManager found"
 msgstr ""
 
@@ -1597,60 +1603,60 @@ msgid ""
 "setSavePoint not allowed while an XA transaction is active."
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:177
-#: org/postgresql/xa/PGXAConnection.java:253
-#: org/postgresql/xa/PGXAConnection.java:347
+#: org/postgresql/xa/PGXAConnection.java:186
+#: org/postgresql/xa/PGXAConnection.java:272
+#: org/postgresql/xa/PGXAConnection.java:381
 #, fuzzy, java-format
 msgid "Invalid flags {0}"
 msgstr "Drapeaux invalides"
 
-#: org/postgresql/xa/PGXAConnection.java:181
-#: org/postgresql/xa/PGXAConnection.java:257
-#: org/postgresql/xa/PGXAConnection.java:449
+#: org/postgresql/xa/PGXAConnection.java:190
+#: org/postgresql/xa/PGXAConnection.java:276
+#: org/postgresql/xa/PGXAConnection.java:491
 msgid "xid must not be null"
 msgstr "xid ne doit pas être nul"
 
-#: org/postgresql/xa/PGXAConnection.java:185
+#: org/postgresql/xa/PGXAConnection.java:194
 msgid "Connection is busy with another transaction"
 msgstr "La connection est occupée avec une autre transaction"
 
-#: org/postgresql/xa/PGXAConnection.java:194
-#: org/postgresql/xa/PGXAConnection.java:267
+#: org/postgresql/xa/PGXAConnection.java:203
+#: org/postgresql/xa/PGXAConnection.java:286
 msgid "suspend/resume not implemented"
 msgstr "suspend/resume pas implémenté"
 
-#: org/postgresql/xa/PGXAConnection.java:202
-#: org/postgresql/xa/PGXAConnection.java:209
-#: org/postgresql/xa/PGXAConnection.java:213
+#: org/postgresql/xa/PGXAConnection.java:211
+#: org/postgresql/xa/PGXAConnection.java:218
+#: org/postgresql/xa/PGXAConnection.java:222
 #, java-format
 msgid ""
 "Invalid protocol state requested. Attempted transaction interleaving is not "
 "supported. xid={0}, currentXid={1}, state={2}, flags={3}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:224
+#: org/postgresql/xa/PGXAConnection.java:233
 msgid "Error disabling autocommit"
 msgstr "Erreur en désactivant autocommit"
 
-#: org/postgresql/xa/PGXAConnection.java:261
+#: org/postgresql/xa/PGXAConnection.java:280
 #, fuzzy, java-format
 msgid ""
 "tried to call end without corresponding start call. state={0}, start "
 "xid={1}, currentXid={2}, preparedXid={3}"
 msgstr "tentative d''appel de fin sans l''appel start correspondant"
 
-#: org/postgresql/xa/PGXAConnection.java:297
+#: org/postgresql/xa/PGXAConnection.java:326
 #, java-format
 msgid ""
 "Preparing already prepared transaction, the prepared xid {0}, prepare xid={1}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:300
+#: org/postgresql/xa/PGXAConnection.java:329
 #, java-format
 msgid "Current connection does not have an associated xid. prepare xid={0}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:307
+#: org/postgresql/xa/PGXAConnection.java:336
 #, fuzzy, java-format
 msgid ""
 "Not implemented: Prepare must be issued using the same connection that "
@@ -1659,34 +1665,34 @@ msgstr ""
 "Pas implémenté: Prepare doit être envoyé sur la même connection qui a "
 "démarré la transaction"
 
-#: org/postgresql/xa/PGXAConnection.java:311
+#: org/postgresql/xa/PGXAConnection.java:340
 #, fuzzy, java-format
 msgid "Prepare called before end. prepare xid={0}, state={1}"
 msgstr "Préparation appelée avant la fin"
 
-#: org/postgresql/xa/PGXAConnection.java:331
+#: org/postgresql/xa/PGXAConnection.java:360
 #, fuzzy, java-format
 msgid "Error preparing transaction. prepare xid={0}"
 msgstr "Erreur en préparant la transaction"
 
-#: org/postgresql/xa/PGXAConnection.java:382
+#: org/postgresql/xa/PGXAConnection.java:416
 msgid "Error during recover"
 msgstr "Erreur durant la restauration"
 
-#: org/postgresql/xa/PGXAConnection.java:438
+#: org/postgresql/xa/PGXAConnection.java:480
 #, fuzzy, java-format
 msgid ""
 "Error rolling back prepared transaction. rollback xid={0}, preparedXid={1}, "
 "currentXid={2}"
 msgstr "Erreur en annulant une transaction préparée"
 
-#: org/postgresql/xa/PGXAConnection.java:471
+#: org/postgresql/xa/PGXAConnection.java:521
 #, java-format
 msgid ""
 "One-phase commit called for xid {0} but connection was prepared with xid {1}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:479
+#: org/postgresql/xa/PGXAConnection.java:529
 msgid ""
 "Not implemented: one-phase commit must be issued using the same connection "
 "that was used to start it"
@@ -1694,22 +1700,22 @@ msgstr ""
 "Pas implémenté: le commit à une phase doit avoir lieu en utilisant la même "
 "connection que celle où il a commencé"
 
-#: org/postgresql/xa/PGXAConnection.java:483
+#: org/postgresql/xa/PGXAConnection.java:533
 #, java-format
 msgid "One-phase commit with unknown xid. commit xid={0}, currentXid={1}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:487
+#: org/postgresql/xa/PGXAConnection.java:537
 #, fuzzy, java-format
 msgid "commit called before end. commit xid={0}, state={1}"
 msgstr "Commit appelé avant la fin"
 
-#: org/postgresql/xa/PGXAConnection.java:498
+#: org/postgresql/xa/PGXAConnection.java:548
 #, fuzzy, java-format
 msgid "Error during one-phase commit. commit xid={0}"
 msgstr "Erreur pendant le commit à une phase"
 
-#: org/postgresql/xa/PGXAConnection.java:517
+#: org/postgresql/xa/PGXAConnection.java:576
 #, fuzzy
 msgid ""
 "Not implemented: 2nd phase commit must be issued using an idle connection. "
@@ -1718,14 +1724,14 @@ msgstr ""
 "Pas implémenté: le commit à deux phase doit être envoyé sur une connection "
 "inutilisée"
 
-#: org/postgresql/xa/PGXAConnection.java:550
+#: org/postgresql/xa/PGXAConnection.java:609
 #, fuzzy, java-format
 msgid ""
 "Error committing prepared transaction. commit xid={0}, preparedXid={1}, "
 "currentXid={2}"
 msgstr "Erreur en annulant une transaction préparée"
 
-#: org/postgresql/xa/PGXAConnection.java:567
+#: org/postgresql/xa/PGXAConnection.java:626
 #, fuzzy, java-format
 msgid "Heuristic commit/rollback not supported. forget xid={0}"
 msgstr "Heuristic commit/rollback non supporté"

--- a/pgjdbc/src/main/java/org/postgresql/translation/it.po
+++ b/pgjdbc/src/main/java/org/postgresql/translation/it.po
@@ -9,7 +9,6 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PostgreSQL JDBC Driver 8.2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-06-05 10:57+0300\n"
 "PO-Revision-Date: 2006-06-23 17:25+0200\n"
 "Last-Translator: Giuseppe Sacco <eppesuig@debian.org>\n"
 "Language-Team: Italian <tp@lists.linux.it>\n"
@@ -18,24 +17,24 @@ msgstr ""
 "Content-Type: text/plain; charset=ISO-8859-1\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: org/postgresql/Driver.java:214
+#: org/postgresql/Driver.java:217
 msgid "Error loading default settings from driverconfig.properties"
 msgstr ""
 "Si è verificato un errore caricando le impostazioni predefinite da "
 "«driverconfig.properties»."
 
-#: org/postgresql/Driver.java:226
+#: org/postgresql/Driver.java:229
 msgid "Properties for the driver contains a non-string value for the key "
 msgstr ""
 
-#: org/postgresql/Driver.java:270
+#: org/postgresql/Driver.java:272
 msgid ""
 "Your security policy has prevented the connection from being attempted.  You "
 "probably need to grant the connect java.net.SocketPermission to the database "
 "server host and port that you wish to connect to."
 msgstr ""
 
-#: org/postgresql/Driver.java:276 org/postgresql/Driver.java:408
+#: org/postgresql/Driver.java:278 org/postgresql/Driver.java:410
 msgid ""
 "Something unusual has occurred to cause the driver to fail. Please report "
 "this exception."
@@ -43,35 +42,35 @@ msgstr ""
 "Qualcosa di insolito si è verificato causando il fallimento del driver. Per "
 "favore riferire all''autore del driver questa eccezione."
 
-#: org/postgresql/Driver.java:416
+#: org/postgresql/Driver.java:418
 msgid "Connection attempt timed out."
 msgstr "Il tentativo di connessione è scaduto."
 
-#: org/postgresql/Driver.java:429
+#: org/postgresql/Driver.java:431
 msgid "Interrupted while attempting to connect."
 msgstr "Si è verificata una interruzione durante il tentativo di connessione."
 
-#: org/postgresql/Driver.java:682
+#: org/postgresql/Driver.java:687
 #, java-format
 msgid "Method {0} is not yet implemented."
 msgstr "Il metodo «{0}» non è stato ancora implementato."
 
-#: org/postgresql/PGProperty.java:535 org/postgresql/PGProperty.java:555
+#: org/postgresql/PGProperty.java:537 org/postgresql/PGProperty.java:557
 #, java-format
 msgid "{0} parameter value must be an integer but was: {1}"
 msgstr ""
 
-#: org/postgresql/copy/CopyManager.java:53
+#: org/postgresql/copy/CopyManager.java:49
 #, java-format
 msgid "Requested CopyIn but got {0}"
 msgstr ""
 
-#: org/postgresql/copy/CopyManager.java:64
+#: org/postgresql/copy/CopyManager.java:60
 #, java-format
 msgid "Requested CopyOut but got {0}"
 msgstr ""
 
-#: org/postgresql/copy/CopyManager.java:75
+#: org/postgresql/copy/CopyManager.java:71
 #, java-format
 msgid "Requested CopyDual but got {0}"
 msgstr ""
@@ -95,6 +94,13 @@ msgstr ""
 #, java-format
 msgid "Cannot write to copy a byte of value {0}"
 msgstr ""
+
+#: org/postgresql/core/CommandCompleteParser.java:71
+#, fuzzy, java-format
+msgid "Unable to parse the count in command completion tag: {0}."
+msgstr ""
+"Impossibile interpretare il numero degli aggiornamenti nel «tag» di "
+"completamento del comando: {0}."
 
 #: org/postgresql/core/ConnectionFactory.java:57
 #, java-format
@@ -120,7 +126,7 @@ msgstr ""
 msgid "Expected an EOF from server, got: {0}"
 msgstr "Ricevuto dal server «{0}» mentre era atteso un EOF"
 
-#: org/postgresql/core/Parser.java:1006
+#: org/postgresql/core/Parser.java:1051
 #, java-format
 msgid "Malformed function or procedure escape syntax at offset {0}."
 msgstr ""
@@ -188,23 +194,23 @@ msgstr ""
 #: org/postgresql/core/v3/CompositeParameterList.java:33
 #: org/postgresql/core/v3/SimpleParameterList.java:54
 #: org/postgresql/core/v3/SimpleParameterList.java:65
-#: org/postgresql/jdbc/PgResultSet.java:2757
-#: org/postgresql/jdbc/PgResultSetMetaData.java:494
+#: org/postgresql/jdbc/PgResultSet.java:2755
+#: org/postgresql/jdbc/PgResultSetMetaData.java:388
 #, java-format
 msgid "The column index is out of range: {0}, number of columns: {1}."
 msgstr "Indice di colonna, {0}, è maggiore del numero di colonne {1}."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:109
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:103
 #, fuzzy, java-format
 msgid "Invalid sslmode value: {0}"
 msgstr "La dimensione specificata, {0}, per lo «stream» non è valida."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:124
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:118
 #, fuzzy, java-format
 msgid "Invalid targetServerType value: {0}"
 msgstr "La dimensione specificata, {0}, per lo «stream» non è valida."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:246
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:239
 #, fuzzy, java-format
 msgid ""
 "Connection to {0} refused. Check that the hostname and port are correct and "
@@ -214,27 +220,27 @@ msgstr ""
 "corretti, e che il server (postmaster) sia in esecuzione con l''opzione -i, "
 "che abilita le connessioni attraverso la rete TCP/IP."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:257
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:250
 #: org/postgresql/core/v3/replication/V3ReplicationProtocol.java:133
 msgid "The connection attempt failed."
 msgstr "Il tentativo di connessione è fallito."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:272
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:265
 #, java-format
 msgid "Could not find a server with specified targetServerType: {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:368
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:381
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:361
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:374
 msgid "The server does not support SSL."
 msgstr "Il server non supporta SSL."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:395
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:388
 msgid "An error occurred while setting up the SSL connection."
 msgstr "Si è verificato un errore impostando la connessione SSL."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:496
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:523
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:484
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:511
 msgid ""
 "The server requested password-based authentication, but no password was "
 "provided."
@@ -242,13 +248,13 @@ msgstr ""
 "Il server ha richiesto l''autenticazione con password, ma tale password non "
 "è stata fornita."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:626
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:614
 msgid ""
 "SCRAM authentication is not supported by this driver. You need JDK >= 8 and "
 "pgjdbc >= 42.2.0 (not \".jre\" versions)"
 msgstr ""
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:650
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:638
 #, java-format
 msgid ""
 "The authentication type {0} is not supported. Check that you have configured "
@@ -260,16 +266,16 @@ msgstr ""
 "client, e che lo schema di autenticazione utilizzato sia supportato dal "
 "driver."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:657
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2550
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2581
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2585
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2653
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:645
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2543
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2576
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2580
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2648
 #: org/postgresql/gss/GssAction.java:126
 msgid "Protocol error.  Session setup failed."
 msgstr "Errore di protocollo. Impostazione della sessione fallita."
 
-#: org/postgresql/core/v3/CopyInImpl.java:47
+#: org/postgresql/core/v3/CopyInImpl.java:49
 msgid "CopyIn copy direction can't receive data"
 msgstr ""
 
@@ -277,145 +283,145 @@ msgstr ""
 msgid "CommandComplete expected COPY but got: "
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:161
+#: org/postgresql/core/v3/QueryExecutorImpl.java:163
 msgid "Tried to obtain lock while already holding it"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:177
+#: org/postgresql/core/v3/QueryExecutorImpl.java:179
 msgid "Tried to break lock on database connection"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:195
+#: org/postgresql/core/v3/QueryExecutorImpl.java:197
 #, fuzzy
 msgid "Interrupted while waiting to obtain lock on database connection"
 msgstr "Si è verificata una interruzione durante il tentativo di connessione."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:327
+#: org/postgresql/core/v3/QueryExecutorImpl.java:329
 msgid "Unable to bind parameter values for statement."
 msgstr ""
 "Impossibile fare il «bind» dei valori passati come parametri per lo "
 "statement."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:333
-#: org/postgresql/core/v3/QueryExecutorImpl.java:485
-#: org/postgresql/core/v3/QueryExecutorImpl.java:559
-#: org/postgresql/core/v3/QueryExecutorImpl.java:602
-#: org/postgresql/core/v3/QueryExecutorImpl.java:729
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2372
+#: org/postgresql/core/v3/QueryExecutorImpl.java:335
+#: org/postgresql/core/v3/QueryExecutorImpl.java:487
+#: org/postgresql/core/v3/QueryExecutorImpl.java:561
+#: org/postgresql/core/v3/QueryExecutorImpl.java:604
+#: org/postgresql/core/v3/QueryExecutorImpl.java:731
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2377
 #: org/postgresql/util/StreamWrapper.java:130
 msgid "An I/O error occurred while sending to the backend."
 msgstr "Si è verificato un errore di I/O nella spedizione di dati al server."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:534
-#: org/postgresql/core/v3/QueryExecutorImpl.java:576
+#: org/postgresql/core/v3/QueryExecutorImpl.java:536
+#: org/postgresql/core/v3/QueryExecutorImpl.java:578
 #, java-format
 msgid "Expected command status BEGIN, got {0}."
 msgstr "Lo stato del comando avrebbe dovuto essere BEGIN, mentre invece è {0}."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:581
+#: org/postgresql/core/v3/QueryExecutorImpl.java:583
 #: org/postgresql/jdbc/PgResultSet.java:1778
 #, java-format
 msgid "Unexpected command status: {0}."
 msgstr "Stato del comando non previsto: {0}."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:687
+#: org/postgresql/core/v3/QueryExecutorImpl.java:689
 #, fuzzy
 msgid "An error occurred while trying to get the socket timeout."
 msgstr "Si è verificato un errore di I/O nella spedizione di dati al server."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:722
-#: org/postgresql/core/v3/QueryExecutorImpl.java:798
+#: org/postgresql/core/v3/QueryExecutorImpl.java:724
+#: org/postgresql/core/v3/QueryExecutorImpl.java:800
 #, java-format
 msgid "Unknown Response Type {0}."
 msgstr "Risposta di tipo sconosciuto {0}."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:745
+#: org/postgresql/core/v3/QueryExecutorImpl.java:747
 #, fuzzy
 msgid "An error occurred while trying to reset the socket timeout."
 msgstr "Si è verificato un errore di I/O nella spedizione di dati al server."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:843
+#: org/postgresql/core/v3/QueryExecutorImpl.java:845
 msgid "Database connection failed when starting copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:878
+#: org/postgresql/core/v3/QueryExecutorImpl.java:880
 msgid "Tried to cancel an inactive copy operation"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:917
+#: org/postgresql/core/v3/QueryExecutorImpl.java:919
 msgid "Database connection failed when canceling copy operation"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:933
+#: org/postgresql/core/v3/QueryExecutorImpl.java:935
 msgid "Missing expected error response to copy cancel request"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:937
+#: org/postgresql/core/v3/QueryExecutorImpl.java:939
 #, java-format
 msgid "Got {0} error responses to single copy cancel request"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:952
+#: org/postgresql/core/v3/QueryExecutorImpl.java:954
 msgid "Tried to end inactive copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:967
+#: org/postgresql/core/v3/QueryExecutorImpl.java:969
 msgid "Database connection failed when ending copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:985
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1005
+#: org/postgresql/core/v3/QueryExecutorImpl.java:987
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1007
 msgid "Tried to write to an inactive copy operation"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:998
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1013
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1000
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1015
 msgid "Database connection failed when writing to copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1028
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1030
 msgid "Tried to read from inactive copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1035
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1037
 msgid "Database connection failed when reading from copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1101
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1103
 #, java-format
 msgid "Received CommandComplete ''{0}'' without an active copy operation"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1126
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1128
 #, java-format
 msgid "Got CopyInResponse from server during an active {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1140
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1142
 #, java-format
 msgid "Got CopyOutResponse from server during an active {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1154
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1156
 #, java-format
 msgid "Got CopyBothResponse from server during an active {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1170
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1172
 msgid "Got CopyData without an active copy operation"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1174
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1176
 #, fuzzy, java-format
 msgid "Unexpected copydata from server for {0}"
 msgstr "Ricevuto dal server «{0}» mentre era atteso un EOF"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1234
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1236
 #, java-format
 msgid "Unexpected packet type during copy: {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1524
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1526
 #, java-format
 msgid ""
 "Bind message length {0} too long.  This can be caused by very large or "
@@ -424,22 +430,15 @@ msgstr ""
 "Il messaggio di «bind» è troppo lungo ({0}). Questo può essere causato da "
 "una dimensione eccessiva o non corretta dei parametri dell''«InputStream»."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2145
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2150
 msgid "Ran out of memory retrieving query results."
 msgstr "Fine memoria scaricando i risultati della query."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2313
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2318
 msgid "The driver currently does not support COPY operations."
 msgstr "Il driver non supporta al momento l''operazione «COPY»."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2487
-#, fuzzy, java-format
-msgid "Unable to parse the count in command completion tag: {0}."
-msgstr ""
-"Impossibile interpretare il numero degli aggiornamenti nel «tag» di "
-"completamento del comando: {0}."
-
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2610
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2605
 #, fuzzy, java-format
 msgid ""
 "The server''s client_encoding parameter was changed to {0}. The JDBC driver "
@@ -449,7 +448,7 @@ msgstr ""
 "JDBC richiede che «client_encoding» sia UNICODE per un corretto "
 "funzionamento."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2620
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2615
 #, java-format
 msgid ""
 "The server''s DateStyle parameter was changed to {0}. The JDBC driver "
@@ -458,7 +457,7 @@ msgstr ""
 "Il parametro del server «DateStyle» è stato cambiato in {0}. Il driver JDBC "
 "richiede che «DateStyle» cominci con «ISO» per un corretto funzionamento."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2633
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2628
 #, fuzzy, java-format
 msgid ""
 "The server''s standard_conforming_strings parameter was reported as {0}. The "
@@ -523,21 +522,21 @@ msgstr "Questo «DataSource» è stato chiuso."
 msgid "Unsupported property name: {0}"
 msgstr "Valore di tipo «{0}» non supportato."
 
-#: org/postgresql/fastpath/Fastpath.java:86
+#: org/postgresql/fastpath/Fastpath.java:84
 #, fuzzy, java-format
 msgid "Fastpath call {0} - No result was returned and we expected a numeric."
 msgstr ""
 "Chiamata Fastpath «{0}»: Nessun risultato restituito mentre ci si aspettava "
 "un intero."
 
-#: org/postgresql/fastpath/Fastpath.java:163
+#: org/postgresql/fastpath/Fastpath.java:161
 #, java-format
 msgid "Fastpath call {0} - No result was returned and we expected an integer."
 msgstr ""
 "Chiamata Fastpath «{0}»: Nessun risultato restituito mentre ci si aspettava "
 "un intero."
 
-#: org/postgresql/fastpath/Fastpath.java:171
+#: org/postgresql/fastpath/Fastpath.java:169
 #, fuzzy, java-format
 msgid ""
 "Fastpath call {0} - No result was returned or wrong size while expecting an "
@@ -546,14 +545,14 @@ msgstr ""
 "Chiamata Fastpath «{0}»: Nessun risultato restituito mentre ci si aspettava "
 "un intero."
 
-#: org/postgresql/fastpath/Fastpath.java:188
+#: org/postgresql/fastpath/Fastpath.java:186
 #, fuzzy, java-format
 msgid "Fastpath call {0} - No result was returned and we expected a long."
 msgstr ""
 "Chiamata Fastpath «{0}»: Nessun risultato restituito mentre ci si aspettava "
 "un intero."
 
-#: org/postgresql/fastpath/Fastpath.java:196
+#: org/postgresql/fastpath/Fastpath.java:194
 #, fuzzy, java-format
 msgid ""
 "Fastpath call {0} - No result was returned or wrong size while expecting a "
@@ -562,7 +561,7 @@ msgstr ""
 "Chiamata Fastpath «{0}»: Nessun risultato restituito mentre ci si aspettava "
 "un intero."
 
-#: org/postgresql/fastpath/Fastpath.java:308
+#: org/postgresql/fastpath/Fastpath.java:297
 #, java-format
 msgid "The fastpath function {0} is unknown."
 msgstr "La funzione fastpath «{0}» è sconosciuta."
@@ -630,63 +629,70 @@ msgid "Cannot cast to boolean: \"{0}\""
 msgstr ""
 
 #: org/postgresql/jdbc/EscapedFunctions.java:240
+#: org/postgresql/jdbc/EscapedFunctions2.java:167
 #, java-format
 msgid "{0} function takes four and only four argument."
 msgstr "Il metodo «{0}» accetta quattro e solo quattro argomenti."
 
 #: org/postgresql/jdbc/EscapedFunctions.java:270
-#: org/postgresql/jdbc/EscapedFunctions.java:344
-#: org/postgresql/jdbc/EscapedFunctions.java:749
-#: org/postgresql/jdbc/EscapedFunctions.java:787
+#: org/postgresql/jdbc/EscapedFunctions.java:337
+#: org/postgresql/jdbc/EscapedFunctions.java:740
+#: org/postgresql/jdbc/EscapedFunctions2.java:196
+#: org/postgresql/jdbc/EscapedFunctions2.java:263
+#: org/postgresql/jdbc/EscapedFunctions2.java:665
 #, java-format
 msgid "{0} function takes two and only two arguments."
 msgstr "Il metodo «{0}» accetta due e solo due argomenti."
 
 #: org/postgresql/jdbc/EscapedFunctions.java:288
-#: org/postgresql/jdbc/EscapedFunctions.java:326
-#: org/postgresql/jdbc/EscapedFunctions.java:446
-#: org/postgresql/jdbc/EscapedFunctions.java:461
-#: org/postgresql/jdbc/EscapedFunctions.java:476
-#: org/postgresql/jdbc/EscapedFunctions.java:491
-#: org/postgresql/jdbc/EscapedFunctions.java:506
-#: org/postgresql/jdbc/EscapedFunctions.java:521
-#: org/postgresql/jdbc/EscapedFunctions.java:536
-#: org/postgresql/jdbc/EscapedFunctions.java:551
-#: org/postgresql/jdbc/EscapedFunctions.java:566
-#: org/postgresql/jdbc/EscapedFunctions.java:581
-#: org/postgresql/jdbc/EscapedFunctions.java:596
-#: org/postgresql/jdbc/EscapedFunctions.java:611
-#: org/postgresql/jdbc/EscapedFunctions.java:775
+#: org/postgresql/jdbc/EscapedFunctions.java:441
+#: org/postgresql/jdbc/EscapedFunctions.java:467
+#: org/postgresql/jdbc/EscapedFunctions.java:526
+#: org/postgresql/jdbc/EscapedFunctions.java:728
+#: org/postgresql/jdbc/EscapedFunctions2.java:211
+#: org/postgresql/jdbc/EscapedFunctions2.java:355
+#: org/postgresql/jdbc/EscapedFunctions2.java:381
+#: org/postgresql/jdbc/EscapedFunctions2.java:440
+#: org/postgresql/jdbc/EscapedFunctions2.java:654
 #, java-format
 msgid "{0} function takes one and only one argument."
 msgstr "Il metodo «{0}» accetta un ed un solo argomento."
 
-#: org/postgresql/jdbc/EscapedFunctions.java:310
-#: org/postgresql/jdbc/EscapedFunctions.java:391
+#: org/postgresql/jdbc/EscapedFunctions.java:312
+#: org/postgresql/jdbc/EscapedFunctions.java:386
+#: org/postgresql/jdbc/EscapedFunctions2.java:238
+#: org/postgresql/jdbc/EscapedFunctions2.java:307
 #, java-format
 msgid "{0} function takes two or three arguments."
 msgstr "Il metodo «{0}» accetta due o tre argomenti."
 
-#: org/postgresql/jdbc/EscapedFunctions.java:416
-#: org/postgresql/jdbc/EscapedFunctions.java:431
-#: org/postgresql/jdbc/EscapedFunctions.java:734
-#: org/postgresql/jdbc/EscapedFunctions.java:764
+#: org/postgresql/jdbc/EscapedFunctions.java:411
+#: org/postgresql/jdbc/EscapedFunctions.java:426
+#: org/postgresql/jdbc/EscapedFunctions.java:693
+#: org/postgresql/jdbc/EscapedFunctions.java:719
+#: org/postgresql/jdbc/EscapedFunctions2.java:645
 #, java-format
 msgid "{0} function doesn''t take any argument."
 msgstr "Il metodo «{0}» non accetta argomenti."
 
-#: org/postgresql/jdbc/EscapedFunctions.java:627
-#: org/postgresql/jdbc/EscapedFunctions.java:680
+#: org/postgresql/jdbc/EscapedFunctions.java:586
+#: org/postgresql/jdbc/EscapedFunctions.java:639
+#: org/postgresql/jdbc/EscapedFunctions2.java:500
+#: org/postgresql/jdbc/EscapedFunctions2.java:571
 #, java-format
 msgid "{0} function takes three and only three arguments."
 msgstr "Il metodo «{0}» accetta tre e solo tre argomenti."
 
-#: org/postgresql/jdbc/EscapedFunctions.java:640
-#: org/postgresql/jdbc/EscapedFunctions.java:661
-#: org/postgresql/jdbc/EscapedFunctions.java:664
-#: org/postgresql/jdbc/EscapedFunctions.java:697
-#: org/postgresql/jdbc/EscapedFunctions.java:710
-#: org/postgresql/jdbc/EscapedFunctions.java:713
+#: org/postgresql/jdbc/EscapedFunctions.java:599
+#: org/postgresql/jdbc/EscapedFunctions.java:620
+#: org/postgresql/jdbc/EscapedFunctions.java:623
+#: org/postgresql/jdbc/EscapedFunctions.java:656
+#: org/postgresql/jdbc/EscapedFunctions.java:669
+#: org/postgresql/jdbc/EscapedFunctions.java:672
+#: org/postgresql/jdbc/EscapedFunctions2.java:510
+#: org/postgresql/jdbc/EscapedFunctions2.java:527
+#: org/postgresql/jdbc/EscapedFunctions2.java:585
+#: org/postgresql/jdbc/EscapedFunctions2.java:597
 #, java-format
 msgid "Interval {0} not yet implemented"
 msgstr "L''intervallo «{0}» non è stato ancora implementato."
@@ -707,18 +713,18 @@ msgstr "Non è possibile trovare l''id del punto di ripristino indicato."
 msgid "Cannot retrieve the name of an unnamed savepoint."
 msgstr "Non è possibile trovare il nome di un punto di ripristino anonimo."
 
-#: org/postgresql/jdbc/PgArray.java:157 org/postgresql/jdbc/PgArray.java:844
+#: org/postgresql/jdbc/PgArray.java:155 org/postgresql/jdbc/PgArray.java:842
 #, java-format
 msgid "The array index is out of range: {0}"
 msgstr "Indice di colonna fuori dall''intervallo ammissibile: {0}"
 
-#: org/postgresql/jdbc/PgArray.java:178 org/postgresql/jdbc/PgArray.java:861
+#: org/postgresql/jdbc/PgArray.java:176 org/postgresql/jdbc/PgArray.java:859
 #, java-format
 msgid "The array index is out of range: {0}, number of elements: {1}."
 msgstr ""
 "L''indice dell''array è fuori intervallo: {0}, numero di elementi: {1}."
 
-#: org/postgresql/jdbc/PgArray.java:210
+#: org/postgresql/jdbc/PgArray.java:208
 #: org/postgresql/jdbc/PgResultSet.java:1930
 #: org/postgresql/util/HStoreConverter.java:43
 #: org/postgresql/util/HStoreConverter.java:74
@@ -734,19 +740,19 @@ msgstr ""
 "quello nel quale si memorizzano caratteri a 8bit in un database con codifica "
 "SQL_ASCII."
 
-#: org/postgresql/jdbc/PgCallableStatement.java:86
-#: org/postgresql/jdbc/PgCallableStatement.java:96
+#: org/postgresql/jdbc/PgCallableStatement.java:85
+#: org/postgresql/jdbc/PgCallableStatement.java:95
 msgid "A CallableStatement was executed with nothing returned."
 msgstr ""
 "Un «CallableStatement» è stato eseguito senza produrre alcun risultato. "
 
-#: org/postgresql/jdbc/PgCallableStatement.java:107
+#: org/postgresql/jdbc/PgCallableStatement.java:106
 #, fuzzy
 msgid "A CallableStatement was executed with an invalid number of parameters"
 msgstr ""
 "Un «CallableStatement» è stato eseguito con un numero errato di parametri."
 
-#: org/postgresql/jdbc/PgCallableStatement.java:145
+#: org/postgresql/jdbc/PgCallableStatement.java:144
 #, java-format
 msgid ""
 "A CallableStatement function was executed and the out parameter {0} was of "
@@ -755,7 +761,7 @@ msgstr ""
 "È stato eseguito un «CallableStatement» ma il parametro in uscita «{0}» era "
 "di tipo «{1}» al posto di «{2}», che era stato dichiarato."
 
-#: org/postgresql/jdbc/PgCallableStatement.java:202
+#: org/postgresql/jdbc/PgCallableStatement.java:206
 msgid ""
 "This statement does not declare an OUT parameter.  Use '{' ?= call ... '}' "
 "to declare one."
@@ -763,12 +769,12 @@ msgstr ""
 "Questo statement non dichiara il parametro in uscita. Usare «{ ?= "
 "call ... }» per farlo."
 
-#: org/postgresql/jdbc/PgCallableStatement.java:246
+#: org/postgresql/jdbc/PgCallableStatement.java:229
 msgid "wasNull cannot be call before fetching a result."
 msgstr ""
 
-#: org/postgresql/jdbc/PgCallableStatement.java:384
-#: org/postgresql/jdbc/PgCallableStatement.java:403
+#: org/postgresql/jdbc/PgCallableStatement.java:367
+#: org/postgresql/jdbc/PgCallableStatement.java:386
 #, java-format
 msgid ""
 "Parameter of type {0} was registered, but call to get{1} (sqltype={2}) was "
@@ -777,7 +783,7 @@ msgstr ""
 "È stato definito il parametro di tipo «{0}», ma poi è stato invocato il "
 "metodo «get{1}()» (sqltype={2})."
 
-#: org/postgresql/jdbc/PgCallableStatement.java:424
+#: org/postgresql/jdbc/PgCallableStatement.java:407
 msgid ""
 "A CallableStatement was declared, but no call to registerOutParameter(1, "
 "<some type>) was made."
@@ -785,27 +791,27 @@ msgstr ""
 "È stato definito un «CallableStatement» ma non è stato invocato il metodo "
 "«registerOutParameter(1, <tipo>)»."
 
-#: org/postgresql/jdbc/PgCallableStatement.java:430
+#: org/postgresql/jdbc/PgCallableStatement.java:413
 msgid "No function outputs were registered."
 msgstr ""
 
-#: org/postgresql/jdbc/PgCallableStatement.java:436
+#: org/postgresql/jdbc/PgCallableStatement.java:419
 msgid ""
 "Results cannot be retrieved from a CallableStatement before it is executed."
 msgstr ""
 
-#: org/postgresql/jdbc/PgCallableStatement.java:703
+#: org/postgresql/jdbc/PgCallableStatement.java:686
 #, fuzzy, java-format
 msgid "Unsupported type conversion to {1}."
 msgstr "Valore di tipo «{0}» non supportato."
 
-#: org/postgresql/jdbc/PgConnection.java:272
+#: org/postgresql/jdbc/PgConnection.java:241
 #, java-format
 msgid "Unsupported value for stringtype parameter: {0}"
 msgstr "Il valore per il parametro di tipo string «{0}» non è supportato."
 
 #: org/postgresql/jdbc/PgConnection.java:424
-#: org/postgresql/jdbc/PgPreparedStatement.java:119
+#: org/postgresql/jdbc/PgPreparedStatement.java:107
 #: org/postgresql/jdbc/PgStatement.java:225
 #: org/postgresql/jdbc/TypeInfoCache.java:226
 #: org/postgresql/jdbc/TypeInfoCache.java:371
@@ -817,132 +823,132 @@ msgstr "Il valore per il parametro di tipo string «{0}» non è supportato."
 msgid "No results were returned by the query."
 msgstr "Nessun risultato è stato restituito dalla query."
 
-#: org/postgresql/jdbc/PgConnection.java:441
+#: org/postgresql/jdbc/PgConnection.java:442
 #: org/postgresql/jdbc/PgStatement.java:254
 msgid "A result was returned when none was expected."
 msgstr "È stato restituito un valore nonostante non ne fosse atteso nessuno."
 
-#: org/postgresql/jdbc/PgConnection.java:545
+#: org/postgresql/jdbc/PgConnection.java:547
 msgid "Custom type maps are not supported."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:587
+#: org/postgresql/jdbc/PgConnection.java:589
 #, java-format
 msgid "Failed to create object for: {0}."
 msgstr "Fallita la creazione dell''oggetto per: {0}."
 
-#: org/postgresql/jdbc/PgConnection.java:641
+#: org/postgresql/jdbc/PgConnection.java:643
 #, java-format
 msgid "Unable to load the class {0} responsible for the datatype {1}"
 msgstr "Non è possibile caricare la class «{0}» per gestire il tipo «{1}»."
 
-#: org/postgresql/jdbc/PgConnection.java:693
+#: org/postgresql/jdbc/PgConnection.java:705
 msgid ""
 "Cannot change transaction read-only property in the middle of a transaction."
 msgstr ""
 "Non è possibile modificare la proprietà «read-only» delle transazioni nel "
 "mezzo di una transazione."
 
-#: org/postgresql/jdbc/PgConnection.java:756
+#: org/postgresql/jdbc/PgConnection.java:772
 msgid "Cannot commit when autoCommit is enabled."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:767
-#: org/postgresql/jdbc/PgConnection.java:1384
-#: org/postgresql/jdbc/PgConnection.java:1428
+#: org/postgresql/jdbc/PgConnection.java:783
+#: org/postgresql/jdbc/PgConnection.java:1401
+#: org/postgresql/jdbc/PgConnection.java:1445
 #, fuzzy
 msgid "This connection has been closed."
 msgstr "Questo «Connection» è stato chiuso."
 
-#: org/postgresql/jdbc/PgConnection.java:777
+#: org/postgresql/jdbc/PgConnection.java:794
 msgid "Cannot rollback when autoCommit is enabled."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:827
+#: org/postgresql/jdbc/PgConnection.java:844
 msgid ""
 "Cannot change transaction isolation level in the middle of a transaction."
 msgstr ""
 "Non è possibile cambiare il livello di isolamento delle transazioni nel "
 "mezzo di una transazione."
 
-#: org/postgresql/jdbc/PgConnection.java:833
+#: org/postgresql/jdbc/PgConnection.java:850
 #, java-format
 msgid "Transaction isolation level {0} not supported."
 msgstr "Il livello di isolamento delle transazioni «{0}» non è supportato."
 
-#: org/postgresql/jdbc/PgConnection.java:878
+#: org/postgresql/jdbc/PgConnection.java:895
 msgid "Finalizing a Connection that was never closed:"
 msgstr "Finalizzazione di una «Connection» che non è stata chiusa."
 
-#: org/postgresql/jdbc/PgConnection.java:945
+#: org/postgresql/jdbc/PgConnection.java:962
 msgid "Unable to translate data into the desired encoding."
 msgstr "Impossibile tradurre i dati nella codifica richiesta."
 
-#: org/postgresql/jdbc/PgConnection.java:1008
+#: org/postgresql/jdbc/PgConnection.java:1025
 #: org/postgresql/jdbc/PgResultSet.java:1817
-#: org/postgresql/jdbc/PgStatement.java:903
+#: org/postgresql/jdbc/PgStatement.java:908
 msgid "Fetch size must be a value greater to or equal to 0."
 msgstr "La dimensione dell''area di «fetch» deve essere maggiore o eguale a 0."
 
-#: org/postgresql/jdbc/PgConnection.java:1289
-#: org/postgresql/jdbc/PgConnection.java:1330
+#: org/postgresql/jdbc/PgConnection.java:1306
+#: org/postgresql/jdbc/PgConnection.java:1347
 #, java-format
 msgid "Unable to find server array type for provided name {0}."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1312
+#: org/postgresql/jdbc/PgConnection.java:1329
 #, fuzzy, java-format
 msgid "Invalid elements {0}"
 msgstr "La dimensione specificata, {0}, per lo «stream» non è valida."
 
-#: org/postgresql/jdbc/PgConnection.java:1348
+#: org/postgresql/jdbc/PgConnection.java:1365
 #, fuzzy, java-format
 msgid "Invalid timeout ({0}<0)."
 msgstr "La dimensione specificata, {0}, per lo «stream» non è valida."
 
-#: org/postgresql/jdbc/PgConnection.java:1372
+#: org/postgresql/jdbc/PgConnection.java:1389
 msgid "Validating connection."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1405
+#: org/postgresql/jdbc/PgConnection.java:1422
 #, fuzzy, java-format
 msgid "Failed to set ClientInfo property: {0}"
 msgstr "Fallita la creazione dell''oggetto per: {0}."
 
-#: org/postgresql/jdbc/PgConnection.java:1415
+#: org/postgresql/jdbc/PgConnection.java:1432
 #, fuzzy
 msgid "ClientInfo property not supported."
 msgstr "La restituzione di chiavi autogenerate non è supportata."
 
-#: org/postgresql/jdbc/PgConnection.java:1441
+#: org/postgresql/jdbc/PgConnection.java:1458
 msgid "One ore more ClientInfo failed."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1540
+#: org/postgresql/jdbc/PgConnection.java:1559
 #, fuzzy
 msgid "Network timeout must be a value greater than or equal to 0."
 msgstr "Il timeout relativo alle query deve essere maggiore o eguale a 0."
 
-#: org/postgresql/jdbc/PgConnection.java:1552
+#: org/postgresql/jdbc/PgConnection.java:1571
 msgid "Unable to set network timeout."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1563
+#: org/postgresql/jdbc/PgConnection.java:1582
 msgid "Unable to get network timeout."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1580
+#: org/postgresql/jdbc/PgConnection.java:1599
 #, java-format
 msgid "Unknown ResultSet holdability setting: {0}."
 msgstr "Il parametro «holdability» per il «ResultSet» è sconosciuto: {0}."
 
-#: org/postgresql/jdbc/PgConnection.java:1598
-#: org/postgresql/jdbc/PgConnection.java:1619
+#: org/postgresql/jdbc/PgConnection.java:1617
+#: org/postgresql/jdbc/PgConnection.java:1638
 msgid "Cannot establish a savepoint in auto-commit mode."
 msgstr ""
 "Non è possibile impostare i punti di ripristino in modalità «auto-commit»."
 
-#: org/postgresql/jdbc/PgConnection.java:1685
+#: org/postgresql/jdbc/PgConnection.java:1707
 msgid "Returning autogenerated keys is not supported."
 msgstr "La restituzione di chiavi autogenerate non è supportata."
 
@@ -957,47 +963,47 @@ msgstr ""
 msgid "Unable to find name datatype in the system catalogs."
 msgstr "Non è possibile trovare il datatype «name» nel catalogo di sistema."
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:323
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:322
 #, fuzzy
 msgid "Unable to find keywords in the system catalogs."
 msgstr "Non è possibile trovare il datatype «name» nel catalogo di sistema."
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1105
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1095
 msgid "oid"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1105
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1095
 msgid "proname"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1107
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1558
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1097
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1548
 msgid "typtype"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1110
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1100
 msgid "proargtypes"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1576
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1566
 msgid "adsrc"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1589
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1579
 msgid "attidentity"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1685
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1761
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1675
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1751
 msgid "rolname"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1686
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1762
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1676
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1752
 msgid "relacl"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1692
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1682
 msgid "attacl"
 msgstr ""
 
@@ -1006,68 +1012,68 @@ msgstr ""
 msgid "The parameter index is out of range: {0}, number of parameters: {1}."
 msgstr "Il parametro indice è fuori intervallo: {0}, numero di elementi: {1}."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:106
+#: org/postgresql/jdbc/PgPreparedStatement.java:94
+#: org/postgresql/jdbc/PgPreparedStatement.java:115
 #: org/postgresql/jdbc/PgPreparedStatement.java:127
-#: org/postgresql/jdbc/PgPreparedStatement.java:139
-#: org/postgresql/jdbc/PgPreparedStatement.java:1035
+#: org/postgresql/jdbc/PgPreparedStatement.java:1008
 msgid ""
 "Can''t use query methods that take a query string on a PreparedStatement."
 msgstr ""
 "Non si possono utilizzare i metodi \"query\" che hanno come argomento una "
 "stringa nel caso di «PreparedStatement»."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:249
+#: org/postgresql/jdbc/PgPreparedStatement.java:237
 msgid "Unknown Types value."
 msgstr "Valore di tipo sconosciuto."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:382
-#: org/postgresql/jdbc/PgPreparedStatement.java:439
-#: org/postgresql/jdbc/PgPreparedStatement.java:1191
-#: org/postgresql/jdbc/PgPreparedStatement.java:1490
+#: org/postgresql/jdbc/PgPreparedStatement.java:364
+#: org/postgresql/jdbc/PgPreparedStatement.java:421
+#: org/postgresql/jdbc/PgPreparedStatement.java:1164
+#: org/postgresql/jdbc/PgPreparedStatement.java:1472
 #, java-format
 msgid "Invalid stream length {0}."
 msgstr "La dimensione specificata, {0}, per lo «stream» non è valida."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:411
+#: org/postgresql/jdbc/PgPreparedStatement.java:393
 #, java-format
 msgid "The JVM claims not to support the {0} encoding."
 msgstr "La JVM sostiene di non supportare la codifica {0}."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:414
+#: org/postgresql/jdbc/PgPreparedStatement.java:396
 #: org/postgresql/jdbc/PgResultSet.java:1122
 #: org/postgresql/jdbc/PgResultSet.java:1156
 msgid "Provided InputStream failed."
 msgstr "L''«InputStream» fornito è fallito."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:460
-#: org/postgresql/jdbc/PgPreparedStatement.java:1096
+#: org/postgresql/jdbc/PgPreparedStatement.java:442
+#: org/postgresql/jdbc/PgPreparedStatement.java:1069
 #, java-format
 msgid "Unknown type {0}."
 msgstr "Tipo sconosciuto {0}."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:477
+#: org/postgresql/jdbc/PgPreparedStatement.java:459
 msgid "No hstore extension installed."
 msgstr ""
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:619
-#: org/postgresql/jdbc/PgPreparedStatement.java:642
-#: org/postgresql/jdbc/PgPreparedStatement.java:652
-#: org/postgresql/jdbc/PgPreparedStatement.java:664
+#: org/postgresql/jdbc/PgPreparedStatement.java:601
+#: org/postgresql/jdbc/PgPreparedStatement.java:624
+#: org/postgresql/jdbc/PgPreparedStatement.java:634
+#: org/postgresql/jdbc/PgPreparedStatement.java:646
 #, java-format
 msgid "Cannot cast an instance of {0} to type {1}"
 msgstr "Non è possibile fare il cast di una istanza di «{0}» al tipo «{1}»."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:682
+#: org/postgresql/jdbc/PgPreparedStatement.java:664
 #, java-format
 msgid "Unsupported Types value: {0}"
 msgstr "Valore di tipo «{0}» non supportato."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:894
+#: org/postgresql/jdbc/PgPreparedStatement.java:876
 #, java-format
 msgid "Cannot convert an instance of {0} to type {1}"
 msgstr "Non è possibile convertire una istanza di «{0}» nel tipo «{1}»"
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:968
+#: org/postgresql/jdbc/PgPreparedStatement.java:950
 #, java-format
 msgid ""
 "Can''t infer the SQL type to use for an instance of {0}. Use setObject() "
@@ -1077,17 +1083,17 @@ msgstr ""
 "«{0}». Usare «setObject()» specificando esplicitamente il tipo da usare per "
 "questo valore."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:1133
-#: org/postgresql/jdbc/PgPreparedStatement.java:1233
+#: org/postgresql/jdbc/PgPreparedStatement.java:1106
+#: org/postgresql/jdbc/PgPreparedStatement.java:1206
 msgid "Unexpected error writing large object to database."
 msgstr "Errore inatteso inviando un «large object» al database."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:1178
+#: org/postgresql/jdbc/PgPreparedStatement.java:1151
 #: org/postgresql/jdbc/PgResultSet.java:1210
 msgid "Provided Reader failed."
 msgstr "Il «Reader» fornito è fallito."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:1449
+#: org/postgresql/jdbc/PgPreparedStatement.java:1431
 #: org/postgresql/util/StreamWrapper.java:56
 msgid "Object is too large to send over the protocol."
 msgstr ""
@@ -1105,8 +1111,8 @@ msgstr ""
 #: org/postgresql/jdbc/PgResultSet.java:556
 #: org/postgresql/jdbc/PgResultSet.java:594
 #: org/postgresql/jdbc/PgResultSet.java:624
-#: org/postgresql/jdbc/PgResultSet.java:3014
-#: org/postgresql/jdbc/PgResultSet.java:3058
+#: org/postgresql/jdbc/PgResultSet.java:3012
+#: org/postgresql/jdbc/PgResultSet.java:3057
 #, fuzzy, java-format
 msgid "Cannot convert the column of type {0} to requested type {1}."
 msgstr "Non è possibile convertire una istanza di «{0}» nel tipo «{1}»"
@@ -1120,7 +1126,7 @@ msgstr ""
 "di una riga."
 
 #: org/postgresql/jdbc/PgResultSet.java:878
-#: org/postgresql/jdbc/PgStatement.java:895
+#: org/postgresql/jdbc/PgStatement.java:900
 #, java-format
 msgid "Invalid fetch direction constant: {0}."
 msgstr "Costante per la direzione dell''estrazione non valida: {0}."
@@ -1167,8 +1173,8 @@ msgstr ""
 
 #: org/postgresql/jdbc/PgResultSet.java:1119
 #: org/postgresql/jdbc/PgResultSet.java:1754
-#: org/postgresql/jdbc/PgResultSet.java:2422
-#: org/postgresql/jdbc/PgResultSet.java:2443
+#: org/postgresql/jdbc/PgResultSet.java:2420
+#: org/postgresql/jdbc/PgResultSet.java:2441
 #, java-format
 msgid "The JVM claims not to support the encoding: {0}"
 msgstr "La JVM sostiene di non supportare la codifica: {0}."
@@ -1183,7 +1189,7 @@ msgstr ""
 "Non è possibile invocare «updateRow()» durante l''inserimento di una riga."
 
 #: org/postgresql/jdbc/PgResultSet.java:1335
-#: org/postgresql/jdbc/PgResultSet.java:3075
+#: org/postgresql/jdbc/PgResultSet.java:3074
 msgid ""
 "Cannot update the ResultSet because it is either before the start or after "
 "the end of the results."
@@ -1203,27 +1209,27 @@ msgstr "Non è stata trovata la chiave primaria della tabella «{0}»."
 
 #: org/postgresql/jdbc/PgResultSet.java:2017
 #: org/postgresql/jdbc/PgResultSet.java:2022
-#: org/postgresql/jdbc/PgResultSet.java:2809
-#: org/postgresql/jdbc/PgResultSet.java:2815
-#: org/postgresql/jdbc/PgResultSet.java:2840
-#: org/postgresql/jdbc/PgResultSet.java:2846
-#: org/postgresql/jdbc/PgResultSet.java:2870
-#: org/postgresql/jdbc/PgResultSet.java:2875
-#: org/postgresql/jdbc/PgResultSet.java:2891
-#: org/postgresql/jdbc/PgResultSet.java:2912
-#: org/postgresql/jdbc/PgResultSet.java:2923
-#: org/postgresql/jdbc/PgResultSet.java:2936
-#: org/postgresql/jdbc/PgResultSet.java:3063
+#: org/postgresql/jdbc/PgResultSet.java:2807
+#: org/postgresql/jdbc/PgResultSet.java:2813
+#: org/postgresql/jdbc/PgResultSet.java:2838
+#: org/postgresql/jdbc/PgResultSet.java:2844
+#: org/postgresql/jdbc/PgResultSet.java:2868
+#: org/postgresql/jdbc/PgResultSet.java:2873
+#: org/postgresql/jdbc/PgResultSet.java:2889
+#: org/postgresql/jdbc/PgResultSet.java:2910
+#: org/postgresql/jdbc/PgResultSet.java:2921
+#: org/postgresql/jdbc/PgResultSet.java:2934
+#: org/postgresql/jdbc/PgResultSet.java:3062
 #, java-format
 msgid "Bad value for type {0} : {1}"
 msgstr "Il valore «{1}» non è adeguato al tipo «{0}»."
 
-#: org/postgresql/jdbc/PgResultSet.java:2595
+#: org/postgresql/jdbc/PgResultSet.java:2593
 #, java-format
 msgid "The column name {0} was not found in this ResultSet."
 msgstr "Colonna denominata «{0}» non è presente in questo «ResultSet»."
 
-#: org/postgresql/jdbc/PgResultSet.java:2731
+#: org/postgresql/jdbc/PgResultSet.java:2729
 msgid ""
 "ResultSet is not updateable.  The query that generated this result set must "
 "select only one table, and must select all primary keys from that table. See "
@@ -1234,44 +1240,44 @@ msgstr ""
 "chiave primaria. Si vedano le specifiche dell''API JDBC 2.1, sezione 5.6, "
 "per ulteriori dettagli."
 
-#: org/postgresql/jdbc/PgResultSet.java:2743
+#: org/postgresql/jdbc/PgResultSet.java:2741
 msgid "This ResultSet is closed."
 msgstr "Questo «ResultSet» è chiuso."
 
-#: org/postgresql/jdbc/PgResultSet.java:2774
+#: org/postgresql/jdbc/PgResultSet.java:2772
 msgid "ResultSet not positioned properly, perhaps you need to call next."
 msgstr ""
 "Il «ResultSet» non è correttamente posizionato; forse è necessario invocare "
 "«next()»."
 
-#: org/postgresql/jdbc/PgResultSet.java:3095
+#: org/postgresql/jdbc/PgResultSet.java:3094
 #, fuzzy
 msgid "Invalid UUID data."
 msgstr "Flag non valido"
 
-#: org/postgresql/jdbc/PgResultSet.java:3184
-#: org/postgresql/jdbc/PgResultSet.java:3191
-#: org/postgresql/jdbc/PgResultSet.java:3202
-#: org/postgresql/jdbc/PgResultSet.java:3213
-#: org/postgresql/jdbc/PgResultSet.java:3224
-#: org/postgresql/jdbc/PgResultSet.java:3235
-#: org/postgresql/jdbc/PgResultSet.java:3246
-#: org/postgresql/jdbc/PgResultSet.java:3257
-#: org/postgresql/jdbc/PgResultSet.java:3268
-#: org/postgresql/jdbc/PgResultSet.java:3275
-#: org/postgresql/jdbc/PgResultSet.java:3282
-#: org/postgresql/jdbc/PgResultSet.java:3293
-#: org/postgresql/jdbc/PgResultSet.java:3310
-#: org/postgresql/jdbc/PgResultSet.java:3317
-#: org/postgresql/jdbc/PgResultSet.java:3324
-#: org/postgresql/jdbc/PgResultSet.java:3335
-#: org/postgresql/jdbc/PgResultSet.java:3342
-#: org/postgresql/jdbc/PgResultSet.java:3349
-#: org/postgresql/jdbc/PgResultSet.java:3387
-#: org/postgresql/jdbc/PgResultSet.java:3394
-#: org/postgresql/jdbc/PgResultSet.java:3401
-#: org/postgresql/jdbc/PgResultSet.java:3421
-#: org/postgresql/jdbc/PgResultSet.java:3434
+#: org/postgresql/jdbc/PgResultSet.java:3183
+#: org/postgresql/jdbc/PgResultSet.java:3190
+#: org/postgresql/jdbc/PgResultSet.java:3201
+#: org/postgresql/jdbc/PgResultSet.java:3212
+#: org/postgresql/jdbc/PgResultSet.java:3223
+#: org/postgresql/jdbc/PgResultSet.java:3234
+#: org/postgresql/jdbc/PgResultSet.java:3245
+#: org/postgresql/jdbc/PgResultSet.java:3256
+#: org/postgresql/jdbc/PgResultSet.java:3267
+#: org/postgresql/jdbc/PgResultSet.java:3274
+#: org/postgresql/jdbc/PgResultSet.java:3281
+#: org/postgresql/jdbc/PgResultSet.java:3292
+#: org/postgresql/jdbc/PgResultSet.java:3309
+#: org/postgresql/jdbc/PgResultSet.java:3316
+#: org/postgresql/jdbc/PgResultSet.java:3323
+#: org/postgresql/jdbc/PgResultSet.java:3334
+#: org/postgresql/jdbc/PgResultSet.java:3341
+#: org/postgresql/jdbc/PgResultSet.java:3348
+#: org/postgresql/jdbc/PgResultSet.java:3386
+#: org/postgresql/jdbc/PgResultSet.java:3393
+#: org/postgresql/jdbc/PgResultSet.java:3400
+#: org/postgresql/jdbc/PgResultSet.java:3420
+#: org/postgresql/jdbc/PgResultSet.java:3433
 #, fuzzy, java-format
 msgid "conversion to {0} from {1} not supported"
 msgstr "Il livello di isolamento delle transazioni «{0}» non è supportato."
@@ -1337,34 +1343,34 @@ msgstr ""
 msgid "Maximum number of rows must be a value grater than or equal to 0."
 msgstr "Il numero massimo di righe deve essere maggiore o eguale a 0."
 
-#: org/postgresql/jdbc/PgStatement.java:550
+#: org/postgresql/jdbc/PgStatement.java:555
 msgid "Query timeout must be a value greater than or equals to 0."
 msgstr "Il timeout relativo alle query deve essere maggiore o eguale a 0."
 
-#: org/postgresql/jdbc/PgStatement.java:590
+#: org/postgresql/jdbc/PgStatement.java:595
 msgid "The maximum field size must be a value greater than or equal to 0."
 msgstr "La dimensione massima del campo deve essere maggiore o eguale a 0."
 
-#: org/postgresql/jdbc/PgStatement.java:689
+#: org/postgresql/jdbc/PgStatement.java:694
 msgid "This statement has been closed."
 msgstr "Questo statement è stato chiuso."
 
-#: org/postgresql/jdbc/PgStatement.java:1145
-#: org/postgresql/jdbc/PgStatement.java:1173
+#: org/postgresql/jdbc/PgStatement.java:1150
+#: org/postgresql/jdbc/PgStatement.java:1178
 #, fuzzy
 msgid "Returning autogenerated keys by column index is not supported."
 msgstr "La restituzione di chiavi autogenerate non è supportata."
 
-#: org/postgresql/jdbc/TimestampUtils.java:355
-#: org/postgresql/jdbc/TimestampUtils.java:423
+#: org/postgresql/jdbc/TimestampUtils.java:365
+#: org/postgresql/jdbc/TimestampUtils.java:433
 #, fuzzy, java-format
 msgid "Bad value for type timestamp/date/time: {1}"
 msgstr "Il valore «{1}» non è adeguato al tipo «{0}»."
 
-#: org/postgresql/jdbc/TimestampUtils.java:858
-#: org/postgresql/jdbc/TimestampUtils.java:915
-#: org/postgresql/jdbc/TimestampUtils.java:961
-#: org/postgresql/jdbc/TimestampUtils.java:1010
+#: org/postgresql/jdbc/TimestampUtils.java:914
+#: org/postgresql/jdbc/TimestampUtils.java:971
+#: org/postgresql/jdbc/TimestampUtils.java:1017
+#: org/postgresql/jdbc/TimestampUtils.java:1066
 #, fuzzy, java-format
 msgid "Unsupported binary encoding of {0}."
 msgstr "Valore di tipo «{0}» non supportato."
@@ -1377,31 +1383,31 @@ msgstr ""
 msgid "Invalid or unsupported by client SCRAM mechanisms"
 msgstr ""
 
-#: org/postgresql/jre8/sasl/ScramAuthenticator.java:117
+#: org/postgresql/jre8/sasl/ScramAuthenticator.java:119
 #, fuzzy, java-format
 msgid "Invalid server-first-message: {0}"
 msgstr "La dimensione specificata, {0}, per lo «stream» non è valida."
 
-#: org/postgresql/jre8/sasl/ScramAuthenticator.java:147
+#: org/postgresql/jre8/sasl/ScramAuthenticator.java:151
 #, fuzzy, java-format
 msgid "Invalid server-final-message: {0}"
 msgstr "La dimensione specificata, {0}, per lo «stream» non è valida."
 
-#: org/postgresql/jre8/sasl/ScramAuthenticator.java:153
+#: org/postgresql/jre8/sasl/ScramAuthenticator.java:157
 #, java-format
 msgid "SCRAM authentication failed, server returned error: {0}"
 msgstr ""
 
-#: org/postgresql/jre8/sasl/ScramAuthenticator.java:160
+#: org/postgresql/jre8/sasl/ScramAuthenticator.java:164
 msgid "Invalid server SCRAM signature"
 msgstr ""
 
-#: org/postgresql/largeobject/LargeObjectManager.java:144
+#: org/postgresql/largeobject/LargeObjectManager.java:136
 msgid "Failed to initialize LargeObject API"
 msgstr "Inizializzazione di LargeObject API fallita."
 
-#: org/postgresql/largeobject/LargeObjectManager.java:262
-#: org/postgresql/largeobject/LargeObjectManager.java:305
+#: org/postgresql/largeobject/LargeObjectManager.java:254
+#: org/postgresql/largeobject/LargeObjectManager.java:295
 msgid "Large Objects may not be used in auto-commit mode."
 msgstr "Non è possibile impostare i «Large Object» in modalità «auto-commit»."
 
@@ -1437,34 +1443,34 @@ msgstr ""
 msgid "The hostname {0} could not be verified."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:164
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:90
 msgid "The sslfactoryarg property may not be empty."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:180
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:106
 msgid ""
 "The environment variable containing the server's SSL certificate must not be "
 "empty."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:188
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:114
 msgid ""
 "The system property containing the server's SSL certificate must not be "
 "empty."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:195
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:121
 msgid ""
 "The sslfactoryarg property must start with the prefix file:, classpath:, "
 "env:, sys:, or -----BEGIN CERTIFICATE-----."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:207
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:133
 #, fuzzy
 msgid "An error occurred reading the certificate"
 msgstr "Si è verificato un errore impostando la connessione SSL."
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:240
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:166
 msgid "No X509TrustManager found"
 msgstr ""
 
@@ -1600,61 +1606,61 @@ msgid ""
 "setSavePoint not allowed while an XA transaction is active."
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:177
-#: org/postgresql/xa/PGXAConnection.java:253
-#: org/postgresql/xa/PGXAConnection.java:347
+#: org/postgresql/xa/PGXAConnection.java:186
+#: org/postgresql/xa/PGXAConnection.java:272
+#: org/postgresql/xa/PGXAConnection.java:381
 #, fuzzy, java-format
 msgid "Invalid flags {0}"
 msgstr "Flag non validi"
 
-#: org/postgresql/xa/PGXAConnection.java:181
-#: org/postgresql/xa/PGXAConnection.java:257
-#: org/postgresql/xa/PGXAConnection.java:449
+#: org/postgresql/xa/PGXAConnection.java:190
+#: org/postgresql/xa/PGXAConnection.java:276
+#: org/postgresql/xa/PGXAConnection.java:491
 msgid "xid must not be null"
 msgstr "xid non può essere NULL"
 
-#: org/postgresql/xa/PGXAConnection.java:185
+#: org/postgresql/xa/PGXAConnection.java:194
 msgid "Connection is busy with another transaction"
 msgstr "La connessione è utilizzata da un''altra transazione"
 
-#: org/postgresql/xa/PGXAConnection.java:194
-#: org/postgresql/xa/PGXAConnection.java:267
+#: org/postgresql/xa/PGXAConnection.java:203
+#: org/postgresql/xa/PGXAConnection.java:286
 msgid "suspend/resume not implemented"
 msgstr "«suspend»/«resume» non implementato"
 
-#: org/postgresql/xa/PGXAConnection.java:202
-#: org/postgresql/xa/PGXAConnection.java:209
-#: org/postgresql/xa/PGXAConnection.java:213
+#: org/postgresql/xa/PGXAConnection.java:211
+#: org/postgresql/xa/PGXAConnection.java:218
+#: org/postgresql/xa/PGXAConnection.java:222
 #, java-format
 msgid ""
 "Invalid protocol state requested. Attempted transaction interleaving is not "
 "supported. xid={0}, currentXid={1}, state={2}, flags={3}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:224
+#: org/postgresql/xa/PGXAConnection.java:233
 #, fuzzy
 msgid "Error disabling autocommit"
 msgstr "Errore durante il commit \"one-phase\""
 
-#: org/postgresql/xa/PGXAConnection.java:261
+#: org/postgresql/xa/PGXAConnection.java:280
 #, fuzzy, java-format
 msgid ""
 "tried to call end without corresponding start call. state={0}, start "
 "xid={1}, currentXid={2}, preparedXid={3}"
 msgstr "È stata chiamata «end» senza la corrispondente chiamata a «start»"
 
-#: org/postgresql/xa/PGXAConnection.java:297
+#: org/postgresql/xa/PGXAConnection.java:326
 #, java-format
 msgid ""
 "Preparing already prepared transaction, the prepared xid {0}, prepare xid={1}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:300
+#: org/postgresql/xa/PGXAConnection.java:329
 #, java-format
 msgid "Current connection does not have an associated xid. prepare xid={0}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:307
+#: org/postgresql/xa/PGXAConnection.java:336
 #, fuzzy, java-format
 msgid ""
 "Not implemented: Prepare must be issued using the same connection that "
@@ -1663,34 +1669,34 @@ msgstr ""
 "Non implementato: «Prepare» deve essere eseguito nella stessa connessione "
 "che ha iniziato la transazione."
 
-#: org/postgresql/xa/PGXAConnection.java:311
+#: org/postgresql/xa/PGXAConnection.java:340
 #, fuzzy, java-format
 msgid "Prepare called before end. prepare xid={0}, state={1}"
 msgstr "«Prepare» invocato prima della fine"
 
-#: org/postgresql/xa/PGXAConnection.java:331
+#: org/postgresql/xa/PGXAConnection.java:360
 #, fuzzy, java-format
 msgid "Error preparing transaction. prepare xid={0}"
 msgstr "Errore nel preparare una transazione"
 
-#: org/postgresql/xa/PGXAConnection.java:382
+#: org/postgresql/xa/PGXAConnection.java:416
 msgid "Error during recover"
 msgstr "Errore durante il ripristino"
 
-#: org/postgresql/xa/PGXAConnection.java:438
+#: org/postgresql/xa/PGXAConnection.java:480
 #, fuzzy, java-format
 msgid ""
 "Error rolling back prepared transaction. rollback xid={0}, preparedXid={1}, "
 "currentXid={2}"
 msgstr "Errore durante il «rollback» di una transazione preparata"
 
-#: org/postgresql/xa/PGXAConnection.java:471
+#: org/postgresql/xa/PGXAConnection.java:521
 #, java-format
 msgid ""
 "One-phase commit called for xid {0} but connection was prepared with xid {1}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:479
+#: org/postgresql/xa/PGXAConnection.java:529
 msgid ""
 "Not implemented: one-phase commit must be issued using the same connection "
 "that was used to start it"
@@ -1698,22 +1704,22 @@ msgstr ""
 "Non implementato: il commit \"one-phase\" deve essere invocato sulla stessa "
 "connessione che ha iniziato la transazione."
 
-#: org/postgresql/xa/PGXAConnection.java:483
+#: org/postgresql/xa/PGXAConnection.java:533
 #, java-format
 msgid "One-phase commit with unknown xid. commit xid={0}, currentXid={1}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:487
+#: org/postgresql/xa/PGXAConnection.java:537
 #, fuzzy, java-format
 msgid "commit called before end. commit xid={0}, state={1}"
 msgstr "«Commit» è stato chiamato prima della fine"
 
-#: org/postgresql/xa/PGXAConnection.java:498
+#: org/postgresql/xa/PGXAConnection.java:548
 #, fuzzy, java-format
 msgid "Error during one-phase commit. commit xid={0}"
 msgstr "Errore durante il commit \"one-phase\""
 
-#: org/postgresql/xa/PGXAConnection.java:517
+#: org/postgresql/xa/PGXAConnection.java:576
 #, fuzzy
 msgid ""
 "Not implemented: 2nd phase commit must be issued using an idle connection. "
@@ -1722,14 +1728,14 @@ msgstr ""
 "Non implementato: la seconda fase del «commit» deve essere effettuata con "
 "una connessione non in uso"
 
-#: org/postgresql/xa/PGXAConnection.java:550
+#: org/postgresql/xa/PGXAConnection.java:609
 #, fuzzy, java-format
 msgid ""
 "Error committing prepared transaction. commit xid={0}, preparedXid={1}, "
 "currentXid={2}"
 msgstr "Errore durante il «rollback» di una transazione preparata"
 
-#: org/postgresql/xa/PGXAConnection.java:567
+#: org/postgresql/xa/PGXAConnection.java:626
 #, fuzzy, java-format
 msgid "Heuristic commit/rollback not supported. forget xid={0}"
 msgstr "«Commit» e «rollback» euristici non sono supportati"

--- a/pgjdbc/src/main/java/org/postgresql/translation/ja.po
+++ b/pgjdbc/src/main/java/org/postgresql/translation/ja.po
@@ -8,7 +8,6 @@ msgid ""
 msgstr ""
 "Project-Id-Version: head-ja\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-06-05 10:57+0300\n"
 "PO-Revision-Date: 2010-04-11 22:58+0900\n"
 "Last-Translator: Hiroshi Saito <z-saito@guitar.ocn.ne.jp>\n"
 "Language-Team: PostgreSQL <z-saito@guitar.ocn.ne.jp>\n"
@@ -20,15 +19,15 @@ msgstr ""
 "X-Poedit-Language: Japanese\n"
 "X-Poedit-Country: Japan\n"
 
-#: org/postgresql/Driver.java:214
+#: org/postgresql/Driver.java:217
 msgid "Error loading default settings from driverconfig.properties"
 msgstr "driverconfig.propertiesによる初期設定のロードエラー。"
 
-#: org/postgresql/Driver.java:226
+#: org/postgresql/Driver.java:229
 msgid "Properties for the driver contains a non-string value for the key "
 msgstr ""
 
-#: org/postgresql/Driver.java:270
+#: org/postgresql/Driver.java:272
 msgid ""
 "Your security policy has prevented the connection from being attempted.  You "
 "probably need to grant the connect java.net.SocketPermission to the database "
@@ -38,42 +37,42 @@ msgstr ""
 "ス・サーバ・ホスト接続のためjava.net.SocketPermissionを許可する必要がありま"
 "す。"
 
-#: org/postgresql/Driver.java:276 org/postgresql/Driver.java:408
+#: org/postgresql/Driver.java:278 org/postgresql/Driver.java:410
 msgid ""
 "Something unusual has occurred to cause the driver to fail. Please report "
 "this exception."
 msgstr ""
 "ドライバの失敗を引き起こす異常が起こりました。この例外を報告して下さい。"
 
-#: org/postgresql/Driver.java:416
+#: org/postgresql/Driver.java:418
 msgid "Connection attempt timed out."
 msgstr "接続試行がタイムアウトしました。"
 
-#: org/postgresql/Driver.java:429
+#: org/postgresql/Driver.java:431
 msgid "Interrupted while attempting to connect."
 msgstr "接続試行中に割り込みがありました。"
 
-#: org/postgresql/Driver.java:682
+#: org/postgresql/Driver.java:687
 #, java-format
 msgid "Method {0} is not yet implemented."
 msgstr "{0} メソッドはまだ実装されていません。"
 
-#: org/postgresql/PGProperty.java:535 org/postgresql/PGProperty.java:555
+#: org/postgresql/PGProperty.java:537 org/postgresql/PGProperty.java:557
 #, fuzzy, java-format
 msgid "{0} parameter value must be an integer but was: {1}"
 msgstr "unknownLengthパラメータ値は整数でなければなりません"
 
-#: org/postgresql/copy/CopyManager.java:53
+#: org/postgresql/copy/CopyManager.java:49
 #, java-format
 msgid "Requested CopyIn but got {0}"
 msgstr "CopyInを要求しましたが {0} を得ました。"
 
-#: org/postgresql/copy/CopyManager.java:64
+#: org/postgresql/copy/CopyManager.java:60
 #, java-format
 msgid "Requested CopyOut but got {0}"
 msgstr "CopyOutを要求しましたが {0} を得ました。"
 
-#: org/postgresql/copy/CopyManager.java:75
+#: org/postgresql/copy/CopyManager.java:71
 #, fuzzy, java-format
 msgid "Requested CopyDual but got {0}"
 msgstr "CopyOutを要求しましたが {0} を得ました。"
@@ -97,6 +96,11 @@ msgstr "copyからの読み取りに失敗しました。"
 msgid "Cannot write to copy a byte of value {0}"
 msgstr "値{0}のバイトコピーで書き込みができません。"
 
+#: org/postgresql/core/CommandCompleteParser.java:71
+#, fuzzy, java-format
+msgid "Unable to parse the count in command completion tag: {0}."
+msgstr "コマンド完了タグの更新数を解釈することができません: {0}"
+
 #: org/postgresql/core/ConnectionFactory.java:57
 #, java-format
 msgid "A connection could not be made using the requested protocol {0}."
@@ -119,7 +123,7 @@ msgstr ""
 msgid "Expected an EOF from server, got: {0}"
 msgstr "サーバからの EOF が想定されましたが、{0} を得ました。"
 
-#: org/postgresql/core/Parser.java:1006
+#: org/postgresql/core/Parser.java:1051
 #, java-format
 msgid "Malformed function or procedure escape syntax at offset {0}."
 msgstr "正しくない関数または手続きは、位置 {0} で文法を逸しました。"
@@ -178,23 +182,23 @@ msgstr "ゼロ・バイトを識別子に含めることはできません。"
 #: org/postgresql/core/v3/CompositeParameterList.java:33
 #: org/postgresql/core/v3/SimpleParameterList.java:54
 #: org/postgresql/core/v3/SimpleParameterList.java:65
-#: org/postgresql/jdbc/PgResultSet.java:2757
-#: org/postgresql/jdbc/PgResultSetMetaData.java:494
+#: org/postgresql/jdbc/PgResultSet.java:2755
+#: org/postgresql/jdbc/PgResultSetMetaData.java:388
 #, java-format
 msgid "The column index is out of range: {0}, number of columns: {1}."
 msgstr "列インデックスは範囲外です: {0} , 列の数: {1}"
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:109
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:103
 #, fuzzy, java-format
 msgid "Invalid sslmode value: {0}"
 msgstr "無効な sslmode 値です。{0}."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:124
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:118
 #, fuzzy, java-format
 msgid "Invalid targetServerType value: {0}"
 msgstr "無効な sslmode 値です。{0}."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:246
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:239
 #, fuzzy, java-format
 msgid ""
 "Connection to {0} refused. Check that the hostname and port are correct and "
@@ -203,27 +207,27 @@ msgstr ""
 "接続は拒絶されました。ホスト名とポート番号が正しいことと、ポストマスタがTCP/"
 "IP接続を受け入れていることを調べて下さい。"
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:257
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:250
 #: org/postgresql/core/v3/replication/V3ReplicationProtocol.java:133
 msgid "The connection attempt failed."
 msgstr "接続試行は失敗しました。"
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:272
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:265
 #, java-format
 msgid "Could not find a server with specified targetServerType: {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:368
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:381
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:361
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:374
 msgid "The server does not support SSL."
 msgstr "サーバはSSLをサポートしていません。"
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:395
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:388
 msgid "An error occurred while setting up the SSL connection."
 msgstr "SSL接続のセットアップ中に、エラーが起こりました。"
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:496
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:523
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:484
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:511
 msgid ""
 "The server requested password-based authentication, but no password was "
 "provided."
@@ -231,13 +235,13 @@ msgstr ""
 "サーバはパスワード・ベースの認証を要求しましたが、いかなるパスワードも提供さ"
 "れませんでした。"
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:626
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:614
 msgid ""
 "SCRAM authentication is not supported by this driver. You need JDK >= 8 and "
 "pgjdbc >= 42.2.0 (not \".jre\" versions)"
 msgstr ""
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:650
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:638
 #, java-format
 msgid ""
 "The authentication type {0} is not supported. Check that you have configured "
@@ -248,16 +252,16 @@ msgstr ""
 "アドレス、サブネットが含まれているか、そしてドライバがサポートする認証機構を"
 "使っているかを調べてください。"
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:657
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2550
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2581
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2585
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2653
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:645
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2543
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2576
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2580
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2648
 #: org/postgresql/gss/GssAction.java:126
 msgid "Protocol error.  Session setup failed."
 msgstr "プロトコルエラー。セッション設定は失敗しました。"
 
-#: org/postgresql/core/v3/CopyInImpl.java:47
+#: org/postgresql/core/v3/CopyInImpl.java:49
 msgid "CopyIn copy direction can't receive data"
 msgstr ""
 
@@ -265,143 +269,143 @@ msgstr ""
 msgid "CommandComplete expected COPY but got: "
 msgstr "コマンド完了はCOPYを想定しましたが、次の結果を得ました:"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:161
+#: org/postgresql/core/v3/QueryExecutorImpl.java:163
 msgid "Tried to obtain lock while already holding it"
 msgstr "すでに占有している最中のロック取得です。"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:177
+#: org/postgresql/core/v3/QueryExecutorImpl.java:179
 msgid "Tried to break lock on database connection"
 msgstr "データベース接続のロック中断を試みます。"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:195
+#: org/postgresql/core/v3/QueryExecutorImpl.java:197
 msgid "Interrupted while waiting to obtain lock on database connection"
 msgstr "データベース接続でロック待ちの最中に割り込みがありました。"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:327
+#: org/postgresql/core/v3/QueryExecutorImpl.java:329
 msgid "Unable to bind parameter values for statement."
 msgstr "ステートメントのパラメータ値をバインドできません。"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:333
-#: org/postgresql/core/v3/QueryExecutorImpl.java:485
-#: org/postgresql/core/v3/QueryExecutorImpl.java:559
-#: org/postgresql/core/v3/QueryExecutorImpl.java:602
-#: org/postgresql/core/v3/QueryExecutorImpl.java:729
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2372
+#: org/postgresql/core/v3/QueryExecutorImpl.java:335
+#: org/postgresql/core/v3/QueryExecutorImpl.java:487
+#: org/postgresql/core/v3/QueryExecutorImpl.java:561
+#: org/postgresql/core/v3/QueryExecutorImpl.java:604
+#: org/postgresql/core/v3/QueryExecutorImpl.java:731
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2377
 #: org/postgresql/util/StreamWrapper.java:130
 #, fuzzy
 msgid "An I/O error occurred while sending to the backend."
 msgstr "バックエンドに送信中に、入出力エラーが起こりました。"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:534
-#: org/postgresql/core/v3/QueryExecutorImpl.java:576
+#: org/postgresql/core/v3/QueryExecutorImpl.java:536
+#: org/postgresql/core/v3/QueryExecutorImpl.java:578
 #, java-format
 msgid "Expected command status BEGIN, got {0}."
 msgstr "BEGINコマンドステータスを想定しましたが、{0} を得ました。"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:581
+#: org/postgresql/core/v3/QueryExecutorImpl.java:583
 #: org/postgresql/jdbc/PgResultSet.java:1778
 #, java-format
 msgid "Unexpected command status: {0}."
 msgstr "想定外のコマンドステータス: {0}"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:687
+#: org/postgresql/core/v3/QueryExecutorImpl.java:689
 #, fuzzy
 msgid "An error occurred while trying to get the socket timeout."
 msgstr "バックエンドに送信中に、入出力エラーが起こりました。"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:722
-#: org/postgresql/core/v3/QueryExecutorImpl.java:798
+#: org/postgresql/core/v3/QueryExecutorImpl.java:724
+#: org/postgresql/core/v3/QueryExecutorImpl.java:800
 #, java-format
 msgid "Unknown Response Type {0}."
 msgstr "未知の応答型 {0} です。"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:745
+#: org/postgresql/core/v3/QueryExecutorImpl.java:747
 #, fuzzy
 msgid "An error occurred while trying to reset the socket timeout."
 msgstr "バックエンドに送信中に、入出力エラーが起こりました。"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:843
+#: org/postgresql/core/v3/QueryExecutorImpl.java:845
 msgid "Database connection failed when starting copy"
 msgstr "コピー開始時のデータベース接続に失敗しました。"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:878
+#: org/postgresql/core/v3/QueryExecutorImpl.java:880
 msgid "Tried to cancel an inactive copy operation"
 msgstr "動作していないコピー操作の取り消しを試みました。"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:917
+#: org/postgresql/core/v3/QueryExecutorImpl.java:919
 msgid "Database connection failed when canceling copy operation"
 msgstr "コピー操作取り消し時のデータベース接続に失敗しました。"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:933
+#: org/postgresql/core/v3/QueryExecutorImpl.java:935
 msgid "Missing expected error response to copy cancel request"
 msgstr "コピー取り消し要求のエラー応答を想定しました。"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:937
+#: org/postgresql/core/v3/QueryExecutorImpl.java:939
 #, java-format
 msgid "Got {0} error responses to single copy cancel request"
 msgstr "単一copy取り消し要求に {0} エラー応答を得ました。"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:952
+#: org/postgresql/core/v3/QueryExecutorImpl.java:954
 msgid "Tried to end inactive copy"
 msgstr "動作していないコピーの終了を試みました。"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:967
+#: org/postgresql/core/v3/QueryExecutorImpl.java:969
 msgid "Database connection failed when ending copy"
 msgstr "コピー終了時のデータベース接続に失敗しました。"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:985
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1005
+#: org/postgresql/core/v3/QueryExecutorImpl.java:987
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1007
 msgid "Tried to write to an inactive copy operation"
 msgstr "動作していないコピー操作で書き込みを試みました。"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:998
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1013
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1000
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1015
 msgid "Database connection failed when writing to copy"
 msgstr "コピーへの書き込み時のデータベース接続に失敗しました。"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1028
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1030
 msgid "Tried to read from inactive copy"
 msgstr "動作していないコピーから読み取りを試みました。"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1035
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1037
 msgid "Database connection failed when reading from copy"
 msgstr "コピーからの読み取り時のデータベース接続に失敗しました。"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1101
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1103
 #, java-format
 msgid "Received CommandComplete ''{0}'' without an active copy operation"
 msgstr "活動中のコピー操作なしでCommandComplete ''{0}'' を受け取りました。"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1126
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1128
 #, java-format
 msgid "Got CopyInResponse from server during an active {0}"
 msgstr "活動中のサーバ {0} からCopyInResponseを得ました"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1140
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1142
 #, java-format
 msgid "Got CopyOutResponse from server during an active {0}"
 msgstr "活動中のサーバ {0} からCopyOutResponseを得ました"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1154
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1156
 #, fuzzy, java-format
 msgid "Got CopyBothResponse from server during an active {0}"
 msgstr "活動中のサーバ {0} からCopyOutResponseを得ました"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1170
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1172
 msgid "Got CopyData without an active copy operation"
 msgstr "動作中のコピー操作なしでCopyDataを得ました。"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1174
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1176
 #, java-format
 msgid "Unexpected copydata from server for {0}"
 msgstr "{0} のサーバからの思いがけない copydata です。"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1234
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1236
 #, java-format
 msgid "Unexpected packet type during copy: {0}"
 msgstr "コピー中の想定外のパケット型です: {0}"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1524
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1526
 #, java-format
 msgid ""
 "Bind message length {0} too long.  This can be caused by very large or "
@@ -410,20 +414,15 @@ msgstr ""
 "バインドメッセージ長 {0} は長すぎます。InputStreamパラメータにとても大きな長"
 "さ、あるいは不正確な長さが設定されている可能性があります。"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2145
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2150
 msgid "Ran out of memory retrieving query results."
 msgstr "クエリの結果取得にメモリを使い果たしました。"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2313
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2318
 msgid "The driver currently does not support COPY operations."
 msgstr "現在、ドライバはコピー操作をサポートしません。"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2487
-#, fuzzy, java-format
-msgid "Unable to parse the count in command completion tag: {0}."
-msgstr "コマンド完了タグの更新数を解釈することができません: {0}"
-
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2610
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2605
 #, fuzzy, java-format
 msgid ""
 "The server''s client_encoding parameter was changed to {0}. The JDBC driver "
@@ -432,7 +431,7 @@ msgstr ""
 "サーバのclient_encodingパラメータが {0} に変わりました。JDBCドライバは、正し"
 "い操作のためclient_encodingをUNICODEにすることを要求します。"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2620
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2615
 #, java-format
 msgid ""
 "The server''s DateStyle parameter was changed to {0}. The JDBC driver "
@@ -441,7 +440,7 @@ msgstr ""
 "サーバのDateStyleパラメータは、{0} に変わりました。JDBCドライバは、正しい操作"
 "のためISOで開始するDateStyleを要求します。"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2633
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2628
 #, java-format
 msgid ""
 "The server''s standard_conforming_strings parameter was reported as {0}. The "
@@ -504,21 +503,21 @@ msgstr "データソースは閉じられました。"
 msgid "Unsupported property name: {0}"
 msgstr "サポートされない型の値: {0}."
 
-#: org/postgresql/fastpath/Fastpath.java:86
+#: org/postgresql/fastpath/Fastpath.java:84
 #, fuzzy, java-format
 msgid "Fastpath call {0} - No result was returned and we expected a numeric."
 msgstr ""
 "Fastpath 呼び出し {0} - 整数値を想定しましたが、いかなる結果も返されませんで"
 "した。"
 
-#: org/postgresql/fastpath/Fastpath.java:163
+#: org/postgresql/fastpath/Fastpath.java:161
 #, java-format
 msgid "Fastpath call {0} - No result was returned and we expected an integer."
 msgstr ""
 "Fastpath 呼び出し {0} - 整数値を想定しましたが、いかなる結果も返されませんで"
 "した。"
 
-#: org/postgresql/fastpath/Fastpath.java:171
+#: org/postgresql/fastpath/Fastpath.java:169
 #, fuzzy, java-format
 msgid ""
 "Fastpath call {0} - No result was returned or wrong size while expecting an "
@@ -527,14 +526,14 @@ msgstr ""
 "Fastpath 呼び出し {0} - 整数値を想定しましたが、いかなる結果も返されませんで"
 "した。"
 
-#: org/postgresql/fastpath/Fastpath.java:188
+#: org/postgresql/fastpath/Fastpath.java:186
 #, fuzzy, java-format
 msgid "Fastpath call {0} - No result was returned and we expected a long."
 msgstr ""
 "Fastpath 呼び出し {0} - 整数値を想定しましたが、いかなる結果も返されませんで"
 "した。"
 
-#: org/postgresql/fastpath/Fastpath.java:196
+#: org/postgresql/fastpath/Fastpath.java:194
 #, fuzzy, java-format
 msgid ""
 "Fastpath call {0} - No result was returned or wrong size while expecting a "
@@ -543,7 +542,7 @@ msgstr ""
 "Fastpath 呼び出し {0} - 整数値を想定しましたが、いかなる結果も返されませんで"
 "した。"
 
-#: org/postgresql/fastpath/Fastpath.java:308
+#: org/postgresql/fastpath/Fastpath.java:297
 #, java-format
 msgid "The fastpath function {0} is unknown."
 msgstr "{0} は未知の fastpath 関数です。"
@@ -611,63 +610,70 @@ msgid "Cannot cast to boolean: \"{0}\""
 msgstr ""
 
 #: org/postgresql/jdbc/EscapedFunctions.java:240
+#: org/postgresql/jdbc/EscapedFunctions2.java:167
 #, java-format
 msgid "{0} function takes four and only four argument."
 msgstr "{0} 関数は、四つの引数のみを用います。"
 
 #: org/postgresql/jdbc/EscapedFunctions.java:270
-#: org/postgresql/jdbc/EscapedFunctions.java:344
-#: org/postgresql/jdbc/EscapedFunctions.java:749
-#: org/postgresql/jdbc/EscapedFunctions.java:787
+#: org/postgresql/jdbc/EscapedFunctions.java:337
+#: org/postgresql/jdbc/EscapedFunctions.java:740
+#: org/postgresql/jdbc/EscapedFunctions2.java:196
+#: org/postgresql/jdbc/EscapedFunctions2.java:263
+#: org/postgresql/jdbc/EscapedFunctions2.java:665
 #, java-format
 msgid "{0} function takes two and only two arguments."
 msgstr "{0} 関数は、二つの引数のみを用います。"
 
 #: org/postgresql/jdbc/EscapedFunctions.java:288
-#: org/postgresql/jdbc/EscapedFunctions.java:326
-#: org/postgresql/jdbc/EscapedFunctions.java:446
-#: org/postgresql/jdbc/EscapedFunctions.java:461
-#: org/postgresql/jdbc/EscapedFunctions.java:476
-#: org/postgresql/jdbc/EscapedFunctions.java:491
-#: org/postgresql/jdbc/EscapedFunctions.java:506
-#: org/postgresql/jdbc/EscapedFunctions.java:521
-#: org/postgresql/jdbc/EscapedFunctions.java:536
-#: org/postgresql/jdbc/EscapedFunctions.java:551
-#: org/postgresql/jdbc/EscapedFunctions.java:566
-#: org/postgresql/jdbc/EscapedFunctions.java:581
-#: org/postgresql/jdbc/EscapedFunctions.java:596
-#: org/postgresql/jdbc/EscapedFunctions.java:611
-#: org/postgresql/jdbc/EscapedFunctions.java:775
+#: org/postgresql/jdbc/EscapedFunctions.java:441
+#: org/postgresql/jdbc/EscapedFunctions.java:467
+#: org/postgresql/jdbc/EscapedFunctions.java:526
+#: org/postgresql/jdbc/EscapedFunctions.java:728
+#: org/postgresql/jdbc/EscapedFunctions2.java:211
+#: org/postgresql/jdbc/EscapedFunctions2.java:355
+#: org/postgresql/jdbc/EscapedFunctions2.java:381
+#: org/postgresql/jdbc/EscapedFunctions2.java:440
+#: org/postgresql/jdbc/EscapedFunctions2.java:654
 #, java-format
 msgid "{0} function takes one and only one argument."
 msgstr "{0} 関数は、単一の引数のみを用います。"
 
-#: org/postgresql/jdbc/EscapedFunctions.java:310
-#: org/postgresql/jdbc/EscapedFunctions.java:391
+#: org/postgresql/jdbc/EscapedFunctions.java:312
+#: org/postgresql/jdbc/EscapedFunctions.java:386
+#: org/postgresql/jdbc/EscapedFunctions2.java:238
+#: org/postgresql/jdbc/EscapedFunctions2.java:307
 #, java-format
 msgid "{0} function takes two or three arguments."
 msgstr "{0} 関数は、二つ、または三つの引数を用います。"
 
-#: org/postgresql/jdbc/EscapedFunctions.java:416
-#: org/postgresql/jdbc/EscapedFunctions.java:431
-#: org/postgresql/jdbc/EscapedFunctions.java:734
-#: org/postgresql/jdbc/EscapedFunctions.java:764
+#: org/postgresql/jdbc/EscapedFunctions.java:411
+#: org/postgresql/jdbc/EscapedFunctions.java:426
+#: org/postgresql/jdbc/EscapedFunctions.java:693
+#: org/postgresql/jdbc/EscapedFunctions.java:719
+#: org/postgresql/jdbc/EscapedFunctions2.java:645
 #, java-format
 msgid "{0} function doesn''t take any argument."
 msgstr "{0} 関数は、どのような引数も用いません。"
 
-#: org/postgresql/jdbc/EscapedFunctions.java:627
-#: org/postgresql/jdbc/EscapedFunctions.java:680
+#: org/postgresql/jdbc/EscapedFunctions.java:586
+#: org/postgresql/jdbc/EscapedFunctions.java:639
+#: org/postgresql/jdbc/EscapedFunctions2.java:500
+#: org/postgresql/jdbc/EscapedFunctions2.java:571
 #, java-format
 msgid "{0} function takes three and only three arguments."
 msgstr "{0} 関数は、三つの引数のみを用います。"
 
-#: org/postgresql/jdbc/EscapedFunctions.java:640
-#: org/postgresql/jdbc/EscapedFunctions.java:661
-#: org/postgresql/jdbc/EscapedFunctions.java:664
-#: org/postgresql/jdbc/EscapedFunctions.java:697
-#: org/postgresql/jdbc/EscapedFunctions.java:710
-#: org/postgresql/jdbc/EscapedFunctions.java:713
+#: org/postgresql/jdbc/EscapedFunctions.java:599
+#: org/postgresql/jdbc/EscapedFunctions.java:620
+#: org/postgresql/jdbc/EscapedFunctions.java:623
+#: org/postgresql/jdbc/EscapedFunctions.java:656
+#: org/postgresql/jdbc/EscapedFunctions.java:669
+#: org/postgresql/jdbc/EscapedFunctions.java:672
+#: org/postgresql/jdbc/EscapedFunctions2.java:510
+#: org/postgresql/jdbc/EscapedFunctions2.java:527
+#: org/postgresql/jdbc/EscapedFunctions2.java:585
+#: org/postgresql/jdbc/EscapedFunctions2.java:597
 #, java-format
 msgid "Interval {0} not yet implemented"
 msgstr "間隔 {0} はまだ実装されていません。"
@@ -686,17 +692,17 @@ msgstr "名前の付いたsavepointのidを取得することができません�
 msgid "Cannot retrieve the name of an unnamed savepoint."
 msgstr "名前のないsavepointの名前を取得することができません。"
 
-#: org/postgresql/jdbc/PgArray.java:157 org/postgresql/jdbc/PgArray.java:844
+#: org/postgresql/jdbc/PgArray.java:155 org/postgresql/jdbc/PgArray.java:842
 #, java-format
 msgid "The array index is out of range: {0}"
 msgstr "配列インデックスは、範囲外です: {0}"
 
-#: org/postgresql/jdbc/PgArray.java:178 org/postgresql/jdbc/PgArray.java:861
+#: org/postgresql/jdbc/PgArray.java:176 org/postgresql/jdbc/PgArray.java:859
 #, java-format
 msgid "The array index is out of range: {0}, number of elements: {1}."
 msgstr "配列インデックスは、範囲外です: {0} 、要素の数: {1}"
 
-#: org/postgresql/jdbc/PgArray.java:210
+#: org/postgresql/jdbc/PgArray.java:208
 #: org/postgresql/jdbc/PgResultSet.java:1930
 #: org/postgresql/util/HStoreConverter.java:43
 #: org/postgresql/util/HStoreConverter.java:74
@@ -710,16 +716,16 @@ msgstr ""
 "セットにとって無効である文字を含むデータが格納されたことによって引き起こされ"
 "ます。最も一般的な例は、SQL_ASCIIデータベースに保存された8bitデータ等です。"
 
-#: org/postgresql/jdbc/PgCallableStatement.java:86
-#: org/postgresql/jdbc/PgCallableStatement.java:96
+#: org/postgresql/jdbc/PgCallableStatement.java:85
+#: org/postgresql/jdbc/PgCallableStatement.java:95
 msgid "A CallableStatement was executed with nothing returned."
 msgstr "CallableStatementは、戻りなしで実行されました。"
 
-#: org/postgresql/jdbc/PgCallableStatement.java:107
+#: org/postgresql/jdbc/PgCallableStatement.java:106
 msgid "A CallableStatement was executed with an invalid number of parameters"
 msgstr "CallableStatementは、不正な数のパラメータで実行されました。"
 
-#: org/postgresql/jdbc/PgCallableStatement.java:145
+#: org/postgresql/jdbc/PgCallableStatement.java:144
 #, java-format
 msgid ""
 "A CallableStatement function was executed and the out parameter {0} was of "
@@ -728,7 +734,7 @@ msgstr ""
 "CallableStatement機能が実行され、出力パラメータ {0} は、型 {1} でした。しか"
 "し、型 {2} が登録されました。"
 
-#: org/postgresql/jdbc/PgCallableStatement.java:202
+#: org/postgresql/jdbc/PgCallableStatement.java:206
 msgid ""
 "This statement does not declare an OUT parameter.  Use '{' ?= call ... '}' "
 "to declare one."
@@ -736,12 +742,12 @@ msgstr ""
 "ステートメントは、OUTパラメータを宣言していません。'{' ?= call ... '}' を使っ"
 "て宣言して下さい。"
 
-#: org/postgresql/jdbc/PgCallableStatement.java:246
+#: org/postgresql/jdbc/PgCallableStatement.java:229
 msgid "wasNull cannot be call before fetching a result."
 msgstr "wasNullは、結果フェッチ前に呼び出せません。"
 
-#: org/postgresql/jdbc/PgCallableStatement.java:384
-#: org/postgresql/jdbc/PgCallableStatement.java:403
+#: org/postgresql/jdbc/PgCallableStatement.java:367
+#: org/postgresql/jdbc/PgCallableStatement.java:386
 #, java-format
 msgid ""
 "Parameter of type {0} was registered, but call to get{1} (sqltype={2}) was "
@@ -750,7 +756,7 @@ msgstr ""
 "型 {0}  のパラメータが登録されましたが、get{1} (sqltype={2}) が呼び出されまし"
 "た。"
 
-#: org/postgresql/jdbc/PgCallableStatement.java:424
+#: org/postgresql/jdbc/PgCallableStatement.java:407
 msgid ""
 "A CallableStatement was declared, but no call to registerOutParameter(1, "
 "<some type>) was made."
@@ -758,27 +764,27 @@ msgstr ""
 "CallableStatementは宣言されましたが、registerOutParameter(1, <some type>) は"
 "呼び出されませんでした。"
 
-#: org/postgresql/jdbc/PgCallableStatement.java:430
+#: org/postgresql/jdbc/PgCallableStatement.java:413
 msgid "No function outputs were registered."
 msgstr "関数出力は登録されませんでした。"
 
-#: org/postgresql/jdbc/PgCallableStatement.java:436
+#: org/postgresql/jdbc/PgCallableStatement.java:419
 msgid ""
 "Results cannot be retrieved from a CallableStatement before it is executed."
 msgstr "実行される前に、CallableStatement から結果を得ることはできません。"
 
-#: org/postgresql/jdbc/PgCallableStatement.java:703
+#: org/postgresql/jdbc/PgCallableStatement.java:686
 #, fuzzy, java-format
 msgid "Unsupported type conversion to {1}."
 msgstr "サポートされないバイナリエンコーディングです: {0}."
 
-#: org/postgresql/jdbc/PgConnection.java:272
+#: org/postgresql/jdbc/PgConnection.java:241
 #, java-format
 msgid "Unsupported value for stringtype parameter: {0}"
 msgstr "サポートされないstringtypeパラメータ値です: {0}"
 
 #: org/postgresql/jdbc/PgConnection.java:424
-#: org/postgresql/jdbc/PgPreparedStatement.java:119
+#: org/postgresql/jdbc/PgPreparedStatement.java:107
 #: org/postgresql/jdbc/PgStatement.java:225
 #: org/postgresql/jdbc/TypeInfoCache.java:226
 #: org/postgresql/jdbc/TypeInfoCache.java:371
@@ -790,126 +796,126 @@ msgstr "サポートされないstringtypeパラメータ値です: {0}"
 msgid "No results were returned by the query."
 msgstr "いかなる結果も、クエリによって返されませんでした。"
 
-#: org/postgresql/jdbc/PgConnection.java:441
+#: org/postgresql/jdbc/PgConnection.java:442
 #: org/postgresql/jdbc/PgStatement.java:254
 msgid "A result was returned when none was expected."
 msgstr "結果がないことを想定しましたが、結果が返されました。"
 
-#: org/postgresql/jdbc/PgConnection.java:545
+#: org/postgresql/jdbc/PgConnection.java:547
 msgid "Custom type maps are not supported."
 msgstr "カスタム型マップはサポートされません。"
 
-#: org/postgresql/jdbc/PgConnection.java:587
+#: org/postgresql/jdbc/PgConnection.java:589
 #, java-format
 msgid "Failed to create object for: {0}."
 msgstr "{0} へのオブジェクト生成に失敗しました。"
 
-#: org/postgresql/jdbc/PgConnection.java:641
+#: org/postgresql/jdbc/PgConnection.java:643
 #, java-format
 msgid "Unable to load the class {0} responsible for the datatype {1}"
 msgstr "データ型 {1} に対応するクラス{0} をロードできません。"
 
-#: org/postgresql/jdbc/PgConnection.java:693
+#: org/postgresql/jdbc/PgConnection.java:705
 msgid ""
 "Cannot change transaction read-only property in the middle of a transaction."
 msgstr ""
 "トランザクションの最中に読み出し専用プロパティを変えることはできません。"
 
-#: org/postgresql/jdbc/PgConnection.java:756
+#: org/postgresql/jdbc/PgConnection.java:772
 msgid "Cannot commit when autoCommit is enabled."
 msgstr "autoCommit有効時に、明示的なコミットはできません。"
 
-#: org/postgresql/jdbc/PgConnection.java:767
-#: org/postgresql/jdbc/PgConnection.java:1384
-#: org/postgresql/jdbc/PgConnection.java:1428
+#: org/postgresql/jdbc/PgConnection.java:783
+#: org/postgresql/jdbc/PgConnection.java:1401
+#: org/postgresql/jdbc/PgConnection.java:1445
 msgid "This connection has been closed."
 msgstr "この接続は既に閉じられています。"
 
-#: org/postgresql/jdbc/PgConnection.java:777
+#: org/postgresql/jdbc/PgConnection.java:794
 msgid "Cannot rollback when autoCommit is enabled."
 msgstr "autoCommit有効時に、明示的なロールバックはできません。"
 
-#: org/postgresql/jdbc/PgConnection.java:827
+#: org/postgresql/jdbc/PgConnection.java:844
 msgid ""
 "Cannot change transaction isolation level in the middle of a transaction."
 msgstr "トランザクションの最中に隔離レベルを変えることができません。"
 
-#: org/postgresql/jdbc/PgConnection.java:833
+#: org/postgresql/jdbc/PgConnection.java:850
 #, java-format
 msgid "Transaction isolation level {0} not supported."
 msgstr "トランザクション隔離レベル{0} はサポートされていません。"
 
-#: org/postgresql/jdbc/PgConnection.java:878
+#: org/postgresql/jdbc/PgConnection.java:895
 msgid "Finalizing a Connection that was never closed:"
 msgstr "接続終了で閉じられませんでした:"
 
-#: org/postgresql/jdbc/PgConnection.java:945
+#: org/postgresql/jdbc/PgConnection.java:962
 msgid "Unable to translate data into the desired encoding."
 msgstr "望む符号化にデータを訳すことができません。"
 
-#: org/postgresql/jdbc/PgConnection.java:1008
+#: org/postgresql/jdbc/PgConnection.java:1025
 #: org/postgresql/jdbc/PgResultSet.java:1817
-#: org/postgresql/jdbc/PgStatement.java:903
+#: org/postgresql/jdbc/PgStatement.java:908
 msgid "Fetch size must be a value greater to or equal to 0."
 msgstr "フェッチサイズは、0に等しいか、より大きな値でなくてはなりません。"
 
-#: org/postgresql/jdbc/PgConnection.java:1289
-#: org/postgresql/jdbc/PgConnection.java:1330
+#: org/postgresql/jdbc/PgConnection.java:1306
+#: org/postgresql/jdbc/PgConnection.java:1347
 #, java-format
 msgid "Unable to find server array type for provided name {0}."
 msgstr "提供名 {0} で、サーバの配列型を見つけることができません。"
 
-#: org/postgresql/jdbc/PgConnection.java:1312
+#: org/postgresql/jdbc/PgConnection.java:1329
 #, fuzzy, java-format
 msgid "Invalid elements {0}"
 msgstr "無効なフラグです。{0}"
 
-#: org/postgresql/jdbc/PgConnection.java:1348
+#: org/postgresql/jdbc/PgConnection.java:1365
 #, fuzzy, java-format
 msgid "Invalid timeout ({0}<0)."
 msgstr "無効なタイムアウト値です ({0}<0)。"
 
-#: org/postgresql/jdbc/PgConnection.java:1372
+#: org/postgresql/jdbc/PgConnection.java:1389
 msgid "Validating connection."
 msgstr "有効確認の接続"
 
-#: org/postgresql/jdbc/PgConnection.java:1405
+#: org/postgresql/jdbc/PgConnection.java:1422
 #, fuzzy, java-format
 msgid "Failed to set ClientInfo property: {0}"
 msgstr "ClientInfo プロパティ:{0} の設定に失敗しました。"
 
-#: org/postgresql/jdbc/PgConnection.java:1415
+#: org/postgresql/jdbc/PgConnection.java:1432
 msgid "ClientInfo property not supported."
 msgstr "ClientInfo プロパティはサポートされていません。"
 
-#: org/postgresql/jdbc/PgConnection.java:1441
+#: org/postgresql/jdbc/PgConnection.java:1458
 msgid "One ore more ClientInfo failed."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1540
+#: org/postgresql/jdbc/PgConnection.java:1559
 #, fuzzy
 msgid "Network timeout must be a value greater than or equal to 0."
 msgstr "クエリタイムアウトは、0に等しいか、より大きな値でなくてはなりません。"
 
-#: org/postgresql/jdbc/PgConnection.java:1552
+#: org/postgresql/jdbc/PgConnection.java:1571
 msgid "Unable to set network timeout."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1563
+#: org/postgresql/jdbc/PgConnection.java:1582
 msgid "Unable to get network timeout."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1580
+#: org/postgresql/jdbc/PgConnection.java:1599
 #, java-format
 msgid "Unknown ResultSet holdability setting: {0}."
 msgstr "未知の ResultSet に対するholdability設定です: {0}"
 
-#: org/postgresql/jdbc/PgConnection.java:1598
-#: org/postgresql/jdbc/PgConnection.java:1619
+#: org/postgresql/jdbc/PgConnection.java:1617
+#: org/postgresql/jdbc/PgConnection.java:1638
 msgid "Cannot establish a savepoint in auto-commit mode."
 msgstr "自動コミットモードでsavepointを作成できません。"
 
-#: org/postgresql/jdbc/PgConnection.java:1685
+#: org/postgresql/jdbc/PgConnection.java:1707
 msgid "Returning autogenerated keys is not supported."
 msgstr "自動生成キーを返すことはサポートされていません。"
 
@@ -925,47 +931,47 @@ msgstr ""
 msgid "Unable to find name datatype in the system catalogs."
 msgstr "名前データ型をシステムカタログで見つけることができません。"
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:323
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:322
 #, fuzzy
 msgid "Unable to find keywords in the system catalogs."
 msgstr "名前データ型をシステムカタログで見つけることができません。"
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1105
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1095
 msgid "oid"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1105
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1095
 msgid "proname"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1107
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1558
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1097
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1548
 msgid "typtype"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1110
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1100
 msgid "proargtypes"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1576
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1566
 msgid "adsrc"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1589
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1579
 msgid "attidentity"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1685
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1761
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1675
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1751
 msgid "rolname"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1686
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1762
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1676
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1752
 msgid "relacl"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1692
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1682
 msgid "attacl"
 msgstr ""
 
@@ -974,66 +980,66 @@ msgstr ""
 msgid "The parameter index is out of range: {0}, number of parameters: {1}."
 msgstr "パラメータ・インデックスは範囲外です: {0} , パラメータ数: {1}"
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:106
+#: org/postgresql/jdbc/PgPreparedStatement.java:94
+#: org/postgresql/jdbc/PgPreparedStatement.java:115
 #: org/postgresql/jdbc/PgPreparedStatement.java:127
-#: org/postgresql/jdbc/PgPreparedStatement.java:139
-#: org/postgresql/jdbc/PgPreparedStatement.java:1035
+#: org/postgresql/jdbc/PgPreparedStatement.java:1008
 msgid ""
 "Can''t use query methods that take a query string on a PreparedStatement."
 msgstr "PreparedStatementでクエリ文字を持ったクエリメソッドは使えません。"
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:249
+#: org/postgresql/jdbc/PgPreparedStatement.java:237
 msgid "Unknown Types value."
 msgstr "未知の型の値です。"
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:382
-#: org/postgresql/jdbc/PgPreparedStatement.java:439
-#: org/postgresql/jdbc/PgPreparedStatement.java:1191
-#: org/postgresql/jdbc/PgPreparedStatement.java:1490
+#: org/postgresql/jdbc/PgPreparedStatement.java:364
+#: org/postgresql/jdbc/PgPreparedStatement.java:421
+#: org/postgresql/jdbc/PgPreparedStatement.java:1164
+#: org/postgresql/jdbc/PgPreparedStatement.java:1472
 #, java-format
 msgid "Invalid stream length {0}."
 msgstr "無効なストリーム長 {0}."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:411
+#: org/postgresql/jdbc/PgPreparedStatement.java:393
 #, java-format
 msgid "The JVM claims not to support the {0} encoding."
 msgstr "JVMは、エンコーディング {0} をサポートしません。"
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:414
+#: org/postgresql/jdbc/PgPreparedStatement.java:396
 #: org/postgresql/jdbc/PgResultSet.java:1122
 #: org/postgresql/jdbc/PgResultSet.java:1156
 msgid "Provided InputStream failed."
 msgstr "提供された InputStream は失敗しました。"
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:460
-#: org/postgresql/jdbc/PgPreparedStatement.java:1096
+#: org/postgresql/jdbc/PgPreparedStatement.java:442
+#: org/postgresql/jdbc/PgPreparedStatement.java:1069
 #, java-format
 msgid "Unknown type {0}."
 msgstr "未知の型 {0}."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:477
+#: org/postgresql/jdbc/PgPreparedStatement.java:459
 msgid "No hstore extension installed."
 msgstr "hstore 拡張がインストールされてません。"
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:619
-#: org/postgresql/jdbc/PgPreparedStatement.java:642
-#: org/postgresql/jdbc/PgPreparedStatement.java:652
-#: org/postgresql/jdbc/PgPreparedStatement.java:664
+#: org/postgresql/jdbc/PgPreparedStatement.java:601
+#: org/postgresql/jdbc/PgPreparedStatement.java:624
+#: org/postgresql/jdbc/PgPreparedStatement.java:634
+#: org/postgresql/jdbc/PgPreparedStatement.java:646
 #, java-format
 msgid "Cannot cast an instance of {0} to type {1}"
 msgstr "インスタンス {0} を型 {1} へキャストできません"
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:682
+#: org/postgresql/jdbc/PgPreparedStatement.java:664
 #, java-format
 msgid "Unsupported Types value: {0}"
 msgstr "サポートされない型の値: {0}."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:894
+#: org/postgresql/jdbc/PgPreparedStatement.java:876
 #, java-format
 msgid "Cannot convert an instance of {0} to type {1}"
 msgstr "型 {1} に {0} のインスタンスを変換できません。"
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:968
+#: org/postgresql/jdbc/PgPreparedStatement.java:950
 #, java-format
 msgid ""
 "Can''t infer the SQL type to use for an instance of {0}. Use setObject() "
@@ -1042,18 +1048,18 @@ msgstr ""
 "インスタンス {0} で使うべきSQL型を推測できません。明確な型値を記述した "
 "setObject() を使ってください。"
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:1133
-#: org/postgresql/jdbc/PgPreparedStatement.java:1233
+#: org/postgresql/jdbc/PgPreparedStatement.java:1106
+#: org/postgresql/jdbc/PgPreparedStatement.java:1206
 msgid "Unexpected error writing large object to database."
 msgstr ""
 "データベースへのラージオブジェクト書き込み中に想定外のエラーが起きました。"
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:1178
+#: org/postgresql/jdbc/PgPreparedStatement.java:1151
 #: org/postgresql/jdbc/PgResultSet.java:1210
 msgid "Provided Reader failed."
 msgstr "提供された Reader は失敗しました。"
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:1449
+#: org/postgresql/jdbc/PgPreparedStatement.java:1431
 #: org/postgresql/util/StreamWrapper.java:56
 msgid "Object is too large to send over the protocol."
 msgstr "プロトコルで送信するにはオブジェクトが大きすぎます。"
@@ -1071,8 +1077,8 @@ msgstr ""
 #: org/postgresql/jdbc/PgResultSet.java:556
 #: org/postgresql/jdbc/PgResultSet.java:594
 #: org/postgresql/jdbc/PgResultSet.java:624
-#: org/postgresql/jdbc/PgResultSet.java:3014
-#: org/postgresql/jdbc/PgResultSet.java:3058
+#: org/postgresql/jdbc/PgResultSet.java:3012
+#: org/postgresql/jdbc/PgResultSet.java:3057
 #, fuzzy, java-format
 msgid "Cannot convert the column of type {0} to requested type {1}."
 msgstr "型 {0} の列値を型 {1} に変換できません。"
@@ -1084,7 +1090,7 @@ msgid "Can''t use relative move methods while on the insert row."
 msgstr "行挿入の最中に関連の動作方法を使うことはできません。"
 
 #: org/postgresql/jdbc/PgResultSet.java:878
-#: org/postgresql/jdbc/PgStatement.java:895
+#: org/postgresql/jdbc/PgStatement.java:900
 #, java-format
 msgid "Invalid fetch direction constant: {0}."
 msgstr "無効なフェッチ方向の定数です: {0}"
@@ -1127,8 +1133,8 @@ msgstr "行挿入には、最低でも１つの列の値が必要です。"
 
 #: org/postgresql/jdbc/PgResultSet.java:1119
 #: org/postgresql/jdbc/PgResultSet.java:1754
-#: org/postgresql/jdbc/PgResultSet.java:2422
-#: org/postgresql/jdbc/PgResultSet.java:2443
+#: org/postgresql/jdbc/PgResultSet.java:2420
+#: org/postgresql/jdbc/PgResultSet.java:2441
 #, java-format
 msgid "The JVM claims not to support the encoding: {0}"
 msgstr "JVMでサポートされないエンコーディングです: {0}"
@@ -1142,7 +1148,7 @@ msgid "Cannot call updateRow() when on the insert row."
 msgstr "行を挿入したときに、updateRow() を呼び出すことができません。"
 
 #: org/postgresql/jdbc/PgResultSet.java:1335
-#: org/postgresql/jdbc/PgResultSet.java:3075
+#: org/postgresql/jdbc/PgResultSet.java:3074
 msgid ""
 "Cannot update the ResultSet because it is either before the start or after "
 "the end of the results."
@@ -1159,27 +1165,27 @@ msgstr "テーブル {0} の主キーがありません。"
 
 #: org/postgresql/jdbc/PgResultSet.java:2017
 #: org/postgresql/jdbc/PgResultSet.java:2022
-#: org/postgresql/jdbc/PgResultSet.java:2809
-#: org/postgresql/jdbc/PgResultSet.java:2815
-#: org/postgresql/jdbc/PgResultSet.java:2840
-#: org/postgresql/jdbc/PgResultSet.java:2846
-#: org/postgresql/jdbc/PgResultSet.java:2870
-#: org/postgresql/jdbc/PgResultSet.java:2875
-#: org/postgresql/jdbc/PgResultSet.java:2891
-#: org/postgresql/jdbc/PgResultSet.java:2912
-#: org/postgresql/jdbc/PgResultSet.java:2923
-#: org/postgresql/jdbc/PgResultSet.java:2936
-#: org/postgresql/jdbc/PgResultSet.java:3063
+#: org/postgresql/jdbc/PgResultSet.java:2807
+#: org/postgresql/jdbc/PgResultSet.java:2813
+#: org/postgresql/jdbc/PgResultSet.java:2838
+#: org/postgresql/jdbc/PgResultSet.java:2844
+#: org/postgresql/jdbc/PgResultSet.java:2868
+#: org/postgresql/jdbc/PgResultSet.java:2873
+#: org/postgresql/jdbc/PgResultSet.java:2889
+#: org/postgresql/jdbc/PgResultSet.java:2910
+#: org/postgresql/jdbc/PgResultSet.java:2921
+#: org/postgresql/jdbc/PgResultSet.java:2934
+#: org/postgresql/jdbc/PgResultSet.java:3062
 #, java-format
 msgid "Bad value for type {0} : {1}"
 msgstr "型 {0} で不正な値 : {1}"
 
-#: org/postgresql/jdbc/PgResultSet.java:2595
+#: org/postgresql/jdbc/PgResultSet.java:2593
 #, java-format
 msgid "The column name {0} was not found in this ResultSet."
 msgstr "ResultSet に列名 {0} は見つかりませんでした。"
 
-#: org/postgresql/jdbc/PgResultSet.java:2731
+#: org/postgresql/jdbc/PgResultSet.java:2729
 msgid ""
 "ResultSet is not updateable.  The query that generated this result set must "
 "select only one table, and must select all primary keys from that table. See "
@@ -1189,42 +1195,42 @@ msgstr ""
 "のテーブルを選び、そのテーブルから全ての主キーを選ばなくてはいけません。より"
 "多くの詳細に関して JDBC 2.1 API仕様、章 5.6 を参照して下さい。"
 
-#: org/postgresql/jdbc/PgResultSet.java:2743
+#: org/postgresql/jdbc/PgResultSet.java:2741
 msgid "This ResultSet is closed."
 msgstr "ResultSetは閉じられました。"
 
-#: org/postgresql/jdbc/PgResultSet.java:2774
+#: org/postgresql/jdbc/PgResultSet.java:2772
 msgid "ResultSet not positioned properly, perhaps you need to call next."
 msgstr ""
 "適切な位置を指していないResultSetです。おそらく、nextを呼ぶ必要があります。"
 
-#: org/postgresql/jdbc/PgResultSet.java:3095
+#: org/postgresql/jdbc/PgResultSet.java:3094
 msgid "Invalid UUID data."
 msgstr "無効なUUIDデータです。"
 
-#: org/postgresql/jdbc/PgResultSet.java:3184
-#: org/postgresql/jdbc/PgResultSet.java:3191
-#: org/postgresql/jdbc/PgResultSet.java:3202
-#: org/postgresql/jdbc/PgResultSet.java:3213
-#: org/postgresql/jdbc/PgResultSet.java:3224
-#: org/postgresql/jdbc/PgResultSet.java:3235
-#: org/postgresql/jdbc/PgResultSet.java:3246
-#: org/postgresql/jdbc/PgResultSet.java:3257
-#: org/postgresql/jdbc/PgResultSet.java:3268
-#: org/postgresql/jdbc/PgResultSet.java:3275
-#: org/postgresql/jdbc/PgResultSet.java:3282
-#: org/postgresql/jdbc/PgResultSet.java:3293
-#: org/postgresql/jdbc/PgResultSet.java:3310
-#: org/postgresql/jdbc/PgResultSet.java:3317
-#: org/postgresql/jdbc/PgResultSet.java:3324
-#: org/postgresql/jdbc/PgResultSet.java:3335
-#: org/postgresql/jdbc/PgResultSet.java:3342
-#: org/postgresql/jdbc/PgResultSet.java:3349
-#: org/postgresql/jdbc/PgResultSet.java:3387
-#: org/postgresql/jdbc/PgResultSet.java:3394
-#: org/postgresql/jdbc/PgResultSet.java:3401
-#: org/postgresql/jdbc/PgResultSet.java:3421
-#: org/postgresql/jdbc/PgResultSet.java:3434
+#: org/postgresql/jdbc/PgResultSet.java:3183
+#: org/postgresql/jdbc/PgResultSet.java:3190
+#: org/postgresql/jdbc/PgResultSet.java:3201
+#: org/postgresql/jdbc/PgResultSet.java:3212
+#: org/postgresql/jdbc/PgResultSet.java:3223
+#: org/postgresql/jdbc/PgResultSet.java:3234
+#: org/postgresql/jdbc/PgResultSet.java:3245
+#: org/postgresql/jdbc/PgResultSet.java:3256
+#: org/postgresql/jdbc/PgResultSet.java:3267
+#: org/postgresql/jdbc/PgResultSet.java:3274
+#: org/postgresql/jdbc/PgResultSet.java:3281
+#: org/postgresql/jdbc/PgResultSet.java:3292
+#: org/postgresql/jdbc/PgResultSet.java:3309
+#: org/postgresql/jdbc/PgResultSet.java:3316
+#: org/postgresql/jdbc/PgResultSet.java:3323
+#: org/postgresql/jdbc/PgResultSet.java:3334
+#: org/postgresql/jdbc/PgResultSet.java:3341
+#: org/postgresql/jdbc/PgResultSet.java:3348
+#: org/postgresql/jdbc/PgResultSet.java:3386
+#: org/postgresql/jdbc/PgResultSet.java:3393
+#: org/postgresql/jdbc/PgResultSet.java:3400
+#: org/postgresql/jdbc/PgResultSet.java:3420
+#: org/postgresql/jdbc/PgResultSet.java:3433
 #, fuzzy, java-format
 msgid "conversion to {0} from {1} not supported"
 msgstr "トランザクション隔離レベル{0} はサポートされていません。"
@@ -1290,33 +1296,33 @@ msgstr ""
 msgid "Maximum number of rows must be a value grater than or equal to 0."
 msgstr "行の最大数は、0に等しいか、より大きな値でなくてはなりません。"
 
-#: org/postgresql/jdbc/PgStatement.java:550
+#: org/postgresql/jdbc/PgStatement.java:555
 msgid "Query timeout must be a value greater than or equals to 0."
 msgstr "クエリタイムアウトは、0に等しいか、より大きな値でなくてはなりません。"
 
-#: org/postgresql/jdbc/PgStatement.java:590
+#: org/postgresql/jdbc/PgStatement.java:595
 msgid "The maximum field size must be a value greater than or equal to 0."
 msgstr "最大の項目サイズは、0に等しいか、より大きな値でなくてはなりません。"
 
-#: org/postgresql/jdbc/PgStatement.java:689
+#: org/postgresql/jdbc/PgStatement.java:694
 msgid "This statement has been closed."
 msgstr "このステートメントは閉じられました。"
 
-#: org/postgresql/jdbc/PgStatement.java:1145
-#: org/postgresql/jdbc/PgStatement.java:1173
+#: org/postgresql/jdbc/PgStatement.java:1150
+#: org/postgresql/jdbc/PgStatement.java:1178
 msgid "Returning autogenerated keys by column index is not supported."
 msgstr "列インデックスで自動生成キーを返すことはサポートされていません。"
 
-#: org/postgresql/jdbc/TimestampUtils.java:355
-#: org/postgresql/jdbc/TimestampUtils.java:423
+#: org/postgresql/jdbc/TimestampUtils.java:365
+#: org/postgresql/jdbc/TimestampUtils.java:433
 #, fuzzy, java-format
 msgid "Bad value for type timestamp/date/time: {1}"
 msgstr "型 {0} で不正な値 : {1}"
 
-#: org/postgresql/jdbc/TimestampUtils.java:858
-#: org/postgresql/jdbc/TimestampUtils.java:915
-#: org/postgresql/jdbc/TimestampUtils.java:961
-#: org/postgresql/jdbc/TimestampUtils.java:1010
+#: org/postgresql/jdbc/TimestampUtils.java:914
+#: org/postgresql/jdbc/TimestampUtils.java:971
+#: org/postgresql/jdbc/TimestampUtils.java:1017
+#: org/postgresql/jdbc/TimestampUtils.java:1066
 #, fuzzy, java-format
 msgid "Unsupported binary encoding of {0}."
 msgstr "サポートされないバイナリエンコーディングです: {0}."
@@ -1329,31 +1335,31 @@ msgstr ""
 msgid "Invalid or unsupported by client SCRAM mechanisms"
 msgstr ""
 
-#: org/postgresql/jre8/sasl/ScramAuthenticator.java:117
+#: org/postgresql/jre8/sasl/ScramAuthenticator.java:119
 #, fuzzy, java-format
 msgid "Invalid server-first-message: {0}"
 msgstr "無効な sslmode 値です。{0}."
 
-#: org/postgresql/jre8/sasl/ScramAuthenticator.java:147
+#: org/postgresql/jre8/sasl/ScramAuthenticator.java:151
 #, fuzzy, java-format
 msgid "Invalid server-final-message: {0}"
 msgstr "無効な sslmode 値です。{0}."
 
-#: org/postgresql/jre8/sasl/ScramAuthenticator.java:153
+#: org/postgresql/jre8/sasl/ScramAuthenticator.java:157
 #, java-format
 msgid "SCRAM authentication failed, server returned error: {0}"
 msgstr ""
 
-#: org/postgresql/jre8/sasl/ScramAuthenticator.java:160
+#: org/postgresql/jre8/sasl/ScramAuthenticator.java:164
 msgid "Invalid server SCRAM signature"
 msgstr ""
 
-#: org/postgresql/largeobject/LargeObjectManager.java:144
+#: org/postgresql/largeobject/LargeObjectManager.java:136
 msgid "Failed to initialize LargeObject API"
 msgstr "ラージオブジェクトAPIの初期化に失敗しました。"
 
-#: org/postgresql/largeobject/LargeObjectManager.java:262
-#: org/postgresql/largeobject/LargeObjectManager.java:305
+#: org/postgresql/largeobject/LargeObjectManager.java:254
+#: org/postgresql/largeobject/LargeObjectManager.java:295
 msgid "Large Objects may not be used in auto-commit mode."
 msgstr "ラージオブジェクトは、自動コミットモードで使うことができません。"
 
@@ -1387,34 +1393,34 @@ msgstr "ホスト名 {0} は、hostnameverifier {1} で確認できませんで�
 msgid "The hostname {0} could not be verified."
 msgstr "ホスト名 {0} は確認できませんでした。"
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:164
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:90
 msgid "The sslfactoryarg property may not be empty."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:180
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:106
 msgid ""
 "The environment variable containing the server's SSL certificate must not be "
 "empty."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:188
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:114
 msgid ""
 "The system property containing the server's SSL certificate must not be "
 "empty."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:195
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:121
 msgid ""
 "The sslfactoryarg property must start with the prefix file:, classpath:, "
 "env:, sys:, or -----BEGIN CERTIFICATE-----."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:207
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:133
 #, fuzzy
 msgid "An error occurred reading the certificate"
 msgstr "SSL接続のセットアップ中に、エラーが起こりました。"
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:240
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:166
 msgid "No X509TrustManager found"
 msgstr ""
 
@@ -1554,31 +1560,31 @@ msgstr ""
 "トランザクション制御メソッドである setAutoCommit(true), commit, rollback, "
 "setSavePoint は、XAトランザクションが有効では利用できません。"
 
-#: org/postgresql/xa/PGXAConnection.java:177
-#: org/postgresql/xa/PGXAConnection.java:253
-#: org/postgresql/xa/PGXAConnection.java:347
+#: org/postgresql/xa/PGXAConnection.java:186
+#: org/postgresql/xa/PGXAConnection.java:272
+#: org/postgresql/xa/PGXAConnection.java:381
 #, java-format
 msgid "Invalid flags {0}"
 msgstr "無効なフラグです。{0}"
 
-#: org/postgresql/xa/PGXAConnection.java:181
-#: org/postgresql/xa/PGXAConnection.java:257
-#: org/postgresql/xa/PGXAConnection.java:449
+#: org/postgresql/xa/PGXAConnection.java:190
+#: org/postgresql/xa/PGXAConnection.java:276
+#: org/postgresql/xa/PGXAConnection.java:491
 msgid "xid must not be null"
 msgstr "xidはnullではいけません。"
 
-#: org/postgresql/xa/PGXAConnection.java:185
+#: org/postgresql/xa/PGXAConnection.java:194
 msgid "Connection is busy with another transaction"
 msgstr "接続は、別のトランザクションに対応中です。"
 
-#: org/postgresql/xa/PGXAConnection.java:194
-#: org/postgresql/xa/PGXAConnection.java:267
+#: org/postgresql/xa/PGXAConnection.java:203
+#: org/postgresql/xa/PGXAConnection.java:286
 msgid "suspend/resume not implemented"
 msgstr "停止/再開 は実装されていません。"
 
-#: org/postgresql/xa/PGXAConnection.java:202
-#: org/postgresql/xa/PGXAConnection.java:209
-#: org/postgresql/xa/PGXAConnection.java:213
+#: org/postgresql/xa/PGXAConnection.java:211
+#: org/postgresql/xa/PGXAConnection.java:218
+#: org/postgresql/xa/PGXAConnection.java:222
 #, java-format
 msgid ""
 "Invalid protocol state requested. Attempted transaction interleaving is not "
@@ -1587,11 +1593,11 @@ msgstr ""
 "Transaction interleaving は実装されていません。xid={0}, currentXid={1}, "
 "state={2}, flags={3}"
 
-#: org/postgresql/xa/PGXAConnection.java:224
+#: org/postgresql/xa/PGXAConnection.java:233
 msgid "Error disabling autocommit"
 msgstr "自動コミットの無効化エラー"
 
-#: org/postgresql/xa/PGXAConnection.java:261
+#: org/postgresql/xa/PGXAConnection.java:280
 #, java-format
 msgid ""
 "tried to call end without corresponding start call. state={0}, start "
@@ -1600,7 +1606,7 @@ msgstr ""
 "対応する開始呼び出しなしで、終了呼び出しました。state={0}, start xid={1}, "
 "currentXid={2}, preparedXid={3}"
 
-#: org/postgresql/xa/PGXAConnection.java:297
+#: org/postgresql/xa/PGXAConnection.java:326
 #, fuzzy, java-format
 msgid ""
 "Preparing already prepared transaction, the prepared xid {0}, prepare xid={1}"
@@ -1608,12 +1614,12 @@ msgstr ""
 "準備トランザクションのロールバックエラー rollback xid={0}, preparedXid={1}, "
 "currentXid={2}"
 
-#: org/postgresql/xa/PGXAConnection.java:300
+#: org/postgresql/xa/PGXAConnection.java:329
 #, java-format
 msgid "Current connection does not have an associated xid. prepare xid={0}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:307
+#: org/postgresql/xa/PGXAConnection.java:336
 #, java-format
 msgid ""
 "Not implemented: Prepare must be issued using the same connection that "
@@ -1622,21 +1628,21 @@ msgstr ""
 "実装されていません: Prepareは、トランザクションを開始したときと同じ接続で使わ"
 "なくてはなりません。currentXid={0}, prepare xid={1}"
 
-#: org/postgresql/xa/PGXAConnection.java:311
+#: org/postgresql/xa/PGXAConnection.java:340
 #, java-format
 msgid "Prepare called before end. prepare xid={0}, state={1}"
 msgstr "終了前に\"Prepare\"が呼ばれました prepare xid={0}, state={1}"
 
-#: org/postgresql/xa/PGXAConnection.java:331
+#: org/postgresql/xa/PGXAConnection.java:360
 #, java-format
 msgid "Error preparing transaction. prepare xid={0}"
 msgstr "トランザクションの準備エラー。prepare xid={0}"
 
-#: org/postgresql/xa/PGXAConnection.java:382
+#: org/postgresql/xa/PGXAConnection.java:416
 msgid "Error during recover"
 msgstr "回復中にエラー"
 
-#: org/postgresql/xa/PGXAConnection.java:438
+#: org/postgresql/xa/PGXAConnection.java:480
 #, java-format
 msgid ""
 "Error rolling back prepared transaction. rollback xid={0}, preparedXid={1}, "
@@ -1645,13 +1651,13 @@ msgstr ""
 "準備トランザクションのロールバックエラー rollback xid={0}, preparedXid={1}, "
 "currentXid={2}"
 
-#: org/postgresql/xa/PGXAConnection.java:471
+#: org/postgresql/xa/PGXAConnection.java:521
 #, java-format
 msgid ""
 "One-phase commit called for xid {0} but connection was prepared with xid {1}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:479
+#: org/postgresql/xa/PGXAConnection.java:529
 msgid ""
 "Not implemented: one-phase commit must be issued using the same connection "
 "that was used to start it"
@@ -1659,22 +1665,22 @@ msgstr ""
 "実装されていません: 単一フェーズのCOMMITは、開始時と同じ接続で実行されなけれ"
 "ばなりません。"
 
-#: org/postgresql/xa/PGXAConnection.java:483
+#: org/postgresql/xa/PGXAConnection.java:533
 #, java-format
 msgid "One-phase commit with unknown xid. commit xid={0}, currentXid={1}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:487
+#: org/postgresql/xa/PGXAConnection.java:537
 #, java-format
 msgid "commit called before end. commit xid={0}, state={1}"
 msgstr "終了の前に COMMIT を呼びました commit xid={0}, state={1}"
 
-#: org/postgresql/xa/PGXAConnection.java:498
+#: org/postgresql/xa/PGXAConnection.java:548
 #, java-format
 msgid "Error during one-phase commit. commit xid={0}"
 msgstr "単一フェーズのCOMMITの最中にエラー commit xid={0}"
 
-#: org/postgresql/xa/PGXAConnection.java:517
+#: org/postgresql/xa/PGXAConnection.java:576
 msgid ""
 "Not implemented: 2nd phase commit must be issued using an idle connection. "
 "commit xid={0}, currentXid={1}, state={2], transactionState={3}"
@@ -1682,7 +1688,7 @@ msgstr ""
 "実装されていません: 第二フェーズの COMMIT は、待機接続で使わなくてはなりませ"
 "ん。xid={0}, currentXid={1}, state={2], transactionState={3}"
 
-#: org/postgresql/xa/PGXAConnection.java:550
+#: org/postgresql/xa/PGXAConnection.java:609
 #, java-format
 msgid ""
 "Error committing prepared transaction. commit xid={0}, preparedXid={1}, "
@@ -1691,7 +1697,7 @@ msgstr ""
 "準備トランザクションのコミットエラー。commit xid={0}, preparedXid={1}, "
 "currentXid={2}"
 
-#: org/postgresql/xa/PGXAConnection.java:567
+#: org/postgresql/xa/PGXAConnection.java:626
 #, java-format
 msgid "Heuristic commit/rollback not supported. forget xid={0}"
 msgstr "サポートされない commit/rollback が見つかりました。forget xid={0}"

--- a/pgjdbc/src/main/java/org/postgresql/translation/messages.pot
+++ b/pgjdbc/src/main/java/org/postgresql/translation/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-06-05 10:59+0300\n"
+""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,56 +17,56 @@ msgstr ""
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: org/postgresql/Driver.java:214
+#: org/postgresql/Driver.java:217
 msgid "Error loading default settings from driverconfig.properties"
 msgstr ""
 
-#: org/postgresql/Driver.java:226
+#: org/postgresql/Driver.java:229
 msgid "Properties for the driver contains a non-string value for the key "
 msgstr ""
 
-#: org/postgresql/Driver.java:270
+#: org/postgresql/Driver.java:272
 msgid ""
 "Your security policy has prevented the connection from being attempted.  You "
 "probably need to grant the connect java.net.SocketPermission to the database "
 "server host and port that you wish to connect to."
 msgstr ""
 
-#: org/postgresql/Driver.java:276 org/postgresql/Driver.java:408
+#: org/postgresql/Driver.java:278 org/postgresql/Driver.java:410
 msgid ""
 "Something unusual has occurred to cause the driver to fail. Please report "
 "this exception."
 msgstr ""
 
-#: org/postgresql/Driver.java:416
+#: org/postgresql/Driver.java:418
 msgid "Connection attempt timed out."
 msgstr ""
 
-#: org/postgresql/Driver.java:429
+#: org/postgresql/Driver.java:431
 msgid "Interrupted while attempting to connect."
 msgstr ""
 
-#: org/postgresql/Driver.java:682
+#: org/postgresql/Driver.java:687
 #, java-format
 msgid "Method {0} is not yet implemented."
 msgstr ""
 
-#: org/postgresql/PGProperty.java:535 org/postgresql/PGProperty.java:555
+#: org/postgresql/PGProperty.java:537 org/postgresql/PGProperty.java:557
 #, java-format
 msgid "{0} parameter value must be an integer but was: {1}"
 msgstr ""
 
-#: org/postgresql/copy/CopyManager.java:53
+#: org/postgresql/copy/CopyManager.java:49
 #, java-format
 msgid "Requested CopyIn but got {0}"
 msgstr ""
 
-#: org/postgresql/copy/CopyManager.java:64
+#: org/postgresql/copy/CopyManager.java:60
 #, java-format
 msgid "Requested CopyOut but got {0}"
 msgstr ""
 
-#: org/postgresql/copy/CopyManager.java:75
+#: org/postgresql/copy/CopyManager.java:71
 #, java-format
 msgid "Requested CopyDual but got {0}"
 msgstr ""
@@ -90,6 +90,11 @@ msgstr ""
 msgid "Cannot write to copy a byte of value {0}"
 msgstr ""
 
+#: org/postgresql/core/CommandCompleteParser.java:71
+#, java-format
+msgid "Unable to parse the count in command completion tag: {0}."
+msgstr ""
+
 #: org/postgresql/core/ConnectionFactory.java:57
 #, java-format
 msgid "A connection could not be made using the requested protocol {0}."
@@ -110,7 +115,7 @@ msgstr ""
 msgid "Expected an EOF from server, got: {0}"
 msgstr ""
 
-#: org/postgresql/core/Parser.java:1006
+#: org/postgresql/core/Parser.java:1051
 #, java-format
 msgid "Malformed function or procedure escape syntax at offset {0}."
 msgstr ""
@@ -166,62 +171,62 @@ msgstr ""
 #: org/postgresql/core/v3/CompositeParameterList.java:33
 #: org/postgresql/core/v3/SimpleParameterList.java:54
 #: org/postgresql/core/v3/SimpleParameterList.java:65
-#: org/postgresql/jdbc/PgResultSet.java:2757
-#: org/postgresql/jdbc/PgResultSetMetaData.java:494
+#: org/postgresql/jdbc/PgResultSet.java:2755
+#: org/postgresql/jdbc/PgResultSetMetaData.java:388
 #, java-format
 msgid "The column index is out of range: {0}, number of columns: {1}."
 msgstr ""
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:109
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:103
 #, java-format
 msgid "Invalid sslmode value: {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:124
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:118
 #, java-format
 msgid "Invalid targetServerType value: {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:246
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:239
 #, java-format
 msgid ""
 "Connection to {0} refused. Check that the hostname and port are correct and "
 "that the postmaster is accepting TCP/IP connections."
 msgstr ""
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:257
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:250
 #: org/postgresql/core/v3/replication/V3ReplicationProtocol.java:133
 msgid "The connection attempt failed."
 msgstr ""
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:272
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:265
 #, java-format
 msgid "Could not find a server with specified targetServerType: {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:368
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:381
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:361
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:374
 msgid "The server does not support SSL."
 msgstr ""
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:395
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:388
 msgid "An error occurred while setting up the SSL connection."
 msgstr ""
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:496
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:523
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:484
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:511
 msgid ""
 "The server requested password-based authentication, but no password was "
 "provided."
 msgstr ""
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:626
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:614
 msgid ""
 "SCRAM authentication is not supported by this driver. You need JDK >= 8 and "
 "pgjdbc >= 42.2.0 (not \".jre\" versions)"
 msgstr ""
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:650
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:638
 #, java-format
 msgid ""
 "The authentication type {0} is not supported. Check that you have configured "
@@ -229,16 +234,16 @@ msgid ""
 "it is using an authentication scheme supported by the driver."
 msgstr ""
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:657
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2550
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2581
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2585
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2653
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:645
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2543
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2576
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2580
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2648
 #: org/postgresql/gss/GssAction.java:126
 msgid "Protocol error.  Session setup failed."
 msgstr ""
 
-#: org/postgresql/core/v3/CopyInImpl.java:47
+#: org/postgresql/core/v3/CopyInImpl.java:49
 msgid "CopyIn copy direction can't receive data"
 msgstr ""
 
@@ -246,174 +251,169 @@ msgstr ""
 msgid "CommandComplete expected COPY but got: "
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:161
+#: org/postgresql/core/v3/QueryExecutorImpl.java:163
 msgid "Tried to obtain lock while already holding it"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:177
+#: org/postgresql/core/v3/QueryExecutorImpl.java:179
 msgid "Tried to break lock on database connection"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:195
+#: org/postgresql/core/v3/QueryExecutorImpl.java:197
 msgid "Interrupted while waiting to obtain lock on database connection"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:327
+#: org/postgresql/core/v3/QueryExecutorImpl.java:329
 msgid "Unable to bind parameter values for statement."
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:333
-#: org/postgresql/core/v3/QueryExecutorImpl.java:485
-#: org/postgresql/core/v3/QueryExecutorImpl.java:559
-#: org/postgresql/core/v3/QueryExecutorImpl.java:602
-#: org/postgresql/core/v3/QueryExecutorImpl.java:729
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2372
+#: org/postgresql/core/v3/QueryExecutorImpl.java:335
+#: org/postgresql/core/v3/QueryExecutorImpl.java:487
+#: org/postgresql/core/v3/QueryExecutorImpl.java:561
+#: org/postgresql/core/v3/QueryExecutorImpl.java:604
+#: org/postgresql/core/v3/QueryExecutorImpl.java:731
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2377
 #: org/postgresql/util/StreamWrapper.java:130
 msgid "An I/O error occurred while sending to the backend."
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:534
-#: org/postgresql/core/v3/QueryExecutorImpl.java:576
+#: org/postgresql/core/v3/QueryExecutorImpl.java:536
+#: org/postgresql/core/v3/QueryExecutorImpl.java:578
 #, java-format
 msgid "Expected command status BEGIN, got {0}."
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:581
+#: org/postgresql/core/v3/QueryExecutorImpl.java:583
 #: org/postgresql/jdbc/PgResultSet.java:1778
 #, java-format
 msgid "Unexpected command status: {0}."
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:687
+#: org/postgresql/core/v3/QueryExecutorImpl.java:689
 msgid "An error occurred while trying to get the socket timeout."
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:722
-#: org/postgresql/core/v3/QueryExecutorImpl.java:798
+#: org/postgresql/core/v3/QueryExecutorImpl.java:724
+#: org/postgresql/core/v3/QueryExecutorImpl.java:800
 #, java-format
 msgid "Unknown Response Type {0}."
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:745
+#: org/postgresql/core/v3/QueryExecutorImpl.java:747
 msgid "An error occurred while trying to reset the socket timeout."
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:843
+#: org/postgresql/core/v3/QueryExecutorImpl.java:845
 msgid "Database connection failed when starting copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:878
+#: org/postgresql/core/v3/QueryExecutorImpl.java:880
 msgid "Tried to cancel an inactive copy operation"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:917
+#: org/postgresql/core/v3/QueryExecutorImpl.java:919
 msgid "Database connection failed when canceling copy operation"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:933
+#: org/postgresql/core/v3/QueryExecutorImpl.java:935
 msgid "Missing expected error response to copy cancel request"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:937
+#: org/postgresql/core/v3/QueryExecutorImpl.java:939
 #, java-format
 msgid "Got {0} error responses to single copy cancel request"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:952
+#: org/postgresql/core/v3/QueryExecutorImpl.java:954
 msgid "Tried to end inactive copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:967
+#: org/postgresql/core/v3/QueryExecutorImpl.java:969
 msgid "Database connection failed when ending copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:985
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1005
+#: org/postgresql/core/v3/QueryExecutorImpl.java:987
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1007
 msgid "Tried to write to an inactive copy operation"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:998
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1013
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1000
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1015
 msgid "Database connection failed when writing to copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1028
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1030
 msgid "Tried to read from inactive copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1035
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1037
 msgid "Database connection failed when reading from copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1101
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1103
 #, java-format
 msgid "Received CommandComplete ''{0}'' without an active copy operation"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1126
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1128
 #, java-format
 msgid "Got CopyInResponse from server during an active {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1140
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1142
 #, java-format
 msgid "Got CopyOutResponse from server during an active {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1154
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1156
 #, java-format
 msgid "Got CopyBothResponse from server during an active {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1170
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1172
 msgid "Got CopyData without an active copy operation"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1174
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1176
 #, java-format
 msgid "Unexpected copydata from server for {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1234
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1236
 #, java-format
 msgid "Unexpected packet type during copy: {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1524
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1526
 #, java-format
 msgid ""
 "Bind message length {0} too long.  This can be caused by very large or "
 "incorrect length specifications on InputStream parameters."
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2145
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2150
 msgid "Ran out of memory retrieving query results."
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2313
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2318
 msgid "The driver currently does not support COPY operations."
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2487
-#, java-format
-msgid "Unable to parse the count in command completion tag: {0}."
-msgstr ""
-
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2610
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2605
 #, java-format
 msgid ""
 "The server''s client_encoding parameter was changed to {0}. The JDBC driver "
 "requires client_encoding to be UTF8 for correct operation."
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2620
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2615
 #, java-format
 msgid ""
 "The server''s DateStyle parameter was changed to {0}. The JDBC driver "
 "requires DateStyle to begin with ISO for correct operation."
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2633
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2628
 #, java-format
 msgid ""
 "The server''s standard_conforming_strings parameter was reported as {0}. The "
@@ -471,36 +471,36 @@ msgstr ""
 msgid "Unsupported property name: {0}"
 msgstr ""
 
-#: org/postgresql/fastpath/Fastpath.java:86
+#: org/postgresql/fastpath/Fastpath.java:84
 #, java-format
 msgid "Fastpath call {0} - No result was returned and we expected a numeric."
 msgstr ""
 
-#: org/postgresql/fastpath/Fastpath.java:163
+#: org/postgresql/fastpath/Fastpath.java:161
 #, java-format
 msgid "Fastpath call {0} - No result was returned and we expected an integer."
 msgstr ""
 
-#: org/postgresql/fastpath/Fastpath.java:171
+#: org/postgresql/fastpath/Fastpath.java:169
 #, java-format
 msgid ""
 "Fastpath call {0} - No result was returned or wrong size while expecting an "
 "integer."
 msgstr ""
 
-#: org/postgresql/fastpath/Fastpath.java:188
+#: org/postgresql/fastpath/Fastpath.java:186
 #, java-format
 msgid "Fastpath call {0} - No result was returned and we expected a long."
 msgstr ""
 
-#: org/postgresql/fastpath/Fastpath.java:196
+#: org/postgresql/fastpath/Fastpath.java:194
 #, java-format
 msgid ""
 "Fastpath call {0} - No result was returned or wrong size while expecting a "
 "long."
 msgstr ""
 
-#: org/postgresql/fastpath/Fastpath.java:308
+#: org/postgresql/fastpath/Fastpath.java:297
 #, java-format
 msgid "The fastpath function {0} is unknown."
 msgstr ""
@@ -566,63 +566,70 @@ msgid "Cannot cast to boolean: \"{0}\""
 msgstr ""
 
 #: org/postgresql/jdbc/EscapedFunctions.java:240
+#: org/postgresql/jdbc/EscapedFunctions2.java:167
 #, java-format
 msgid "{0} function takes four and only four argument."
 msgstr ""
 
 #: org/postgresql/jdbc/EscapedFunctions.java:270
-#: org/postgresql/jdbc/EscapedFunctions.java:344
-#: org/postgresql/jdbc/EscapedFunctions.java:749
-#: org/postgresql/jdbc/EscapedFunctions.java:787
+#: org/postgresql/jdbc/EscapedFunctions.java:337
+#: org/postgresql/jdbc/EscapedFunctions.java:740
+#: org/postgresql/jdbc/EscapedFunctions2.java:196
+#: org/postgresql/jdbc/EscapedFunctions2.java:263
+#: org/postgresql/jdbc/EscapedFunctions2.java:665
 #, java-format
 msgid "{0} function takes two and only two arguments."
 msgstr ""
 
 #: org/postgresql/jdbc/EscapedFunctions.java:288
-#: org/postgresql/jdbc/EscapedFunctions.java:326
-#: org/postgresql/jdbc/EscapedFunctions.java:446
-#: org/postgresql/jdbc/EscapedFunctions.java:461
-#: org/postgresql/jdbc/EscapedFunctions.java:476
-#: org/postgresql/jdbc/EscapedFunctions.java:491
-#: org/postgresql/jdbc/EscapedFunctions.java:506
-#: org/postgresql/jdbc/EscapedFunctions.java:521
-#: org/postgresql/jdbc/EscapedFunctions.java:536
-#: org/postgresql/jdbc/EscapedFunctions.java:551
-#: org/postgresql/jdbc/EscapedFunctions.java:566
-#: org/postgresql/jdbc/EscapedFunctions.java:581
-#: org/postgresql/jdbc/EscapedFunctions.java:596
-#: org/postgresql/jdbc/EscapedFunctions.java:611
-#: org/postgresql/jdbc/EscapedFunctions.java:775
+#: org/postgresql/jdbc/EscapedFunctions.java:441
+#: org/postgresql/jdbc/EscapedFunctions.java:467
+#: org/postgresql/jdbc/EscapedFunctions.java:526
+#: org/postgresql/jdbc/EscapedFunctions.java:728
+#: org/postgresql/jdbc/EscapedFunctions2.java:211
+#: org/postgresql/jdbc/EscapedFunctions2.java:355
+#: org/postgresql/jdbc/EscapedFunctions2.java:381
+#: org/postgresql/jdbc/EscapedFunctions2.java:440
+#: org/postgresql/jdbc/EscapedFunctions2.java:654
 #, java-format
 msgid "{0} function takes one and only one argument."
 msgstr ""
 
-#: org/postgresql/jdbc/EscapedFunctions.java:310
-#: org/postgresql/jdbc/EscapedFunctions.java:391
+#: org/postgresql/jdbc/EscapedFunctions.java:312
+#: org/postgresql/jdbc/EscapedFunctions.java:386
+#: org/postgresql/jdbc/EscapedFunctions2.java:238
+#: org/postgresql/jdbc/EscapedFunctions2.java:307
 #, java-format
 msgid "{0} function takes two or three arguments."
 msgstr ""
 
-#: org/postgresql/jdbc/EscapedFunctions.java:416
-#: org/postgresql/jdbc/EscapedFunctions.java:431
-#: org/postgresql/jdbc/EscapedFunctions.java:734
-#: org/postgresql/jdbc/EscapedFunctions.java:764
+#: org/postgresql/jdbc/EscapedFunctions.java:411
+#: org/postgresql/jdbc/EscapedFunctions.java:426
+#: org/postgresql/jdbc/EscapedFunctions.java:693
+#: org/postgresql/jdbc/EscapedFunctions.java:719
+#: org/postgresql/jdbc/EscapedFunctions2.java:645
 #, java-format
 msgid "{0} function doesn''t take any argument."
 msgstr ""
 
-#: org/postgresql/jdbc/EscapedFunctions.java:627
-#: org/postgresql/jdbc/EscapedFunctions.java:680
+#: org/postgresql/jdbc/EscapedFunctions.java:586
+#: org/postgresql/jdbc/EscapedFunctions.java:639
+#: org/postgresql/jdbc/EscapedFunctions2.java:500
+#: org/postgresql/jdbc/EscapedFunctions2.java:571
 #, java-format
 msgid "{0} function takes three and only three arguments."
 msgstr ""
 
-#: org/postgresql/jdbc/EscapedFunctions.java:640
-#: org/postgresql/jdbc/EscapedFunctions.java:661
-#: org/postgresql/jdbc/EscapedFunctions.java:664
-#: org/postgresql/jdbc/EscapedFunctions.java:697
-#: org/postgresql/jdbc/EscapedFunctions.java:710
-#: org/postgresql/jdbc/EscapedFunctions.java:713
+#: org/postgresql/jdbc/EscapedFunctions.java:599
+#: org/postgresql/jdbc/EscapedFunctions.java:620
+#: org/postgresql/jdbc/EscapedFunctions.java:623
+#: org/postgresql/jdbc/EscapedFunctions.java:656
+#: org/postgresql/jdbc/EscapedFunctions.java:669
+#: org/postgresql/jdbc/EscapedFunctions.java:672
+#: org/postgresql/jdbc/EscapedFunctions2.java:510
+#: org/postgresql/jdbc/EscapedFunctions2.java:527
+#: org/postgresql/jdbc/EscapedFunctions2.java:585
+#: org/postgresql/jdbc/EscapedFunctions2.java:597
 #, java-format
 msgid "Interval {0} not yet implemented"
 msgstr ""
@@ -641,17 +648,17 @@ msgstr ""
 msgid "Cannot retrieve the name of an unnamed savepoint."
 msgstr ""
 
-#: org/postgresql/jdbc/PgArray.java:157 org/postgresql/jdbc/PgArray.java:844
+#: org/postgresql/jdbc/PgArray.java:155 org/postgresql/jdbc/PgArray.java:842
 #, java-format
 msgid "The array index is out of range: {0}"
 msgstr ""
 
-#: org/postgresql/jdbc/PgArray.java:178 org/postgresql/jdbc/PgArray.java:861
+#: org/postgresql/jdbc/PgArray.java:176 org/postgresql/jdbc/PgArray.java:859
 #, java-format
 msgid "The array index is out of range: {0}, number of elements: {1}."
 msgstr ""
 
-#: org/postgresql/jdbc/PgArray.java:210
+#: org/postgresql/jdbc/PgArray.java:208
 #: org/postgresql/jdbc/PgResultSet.java:1930
 #: org/postgresql/util/HStoreConverter.java:43
 #: org/postgresql/util/HStoreConverter.java:74
@@ -662,67 +669,67 @@ msgid ""
 "SQL_ASCII database."
 msgstr ""
 
-#: org/postgresql/jdbc/PgCallableStatement.java:86
-#: org/postgresql/jdbc/PgCallableStatement.java:96
+#: org/postgresql/jdbc/PgCallableStatement.java:85
+#: org/postgresql/jdbc/PgCallableStatement.java:95
 msgid "A CallableStatement was executed with nothing returned."
 msgstr ""
 
-#: org/postgresql/jdbc/PgCallableStatement.java:107
+#: org/postgresql/jdbc/PgCallableStatement.java:106
 msgid "A CallableStatement was executed with an invalid number of parameters"
 msgstr ""
 
-#: org/postgresql/jdbc/PgCallableStatement.java:145
+#: org/postgresql/jdbc/PgCallableStatement.java:144
 #, java-format
 msgid ""
 "A CallableStatement function was executed and the out parameter {0} was of "
 "type {1} however type {2} was registered."
 msgstr ""
 
-#: org/postgresql/jdbc/PgCallableStatement.java:202
+#: org/postgresql/jdbc/PgCallableStatement.java:206
 msgid ""
 "This statement does not declare an OUT parameter.  Use '{' ?= call ... '}' "
 "to declare one."
 msgstr ""
 
-#: org/postgresql/jdbc/PgCallableStatement.java:246
+#: org/postgresql/jdbc/PgCallableStatement.java:229
 msgid "wasNull cannot be call before fetching a result."
 msgstr ""
 
-#: org/postgresql/jdbc/PgCallableStatement.java:384
-#: org/postgresql/jdbc/PgCallableStatement.java:403
+#: org/postgresql/jdbc/PgCallableStatement.java:367
+#: org/postgresql/jdbc/PgCallableStatement.java:386
 #, java-format
 msgid ""
 "Parameter of type {0} was registered, but call to get{1} (sqltype={2}) was "
 "made."
 msgstr ""
 
-#: org/postgresql/jdbc/PgCallableStatement.java:424
+#: org/postgresql/jdbc/PgCallableStatement.java:407
 msgid ""
 "A CallableStatement was declared, but no call to registerOutParameter(1, "
 "<some type>) was made."
 msgstr ""
 
-#: org/postgresql/jdbc/PgCallableStatement.java:430
+#: org/postgresql/jdbc/PgCallableStatement.java:413
 msgid "No function outputs were registered."
 msgstr ""
 
-#: org/postgresql/jdbc/PgCallableStatement.java:436
+#: org/postgresql/jdbc/PgCallableStatement.java:419
 msgid ""
 "Results cannot be retrieved from a CallableStatement before it is executed."
 msgstr ""
 
-#: org/postgresql/jdbc/PgCallableStatement.java:703
+#: org/postgresql/jdbc/PgCallableStatement.java:686
 #, java-format
 msgid "Unsupported type conversion to {1}."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:272
+#: org/postgresql/jdbc/PgConnection.java:241
 #, java-format
 msgid "Unsupported value for stringtype parameter: {0}"
 msgstr ""
 
 #: org/postgresql/jdbc/PgConnection.java:424
-#: org/postgresql/jdbc/PgPreparedStatement.java:119
+#: org/postgresql/jdbc/PgPreparedStatement.java:107
 #: org/postgresql/jdbc/PgStatement.java:225
 #: org/postgresql/jdbc/TypeInfoCache.java:226
 #: org/postgresql/jdbc/TypeInfoCache.java:371
@@ -734,124 +741,124 @@ msgstr ""
 msgid "No results were returned by the query."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:441
+#: org/postgresql/jdbc/PgConnection.java:442
 #: org/postgresql/jdbc/PgStatement.java:254
 msgid "A result was returned when none was expected."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:545
+#: org/postgresql/jdbc/PgConnection.java:547
 msgid "Custom type maps are not supported."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:587
+#: org/postgresql/jdbc/PgConnection.java:589
 #, java-format
 msgid "Failed to create object for: {0}."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:641
+#: org/postgresql/jdbc/PgConnection.java:643
 #, java-format
 msgid "Unable to load the class {0} responsible for the datatype {1}"
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:693
+#: org/postgresql/jdbc/PgConnection.java:705
 msgid ""
 "Cannot change transaction read-only property in the middle of a transaction."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:756
+#: org/postgresql/jdbc/PgConnection.java:772
 msgid "Cannot commit when autoCommit is enabled."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:767
-#: org/postgresql/jdbc/PgConnection.java:1384
-#: org/postgresql/jdbc/PgConnection.java:1428
+#: org/postgresql/jdbc/PgConnection.java:783
+#: org/postgresql/jdbc/PgConnection.java:1401
+#: org/postgresql/jdbc/PgConnection.java:1445
 msgid "This connection has been closed."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:777
+#: org/postgresql/jdbc/PgConnection.java:794
 msgid "Cannot rollback when autoCommit is enabled."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:827
+#: org/postgresql/jdbc/PgConnection.java:844
 msgid ""
 "Cannot change transaction isolation level in the middle of a transaction."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:833
+#: org/postgresql/jdbc/PgConnection.java:850
 #, java-format
 msgid "Transaction isolation level {0} not supported."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:878
+#: org/postgresql/jdbc/PgConnection.java:895
 msgid "Finalizing a Connection that was never closed:"
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:945
+#: org/postgresql/jdbc/PgConnection.java:962
 msgid "Unable to translate data into the desired encoding."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1008
+#: org/postgresql/jdbc/PgConnection.java:1025
 #: org/postgresql/jdbc/PgResultSet.java:1817
-#: org/postgresql/jdbc/PgStatement.java:903
+#: org/postgresql/jdbc/PgStatement.java:908
 msgid "Fetch size must be a value greater to or equal to 0."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1289
-#: org/postgresql/jdbc/PgConnection.java:1330
+#: org/postgresql/jdbc/PgConnection.java:1306
+#: org/postgresql/jdbc/PgConnection.java:1347
 #, java-format
 msgid "Unable to find server array type for provided name {0}."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1312
+#: org/postgresql/jdbc/PgConnection.java:1329
 #, java-format
 msgid "Invalid elements {0}"
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1348
+#: org/postgresql/jdbc/PgConnection.java:1365
 #, java-format
 msgid "Invalid timeout ({0}<0)."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1372
+#: org/postgresql/jdbc/PgConnection.java:1389
 msgid "Validating connection."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1405
+#: org/postgresql/jdbc/PgConnection.java:1422
 #, java-format
 msgid "Failed to set ClientInfo property: {0}"
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1415
+#: org/postgresql/jdbc/PgConnection.java:1432
 msgid "ClientInfo property not supported."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1441
+#: org/postgresql/jdbc/PgConnection.java:1458
 msgid "One ore more ClientInfo failed."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1540
+#: org/postgresql/jdbc/PgConnection.java:1559
 msgid "Network timeout must be a value greater than or equal to 0."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1552
+#: org/postgresql/jdbc/PgConnection.java:1571
 msgid "Unable to set network timeout."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1563
+#: org/postgresql/jdbc/PgConnection.java:1582
 msgid "Unable to get network timeout."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1580
+#: org/postgresql/jdbc/PgConnection.java:1599
 #, java-format
 msgid "Unknown ResultSet holdability setting: {0}."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1598
-#: org/postgresql/jdbc/PgConnection.java:1619
+#: org/postgresql/jdbc/PgConnection.java:1617
+#: org/postgresql/jdbc/PgConnection.java:1638
 msgid "Cannot establish a savepoint in auto-commit mode."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1685
+#: org/postgresql/jdbc/PgConnection.java:1707
 msgid "Returning autogenerated keys is not supported."
 msgstr ""
 
@@ -865,46 +872,46 @@ msgstr ""
 msgid "Unable to find name datatype in the system catalogs."
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:323
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:322
 msgid "Unable to find keywords in the system catalogs."
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1105
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1095
 msgid "oid"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1105
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1095
 msgid "proname"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1107
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1558
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1097
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1548
 msgid "typtype"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1110
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1100
 msgid "proargtypes"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1576
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1566
 msgid "adsrc"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1589
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1579
 msgid "attidentity"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1685
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1761
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1675
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1751
 msgid "rolname"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1686
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1762
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1676
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1752
 msgid "relacl"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1692
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1682
 msgid "attacl"
 msgstr ""
 
@@ -913,83 +920,83 @@ msgstr ""
 msgid "The parameter index is out of range: {0}, number of parameters: {1}."
 msgstr ""
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:106
+#: org/postgresql/jdbc/PgPreparedStatement.java:94
+#: org/postgresql/jdbc/PgPreparedStatement.java:115
 #: org/postgresql/jdbc/PgPreparedStatement.java:127
-#: org/postgresql/jdbc/PgPreparedStatement.java:139
-#: org/postgresql/jdbc/PgPreparedStatement.java:1035
+#: org/postgresql/jdbc/PgPreparedStatement.java:1008
 msgid ""
 "Can''t use query methods that take a query string on a PreparedStatement."
 msgstr ""
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:249
+#: org/postgresql/jdbc/PgPreparedStatement.java:237
 msgid "Unknown Types value."
 msgstr ""
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:382
-#: org/postgresql/jdbc/PgPreparedStatement.java:439
-#: org/postgresql/jdbc/PgPreparedStatement.java:1191
-#: org/postgresql/jdbc/PgPreparedStatement.java:1490
+#: org/postgresql/jdbc/PgPreparedStatement.java:364
+#: org/postgresql/jdbc/PgPreparedStatement.java:421
+#: org/postgresql/jdbc/PgPreparedStatement.java:1164
+#: org/postgresql/jdbc/PgPreparedStatement.java:1472
 #, java-format
 msgid "Invalid stream length {0}."
 msgstr ""
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:411
+#: org/postgresql/jdbc/PgPreparedStatement.java:393
 #, java-format
 msgid "The JVM claims not to support the {0} encoding."
 msgstr ""
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:414
+#: org/postgresql/jdbc/PgPreparedStatement.java:396
 #: org/postgresql/jdbc/PgResultSet.java:1122
 #: org/postgresql/jdbc/PgResultSet.java:1156
 msgid "Provided InputStream failed."
 msgstr ""
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:460
-#: org/postgresql/jdbc/PgPreparedStatement.java:1096
+#: org/postgresql/jdbc/PgPreparedStatement.java:442
+#: org/postgresql/jdbc/PgPreparedStatement.java:1069
 #, java-format
 msgid "Unknown type {0}."
 msgstr ""
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:477
+#: org/postgresql/jdbc/PgPreparedStatement.java:459
 msgid "No hstore extension installed."
 msgstr ""
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:619
-#: org/postgresql/jdbc/PgPreparedStatement.java:642
-#: org/postgresql/jdbc/PgPreparedStatement.java:652
-#: org/postgresql/jdbc/PgPreparedStatement.java:664
+#: org/postgresql/jdbc/PgPreparedStatement.java:601
+#: org/postgresql/jdbc/PgPreparedStatement.java:624
+#: org/postgresql/jdbc/PgPreparedStatement.java:634
+#: org/postgresql/jdbc/PgPreparedStatement.java:646
 #, java-format
 msgid "Cannot cast an instance of {0} to type {1}"
 msgstr ""
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:682
+#: org/postgresql/jdbc/PgPreparedStatement.java:664
 #, java-format
 msgid "Unsupported Types value: {0}"
 msgstr ""
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:894
+#: org/postgresql/jdbc/PgPreparedStatement.java:876
 #, java-format
 msgid "Cannot convert an instance of {0} to type {1}"
 msgstr ""
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:968
+#: org/postgresql/jdbc/PgPreparedStatement.java:950
 #, java-format
 msgid ""
 "Can''t infer the SQL type to use for an instance of {0}. Use setObject() "
 "with an explicit Types value to specify the type to use."
 msgstr ""
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:1133
-#: org/postgresql/jdbc/PgPreparedStatement.java:1233
+#: org/postgresql/jdbc/PgPreparedStatement.java:1106
+#: org/postgresql/jdbc/PgPreparedStatement.java:1206
 msgid "Unexpected error writing large object to database."
 msgstr ""
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:1178
+#: org/postgresql/jdbc/PgPreparedStatement.java:1151
 #: org/postgresql/jdbc/PgResultSet.java:1210
 msgid "Provided Reader failed."
 msgstr ""
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:1449
+#: org/postgresql/jdbc/PgPreparedStatement.java:1431
 #: org/postgresql/util/StreamWrapper.java:56
 msgid "Object is too large to send over the protocol."
 msgstr ""
@@ -1005,8 +1012,8 @@ msgstr ""
 #: org/postgresql/jdbc/PgResultSet.java:556
 #: org/postgresql/jdbc/PgResultSet.java:594
 #: org/postgresql/jdbc/PgResultSet.java:624
-#: org/postgresql/jdbc/PgResultSet.java:3014
-#: org/postgresql/jdbc/PgResultSet.java:3058
+#: org/postgresql/jdbc/PgResultSet.java:3012
+#: org/postgresql/jdbc/PgResultSet.java:3057
 #, java-format
 msgid "Cannot convert the column of type {0} to requested type {1}."
 msgstr ""
@@ -1018,7 +1025,7 @@ msgid "Can''t use relative move methods while on the insert row."
 msgstr ""
 
 #: org/postgresql/jdbc/PgResultSet.java:878
-#: org/postgresql/jdbc/PgStatement.java:895
+#: org/postgresql/jdbc/PgStatement.java:900
 #, java-format
 msgid "Invalid fetch direction constant: {0}."
 msgstr ""
@@ -1057,8 +1064,8 @@ msgstr ""
 
 #: org/postgresql/jdbc/PgResultSet.java:1119
 #: org/postgresql/jdbc/PgResultSet.java:1754
-#: org/postgresql/jdbc/PgResultSet.java:2422
-#: org/postgresql/jdbc/PgResultSet.java:2443
+#: org/postgresql/jdbc/PgResultSet.java:2420
+#: org/postgresql/jdbc/PgResultSet.java:2441
 #, java-format
 msgid "The JVM claims not to support the encoding: {0}"
 msgstr ""
@@ -1072,7 +1079,7 @@ msgid "Cannot call updateRow() when on the insert row."
 msgstr ""
 
 #: org/postgresql/jdbc/PgResultSet.java:1335
-#: org/postgresql/jdbc/PgResultSet.java:3075
+#: org/postgresql/jdbc/PgResultSet.java:3074
 msgid ""
 "Cannot update the ResultSet because it is either before the start or after "
 "the end of the results."
@@ -1089,68 +1096,68 @@ msgstr ""
 
 #: org/postgresql/jdbc/PgResultSet.java:2017
 #: org/postgresql/jdbc/PgResultSet.java:2022
-#: org/postgresql/jdbc/PgResultSet.java:2809
-#: org/postgresql/jdbc/PgResultSet.java:2815
-#: org/postgresql/jdbc/PgResultSet.java:2840
-#: org/postgresql/jdbc/PgResultSet.java:2846
-#: org/postgresql/jdbc/PgResultSet.java:2870
-#: org/postgresql/jdbc/PgResultSet.java:2875
-#: org/postgresql/jdbc/PgResultSet.java:2891
-#: org/postgresql/jdbc/PgResultSet.java:2912
-#: org/postgresql/jdbc/PgResultSet.java:2923
-#: org/postgresql/jdbc/PgResultSet.java:2936
-#: org/postgresql/jdbc/PgResultSet.java:3063
+#: org/postgresql/jdbc/PgResultSet.java:2807
+#: org/postgresql/jdbc/PgResultSet.java:2813
+#: org/postgresql/jdbc/PgResultSet.java:2838
+#: org/postgresql/jdbc/PgResultSet.java:2844
+#: org/postgresql/jdbc/PgResultSet.java:2868
+#: org/postgresql/jdbc/PgResultSet.java:2873
+#: org/postgresql/jdbc/PgResultSet.java:2889
+#: org/postgresql/jdbc/PgResultSet.java:2910
+#: org/postgresql/jdbc/PgResultSet.java:2921
+#: org/postgresql/jdbc/PgResultSet.java:2934
+#: org/postgresql/jdbc/PgResultSet.java:3062
 #, java-format
 msgid "Bad value for type {0} : {1}"
 msgstr ""
 
-#: org/postgresql/jdbc/PgResultSet.java:2595
+#: org/postgresql/jdbc/PgResultSet.java:2593
 #, java-format
 msgid "The column name {0} was not found in this ResultSet."
 msgstr ""
 
-#: org/postgresql/jdbc/PgResultSet.java:2731
+#: org/postgresql/jdbc/PgResultSet.java:2729
 msgid ""
 "ResultSet is not updateable.  The query that generated this result set must "
 "select only one table, and must select all primary keys from that table. See "
 "the JDBC 2.1 API Specification, section 5.6 for more details."
 msgstr ""
 
-#: org/postgresql/jdbc/PgResultSet.java:2743
+#: org/postgresql/jdbc/PgResultSet.java:2741
 msgid "This ResultSet is closed."
 msgstr ""
 
-#: org/postgresql/jdbc/PgResultSet.java:2774
+#: org/postgresql/jdbc/PgResultSet.java:2772
 msgid "ResultSet not positioned properly, perhaps you need to call next."
 msgstr ""
 
-#: org/postgresql/jdbc/PgResultSet.java:3095
+#: org/postgresql/jdbc/PgResultSet.java:3094
 msgid "Invalid UUID data."
 msgstr ""
 
-#: org/postgresql/jdbc/PgResultSet.java:3184
-#: org/postgresql/jdbc/PgResultSet.java:3191
-#: org/postgresql/jdbc/PgResultSet.java:3202
-#: org/postgresql/jdbc/PgResultSet.java:3213
-#: org/postgresql/jdbc/PgResultSet.java:3224
-#: org/postgresql/jdbc/PgResultSet.java:3235
-#: org/postgresql/jdbc/PgResultSet.java:3246
-#: org/postgresql/jdbc/PgResultSet.java:3257
-#: org/postgresql/jdbc/PgResultSet.java:3268
-#: org/postgresql/jdbc/PgResultSet.java:3275
-#: org/postgresql/jdbc/PgResultSet.java:3282
-#: org/postgresql/jdbc/PgResultSet.java:3293
-#: org/postgresql/jdbc/PgResultSet.java:3310
-#: org/postgresql/jdbc/PgResultSet.java:3317
-#: org/postgresql/jdbc/PgResultSet.java:3324
-#: org/postgresql/jdbc/PgResultSet.java:3335
-#: org/postgresql/jdbc/PgResultSet.java:3342
-#: org/postgresql/jdbc/PgResultSet.java:3349
-#: org/postgresql/jdbc/PgResultSet.java:3387
-#: org/postgresql/jdbc/PgResultSet.java:3394
-#: org/postgresql/jdbc/PgResultSet.java:3401
-#: org/postgresql/jdbc/PgResultSet.java:3421
-#: org/postgresql/jdbc/PgResultSet.java:3434
+#: org/postgresql/jdbc/PgResultSet.java:3183
+#: org/postgresql/jdbc/PgResultSet.java:3190
+#: org/postgresql/jdbc/PgResultSet.java:3201
+#: org/postgresql/jdbc/PgResultSet.java:3212
+#: org/postgresql/jdbc/PgResultSet.java:3223
+#: org/postgresql/jdbc/PgResultSet.java:3234
+#: org/postgresql/jdbc/PgResultSet.java:3245
+#: org/postgresql/jdbc/PgResultSet.java:3256
+#: org/postgresql/jdbc/PgResultSet.java:3267
+#: org/postgresql/jdbc/PgResultSet.java:3274
+#: org/postgresql/jdbc/PgResultSet.java:3281
+#: org/postgresql/jdbc/PgResultSet.java:3292
+#: org/postgresql/jdbc/PgResultSet.java:3309
+#: org/postgresql/jdbc/PgResultSet.java:3316
+#: org/postgresql/jdbc/PgResultSet.java:3323
+#: org/postgresql/jdbc/PgResultSet.java:3334
+#: org/postgresql/jdbc/PgResultSet.java:3341
+#: org/postgresql/jdbc/PgResultSet.java:3348
+#: org/postgresql/jdbc/PgResultSet.java:3386
+#: org/postgresql/jdbc/PgResultSet.java:3393
+#: org/postgresql/jdbc/PgResultSet.java:3400
+#: org/postgresql/jdbc/PgResultSet.java:3420
+#: org/postgresql/jdbc/PgResultSet.java:3433
 #, java-format
 msgid "conversion to {0} from {1} not supported"
 msgstr ""
@@ -1214,33 +1221,33 @@ msgstr ""
 msgid "Maximum number of rows must be a value grater than or equal to 0."
 msgstr ""
 
-#: org/postgresql/jdbc/PgStatement.java:550
+#: org/postgresql/jdbc/PgStatement.java:555
 msgid "Query timeout must be a value greater than or equals to 0."
 msgstr ""
 
-#: org/postgresql/jdbc/PgStatement.java:590
+#: org/postgresql/jdbc/PgStatement.java:595
 msgid "The maximum field size must be a value greater than or equal to 0."
 msgstr ""
 
-#: org/postgresql/jdbc/PgStatement.java:689
+#: org/postgresql/jdbc/PgStatement.java:694
 msgid "This statement has been closed."
 msgstr ""
 
-#: org/postgresql/jdbc/PgStatement.java:1145
-#: org/postgresql/jdbc/PgStatement.java:1173
+#: org/postgresql/jdbc/PgStatement.java:1150
+#: org/postgresql/jdbc/PgStatement.java:1178
 msgid "Returning autogenerated keys by column index is not supported."
 msgstr ""
 
-#: org/postgresql/jdbc/TimestampUtils.java:355
-#: org/postgresql/jdbc/TimestampUtils.java:423
+#: org/postgresql/jdbc/TimestampUtils.java:365
+#: org/postgresql/jdbc/TimestampUtils.java:433
 #, java-format
 msgid "Bad value for type timestamp/date/time: {1}"
 msgstr ""
 
-#: org/postgresql/jdbc/TimestampUtils.java:858
-#: org/postgresql/jdbc/TimestampUtils.java:915
-#: org/postgresql/jdbc/TimestampUtils.java:961
-#: org/postgresql/jdbc/TimestampUtils.java:1010
+#: org/postgresql/jdbc/TimestampUtils.java:914
+#: org/postgresql/jdbc/TimestampUtils.java:971
+#: org/postgresql/jdbc/TimestampUtils.java:1017
+#: org/postgresql/jdbc/TimestampUtils.java:1066
 #, java-format
 msgid "Unsupported binary encoding of {0}."
 msgstr ""
@@ -1253,31 +1260,31 @@ msgstr ""
 msgid "Invalid or unsupported by client SCRAM mechanisms"
 msgstr ""
 
-#: org/postgresql/jre8/sasl/ScramAuthenticator.java:117
+#: org/postgresql/jre8/sasl/ScramAuthenticator.java:119
 #, java-format
 msgid "Invalid server-first-message: {0}"
 msgstr ""
 
-#: org/postgresql/jre8/sasl/ScramAuthenticator.java:147
+#: org/postgresql/jre8/sasl/ScramAuthenticator.java:151
 #, java-format
 msgid "Invalid server-final-message: {0}"
 msgstr ""
 
-#: org/postgresql/jre8/sasl/ScramAuthenticator.java:153
+#: org/postgresql/jre8/sasl/ScramAuthenticator.java:157
 #, java-format
 msgid "SCRAM authentication failed, server returned error: {0}"
 msgstr ""
 
-#: org/postgresql/jre8/sasl/ScramAuthenticator.java:160
+#: org/postgresql/jre8/sasl/ScramAuthenticator.java:164
 msgid "Invalid server SCRAM signature"
 msgstr ""
 
-#: org/postgresql/largeobject/LargeObjectManager.java:144
+#: org/postgresql/largeobject/LargeObjectManager.java:136
 msgid "Failed to initialize LargeObject API"
 msgstr ""
 
-#: org/postgresql/largeobject/LargeObjectManager.java:262
-#: org/postgresql/largeobject/LargeObjectManager.java:305
+#: org/postgresql/largeobject/LargeObjectManager.java:254
+#: org/postgresql/largeobject/LargeObjectManager.java:295
 msgid "Large Objects may not be used in auto-commit mode."
 msgstr ""
 
@@ -1311,33 +1318,33 @@ msgstr ""
 msgid "The hostname {0} could not be verified."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:164
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:90
 msgid "The sslfactoryarg property may not be empty."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:180
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:106
 msgid ""
 "The environment variable containing the server's SSL certificate must not be "
 "empty."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:188
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:114
 msgid ""
 "The system property containing the server's SSL certificate must not be "
 "empty."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:195
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:121
 msgid ""
 "The sslfactoryarg property must start with the prefix file:, classpath:, "
 "env:, sys:, or -----BEGIN CERTIFICATE-----."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:207
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:133
 msgid "An error occurred reading the certificate"
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:240
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:166
 msgid "No X509TrustManager found"
 msgstr ""
 
@@ -1472,128 +1479,128 @@ msgid ""
 "setSavePoint not allowed while an XA transaction is active."
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:177
-#: org/postgresql/xa/PGXAConnection.java:253
-#: org/postgresql/xa/PGXAConnection.java:347
+#: org/postgresql/xa/PGXAConnection.java:186
+#: org/postgresql/xa/PGXAConnection.java:272
+#: org/postgresql/xa/PGXAConnection.java:381
 #, java-format
 msgid "Invalid flags {0}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:181
-#: org/postgresql/xa/PGXAConnection.java:257
-#: org/postgresql/xa/PGXAConnection.java:449
+#: org/postgresql/xa/PGXAConnection.java:190
+#: org/postgresql/xa/PGXAConnection.java:276
+#: org/postgresql/xa/PGXAConnection.java:491
 msgid "xid must not be null"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:185
+#: org/postgresql/xa/PGXAConnection.java:194
 msgid "Connection is busy with another transaction"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:194
-#: org/postgresql/xa/PGXAConnection.java:267
+#: org/postgresql/xa/PGXAConnection.java:203
+#: org/postgresql/xa/PGXAConnection.java:286
 msgid "suspend/resume not implemented"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:202
-#: org/postgresql/xa/PGXAConnection.java:209
-#: org/postgresql/xa/PGXAConnection.java:213
+#: org/postgresql/xa/PGXAConnection.java:211
+#: org/postgresql/xa/PGXAConnection.java:218
+#: org/postgresql/xa/PGXAConnection.java:222
 #, java-format
 msgid ""
 "Invalid protocol state requested. Attempted transaction interleaving is not "
 "supported. xid={0}, currentXid={1}, state={2}, flags={3}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:224
+#: org/postgresql/xa/PGXAConnection.java:233
 msgid "Error disabling autocommit"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:261
+#: org/postgresql/xa/PGXAConnection.java:280
 #, java-format
 msgid ""
 "tried to call end without corresponding start call. state={0}, start "
 "xid={1}, currentXid={2}, preparedXid={3}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:297
+#: org/postgresql/xa/PGXAConnection.java:326
 #, java-format
 msgid ""
 "Preparing already prepared transaction, the prepared xid {0}, prepare xid={1}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:300
+#: org/postgresql/xa/PGXAConnection.java:329
 #, java-format
 msgid "Current connection does not have an associated xid. prepare xid={0}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:307
+#: org/postgresql/xa/PGXAConnection.java:336
 #, java-format
 msgid ""
 "Not implemented: Prepare must be issued using the same connection that "
 "started the transaction. currentXid={0}, prepare xid={1}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:311
+#: org/postgresql/xa/PGXAConnection.java:340
 #, java-format
 msgid "Prepare called before end. prepare xid={0}, state={1}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:331
+#: org/postgresql/xa/PGXAConnection.java:360
 #, java-format
 msgid "Error preparing transaction. prepare xid={0}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:382
+#: org/postgresql/xa/PGXAConnection.java:416
 msgid "Error during recover"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:438
+#: org/postgresql/xa/PGXAConnection.java:480
 #, java-format
 msgid ""
 "Error rolling back prepared transaction. rollback xid={0}, preparedXid={1}, "
 "currentXid={2}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:471
+#: org/postgresql/xa/PGXAConnection.java:521
 #, java-format
 msgid ""
 "One-phase commit called for xid {0} but connection was prepared with xid {1}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:479
+#: org/postgresql/xa/PGXAConnection.java:529
 msgid ""
 "Not implemented: one-phase commit must be issued using the same connection "
 "that was used to start it"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:483
+#: org/postgresql/xa/PGXAConnection.java:533
 #, java-format
 msgid "One-phase commit with unknown xid. commit xid={0}, currentXid={1}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:487
+#: org/postgresql/xa/PGXAConnection.java:537
 #, java-format
 msgid "commit called before end. commit xid={0}, state={1}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:498
+#: org/postgresql/xa/PGXAConnection.java:548
 #, java-format
 msgid "Error during one-phase commit. commit xid={0}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:517
+#: org/postgresql/xa/PGXAConnection.java:576
 msgid ""
 "Not implemented: 2nd phase commit must be issued using an idle connection. "
 "commit xid={0}, currentXid={1}, state={2], transactionState={3}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:550
+#: org/postgresql/xa/PGXAConnection.java:609
 #, java-format
 msgid ""
 "Error committing prepared transaction. commit xid={0}, preparedXid={1}, "
 "currentXid={2}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:567
+#: org/postgresql/xa/PGXAConnection.java:626
 #, java-format
 msgid "Heuristic commit/rollback not supported. forget xid={0}"
 msgstr ""

--- a/pgjdbc/src/main/java/org/postgresql/translation/messages_bg.java
+++ b/pgjdbc/src/main/java/org/postgresql/translation/messages_bg.java
@@ -5,7 +5,7 @@ public class messages_bg extends java.util.ResourceBundle {
   static {
     java.lang.String[] t = new java.lang.String[890];
     t[0] = "";
-    t[1] = "Project-Id-Version: JDBC Driver for PostgreSQL 8.x\nReport-Msgid-Bugs-To: \nPOT-Creation-Date: 2018-06-05 10:57+0300\nPO-Revision-Date: 2009-12-28 00:01+0100\nLast-Translator: <usun0v@mail.bg>\nLanguage-Team: <bg@li.org>\nLanguage: \nMIME-Version: 1.0\nContent-Type: text/plain; charset=UTF-8\nContent-Transfer-Encoding: 8bit\nX-Poedit-Language: Bulgarian\nX-Poedit-Country: BULGARIA\n";
+    t[1] = "Project-Id-Version: JDBC Driver for PostgreSQL 8.x\nReport-Msgid-Bugs-To: \nPO-Revision-Date: 2009-12-28 00:01+0100\nLast-Translator: <usun0v@mail.bg>\nLanguage-Team: <bg@li.org>\nLanguage: \nMIME-Version: 1.0\nContent-Type: text/plain; charset=UTF-8\nContent-Transfer-Encoding: 8bit\nX-Poedit-Language: Bulgarian\nX-Poedit-Country: BULGARIA\n";
     t[2] = "A CallableStatement function was executed and the out parameter {0} was of type {1} however type {2} was registered.";
     t[3] = "CallableStatement \u0444\u0443\u043d\u043a\u0446\u0438\u044f \u0431\u0435 \u043e\u0431\u0440\u0430\u0431\u043e\u0442\u0435\u043d\u0430 \u0438 \u0438\u0437\u0445\u043e\u0434\u043d\u0438\u044f \u043f\u0430\u0440\u0430\u043c\u0435\u0442\u044a\u0440 {0} \u0431\u0435 \u043e\u0442 \u0442\u0438\u043f {1}, \u043e\u0431\u0430\u0447\u0435 \u0442\u0438\u043f {2} \u0431\u0435 \u0438\u0437\u043f\u043e\u043b\u0437\u0432\u0430\u043d.";
     t[6] = "Too many update results were returned.";

--- a/pgjdbc/src/main/java/org/postgresql/translation/messages_cs.java
+++ b/pgjdbc/src/main/java/org/postgresql/translation/messages_cs.java
@@ -5,7 +5,7 @@ public class messages_cs extends java.util.ResourceBundle {
   static {
     java.lang.String[] t = new java.lang.String[314];
     t[0] = "";
-    t[1] = "Project-Id-Version: PostgreSQL JDBC Driver 8.0\nReport-Msgid-Bugs-To: \nPOT-Creation-Date: 2018-06-05 10:57+0300\nPO-Revision-Date: 2005-08-21 20:00+0200\nLast-Translator: Petr Dittrich <bodyn@medoro.org>\nLanguage-Team: \nLanguage: \nMIME-Version: 1.0\nContent-Type: text/plain; charset=UTF-8\nContent-Transfer-Encoding: 8bit\n";
+    t[1] = "Project-Id-Version: PostgreSQL JDBC Driver 8.0\nReport-Msgid-Bugs-To: \nPO-Revision-Date: 2005-08-21 20:00+0200\nLast-Translator: Petr Dittrich <bodyn@medoro.org>\nLanguage-Team: \nLanguage: \nMIME-Version: 1.0\nContent-Type: text/plain; charset=UTF-8\nContent-Transfer-Encoding: 8bit\n";
     t[2] = "A connection could not be made using the requested protocol {0}.";
     t[3] = "Spojen\u00ed nelze vytvo\u0159it s pou\u017eit\u00edm \u017e\u00e1dan\u00e9ho protokolu {0}.";
     t[4] = "Malformed function or procedure escape syntax at offset {0}.";

--- a/pgjdbc/src/main/java/org/postgresql/translation/messages_de.java
+++ b/pgjdbc/src/main/java/org/postgresql/translation/messages_de.java
@@ -5,7 +5,7 @@ public class messages_de extends java.util.ResourceBundle {
   static {
     java.lang.String[] t = new java.lang.String[794];
     t[0] = "";
-    t[1] = "Project-Id-Version: head-de\nReport-Msgid-Bugs-To: \nPOT-Creation-Date: 2018-06-05 10:57+0300\nPO-Revision-Date: 2008-09-12 14:22+0200\nLast-Translator: Andre Bialojahn <ab.spamnews@freenet.de>\nLanguage-Team: Deutsch\nLanguage: \nMIME-Version: 1.0\nContent-Type: text/plain; charset=UTF-8\nContent-Transfer-Encoding: 8bit\nX-Generator: KBabel 1.0.2\nX-Poedit-Language: German\nX-Poedit-Country: GERMANY\n";
+    t[1] = "Project-Id-Version: head-de\nReport-Msgid-Bugs-To: \nPO-Revision-Date: 2008-09-12 14:22+0200\nLast-Translator: Andre Bialojahn <ab.spamnews@freenet.de>\nLanguage-Team: Deutsch\nLanguage: \nMIME-Version: 1.0\nContent-Type: text/plain; charset=UTF-8\nContent-Transfer-Encoding: 8bit\nX-Generator: KBabel 1.0.2\nX-Poedit-Language: German\nX-Poedit-Country: GERMANY\n";
     t[4] = "DataSource has been closed.";
     t[5] = "Die Datenquelle wurde geschlossen.";
     t[18] = "Where: {0}";

--- a/pgjdbc/src/main/java/org/postgresql/translation/messages_es.java
+++ b/pgjdbc/src/main/java/org/postgresql/translation/messages_es.java
@@ -5,7 +5,7 @@ public class messages_es extends java.util.ResourceBundle {
   static {
     java.lang.String[] t = new java.lang.String[74];
     t[0] = "";
-    t[1] = "Project-Id-Version: JDBC PostgreSQL Driver\nReport-Msgid-Bugs-To: \nPOT-Creation-Date: 2018-06-05 10:57+0300\nPO-Revision-Date: 2004-10-22 16:51-0300\nLast-Translator: Diego Gil <diego@adminsa.com>\nLanguage-Team: \nLanguage: \nMIME-Version: 1.0\nContent-Type: text/plain; charset=UTF-8\nContent-Transfer-Encoding: 8bit\nX-Poedit-Language: Spanish\n";
+    t[1] = "Project-Id-Version: JDBC PostgreSQL Driver\nReport-Msgid-Bugs-To: \nPO-Revision-Date: 2004-10-22 16:51-0300\nLast-Translator: Diego Gil <diego@adminsa.com>\nLanguage-Team: \nLanguage: \nMIME-Version: 1.0\nContent-Type: text/plain; charset=UTF-8\nContent-Transfer-Encoding: 8bit\nX-Poedit-Language: Spanish\n";
     t[4] = "The column index is out of range: {0}, number of columns: {1}.";
     t[5] = "El \u00edndice de la columna est\u00e1 fuera de rango: {0}, n\u00famero de columnas: {1}.";
     t[12] = "Unknown Response Type {0}.";

--- a/pgjdbc/src/main/java/org/postgresql/translation/messages_fr.java
+++ b/pgjdbc/src/main/java/org/postgresql/translation/messages_fr.java
@@ -5,7 +5,7 @@ public class messages_fr extends java.util.ResourceBundle {
   static {
     java.lang.String[] t = new java.lang.String[794];
     t[0] = "";
-    t[1] = "Project-Id-Version: head-fr\nReport-Msgid-Bugs-To: \nPOT-Creation-Date: 2018-06-05 10:57+0300\nPO-Revision-Date: 2007-07-27 12:27+0200\nLast-Translator: \nLanguage-Team:  <en@li.org>\nLanguage: \nMIME-Version: 1.0\nContent-Type: text/plain; charset=UTF-8\nContent-Transfer-Encoding: 8bit\nX-Generator: KBabel 1.11.4\nPlural-Forms:  nplurals=2; plural=(n > 1);\n";
+    t[1] = "Project-Id-Version: head-fr\nReport-Msgid-Bugs-To: \nPO-Revision-Date: 2007-07-27 12:27+0200\nLast-Translator: \nLanguage-Team:  <en@li.org>\nLanguage: \nMIME-Version: 1.0\nContent-Type: text/plain; charset=UTF-8\nContent-Transfer-Encoding: 8bit\nX-Generator: KBabel 1.11.4\nPlural-Forms:  nplurals=2; plural=(n > 1);\n";
     t[4] = "DataSource has been closed.";
     t[5] = "DataSource a \u00e9t\u00e9 ferm\u00e9e.";
     t[18] = "Where: {0}";

--- a/pgjdbc/src/main/java/org/postgresql/translation/messages_it.java
+++ b/pgjdbc/src/main/java/org/postgresql/translation/messages_it.java
@@ -5,7 +5,7 @@ public class messages_it extends java.util.ResourceBundle {
   static {
     java.lang.String[] t = new java.lang.String[794];
     t[0] = "";
-    t[1] = "Project-Id-Version: PostgreSQL JDBC Driver 8.2\nReport-Msgid-Bugs-To: \nPOT-Creation-Date: 2018-06-05 10:57+0300\nPO-Revision-Date: 2006-06-23 17:25+0200\nLast-Translator: Giuseppe Sacco <eppesuig@debian.org>\nLanguage-Team: Italian <tp@lists.linux.it>\nLanguage: it\nMIME-Version: 1.0\nContent-Type: text/plain; charset=UTF-8\nContent-Transfer-Encoding: 8bit\n";
+    t[1] = "Project-Id-Version: PostgreSQL JDBC Driver 8.2\nReport-Msgid-Bugs-To: \nPO-Revision-Date: 2006-06-23 17:25+0200\nLast-Translator: Giuseppe Sacco <eppesuig@debian.org>\nLanguage-Team: Italian <tp@lists.linux.it>\nLanguage: it\nMIME-Version: 1.0\nContent-Type: text/plain; charset=UTF-8\nContent-Transfer-Encoding: 8bit\n";
     t[4] = "DataSource has been closed.";
     t[5] = "Questo \u00abDataSource\u00bb \u00e8 stato chiuso.";
     t[18] = "Where: {0}";

--- a/pgjdbc/src/main/java/org/postgresql/translation/messages_ja.java
+++ b/pgjdbc/src/main/java/org/postgresql/translation/messages_ja.java
@@ -5,7 +5,7 @@ public class messages_ja extends java.util.ResourceBundle {
   static {
     java.lang.String[] t = new java.lang.String[1178];
     t[0] = "";
-    t[1] = "Project-Id-Version: head-ja\nReport-Msgid-Bugs-To: \nPOT-Creation-Date: 2018-06-05 10:57+0300\nPO-Revision-Date: 2010-04-11 22:58+0900\nLast-Translator: Hiroshi Saito <z-saito@guitar.ocn.ne.jp>\nLanguage-Team: PostgreSQL <z-saito@guitar.ocn.ne.jp>\nLanguage: \nMIME-Version: 1.0\nContent-Type: text/plain; charset=UTF-8\nContent-Transfer-Encoding: 8bit\nX-Generator: KBabel 1.0.2\nX-Poedit-Language: Japanese\nX-Poedit-Country: Japan\n";
+    t[1] = "Project-Id-Version: head-ja\nReport-Msgid-Bugs-To: \nPO-Revision-Date: 2010-04-11 22:58+0900\nLast-Translator: Hiroshi Saito <z-saito@guitar.ocn.ne.jp>\nLanguage-Team: PostgreSQL <z-saito@guitar.ocn.ne.jp>\nLanguage: \nMIME-Version: 1.0\nContent-Type: text/plain; charset=UTF-8\nContent-Transfer-Encoding: 8bit\nX-Generator: KBabel 1.0.2\nX-Poedit-Language: Japanese\nX-Poedit-Country: Japan\n";
     t[6] = "PostgreSQL LOBs can only index to: {0}";
     t[7] = "PostgreSQL LOB \u306f\u3001\u30a4\u30f3\u30c7\u30c3\u30af\u30b9 {0} \u307e\u3067\u306e\u307f\u53ef\u80fd\u3067\u3059\u3002 ";
     t[14] = "The server does not support SSL.";

--- a/pgjdbc/src/main/java/org/postgresql/translation/messages_nl.java
+++ b/pgjdbc/src/main/java/org/postgresql/translation/messages_nl.java
@@ -5,7 +5,7 @@ public class messages_nl extends java.util.ResourceBundle {
   static {
     java.lang.String[] t = new java.lang.String[36];
     t[0] = "";
-    t[1] = "Project-Id-Version: PostgreSQL JDBC Driver 8.0\nReport-Msgid-Bugs-To: \nPOT-Creation-Date: 2018-06-05 10:57+0300\nPO-Revision-Date: 2004-10-11 23:55-0700\nLast-Translator: Arnout Kuiper <ajkuiper@wxs.nl>\nLanguage-Team: Dutch <ajkuiper@wxs.nl>\nLanguage: nl\nMIME-Version: 1.0\nContent-Type: text/plain; charset=UTF-8\nContent-Transfer-Encoding: 8bit\n";
+    t[1] = "Project-Id-Version: PostgreSQL JDBC Driver 8.0\nReport-Msgid-Bugs-To: \nPO-Revision-Date: 2004-10-11 23:55-0700\nLast-Translator: Arnout Kuiper <ajkuiper@wxs.nl>\nLanguage-Team: Dutch <ajkuiper@wxs.nl>\nLanguage: nl\nMIME-Version: 1.0\nContent-Type: text/plain; charset=UTF-8\nContent-Transfer-Encoding: 8bit\n";
     t[2] = "Something unusual has occurred to cause the driver to fail. Please report this exception.";
     t[3] = "Iets ongewoons is opgetreden, wat deze driver doet falen. Rapporteer deze fout AUB: {0}";
     t[8] = "Unknown Types value.";

--- a/pgjdbc/src/main/java/org/postgresql/translation/messages_pl.java
+++ b/pgjdbc/src/main/java/org/postgresql/translation/messages_pl.java
@@ -5,7 +5,7 @@ public class messages_pl extends java.util.ResourceBundle {
   static {
     java.lang.String[] t = new java.lang.String[346];
     t[0] = "";
-    t[1] = "Project-Id-Version: head-pl\nReport-Msgid-Bugs-To: \nPOT-Creation-Date: 2018-06-05 10:57+0300\nPO-Revision-Date: 2005-05-22 03:01+0200\nLast-Translator: Jaros\u0142aw Jan Pyszny <jarek@pyszny.net>\nLanguage-Team:  <pl@li.org>\nLanguage: \nMIME-Version: 1.0\nContent-Type: text/plain; charset=UTF-8\nContent-Transfer-Encoding: 8bit\nX-Generator: KBabel 1.10\nPlural-Forms:  nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n";
+    t[1] = "Project-Id-Version: head-pl\nReport-Msgid-Bugs-To: \nPO-Revision-Date: 2005-05-22 03:01+0200\nLast-Translator: Jaros\u0142aw Jan Pyszny <jarek@pyszny.net>\nLanguage-Team:  <pl@li.org>\nLanguage: \nMIME-Version: 1.0\nContent-Type: text/plain; charset=UTF-8\nContent-Transfer-Encoding: 8bit\nX-Generator: KBabel 1.10\nPlural-Forms:  nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n";
     t[2] = "The driver currently does not support COPY operations.";
     t[3] = "Sterownik nie obs\u0142uguje aktualnie operacji COPY.";
     t[4] = "Internal Query: {0}";

--- a/pgjdbc/src/main/java/org/postgresql/translation/messages_pt_BR.java
+++ b/pgjdbc/src/main/java/org/postgresql/translation/messages_pt_BR.java
@@ -5,7 +5,7 @@ public class messages_pt_BR extends java.util.ResourceBundle {
   static {
     java.lang.String[] t = new java.lang.String[794];
     t[0] = "";
-    t[1] = "Project-Id-Version: PostgreSQL 8.4\nReport-Msgid-Bugs-To: \nPOT-Creation-Date: 2018-06-05 10:57+0300\nPO-Revision-Date: 2004-10-31 20:48-0300\nLast-Translator: Euler Taveira de Oliveira <euler@timbira.com>\nLanguage-Team: Brazilian Portuguese <pgbr-dev@listas.postgresql.org.br>\nLanguage: pt_BR\nMIME-Version: 1.0\nContent-Type: text/plain; charset=UTF-8\nContent-Transfer-Encoding: 8bit\n";
+    t[1] = "Project-Id-Version: PostgreSQL 8.4\nReport-Msgid-Bugs-To: \nPO-Revision-Date: 2004-10-31 20:48-0300\nLast-Translator: Euler Taveira de Oliveira <euler@timbira.com>\nLanguage-Team: Brazilian Portuguese <pgbr-dev@listas.postgresql.org.br>\nLanguage: pt_BR\nMIME-Version: 1.0\nContent-Type: text/plain; charset=UTF-8\nContent-Transfer-Encoding: 8bit\n";
     t[4] = "DataSource has been closed.";
     t[5] = "DataSource foi fechado.";
     t[8] = "Invalid flags {0}";

--- a/pgjdbc/src/main/java/org/postgresql/translation/messages_ru.java
+++ b/pgjdbc/src/main/java/org/postgresql/translation/messages_ru.java
@@ -5,7 +5,7 @@ public class messages_ru extends java.util.ResourceBundle {
   static {
     java.lang.String[] t = new java.lang.String[554];
     t[0] = "";
-    t[1] = "Project-Id-Version: JDBC Driver for PostgreSQL 8.x.x\nReport-Msgid-Bugs-To: \nPOT-Creation-Date: 2018-06-05 10:57+0300\nPO-Revision-Date: 2016-01-07 15:09+0300\nLast-Translator: Vladimir Sitnikov <sitnikov.vladimir@gmail.com>\nLanguage-Team: pgsql-rus <pgsql-rus@yahoogroups.com>\nLanguage: ru_RU\nMIME-Version: 1.0\nContent-Type: text/plain; charset=UTF-8\nContent-Transfer-Encoding: 8bit\nX-Generator: Poedit 1.5.7\n";
+    t[1] = "Project-Id-Version: JDBC Driver for PostgreSQL 8.x.x\nReport-Msgid-Bugs-To: \nPO-Revision-Date: 2016-01-07 15:09+0300\nLast-Translator: Vladimir Sitnikov <sitnikov.vladimir@gmail.com>\nLanguage-Team: pgsql-rus <pgsql-rus@yahoogroups.com>\nLanguage: ru_RU\nMIME-Version: 1.0\nContent-Type: text/plain; charset=UTF-8\nContent-Transfer-Encoding: 8bit\nX-Generator: Poedit 1.5.7\n";
     t[4] = "The HostnameVerifier class provided {0} could not be instantiated.";
     t[5] = "\u041d\u0435\u0432\u043e\u0437\u043c\u043e\u0436\u043d\u043e \u0441\u043e\u0437\u0434\u0430\u0442\u044c HostnameVerifier \u0441 \u043f\u043e\u043c\u043e\u0449\u044c\u044e \u0443\u043a\u0430\u0437\u0430\u043d\u043d\u043e\u0433\u043e \u043a\u043b\u0430\u0441\u0441\u0430 {0}";
     t[8] = "Unknown Types value.";

--- a/pgjdbc/src/main/java/org/postgresql/translation/messages_sr.java
+++ b/pgjdbc/src/main/java/org/postgresql/translation/messages_sr.java
@@ -5,7 +5,7 @@ public class messages_sr extends java.util.ResourceBundle {
   static {
     java.lang.String[] t = new java.lang.String[794];
     t[0] = "";
-    t[1] = "Project-Id-Version: PostgreSQL 8.1\nReport-Msgid-Bugs-To: \nPOT-Creation-Date: 2018-06-05 10:57+0300\nPO-Revision-Date: 2009-05-26 11:13+0100\nLast-Translator: Bojan \u0160kaljac <skaljac (at) gmail.com>\nLanguage-Team: Srpski <skaljac@gmail.com>\nLanguage: \nMIME-Version: 1.0\nContent-Type: text/plain; charset=UTF-8\nContent-Transfer-Encoding: 8bit\nX-Poedit-Language: Serbian\nX-Poedit-Country: YUGOSLAVIA\n";
+    t[1] = "Project-Id-Version: PostgreSQL 8.1\nReport-Msgid-Bugs-To: \nPO-Revision-Date: 2009-05-26 11:13+0100\nLast-Translator: Bojan \u0160kaljac <skaljac (at) gmail.com>\nLanguage-Team: Srpski <skaljac@gmail.com>\nLanguage: \nMIME-Version: 1.0\nContent-Type: text/plain; charset=UTF-8\nContent-Transfer-Encoding: 8bit\nX-Poedit-Language: Serbian\nX-Poedit-Country: YUGOSLAVIA\n";
     t[4] = "DataSource has been closed.";
     t[5] = "DataSource je zatvoren.";
     t[8] = "Invalid flags {0}";

--- a/pgjdbc/src/main/java/org/postgresql/translation/messages_tr.java
+++ b/pgjdbc/src/main/java/org/postgresql/translation/messages_tr.java
@@ -5,7 +5,7 @@ public class messages_tr extends java.util.ResourceBundle {
   static {
     java.lang.String[] t = new java.lang.String[794];
     t[0] = "";
-    t[1] = "Project-Id-Version: jdbc-tr\nReport-Msgid-Bugs-To: \nPOT-Creation-Date: 2018-06-05 10:57+0300\nPO-Revision-Date: 2009-05-31 21:47+0200\nLast-Translator: Devrim G\u00dcND\u00dcZ <devrim@gunduz.org>\nLanguage-Team: Turkish <pgsql-tr-genel@PostgreSQL.org>\nLanguage: tr\nMIME-Version: 1.0\nContent-Type: text/plain; charset=UTF-8\nContent-Transfer-Encoding: 8bit\nX-Generator: KBabel 1.3.1\nX-Poedit-Language: Turkish\nX-Poedit-Country: TURKEY\n";
+    t[1] = "Project-Id-Version: jdbc-tr\nReport-Msgid-Bugs-To: \nPO-Revision-Date: 2009-05-31 21:47+0200\nLast-Translator: Devrim G\u00dcND\u00dcZ <devrim@gunduz.org>\nLanguage-Team: Turkish <pgsql-tr-genel@PostgreSQL.org>\nLanguage: tr\nMIME-Version: 1.0\nContent-Type: text/plain; charset=UTF-8\nContent-Transfer-Encoding: 8bit\nX-Generator: KBabel 1.3.1\nX-Poedit-Language: Turkish\nX-Poedit-Country: TURKEY\n";
     t[4] = "DataSource has been closed.";
     t[5] = "DataSource kapat\u0131ld\u0131.";
     t[8] = "Invalid flags {0}";

--- a/pgjdbc/src/main/java/org/postgresql/translation/messages_zh_CN.java
+++ b/pgjdbc/src/main/java/org/postgresql/translation/messages_zh_CN.java
@@ -5,7 +5,7 @@ public class messages_zh_CN extends java.util.ResourceBundle {
   static {
     java.lang.String[] t = new java.lang.String[578];
     t[0] = "";
-    t[1] = "Project-Id-Version: PostgreSQL JDBC Driver 8.3\nReport-Msgid-Bugs-To: \nPOT-Creation-Date: 2018-06-05 10:57+0300\nPO-Revision-Date: 2008-01-31 14:34+0800\nLast-Translator: \u90ed\u671d\u76ca(ChaoYi, Kuo) <Kuo.ChaoYi@gmail.com>\nLanguage-Team: The PostgreSQL Development Team <Kuo.ChaoYi@gmail.com>\nLanguage: \nMIME-Version: 1.0\nContent-Type: text/plain; charset=UTF-8\nContent-Transfer-Encoding: 8bit\nX-Poedit-Language: Chinese\nX-Poedit-Country: CHINA\nX-Poedit-SourceCharset: utf-8\n";
+    t[1] = "Project-Id-Version: PostgreSQL JDBC Driver 8.3\nReport-Msgid-Bugs-To: \nPO-Revision-Date: 2008-01-31 14:34+0800\nLast-Translator: \u90ed\u671d\u76ca(ChaoYi, Kuo) <Kuo.ChaoYi@gmail.com>\nLanguage-Team: The PostgreSQL Development Team <Kuo.ChaoYi@gmail.com>\nLanguage: \nMIME-Version: 1.0\nContent-Type: text/plain; charset=UTF-8\nContent-Transfer-Encoding: 8bit\nX-Poedit-Language: Chinese\nX-Poedit-Country: CHINA\nX-Poedit-SourceCharset: utf-8\n";
     t[6] = "Cannot call cancelRowUpdates() when on the insert row.";
     t[7] = "\u4e0d\u80fd\u5728\u65b0\u589e\u7684\u6570\u636e\u5217\u4e0a\u547c\u53eb cancelRowUpdates()\u3002";
     t[8] = "The server requested password-based authentication, but no password was provided.";

--- a/pgjdbc/src/main/java/org/postgresql/translation/messages_zh_TW.java
+++ b/pgjdbc/src/main/java/org/postgresql/translation/messages_zh_TW.java
@@ -5,7 +5,7 @@ public class messages_zh_TW extends java.util.ResourceBundle {
   static {
     java.lang.String[] t = new java.lang.String[578];
     t[0] = "";
-    t[1] = "Project-Id-Version: PostgreSQL JDBC Driver 8.3\nReport-Msgid-Bugs-To: \nPOT-Creation-Date: 2018-06-05 10:57+0300\nPO-Revision-Date: 2008-01-21 16:50+0800\nLast-Translator: \u90ed\u671d\u76ca(ChaoYi, Kuo) <Kuo.ChaoYi@gmail.com>\nLanguage-Team: The PostgreSQL Development Team <Kuo.ChaoYi@gmail.com>\nLanguage: \nMIME-Version: 1.0\nContent-Type: text/plain; charset=UTF-8\nContent-Transfer-Encoding: 8bit\nX-Poedit-Language: Chinese\nX-Poedit-Country: TAIWAN\nX-Poedit-SourceCharset: utf-8\n";
+    t[1] = "Project-Id-Version: PostgreSQL JDBC Driver 8.3\nReport-Msgid-Bugs-To: \nPO-Revision-Date: 2008-01-21 16:50+0800\nLast-Translator: \u90ed\u671d\u76ca(ChaoYi, Kuo) <Kuo.ChaoYi@gmail.com>\nLanguage-Team: The PostgreSQL Development Team <Kuo.ChaoYi@gmail.com>\nLanguage: \nMIME-Version: 1.0\nContent-Type: text/plain; charset=UTF-8\nContent-Transfer-Encoding: 8bit\nX-Poedit-Language: Chinese\nX-Poedit-Country: TAIWAN\nX-Poedit-SourceCharset: utf-8\n";
     t[6] = "Cannot call cancelRowUpdates() when on the insert row.";
     t[7] = "\u4e0d\u80fd\u5728\u65b0\u589e\u7684\u8cc7\u6599\u5217\u4e0a\u547c\u53eb cancelRowUpdates()\u3002";
     t[8] = "The server requested password-based authentication, but no password was provided.";

--- a/pgjdbc/src/main/java/org/postgresql/translation/nl.po
+++ b/pgjdbc/src/main/java/org/postgresql/translation/nl.po
@@ -6,7 +6,6 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PostgreSQL JDBC Driver 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-06-05 10:57+0300\n"
 "PO-Revision-Date: 2004-10-11 23:55-0700\n"
 "Last-Translator: Arnout Kuiper <ajkuiper@wxs.nl>\n"
 "Language-Team: Dutch <ajkuiper@wxs.nl>\n"
@@ -15,22 +14,22 @@ msgstr ""
 "Content-Type: text/plain; charset=ISO-8859-1\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: org/postgresql/Driver.java:214
+#: org/postgresql/Driver.java:217
 msgid "Error loading default settings from driverconfig.properties"
 msgstr ""
 
-#: org/postgresql/Driver.java:226
+#: org/postgresql/Driver.java:229
 msgid "Properties for the driver contains a non-string value for the key "
 msgstr ""
 
-#: org/postgresql/Driver.java:270
+#: org/postgresql/Driver.java:272
 msgid ""
 "Your security policy has prevented the connection from being attempted.  You "
 "probably need to grant the connect java.net.SocketPermission to the database "
 "server host and port that you wish to connect to."
 msgstr ""
 
-#: org/postgresql/Driver.java:276 org/postgresql/Driver.java:408
+#: org/postgresql/Driver.java:278 org/postgresql/Driver.java:410
 msgid ""
 "Something unusual has occurred to cause the driver to fail. Please report "
 "this exception."
@@ -38,37 +37,37 @@ msgstr ""
 "Iets ongewoons is opgetreden, wat deze driver doet falen. Rapporteer deze "
 "fout AUB: {0}"
 
-#: org/postgresql/Driver.java:416
+#: org/postgresql/Driver.java:418
 #, fuzzy
 msgid "Connection attempt timed out."
 msgstr "De poging om verbinding the maken faalde omdat {0}"
 
-#: org/postgresql/Driver.java:429
+#: org/postgresql/Driver.java:431
 #, fuzzy
 msgid "Interrupted while attempting to connect."
 msgstr "Een fout trad op tijdens het ophalen van het authenticatie verzoek."
 
-#: org/postgresql/Driver.java:682
+#: org/postgresql/Driver.java:687
 #, fuzzy, java-format
 msgid "Method {0} is not yet implemented."
 msgstr "Deze methode is nog niet geimplementeerd"
 
-#: org/postgresql/PGProperty.java:535 org/postgresql/PGProperty.java:555
+#: org/postgresql/PGProperty.java:537 org/postgresql/PGProperty.java:557
 #, java-format
 msgid "{0} parameter value must be an integer but was: {1}"
 msgstr ""
 
-#: org/postgresql/copy/CopyManager.java:53
+#: org/postgresql/copy/CopyManager.java:49
 #, java-format
 msgid "Requested CopyIn but got {0}"
 msgstr ""
 
-#: org/postgresql/copy/CopyManager.java:64
+#: org/postgresql/copy/CopyManager.java:60
 #, java-format
 msgid "Requested CopyOut but got {0}"
 msgstr ""
 
-#: org/postgresql/copy/CopyManager.java:75
+#: org/postgresql/copy/CopyManager.java:71
 #, java-format
 msgid "Requested CopyDual but got {0}"
 msgstr ""
@@ -92,6 +91,11 @@ msgstr ""
 msgid "Cannot write to copy a byte of value {0}"
 msgstr ""
 
+#: org/postgresql/core/CommandCompleteParser.java:71
+#, java-format
+msgid "Unable to parse the count in command completion tag: {0}."
+msgstr ""
+
 #: org/postgresql/core/ConnectionFactory.java:57
 #, java-format
 msgid "A connection could not be made using the requested protocol {0}."
@@ -112,7 +116,7 @@ msgstr ""
 msgid "Expected an EOF from server, got: {0}"
 msgstr ""
 
-#: org/postgresql/core/Parser.java:1006
+#: org/postgresql/core/Parser.java:1051
 #, java-format
 msgid "Malformed function or procedure escape syntax at offset {0}."
 msgstr ""
@@ -168,23 +172,23 @@ msgstr ""
 #: org/postgresql/core/v3/CompositeParameterList.java:33
 #: org/postgresql/core/v3/SimpleParameterList.java:54
 #: org/postgresql/core/v3/SimpleParameterList.java:65
-#: org/postgresql/jdbc/PgResultSet.java:2757
-#: org/postgresql/jdbc/PgResultSetMetaData.java:494
+#: org/postgresql/jdbc/PgResultSet.java:2755
+#: org/postgresql/jdbc/PgResultSetMetaData.java:388
 #, fuzzy, java-format
 msgid "The column index is out of range: {0}, number of columns: {1}."
 msgstr "De kolom index is buiten bereik."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:109
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:103
 #, java-format
 msgid "Invalid sslmode value: {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:124
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:118
 #, fuzzy, java-format
 msgid "Invalid targetServerType value: {0}"
 msgstr "Onbekende Types waarde."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:246
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:239
 #, fuzzy, java-format
 msgid ""
 "Connection to {0} refused. Check that the hostname and port are correct and "
@@ -194,41 +198,41 @@ msgstr ""
 "dat de postmaster is opgestart met de -i vlag, welke TCP/IP networking "
 "aanzet."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:257
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:250
 #: org/postgresql/core/v3/replication/V3ReplicationProtocol.java:133
 #, fuzzy
 msgid "The connection attempt failed."
 msgstr "De poging om verbinding the maken faalde omdat {0}"
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:272
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:265
 #, java-format
 msgid "Could not find a server with specified targetServerType: {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:368
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:381
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:361
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:374
 msgid "The server does not support SSL."
 msgstr ""
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:395
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:388
 #, fuzzy
 msgid "An error occurred while setting up the SSL connection."
 msgstr "Een fout trad op tijdens het ophalen van het authenticatie verzoek."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:496
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:523
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:484
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:511
 msgid ""
 "The server requested password-based authentication, but no password was "
 "provided."
 msgstr ""
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:626
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:614
 msgid ""
 "SCRAM authentication is not supported by this driver. You need JDK >= 8 and "
 "pgjdbc >= 42.2.0 (not \".jre\" versions)"
 msgstr ""
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:650
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:638
 #, fuzzy, java-format
 msgid ""
 "The authentication type {0} is not supported. Check that you have configured "
@@ -240,16 +244,16 @@ msgstr ""
 "dat het een authenticatie protocol gebruikt dat door de driver ondersteund "
 "wordt."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:657
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2550
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2581
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2585
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2653
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:645
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2543
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2576
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2580
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2648
 #: org/postgresql/gss/GssAction.java:126
 msgid "Protocol error.  Session setup failed."
 msgstr ""
 
-#: org/postgresql/core/v3/CopyInImpl.java:47
+#: org/postgresql/core/v3/CopyInImpl.java:49
 msgid "CopyIn copy direction can't receive data"
 msgstr ""
 
@@ -257,177 +261,172 @@ msgstr ""
 msgid "CommandComplete expected COPY but got: "
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:161
+#: org/postgresql/core/v3/QueryExecutorImpl.java:163
 msgid "Tried to obtain lock while already holding it"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:177
+#: org/postgresql/core/v3/QueryExecutorImpl.java:179
 msgid "Tried to break lock on database connection"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:195
+#: org/postgresql/core/v3/QueryExecutorImpl.java:197
 msgid "Interrupted while waiting to obtain lock on database connection"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:327
+#: org/postgresql/core/v3/QueryExecutorImpl.java:329
 msgid "Unable to bind parameter values for statement."
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:333
-#: org/postgresql/core/v3/QueryExecutorImpl.java:485
-#: org/postgresql/core/v3/QueryExecutorImpl.java:559
-#: org/postgresql/core/v3/QueryExecutorImpl.java:602
-#: org/postgresql/core/v3/QueryExecutorImpl.java:729
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2372
+#: org/postgresql/core/v3/QueryExecutorImpl.java:335
+#: org/postgresql/core/v3/QueryExecutorImpl.java:487
+#: org/postgresql/core/v3/QueryExecutorImpl.java:561
+#: org/postgresql/core/v3/QueryExecutorImpl.java:604
+#: org/postgresql/core/v3/QueryExecutorImpl.java:731
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2377
 #: org/postgresql/util/StreamWrapper.java:130
 #, fuzzy
 msgid "An I/O error occurred while sending to the backend."
 msgstr "Een I/O fout trad op tijdens het zenden naar de achterkant - {0}"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:534
-#: org/postgresql/core/v3/QueryExecutorImpl.java:576
+#: org/postgresql/core/v3/QueryExecutorImpl.java:536
+#: org/postgresql/core/v3/QueryExecutorImpl.java:578
 #, java-format
 msgid "Expected command status BEGIN, got {0}."
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:581
+#: org/postgresql/core/v3/QueryExecutorImpl.java:583
 #: org/postgresql/jdbc/PgResultSet.java:1778
 #, java-format
 msgid "Unexpected command status: {0}."
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:687
+#: org/postgresql/core/v3/QueryExecutorImpl.java:689
 #, fuzzy
 msgid "An error occurred while trying to get the socket timeout."
 msgstr "Een I/O fout trad op tijdens het zenden naar de achterkant - {0}"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:722
-#: org/postgresql/core/v3/QueryExecutorImpl.java:798
+#: org/postgresql/core/v3/QueryExecutorImpl.java:724
+#: org/postgresql/core/v3/QueryExecutorImpl.java:800
 #, fuzzy, java-format
 msgid "Unknown Response Type {0}."
 msgstr "Onbekend antwoord type {0}"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:745
+#: org/postgresql/core/v3/QueryExecutorImpl.java:747
 #, fuzzy
 msgid "An error occurred while trying to reset the socket timeout."
 msgstr "Een I/O fout trad op tijdens het zenden naar de achterkant - {0}"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:843
+#: org/postgresql/core/v3/QueryExecutorImpl.java:845
 msgid "Database connection failed when starting copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:878
+#: org/postgresql/core/v3/QueryExecutorImpl.java:880
 msgid "Tried to cancel an inactive copy operation"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:917
+#: org/postgresql/core/v3/QueryExecutorImpl.java:919
 msgid "Database connection failed when canceling copy operation"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:933
+#: org/postgresql/core/v3/QueryExecutorImpl.java:935
 msgid "Missing expected error response to copy cancel request"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:937
+#: org/postgresql/core/v3/QueryExecutorImpl.java:939
 #, java-format
 msgid "Got {0} error responses to single copy cancel request"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:952
+#: org/postgresql/core/v3/QueryExecutorImpl.java:954
 msgid "Tried to end inactive copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:967
+#: org/postgresql/core/v3/QueryExecutorImpl.java:969
 msgid "Database connection failed when ending copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:985
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1005
+#: org/postgresql/core/v3/QueryExecutorImpl.java:987
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1007
 msgid "Tried to write to an inactive copy operation"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:998
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1013
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1000
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1015
 msgid "Database connection failed when writing to copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1028
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1030
 msgid "Tried to read from inactive copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1035
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1037
 msgid "Database connection failed when reading from copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1101
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1103
 #, java-format
 msgid "Received CommandComplete ''{0}'' without an active copy operation"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1126
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1128
 #, java-format
 msgid "Got CopyInResponse from server during an active {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1140
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1142
 #, java-format
 msgid "Got CopyOutResponse from server during an active {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1154
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1156
 #, java-format
 msgid "Got CopyBothResponse from server during an active {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1170
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1172
 msgid "Got CopyData without an active copy operation"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1174
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1176
 #, java-format
 msgid "Unexpected copydata from server for {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1234
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1236
 #, java-format
 msgid "Unexpected packet type during copy: {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1524
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1526
 #, java-format
 msgid ""
 "Bind message length {0} too long.  This can be caused by very large or "
 "incorrect length specifications on InputStream parameters."
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2145
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2150
 msgid "Ran out of memory retrieving query results."
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2313
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2318
 msgid "The driver currently does not support COPY operations."
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2487
-#, java-format
-msgid "Unable to parse the count in command completion tag: {0}."
-msgstr ""
-
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2610
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2605
 #, java-format
 msgid ""
 "The server''s client_encoding parameter was changed to {0}. The JDBC driver "
 "requires client_encoding to be UTF8 for correct operation."
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2620
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2615
 #, java-format
 msgid ""
 "The server''s DateStyle parameter was changed to {0}. The JDBC driver "
 "requires DateStyle to begin with ISO for correct operation."
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2633
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2628
 #, java-format
 msgid ""
 "The server''s standard_conforming_strings parameter was reported as {0}. The "
@@ -486,21 +485,21 @@ msgstr ""
 msgid "Unsupported property name: {0}"
 msgstr "Onbekende Types waarde."
 
-#: org/postgresql/fastpath/Fastpath.java:86
+#: org/postgresql/fastpath/Fastpath.java:84
 #, fuzzy, java-format
 msgid "Fastpath call {0} - No result was returned and we expected a numeric."
 msgstr ""
 "Fastpath aanroep {0} - Geen resultaat werd teruggegeven, terwijl we een "
 "integer verwacht hadden."
 
-#: org/postgresql/fastpath/Fastpath.java:163
+#: org/postgresql/fastpath/Fastpath.java:161
 #, java-format
 msgid "Fastpath call {0} - No result was returned and we expected an integer."
 msgstr ""
 "Fastpath aanroep {0} - Geen resultaat werd teruggegeven, terwijl we een "
 "integer verwacht hadden."
 
-#: org/postgresql/fastpath/Fastpath.java:171
+#: org/postgresql/fastpath/Fastpath.java:169
 #, fuzzy, java-format
 msgid ""
 "Fastpath call {0} - No result was returned or wrong size while expecting an "
@@ -509,14 +508,14 @@ msgstr ""
 "Fastpath aanroep {0} - Geen resultaat werd teruggegeven, terwijl we een "
 "integer verwacht hadden."
 
-#: org/postgresql/fastpath/Fastpath.java:188
+#: org/postgresql/fastpath/Fastpath.java:186
 #, fuzzy, java-format
 msgid "Fastpath call {0} - No result was returned and we expected a long."
 msgstr ""
 "Fastpath aanroep {0} - Geen resultaat werd teruggegeven, terwijl we een "
 "integer verwacht hadden."
 
-#: org/postgresql/fastpath/Fastpath.java:196
+#: org/postgresql/fastpath/Fastpath.java:194
 #, fuzzy, java-format
 msgid ""
 "Fastpath call {0} - No result was returned or wrong size while expecting a "
@@ -525,7 +524,7 @@ msgstr ""
 "Fastpath aanroep {0} - Geen resultaat werd teruggegeven, terwijl we een "
 "integer verwacht hadden."
 
-#: org/postgresql/fastpath/Fastpath.java:308
+#: org/postgresql/fastpath/Fastpath.java:297
 #, java-format
 msgid "The fastpath function {0} is unknown."
 msgstr "De fastpath functie {0} is onbekend."
@@ -592,63 +591,70 @@ msgid "Cannot cast to boolean: \"{0}\""
 msgstr ""
 
 #: org/postgresql/jdbc/EscapedFunctions.java:240
+#: org/postgresql/jdbc/EscapedFunctions2.java:167
 #, java-format
 msgid "{0} function takes four and only four argument."
 msgstr ""
 
 #: org/postgresql/jdbc/EscapedFunctions.java:270
-#: org/postgresql/jdbc/EscapedFunctions.java:344
-#: org/postgresql/jdbc/EscapedFunctions.java:749
-#: org/postgresql/jdbc/EscapedFunctions.java:787
+#: org/postgresql/jdbc/EscapedFunctions.java:337
+#: org/postgresql/jdbc/EscapedFunctions.java:740
+#: org/postgresql/jdbc/EscapedFunctions2.java:196
+#: org/postgresql/jdbc/EscapedFunctions2.java:263
+#: org/postgresql/jdbc/EscapedFunctions2.java:665
 #, java-format
 msgid "{0} function takes two and only two arguments."
 msgstr ""
 
 #: org/postgresql/jdbc/EscapedFunctions.java:288
-#: org/postgresql/jdbc/EscapedFunctions.java:326
-#: org/postgresql/jdbc/EscapedFunctions.java:446
-#: org/postgresql/jdbc/EscapedFunctions.java:461
-#: org/postgresql/jdbc/EscapedFunctions.java:476
-#: org/postgresql/jdbc/EscapedFunctions.java:491
-#: org/postgresql/jdbc/EscapedFunctions.java:506
-#: org/postgresql/jdbc/EscapedFunctions.java:521
-#: org/postgresql/jdbc/EscapedFunctions.java:536
-#: org/postgresql/jdbc/EscapedFunctions.java:551
-#: org/postgresql/jdbc/EscapedFunctions.java:566
-#: org/postgresql/jdbc/EscapedFunctions.java:581
-#: org/postgresql/jdbc/EscapedFunctions.java:596
-#: org/postgresql/jdbc/EscapedFunctions.java:611
-#: org/postgresql/jdbc/EscapedFunctions.java:775
+#: org/postgresql/jdbc/EscapedFunctions.java:441
+#: org/postgresql/jdbc/EscapedFunctions.java:467
+#: org/postgresql/jdbc/EscapedFunctions.java:526
+#: org/postgresql/jdbc/EscapedFunctions.java:728
+#: org/postgresql/jdbc/EscapedFunctions2.java:211
+#: org/postgresql/jdbc/EscapedFunctions2.java:355
+#: org/postgresql/jdbc/EscapedFunctions2.java:381
+#: org/postgresql/jdbc/EscapedFunctions2.java:440
+#: org/postgresql/jdbc/EscapedFunctions2.java:654
 #, java-format
 msgid "{0} function takes one and only one argument."
 msgstr ""
 
-#: org/postgresql/jdbc/EscapedFunctions.java:310
-#: org/postgresql/jdbc/EscapedFunctions.java:391
+#: org/postgresql/jdbc/EscapedFunctions.java:312
+#: org/postgresql/jdbc/EscapedFunctions.java:386
+#: org/postgresql/jdbc/EscapedFunctions2.java:238
+#: org/postgresql/jdbc/EscapedFunctions2.java:307
 #, java-format
 msgid "{0} function takes two or three arguments."
 msgstr ""
 
-#: org/postgresql/jdbc/EscapedFunctions.java:416
-#: org/postgresql/jdbc/EscapedFunctions.java:431
-#: org/postgresql/jdbc/EscapedFunctions.java:734
-#: org/postgresql/jdbc/EscapedFunctions.java:764
+#: org/postgresql/jdbc/EscapedFunctions.java:411
+#: org/postgresql/jdbc/EscapedFunctions.java:426
+#: org/postgresql/jdbc/EscapedFunctions.java:693
+#: org/postgresql/jdbc/EscapedFunctions.java:719
+#: org/postgresql/jdbc/EscapedFunctions2.java:645
 #, java-format
 msgid "{0} function doesn''t take any argument."
 msgstr ""
 
-#: org/postgresql/jdbc/EscapedFunctions.java:627
-#: org/postgresql/jdbc/EscapedFunctions.java:680
+#: org/postgresql/jdbc/EscapedFunctions.java:586
+#: org/postgresql/jdbc/EscapedFunctions.java:639
+#: org/postgresql/jdbc/EscapedFunctions2.java:500
+#: org/postgresql/jdbc/EscapedFunctions2.java:571
 #, java-format
 msgid "{0} function takes three and only three arguments."
 msgstr ""
 
-#: org/postgresql/jdbc/EscapedFunctions.java:640
-#: org/postgresql/jdbc/EscapedFunctions.java:661
-#: org/postgresql/jdbc/EscapedFunctions.java:664
-#: org/postgresql/jdbc/EscapedFunctions.java:697
-#: org/postgresql/jdbc/EscapedFunctions.java:710
-#: org/postgresql/jdbc/EscapedFunctions.java:713
+#: org/postgresql/jdbc/EscapedFunctions.java:599
+#: org/postgresql/jdbc/EscapedFunctions.java:620
+#: org/postgresql/jdbc/EscapedFunctions.java:623
+#: org/postgresql/jdbc/EscapedFunctions.java:656
+#: org/postgresql/jdbc/EscapedFunctions.java:669
+#: org/postgresql/jdbc/EscapedFunctions.java:672
+#: org/postgresql/jdbc/EscapedFunctions2.java:510
+#: org/postgresql/jdbc/EscapedFunctions2.java:527
+#: org/postgresql/jdbc/EscapedFunctions2.java:585
+#: org/postgresql/jdbc/EscapedFunctions2.java:597
 #, fuzzy, java-format
 msgid "Interval {0} not yet implemented"
 msgstr "Deze methode is nog niet geimplementeerd"
@@ -667,17 +673,17 @@ msgstr ""
 msgid "Cannot retrieve the name of an unnamed savepoint."
 msgstr ""
 
-#: org/postgresql/jdbc/PgArray.java:157 org/postgresql/jdbc/PgArray.java:844
+#: org/postgresql/jdbc/PgArray.java:155 org/postgresql/jdbc/PgArray.java:842
 #, fuzzy, java-format
 msgid "The array index is out of range: {0}"
 msgstr "De kolom index is buiten bereik."
 
-#: org/postgresql/jdbc/PgArray.java:178 org/postgresql/jdbc/PgArray.java:861
+#: org/postgresql/jdbc/PgArray.java:176 org/postgresql/jdbc/PgArray.java:859
 #, java-format
 msgid "The array index is out of range: {0}, number of elements: {1}."
 msgstr ""
 
-#: org/postgresql/jdbc/PgArray.java:210
+#: org/postgresql/jdbc/PgArray.java:208
 #: org/postgresql/jdbc/PgResultSet.java:1930
 #: org/postgresql/util/HStoreConverter.java:43
 #: org/postgresql/util/HStoreConverter.java:74
@@ -688,69 +694,69 @@ msgid ""
 "SQL_ASCII database."
 msgstr ""
 
-#: org/postgresql/jdbc/PgCallableStatement.java:86
-#: org/postgresql/jdbc/PgCallableStatement.java:96
+#: org/postgresql/jdbc/PgCallableStatement.java:85
+#: org/postgresql/jdbc/PgCallableStatement.java:95
 #, fuzzy
 msgid "A CallableStatement was executed with nothing returned."
 msgstr "Callable Statements worden op dit moment niet ondersteund."
 
-#: org/postgresql/jdbc/PgCallableStatement.java:107
+#: org/postgresql/jdbc/PgCallableStatement.java:106
 #, fuzzy
 msgid "A CallableStatement was executed with an invalid number of parameters"
 msgstr "Callable Statements worden op dit moment niet ondersteund."
 
-#: org/postgresql/jdbc/PgCallableStatement.java:145
+#: org/postgresql/jdbc/PgCallableStatement.java:144
 #, java-format
 msgid ""
 "A CallableStatement function was executed and the out parameter {0} was of "
 "type {1} however type {2} was registered."
 msgstr ""
 
-#: org/postgresql/jdbc/PgCallableStatement.java:202
+#: org/postgresql/jdbc/PgCallableStatement.java:206
 msgid ""
 "This statement does not declare an OUT parameter.  Use '{' ?= call ... '}' "
 "to declare one."
 msgstr ""
 
-#: org/postgresql/jdbc/PgCallableStatement.java:246
+#: org/postgresql/jdbc/PgCallableStatement.java:229
 msgid "wasNull cannot be call before fetching a result."
 msgstr ""
 
-#: org/postgresql/jdbc/PgCallableStatement.java:384
-#: org/postgresql/jdbc/PgCallableStatement.java:403
+#: org/postgresql/jdbc/PgCallableStatement.java:367
+#: org/postgresql/jdbc/PgCallableStatement.java:386
 #, java-format
 msgid ""
 "Parameter of type {0} was registered, but call to get{1} (sqltype={2}) was "
 "made."
 msgstr ""
 
-#: org/postgresql/jdbc/PgCallableStatement.java:424
+#: org/postgresql/jdbc/PgCallableStatement.java:407
 msgid ""
 "A CallableStatement was declared, but no call to registerOutParameter(1, "
 "<some type>) was made."
 msgstr ""
 
-#: org/postgresql/jdbc/PgCallableStatement.java:430
+#: org/postgresql/jdbc/PgCallableStatement.java:413
 msgid "No function outputs were registered."
 msgstr ""
 
-#: org/postgresql/jdbc/PgCallableStatement.java:436
+#: org/postgresql/jdbc/PgCallableStatement.java:419
 msgid ""
 "Results cannot be retrieved from a CallableStatement before it is executed."
 msgstr ""
 
-#: org/postgresql/jdbc/PgCallableStatement.java:703
+#: org/postgresql/jdbc/PgCallableStatement.java:686
 #, fuzzy, java-format
 msgid "Unsupported type conversion to {1}."
 msgstr "Onbekende Types waarde."
 
-#: org/postgresql/jdbc/PgConnection.java:272
+#: org/postgresql/jdbc/PgConnection.java:241
 #, java-format
 msgid "Unsupported value for stringtype parameter: {0}"
 msgstr ""
 
 #: org/postgresql/jdbc/PgConnection.java:424
-#: org/postgresql/jdbc/PgPreparedStatement.java:119
+#: org/postgresql/jdbc/PgPreparedStatement.java:107
 #: org/postgresql/jdbc/PgStatement.java:225
 #: org/postgresql/jdbc/TypeInfoCache.java:226
 #: org/postgresql/jdbc/TypeInfoCache.java:371
@@ -762,125 +768,125 @@ msgstr ""
 msgid "No results were returned by the query."
 msgstr "Geen resultaten werden teruggegeven door de query."
 
-#: org/postgresql/jdbc/PgConnection.java:441
+#: org/postgresql/jdbc/PgConnection.java:442
 #: org/postgresql/jdbc/PgStatement.java:254
 msgid "A result was returned when none was expected."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:545
+#: org/postgresql/jdbc/PgConnection.java:547
 msgid "Custom type maps are not supported."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:587
+#: org/postgresql/jdbc/PgConnection.java:589
 #, fuzzy, java-format
 msgid "Failed to create object for: {0}."
 msgstr "Kon geen object aanmaken voor  {0} {1}"
 
-#: org/postgresql/jdbc/PgConnection.java:641
+#: org/postgresql/jdbc/PgConnection.java:643
 #, java-format
 msgid "Unable to load the class {0} responsible for the datatype {1}"
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:693
+#: org/postgresql/jdbc/PgConnection.java:705
 msgid ""
 "Cannot change transaction read-only property in the middle of a transaction."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:756
+#: org/postgresql/jdbc/PgConnection.java:772
 msgid "Cannot commit when autoCommit is enabled."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:767
-#: org/postgresql/jdbc/PgConnection.java:1384
-#: org/postgresql/jdbc/PgConnection.java:1428
+#: org/postgresql/jdbc/PgConnection.java:783
+#: org/postgresql/jdbc/PgConnection.java:1401
+#: org/postgresql/jdbc/PgConnection.java:1445
 #, fuzzy
 msgid "This connection has been closed."
 msgstr "De poging om verbinding the maken faalde omdat {0}"
 
-#: org/postgresql/jdbc/PgConnection.java:777
+#: org/postgresql/jdbc/PgConnection.java:794
 msgid "Cannot rollback when autoCommit is enabled."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:827
+#: org/postgresql/jdbc/PgConnection.java:844
 msgid ""
 "Cannot change transaction isolation level in the middle of a transaction."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:833
+#: org/postgresql/jdbc/PgConnection.java:850
 #, java-format
 msgid "Transaction isolation level {0} not supported."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:878
+#: org/postgresql/jdbc/PgConnection.java:895
 msgid "Finalizing a Connection that was never closed:"
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:945
+#: org/postgresql/jdbc/PgConnection.java:962
 msgid "Unable to translate data into the desired encoding."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1008
+#: org/postgresql/jdbc/PgConnection.java:1025
 #: org/postgresql/jdbc/PgResultSet.java:1817
-#: org/postgresql/jdbc/PgStatement.java:903
+#: org/postgresql/jdbc/PgStatement.java:908
 msgid "Fetch size must be a value greater to or equal to 0."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1289
-#: org/postgresql/jdbc/PgConnection.java:1330
+#: org/postgresql/jdbc/PgConnection.java:1306
+#: org/postgresql/jdbc/PgConnection.java:1347
 #, java-format
 msgid "Unable to find server array type for provided name {0}."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1312
+#: org/postgresql/jdbc/PgConnection.java:1329
 #, java-format
 msgid "Invalid elements {0}"
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1348
+#: org/postgresql/jdbc/PgConnection.java:1365
 #, java-format
 msgid "Invalid timeout ({0}<0)."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1372
+#: org/postgresql/jdbc/PgConnection.java:1389
 msgid "Validating connection."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1405
+#: org/postgresql/jdbc/PgConnection.java:1422
 #, fuzzy, java-format
 msgid "Failed to set ClientInfo property: {0}"
 msgstr "Kon geen object aanmaken voor  {0} {1}"
 
-#: org/postgresql/jdbc/PgConnection.java:1415
+#: org/postgresql/jdbc/PgConnection.java:1432
 msgid "ClientInfo property not supported."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1441
+#: org/postgresql/jdbc/PgConnection.java:1458
 msgid "One ore more ClientInfo failed."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1540
+#: org/postgresql/jdbc/PgConnection.java:1559
 msgid "Network timeout must be a value greater than or equal to 0."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1552
+#: org/postgresql/jdbc/PgConnection.java:1571
 msgid "Unable to set network timeout."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1563
+#: org/postgresql/jdbc/PgConnection.java:1582
 msgid "Unable to get network timeout."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1580
+#: org/postgresql/jdbc/PgConnection.java:1599
 #, java-format
 msgid "Unknown ResultSet holdability setting: {0}."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1598
-#: org/postgresql/jdbc/PgConnection.java:1619
+#: org/postgresql/jdbc/PgConnection.java:1617
+#: org/postgresql/jdbc/PgConnection.java:1638
 msgid "Cannot establish a savepoint in auto-commit mode."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1685
+#: org/postgresql/jdbc/PgConnection.java:1707
 msgid "Returning autogenerated keys is not supported."
 msgstr ""
 
@@ -894,46 +900,46 @@ msgstr ""
 msgid "Unable to find name datatype in the system catalogs."
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:323
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:322
 msgid "Unable to find keywords in the system catalogs."
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1105
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1095
 msgid "oid"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1105
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1095
 msgid "proname"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1107
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1558
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1097
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1548
 msgid "typtype"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1110
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1100
 msgid "proargtypes"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1576
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1566
 msgid "adsrc"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1589
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1579
 msgid "attidentity"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1685
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1761
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1675
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1751
 msgid "rolname"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1686
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1762
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1676
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1752
 msgid "relacl"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1692
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1682
 msgid "attacl"
 msgstr ""
 
@@ -942,83 +948,83 @@ msgstr ""
 msgid "The parameter index is out of range: {0}, number of parameters: {1}."
 msgstr "De kolom index is buiten bereik."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:106
+#: org/postgresql/jdbc/PgPreparedStatement.java:94
+#: org/postgresql/jdbc/PgPreparedStatement.java:115
 #: org/postgresql/jdbc/PgPreparedStatement.java:127
-#: org/postgresql/jdbc/PgPreparedStatement.java:139
-#: org/postgresql/jdbc/PgPreparedStatement.java:1035
+#: org/postgresql/jdbc/PgPreparedStatement.java:1008
 msgid ""
 "Can''t use query methods that take a query string on a PreparedStatement."
 msgstr ""
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:249
+#: org/postgresql/jdbc/PgPreparedStatement.java:237
 msgid "Unknown Types value."
 msgstr "Onbekende Types waarde."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:382
-#: org/postgresql/jdbc/PgPreparedStatement.java:439
-#: org/postgresql/jdbc/PgPreparedStatement.java:1191
-#: org/postgresql/jdbc/PgPreparedStatement.java:1490
+#: org/postgresql/jdbc/PgPreparedStatement.java:364
+#: org/postgresql/jdbc/PgPreparedStatement.java:421
+#: org/postgresql/jdbc/PgPreparedStatement.java:1164
+#: org/postgresql/jdbc/PgPreparedStatement.java:1472
 #, java-format
 msgid "Invalid stream length {0}."
 msgstr ""
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:411
+#: org/postgresql/jdbc/PgPreparedStatement.java:393
 #, java-format
 msgid "The JVM claims not to support the {0} encoding."
 msgstr ""
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:414
+#: org/postgresql/jdbc/PgPreparedStatement.java:396
 #: org/postgresql/jdbc/PgResultSet.java:1122
 #: org/postgresql/jdbc/PgResultSet.java:1156
 msgid "Provided InputStream failed."
 msgstr ""
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:460
-#: org/postgresql/jdbc/PgPreparedStatement.java:1096
+#: org/postgresql/jdbc/PgPreparedStatement.java:442
+#: org/postgresql/jdbc/PgPreparedStatement.java:1069
 #, fuzzy, java-format
 msgid "Unknown type {0}."
 msgstr "Onbekend antwoord type {0}"
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:477
+#: org/postgresql/jdbc/PgPreparedStatement.java:459
 msgid "No hstore extension installed."
 msgstr ""
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:619
-#: org/postgresql/jdbc/PgPreparedStatement.java:642
-#: org/postgresql/jdbc/PgPreparedStatement.java:652
-#: org/postgresql/jdbc/PgPreparedStatement.java:664
+#: org/postgresql/jdbc/PgPreparedStatement.java:601
+#: org/postgresql/jdbc/PgPreparedStatement.java:624
+#: org/postgresql/jdbc/PgPreparedStatement.java:634
+#: org/postgresql/jdbc/PgPreparedStatement.java:646
 #, java-format
 msgid "Cannot cast an instance of {0} to type {1}"
 msgstr ""
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:682
+#: org/postgresql/jdbc/PgPreparedStatement.java:664
 #, fuzzy, java-format
 msgid "Unsupported Types value: {0}"
 msgstr "Onbekende Types waarde."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:894
+#: org/postgresql/jdbc/PgPreparedStatement.java:876
 #, java-format
 msgid "Cannot convert an instance of {0} to type {1}"
 msgstr ""
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:968
+#: org/postgresql/jdbc/PgPreparedStatement.java:950
 #, java-format
 msgid ""
 "Can''t infer the SQL type to use for an instance of {0}. Use setObject() "
 "with an explicit Types value to specify the type to use."
 msgstr ""
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:1133
-#: org/postgresql/jdbc/PgPreparedStatement.java:1233
+#: org/postgresql/jdbc/PgPreparedStatement.java:1106
+#: org/postgresql/jdbc/PgPreparedStatement.java:1206
 msgid "Unexpected error writing large object to database."
 msgstr ""
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:1178
+#: org/postgresql/jdbc/PgPreparedStatement.java:1151
 #: org/postgresql/jdbc/PgResultSet.java:1210
 msgid "Provided Reader failed."
 msgstr ""
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:1449
+#: org/postgresql/jdbc/PgPreparedStatement.java:1431
 #: org/postgresql/util/StreamWrapper.java:56
 msgid "Object is too large to send over the protocol."
 msgstr ""
@@ -1034,8 +1040,8 @@ msgstr ""
 #: org/postgresql/jdbc/PgResultSet.java:556
 #: org/postgresql/jdbc/PgResultSet.java:594
 #: org/postgresql/jdbc/PgResultSet.java:624
-#: org/postgresql/jdbc/PgResultSet.java:3014
-#: org/postgresql/jdbc/PgResultSet.java:3058
+#: org/postgresql/jdbc/PgResultSet.java:3012
+#: org/postgresql/jdbc/PgResultSet.java:3057
 #, java-format
 msgid "Cannot convert the column of type {0} to requested type {1}."
 msgstr ""
@@ -1047,7 +1053,7 @@ msgid "Can''t use relative move methods while on the insert row."
 msgstr ""
 
 #: org/postgresql/jdbc/PgResultSet.java:878
-#: org/postgresql/jdbc/PgStatement.java:895
+#: org/postgresql/jdbc/PgStatement.java:900
 #, java-format
 msgid "Invalid fetch direction constant: {0}."
 msgstr ""
@@ -1087,8 +1093,8 @@ msgstr ""
 
 #: org/postgresql/jdbc/PgResultSet.java:1119
 #: org/postgresql/jdbc/PgResultSet.java:1754
-#: org/postgresql/jdbc/PgResultSet.java:2422
-#: org/postgresql/jdbc/PgResultSet.java:2443
+#: org/postgresql/jdbc/PgResultSet.java:2420
+#: org/postgresql/jdbc/PgResultSet.java:2441
 #, java-format
 msgid "The JVM claims not to support the encoding: {0}"
 msgstr ""
@@ -1102,7 +1108,7 @@ msgid "Cannot call updateRow() when on the insert row."
 msgstr ""
 
 #: org/postgresql/jdbc/PgResultSet.java:1335
-#: org/postgresql/jdbc/PgResultSet.java:3075
+#: org/postgresql/jdbc/PgResultSet.java:3074
 msgid ""
 "Cannot update the ResultSet because it is either before the start or after "
 "the end of the results."
@@ -1119,68 +1125,68 @@ msgstr ""
 
 #: org/postgresql/jdbc/PgResultSet.java:2017
 #: org/postgresql/jdbc/PgResultSet.java:2022
-#: org/postgresql/jdbc/PgResultSet.java:2809
-#: org/postgresql/jdbc/PgResultSet.java:2815
-#: org/postgresql/jdbc/PgResultSet.java:2840
-#: org/postgresql/jdbc/PgResultSet.java:2846
-#: org/postgresql/jdbc/PgResultSet.java:2870
-#: org/postgresql/jdbc/PgResultSet.java:2875
-#: org/postgresql/jdbc/PgResultSet.java:2891
-#: org/postgresql/jdbc/PgResultSet.java:2912
-#: org/postgresql/jdbc/PgResultSet.java:2923
-#: org/postgresql/jdbc/PgResultSet.java:2936
-#: org/postgresql/jdbc/PgResultSet.java:3063
+#: org/postgresql/jdbc/PgResultSet.java:2807
+#: org/postgresql/jdbc/PgResultSet.java:2813
+#: org/postgresql/jdbc/PgResultSet.java:2838
+#: org/postgresql/jdbc/PgResultSet.java:2844
+#: org/postgresql/jdbc/PgResultSet.java:2868
+#: org/postgresql/jdbc/PgResultSet.java:2873
+#: org/postgresql/jdbc/PgResultSet.java:2889
+#: org/postgresql/jdbc/PgResultSet.java:2910
+#: org/postgresql/jdbc/PgResultSet.java:2921
+#: org/postgresql/jdbc/PgResultSet.java:2934
+#: org/postgresql/jdbc/PgResultSet.java:3062
 #, java-format
 msgid "Bad value for type {0} : {1}"
 msgstr ""
 
-#: org/postgresql/jdbc/PgResultSet.java:2595
+#: org/postgresql/jdbc/PgResultSet.java:2593
 #, fuzzy, java-format
 msgid "The column name {0} was not found in this ResultSet."
 msgstr "De kolom naam {0} is niet gevonden."
 
-#: org/postgresql/jdbc/PgResultSet.java:2731
+#: org/postgresql/jdbc/PgResultSet.java:2729
 msgid ""
 "ResultSet is not updateable.  The query that generated this result set must "
 "select only one table, and must select all primary keys from that table. See "
 "the JDBC 2.1 API Specification, section 5.6 for more details."
 msgstr ""
 
-#: org/postgresql/jdbc/PgResultSet.java:2743
+#: org/postgresql/jdbc/PgResultSet.java:2741
 msgid "This ResultSet is closed."
 msgstr ""
 
-#: org/postgresql/jdbc/PgResultSet.java:2774
+#: org/postgresql/jdbc/PgResultSet.java:2772
 msgid "ResultSet not positioned properly, perhaps you need to call next."
 msgstr ""
 
-#: org/postgresql/jdbc/PgResultSet.java:3095
+#: org/postgresql/jdbc/PgResultSet.java:3094
 msgid "Invalid UUID data."
 msgstr ""
 
-#: org/postgresql/jdbc/PgResultSet.java:3184
-#: org/postgresql/jdbc/PgResultSet.java:3191
-#: org/postgresql/jdbc/PgResultSet.java:3202
-#: org/postgresql/jdbc/PgResultSet.java:3213
-#: org/postgresql/jdbc/PgResultSet.java:3224
-#: org/postgresql/jdbc/PgResultSet.java:3235
-#: org/postgresql/jdbc/PgResultSet.java:3246
-#: org/postgresql/jdbc/PgResultSet.java:3257
-#: org/postgresql/jdbc/PgResultSet.java:3268
-#: org/postgresql/jdbc/PgResultSet.java:3275
-#: org/postgresql/jdbc/PgResultSet.java:3282
-#: org/postgresql/jdbc/PgResultSet.java:3293
-#: org/postgresql/jdbc/PgResultSet.java:3310
-#: org/postgresql/jdbc/PgResultSet.java:3317
-#: org/postgresql/jdbc/PgResultSet.java:3324
-#: org/postgresql/jdbc/PgResultSet.java:3335
-#: org/postgresql/jdbc/PgResultSet.java:3342
-#: org/postgresql/jdbc/PgResultSet.java:3349
-#: org/postgresql/jdbc/PgResultSet.java:3387
-#: org/postgresql/jdbc/PgResultSet.java:3394
-#: org/postgresql/jdbc/PgResultSet.java:3401
-#: org/postgresql/jdbc/PgResultSet.java:3421
-#: org/postgresql/jdbc/PgResultSet.java:3434
+#: org/postgresql/jdbc/PgResultSet.java:3183
+#: org/postgresql/jdbc/PgResultSet.java:3190
+#: org/postgresql/jdbc/PgResultSet.java:3201
+#: org/postgresql/jdbc/PgResultSet.java:3212
+#: org/postgresql/jdbc/PgResultSet.java:3223
+#: org/postgresql/jdbc/PgResultSet.java:3234
+#: org/postgresql/jdbc/PgResultSet.java:3245
+#: org/postgresql/jdbc/PgResultSet.java:3256
+#: org/postgresql/jdbc/PgResultSet.java:3267
+#: org/postgresql/jdbc/PgResultSet.java:3274
+#: org/postgresql/jdbc/PgResultSet.java:3281
+#: org/postgresql/jdbc/PgResultSet.java:3292
+#: org/postgresql/jdbc/PgResultSet.java:3309
+#: org/postgresql/jdbc/PgResultSet.java:3316
+#: org/postgresql/jdbc/PgResultSet.java:3323
+#: org/postgresql/jdbc/PgResultSet.java:3334
+#: org/postgresql/jdbc/PgResultSet.java:3341
+#: org/postgresql/jdbc/PgResultSet.java:3348
+#: org/postgresql/jdbc/PgResultSet.java:3386
+#: org/postgresql/jdbc/PgResultSet.java:3393
+#: org/postgresql/jdbc/PgResultSet.java:3400
+#: org/postgresql/jdbc/PgResultSet.java:3420
+#: org/postgresql/jdbc/PgResultSet.java:3433
 #, java-format
 msgid "conversion to {0} from {1} not supported"
 msgstr ""
@@ -1246,33 +1252,33 @@ msgstr ""
 msgid "Maximum number of rows must be a value grater than or equal to 0."
 msgstr ""
 
-#: org/postgresql/jdbc/PgStatement.java:550
+#: org/postgresql/jdbc/PgStatement.java:555
 msgid "Query timeout must be a value greater than or equals to 0."
 msgstr ""
 
-#: org/postgresql/jdbc/PgStatement.java:590
+#: org/postgresql/jdbc/PgStatement.java:595
 msgid "The maximum field size must be a value greater than or equal to 0."
 msgstr ""
 
-#: org/postgresql/jdbc/PgStatement.java:689
+#: org/postgresql/jdbc/PgStatement.java:694
 msgid "This statement has been closed."
 msgstr ""
 
-#: org/postgresql/jdbc/PgStatement.java:1145
-#: org/postgresql/jdbc/PgStatement.java:1173
+#: org/postgresql/jdbc/PgStatement.java:1150
+#: org/postgresql/jdbc/PgStatement.java:1178
 msgid "Returning autogenerated keys by column index is not supported."
 msgstr ""
 
-#: org/postgresql/jdbc/TimestampUtils.java:355
-#: org/postgresql/jdbc/TimestampUtils.java:423
+#: org/postgresql/jdbc/TimestampUtils.java:365
+#: org/postgresql/jdbc/TimestampUtils.java:433
 #, java-format
 msgid "Bad value for type timestamp/date/time: {1}"
 msgstr ""
 
-#: org/postgresql/jdbc/TimestampUtils.java:858
-#: org/postgresql/jdbc/TimestampUtils.java:915
-#: org/postgresql/jdbc/TimestampUtils.java:961
-#: org/postgresql/jdbc/TimestampUtils.java:1010
+#: org/postgresql/jdbc/TimestampUtils.java:914
+#: org/postgresql/jdbc/TimestampUtils.java:971
+#: org/postgresql/jdbc/TimestampUtils.java:1017
+#: org/postgresql/jdbc/TimestampUtils.java:1066
 #, java-format
 msgid "Unsupported binary encoding of {0}."
 msgstr ""
@@ -1285,32 +1291,32 @@ msgstr ""
 msgid "Invalid or unsupported by client SCRAM mechanisms"
 msgstr ""
 
-#: org/postgresql/jre8/sasl/ScramAuthenticator.java:117
+#: org/postgresql/jre8/sasl/ScramAuthenticator.java:119
 #, fuzzy, java-format
 msgid "Invalid server-first-message: {0}"
 msgstr "Onbekende Types waarde."
 
-#: org/postgresql/jre8/sasl/ScramAuthenticator.java:147
+#: org/postgresql/jre8/sasl/ScramAuthenticator.java:151
 #, fuzzy, java-format
 msgid "Invalid server-final-message: {0}"
 msgstr "Onbekende Types waarde."
 
-#: org/postgresql/jre8/sasl/ScramAuthenticator.java:153
+#: org/postgresql/jre8/sasl/ScramAuthenticator.java:157
 #, java-format
 msgid "SCRAM authentication failed, server returned error: {0}"
 msgstr ""
 
-#: org/postgresql/jre8/sasl/ScramAuthenticator.java:160
+#: org/postgresql/jre8/sasl/ScramAuthenticator.java:164
 msgid "Invalid server SCRAM signature"
 msgstr ""
 
-#: org/postgresql/largeobject/LargeObjectManager.java:144
+#: org/postgresql/largeobject/LargeObjectManager.java:136
 #, fuzzy
 msgid "Failed to initialize LargeObject API"
 msgstr "Kon LargeObject API niet initialiseren"
 
-#: org/postgresql/largeobject/LargeObjectManager.java:262
-#: org/postgresql/largeobject/LargeObjectManager.java:305
+#: org/postgresql/largeobject/LargeObjectManager.java:254
+#: org/postgresql/largeobject/LargeObjectManager.java:295
 msgid "Large Objects may not be used in auto-commit mode."
 msgstr ""
 
@@ -1344,34 +1350,34 @@ msgstr ""
 msgid "The hostname {0} could not be verified."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:164
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:90
 msgid "The sslfactoryarg property may not be empty."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:180
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:106
 msgid ""
 "The environment variable containing the server's SSL certificate must not be "
 "empty."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:188
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:114
 msgid ""
 "The system property containing the server's SSL certificate must not be "
 "empty."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:195
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:121
 msgid ""
 "The sslfactoryarg property must start with the prefix file:, classpath:, "
 "env:, sys:, or -----BEGIN CERTIFICATE-----."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:207
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:133
 #, fuzzy
 msgid "An error occurred reading the certificate"
 msgstr "Een fout trad op tijdens het ophalen van het authenticatie verzoek."
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:240
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:166
 msgid "No X509TrustManager found"
 msgstr ""
 
@@ -1508,129 +1514,129 @@ msgid ""
 "setSavePoint not allowed while an XA transaction is active."
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:177
-#: org/postgresql/xa/PGXAConnection.java:253
-#: org/postgresql/xa/PGXAConnection.java:347
+#: org/postgresql/xa/PGXAConnection.java:186
+#: org/postgresql/xa/PGXAConnection.java:272
+#: org/postgresql/xa/PGXAConnection.java:381
 #, java-format
 msgid "Invalid flags {0}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:181
-#: org/postgresql/xa/PGXAConnection.java:257
-#: org/postgresql/xa/PGXAConnection.java:449
+#: org/postgresql/xa/PGXAConnection.java:190
+#: org/postgresql/xa/PGXAConnection.java:276
+#: org/postgresql/xa/PGXAConnection.java:491
 msgid "xid must not be null"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:185
+#: org/postgresql/xa/PGXAConnection.java:194
 msgid "Connection is busy with another transaction"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:194
-#: org/postgresql/xa/PGXAConnection.java:267
+#: org/postgresql/xa/PGXAConnection.java:203
+#: org/postgresql/xa/PGXAConnection.java:286
 #, fuzzy
 msgid "suspend/resume not implemented"
 msgstr "Deze methode is nog niet geimplementeerd"
 
-#: org/postgresql/xa/PGXAConnection.java:202
-#: org/postgresql/xa/PGXAConnection.java:209
-#: org/postgresql/xa/PGXAConnection.java:213
+#: org/postgresql/xa/PGXAConnection.java:211
+#: org/postgresql/xa/PGXAConnection.java:218
+#: org/postgresql/xa/PGXAConnection.java:222
 #, java-format
 msgid ""
 "Invalid protocol state requested. Attempted transaction interleaving is not "
 "supported. xid={0}, currentXid={1}, state={2}, flags={3}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:224
+#: org/postgresql/xa/PGXAConnection.java:233
 msgid "Error disabling autocommit"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:261
+#: org/postgresql/xa/PGXAConnection.java:280
 #, java-format
 msgid ""
 "tried to call end without corresponding start call. state={0}, start "
 "xid={1}, currentXid={2}, preparedXid={3}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:297
+#: org/postgresql/xa/PGXAConnection.java:326
 #, java-format
 msgid ""
 "Preparing already prepared transaction, the prepared xid {0}, prepare xid={1}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:300
+#: org/postgresql/xa/PGXAConnection.java:329
 #, java-format
 msgid "Current connection does not have an associated xid. prepare xid={0}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:307
+#: org/postgresql/xa/PGXAConnection.java:336
 #, java-format
 msgid ""
 "Not implemented: Prepare must be issued using the same connection that "
 "started the transaction. currentXid={0}, prepare xid={1}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:311
+#: org/postgresql/xa/PGXAConnection.java:340
 #, java-format
 msgid "Prepare called before end. prepare xid={0}, state={1}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:331
+#: org/postgresql/xa/PGXAConnection.java:360
 #, java-format
 msgid "Error preparing transaction. prepare xid={0}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:382
+#: org/postgresql/xa/PGXAConnection.java:416
 msgid "Error during recover"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:438
+#: org/postgresql/xa/PGXAConnection.java:480
 #, java-format
 msgid ""
 "Error rolling back prepared transaction. rollback xid={0}, preparedXid={1}, "
 "currentXid={2}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:471
+#: org/postgresql/xa/PGXAConnection.java:521
 #, java-format
 msgid ""
 "One-phase commit called for xid {0} but connection was prepared with xid {1}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:479
+#: org/postgresql/xa/PGXAConnection.java:529
 msgid ""
 "Not implemented: one-phase commit must be issued using the same connection "
 "that was used to start it"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:483
+#: org/postgresql/xa/PGXAConnection.java:533
 #, java-format
 msgid "One-phase commit with unknown xid. commit xid={0}, currentXid={1}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:487
+#: org/postgresql/xa/PGXAConnection.java:537
 #, java-format
 msgid "commit called before end. commit xid={0}, state={1}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:498
+#: org/postgresql/xa/PGXAConnection.java:548
 #, java-format
 msgid "Error during one-phase commit. commit xid={0}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:517
+#: org/postgresql/xa/PGXAConnection.java:576
 msgid ""
 "Not implemented: 2nd phase commit must be issued using an idle connection. "
 "commit xid={0}, currentXid={1}, state={2], transactionState={3}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:550
+#: org/postgresql/xa/PGXAConnection.java:609
 #, java-format
 msgid ""
 "Error committing prepared transaction. commit xid={0}, preparedXid={1}, "
 "currentXid={2}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:567
+#: org/postgresql/xa/PGXAConnection.java:626
 #, java-format
 msgid "Heuristic commit/rollback not supported. forget xid={0}"
 msgstr ""

--- a/pgjdbc/src/main/java/org/postgresql/translation/pl.po
+++ b/pgjdbc/src/main/java/org/postgresql/translation/pl.po
@@ -10,7 +10,6 @@ msgid ""
 msgstr ""
 "Project-Id-Version: head-pl\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-06-05 10:57+0300\n"
 "PO-Revision-Date: 2005-05-22 03:01+0200\n"
 "Last-Translator: Jarosław Jan Pyszny <jarek@pyszny.net>\n"
 "Language-Team:  <pl@li.org>\n"
@@ -22,56 +21,56 @@ msgstr ""
 "Plural-Forms:  nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n"
 "%100<10 || n%100>=20) ? 1 : 2);\n"
 
-#: org/postgresql/Driver.java:214
+#: org/postgresql/Driver.java:217
 msgid "Error loading default settings from driverconfig.properties"
 msgstr "Błąd podczas wczytywania ustawień domyślnych z driverconfig.properties"
 
-#: org/postgresql/Driver.java:226
+#: org/postgresql/Driver.java:229
 msgid "Properties for the driver contains a non-string value for the key "
 msgstr ""
 
-#: org/postgresql/Driver.java:270
+#: org/postgresql/Driver.java:272
 msgid ""
 "Your security policy has prevented the connection from being attempted.  You "
 "probably need to grant the connect java.net.SocketPermission to the database "
 "server host and port that you wish to connect to."
 msgstr ""
 
-#: org/postgresql/Driver.java:276 org/postgresql/Driver.java:408
+#: org/postgresql/Driver.java:278 org/postgresql/Driver.java:410
 msgid ""
 "Something unusual has occurred to cause the driver to fail. Please report "
 "this exception."
 msgstr "Coś niezwykłego spowodowało pad sterownika. Proszę, zgłoś ten wyjątek."
 
-#: org/postgresql/Driver.java:416
+#: org/postgresql/Driver.java:418
 msgid "Connection attempt timed out."
 msgstr ""
 
-#: org/postgresql/Driver.java:429
+#: org/postgresql/Driver.java:431
 msgid "Interrupted while attempting to connect."
 msgstr ""
 
-#: org/postgresql/Driver.java:682
+#: org/postgresql/Driver.java:687
 #, java-format
 msgid "Method {0} is not yet implemented."
 msgstr "Metoda {0}nie jest jeszcze obsługiwana."
 
-#: org/postgresql/PGProperty.java:535 org/postgresql/PGProperty.java:555
+#: org/postgresql/PGProperty.java:537 org/postgresql/PGProperty.java:557
 #, java-format
 msgid "{0} parameter value must be an integer but was: {1}"
 msgstr ""
 
-#: org/postgresql/copy/CopyManager.java:53
+#: org/postgresql/copy/CopyManager.java:49
 #, java-format
 msgid "Requested CopyIn but got {0}"
 msgstr ""
 
-#: org/postgresql/copy/CopyManager.java:64
+#: org/postgresql/copy/CopyManager.java:60
 #, java-format
 msgid "Requested CopyOut but got {0}"
 msgstr ""
 
-#: org/postgresql/copy/CopyManager.java:75
+#: org/postgresql/copy/CopyManager.java:71
 #, java-format
 msgid "Requested CopyDual but got {0}"
 msgstr ""
@@ -96,6 +95,11 @@ msgstr ""
 msgid "Cannot write to copy a byte of value {0}"
 msgstr ""
 
+#: org/postgresql/core/CommandCompleteParser.java:71
+#, java-format
+msgid "Unable to parse the count in command completion tag: {0}."
+msgstr ""
+
 #: org/postgresql/core/ConnectionFactory.java:57
 #, java-format
 msgid "A connection could not be made using the requested protocol {0}."
@@ -118,7 +122,7 @@ msgstr ""
 msgid "Expected an EOF from server, got: {0}"
 msgstr ""
 
-#: org/postgresql/core/Parser.java:1006
+#: org/postgresql/core/Parser.java:1051
 #, java-format
 msgid "Malformed function or procedure escape syntax at offset {0}."
 msgstr ""
@@ -175,23 +179,23 @@ msgstr "Zerowe bajty nie mogą pojawiać się w parametrach typu łańcuch znako
 #: org/postgresql/core/v3/CompositeParameterList.java:33
 #: org/postgresql/core/v3/SimpleParameterList.java:54
 #: org/postgresql/core/v3/SimpleParameterList.java:65
-#: org/postgresql/jdbc/PgResultSet.java:2757
-#: org/postgresql/jdbc/PgResultSetMetaData.java:494
+#: org/postgresql/jdbc/PgResultSet.java:2755
+#: org/postgresql/jdbc/PgResultSetMetaData.java:388
 #, java-format
 msgid "The column index is out of range: {0}, number of columns: {1}."
 msgstr "Indeks kolumny jest poza zakresem: {0}, liczba kolumn: {1}."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:109
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:103
 #, java-format
 msgid "Invalid sslmode value: {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:124
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:118
 #, fuzzy, java-format
 msgid "Invalid targetServerType value: {0}"
 msgstr "Nieznana wartość Types: {0}"
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:246
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:239
 #, fuzzy, java-format
 msgid ""
 "Connection to {0} refused. Check that the hostname and port are correct and "
@@ -200,27 +204,27 @@ msgstr ""
 "Połączenie odrzucone. Sprawdź, czy prawidłowo ustawiłeś nazwę hosta oraz "
 "port i upewnij się, czy postmaster przyjmuje połączenia TCP/IP."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:257
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:250
 #: org/postgresql/core/v3/replication/V3ReplicationProtocol.java:133
 msgid "The connection attempt failed."
 msgstr "Próba nawiązania połączenia nie powiodła się."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:272
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:265
 #, java-format
 msgid "Could not find a server with specified targetServerType: {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:368
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:381
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:361
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:374
 msgid "The server does not support SSL."
 msgstr "Serwer nie obsługuje SSL."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:395
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:388
 msgid "An error occurred while setting up the SSL connection."
 msgstr "Wystąpił błąd podczas ustanawiania połączenia SSL."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:496
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:523
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:484
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:511
 msgid ""
 "The server requested password-based authentication, but no password was "
 "provided."
@@ -228,13 +232,13 @@ msgstr ""
 "Serwer zażądał uwierzytelnienia opartego na haśle, ale żadne hasło nie "
 "zostało dostarczone."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:626
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:614
 msgid ""
 "SCRAM authentication is not supported by this driver. You need JDK >= 8 and "
 "pgjdbc >= 42.2.0 (not \".jre\" versions)"
 msgstr ""
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:650
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:638
 #, java-format
 msgid ""
 "The authentication type {0} is not supported. Check that you have configured "
@@ -246,16 +250,16 @@ msgstr ""
 "klienta oraz że użyta metoda uwierzytelnienia jest wspierana przez ten "
 "sterownik."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:657
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2550
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2581
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2585
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2653
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:645
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2543
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2576
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2580
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2648
 #: org/postgresql/gss/GssAction.java:126
 msgid "Protocol error.  Session setup failed."
 msgstr "Błąd protokołu. Nie udało się utworzyć sesji."
 
-#: org/postgresql/core/v3/CopyInImpl.java:47
+#: org/postgresql/core/v3/CopyInImpl.java:49
 msgid "CopyIn copy direction can't receive data"
 msgstr ""
 
@@ -263,177 +267,172 @@ msgstr ""
 msgid "CommandComplete expected COPY but got: "
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:161
+#: org/postgresql/core/v3/QueryExecutorImpl.java:163
 msgid "Tried to obtain lock while already holding it"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:177
+#: org/postgresql/core/v3/QueryExecutorImpl.java:179
 msgid "Tried to break lock on database connection"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:195
+#: org/postgresql/core/v3/QueryExecutorImpl.java:197
 msgid "Interrupted while waiting to obtain lock on database connection"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:327
+#: org/postgresql/core/v3/QueryExecutorImpl.java:329
 msgid "Unable to bind parameter values for statement."
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:333
-#: org/postgresql/core/v3/QueryExecutorImpl.java:485
-#: org/postgresql/core/v3/QueryExecutorImpl.java:559
-#: org/postgresql/core/v3/QueryExecutorImpl.java:602
-#: org/postgresql/core/v3/QueryExecutorImpl.java:729
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2372
+#: org/postgresql/core/v3/QueryExecutorImpl.java:335
+#: org/postgresql/core/v3/QueryExecutorImpl.java:487
+#: org/postgresql/core/v3/QueryExecutorImpl.java:561
+#: org/postgresql/core/v3/QueryExecutorImpl.java:604
+#: org/postgresql/core/v3/QueryExecutorImpl.java:731
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2377
 #: org/postgresql/util/StreamWrapper.java:130
 #, fuzzy
 msgid "An I/O error occurred while sending to the backend."
 msgstr "Wystąpił błąd We/Wy podczas wysyłania do serwera."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:534
-#: org/postgresql/core/v3/QueryExecutorImpl.java:576
+#: org/postgresql/core/v3/QueryExecutorImpl.java:536
+#: org/postgresql/core/v3/QueryExecutorImpl.java:578
 #, java-format
 msgid "Expected command status BEGIN, got {0}."
 msgstr "Spodziewano się statusu komendy BEGIN, otrzymano {0}."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:581
+#: org/postgresql/core/v3/QueryExecutorImpl.java:583
 #: org/postgresql/jdbc/PgResultSet.java:1778
 #, java-format
 msgid "Unexpected command status: {0}."
 msgstr "Nieoczekiwany status komendy: {0}."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:687
+#: org/postgresql/core/v3/QueryExecutorImpl.java:689
 #, fuzzy
 msgid "An error occurred while trying to get the socket timeout."
 msgstr "Wystąpił błąd We/Wy podczas wysyłania do serwera."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:722
-#: org/postgresql/core/v3/QueryExecutorImpl.java:798
+#: org/postgresql/core/v3/QueryExecutorImpl.java:724
+#: org/postgresql/core/v3/QueryExecutorImpl.java:800
 #, java-format
 msgid "Unknown Response Type {0}."
 msgstr "Nieznany typ odpowiedzi {0}."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:745
+#: org/postgresql/core/v3/QueryExecutorImpl.java:747
 #, fuzzy
 msgid "An error occurred while trying to reset the socket timeout."
 msgstr "Wystąpił błąd We/Wy podczas wysyłania do serwera."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:843
+#: org/postgresql/core/v3/QueryExecutorImpl.java:845
 msgid "Database connection failed when starting copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:878
+#: org/postgresql/core/v3/QueryExecutorImpl.java:880
 msgid "Tried to cancel an inactive copy operation"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:917
+#: org/postgresql/core/v3/QueryExecutorImpl.java:919
 msgid "Database connection failed when canceling copy operation"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:933
+#: org/postgresql/core/v3/QueryExecutorImpl.java:935
 msgid "Missing expected error response to copy cancel request"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:937
+#: org/postgresql/core/v3/QueryExecutorImpl.java:939
 #, java-format
 msgid "Got {0} error responses to single copy cancel request"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:952
+#: org/postgresql/core/v3/QueryExecutorImpl.java:954
 msgid "Tried to end inactive copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:967
+#: org/postgresql/core/v3/QueryExecutorImpl.java:969
 msgid "Database connection failed when ending copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:985
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1005
+#: org/postgresql/core/v3/QueryExecutorImpl.java:987
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1007
 msgid "Tried to write to an inactive copy operation"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:998
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1013
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1000
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1015
 msgid "Database connection failed when writing to copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1028
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1030
 msgid "Tried to read from inactive copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1035
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1037
 msgid "Database connection failed when reading from copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1101
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1103
 #, java-format
 msgid "Received CommandComplete ''{0}'' without an active copy operation"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1126
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1128
 #, java-format
 msgid "Got CopyInResponse from server during an active {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1140
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1142
 #, java-format
 msgid "Got CopyOutResponse from server during an active {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1154
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1156
 #, java-format
 msgid "Got CopyBothResponse from server during an active {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1170
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1172
 msgid "Got CopyData without an active copy operation"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1174
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1176
 #, fuzzy, java-format
 msgid "Unexpected copydata from server for {0}"
 msgstr "Nieoczekiwany status komendy: {0}."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1234
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1236
 #, java-format
 msgid "Unexpected packet type during copy: {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1524
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1526
 #, java-format
 msgid ""
 "Bind message length {0} too long.  This can be caused by very large or "
 "incorrect length specifications on InputStream parameters."
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2145
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2150
 msgid "Ran out of memory retrieving query results."
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2313
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2318
 msgid "The driver currently does not support COPY operations."
 msgstr "Sterownik nie obsługuje aktualnie operacji COPY."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2487
-#, java-format
-msgid "Unable to parse the count in command completion tag: {0}."
-msgstr ""
-
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2610
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2605
 #, java-format
 msgid ""
 "The server''s client_encoding parameter was changed to {0}. The JDBC driver "
 "requires client_encoding to be UTF8 for correct operation."
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2620
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2615
 #, java-format
 msgid ""
 "The server''s DateStyle parameter was changed to {0}. The JDBC driver "
 "requires DateStyle to begin with ISO for correct operation."
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2633
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2628
 #, java-format
 msgid ""
 "The server''s standard_conforming_strings parameter was reported as {0}. The "
@@ -495,21 +494,21 @@ msgstr "DataSource zostało zamknięte."
 msgid "Unsupported property name: {0}"
 msgstr "Nieznana wartość Types: {0}"
 
-#: org/postgresql/fastpath/Fastpath.java:86
+#: org/postgresql/fastpath/Fastpath.java:84
 #, fuzzy, java-format
 msgid "Fastpath call {0} - No result was returned and we expected a numeric."
 msgstr ""
 "Wywołanie fastpath {0} - Nie otrzymano żadnego wyniku, a oczekiwano liczby "
 "całkowitej."
 
-#: org/postgresql/fastpath/Fastpath.java:163
+#: org/postgresql/fastpath/Fastpath.java:161
 #, java-format
 msgid "Fastpath call {0} - No result was returned and we expected an integer."
 msgstr ""
 "Wywołanie fastpath {0} - Nie otrzymano żadnego wyniku, a oczekiwano liczby "
 "całkowitej."
 
-#: org/postgresql/fastpath/Fastpath.java:171
+#: org/postgresql/fastpath/Fastpath.java:169
 #, fuzzy, java-format
 msgid ""
 "Fastpath call {0} - No result was returned or wrong size while expecting an "
@@ -518,14 +517,14 @@ msgstr ""
 "Wywołanie fastpath {0} - Nie otrzymano żadnego wyniku, a oczekiwano liczby "
 "całkowitej."
 
-#: org/postgresql/fastpath/Fastpath.java:188
+#: org/postgresql/fastpath/Fastpath.java:186
 #, fuzzy, java-format
 msgid "Fastpath call {0} - No result was returned and we expected a long."
 msgstr ""
 "Wywołanie fastpath {0} - Nie otrzymano żadnego wyniku, a oczekiwano liczby "
 "całkowitej."
 
-#: org/postgresql/fastpath/Fastpath.java:196
+#: org/postgresql/fastpath/Fastpath.java:194
 #, fuzzy, java-format
 msgid ""
 "Fastpath call {0} - No result was returned or wrong size while expecting a "
@@ -534,7 +533,7 @@ msgstr ""
 "Wywołanie fastpath {0} - Nie otrzymano żadnego wyniku, a oczekiwano liczby "
 "całkowitej."
 
-#: org/postgresql/fastpath/Fastpath.java:308
+#: org/postgresql/fastpath/Fastpath.java:297
 #, java-format
 msgid "The fastpath function {0} is unknown."
 msgstr "Funkcja fastpath {0} jest nieznana."
@@ -602,63 +601,70 @@ msgid "Cannot cast to boolean: \"{0}\""
 msgstr ""
 
 #: org/postgresql/jdbc/EscapedFunctions.java:240
+#: org/postgresql/jdbc/EscapedFunctions2.java:167
 #, java-format
 msgid "{0} function takes four and only four argument."
 msgstr ""
 
 #: org/postgresql/jdbc/EscapedFunctions.java:270
-#: org/postgresql/jdbc/EscapedFunctions.java:344
-#: org/postgresql/jdbc/EscapedFunctions.java:749
-#: org/postgresql/jdbc/EscapedFunctions.java:787
+#: org/postgresql/jdbc/EscapedFunctions.java:337
+#: org/postgresql/jdbc/EscapedFunctions.java:740
+#: org/postgresql/jdbc/EscapedFunctions2.java:196
+#: org/postgresql/jdbc/EscapedFunctions2.java:263
+#: org/postgresql/jdbc/EscapedFunctions2.java:665
 #, java-format
 msgid "{0} function takes two and only two arguments."
 msgstr ""
 
 #: org/postgresql/jdbc/EscapedFunctions.java:288
-#: org/postgresql/jdbc/EscapedFunctions.java:326
-#: org/postgresql/jdbc/EscapedFunctions.java:446
-#: org/postgresql/jdbc/EscapedFunctions.java:461
-#: org/postgresql/jdbc/EscapedFunctions.java:476
-#: org/postgresql/jdbc/EscapedFunctions.java:491
-#: org/postgresql/jdbc/EscapedFunctions.java:506
-#: org/postgresql/jdbc/EscapedFunctions.java:521
-#: org/postgresql/jdbc/EscapedFunctions.java:536
-#: org/postgresql/jdbc/EscapedFunctions.java:551
-#: org/postgresql/jdbc/EscapedFunctions.java:566
-#: org/postgresql/jdbc/EscapedFunctions.java:581
-#: org/postgresql/jdbc/EscapedFunctions.java:596
-#: org/postgresql/jdbc/EscapedFunctions.java:611
-#: org/postgresql/jdbc/EscapedFunctions.java:775
+#: org/postgresql/jdbc/EscapedFunctions.java:441
+#: org/postgresql/jdbc/EscapedFunctions.java:467
+#: org/postgresql/jdbc/EscapedFunctions.java:526
+#: org/postgresql/jdbc/EscapedFunctions.java:728
+#: org/postgresql/jdbc/EscapedFunctions2.java:211
+#: org/postgresql/jdbc/EscapedFunctions2.java:355
+#: org/postgresql/jdbc/EscapedFunctions2.java:381
+#: org/postgresql/jdbc/EscapedFunctions2.java:440
+#: org/postgresql/jdbc/EscapedFunctions2.java:654
 #, java-format
 msgid "{0} function takes one and only one argument."
 msgstr ""
 
-#: org/postgresql/jdbc/EscapedFunctions.java:310
-#: org/postgresql/jdbc/EscapedFunctions.java:391
+#: org/postgresql/jdbc/EscapedFunctions.java:312
+#: org/postgresql/jdbc/EscapedFunctions.java:386
+#: org/postgresql/jdbc/EscapedFunctions2.java:238
+#: org/postgresql/jdbc/EscapedFunctions2.java:307
 #, java-format
 msgid "{0} function takes two or three arguments."
 msgstr ""
 
-#: org/postgresql/jdbc/EscapedFunctions.java:416
-#: org/postgresql/jdbc/EscapedFunctions.java:431
-#: org/postgresql/jdbc/EscapedFunctions.java:734
-#: org/postgresql/jdbc/EscapedFunctions.java:764
+#: org/postgresql/jdbc/EscapedFunctions.java:411
+#: org/postgresql/jdbc/EscapedFunctions.java:426
+#: org/postgresql/jdbc/EscapedFunctions.java:693
+#: org/postgresql/jdbc/EscapedFunctions.java:719
+#: org/postgresql/jdbc/EscapedFunctions2.java:645
 #, java-format
 msgid "{0} function doesn''t take any argument."
 msgstr ""
 
-#: org/postgresql/jdbc/EscapedFunctions.java:627
-#: org/postgresql/jdbc/EscapedFunctions.java:680
+#: org/postgresql/jdbc/EscapedFunctions.java:586
+#: org/postgresql/jdbc/EscapedFunctions.java:639
+#: org/postgresql/jdbc/EscapedFunctions2.java:500
+#: org/postgresql/jdbc/EscapedFunctions2.java:571
 #, java-format
 msgid "{0} function takes three and only three arguments."
 msgstr ""
 
-#: org/postgresql/jdbc/EscapedFunctions.java:640
-#: org/postgresql/jdbc/EscapedFunctions.java:661
-#: org/postgresql/jdbc/EscapedFunctions.java:664
-#: org/postgresql/jdbc/EscapedFunctions.java:697
-#: org/postgresql/jdbc/EscapedFunctions.java:710
-#: org/postgresql/jdbc/EscapedFunctions.java:713
+#: org/postgresql/jdbc/EscapedFunctions.java:599
+#: org/postgresql/jdbc/EscapedFunctions.java:620
+#: org/postgresql/jdbc/EscapedFunctions.java:623
+#: org/postgresql/jdbc/EscapedFunctions.java:656
+#: org/postgresql/jdbc/EscapedFunctions.java:669
+#: org/postgresql/jdbc/EscapedFunctions.java:672
+#: org/postgresql/jdbc/EscapedFunctions2.java:510
+#: org/postgresql/jdbc/EscapedFunctions2.java:527
+#: org/postgresql/jdbc/EscapedFunctions2.java:585
+#: org/postgresql/jdbc/EscapedFunctions2.java:597
 #, fuzzy, java-format
 msgid "Interval {0} not yet implemented"
 msgstr "Metoda {0}nie jest jeszcze obsługiwana."
@@ -677,17 +683,17 @@ msgstr ""
 msgid "Cannot retrieve the name of an unnamed savepoint."
 msgstr ""
 
-#: org/postgresql/jdbc/PgArray.java:157 org/postgresql/jdbc/PgArray.java:844
+#: org/postgresql/jdbc/PgArray.java:155 org/postgresql/jdbc/PgArray.java:842
 #, java-format
 msgid "The array index is out of range: {0}"
 msgstr "Indeks tablicy jest poza zakresem: {0}"
 
-#: org/postgresql/jdbc/PgArray.java:178 org/postgresql/jdbc/PgArray.java:861
+#: org/postgresql/jdbc/PgArray.java:176 org/postgresql/jdbc/PgArray.java:859
 #, java-format
 msgid "The array index is out of range: {0}, number of elements: {1}."
 msgstr "Indeks tablicy jest poza zakresem: {0}, liczba elementów: {1}."
 
-#: org/postgresql/jdbc/PgArray.java:210
+#: org/postgresql/jdbc/PgArray.java:208
 #: org/postgresql/jdbc/PgResultSet.java:1930
 #: org/postgresql/util/HStoreConverter.java:43
 #: org/postgresql/util/HStoreConverter.java:74
@@ -702,41 +708,41 @@ msgstr ""
 "podczas tworzenia bazy danych. Najczęstszy przykład to przechowywanie 8-"
 "bitowych znaków w bazie o kodowaniu SQL_ASCII."
 
-#: org/postgresql/jdbc/PgCallableStatement.java:86
-#: org/postgresql/jdbc/PgCallableStatement.java:96
+#: org/postgresql/jdbc/PgCallableStatement.java:85
+#: org/postgresql/jdbc/PgCallableStatement.java:95
 msgid "A CallableStatement was executed with nothing returned."
 msgstr ""
 
-#: org/postgresql/jdbc/PgCallableStatement.java:107
+#: org/postgresql/jdbc/PgCallableStatement.java:106
 msgid "A CallableStatement was executed with an invalid number of parameters"
 msgstr ""
 
-#: org/postgresql/jdbc/PgCallableStatement.java:145
+#: org/postgresql/jdbc/PgCallableStatement.java:144
 #, java-format
 msgid ""
 "A CallableStatement function was executed and the out parameter {0} was of "
 "type {1} however type {2} was registered."
 msgstr ""
 
-#: org/postgresql/jdbc/PgCallableStatement.java:202
+#: org/postgresql/jdbc/PgCallableStatement.java:206
 msgid ""
 "This statement does not declare an OUT parameter.  Use '{' ?= call ... '}' "
 "to declare one."
 msgstr ""
 
-#: org/postgresql/jdbc/PgCallableStatement.java:246
+#: org/postgresql/jdbc/PgCallableStatement.java:229
 msgid "wasNull cannot be call before fetching a result."
 msgstr ""
 
-#: org/postgresql/jdbc/PgCallableStatement.java:384
-#: org/postgresql/jdbc/PgCallableStatement.java:403
+#: org/postgresql/jdbc/PgCallableStatement.java:367
+#: org/postgresql/jdbc/PgCallableStatement.java:386
 #, java-format
 msgid ""
 "Parameter of type {0} was registered, but call to get{1} (sqltype={2}) was "
 "made."
 msgstr ""
 
-#: org/postgresql/jdbc/PgCallableStatement.java:424
+#: org/postgresql/jdbc/PgCallableStatement.java:407
 msgid ""
 "A CallableStatement was declared, but no call to registerOutParameter(1, "
 "<some type>) was made."
@@ -744,27 +750,27 @@ msgstr ""
 "Funkcja CallableStatement została zadeklarowana, ale nie wywołano "
 "registerOutParameter (1, <jakiś typ>)."
 
-#: org/postgresql/jdbc/PgCallableStatement.java:430
+#: org/postgresql/jdbc/PgCallableStatement.java:413
 msgid "No function outputs were registered."
 msgstr ""
 
-#: org/postgresql/jdbc/PgCallableStatement.java:436
+#: org/postgresql/jdbc/PgCallableStatement.java:419
 msgid ""
 "Results cannot be retrieved from a CallableStatement before it is executed."
 msgstr ""
 
-#: org/postgresql/jdbc/PgCallableStatement.java:703
+#: org/postgresql/jdbc/PgCallableStatement.java:686
 #, fuzzy, java-format
 msgid "Unsupported type conversion to {1}."
 msgstr "Nieznana wartość Types: {0}"
 
-#: org/postgresql/jdbc/PgConnection.java:272
+#: org/postgresql/jdbc/PgConnection.java:241
 #, fuzzy, java-format
 msgid "Unsupported value for stringtype parameter: {0}"
 msgstr "Nieznana wartość Types: {0}"
 
 #: org/postgresql/jdbc/PgConnection.java:424
-#: org/postgresql/jdbc/PgPreparedStatement.java:119
+#: org/postgresql/jdbc/PgPreparedStatement.java:107
 #: org/postgresql/jdbc/PgStatement.java:225
 #: org/postgresql/jdbc/TypeInfoCache.java:226
 #: org/postgresql/jdbc/TypeInfoCache.java:371
@@ -776,128 +782,128 @@ msgstr "Nieznana wartość Types: {0}"
 msgid "No results were returned by the query."
 msgstr "Zapytanie nie zwróciło żadnych wyników."
 
-#: org/postgresql/jdbc/PgConnection.java:441
+#: org/postgresql/jdbc/PgConnection.java:442
 #: org/postgresql/jdbc/PgStatement.java:254
 msgid "A result was returned when none was expected."
 msgstr "Zwrócono wynik zapytania, choć nie był on oczekiwany."
 
-#: org/postgresql/jdbc/PgConnection.java:545
+#: org/postgresql/jdbc/PgConnection.java:547
 msgid "Custom type maps are not supported."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:587
+#: org/postgresql/jdbc/PgConnection.java:589
 #, java-format
 msgid "Failed to create object for: {0}."
 msgstr "Nie powiodło się utworzenie obiektu dla: {0}."
 
-#: org/postgresql/jdbc/PgConnection.java:641
+#: org/postgresql/jdbc/PgConnection.java:643
 #, java-format
 msgid "Unable to load the class {0} responsible for the datatype {1}"
 msgstr ""
 "Nie jest możliwe załadowanie klasy {0} odpowiedzialnej za typ danych {1}"
 
-#: org/postgresql/jdbc/PgConnection.java:693
+#: org/postgresql/jdbc/PgConnection.java:705
 msgid ""
 "Cannot change transaction read-only property in the middle of a transaction."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:756
+#: org/postgresql/jdbc/PgConnection.java:772
 msgid "Cannot commit when autoCommit is enabled."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:767
-#: org/postgresql/jdbc/PgConnection.java:1384
-#: org/postgresql/jdbc/PgConnection.java:1428
+#: org/postgresql/jdbc/PgConnection.java:783
+#: org/postgresql/jdbc/PgConnection.java:1401
+#: org/postgresql/jdbc/PgConnection.java:1445
 #, fuzzy
 msgid "This connection has been closed."
 msgstr "Połączenie zostało zamknięte."
 
-#: org/postgresql/jdbc/PgConnection.java:777
+#: org/postgresql/jdbc/PgConnection.java:794
 msgid "Cannot rollback when autoCommit is enabled."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:827
+#: org/postgresql/jdbc/PgConnection.java:844
 msgid ""
 "Cannot change transaction isolation level in the middle of a transaction."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:833
+#: org/postgresql/jdbc/PgConnection.java:850
 #, java-format
 msgid "Transaction isolation level {0} not supported."
 msgstr "Poziom izolacji transakcji {0} nie jest obsługiwany."
 
-#: org/postgresql/jdbc/PgConnection.java:878
+#: org/postgresql/jdbc/PgConnection.java:895
 #, fuzzy
 msgid "Finalizing a Connection that was never closed:"
 msgstr "Połączenie zostało zamknięte."
 
-#: org/postgresql/jdbc/PgConnection.java:945
+#: org/postgresql/jdbc/PgConnection.java:962
 msgid "Unable to translate data into the desired encoding."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1008
+#: org/postgresql/jdbc/PgConnection.java:1025
 #: org/postgresql/jdbc/PgResultSet.java:1817
-#: org/postgresql/jdbc/PgStatement.java:903
+#: org/postgresql/jdbc/PgStatement.java:908
 msgid "Fetch size must be a value greater to or equal to 0."
 msgstr "Rozmiar pobierania musi być wartością dodatnią lub 0."
 
-#: org/postgresql/jdbc/PgConnection.java:1289
-#: org/postgresql/jdbc/PgConnection.java:1330
+#: org/postgresql/jdbc/PgConnection.java:1306
+#: org/postgresql/jdbc/PgConnection.java:1347
 #, java-format
 msgid "Unable to find server array type for provided name {0}."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1312
+#: org/postgresql/jdbc/PgConnection.java:1329
 #, java-format
 msgid "Invalid elements {0}"
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1348
+#: org/postgresql/jdbc/PgConnection.java:1365
 #, java-format
 msgid "Invalid timeout ({0}<0)."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1372
+#: org/postgresql/jdbc/PgConnection.java:1389
 msgid "Validating connection."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1405
+#: org/postgresql/jdbc/PgConnection.java:1422
 #, fuzzy, java-format
 msgid "Failed to set ClientInfo property: {0}"
 msgstr "Nie powiodło się utworzenie obiektu dla: {0}."
 
-#: org/postgresql/jdbc/PgConnection.java:1415
+#: org/postgresql/jdbc/PgConnection.java:1432
 msgid "ClientInfo property not supported."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1441
+#: org/postgresql/jdbc/PgConnection.java:1458
 msgid "One ore more ClientInfo failed."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1540
+#: org/postgresql/jdbc/PgConnection.java:1559
 #, fuzzy
 msgid "Network timeout must be a value greater than or equal to 0."
 msgstr "Timeout zapytania musi być wartością dodatnią lub 0."
 
-#: org/postgresql/jdbc/PgConnection.java:1552
+#: org/postgresql/jdbc/PgConnection.java:1571
 msgid "Unable to set network timeout."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1563
+#: org/postgresql/jdbc/PgConnection.java:1582
 msgid "Unable to get network timeout."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1580
+#: org/postgresql/jdbc/PgConnection.java:1599
 #, java-format
 msgid "Unknown ResultSet holdability setting: {0}."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1598
-#: org/postgresql/jdbc/PgConnection.java:1619
+#: org/postgresql/jdbc/PgConnection.java:1617
+#: org/postgresql/jdbc/PgConnection.java:1638
 msgid "Cannot establish a savepoint in auto-commit mode."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1685
+#: org/postgresql/jdbc/PgConnection.java:1707
 msgid "Returning autogenerated keys is not supported."
 msgstr ""
 
@@ -911,46 +917,46 @@ msgstr ""
 msgid "Unable to find name datatype in the system catalogs."
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:323
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:322
 msgid "Unable to find keywords in the system catalogs."
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1105
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1095
 msgid "oid"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1105
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1095
 msgid "proname"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1107
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1558
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1097
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1548
 msgid "typtype"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1110
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1100
 msgid "proargtypes"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1576
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1566
 msgid "adsrc"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1589
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1579
 msgid "attidentity"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1685
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1761
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1675
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1751
 msgid "rolname"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1686
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1762
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1676
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1752
 msgid "relacl"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1692
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1682
 msgid "attacl"
 msgstr ""
 
@@ -959,83 +965,83 @@ msgstr ""
 msgid "The parameter index is out of range: {0}, number of parameters: {1}."
 msgstr "Indeks parametru jest poza zakresem: {0}, liczba parametrów: {1}."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:106
+#: org/postgresql/jdbc/PgPreparedStatement.java:94
+#: org/postgresql/jdbc/PgPreparedStatement.java:115
 #: org/postgresql/jdbc/PgPreparedStatement.java:127
-#: org/postgresql/jdbc/PgPreparedStatement.java:139
-#: org/postgresql/jdbc/PgPreparedStatement.java:1035
+#: org/postgresql/jdbc/PgPreparedStatement.java:1008
 msgid ""
 "Can''t use query methods that take a query string on a PreparedStatement."
 msgstr ""
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:249
+#: org/postgresql/jdbc/PgPreparedStatement.java:237
 msgid "Unknown Types value."
 msgstr "Nieznana wartość Types."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:382
-#: org/postgresql/jdbc/PgPreparedStatement.java:439
-#: org/postgresql/jdbc/PgPreparedStatement.java:1191
-#: org/postgresql/jdbc/PgPreparedStatement.java:1490
+#: org/postgresql/jdbc/PgPreparedStatement.java:364
+#: org/postgresql/jdbc/PgPreparedStatement.java:421
+#: org/postgresql/jdbc/PgPreparedStatement.java:1164
+#: org/postgresql/jdbc/PgPreparedStatement.java:1472
 #, java-format
 msgid "Invalid stream length {0}."
 msgstr ""
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:411
+#: org/postgresql/jdbc/PgPreparedStatement.java:393
 #, java-format
 msgid "The JVM claims not to support the {0} encoding."
 msgstr ""
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:414
+#: org/postgresql/jdbc/PgPreparedStatement.java:396
 #: org/postgresql/jdbc/PgResultSet.java:1122
 #: org/postgresql/jdbc/PgResultSet.java:1156
 msgid "Provided InputStream failed."
 msgstr ""
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:460
-#: org/postgresql/jdbc/PgPreparedStatement.java:1096
+#: org/postgresql/jdbc/PgPreparedStatement.java:442
+#: org/postgresql/jdbc/PgPreparedStatement.java:1069
 #, java-format
 msgid "Unknown type {0}."
 msgstr "Nieznany typ {0}."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:477
+#: org/postgresql/jdbc/PgPreparedStatement.java:459
 msgid "No hstore extension installed."
 msgstr ""
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:619
-#: org/postgresql/jdbc/PgPreparedStatement.java:642
-#: org/postgresql/jdbc/PgPreparedStatement.java:652
-#: org/postgresql/jdbc/PgPreparedStatement.java:664
+#: org/postgresql/jdbc/PgPreparedStatement.java:601
+#: org/postgresql/jdbc/PgPreparedStatement.java:624
+#: org/postgresql/jdbc/PgPreparedStatement.java:634
+#: org/postgresql/jdbc/PgPreparedStatement.java:646
 #, java-format
 msgid "Cannot cast an instance of {0} to type {1}"
 msgstr ""
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:682
+#: org/postgresql/jdbc/PgPreparedStatement.java:664
 #, java-format
 msgid "Unsupported Types value: {0}"
 msgstr "Nieznana wartość Types: {0}"
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:894
+#: org/postgresql/jdbc/PgPreparedStatement.java:876
 #, java-format
 msgid "Cannot convert an instance of {0} to type {1}"
 msgstr ""
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:968
+#: org/postgresql/jdbc/PgPreparedStatement.java:950
 #, java-format
 msgid ""
 "Can''t infer the SQL type to use for an instance of {0}. Use setObject() "
 "with an explicit Types value to specify the type to use."
 msgstr ""
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:1133
-#: org/postgresql/jdbc/PgPreparedStatement.java:1233
+#: org/postgresql/jdbc/PgPreparedStatement.java:1106
+#: org/postgresql/jdbc/PgPreparedStatement.java:1206
 msgid "Unexpected error writing large object to database."
 msgstr ""
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:1178
+#: org/postgresql/jdbc/PgPreparedStatement.java:1151
 #: org/postgresql/jdbc/PgResultSet.java:1210
 msgid "Provided Reader failed."
 msgstr ""
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:1449
+#: org/postgresql/jdbc/PgPreparedStatement.java:1431
 #: org/postgresql/util/StreamWrapper.java:56
 msgid "Object is too large to send over the protocol."
 msgstr ""
@@ -1051,8 +1057,8 @@ msgstr ""
 #: org/postgresql/jdbc/PgResultSet.java:556
 #: org/postgresql/jdbc/PgResultSet.java:594
 #: org/postgresql/jdbc/PgResultSet.java:624
-#: org/postgresql/jdbc/PgResultSet.java:3014
-#: org/postgresql/jdbc/PgResultSet.java:3058
+#: org/postgresql/jdbc/PgResultSet.java:3012
+#: org/postgresql/jdbc/PgResultSet.java:3057
 #, java-format
 msgid "Cannot convert the column of type {0} to requested type {1}."
 msgstr ""
@@ -1064,7 +1070,7 @@ msgid "Can''t use relative move methods while on the insert row."
 msgstr ""
 
 #: org/postgresql/jdbc/PgResultSet.java:878
-#: org/postgresql/jdbc/PgStatement.java:895
+#: org/postgresql/jdbc/PgStatement.java:900
 #, java-format
 msgid "Invalid fetch direction constant: {0}."
 msgstr ""
@@ -1104,8 +1110,8 @@ msgstr ""
 
 #: org/postgresql/jdbc/PgResultSet.java:1119
 #: org/postgresql/jdbc/PgResultSet.java:1754
-#: org/postgresql/jdbc/PgResultSet.java:2422
-#: org/postgresql/jdbc/PgResultSet.java:2443
+#: org/postgresql/jdbc/PgResultSet.java:2420
+#: org/postgresql/jdbc/PgResultSet.java:2441
 #, java-format
 msgid "The JVM claims not to support the encoding: {0}"
 msgstr ""
@@ -1119,7 +1125,7 @@ msgid "Cannot call updateRow() when on the insert row."
 msgstr "Nie można wywołać updateRow() na wstawianym rekordzie."
 
 #: org/postgresql/jdbc/PgResultSet.java:1335
-#: org/postgresql/jdbc/PgResultSet.java:3075
+#: org/postgresql/jdbc/PgResultSet.java:3074
 msgid ""
 "Cannot update the ResultSet because it is either before the start or after "
 "the end of the results."
@@ -1136,27 +1142,27 @@ msgstr ""
 
 #: org/postgresql/jdbc/PgResultSet.java:2017
 #: org/postgresql/jdbc/PgResultSet.java:2022
-#: org/postgresql/jdbc/PgResultSet.java:2809
-#: org/postgresql/jdbc/PgResultSet.java:2815
-#: org/postgresql/jdbc/PgResultSet.java:2840
-#: org/postgresql/jdbc/PgResultSet.java:2846
-#: org/postgresql/jdbc/PgResultSet.java:2870
-#: org/postgresql/jdbc/PgResultSet.java:2875
-#: org/postgresql/jdbc/PgResultSet.java:2891
-#: org/postgresql/jdbc/PgResultSet.java:2912
-#: org/postgresql/jdbc/PgResultSet.java:2923
-#: org/postgresql/jdbc/PgResultSet.java:2936
-#: org/postgresql/jdbc/PgResultSet.java:3063
+#: org/postgresql/jdbc/PgResultSet.java:2807
+#: org/postgresql/jdbc/PgResultSet.java:2813
+#: org/postgresql/jdbc/PgResultSet.java:2838
+#: org/postgresql/jdbc/PgResultSet.java:2844
+#: org/postgresql/jdbc/PgResultSet.java:2868
+#: org/postgresql/jdbc/PgResultSet.java:2873
+#: org/postgresql/jdbc/PgResultSet.java:2889
+#: org/postgresql/jdbc/PgResultSet.java:2910
+#: org/postgresql/jdbc/PgResultSet.java:2921
+#: org/postgresql/jdbc/PgResultSet.java:2934
+#: org/postgresql/jdbc/PgResultSet.java:3062
 #, java-format
 msgid "Bad value for type {0} : {1}"
 msgstr "Zła wartość dla typu {0}: {1}"
 
-#: org/postgresql/jdbc/PgResultSet.java:2595
+#: org/postgresql/jdbc/PgResultSet.java:2593
 #, java-format
 msgid "The column name {0} was not found in this ResultSet."
 msgstr ""
 
-#: org/postgresql/jdbc/PgResultSet.java:2731
+#: org/postgresql/jdbc/PgResultSet.java:2729
 msgid ""
 "ResultSet is not updateable.  The query that generated this result set must "
 "select only one table, and must select all primary keys from that table. See "
@@ -1167,41 +1173,41 @@ msgstr ""
 "klucze główne tej tabeli. Zobacz Specyfikację JDBC 2.1 API, rozdział 5.6, by "
 "uzyskać więcej szczegółów."
 
-#: org/postgresql/jdbc/PgResultSet.java:2743
+#: org/postgresql/jdbc/PgResultSet.java:2741
 msgid "This ResultSet is closed."
 msgstr "Ten ResultSet jest zamknięty."
 
-#: org/postgresql/jdbc/PgResultSet.java:2774
+#: org/postgresql/jdbc/PgResultSet.java:2772
 msgid "ResultSet not positioned properly, perhaps you need to call next."
 msgstr "Zła pozycja w ResultSet, może musisz wywołać next."
 
-#: org/postgresql/jdbc/PgResultSet.java:3095
+#: org/postgresql/jdbc/PgResultSet.java:3094
 msgid "Invalid UUID data."
 msgstr ""
 
-#: org/postgresql/jdbc/PgResultSet.java:3184
-#: org/postgresql/jdbc/PgResultSet.java:3191
-#: org/postgresql/jdbc/PgResultSet.java:3202
-#: org/postgresql/jdbc/PgResultSet.java:3213
-#: org/postgresql/jdbc/PgResultSet.java:3224
-#: org/postgresql/jdbc/PgResultSet.java:3235
-#: org/postgresql/jdbc/PgResultSet.java:3246
-#: org/postgresql/jdbc/PgResultSet.java:3257
-#: org/postgresql/jdbc/PgResultSet.java:3268
-#: org/postgresql/jdbc/PgResultSet.java:3275
-#: org/postgresql/jdbc/PgResultSet.java:3282
-#: org/postgresql/jdbc/PgResultSet.java:3293
-#: org/postgresql/jdbc/PgResultSet.java:3310
-#: org/postgresql/jdbc/PgResultSet.java:3317
-#: org/postgresql/jdbc/PgResultSet.java:3324
-#: org/postgresql/jdbc/PgResultSet.java:3335
-#: org/postgresql/jdbc/PgResultSet.java:3342
-#: org/postgresql/jdbc/PgResultSet.java:3349
-#: org/postgresql/jdbc/PgResultSet.java:3387
-#: org/postgresql/jdbc/PgResultSet.java:3394
-#: org/postgresql/jdbc/PgResultSet.java:3401
-#: org/postgresql/jdbc/PgResultSet.java:3421
-#: org/postgresql/jdbc/PgResultSet.java:3434
+#: org/postgresql/jdbc/PgResultSet.java:3183
+#: org/postgresql/jdbc/PgResultSet.java:3190
+#: org/postgresql/jdbc/PgResultSet.java:3201
+#: org/postgresql/jdbc/PgResultSet.java:3212
+#: org/postgresql/jdbc/PgResultSet.java:3223
+#: org/postgresql/jdbc/PgResultSet.java:3234
+#: org/postgresql/jdbc/PgResultSet.java:3245
+#: org/postgresql/jdbc/PgResultSet.java:3256
+#: org/postgresql/jdbc/PgResultSet.java:3267
+#: org/postgresql/jdbc/PgResultSet.java:3274
+#: org/postgresql/jdbc/PgResultSet.java:3281
+#: org/postgresql/jdbc/PgResultSet.java:3292
+#: org/postgresql/jdbc/PgResultSet.java:3309
+#: org/postgresql/jdbc/PgResultSet.java:3316
+#: org/postgresql/jdbc/PgResultSet.java:3323
+#: org/postgresql/jdbc/PgResultSet.java:3334
+#: org/postgresql/jdbc/PgResultSet.java:3341
+#: org/postgresql/jdbc/PgResultSet.java:3348
+#: org/postgresql/jdbc/PgResultSet.java:3386
+#: org/postgresql/jdbc/PgResultSet.java:3393
+#: org/postgresql/jdbc/PgResultSet.java:3400
+#: org/postgresql/jdbc/PgResultSet.java:3420
+#: org/postgresql/jdbc/PgResultSet.java:3433
 #, fuzzy, java-format
 msgid "conversion to {0} from {1} not supported"
 msgstr "Poziom izolacji transakcji {0} nie jest obsługiwany."
@@ -1267,33 +1273,33 @@ msgstr ""
 msgid "Maximum number of rows must be a value grater than or equal to 0."
 msgstr "Maksymalna liczba rekordów musi być wartością dodatnią lub 0."
 
-#: org/postgresql/jdbc/PgStatement.java:550
+#: org/postgresql/jdbc/PgStatement.java:555
 msgid "Query timeout must be a value greater than or equals to 0."
 msgstr "Timeout zapytania musi być wartością dodatnią lub 0."
 
-#: org/postgresql/jdbc/PgStatement.java:590
+#: org/postgresql/jdbc/PgStatement.java:595
 msgid "The maximum field size must be a value greater than or equal to 0."
 msgstr "Maksymalny rozmiar pola musi być wartością dodatnią lub 0."
 
-#: org/postgresql/jdbc/PgStatement.java:689
+#: org/postgresql/jdbc/PgStatement.java:694
 msgid "This statement has been closed."
 msgstr ""
 
-#: org/postgresql/jdbc/PgStatement.java:1145
-#: org/postgresql/jdbc/PgStatement.java:1173
+#: org/postgresql/jdbc/PgStatement.java:1150
+#: org/postgresql/jdbc/PgStatement.java:1178
 msgid "Returning autogenerated keys by column index is not supported."
 msgstr ""
 
-#: org/postgresql/jdbc/TimestampUtils.java:355
-#: org/postgresql/jdbc/TimestampUtils.java:423
+#: org/postgresql/jdbc/TimestampUtils.java:365
+#: org/postgresql/jdbc/TimestampUtils.java:433
 #, fuzzy, java-format
 msgid "Bad value for type timestamp/date/time: {1}"
 msgstr "Zła wartość dla typu {0}: {1}"
 
-#: org/postgresql/jdbc/TimestampUtils.java:858
-#: org/postgresql/jdbc/TimestampUtils.java:915
-#: org/postgresql/jdbc/TimestampUtils.java:961
-#: org/postgresql/jdbc/TimestampUtils.java:1010
+#: org/postgresql/jdbc/TimestampUtils.java:914
+#: org/postgresql/jdbc/TimestampUtils.java:971
+#: org/postgresql/jdbc/TimestampUtils.java:1017
+#: org/postgresql/jdbc/TimestampUtils.java:1066
 #, fuzzy, java-format
 msgid "Unsupported binary encoding of {0}."
 msgstr "Nieznana wartość Types: {0}"
@@ -1306,31 +1312,31 @@ msgstr ""
 msgid "Invalid or unsupported by client SCRAM mechanisms"
 msgstr ""
 
-#: org/postgresql/jre8/sasl/ScramAuthenticator.java:117
+#: org/postgresql/jre8/sasl/ScramAuthenticator.java:119
 #, fuzzy, java-format
 msgid "Invalid server-first-message: {0}"
 msgstr "Nieznana wartość Types: {0}"
 
-#: org/postgresql/jre8/sasl/ScramAuthenticator.java:147
+#: org/postgresql/jre8/sasl/ScramAuthenticator.java:151
 #, fuzzy, java-format
 msgid "Invalid server-final-message: {0}"
 msgstr "Nieznana wartość Types: {0}"
 
-#: org/postgresql/jre8/sasl/ScramAuthenticator.java:153
+#: org/postgresql/jre8/sasl/ScramAuthenticator.java:157
 #, java-format
 msgid "SCRAM authentication failed, server returned error: {0}"
 msgstr ""
 
-#: org/postgresql/jre8/sasl/ScramAuthenticator.java:160
+#: org/postgresql/jre8/sasl/ScramAuthenticator.java:164
 msgid "Invalid server SCRAM signature"
 msgstr ""
 
-#: org/postgresql/largeobject/LargeObjectManager.java:144
+#: org/postgresql/largeobject/LargeObjectManager.java:136
 msgid "Failed to initialize LargeObject API"
 msgstr "Nie udało się zainicjować LargeObject API"
 
-#: org/postgresql/largeobject/LargeObjectManager.java:262
-#: org/postgresql/largeobject/LargeObjectManager.java:305
+#: org/postgresql/largeobject/LargeObjectManager.java:254
+#: org/postgresql/largeobject/LargeObjectManager.java:295
 msgid "Large Objects may not be used in auto-commit mode."
 msgstr ""
 
@@ -1364,34 +1370,34 @@ msgstr ""
 msgid "The hostname {0} could not be verified."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:164
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:90
 msgid "The sslfactoryarg property may not be empty."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:180
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:106
 msgid ""
 "The environment variable containing the server's SSL certificate must not be "
 "empty."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:188
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:114
 msgid ""
 "The system property containing the server's SSL certificate must not be "
 "empty."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:195
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:121
 msgid ""
 "The sslfactoryarg property must start with the prefix file:, classpath:, "
 "env:, sys:, or -----BEGIN CERTIFICATE-----."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:207
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:133
 #, fuzzy
 msgid "An error occurred reading the certificate"
 msgstr "Wystąpił błąd podczas ustanawiania połączenia SSL."
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:240
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:166
 msgid "No X509TrustManager found"
 msgstr ""
 
@@ -1526,31 +1532,31 @@ msgid ""
 "setSavePoint not allowed while an XA transaction is active."
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:177
-#: org/postgresql/xa/PGXAConnection.java:253
-#: org/postgresql/xa/PGXAConnection.java:347
+#: org/postgresql/xa/PGXAConnection.java:186
+#: org/postgresql/xa/PGXAConnection.java:272
+#: org/postgresql/xa/PGXAConnection.java:381
 #, java-format
 msgid "Invalid flags {0}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:181
-#: org/postgresql/xa/PGXAConnection.java:257
-#: org/postgresql/xa/PGXAConnection.java:449
+#: org/postgresql/xa/PGXAConnection.java:190
+#: org/postgresql/xa/PGXAConnection.java:276
+#: org/postgresql/xa/PGXAConnection.java:491
 msgid "xid must not be null"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:185
+#: org/postgresql/xa/PGXAConnection.java:194
 msgid "Connection is busy with another transaction"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:194
-#: org/postgresql/xa/PGXAConnection.java:267
+#: org/postgresql/xa/PGXAConnection.java:203
+#: org/postgresql/xa/PGXAConnection.java:286
 msgid "suspend/resume not implemented"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:202
-#: org/postgresql/xa/PGXAConnection.java:209
-#: org/postgresql/xa/PGXAConnection.java:213
+#: org/postgresql/xa/PGXAConnection.java:211
+#: org/postgresql/xa/PGXAConnection.java:218
+#: org/postgresql/xa/PGXAConnection.java:222
 #, fuzzy, java-format
 msgid ""
 "Invalid protocol state requested. Attempted transaction interleaving is not "
@@ -1559,97 +1565,97 @@ msgstr ""
 "Poziom izolacji transakcji {0} nie jest obsługiwany. xid={0}, "
 "currentXid={1}, state={2}, flags={3}"
 
-#: org/postgresql/xa/PGXAConnection.java:224
+#: org/postgresql/xa/PGXAConnection.java:233
 msgid "Error disabling autocommit"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:261
+#: org/postgresql/xa/PGXAConnection.java:280
 #, java-format
 msgid ""
 "tried to call end without corresponding start call. state={0}, start "
 "xid={1}, currentXid={2}, preparedXid={3}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:297
+#: org/postgresql/xa/PGXAConnection.java:326
 #, java-format
 msgid ""
 "Preparing already prepared transaction, the prepared xid {0}, prepare xid={1}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:300
+#: org/postgresql/xa/PGXAConnection.java:329
 #, java-format
 msgid "Current connection does not have an associated xid. prepare xid={0}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:307
+#: org/postgresql/xa/PGXAConnection.java:336
 #, java-format
 msgid ""
 "Not implemented: Prepare must be issued using the same connection that "
 "started the transaction. currentXid={0}, prepare xid={1}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:311
+#: org/postgresql/xa/PGXAConnection.java:340
 #, java-format
 msgid "Prepare called before end. prepare xid={0}, state={1}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:331
+#: org/postgresql/xa/PGXAConnection.java:360
 #, java-format
 msgid "Error preparing transaction. prepare xid={0}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:382
+#: org/postgresql/xa/PGXAConnection.java:416
 msgid "Error during recover"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:438
+#: org/postgresql/xa/PGXAConnection.java:480
 #, java-format
 msgid ""
 "Error rolling back prepared transaction. rollback xid={0}, preparedXid={1}, "
 "currentXid={2}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:471
+#: org/postgresql/xa/PGXAConnection.java:521
 #, java-format
 msgid ""
 "One-phase commit called for xid {0} but connection was prepared with xid {1}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:479
+#: org/postgresql/xa/PGXAConnection.java:529
 msgid ""
 "Not implemented: one-phase commit must be issued using the same connection "
 "that was used to start it"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:483
+#: org/postgresql/xa/PGXAConnection.java:533
 #, java-format
 msgid "One-phase commit with unknown xid. commit xid={0}, currentXid={1}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:487
+#: org/postgresql/xa/PGXAConnection.java:537
 #, java-format
 msgid "commit called before end. commit xid={0}, state={1}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:498
+#: org/postgresql/xa/PGXAConnection.java:548
 #, java-format
 msgid "Error during one-phase commit. commit xid={0}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:517
+#: org/postgresql/xa/PGXAConnection.java:576
 msgid ""
 "Not implemented: 2nd phase commit must be issued using an idle connection. "
 "commit xid={0}, currentXid={1}, state={2], transactionState={3}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:550
+#: org/postgresql/xa/PGXAConnection.java:609
 #, java-format
 msgid ""
 "Error committing prepared transaction. commit xid={0}, preparedXid={1}, "
 "currentXid={2}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:567
+#: org/postgresql/xa/PGXAConnection.java:626
 #, java-format
 msgid "Heuristic commit/rollback not supported. forget xid={0}"
 msgstr ""

--- a/pgjdbc/src/main/java/org/postgresql/translation/pt_BR.po
+++ b/pgjdbc/src/main/java/org/postgresql/translation/pt_BR.po
@@ -8,7 +8,6 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PostgreSQL 8.4\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-06-05 10:57+0300\n"
 "PO-Revision-Date: 2004-10-31 20:48-0300\n"
 "Last-Translator: Euler Taveira de Oliveira <euler@timbira.com>\n"
 "Language-Team: Brazilian Portuguese <pgbr-dev@listas.postgresql.org.br>\n"
@@ -17,15 +16,15 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: org/postgresql/Driver.java:214
+#: org/postgresql/Driver.java:217
 msgid "Error loading default settings from driverconfig.properties"
 msgstr "Erro ao carregar configurações padrão do driverconfig.properties"
 
-#: org/postgresql/Driver.java:226
+#: org/postgresql/Driver.java:229
 msgid "Properties for the driver contains a non-string value for the key "
 msgstr ""
 
-#: org/postgresql/Driver.java:270
+#: org/postgresql/Driver.java:272
 msgid ""
 "Your security policy has prevented the connection from being attempted.  You "
 "probably need to grant the connect java.net.SocketPermission to the database "
@@ -36,7 +35,7 @@ msgstr ""
 "para a máquina e a porta do servidor de banco de dados que você deseja se "
 "conectar."
 
-#: org/postgresql/Driver.java:276 org/postgresql/Driver.java:408
+#: org/postgresql/Driver.java:278 org/postgresql/Driver.java:410
 msgid ""
 "Something unusual has occurred to cause the driver to fail. Please report "
 "this exception."
@@ -44,35 +43,35 @@ msgstr ""
 "Alguma coisa não usual ocorreu para causar a falha do driver. Por favor "
 "reporte esta exceção."
 
-#: org/postgresql/Driver.java:416
+#: org/postgresql/Driver.java:418
 msgid "Connection attempt timed out."
 msgstr "Tentativa de conexão falhou."
 
-#: org/postgresql/Driver.java:429
+#: org/postgresql/Driver.java:431
 msgid "Interrupted while attempting to connect."
 msgstr "Interrompido ao tentar se conectar."
 
-#: org/postgresql/Driver.java:682
+#: org/postgresql/Driver.java:687
 #, java-format
 msgid "Method {0} is not yet implemented."
 msgstr "Método {0} ainda não foi implementado."
 
-#: org/postgresql/PGProperty.java:535 org/postgresql/PGProperty.java:555
+#: org/postgresql/PGProperty.java:537 org/postgresql/PGProperty.java:557
 #, java-format
 msgid "{0} parameter value must be an integer but was: {1}"
 msgstr ""
 
-#: org/postgresql/copy/CopyManager.java:53
+#: org/postgresql/copy/CopyManager.java:49
 #, java-format
 msgid "Requested CopyIn but got {0}"
 msgstr ""
 
-#: org/postgresql/copy/CopyManager.java:64
+#: org/postgresql/copy/CopyManager.java:60
 #, java-format
 msgid "Requested CopyOut but got {0}"
 msgstr ""
 
-#: org/postgresql/copy/CopyManager.java:75
+#: org/postgresql/copy/CopyManager.java:71
 #, java-format
 msgid "Requested CopyDual but got {0}"
 msgstr ""
@@ -97,6 +96,13 @@ msgstr ""
 msgid "Cannot write to copy a byte of value {0}"
 msgstr ""
 
+#: org/postgresql/core/CommandCompleteParser.java:71
+#, fuzzy, java-format
+msgid "Unable to parse the count in command completion tag: {0}."
+msgstr ""
+"Não foi possível interpretar o contador de atualização na marcação de "
+"comando completo: {0}."
+
 #: org/postgresql/core/ConnectionFactory.java:57
 #, java-format
 msgid "A connection could not be made using the requested protocol {0}."
@@ -119,7 +125,7 @@ msgstr ""
 msgid "Expected an EOF from server, got: {0}"
 msgstr "Esperado um EOF do servidor, recebido: {0}"
 
-#: org/postgresql/core/Parser.java:1006
+#: org/postgresql/core/Parser.java:1051
 #, java-format
 msgid "Malformed function or procedure escape syntax at offset {0}."
 msgstr ""
@@ -181,24 +187,24 @@ msgstr "Zero bytes não podem ocorrer em identificadores."
 #: org/postgresql/core/v3/CompositeParameterList.java:33
 #: org/postgresql/core/v3/SimpleParameterList.java:54
 #: org/postgresql/core/v3/SimpleParameterList.java:65
-#: org/postgresql/jdbc/PgResultSet.java:2757
-#: org/postgresql/jdbc/PgResultSetMetaData.java:494
+#: org/postgresql/jdbc/PgResultSet.java:2755
+#: org/postgresql/jdbc/PgResultSetMetaData.java:388
 #, java-format
 msgid "The column index is out of range: {0}, number of columns: {1}."
 msgstr ""
 "O índice da coluna está fora do intervalo: {0}, número de colunas: {1}."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:109
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:103
 #, fuzzy, java-format
 msgid "Invalid sslmode value: {0}"
 msgstr "Tamanho de dado {0} é inválido."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:124
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:118
 #, fuzzy, java-format
 msgid "Invalid targetServerType value: {0}"
 msgstr "Tamanho de dado {0} é inválido."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:246
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:239
 #, fuzzy, java-format
 msgid ""
 "Connection to {0} refused. Check that the hostname and port are correct and "
@@ -207,27 +213,27 @@ msgstr ""
 "Conexão negada. Verifique se o nome da máquina e a porta estão corretos e se "
 "o postmaster está aceitando conexões TCP/IP."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:257
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:250
 #: org/postgresql/core/v3/replication/V3ReplicationProtocol.java:133
 msgid "The connection attempt failed."
 msgstr "A tentativa de conexão falhou."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:272
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:265
 #, java-format
 msgid "Could not find a server with specified targetServerType: {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:368
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:381
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:361
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:374
 msgid "The server does not support SSL."
 msgstr "O servidor não suporta SSL."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:395
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:388
 msgid "An error occurred while setting up the SSL connection."
 msgstr "Um erro ocorreu ao estabelecer uma conexão SSL."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:496
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:523
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:484
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:511
 msgid ""
 "The server requested password-based authentication, but no password was "
 "provided."
@@ -235,13 +241,13 @@ msgstr ""
 "O servidor pediu autenticação baseada em senha, mas nenhuma senha foi "
 "fornecida."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:626
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:614
 msgid ""
 "SCRAM authentication is not supported by this driver. You need JDK >= 8 and "
 "pgjdbc >= 42.2.0 (not \".jre\" versions)"
 msgstr ""
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:650
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:638
 #, java-format
 msgid ""
 "The authentication type {0} is not supported. Check that you have configured "
@@ -252,16 +258,16 @@ msgstr ""
 "arquivo pg_hba.conf incluindo a subrede ou endereço IP do cliente, e se está "
 "utilizando o esquema de autenticação suportado pelo driver."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:657
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2550
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2581
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2585
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2653
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:645
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2543
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2576
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2580
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2648
 #: org/postgresql/gss/GssAction.java:126
 msgid "Protocol error.  Session setup failed."
 msgstr "Erro de Protocolo. Configuração da sessão falhou."
 
-#: org/postgresql/core/v3/CopyInImpl.java:47
+#: org/postgresql/core/v3/CopyInImpl.java:49
 msgid "CopyIn copy direction can't receive data"
 msgstr ""
 
@@ -269,144 +275,144 @@ msgstr ""
 msgid "CommandComplete expected COPY but got: "
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:161
+#: org/postgresql/core/v3/QueryExecutorImpl.java:163
 msgid "Tried to obtain lock while already holding it"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:177
+#: org/postgresql/core/v3/QueryExecutorImpl.java:179
 msgid "Tried to break lock on database connection"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:195
+#: org/postgresql/core/v3/QueryExecutorImpl.java:197
 #, fuzzy
 msgid "Interrupted while waiting to obtain lock on database connection"
 msgstr "Interrompido ao tentar se conectar."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:327
+#: org/postgresql/core/v3/QueryExecutorImpl.java:329
 msgid "Unable to bind parameter values for statement."
 msgstr "Não foi possível ligar valores de parâmetro ao comando."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:333
-#: org/postgresql/core/v3/QueryExecutorImpl.java:485
-#: org/postgresql/core/v3/QueryExecutorImpl.java:559
-#: org/postgresql/core/v3/QueryExecutorImpl.java:602
-#: org/postgresql/core/v3/QueryExecutorImpl.java:729
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2372
+#: org/postgresql/core/v3/QueryExecutorImpl.java:335
+#: org/postgresql/core/v3/QueryExecutorImpl.java:487
+#: org/postgresql/core/v3/QueryExecutorImpl.java:561
+#: org/postgresql/core/v3/QueryExecutorImpl.java:604
+#: org/postgresql/core/v3/QueryExecutorImpl.java:731
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2377
 #: org/postgresql/util/StreamWrapper.java:130
 #, fuzzy
 msgid "An I/O error occurred while sending to the backend."
 msgstr "Um erro de E/S ocorreu ao enviar para o processo servidor."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:534
-#: org/postgresql/core/v3/QueryExecutorImpl.java:576
+#: org/postgresql/core/v3/QueryExecutorImpl.java:536
+#: org/postgresql/core/v3/QueryExecutorImpl.java:578
 #, java-format
 msgid "Expected command status BEGIN, got {0}."
 msgstr "Status do comando BEGIN esperado, recebeu {0}."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:581
+#: org/postgresql/core/v3/QueryExecutorImpl.java:583
 #: org/postgresql/jdbc/PgResultSet.java:1778
 #, java-format
 msgid "Unexpected command status: {0}."
 msgstr "Status do comando inesperado: {0}."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:687
+#: org/postgresql/core/v3/QueryExecutorImpl.java:689
 #, fuzzy
 msgid "An error occurred while trying to get the socket timeout."
 msgstr "Um erro de E/S ocorreu ao enviar para o processo servidor."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:722
-#: org/postgresql/core/v3/QueryExecutorImpl.java:798
+#: org/postgresql/core/v3/QueryExecutorImpl.java:724
+#: org/postgresql/core/v3/QueryExecutorImpl.java:800
 #, java-format
 msgid "Unknown Response Type {0}."
 msgstr "Tipo de Resposta Desconhecido {0}."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:745
+#: org/postgresql/core/v3/QueryExecutorImpl.java:747
 #, fuzzy
 msgid "An error occurred while trying to reset the socket timeout."
 msgstr "Um erro de E/S ocorreu ao enviar para o processo servidor."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:843
+#: org/postgresql/core/v3/QueryExecutorImpl.java:845
 msgid "Database connection failed when starting copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:878
+#: org/postgresql/core/v3/QueryExecutorImpl.java:880
 msgid "Tried to cancel an inactive copy operation"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:917
+#: org/postgresql/core/v3/QueryExecutorImpl.java:919
 msgid "Database connection failed when canceling copy operation"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:933
+#: org/postgresql/core/v3/QueryExecutorImpl.java:935
 msgid "Missing expected error response to copy cancel request"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:937
+#: org/postgresql/core/v3/QueryExecutorImpl.java:939
 #, java-format
 msgid "Got {0} error responses to single copy cancel request"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:952
+#: org/postgresql/core/v3/QueryExecutorImpl.java:954
 msgid "Tried to end inactive copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:967
+#: org/postgresql/core/v3/QueryExecutorImpl.java:969
 msgid "Database connection failed when ending copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:985
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1005
+#: org/postgresql/core/v3/QueryExecutorImpl.java:987
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1007
 msgid "Tried to write to an inactive copy operation"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:998
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1013
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1000
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1015
 msgid "Database connection failed when writing to copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1028
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1030
 msgid "Tried to read from inactive copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1035
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1037
 msgid "Database connection failed when reading from copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1101
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1103
 #, java-format
 msgid "Received CommandComplete ''{0}'' without an active copy operation"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1126
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1128
 #, java-format
 msgid "Got CopyInResponse from server during an active {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1140
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1142
 #, java-format
 msgid "Got CopyOutResponse from server during an active {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1154
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1156
 #, java-format
 msgid "Got CopyBothResponse from server during an active {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1170
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1172
 msgid "Got CopyData without an active copy operation"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1174
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1176
 #, fuzzy, java-format
 msgid "Unexpected copydata from server for {0}"
 msgstr "Esperado um EOF do servidor, recebido: {0}"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1234
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1236
 #, java-format
 msgid "Unexpected packet type during copy: {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1524
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1526
 #, java-format
 msgid ""
 "Bind message length {0} too long.  This can be caused by very large or "
@@ -416,22 +422,15 @@ msgstr ""
 "especificações de tamanho incorretas ou muito grandes nos parâmetros do "
 "InputStream."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2145
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2150
 msgid "Ran out of memory retrieving query results."
 msgstr "Memória insuficiente ao recuperar resultados da consulta."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2313
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2318
 msgid "The driver currently does not support COPY operations."
 msgstr "O driver atualmente não suporta operações COPY."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2487
-#, fuzzy, java-format
-msgid "Unable to parse the count in command completion tag: {0}."
-msgstr ""
-"Não foi possível interpretar o contador de atualização na marcação de "
-"comando completo: {0}."
-
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2610
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2605
 #, fuzzy, java-format
 msgid ""
 "The server''s client_encoding parameter was changed to {0}. The JDBC driver "
@@ -440,7 +439,7 @@ msgstr ""
 "O parâmetro do servidor client_encoding foi alterado para {0}. O driver JDBC "
 "requer que o client_encoding seja UNICODE para operação normal."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2620
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2615
 #, java-format
 msgid ""
 "The server''s DateStyle parameter was changed to {0}. The JDBC driver "
@@ -449,7 +448,7 @@ msgstr ""
 "O parâmetro do servidor DateStyle foi alterado para {0}. O driver JDBC "
 "requer que o DateStyle começe com ISO para operação normal."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2633
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2628
 #, java-format
 msgid ""
 "The server''s standard_conforming_strings parameter was reported as {0}. The "
@@ -513,21 +512,21 @@ msgstr "DataSource foi fechado."
 msgid "Unsupported property name: {0}"
 msgstr "Valor de Types não é suportado: {0}"
 
-#: org/postgresql/fastpath/Fastpath.java:86
+#: org/postgresql/fastpath/Fastpath.java:84
 #, fuzzy, java-format
 msgid "Fastpath call {0} - No result was returned and we expected a numeric."
 msgstr ""
 "Chamada ao Fastpath {0} - Nenhum resultado foi retornado e nós esperávamos "
 "um inteiro."
 
-#: org/postgresql/fastpath/Fastpath.java:163
+#: org/postgresql/fastpath/Fastpath.java:161
 #, java-format
 msgid "Fastpath call {0} - No result was returned and we expected an integer."
 msgstr ""
 "Chamada ao Fastpath {0} - Nenhum resultado foi retornado e nós esperávamos "
 "um inteiro."
 
-#: org/postgresql/fastpath/Fastpath.java:171
+#: org/postgresql/fastpath/Fastpath.java:169
 #, fuzzy, java-format
 msgid ""
 "Fastpath call {0} - No result was returned or wrong size while expecting an "
@@ -536,14 +535,14 @@ msgstr ""
 "Chamada ao Fastpath {0} - Nenhum resultado foi retornado e nós esperávamos "
 "um inteiro."
 
-#: org/postgresql/fastpath/Fastpath.java:188
+#: org/postgresql/fastpath/Fastpath.java:186
 #, fuzzy, java-format
 msgid "Fastpath call {0} - No result was returned and we expected a long."
 msgstr ""
 "Chamada ao Fastpath {0} - Nenhum resultado foi retornado e nós esperávamos "
 "um inteiro."
 
-#: org/postgresql/fastpath/Fastpath.java:196
+#: org/postgresql/fastpath/Fastpath.java:194
 #, fuzzy, java-format
 msgid ""
 "Fastpath call {0} - No result was returned or wrong size while expecting a "
@@ -552,7 +551,7 @@ msgstr ""
 "Chamada ao Fastpath {0} - Nenhum resultado foi retornado e nós esperávamos "
 "um inteiro."
 
-#: org/postgresql/fastpath/Fastpath.java:308
+#: org/postgresql/fastpath/Fastpath.java:297
 #, java-format
 msgid "The fastpath function {0} is unknown."
 msgstr "A função do fastpath {0} é desconhecida."
@@ -621,63 +620,70 @@ msgid "Cannot cast to boolean: \"{0}\""
 msgstr ""
 
 #: org/postgresql/jdbc/EscapedFunctions.java:240
+#: org/postgresql/jdbc/EscapedFunctions2.java:167
 #, java-format
 msgid "{0} function takes four and only four argument."
 msgstr "função {0} recebe somente quatro argumentos."
 
 #: org/postgresql/jdbc/EscapedFunctions.java:270
-#: org/postgresql/jdbc/EscapedFunctions.java:344
-#: org/postgresql/jdbc/EscapedFunctions.java:749
-#: org/postgresql/jdbc/EscapedFunctions.java:787
+#: org/postgresql/jdbc/EscapedFunctions.java:337
+#: org/postgresql/jdbc/EscapedFunctions.java:740
+#: org/postgresql/jdbc/EscapedFunctions2.java:196
+#: org/postgresql/jdbc/EscapedFunctions2.java:263
+#: org/postgresql/jdbc/EscapedFunctions2.java:665
 #, java-format
 msgid "{0} function takes two and only two arguments."
 msgstr "função {0} recebe somente dois argumentos."
 
 #: org/postgresql/jdbc/EscapedFunctions.java:288
-#: org/postgresql/jdbc/EscapedFunctions.java:326
-#: org/postgresql/jdbc/EscapedFunctions.java:446
-#: org/postgresql/jdbc/EscapedFunctions.java:461
-#: org/postgresql/jdbc/EscapedFunctions.java:476
-#: org/postgresql/jdbc/EscapedFunctions.java:491
-#: org/postgresql/jdbc/EscapedFunctions.java:506
-#: org/postgresql/jdbc/EscapedFunctions.java:521
-#: org/postgresql/jdbc/EscapedFunctions.java:536
-#: org/postgresql/jdbc/EscapedFunctions.java:551
-#: org/postgresql/jdbc/EscapedFunctions.java:566
-#: org/postgresql/jdbc/EscapedFunctions.java:581
-#: org/postgresql/jdbc/EscapedFunctions.java:596
-#: org/postgresql/jdbc/EscapedFunctions.java:611
-#: org/postgresql/jdbc/EscapedFunctions.java:775
+#: org/postgresql/jdbc/EscapedFunctions.java:441
+#: org/postgresql/jdbc/EscapedFunctions.java:467
+#: org/postgresql/jdbc/EscapedFunctions.java:526
+#: org/postgresql/jdbc/EscapedFunctions.java:728
+#: org/postgresql/jdbc/EscapedFunctions2.java:211
+#: org/postgresql/jdbc/EscapedFunctions2.java:355
+#: org/postgresql/jdbc/EscapedFunctions2.java:381
+#: org/postgresql/jdbc/EscapedFunctions2.java:440
+#: org/postgresql/jdbc/EscapedFunctions2.java:654
 #, java-format
 msgid "{0} function takes one and only one argument."
 msgstr "função {0} recebe somente um argumento."
 
-#: org/postgresql/jdbc/EscapedFunctions.java:310
-#: org/postgresql/jdbc/EscapedFunctions.java:391
+#: org/postgresql/jdbc/EscapedFunctions.java:312
+#: org/postgresql/jdbc/EscapedFunctions.java:386
+#: org/postgresql/jdbc/EscapedFunctions2.java:238
+#: org/postgresql/jdbc/EscapedFunctions2.java:307
 #, java-format
 msgid "{0} function takes two or three arguments."
 msgstr "função {0} recebe dois ou três argumentos."
 
-#: org/postgresql/jdbc/EscapedFunctions.java:416
-#: org/postgresql/jdbc/EscapedFunctions.java:431
-#: org/postgresql/jdbc/EscapedFunctions.java:734
-#: org/postgresql/jdbc/EscapedFunctions.java:764
+#: org/postgresql/jdbc/EscapedFunctions.java:411
+#: org/postgresql/jdbc/EscapedFunctions.java:426
+#: org/postgresql/jdbc/EscapedFunctions.java:693
+#: org/postgresql/jdbc/EscapedFunctions.java:719
+#: org/postgresql/jdbc/EscapedFunctions2.java:645
 #, java-format
 msgid "{0} function doesn''t take any argument."
 msgstr "função {0} não recebe nenhum argumento."
 
-#: org/postgresql/jdbc/EscapedFunctions.java:627
-#: org/postgresql/jdbc/EscapedFunctions.java:680
+#: org/postgresql/jdbc/EscapedFunctions.java:586
+#: org/postgresql/jdbc/EscapedFunctions.java:639
+#: org/postgresql/jdbc/EscapedFunctions2.java:500
+#: org/postgresql/jdbc/EscapedFunctions2.java:571
 #, java-format
 msgid "{0} function takes three and only three arguments."
 msgstr "função {0} recebe três e somente três argumentos."
 
-#: org/postgresql/jdbc/EscapedFunctions.java:640
-#: org/postgresql/jdbc/EscapedFunctions.java:661
-#: org/postgresql/jdbc/EscapedFunctions.java:664
-#: org/postgresql/jdbc/EscapedFunctions.java:697
-#: org/postgresql/jdbc/EscapedFunctions.java:710
-#: org/postgresql/jdbc/EscapedFunctions.java:713
+#: org/postgresql/jdbc/EscapedFunctions.java:599
+#: org/postgresql/jdbc/EscapedFunctions.java:620
+#: org/postgresql/jdbc/EscapedFunctions.java:623
+#: org/postgresql/jdbc/EscapedFunctions.java:656
+#: org/postgresql/jdbc/EscapedFunctions.java:669
+#: org/postgresql/jdbc/EscapedFunctions.java:672
+#: org/postgresql/jdbc/EscapedFunctions2.java:510
+#: org/postgresql/jdbc/EscapedFunctions2.java:527
+#: org/postgresql/jdbc/EscapedFunctions2.java:585
+#: org/postgresql/jdbc/EscapedFunctions2.java:597
 #, java-format
 msgid "Interval {0} not yet implemented"
 msgstr "Intervalo {0} ainda não foi implementado"
@@ -696,18 +702,18 @@ msgstr "Não pode recuperar o id de um savepoint com nome."
 msgid "Cannot retrieve the name of an unnamed savepoint."
 msgstr "Não pode recuperar o nome de um savepoint sem nome."
 
-#: org/postgresql/jdbc/PgArray.java:157 org/postgresql/jdbc/PgArray.java:844
+#: org/postgresql/jdbc/PgArray.java:155 org/postgresql/jdbc/PgArray.java:842
 #, java-format
 msgid "The array index is out of range: {0}"
 msgstr "O índice da matriz está fora do intervalo: {0}"
 
-#: org/postgresql/jdbc/PgArray.java:178 org/postgresql/jdbc/PgArray.java:861
+#: org/postgresql/jdbc/PgArray.java:176 org/postgresql/jdbc/PgArray.java:859
 #, java-format
 msgid "The array index is out of range: {0}, number of elements: {1}."
 msgstr ""
 "O índice da matriz está fora do intervalo: {0}, número de elementos: {1}."
 
-#: org/postgresql/jdbc/PgArray.java:210
+#: org/postgresql/jdbc/PgArray.java:208
 #: org/postgresql/jdbc/PgResultSet.java:1930
 #: org/postgresql/util/HStoreConverter.java:43
 #: org/postgresql/util/HStoreConverter.java:74
@@ -722,16 +728,16 @@ msgstr ""
 "foi criado o banco de dados. O exemplo mais comum disso é armazenar dados de "
 "8 bits em um banco de dados SQL_ASCII."
 
-#: org/postgresql/jdbc/PgCallableStatement.java:86
-#: org/postgresql/jdbc/PgCallableStatement.java:96
+#: org/postgresql/jdbc/PgCallableStatement.java:85
+#: org/postgresql/jdbc/PgCallableStatement.java:95
 msgid "A CallableStatement was executed with nothing returned."
 msgstr "Uma função foi executada e nada foi retornado."
 
-#: org/postgresql/jdbc/PgCallableStatement.java:107
+#: org/postgresql/jdbc/PgCallableStatement.java:106
 msgid "A CallableStatement was executed with an invalid number of parameters"
 msgstr "Uma função foi executada com um número inválido de parâmetros"
 
-#: org/postgresql/jdbc/PgCallableStatement.java:145
+#: org/postgresql/jdbc/PgCallableStatement.java:144
 #, java-format
 msgid ""
 "A CallableStatement function was executed and the out parameter {0} was of "
@@ -740,7 +746,7 @@ msgstr ""
 "Uma função foi executada e o parâmetro de retorno {0} era do tipo {1} "
 "contudo tipo {2} foi registrado."
 
-#: org/postgresql/jdbc/PgCallableStatement.java:202
+#: org/postgresql/jdbc/PgCallableStatement.java:206
 msgid ""
 "This statement does not declare an OUT parameter.  Use '{' ?= call ... '}' "
 "to declare one."
@@ -748,12 +754,12 @@ msgstr ""
 "Este comando não declara um parâmetro de saída. Utilize '{' ?= chamada ... "
 "'}' para declarar um)"
 
-#: org/postgresql/jdbc/PgCallableStatement.java:246
+#: org/postgresql/jdbc/PgCallableStatement.java:229
 msgid "wasNull cannot be call before fetching a result."
 msgstr "wasNull não pode ser chamado antes de obter um resultado."
 
-#: org/postgresql/jdbc/PgCallableStatement.java:384
-#: org/postgresql/jdbc/PgCallableStatement.java:403
+#: org/postgresql/jdbc/PgCallableStatement.java:367
+#: org/postgresql/jdbc/PgCallableStatement.java:386
 #, java-format
 msgid ""
 "Parameter of type {0} was registered, but call to get{1} (sqltype={2}) was "
@@ -762,7 +768,7 @@ msgstr ""
 "Parâmetro do tipo {0} foi registrado, mas uma chamada a get{1} (tiposql={2}) "
 "foi feita."
 
-#: org/postgresql/jdbc/PgCallableStatement.java:424
+#: org/postgresql/jdbc/PgCallableStatement.java:407
 msgid ""
 "A CallableStatement was declared, but no call to registerOutParameter(1, "
 "<some type>) was made."
@@ -770,28 +776,28 @@ msgstr ""
 "Uma função foi declarada mas nenhuma chamada a registerOutParameter (1, "
 "<algum_tipo>) foi feita."
 
-#: org/postgresql/jdbc/PgCallableStatement.java:430
+#: org/postgresql/jdbc/PgCallableStatement.java:413
 msgid "No function outputs were registered."
 msgstr "Nenhum saída de função foi registrada."
 
-#: org/postgresql/jdbc/PgCallableStatement.java:436
+#: org/postgresql/jdbc/PgCallableStatement.java:419
 msgid ""
 "Results cannot be retrieved from a CallableStatement before it is executed."
 msgstr ""
 "Resultados não podem ser recuperados de uma função antes dela ser executada."
 
-#: org/postgresql/jdbc/PgCallableStatement.java:703
+#: org/postgresql/jdbc/PgCallableStatement.java:686
 #, fuzzy, java-format
 msgid "Unsupported type conversion to {1}."
 msgstr "Valor de Types não é suportado: {0}"
 
-#: org/postgresql/jdbc/PgConnection.java:272
+#: org/postgresql/jdbc/PgConnection.java:241
 #, java-format
 msgid "Unsupported value for stringtype parameter: {0}"
 msgstr "Valor do parâmetro stringtype não é suportado: {0}"
 
 #: org/postgresql/jdbc/PgConnection.java:424
-#: org/postgresql/jdbc/PgPreparedStatement.java:119
+#: org/postgresql/jdbc/PgPreparedStatement.java:107
 #: org/postgresql/jdbc/PgStatement.java:225
 #: org/postgresql/jdbc/TypeInfoCache.java:226
 #: org/postgresql/jdbc/TypeInfoCache.java:371
@@ -803,132 +809,132 @@ msgstr "Valor do parâmetro stringtype não é suportado: {0}"
 msgid "No results were returned by the query."
 msgstr "Nenhum resultado foi retornado pela consulta."
 
-#: org/postgresql/jdbc/PgConnection.java:441
+#: org/postgresql/jdbc/PgConnection.java:442
 #: org/postgresql/jdbc/PgStatement.java:254
 msgid "A result was returned when none was expected."
 msgstr "Um resultado foi retornado quando nenhum era esperado."
 
-#: org/postgresql/jdbc/PgConnection.java:545
+#: org/postgresql/jdbc/PgConnection.java:547
 msgid "Custom type maps are not supported."
 msgstr "Mapeamento de tipos personalizados não são suportados."
 
-#: org/postgresql/jdbc/PgConnection.java:587
+#: org/postgresql/jdbc/PgConnection.java:589
 #, java-format
 msgid "Failed to create object for: {0}."
 msgstr "Falhou ao criar objeto para: {0}."
 
-#: org/postgresql/jdbc/PgConnection.java:641
+#: org/postgresql/jdbc/PgConnection.java:643
 #, java-format
 msgid "Unable to load the class {0} responsible for the datatype {1}"
 msgstr ""
 "Não foi possível carregar a classe {0} responsável pelo tipo de dado {1}"
 
-#: org/postgresql/jdbc/PgConnection.java:693
+#: org/postgresql/jdbc/PgConnection.java:705
 msgid ""
 "Cannot change transaction read-only property in the middle of a transaction."
 msgstr ""
 "Não pode mudar propriedade somente-leitura da transação no meio de uma "
 "transação."
 
-#: org/postgresql/jdbc/PgConnection.java:756
+#: org/postgresql/jdbc/PgConnection.java:772
 msgid "Cannot commit when autoCommit is enabled."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:767
-#: org/postgresql/jdbc/PgConnection.java:1384
-#: org/postgresql/jdbc/PgConnection.java:1428
+#: org/postgresql/jdbc/PgConnection.java:783
+#: org/postgresql/jdbc/PgConnection.java:1401
+#: org/postgresql/jdbc/PgConnection.java:1445
 #, fuzzy
 msgid "This connection has been closed."
 msgstr "Conexão foi fechada."
 
-#: org/postgresql/jdbc/PgConnection.java:777
+#: org/postgresql/jdbc/PgConnection.java:794
 msgid "Cannot rollback when autoCommit is enabled."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:827
+#: org/postgresql/jdbc/PgConnection.java:844
 msgid ""
 "Cannot change transaction isolation level in the middle of a transaction."
 msgstr ""
 "Não pode mudar nível de isolamento da transação no meio de uma transação."
 
-#: org/postgresql/jdbc/PgConnection.java:833
+#: org/postgresql/jdbc/PgConnection.java:850
 #, java-format
 msgid "Transaction isolation level {0} not supported."
 msgstr "Nível de isolamento da transação {0} não é suportado."
 
-#: org/postgresql/jdbc/PgConnection.java:878
+#: org/postgresql/jdbc/PgConnection.java:895
 msgid "Finalizing a Connection that was never closed:"
 msgstr "Fechando uma Conexão que não foi fechada:"
 
-#: org/postgresql/jdbc/PgConnection.java:945
+#: org/postgresql/jdbc/PgConnection.java:962
 msgid "Unable to translate data into the desired encoding."
 msgstr "Não foi possível traduzir dado para codificação desejada."
 
-#: org/postgresql/jdbc/PgConnection.java:1008
+#: org/postgresql/jdbc/PgConnection.java:1025
 #: org/postgresql/jdbc/PgResultSet.java:1817
-#: org/postgresql/jdbc/PgStatement.java:903
+#: org/postgresql/jdbc/PgStatement.java:908
 msgid "Fetch size must be a value greater to or equal to 0."
 msgstr "Tamanho da busca deve ser um valor maior ou igual a 0."
 
-#: org/postgresql/jdbc/PgConnection.java:1289
-#: org/postgresql/jdbc/PgConnection.java:1330
+#: org/postgresql/jdbc/PgConnection.java:1306
+#: org/postgresql/jdbc/PgConnection.java:1347
 #, java-format
 msgid "Unable to find server array type for provided name {0}."
 msgstr "Não foi possível encontrar tipo matriz para nome fornecido {0}."
 
-#: org/postgresql/jdbc/PgConnection.java:1312
+#: org/postgresql/jdbc/PgConnection.java:1329
 #, fuzzy, java-format
 msgid "Invalid elements {0}"
 msgstr "Marcadores={0} inválidos"
 
-#: org/postgresql/jdbc/PgConnection.java:1348
+#: org/postgresql/jdbc/PgConnection.java:1365
 #, fuzzy, java-format
 msgid "Invalid timeout ({0}<0)."
 msgstr "Tamanho de dado {0} é inválido."
 
-#: org/postgresql/jdbc/PgConnection.java:1372
+#: org/postgresql/jdbc/PgConnection.java:1389
 msgid "Validating connection."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1405
+#: org/postgresql/jdbc/PgConnection.java:1422
 #, fuzzy, java-format
 msgid "Failed to set ClientInfo property: {0}"
 msgstr "Falhou ao criar objeto para: {0}."
 
-#: org/postgresql/jdbc/PgConnection.java:1415
+#: org/postgresql/jdbc/PgConnection.java:1432
 msgid "ClientInfo property not supported."
 msgstr "propriedade ClientInfo não é suportada."
 
-#: org/postgresql/jdbc/PgConnection.java:1441
+#: org/postgresql/jdbc/PgConnection.java:1458
 msgid "One ore more ClientInfo failed."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1540
+#: org/postgresql/jdbc/PgConnection.java:1559
 #, fuzzy
 msgid "Network timeout must be a value greater than or equal to 0."
 msgstr "Tempo de espera da consulta deve ser um valor maior ou igual a 0."
 
-#: org/postgresql/jdbc/PgConnection.java:1552
+#: org/postgresql/jdbc/PgConnection.java:1571
 msgid "Unable to set network timeout."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1563
+#: org/postgresql/jdbc/PgConnection.java:1582
 msgid "Unable to get network timeout."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1580
+#: org/postgresql/jdbc/PgConnection.java:1599
 #, java-format
 msgid "Unknown ResultSet holdability setting: {0}."
 msgstr "Definição de durabilidade do ResultSet desconhecida: {0}."
 
-#: org/postgresql/jdbc/PgConnection.java:1598
-#: org/postgresql/jdbc/PgConnection.java:1619
+#: org/postgresql/jdbc/PgConnection.java:1617
+#: org/postgresql/jdbc/PgConnection.java:1638
 msgid "Cannot establish a savepoint in auto-commit mode."
 msgstr ""
 "Não pode estabelecer um savepoint no modo de efetivação automática (auto-"
 "commit)."
 
-#: org/postgresql/jdbc/PgConnection.java:1685
+#: org/postgresql/jdbc/PgConnection.java:1707
 msgid "Returning autogenerated keys is not supported."
 msgstr "Retorno de chaves geradas automaticamente não é suportado."
 
@@ -944,47 +950,47 @@ msgstr ""
 msgid "Unable to find name datatype in the system catalogs."
 msgstr "Não foi possível encontrar tipo de dado name nos catálogos do sistema."
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:323
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:322
 #, fuzzy
 msgid "Unable to find keywords in the system catalogs."
 msgstr "Não foi possível encontrar tipo de dado name nos catálogos do sistema."
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1105
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1095
 msgid "oid"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1105
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1095
 msgid "proname"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1107
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1558
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1097
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1548
 msgid "typtype"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1110
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1100
 msgid "proargtypes"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1576
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1566
 msgid "adsrc"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1589
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1579
 msgid "attidentity"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1685
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1761
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1675
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1751
 msgid "rolname"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1686
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1762
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1676
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1752
 msgid "relacl"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1692
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1682
 msgid "attacl"
 msgstr ""
 
@@ -994,68 +1000,68 @@ msgid "The parameter index is out of range: {0}, number of parameters: {1}."
 msgstr ""
 "O índice de parâmetro está fora do intervalo: {0}, número de parâmetros: {1}."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:106
+#: org/postgresql/jdbc/PgPreparedStatement.java:94
+#: org/postgresql/jdbc/PgPreparedStatement.java:115
 #: org/postgresql/jdbc/PgPreparedStatement.java:127
-#: org/postgresql/jdbc/PgPreparedStatement.java:139
-#: org/postgresql/jdbc/PgPreparedStatement.java:1035
+#: org/postgresql/jdbc/PgPreparedStatement.java:1008
 msgid ""
 "Can''t use query methods that take a query string on a PreparedStatement."
 msgstr ""
 "Não pode utilizar métodos de consulta que pegam uma consulta de um comando "
 "preparado."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:249
+#: org/postgresql/jdbc/PgPreparedStatement.java:237
 msgid "Unknown Types value."
 msgstr "Valor de Types desconhecido."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:382
-#: org/postgresql/jdbc/PgPreparedStatement.java:439
-#: org/postgresql/jdbc/PgPreparedStatement.java:1191
-#: org/postgresql/jdbc/PgPreparedStatement.java:1490
+#: org/postgresql/jdbc/PgPreparedStatement.java:364
+#: org/postgresql/jdbc/PgPreparedStatement.java:421
+#: org/postgresql/jdbc/PgPreparedStatement.java:1164
+#: org/postgresql/jdbc/PgPreparedStatement.java:1472
 #, java-format
 msgid "Invalid stream length {0}."
 msgstr "Tamanho de dado {0} é inválido."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:411
+#: org/postgresql/jdbc/PgPreparedStatement.java:393
 #, java-format
 msgid "The JVM claims not to support the {0} encoding."
 msgstr "A JVM reclamou que não suporta a codificação {0}."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:414
+#: org/postgresql/jdbc/PgPreparedStatement.java:396
 #: org/postgresql/jdbc/PgResultSet.java:1122
 #: org/postgresql/jdbc/PgResultSet.java:1156
 msgid "Provided InputStream failed."
 msgstr "InputStream fornecido falhou."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:460
-#: org/postgresql/jdbc/PgPreparedStatement.java:1096
+#: org/postgresql/jdbc/PgPreparedStatement.java:442
+#: org/postgresql/jdbc/PgPreparedStatement.java:1069
 #, java-format
 msgid "Unknown type {0}."
 msgstr "Tipo desconhecido {0}."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:477
+#: org/postgresql/jdbc/PgPreparedStatement.java:459
 msgid "No hstore extension installed."
 msgstr ""
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:619
-#: org/postgresql/jdbc/PgPreparedStatement.java:642
-#: org/postgresql/jdbc/PgPreparedStatement.java:652
-#: org/postgresql/jdbc/PgPreparedStatement.java:664
+#: org/postgresql/jdbc/PgPreparedStatement.java:601
+#: org/postgresql/jdbc/PgPreparedStatement.java:624
+#: org/postgresql/jdbc/PgPreparedStatement.java:634
+#: org/postgresql/jdbc/PgPreparedStatement.java:646
 #, java-format
 msgid "Cannot cast an instance of {0} to type {1}"
 msgstr "Não pode converter uma instância de {0} para tipo {1}"
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:682
+#: org/postgresql/jdbc/PgPreparedStatement.java:664
 #, java-format
 msgid "Unsupported Types value: {0}"
 msgstr "Valor de Types não é suportado: {0}"
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:894
+#: org/postgresql/jdbc/PgPreparedStatement.java:876
 #, java-format
 msgid "Cannot convert an instance of {0} to type {1}"
 msgstr "Não pode converter uma instância de {0} para tipo {1}"
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:968
+#: org/postgresql/jdbc/PgPreparedStatement.java:950
 #, java-format
 msgid ""
 "Can''t infer the SQL type to use for an instance of {0}. Use setObject() "
@@ -1065,17 +1071,17 @@ msgstr ""
 "setObject() com um valor de Types explícito para especificar o tipo a ser "
 "usado."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:1133
-#: org/postgresql/jdbc/PgPreparedStatement.java:1233
+#: org/postgresql/jdbc/PgPreparedStatement.java:1106
+#: org/postgresql/jdbc/PgPreparedStatement.java:1206
 msgid "Unexpected error writing large object to database."
 msgstr "Erro inesperado ao escrever objeto grande no banco de dados."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:1178
+#: org/postgresql/jdbc/PgPreparedStatement.java:1151
 #: org/postgresql/jdbc/PgResultSet.java:1210
 msgid "Provided Reader failed."
 msgstr "Reader fornecido falhou."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:1449
+#: org/postgresql/jdbc/PgPreparedStatement.java:1431
 #: org/postgresql/util/StreamWrapper.java:56
 msgid "Object is too large to send over the protocol."
 msgstr ""
@@ -1093,8 +1099,8 @@ msgstr ""
 #: org/postgresql/jdbc/PgResultSet.java:556
 #: org/postgresql/jdbc/PgResultSet.java:594
 #: org/postgresql/jdbc/PgResultSet.java:624
-#: org/postgresql/jdbc/PgResultSet.java:3014
-#: org/postgresql/jdbc/PgResultSet.java:3058
+#: org/postgresql/jdbc/PgResultSet.java:3012
+#: org/postgresql/jdbc/PgResultSet.java:3057
 #, fuzzy, java-format
 msgid "Cannot convert the column of type {0} to requested type {1}."
 msgstr "Não pode converter uma instância de {0} para tipo {1}"
@@ -1108,7 +1114,7 @@ msgstr ""
 "inserindo registro."
 
 #: org/postgresql/jdbc/PgResultSet.java:878
-#: org/postgresql/jdbc/PgStatement.java:895
+#: org/postgresql/jdbc/PgStatement.java:900
 #, java-format
 msgid "Invalid fetch direction constant: {0}."
 msgstr "Constante de direção da busca é inválida: {0}."
@@ -1151,8 +1157,8 @@ msgstr "Você deve especificar pelo menos uma coluna para inserir um registro."
 
 #: org/postgresql/jdbc/PgResultSet.java:1119
 #: org/postgresql/jdbc/PgResultSet.java:1754
-#: org/postgresql/jdbc/PgResultSet.java:2422
-#: org/postgresql/jdbc/PgResultSet.java:2443
+#: org/postgresql/jdbc/PgResultSet.java:2420
+#: org/postgresql/jdbc/PgResultSet.java:2441
 #, java-format
 msgid "The JVM claims not to support the encoding: {0}"
 msgstr "A JVM reclamou que não suporta a codificação: {0}"
@@ -1166,7 +1172,7 @@ msgid "Cannot call updateRow() when on the insert row."
 msgstr "Não pode chamar updateRow() quando estiver inserindo registro."
 
 #: org/postgresql/jdbc/PgResultSet.java:1335
-#: org/postgresql/jdbc/PgResultSet.java:3075
+#: org/postgresql/jdbc/PgResultSet.java:3074
 msgid ""
 "Cannot update the ResultSet because it is either before the start or after "
 "the end of the results."
@@ -1186,27 +1192,27 @@ msgstr "Nenhuma chave primária foi encontrada para tabela {0}."
 
 #: org/postgresql/jdbc/PgResultSet.java:2017
 #: org/postgresql/jdbc/PgResultSet.java:2022
-#: org/postgresql/jdbc/PgResultSet.java:2809
-#: org/postgresql/jdbc/PgResultSet.java:2815
-#: org/postgresql/jdbc/PgResultSet.java:2840
-#: org/postgresql/jdbc/PgResultSet.java:2846
-#: org/postgresql/jdbc/PgResultSet.java:2870
-#: org/postgresql/jdbc/PgResultSet.java:2875
-#: org/postgresql/jdbc/PgResultSet.java:2891
-#: org/postgresql/jdbc/PgResultSet.java:2912
-#: org/postgresql/jdbc/PgResultSet.java:2923
-#: org/postgresql/jdbc/PgResultSet.java:2936
-#: org/postgresql/jdbc/PgResultSet.java:3063
+#: org/postgresql/jdbc/PgResultSet.java:2807
+#: org/postgresql/jdbc/PgResultSet.java:2813
+#: org/postgresql/jdbc/PgResultSet.java:2838
+#: org/postgresql/jdbc/PgResultSet.java:2844
+#: org/postgresql/jdbc/PgResultSet.java:2868
+#: org/postgresql/jdbc/PgResultSet.java:2873
+#: org/postgresql/jdbc/PgResultSet.java:2889
+#: org/postgresql/jdbc/PgResultSet.java:2910
+#: org/postgresql/jdbc/PgResultSet.java:2921
+#: org/postgresql/jdbc/PgResultSet.java:2934
+#: org/postgresql/jdbc/PgResultSet.java:3062
 #, java-format
 msgid "Bad value for type {0} : {1}"
 msgstr "Valor inválido para tipo {0} : {1}"
 
-#: org/postgresql/jdbc/PgResultSet.java:2595
+#: org/postgresql/jdbc/PgResultSet.java:2593
 #, java-format
 msgid "The column name {0} was not found in this ResultSet."
 msgstr "A nome da coluna {0} não foi encontrado neste ResultSet."
 
-#: org/postgresql/jdbc/PgResultSet.java:2731
+#: org/postgresql/jdbc/PgResultSet.java:2729
 msgid ""
 "ResultSet is not updateable.  The query that generated this result set must "
 "select only one table, and must select all primary keys from that table. See "
@@ -1217,42 +1223,42 @@ msgstr ""
 "chaves primárias daquela tabela. Veja a especificação na API do JDBC 2.1, "
 "seção 5.6 para obter mais detalhes."
 
-#: org/postgresql/jdbc/PgResultSet.java:2743
+#: org/postgresql/jdbc/PgResultSet.java:2741
 msgid "This ResultSet is closed."
 msgstr "Este ResultSet está fechado."
 
-#: org/postgresql/jdbc/PgResultSet.java:2774
+#: org/postgresql/jdbc/PgResultSet.java:2772
 msgid "ResultSet not positioned properly, perhaps you need to call next."
 msgstr ""
 "ResultSet não está posicionado corretamente, talvez você precise chamar next."
 
-#: org/postgresql/jdbc/PgResultSet.java:3095
+#: org/postgresql/jdbc/PgResultSet.java:3094
 msgid "Invalid UUID data."
 msgstr "dado UUID é inválido."
 
-#: org/postgresql/jdbc/PgResultSet.java:3184
-#: org/postgresql/jdbc/PgResultSet.java:3191
-#: org/postgresql/jdbc/PgResultSet.java:3202
-#: org/postgresql/jdbc/PgResultSet.java:3213
-#: org/postgresql/jdbc/PgResultSet.java:3224
-#: org/postgresql/jdbc/PgResultSet.java:3235
-#: org/postgresql/jdbc/PgResultSet.java:3246
-#: org/postgresql/jdbc/PgResultSet.java:3257
-#: org/postgresql/jdbc/PgResultSet.java:3268
-#: org/postgresql/jdbc/PgResultSet.java:3275
-#: org/postgresql/jdbc/PgResultSet.java:3282
-#: org/postgresql/jdbc/PgResultSet.java:3293
-#: org/postgresql/jdbc/PgResultSet.java:3310
-#: org/postgresql/jdbc/PgResultSet.java:3317
-#: org/postgresql/jdbc/PgResultSet.java:3324
-#: org/postgresql/jdbc/PgResultSet.java:3335
-#: org/postgresql/jdbc/PgResultSet.java:3342
-#: org/postgresql/jdbc/PgResultSet.java:3349
-#: org/postgresql/jdbc/PgResultSet.java:3387
-#: org/postgresql/jdbc/PgResultSet.java:3394
-#: org/postgresql/jdbc/PgResultSet.java:3401
-#: org/postgresql/jdbc/PgResultSet.java:3421
-#: org/postgresql/jdbc/PgResultSet.java:3434
+#: org/postgresql/jdbc/PgResultSet.java:3183
+#: org/postgresql/jdbc/PgResultSet.java:3190
+#: org/postgresql/jdbc/PgResultSet.java:3201
+#: org/postgresql/jdbc/PgResultSet.java:3212
+#: org/postgresql/jdbc/PgResultSet.java:3223
+#: org/postgresql/jdbc/PgResultSet.java:3234
+#: org/postgresql/jdbc/PgResultSet.java:3245
+#: org/postgresql/jdbc/PgResultSet.java:3256
+#: org/postgresql/jdbc/PgResultSet.java:3267
+#: org/postgresql/jdbc/PgResultSet.java:3274
+#: org/postgresql/jdbc/PgResultSet.java:3281
+#: org/postgresql/jdbc/PgResultSet.java:3292
+#: org/postgresql/jdbc/PgResultSet.java:3309
+#: org/postgresql/jdbc/PgResultSet.java:3316
+#: org/postgresql/jdbc/PgResultSet.java:3323
+#: org/postgresql/jdbc/PgResultSet.java:3334
+#: org/postgresql/jdbc/PgResultSet.java:3341
+#: org/postgresql/jdbc/PgResultSet.java:3348
+#: org/postgresql/jdbc/PgResultSet.java:3386
+#: org/postgresql/jdbc/PgResultSet.java:3393
+#: org/postgresql/jdbc/PgResultSet.java:3400
+#: org/postgresql/jdbc/PgResultSet.java:3420
+#: org/postgresql/jdbc/PgResultSet.java:3433
 #, fuzzy, java-format
 msgid "conversion to {0} from {1} not supported"
 msgstr "Nível de isolamento da transação {0} não é suportado."
@@ -1322,35 +1328,35 @@ msgstr ""
 msgid "Maximum number of rows must be a value grater than or equal to 0."
 msgstr "Número máximo de registros deve ser um valor maior ou igual a 0."
 
-#: org/postgresql/jdbc/PgStatement.java:550
+#: org/postgresql/jdbc/PgStatement.java:555
 msgid "Query timeout must be a value greater than or equals to 0."
 msgstr "Tempo de espera da consulta deve ser um valor maior ou igual a 0."
 
-#: org/postgresql/jdbc/PgStatement.java:590
+#: org/postgresql/jdbc/PgStatement.java:595
 msgid "The maximum field size must be a value greater than or equal to 0."
 msgstr "O tamanho máximo de um campo deve ser um valor maior ou igual a 0."
 
-#: org/postgresql/jdbc/PgStatement.java:689
+#: org/postgresql/jdbc/PgStatement.java:694
 msgid "This statement has been closed."
 msgstr "Este comando foi fechado."
 
-#: org/postgresql/jdbc/PgStatement.java:1145
-#: org/postgresql/jdbc/PgStatement.java:1173
+#: org/postgresql/jdbc/PgStatement.java:1150
+#: org/postgresql/jdbc/PgStatement.java:1178
 msgid "Returning autogenerated keys by column index is not supported."
 msgstr ""
 "Retorno de chaves geradas automaticamente por índice de coluna não é "
 "suportado."
 
-#: org/postgresql/jdbc/TimestampUtils.java:355
-#: org/postgresql/jdbc/TimestampUtils.java:423
+#: org/postgresql/jdbc/TimestampUtils.java:365
+#: org/postgresql/jdbc/TimestampUtils.java:433
 #, fuzzy, java-format
 msgid "Bad value for type timestamp/date/time: {1}"
 msgstr "Valor inválido para tipo {0} : {1}"
 
-#: org/postgresql/jdbc/TimestampUtils.java:858
-#: org/postgresql/jdbc/TimestampUtils.java:915
-#: org/postgresql/jdbc/TimestampUtils.java:961
-#: org/postgresql/jdbc/TimestampUtils.java:1010
+#: org/postgresql/jdbc/TimestampUtils.java:914
+#: org/postgresql/jdbc/TimestampUtils.java:971
+#: org/postgresql/jdbc/TimestampUtils.java:1017
+#: org/postgresql/jdbc/TimestampUtils.java:1066
 #, fuzzy, java-format
 msgid "Unsupported binary encoding of {0}."
 msgstr "Valor de Types não é suportado: {0}"
@@ -1363,31 +1369,31 @@ msgstr ""
 msgid "Invalid or unsupported by client SCRAM mechanisms"
 msgstr ""
 
-#: org/postgresql/jre8/sasl/ScramAuthenticator.java:117
+#: org/postgresql/jre8/sasl/ScramAuthenticator.java:119
 #, fuzzy, java-format
 msgid "Invalid server-first-message: {0}"
 msgstr "Tamanho de dado {0} é inválido."
 
-#: org/postgresql/jre8/sasl/ScramAuthenticator.java:147
+#: org/postgresql/jre8/sasl/ScramAuthenticator.java:151
 #, fuzzy, java-format
 msgid "Invalid server-final-message: {0}"
 msgstr "Tamanho de dado {0} é inválido."
 
-#: org/postgresql/jre8/sasl/ScramAuthenticator.java:153
+#: org/postgresql/jre8/sasl/ScramAuthenticator.java:157
 #, java-format
 msgid "SCRAM authentication failed, server returned error: {0}"
 msgstr ""
 
-#: org/postgresql/jre8/sasl/ScramAuthenticator.java:160
+#: org/postgresql/jre8/sasl/ScramAuthenticator.java:164
 msgid "Invalid server SCRAM signature"
 msgstr ""
 
-#: org/postgresql/largeobject/LargeObjectManager.java:144
+#: org/postgresql/largeobject/LargeObjectManager.java:136
 msgid "Failed to initialize LargeObject API"
 msgstr "Falhou ao inicializar API de Objetos Grandes"
 
-#: org/postgresql/largeobject/LargeObjectManager.java:262
-#: org/postgresql/largeobject/LargeObjectManager.java:305
+#: org/postgresql/largeobject/LargeObjectManager.java:254
+#: org/postgresql/largeobject/LargeObjectManager.java:295
 msgid "Large Objects may not be used in auto-commit mode."
 msgstr ""
 "Objetos Grandes não podem ser usados no modo de efetivação automática (auto-"
@@ -1423,34 +1429,34 @@ msgstr ""
 msgid "The hostname {0} could not be verified."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:164
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:90
 msgid "The sslfactoryarg property may not be empty."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:180
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:106
 msgid ""
 "The environment variable containing the server's SSL certificate must not be "
 "empty."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:188
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:114
 msgid ""
 "The system property containing the server's SSL certificate must not be "
 "empty."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:195
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:121
 msgid ""
 "The sslfactoryarg property must start with the prefix file:, classpath:, "
 "env:, sys:, or -----BEGIN CERTIFICATE-----."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:207
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:133
 #, fuzzy
 msgid "An error occurred reading the certificate"
 msgstr "Um erro ocorreu ao estabelecer uma conexão SSL."
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:240
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:166
 msgid "No X509TrustManager found"
 msgstr ""
 
@@ -1585,31 +1591,31 @@ msgid ""
 "setSavePoint not allowed while an XA transaction is active."
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:177
-#: org/postgresql/xa/PGXAConnection.java:253
-#: org/postgresql/xa/PGXAConnection.java:347
+#: org/postgresql/xa/PGXAConnection.java:186
+#: org/postgresql/xa/PGXAConnection.java:272
+#: org/postgresql/xa/PGXAConnection.java:381
 #, java-format
 msgid "Invalid flags {0}"
 msgstr "Marcadores={0} inválidos"
 
-#: org/postgresql/xa/PGXAConnection.java:181
-#: org/postgresql/xa/PGXAConnection.java:257
-#: org/postgresql/xa/PGXAConnection.java:449
+#: org/postgresql/xa/PGXAConnection.java:190
+#: org/postgresql/xa/PGXAConnection.java:276
+#: org/postgresql/xa/PGXAConnection.java:491
 msgid "xid must not be null"
 msgstr "xid não deve ser nulo"
 
-#: org/postgresql/xa/PGXAConnection.java:185
+#: org/postgresql/xa/PGXAConnection.java:194
 msgid "Connection is busy with another transaction"
 msgstr "Conexão está ocupada com outra transação"
 
-#: org/postgresql/xa/PGXAConnection.java:194
-#: org/postgresql/xa/PGXAConnection.java:267
+#: org/postgresql/xa/PGXAConnection.java:203
+#: org/postgresql/xa/PGXAConnection.java:286
 msgid "suspend/resume not implemented"
 msgstr "suspender/recomeçar não está implementado"
 
-#: org/postgresql/xa/PGXAConnection.java:202
-#: org/postgresql/xa/PGXAConnection.java:209
-#: org/postgresql/xa/PGXAConnection.java:213
+#: org/postgresql/xa/PGXAConnection.java:211
+#: org/postgresql/xa/PGXAConnection.java:218
+#: org/postgresql/xa/PGXAConnection.java:222
 #, java-format
 msgid ""
 "Invalid protocol state requested. Attempted transaction interleaving is not "
@@ -1618,11 +1624,11 @@ msgstr ""
 "Intercalação de transação não está implementado. xid={0}, currentXid={1}, "
 "state={2}, flags={3}"
 
-#: org/postgresql/xa/PGXAConnection.java:224
+#: org/postgresql/xa/PGXAConnection.java:233
 msgid "Error disabling autocommit"
 msgstr "Erro ao desabilitar autocommit"
 
-#: org/postgresql/xa/PGXAConnection.java:261
+#: org/postgresql/xa/PGXAConnection.java:280
 #, java-format
 msgid ""
 "tried to call end without corresponding start call. state={0}, start "
@@ -1631,19 +1637,19 @@ msgstr ""
 "tentou executar end sem a chamada ao start correspondente. state={0}, start "
 "xid={1}, currentXid={2}, preparedXid={3}"
 
-#: org/postgresql/xa/PGXAConnection.java:297
+#: org/postgresql/xa/PGXAConnection.java:326
 #, fuzzy, java-format
 msgid ""
 "Preparing already prepared transaction, the prepared xid {0}, prepare xid={1}"
 msgstr ""
 "Erro ao cancelar transação preparada. rollback xid={0}, preparedXid={1}"
 
-#: org/postgresql/xa/PGXAConnection.java:300
+#: org/postgresql/xa/PGXAConnection.java:329
 #, java-format
 msgid "Current connection does not have an associated xid. prepare xid={0}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:307
+#: org/postgresql/xa/PGXAConnection.java:336
 #, java-format
 msgid ""
 "Not implemented: Prepare must be issued using the same connection that "
@@ -1652,21 +1658,21 @@ msgstr ""
 "Não está implementado: Prepare deve ser executado utilizando a mesma conexão "
 "que iniciou a transação. currentXid={0}, prepare xid={1}"
 
-#: org/postgresql/xa/PGXAConnection.java:311
+#: org/postgresql/xa/PGXAConnection.java:340
 #, java-format
 msgid "Prepare called before end. prepare xid={0}, state={1}"
 msgstr "Prepare executado antes do end. prepare xid={0}, state={1}"
 
-#: org/postgresql/xa/PGXAConnection.java:331
+#: org/postgresql/xa/PGXAConnection.java:360
 #, java-format
 msgid "Error preparing transaction. prepare xid={0}"
 msgstr "Erro ao preparar transação. prepare xid={0}"
 
-#: org/postgresql/xa/PGXAConnection.java:382
+#: org/postgresql/xa/PGXAConnection.java:416
 msgid "Error during recover"
 msgstr "Erro durante recuperação"
 
-#: org/postgresql/xa/PGXAConnection.java:438
+#: org/postgresql/xa/PGXAConnection.java:480
 #, fuzzy, java-format
 msgid ""
 "Error rolling back prepared transaction. rollback xid={0}, preparedXid={1}, "
@@ -1674,13 +1680,13 @@ msgid ""
 msgstr ""
 "Erro ao cancelar transação preparada. rollback xid={0}, preparedXid={1}"
 
-#: org/postgresql/xa/PGXAConnection.java:471
+#: org/postgresql/xa/PGXAConnection.java:521
 #, java-format
 msgid ""
 "One-phase commit called for xid {0} but connection was prepared with xid {1}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:479
+#: org/postgresql/xa/PGXAConnection.java:529
 msgid ""
 "Not implemented: one-phase commit must be issued using the same connection "
 "that was used to start it"
@@ -1688,22 +1694,22 @@ msgstr ""
 "Não está implementado: efetivada da primeira fase deve ser executada "
 "utilizando a mesma conexão que foi utilizada para iniciá-la"
 
-#: org/postgresql/xa/PGXAConnection.java:483
+#: org/postgresql/xa/PGXAConnection.java:533
 #, java-format
 msgid "One-phase commit with unknown xid. commit xid={0}, currentXid={1}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:487
+#: org/postgresql/xa/PGXAConnection.java:537
 #, java-format
 msgid "commit called before end. commit xid={0}, state={1}"
 msgstr "commit executado antes do end. commit xid={0}, state={1}"
 
-#: org/postgresql/xa/PGXAConnection.java:498
+#: org/postgresql/xa/PGXAConnection.java:548
 #, java-format
 msgid "Error during one-phase commit. commit xid={0}"
 msgstr "Erro durante efetivação de uma fase. commit xid={0}"
 
-#: org/postgresql/xa/PGXAConnection.java:517
+#: org/postgresql/xa/PGXAConnection.java:576
 msgid ""
 "Not implemented: 2nd phase commit must be issued using an idle connection. "
 "commit xid={0}, currentXid={1}, state={2], transactionState={3}"
@@ -1712,7 +1718,7 @@ msgstr ""
 "utilizado uma conexão ociosa. commit xid={0}, currentXid={1}, state={2], "
 "transactionState={3}"
 
-#: org/postgresql/xa/PGXAConnection.java:550
+#: org/postgresql/xa/PGXAConnection.java:609
 #, fuzzy, java-format
 msgid ""
 "Error committing prepared transaction. commit xid={0}, preparedXid={1}, "
@@ -1721,7 +1727,7 @@ msgstr ""
 "Erro ao cancelar transação preparada. commit xid={0}, preparedXid={1}, "
 "currentXid={2}"
 
-#: org/postgresql/xa/PGXAConnection.java:567
+#: org/postgresql/xa/PGXAConnection.java:626
 #, java-format
 msgid "Heuristic commit/rollback not supported. forget xid={0}"
 msgstr "Efetivação/Cancelamento heurístico não é suportado. forget xid={0}"

--- a/pgjdbc/src/main/java/org/postgresql/translation/ru.po
+++ b/pgjdbc/src/main/java/org/postgresql/translation/ru.po
@@ -13,7 +13,6 @@ msgid ""
 msgstr ""
 "Project-Id-Version: JDBC Driver for PostgreSQL 8.x.x\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-06-05 10:57+0300\n"
 "PO-Revision-Date: 2016-01-07 15:09+0300\n"
 "Last-Translator: Vladimir Sitnikov <sitnikov.vladimir@gmail.com>\n"
 "Language-Team: pgsql-rus <pgsql-rus@yahoogroups.com>\n"
@@ -23,15 +22,15 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.5.7\n"
 
-#: org/postgresql/Driver.java:214
+#: org/postgresql/Driver.java:217
 msgid "Error loading default settings from driverconfig.properties"
 msgstr ""
 
-#: org/postgresql/Driver.java:226
+#: org/postgresql/Driver.java:229
 msgid "Properties for the driver contains a non-string value for the key "
 msgstr ""
 
-#: org/postgresql/Driver.java:270
+#: org/postgresql/Driver.java:272
 msgid ""
 "Your security policy has prevented the connection from being attempted.  You "
 "probably need to grant the connect java.net.SocketPermission to the database "
@@ -39,7 +38,7 @@ msgid ""
 msgstr ""
 
 # key: postgresql.unusual
-#: org/postgresql/Driver.java:276 org/postgresql/Driver.java:408
+#: org/postgresql/Driver.java:278 org/postgresql/Driver.java:410
 msgid ""
 "Something unusual has occurred to cause the driver to fail. Please report "
 "this exception."
@@ -48,37 +47,37 @@ msgstr ""
 "Пожалуйста сообщите это исключение."
 
 # key: postgresql.con.failed
-#: org/postgresql/Driver.java:416
+#: org/postgresql/Driver.java:418
 msgid "Connection attempt timed out."
 msgstr "Закончилось время ожидания"
 
 # key: postgresql.con.sslfail
-#: org/postgresql/Driver.java:429
+#: org/postgresql/Driver.java:431
 msgid "Interrupted while attempting to connect."
 msgstr "Подключение прервано получаением interrupt"
 
 # key: postgresql.unimplemented
-#: org/postgresql/Driver.java:682
+#: org/postgresql/Driver.java:687
 #, java-format
 msgid "Method {0} is not yet implemented."
 msgstr "Метод {0} ещё не реализован"
 
-#: org/postgresql/PGProperty.java:535 org/postgresql/PGProperty.java:555
+#: org/postgresql/PGProperty.java:537 org/postgresql/PGProperty.java:557
 #, java-format
 msgid "{0} parameter value must be an integer but was: {1}"
 msgstr ""
 
-#: org/postgresql/copy/CopyManager.java:53
+#: org/postgresql/copy/CopyManager.java:49
 #, java-format
 msgid "Requested CopyIn but got {0}"
 msgstr "Ожидался ответ CopyIn, а получен {0}"
 
-#: org/postgresql/copy/CopyManager.java:64
+#: org/postgresql/copy/CopyManager.java:60
 #, java-format
 msgid "Requested CopyOut but got {0}"
 msgstr "Ожидался ответ CopyOut, а получен {0}"
 
-#: org/postgresql/copy/CopyManager.java:75
+#: org/postgresql/copy/CopyManager.java:71
 #, fuzzy, java-format
 msgid "Requested CopyDual but got {0}"
 msgstr "Ожидался ответ CopyOut, а получен {0}"
@@ -103,6 +102,11 @@ msgstr ""
 msgid "Cannot write to copy a byte of value {0}"
 msgstr "Значение byte должно быть в диапазоне 0..255, переданное значение: {0}"
 
+#: org/postgresql/core/CommandCompleteParser.java:71
+#, fuzzy, java-format
+msgid "Unable to parse the count in command completion tag: {0}."
+msgstr "Не удалось узнать количество обновлённых строк по ответу {0}"
+
 #: org/postgresql/core/ConnectionFactory.java:57
 #, java-format
 msgid "A connection could not be made using the requested protocol {0}."
@@ -125,7 +129,7 @@ msgid "Expected an EOF from server, got: {0}"
 msgstr ""
 "Неожиданный ответ от сервера. Ожидалось окончание потока, получен байт {0}"
 
-#: org/postgresql/core/Parser.java:1006
+#: org/postgresql/core/Parser.java:1051
 #, java-format
 msgid "Malformed function or procedure escape syntax at offset {0}."
 msgstr "Невозможно разобрать SQL команду. Ошибка на позиции {0}"
@@ -193,24 +197,24 @@ msgstr "Символ с кодом 0 в идентификаторах не до
 #: org/postgresql/core/v3/CompositeParameterList.java:33
 #: org/postgresql/core/v3/SimpleParameterList.java:54
 #: org/postgresql/core/v3/SimpleParameterList.java:65
-#: org/postgresql/jdbc/PgResultSet.java:2757
-#: org/postgresql/jdbc/PgResultSetMetaData.java:494
+#: org/postgresql/jdbc/PgResultSet.java:2755
+#: org/postgresql/jdbc/PgResultSetMetaData.java:388
 #, java-format
 msgid "The column index is out of range: {0}, number of columns: {1}."
 msgstr "Индекс колонки вне диапазона: {0}. Допустимые значения: 1..{1}"
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:109
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:103
 #, java-format
 msgid "Invalid sslmode value: {0}"
 msgstr "Неверное значение sslmode: {0}"
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:124
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:118
 #, java-format
 msgid "Invalid targetServerType value: {0}"
 msgstr "Неверное значение targetServerType: {0}"
 
 # key: postgresql.con.refused
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:246
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:239
 #, java-format
 msgid ""
 "Connection to {0} refused. Check that the hostname and port are correct and "
@@ -220,42 +224,42 @@ msgstr ""
 "правильно и что postmaster принимает TCP/IP-подсоединения."
 
 # key: postgresql.con.failed
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:257
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:250
 #: org/postgresql/core/v3/replication/V3ReplicationProtocol.java:133
 msgid "The connection attempt failed."
 msgstr "Ошибка при попытке подсоединения."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:272
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:265
 #, java-format
 msgid "Could not find a server with specified targetServerType: {0}"
 msgstr "Не удалось найти сервер с указанным значением targetServerType: {0}"
 
 # key: postgresql.con.sslnotsupported
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:368
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:381
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:361
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:374
 msgid "The server does not support SSL."
 msgstr "Сервер не поддерживает SSL."
 
 # key: postgresql.con.sslfail
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:395
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:388
 msgid "An error occurred while setting up the SSL connection."
 msgstr "Ошибка при установке SSL-подсоединения."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:496
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:523
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:484
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:511
 msgid ""
 "The server requested password-based authentication, but no password was "
 "provided."
 msgstr "Сервер запросил парольную аутентификацию, но пароль не был указан."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:626
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:614
 msgid ""
 "SCRAM authentication is not supported by this driver. You need JDK >= 8 and "
 "pgjdbc >= 42.2.0 (not \".jre\" versions)"
 msgstr ""
 
 # key: postgresql.con.auth
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:650
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:638
 #, java-format
 msgid ""
 "The authentication type {0} is not supported. Check that you have configured "
@@ -268,16 +272,16 @@ msgstr ""
 "драйвером."
 
 # key: postgresql.con.setup
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:657
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2550
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2581
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2585
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2653
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:645
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2543
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2576
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2580
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2648
 #: org/postgresql/gss/GssAction.java:126
 msgid "Protocol error.  Session setup failed."
 msgstr "Ошибка протокола.  Установление сессии не удалось."
 
-#: org/postgresql/core/v3/CopyInImpl.java:47
+#: org/postgresql/core/v3/CopyInImpl.java:49
 msgid "CopyIn copy direction can't receive data"
 msgstr ""
 
@@ -285,186 +289,181 @@ msgstr ""
 msgid "CommandComplete expected COPY but got: "
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:161
+#: org/postgresql/core/v3/QueryExecutorImpl.java:163
 msgid "Tried to obtain lock while already holding it"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:177
+#: org/postgresql/core/v3/QueryExecutorImpl.java:179
 msgid "Tried to break lock on database connection"
 msgstr ""
 
 # key: postgresql.con.sslfail
-#: org/postgresql/core/v3/QueryExecutorImpl.java:195
+#: org/postgresql/core/v3/QueryExecutorImpl.java:197
 msgid "Interrupted while waiting to obtain lock on database connection"
 msgstr "Ожидание COPY блокировки прервано получением interrupt"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:327
+#: org/postgresql/core/v3/QueryExecutorImpl.java:329
 msgid "Unable to bind parameter values for statement."
 msgstr ""
 "Не в состоянии ассоциировать значения параметров для команды "
 "(PGBindException)"
 
 # key: postgresql.con.ioerror
-#: org/postgresql/core/v3/QueryExecutorImpl.java:333
-#: org/postgresql/core/v3/QueryExecutorImpl.java:485
-#: org/postgresql/core/v3/QueryExecutorImpl.java:559
-#: org/postgresql/core/v3/QueryExecutorImpl.java:602
-#: org/postgresql/core/v3/QueryExecutorImpl.java:729
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2372
+#: org/postgresql/core/v3/QueryExecutorImpl.java:335
+#: org/postgresql/core/v3/QueryExecutorImpl.java:487
+#: org/postgresql/core/v3/QueryExecutorImpl.java:561
+#: org/postgresql/core/v3/QueryExecutorImpl.java:604
+#: org/postgresql/core/v3/QueryExecutorImpl.java:731
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2377
 #: org/postgresql/util/StreamWrapper.java:130
 msgid "An I/O error occurred while sending to the backend."
 msgstr "Ошибка ввода/ввывода при отправке бэкенду"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:534
-#: org/postgresql/core/v3/QueryExecutorImpl.java:576
+#: org/postgresql/core/v3/QueryExecutorImpl.java:536
+#: org/postgresql/core/v3/QueryExecutorImpl.java:578
 #, java-format
 msgid "Expected command status BEGIN, got {0}."
 msgstr "Ожидался статус команды BEGIN, но получен {0}"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:581
+#: org/postgresql/core/v3/QueryExecutorImpl.java:583
 #: org/postgresql/jdbc/PgResultSet.java:1778
 #, java-format
 msgid "Unexpected command status: {0}."
 msgstr "Неожиданный статус команды: {0}."
 
 # key: postgresql.con.ioerror
-#: org/postgresql/core/v3/QueryExecutorImpl.java:687
+#: org/postgresql/core/v3/QueryExecutorImpl.java:689
 #, fuzzy
 msgid "An error occurred while trying to get the socket timeout."
 msgstr "Ошибка ввода/ввывода при отправке бэкенду"
 
 # key: postgresql.con.type
-#: org/postgresql/core/v3/QueryExecutorImpl.java:722
-#: org/postgresql/core/v3/QueryExecutorImpl.java:798
+#: org/postgresql/core/v3/QueryExecutorImpl.java:724
+#: org/postgresql/core/v3/QueryExecutorImpl.java:800
 #, java-format
 msgid "Unknown Response Type {0}."
 msgstr "Неизвестный тип ответа {0}."
 
 # key: postgresql.con.ioerror
-#: org/postgresql/core/v3/QueryExecutorImpl.java:745
+#: org/postgresql/core/v3/QueryExecutorImpl.java:747
 #, fuzzy
 msgid "An error occurred while trying to reset the socket timeout."
 msgstr "Ошибка ввода/ввывода при отправке бэкенду"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:843
+#: org/postgresql/core/v3/QueryExecutorImpl.java:845
 msgid "Database connection failed when starting copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:878
+#: org/postgresql/core/v3/QueryExecutorImpl.java:880
 msgid "Tried to cancel an inactive copy operation"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:917
+#: org/postgresql/core/v3/QueryExecutorImpl.java:919
 msgid "Database connection failed when canceling copy operation"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:933
+#: org/postgresql/core/v3/QueryExecutorImpl.java:935
 msgid "Missing expected error response to copy cancel request"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:937
+#: org/postgresql/core/v3/QueryExecutorImpl.java:939
 #, java-format
 msgid "Got {0} error responses to single copy cancel request"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:952
+#: org/postgresql/core/v3/QueryExecutorImpl.java:954
 msgid "Tried to end inactive copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:967
+#: org/postgresql/core/v3/QueryExecutorImpl.java:969
 msgid "Database connection failed when ending copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:985
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1005
+#: org/postgresql/core/v3/QueryExecutorImpl.java:987
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1007
 msgid "Tried to write to an inactive copy operation"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:998
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1013
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1000
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1015
 msgid "Database connection failed when writing to copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1028
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1030
 msgid "Tried to read from inactive copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1035
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1037
 msgid "Database connection failed when reading from copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1101
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1103
 #, java-format
 msgid "Received CommandComplete ''{0}'' without an active copy operation"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1126
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1128
 #, java-format
 msgid "Got CopyInResponse from server during an active {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1140
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1142
 #, java-format
 msgid "Got CopyOutResponse from server during an active {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1154
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1156
 #, java-format
 msgid "Got CopyBothResponse from server during an active {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1170
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1172
 msgid "Got CopyData without an active copy operation"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1174
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1176
 #, java-format
 msgid "Unexpected copydata from server for {0}"
 msgstr "Неожиданный статус команды COPY: {0}"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1234
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1236
 #, java-format
 msgid "Unexpected packet type during copy: {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1524
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1526
 #, java-format
 msgid ""
 "Bind message length {0} too long.  This can be caused by very large or "
 "incorrect length specifications on InputStream parameters."
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2145
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2150
 msgid "Ran out of memory retrieving query results."
 msgstr ""
 "Недостаточно памяти для обработки результатов запроса. Попробуйте увеличить -"
 "Xmx или проверьте размеры обрабатываемых данных"
 
 # key: postgresql.con.sslnotsupported
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2313
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2318
 msgid "The driver currently does not support COPY operations."
 msgstr "Драйвер в данный момент не поддерживате операции COPY."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2487
-#, fuzzy, java-format
-msgid "Unable to parse the count in command completion tag: {0}."
-msgstr "Не удалось узнать количество обновлённых строк по ответу {0}"
-
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2610
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2605
 #, java-format
 msgid ""
 "The server''s client_encoding parameter was changed to {0}. The JDBC driver "
 "requires client_encoding to be UTF8 for correct operation."
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2620
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2615
 #, java-format
 msgid ""
 "The server''s DateStyle parameter was changed to {0}. The JDBC driver "
 "requires DateStyle to begin with ISO for correct operation."
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2633
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2628
 #, java-format
 msgid ""
 "The server''s standard_conforming_strings parameter was reported as {0}. The "
@@ -526,18 +525,18 @@ msgstr "DataSource закрыт."
 msgid "Unsupported property name: {0}"
 msgstr "Свойство {0} не поддерживается"
 
-#: org/postgresql/fastpath/Fastpath.java:86
+#: org/postgresql/fastpath/Fastpath.java:84
 #, java-format
 msgid "Fastpath call {0} - No result was returned and we expected a numeric."
 msgstr ""
 
 # key: postgresql.fp.expint
-#: org/postgresql/fastpath/Fastpath.java:163
+#: org/postgresql/fastpath/Fastpath.java:161
 #, java-format
 msgid "Fastpath call {0} - No result was returned and we expected an integer."
 msgstr ""
 
-#: org/postgresql/fastpath/Fastpath.java:171
+#: org/postgresql/fastpath/Fastpath.java:169
 #, java-format
 msgid ""
 "Fastpath call {0} - No result was returned or wrong size while expecting an "
@@ -545,12 +544,12 @@ msgid ""
 msgstr ""
 
 # key: postgresql.stat.result
-#: org/postgresql/fastpath/Fastpath.java:188
+#: org/postgresql/fastpath/Fastpath.java:186
 #, java-format
 msgid "Fastpath call {0} - No result was returned and we expected a long."
 msgstr "Вызов fastpath {0} ничего не вернул, а ожидалось long"
 
-#: org/postgresql/fastpath/Fastpath.java:196
+#: org/postgresql/fastpath/Fastpath.java:194
 #, java-format
 msgid ""
 "Fastpath call {0} - No result was returned or wrong size while expecting a "
@@ -558,7 +557,7 @@ msgid ""
 msgstr ""
 
 # key: postgresql.fp.unknown
-#: org/postgresql/fastpath/Fastpath.java:308
+#: org/postgresql/fastpath/Fastpath.java:297
 #, java-format
 msgid "The fastpath function {0} is unknown."
 msgstr ""
@@ -627,64 +626,71 @@ msgid "Cannot cast to boolean: \"{0}\""
 msgstr ""
 
 #: org/postgresql/jdbc/EscapedFunctions.java:240
+#: org/postgresql/jdbc/EscapedFunctions2.java:167
 #, java-format
 msgid "{0} function takes four and only four argument."
 msgstr ""
 
 #: org/postgresql/jdbc/EscapedFunctions.java:270
-#: org/postgresql/jdbc/EscapedFunctions.java:344
-#: org/postgresql/jdbc/EscapedFunctions.java:749
-#: org/postgresql/jdbc/EscapedFunctions.java:787
+#: org/postgresql/jdbc/EscapedFunctions.java:337
+#: org/postgresql/jdbc/EscapedFunctions.java:740
+#: org/postgresql/jdbc/EscapedFunctions2.java:196
+#: org/postgresql/jdbc/EscapedFunctions2.java:263
+#: org/postgresql/jdbc/EscapedFunctions2.java:665
 #, java-format
 msgid "{0} function takes two and only two arguments."
 msgstr ""
 
 #: org/postgresql/jdbc/EscapedFunctions.java:288
-#: org/postgresql/jdbc/EscapedFunctions.java:326
-#: org/postgresql/jdbc/EscapedFunctions.java:446
-#: org/postgresql/jdbc/EscapedFunctions.java:461
-#: org/postgresql/jdbc/EscapedFunctions.java:476
-#: org/postgresql/jdbc/EscapedFunctions.java:491
-#: org/postgresql/jdbc/EscapedFunctions.java:506
-#: org/postgresql/jdbc/EscapedFunctions.java:521
-#: org/postgresql/jdbc/EscapedFunctions.java:536
-#: org/postgresql/jdbc/EscapedFunctions.java:551
-#: org/postgresql/jdbc/EscapedFunctions.java:566
-#: org/postgresql/jdbc/EscapedFunctions.java:581
-#: org/postgresql/jdbc/EscapedFunctions.java:596
-#: org/postgresql/jdbc/EscapedFunctions.java:611
-#: org/postgresql/jdbc/EscapedFunctions.java:775
+#: org/postgresql/jdbc/EscapedFunctions.java:441
+#: org/postgresql/jdbc/EscapedFunctions.java:467
+#: org/postgresql/jdbc/EscapedFunctions.java:526
+#: org/postgresql/jdbc/EscapedFunctions.java:728
+#: org/postgresql/jdbc/EscapedFunctions2.java:211
+#: org/postgresql/jdbc/EscapedFunctions2.java:355
+#: org/postgresql/jdbc/EscapedFunctions2.java:381
+#: org/postgresql/jdbc/EscapedFunctions2.java:440
+#: org/postgresql/jdbc/EscapedFunctions2.java:654
 #, java-format
 msgid "{0} function takes one and only one argument."
 msgstr ""
 
-#: org/postgresql/jdbc/EscapedFunctions.java:310
-#: org/postgresql/jdbc/EscapedFunctions.java:391
+#: org/postgresql/jdbc/EscapedFunctions.java:312
+#: org/postgresql/jdbc/EscapedFunctions.java:386
+#: org/postgresql/jdbc/EscapedFunctions2.java:238
+#: org/postgresql/jdbc/EscapedFunctions2.java:307
 #, java-format
 msgid "{0} function takes two or three arguments."
 msgstr ""
 
-#: org/postgresql/jdbc/EscapedFunctions.java:416
-#: org/postgresql/jdbc/EscapedFunctions.java:431
-#: org/postgresql/jdbc/EscapedFunctions.java:734
-#: org/postgresql/jdbc/EscapedFunctions.java:764
+#: org/postgresql/jdbc/EscapedFunctions.java:411
+#: org/postgresql/jdbc/EscapedFunctions.java:426
+#: org/postgresql/jdbc/EscapedFunctions.java:693
+#: org/postgresql/jdbc/EscapedFunctions.java:719
+#: org/postgresql/jdbc/EscapedFunctions2.java:645
 #, java-format
 msgid "{0} function doesn''t take any argument."
 msgstr ""
 
-#: org/postgresql/jdbc/EscapedFunctions.java:627
-#: org/postgresql/jdbc/EscapedFunctions.java:680
+#: org/postgresql/jdbc/EscapedFunctions.java:586
+#: org/postgresql/jdbc/EscapedFunctions.java:639
+#: org/postgresql/jdbc/EscapedFunctions2.java:500
+#: org/postgresql/jdbc/EscapedFunctions2.java:571
 #, java-format
 msgid "{0} function takes three and only three arguments."
 msgstr ""
 
 # key: postgresql.unimplemented
-#: org/postgresql/jdbc/EscapedFunctions.java:640
-#: org/postgresql/jdbc/EscapedFunctions.java:661
-#: org/postgresql/jdbc/EscapedFunctions.java:664
-#: org/postgresql/jdbc/EscapedFunctions.java:697
-#: org/postgresql/jdbc/EscapedFunctions.java:710
-#: org/postgresql/jdbc/EscapedFunctions.java:713
+#: org/postgresql/jdbc/EscapedFunctions.java:599
+#: org/postgresql/jdbc/EscapedFunctions.java:620
+#: org/postgresql/jdbc/EscapedFunctions.java:623
+#: org/postgresql/jdbc/EscapedFunctions.java:656
+#: org/postgresql/jdbc/EscapedFunctions.java:669
+#: org/postgresql/jdbc/EscapedFunctions.java:672
+#: org/postgresql/jdbc/EscapedFunctions2.java:510
+#: org/postgresql/jdbc/EscapedFunctions2.java:527
+#: org/postgresql/jdbc/EscapedFunctions2.java:585
+#: org/postgresql/jdbc/EscapedFunctions2.java:597
 #, java-format
 msgid "Interval {0} not yet implemented"
 msgstr "Интеврвал {0} ещё не реализован"
@@ -704,19 +710,19 @@ msgid "Cannot retrieve the name of an unnamed savepoint."
 msgstr ""
 
 # key: postgresql.arr.range
-#: org/postgresql/jdbc/PgArray.java:157 org/postgresql/jdbc/PgArray.java:844
+#: org/postgresql/jdbc/PgArray.java:155 org/postgresql/jdbc/PgArray.java:842
 #, java-format
 msgid "The array index is out of range: {0}"
 msgstr "Индекс массива вне диапазона: {0}"
 
 # key: postgresql.arr.range
-#: org/postgresql/jdbc/PgArray.java:178 org/postgresql/jdbc/PgArray.java:861
+#: org/postgresql/jdbc/PgArray.java:176 org/postgresql/jdbc/PgArray.java:859
 #, java-format
 msgid "The array index is out of range: {0}, number of elements: {1}."
 msgstr "Индекс массива вне диапазона: {0}. Допустимые значения: 1..{1}"
 
 # key: postgresql.con.invalidchar
-#: org/postgresql/jdbc/PgArray.java:210
+#: org/postgresql/jdbc/PgArray.java:208
 #: org/postgresql/jdbc/PgResultSet.java:1930
 #: org/postgresql/util/HStoreConverter.java:43
 #: org/postgresql/util/HStoreConverter.java:74
@@ -731,35 +737,35 @@ msgstr ""
 "Типичным примером этого является хранение 8-битных данных в базе SQL_ASCII."
 
 # key: postgresql.call.noreturnval
-#: org/postgresql/jdbc/PgCallableStatement.java:86
-#: org/postgresql/jdbc/PgCallableStatement.java:96
+#: org/postgresql/jdbc/PgCallableStatement.java:85
+#: org/postgresql/jdbc/PgCallableStatement.java:95
 msgid "A CallableStatement was executed with nothing returned."
 msgstr ""
 
-#: org/postgresql/jdbc/PgCallableStatement.java:107
+#: org/postgresql/jdbc/PgCallableStatement.java:106
 msgid "A CallableStatement was executed with an invalid number of parameters"
 msgstr ""
 
-#: org/postgresql/jdbc/PgCallableStatement.java:145
+#: org/postgresql/jdbc/PgCallableStatement.java:144
 #, java-format
 msgid ""
 "A CallableStatement function was executed and the out parameter {0} was of "
 "type {1} however type {2} was registered."
 msgstr ""
 
-#: org/postgresql/jdbc/PgCallableStatement.java:202
+#: org/postgresql/jdbc/PgCallableStatement.java:206
 msgid ""
 "This statement does not declare an OUT parameter.  Use '{' ?= call ... '}' "
 "to declare one."
 msgstr ""
 
-#: org/postgresql/jdbc/PgCallableStatement.java:246
+#: org/postgresql/jdbc/PgCallableStatement.java:229
 msgid "wasNull cannot be call before fetching a result."
 msgstr ""
 
 # key: postgresql.call.wrongget
-#: org/postgresql/jdbc/PgCallableStatement.java:384
-#: org/postgresql/jdbc/PgCallableStatement.java:403
+#: org/postgresql/jdbc/PgCallableStatement.java:367
+#: org/postgresql/jdbc/PgCallableStatement.java:386
 #, java-format
 msgid ""
 "Parameter of type {0} was registered, but call to get{1} (sqltype={2}) was "
@@ -767,36 +773,36 @@ msgid ""
 msgstr ""
 
 # key: postgresql.call.noreturntype
-#: org/postgresql/jdbc/PgCallableStatement.java:424
+#: org/postgresql/jdbc/PgCallableStatement.java:407
 msgid ""
 "A CallableStatement was declared, but no call to registerOutParameter(1, "
 "<some type>) was made."
 msgstr ""
 
-#: org/postgresql/jdbc/PgCallableStatement.java:430
+#: org/postgresql/jdbc/PgCallableStatement.java:413
 msgid "No function outputs were registered."
 msgstr ""
 
-#: org/postgresql/jdbc/PgCallableStatement.java:436
+#: org/postgresql/jdbc/PgCallableStatement.java:419
 msgid ""
 "Results cannot be retrieved from a CallableStatement before it is executed."
 msgstr ""
 
 # key: postgresql.prep.type
-#: org/postgresql/jdbc/PgCallableStatement.java:703
+#: org/postgresql/jdbc/PgCallableStatement.java:686
 #, fuzzy, java-format
 msgid "Unsupported type conversion to {1}."
 msgstr "Бинарная передача не поддерживается для типа  {0}"
 
 # key: postgresql.prep.type
-#: org/postgresql/jdbc/PgConnection.java:272
+#: org/postgresql/jdbc/PgConnection.java:241
 #, java-format
 msgid "Unsupported value for stringtype parameter: {0}"
 msgstr "Неподдерживаемое значение для параметра stringtype: {0}"
 
 # key: postgresql.stat.noresult
 #: org/postgresql/jdbc/PgConnection.java:424
-#: org/postgresql/jdbc/PgPreparedStatement.java:119
+#: org/postgresql/jdbc/PgPreparedStatement.java:107
 #: org/postgresql/jdbc/PgStatement.java:225
 #: org/postgresql/jdbc/TypeInfoCache.java:226
 #: org/postgresql/jdbc/TypeInfoCache.java:371
@@ -809,132 +815,132 @@ msgid "No results were returned by the query."
 msgstr "Запрос не вернул результатов."
 
 # key: postgresql.stat.result
-#: org/postgresql/jdbc/PgConnection.java:441
+#: org/postgresql/jdbc/PgConnection.java:442
 #: org/postgresql/jdbc/PgStatement.java:254
 msgid "A result was returned when none was expected."
 msgstr "Результат возвращён когда его не ожидалось."
 
-#: org/postgresql/jdbc/PgConnection.java:545
+#: org/postgresql/jdbc/PgConnection.java:547
 msgid "Custom type maps are not supported."
 msgstr ""
 
 # key: postgresql.con.creobj
-#: org/postgresql/jdbc/PgConnection.java:587
+#: org/postgresql/jdbc/PgConnection.java:589
 #, java-format
 msgid "Failed to create object for: {0}."
 msgstr "Ошибка при создании объект для: {0}."
 
-#: org/postgresql/jdbc/PgConnection.java:641
+#: org/postgresql/jdbc/PgConnection.java:643
 #, java-format
 msgid "Unable to load the class {0} responsible for the datatype {1}"
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:693
+#: org/postgresql/jdbc/PgConnection.java:705
 msgid ""
 "Cannot change transaction read-only property in the middle of a transaction."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:756
+#: org/postgresql/jdbc/PgConnection.java:772
 msgid "Cannot commit when autoCommit is enabled."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:767
-#: org/postgresql/jdbc/PgConnection.java:1384
-#: org/postgresql/jdbc/PgConnection.java:1428
+#: org/postgresql/jdbc/PgConnection.java:783
+#: org/postgresql/jdbc/PgConnection.java:1401
+#: org/postgresql/jdbc/PgConnection.java:1445
 msgid "This connection has been closed."
 msgstr "Соединение уже было закрыто"
 
-#: org/postgresql/jdbc/PgConnection.java:777
+#: org/postgresql/jdbc/PgConnection.java:794
 msgid "Cannot rollback when autoCommit is enabled."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:827
+#: org/postgresql/jdbc/PgConnection.java:844
 msgid ""
 "Cannot change transaction isolation level in the middle of a transaction."
 msgstr ""
 
 # key: postgresql.con.isolevel
-#: org/postgresql/jdbc/PgConnection.java:833
+#: org/postgresql/jdbc/PgConnection.java:850
 #, java-format
 msgid "Transaction isolation level {0} not supported."
 msgstr "Уровень изоляции транзакций {0} не поддерживается."
 
-#: org/postgresql/jdbc/PgConnection.java:878
+#: org/postgresql/jdbc/PgConnection.java:895
 msgid "Finalizing a Connection that was never closed:"
 msgstr ""
 "Соединение «утекло». Проверьте, что в коде приложения вызывается connection."
 "close(). Далее следует стектрейс того места, где создавалось проблемное "
 "соединение"
 
-#: org/postgresql/jdbc/PgConnection.java:945
+#: org/postgresql/jdbc/PgConnection.java:962
 msgid "Unable to translate data into the desired encoding."
 msgstr ""
 
 # key: postgresql.input.fetch.gt0
-#: org/postgresql/jdbc/PgConnection.java:1008
+#: org/postgresql/jdbc/PgConnection.java:1025
 #: org/postgresql/jdbc/PgResultSet.java:1817
-#: org/postgresql/jdbc/PgStatement.java:903
+#: org/postgresql/jdbc/PgStatement.java:908
 msgid "Fetch size must be a value greater to or equal to 0."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1289
-#: org/postgresql/jdbc/PgConnection.java:1330
+#: org/postgresql/jdbc/PgConnection.java:1306
+#: org/postgresql/jdbc/PgConnection.java:1347
 #, java-format
 msgid "Unable to find server array type for provided name {0}."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1312
+#: org/postgresql/jdbc/PgConnection.java:1329
 #, fuzzy, java-format
 msgid "Invalid elements {0}"
 msgstr "Неверные флаги {0}"
 
-#: org/postgresql/jdbc/PgConnection.java:1348
+#: org/postgresql/jdbc/PgConnection.java:1365
 #, java-format
 msgid "Invalid timeout ({0}<0)."
 msgstr "Значение таймаута должно быть неотрицательным: {0}"
 
-#: org/postgresql/jdbc/PgConnection.java:1372
+#: org/postgresql/jdbc/PgConnection.java:1389
 msgid "Validating connection."
 msgstr ""
 
 # key: postgresql.con.creobj
-#: org/postgresql/jdbc/PgConnection.java:1405
+#: org/postgresql/jdbc/PgConnection.java:1422
 #, java-format
 msgid "Failed to set ClientInfo property: {0}"
 msgstr "Невозможно установить свойство ClientInfo: {0}"
 
-#: org/postgresql/jdbc/PgConnection.java:1415
+#: org/postgresql/jdbc/PgConnection.java:1432
 msgid "ClientInfo property not supported."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1441
+#: org/postgresql/jdbc/PgConnection.java:1458
 msgid "One ore more ClientInfo failed."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1540
+#: org/postgresql/jdbc/PgConnection.java:1559
 msgid "Network timeout must be a value greater than or equal to 0."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1552
+#: org/postgresql/jdbc/PgConnection.java:1571
 msgid "Unable to set network timeout."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1563
+#: org/postgresql/jdbc/PgConnection.java:1582
 msgid "Unable to get network timeout."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1580
+#: org/postgresql/jdbc/PgConnection.java:1599
 #, java-format
 msgid "Unknown ResultSet holdability setting: {0}."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1598
-#: org/postgresql/jdbc/PgConnection.java:1619
+#: org/postgresql/jdbc/PgConnection.java:1617
+#: org/postgresql/jdbc/PgConnection.java:1638
 msgid "Cannot establish a savepoint in auto-commit mode."
 msgstr ""
 
 # key: postgresql.con.isolevel
-#: org/postgresql/jdbc/PgConnection.java:1685
+#: org/postgresql/jdbc/PgConnection.java:1707
 msgid "Returning autogenerated keys is not supported."
 msgstr ""
 
@@ -948,46 +954,46 @@ msgstr ""
 msgid "Unable to find name datatype in the system catalogs."
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:323
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:322
 msgid "Unable to find keywords in the system catalogs."
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1105
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1095
 msgid "oid"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1105
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1095
 msgid "proname"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1107
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1558
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1097
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1548
 msgid "typtype"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1110
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1100
 msgid "proargtypes"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1576
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1566
 msgid "adsrc"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1589
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1579
 msgid "attidentity"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1685
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1761
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1675
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1751
 msgid "rolname"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1686
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1762
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1676
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1752
 msgid "relacl"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1692
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1682
 msgid "attacl"
 msgstr ""
 
@@ -997,86 +1003,86 @@ msgstr ""
 msgid "The parameter index is out of range: {0}, number of parameters: {1}."
 msgstr "Индекс параметра вне диапазона: {0}. Допустимые значения: 1..{1}"
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:106
+#: org/postgresql/jdbc/PgPreparedStatement.java:94
+#: org/postgresql/jdbc/PgPreparedStatement.java:115
 #: org/postgresql/jdbc/PgPreparedStatement.java:127
-#: org/postgresql/jdbc/PgPreparedStatement.java:139
-#: org/postgresql/jdbc/PgPreparedStatement.java:1035
+#: org/postgresql/jdbc/PgPreparedStatement.java:1008
 msgid ""
 "Can''t use query methods that take a query string on a PreparedStatement."
 msgstr ""
 
 # key: postgresql.prep.type
-#: org/postgresql/jdbc/PgPreparedStatement.java:249
+#: org/postgresql/jdbc/PgPreparedStatement.java:237
 msgid "Unknown Types value."
 msgstr "Неизвестное значение Types."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:382
-#: org/postgresql/jdbc/PgPreparedStatement.java:439
-#: org/postgresql/jdbc/PgPreparedStatement.java:1191
-#: org/postgresql/jdbc/PgPreparedStatement.java:1490
+#: org/postgresql/jdbc/PgPreparedStatement.java:364
+#: org/postgresql/jdbc/PgPreparedStatement.java:421
+#: org/postgresql/jdbc/PgPreparedStatement.java:1164
+#: org/postgresql/jdbc/PgPreparedStatement.java:1472
 #, java-format
 msgid "Invalid stream length {0}."
 msgstr "Неверная длина потока {0}."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:411
+#: org/postgresql/jdbc/PgPreparedStatement.java:393
 #, java-format
 msgid "The JVM claims not to support the {0} encoding."
 msgstr ""
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:414
+#: org/postgresql/jdbc/PgPreparedStatement.java:396
 #: org/postgresql/jdbc/PgResultSet.java:1122
 #: org/postgresql/jdbc/PgResultSet.java:1156
 msgid "Provided InputStream failed."
 msgstr ""
 
 # key: postgresql.con.type
-#: org/postgresql/jdbc/PgPreparedStatement.java:460
-#: org/postgresql/jdbc/PgPreparedStatement.java:1096
+#: org/postgresql/jdbc/PgPreparedStatement.java:442
+#: org/postgresql/jdbc/PgPreparedStatement.java:1069
 #, java-format
 msgid "Unknown type {0}."
 msgstr "Неизвестный тип {0}."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:477
+#: org/postgresql/jdbc/PgPreparedStatement.java:459
 msgid "No hstore extension installed."
 msgstr ""
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:619
-#: org/postgresql/jdbc/PgPreparedStatement.java:642
-#: org/postgresql/jdbc/PgPreparedStatement.java:652
-#: org/postgresql/jdbc/PgPreparedStatement.java:664
+#: org/postgresql/jdbc/PgPreparedStatement.java:601
+#: org/postgresql/jdbc/PgPreparedStatement.java:624
+#: org/postgresql/jdbc/PgPreparedStatement.java:634
+#: org/postgresql/jdbc/PgPreparedStatement.java:646
 #, java-format
 msgid "Cannot cast an instance of {0} to type {1}"
 msgstr ""
 
 # key: postgresql.prep.type
-#: org/postgresql/jdbc/PgPreparedStatement.java:682
+#: org/postgresql/jdbc/PgPreparedStatement.java:664
 #, java-format
 msgid "Unsupported Types value: {0}"
 msgstr "Неподдерживаемый java.sql.Types тип: {0}"
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:894
+#: org/postgresql/jdbc/PgPreparedStatement.java:876
 #, java-format
 msgid "Cannot convert an instance of {0} to type {1}"
 msgstr ""
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:968
+#: org/postgresql/jdbc/PgPreparedStatement.java:950
 #, java-format
 msgid ""
 "Can''t infer the SQL type to use for an instance of {0}. Use setObject() "
 "with an explicit Types value to specify the type to use."
 msgstr ""
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:1133
-#: org/postgresql/jdbc/PgPreparedStatement.java:1233
+#: org/postgresql/jdbc/PgPreparedStatement.java:1106
+#: org/postgresql/jdbc/PgPreparedStatement.java:1206
 msgid "Unexpected error writing large object to database."
 msgstr ""
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:1178
+#: org/postgresql/jdbc/PgPreparedStatement.java:1151
 #: org/postgresql/jdbc/PgResultSet.java:1210
 msgid "Provided Reader failed."
 msgstr ""
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:1449
+#: org/postgresql/jdbc/PgPreparedStatement.java:1431
 #: org/postgresql/util/StreamWrapper.java:56
 msgid "Object is too large to send over the protocol."
 msgstr ""
@@ -1092,8 +1098,8 @@ msgstr ""
 #: org/postgresql/jdbc/PgResultSet.java:556
 #: org/postgresql/jdbc/PgResultSet.java:594
 #: org/postgresql/jdbc/PgResultSet.java:624
-#: org/postgresql/jdbc/PgResultSet.java:3014
-#: org/postgresql/jdbc/PgResultSet.java:3058
+#: org/postgresql/jdbc/PgResultSet.java:3012
+#: org/postgresql/jdbc/PgResultSet.java:3057
 #, java-format
 msgid "Cannot convert the column of type {0} to requested type {1}."
 msgstr ""
@@ -1105,7 +1111,7 @@ msgid "Can''t use relative move methods while on the insert row."
 msgstr ""
 
 #: org/postgresql/jdbc/PgResultSet.java:878
-#: org/postgresql/jdbc/PgStatement.java:895
+#: org/postgresql/jdbc/PgStatement.java:900
 #, java-format
 msgid "Invalid fetch direction constant: {0}."
 msgstr ""
@@ -1148,8 +1154,8 @@ msgstr ""
 
 #: org/postgresql/jdbc/PgResultSet.java:1119
 #: org/postgresql/jdbc/PgResultSet.java:1754
-#: org/postgresql/jdbc/PgResultSet.java:2422
-#: org/postgresql/jdbc/PgResultSet.java:2443
+#: org/postgresql/jdbc/PgResultSet.java:2420
+#: org/postgresql/jdbc/PgResultSet.java:2441
 #, java-format
 msgid "The JVM claims not to support the encoding: {0}"
 msgstr ""
@@ -1163,7 +1169,7 @@ msgid "Cannot call updateRow() when on the insert row."
 msgstr ""
 
 #: org/postgresql/jdbc/PgResultSet.java:1335
-#: org/postgresql/jdbc/PgResultSet.java:3075
+#: org/postgresql/jdbc/PgResultSet.java:3074
 msgid ""
 "Cannot update the ResultSet because it is either before the start or after "
 "the end of the results."
@@ -1180,71 +1186,71 @@ msgstr ""
 
 #: org/postgresql/jdbc/PgResultSet.java:2017
 #: org/postgresql/jdbc/PgResultSet.java:2022
-#: org/postgresql/jdbc/PgResultSet.java:2809
-#: org/postgresql/jdbc/PgResultSet.java:2815
-#: org/postgresql/jdbc/PgResultSet.java:2840
-#: org/postgresql/jdbc/PgResultSet.java:2846
-#: org/postgresql/jdbc/PgResultSet.java:2870
-#: org/postgresql/jdbc/PgResultSet.java:2875
-#: org/postgresql/jdbc/PgResultSet.java:2891
-#: org/postgresql/jdbc/PgResultSet.java:2912
-#: org/postgresql/jdbc/PgResultSet.java:2923
-#: org/postgresql/jdbc/PgResultSet.java:2936
-#: org/postgresql/jdbc/PgResultSet.java:3063
+#: org/postgresql/jdbc/PgResultSet.java:2807
+#: org/postgresql/jdbc/PgResultSet.java:2813
+#: org/postgresql/jdbc/PgResultSet.java:2838
+#: org/postgresql/jdbc/PgResultSet.java:2844
+#: org/postgresql/jdbc/PgResultSet.java:2868
+#: org/postgresql/jdbc/PgResultSet.java:2873
+#: org/postgresql/jdbc/PgResultSet.java:2889
+#: org/postgresql/jdbc/PgResultSet.java:2910
+#: org/postgresql/jdbc/PgResultSet.java:2921
+#: org/postgresql/jdbc/PgResultSet.java:2934
+#: org/postgresql/jdbc/PgResultSet.java:3062
 #, java-format
 msgid "Bad value for type {0} : {1}"
 msgstr ""
 
-#: org/postgresql/jdbc/PgResultSet.java:2595
+#: org/postgresql/jdbc/PgResultSet.java:2593
 #, java-format
 msgid "The column name {0} was not found in this ResultSet."
 msgstr "Колонки {0} не найдено в этом ResultSet’’е."
 
 # key: postgresql.updateable.notupdateable
-#: org/postgresql/jdbc/PgResultSet.java:2731
+#: org/postgresql/jdbc/PgResultSet.java:2729
 msgid ""
 "ResultSet is not updateable.  The query that generated this result set must "
 "select only one table, and must select all primary keys from that table. See "
 "the JDBC 2.1 API Specification, section 5.6 for more details."
 msgstr ""
 
-#: org/postgresql/jdbc/PgResultSet.java:2743
+#: org/postgresql/jdbc/PgResultSet.java:2741
 msgid "This ResultSet is closed."
 msgstr "ResultSet закрыт."
 
 # key: postgresql.res.nextrequired
-#: org/postgresql/jdbc/PgResultSet.java:2774
+#: org/postgresql/jdbc/PgResultSet.java:2772
 msgid "ResultSet not positioned properly, perhaps you need to call next."
 msgstr ""
 
-#: org/postgresql/jdbc/PgResultSet.java:3095
+#: org/postgresql/jdbc/PgResultSet.java:3094
 msgid "Invalid UUID data."
 msgstr ""
 
 # key: postgresql.con.isolevel
-#: org/postgresql/jdbc/PgResultSet.java:3184
-#: org/postgresql/jdbc/PgResultSet.java:3191
-#: org/postgresql/jdbc/PgResultSet.java:3202
-#: org/postgresql/jdbc/PgResultSet.java:3213
-#: org/postgresql/jdbc/PgResultSet.java:3224
-#: org/postgresql/jdbc/PgResultSet.java:3235
-#: org/postgresql/jdbc/PgResultSet.java:3246
-#: org/postgresql/jdbc/PgResultSet.java:3257
-#: org/postgresql/jdbc/PgResultSet.java:3268
-#: org/postgresql/jdbc/PgResultSet.java:3275
-#: org/postgresql/jdbc/PgResultSet.java:3282
-#: org/postgresql/jdbc/PgResultSet.java:3293
-#: org/postgresql/jdbc/PgResultSet.java:3310
-#: org/postgresql/jdbc/PgResultSet.java:3317
-#: org/postgresql/jdbc/PgResultSet.java:3324
-#: org/postgresql/jdbc/PgResultSet.java:3335
-#: org/postgresql/jdbc/PgResultSet.java:3342
-#: org/postgresql/jdbc/PgResultSet.java:3349
-#: org/postgresql/jdbc/PgResultSet.java:3387
-#: org/postgresql/jdbc/PgResultSet.java:3394
-#: org/postgresql/jdbc/PgResultSet.java:3401
-#: org/postgresql/jdbc/PgResultSet.java:3421
-#: org/postgresql/jdbc/PgResultSet.java:3434
+#: org/postgresql/jdbc/PgResultSet.java:3183
+#: org/postgresql/jdbc/PgResultSet.java:3190
+#: org/postgresql/jdbc/PgResultSet.java:3201
+#: org/postgresql/jdbc/PgResultSet.java:3212
+#: org/postgresql/jdbc/PgResultSet.java:3223
+#: org/postgresql/jdbc/PgResultSet.java:3234
+#: org/postgresql/jdbc/PgResultSet.java:3245
+#: org/postgresql/jdbc/PgResultSet.java:3256
+#: org/postgresql/jdbc/PgResultSet.java:3267
+#: org/postgresql/jdbc/PgResultSet.java:3274
+#: org/postgresql/jdbc/PgResultSet.java:3281
+#: org/postgresql/jdbc/PgResultSet.java:3292
+#: org/postgresql/jdbc/PgResultSet.java:3309
+#: org/postgresql/jdbc/PgResultSet.java:3316
+#: org/postgresql/jdbc/PgResultSet.java:3323
+#: org/postgresql/jdbc/PgResultSet.java:3334
+#: org/postgresql/jdbc/PgResultSet.java:3341
+#: org/postgresql/jdbc/PgResultSet.java:3348
+#: org/postgresql/jdbc/PgResultSet.java:3386
+#: org/postgresql/jdbc/PgResultSet.java:3393
+#: org/postgresql/jdbc/PgResultSet.java:3400
+#: org/postgresql/jdbc/PgResultSet.java:3420
+#: org/postgresql/jdbc/PgResultSet.java:3433
 #, fuzzy, java-format
 msgid "conversion to {0} from {1} not supported"
 msgstr "Уровень изоляции транзакций {0} не поддерживается."
@@ -1312,35 +1318,35 @@ msgid "Maximum number of rows must be a value grater than or equal to 0."
 msgstr ""
 
 # key: postgresql.input.query.gt0
-#: org/postgresql/jdbc/PgStatement.java:550
+#: org/postgresql/jdbc/PgStatement.java:555
 msgid "Query timeout must be a value greater than or equals to 0."
 msgstr ""
 
 # key: postgresql.input.field.gt0
-#: org/postgresql/jdbc/PgStatement.java:590
+#: org/postgresql/jdbc/PgStatement.java:595
 msgid "The maximum field size must be a value greater than or equal to 0."
 msgstr ""
 
-#: org/postgresql/jdbc/PgStatement.java:689
+#: org/postgresql/jdbc/PgStatement.java:694
 msgid "This statement has been closed."
 msgstr "Этот Sstatement был закрыт."
 
-#: org/postgresql/jdbc/PgStatement.java:1145
-#: org/postgresql/jdbc/PgStatement.java:1173
+#: org/postgresql/jdbc/PgStatement.java:1150
+#: org/postgresql/jdbc/PgStatement.java:1178
 msgid "Returning autogenerated keys by column index is not supported."
 msgstr ""
 
-#: org/postgresql/jdbc/TimestampUtils.java:355
-#: org/postgresql/jdbc/TimestampUtils.java:423
+#: org/postgresql/jdbc/TimestampUtils.java:365
+#: org/postgresql/jdbc/TimestampUtils.java:433
 #, java-format
 msgid "Bad value for type timestamp/date/time: {1}"
 msgstr ""
 
 # key: postgresql.prep.type
-#: org/postgresql/jdbc/TimestampUtils.java:858
-#: org/postgresql/jdbc/TimestampUtils.java:915
-#: org/postgresql/jdbc/TimestampUtils.java:961
-#: org/postgresql/jdbc/TimestampUtils.java:1010
+#: org/postgresql/jdbc/TimestampUtils.java:914
+#: org/postgresql/jdbc/TimestampUtils.java:971
+#: org/postgresql/jdbc/TimestampUtils.java:1017
+#: org/postgresql/jdbc/TimestampUtils.java:1066
 #, java-format
 msgid "Unsupported binary encoding of {0}."
 msgstr "Бинарная передача не поддерживается для типа  {0}"
@@ -1353,32 +1359,32 @@ msgstr ""
 msgid "Invalid or unsupported by client SCRAM mechanisms"
 msgstr ""
 
-#: org/postgresql/jre8/sasl/ScramAuthenticator.java:117
+#: org/postgresql/jre8/sasl/ScramAuthenticator.java:119
 #, fuzzy, java-format
 msgid "Invalid server-first-message: {0}"
 msgstr "Неверное значение sslmode: {0}"
 
-#: org/postgresql/jre8/sasl/ScramAuthenticator.java:147
+#: org/postgresql/jre8/sasl/ScramAuthenticator.java:151
 #, fuzzy, java-format
 msgid "Invalid server-final-message: {0}"
 msgstr "Неверное значение sslmode: {0}"
 
-#: org/postgresql/jre8/sasl/ScramAuthenticator.java:153
+#: org/postgresql/jre8/sasl/ScramAuthenticator.java:157
 #, java-format
 msgid "SCRAM authentication failed, server returned error: {0}"
 msgstr ""
 
-#: org/postgresql/jre8/sasl/ScramAuthenticator.java:160
+#: org/postgresql/jre8/sasl/ScramAuthenticator.java:164
 msgid "Invalid server SCRAM signature"
 msgstr ""
 
 # key: postgresql.lo.init
-#: org/postgresql/largeobject/LargeObjectManager.java:144
+#: org/postgresql/largeobject/LargeObjectManager.java:136
 msgid "Failed to initialize LargeObject API"
 msgstr "Ошибка при инициализации LargeObject API"
 
-#: org/postgresql/largeobject/LargeObjectManager.java:262
-#: org/postgresql/largeobject/LargeObjectManager.java:305
+#: org/postgresql/largeobject/LargeObjectManager.java:254
+#: org/postgresql/largeobject/LargeObjectManager.java:295
 msgid "Large Objects may not be used in auto-commit mode."
 msgstr ""
 "Большие объекты не могут использоваться в режиме авто-подтверждения (auto-"
@@ -1415,34 +1421,34 @@ msgstr ""
 msgid "The hostname {0} could not be verified."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:164
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:90
 msgid "The sslfactoryarg property may not be empty."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:180
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:106
 msgid ""
 "The environment variable containing the server's SSL certificate must not be "
 "empty."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:188
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:114
 msgid ""
 "The system property containing the server's SSL certificate must not be "
 "empty."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:195
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:121
 msgid ""
 "The sslfactoryarg property must start with the prefix file:, classpath:, "
 "env:, sys:, or -----BEGIN CERTIFICATE-----."
 msgstr ""
 
 # key: postgresql.con.sslfail
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:207
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:133
 msgid "An error occurred reading the certificate"
 msgstr "Ошибка при чтении сертификата"
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:240
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:166
 msgid "No X509TrustManager found"
 msgstr ""
 
@@ -1585,33 +1591,33 @@ msgid ""
 "setSavePoint not allowed while an XA transaction is active."
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:177
-#: org/postgresql/xa/PGXAConnection.java:253
-#: org/postgresql/xa/PGXAConnection.java:347
+#: org/postgresql/xa/PGXAConnection.java:186
+#: org/postgresql/xa/PGXAConnection.java:272
+#: org/postgresql/xa/PGXAConnection.java:381
 #, java-format
 msgid "Invalid flags {0}"
 msgstr "Неверные флаги {0}"
 
-#: org/postgresql/xa/PGXAConnection.java:181
-#: org/postgresql/xa/PGXAConnection.java:257
-#: org/postgresql/xa/PGXAConnection.java:449
+#: org/postgresql/xa/PGXAConnection.java:190
+#: org/postgresql/xa/PGXAConnection.java:276
+#: org/postgresql/xa/PGXAConnection.java:491
 msgid "xid must not be null"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:185
+#: org/postgresql/xa/PGXAConnection.java:194
 msgid "Connection is busy with another transaction"
 msgstr ""
 
 # key: postgresql.unimplemented
-#: org/postgresql/xa/PGXAConnection.java:194
-#: org/postgresql/xa/PGXAConnection.java:267
+#: org/postgresql/xa/PGXAConnection.java:203
+#: org/postgresql/xa/PGXAConnection.java:286
 msgid "suspend/resume not implemented"
 msgstr "Операции XA suspend/resume не реализованы"
 
 # key: postgresql.con.isolevel
-#: org/postgresql/xa/PGXAConnection.java:202
-#: org/postgresql/xa/PGXAConnection.java:209
-#: org/postgresql/xa/PGXAConnection.java:213
+#: org/postgresql/xa/PGXAConnection.java:211
+#: org/postgresql/xa/PGXAConnection.java:218
+#: org/postgresql/xa/PGXAConnection.java:222
 #, java-format
 msgid ""
 "Invalid protocol state requested. Attempted transaction interleaving is not "
@@ -1620,11 +1626,11 @@ msgstr ""
 "Чередование транзакций в одном соединении не поддерживается. Предыдущую "
 "транзакцию нужно завершить xid={0}, currentXid={1}, state={2}, flags={3}"
 
-#: org/postgresql/xa/PGXAConnection.java:224
+#: org/postgresql/xa/PGXAConnection.java:233
 msgid "Error disabling autocommit"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:261
+#: org/postgresql/xa/PGXAConnection.java:280
 #, java-format
 msgid ""
 "tried to call end without corresponding start call. state={0}, start "
@@ -1633,7 +1639,7 @@ msgstr ""
 "Невозможно завершить транзакцию, т.к. транзакция не была начата. state={0}, "
 "start xid={1}, currentXid={2}, preparedXid={3}"
 
-#: org/postgresql/xa/PGXAConnection.java:297
+#: org/postgresql/xa/PGXAConnection.java:326
 #, fuzzy, java-format
 msgid ""
 "Preparing already prepared transaction, the prepared xid {0}, prepare xid={1}"
@@ -1641,12 +1647,12 @@ msgstr ""
 "Ошибка при откате подготовленной транзакции. rollback xid={0}, "
 "preparedXid={1}, currentXid={2}"
 
-#: org/postgresql/xa/PGXAConnection.java:300
+#: org/postgresql/xa/PGXAConnection.java:329
 #, java-format
 msgid "Current connection does not have an associated xid. prepare xid={0}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:307
+#: org/postgresql/xa/PGXAConnection.java:336
 #, java-format
 msgid ""
 "Not implemented: Prepare must be issued using the same connection that "
@@ -1655,23 +1661,23 @@ msgstr ""
 "В каком соединении транзакцию начинали, в таком и вызывайте prepare. По-"
 "другому не работает. currentXid={0}, prepare xid={1}"
 
-#: org/postgresql/xa/PGXAConnection.java:311
+#: org/postgresql/xa/PGXAConnection.java:340
 #, java-format
 msgid "Prepare called before end. prepare xid={0}, state={1}"
 msgstr ""
 "Вызов prepare должен происходить только после вызова end. prepare xid={0}, "
 "state={1}"
 
-#: org/postgresql/xa/PGXAConnection.java:331
+#: org/postgresql/xa/PGXAConnection.java:360
 #, java-format
 msgid "Error preparing transaction. prepare xid={0}"
 msgstr "Ошибка при выполнении prepare для транзакции {0}"
 
-#: org/postgresql/xa/PGXAConnection.java:382
+#: org/postgresql/xa/PGXAConnection.java:416
 msgid "Error during recover"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:438
+#: org/postgresql/xa/PGXAConnection.java:480
 #, java-format
 msgid ""
 "Error rolling back prepared transaction. rollback xid={0}, preparedXid={1}, "
@@ -1680,36 +1686,36 @@ msgstr ""
 "Ошибка при откате подготовленной транзакции. rollback xid={0}, "
 "preparedXid={1}, currentXid={2}"
 
-#: org/postgresql/xa/PGXAConnection.java:471
+#: org/postgresql/xa/PGXAConnection.java:521
 #, java-format
 msgid ""
 "One-phase commit called for xid {0} but connection was prepared with xid {1}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:479
+#: org/postgresql/xa/PGXAConnection.java:529
 msgid ""
 "Not implemented: one-phase commit must be issued using the same connection "
 "that was used to start it"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:483
+#: org/postgresql/xa/PGXAConnection.java:533
 #, java-format
 msgid "One-phase commit with unknown xid. commit xid={0}, currentXid={1}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:487
+#: org/postgresql/xa/PGXAConnection.java:537
 #, java-format
 msgid "commit called before end. commit xid={0}, state={1}"
 msgstr ""
 "Операция commit должна вызываться только после операции end. commit xid={0}, "
 "state={1}"
 
-#: org/postgresql/xa/PGXAConnection.java:498
+#: org/postgresql/xa/PGXAConnection.java:548
 #, java-format
 msgid "Error during one-phase commit. commit xid={0}"
 msgstr "Ошибка при однофазной фиксации транзакции. commit xid={0}"
 
-#: org/postgresql/xa/PGXAConnection.java:517
+#: org/postgresql/xa/PGXAConnection.java:576
 msgid ""
 "Not implemented: 2nd phase commit must be issued using an idle connection. "
 "commit xid={0}, currentXid={1}, state={2], transactionState={3}"
@@ -1718,7 +1724,7 @@ msgstr ""
 "транзакцция отсутствует). commit xid={0}, currentXid={1}, state={2], "
 "transactionState={3}"
 
-#: org/postgresql/xa/PGXAConnection.java:550
+#: org/postgresql/xa/PGXAConnection.java:609
 #, java-format
 msgid ""
 "Error committing prepared transaction. commit xid={0}, preparedXid={1}, "
@@ -1727,7 +1733,7 @@ msgstr ""
 "Ошибка при фиксации подготовленной транзакции. commit xid={0}, "
 "preparedXid={1}, currentXid={2}"
 
-#: org/postgresql/xa/PGXAConnection.java:567
+#: org/postgresql/xa/PGXAConnection.java:626
 #, java-format
 msgid "Heuristic commit/rollback not supported. forget xid={0}"
 msgstr ""

--- a/pgjdbc/src/main/java/org/postgresql/translation/sr.po
+++ b/pgjdbc/src/main/java/org/postgresql/translation/sr.po
@@ -8,7 +8,6 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PostgreSQL 8.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-06-05 10:57+0300\n"
 "PO-Revision-Date: 2009-05-26 11:13+0100\n"
 "Last-Translator: Bojan Škaljac <skaljac (at) gmail.com>\n"
 "Language-Team: Srpski <skaljac@gmail.com>\n"
@@ -19,15 +18,15 @@ msgstr ""
 "X-Poedit-Language: Serbian\n"
 "X-Poedit-Country: YUGOSLAVIA\n"
 
-#: org/postgresql/Driver.java:214
+#: org/postgresql/Driver.java:217
 msgid "Error loading default settings from driverconfig.properties"
 msgstr "Greška u čitanju standardnih podešavanja iz driverconfig.properties"
 
-#: org/postgresql/Driver.java:226
+#: org/postgresql/Driver.java:229
 msgid "Properties for the driver contains a non-string value for the key "
 msgstr ""
 
-#: org/postgresql/Driver.java:270
+#: org/postgresql/Driver.java:272
 msgid ""
 "Your security policy has prevented the connection from being attempted.  You "
 "probably need to grant the connect java.net.SocketPermission to the database "
@@ -36,7 +35,7 @@ msgstr ""
 "Sigurnosna podešavanja su sprečila konekciju. Verovatno je potrebno da "
 "dozvolite konekciju klasi java.net.SocketPermission na bazu na serveru."
 
-#: org/postgresql/Driver.java:276 org/postgresql/Driver.java:408
+#: org/postgresql/Driver.java:278 org/postgresql/Driver.java:410
 msgid ""
 "Something unusual has occurred to cause the driver to fail. Please report "
 "this exception."
@@ -44,35 +43,35 @@ msgstr ""
 "Nešto neobično se dogodilo i drajver je zakazao. Molim prijavite ovaj "
 "izuzetak."
 
-#: org/postgresql/Driver.java:416
+#: org/postgresql/Driver.java:418
 msgid "Connection attempt timed out."
 msgstr "Isteklo je vreme za pokušaj konektovanja."
 
-#: org/postgresql/Driver.java:429
+#: org/postgresql/Driver.java:431
 msgid "Interrupted while attempting to connect."
 msgstr "Prekinut pokušaj konektovanja."
 
-#: org/postgresql/Driver.java:682
+#: org/postgresql/Driver.java:687
 #, java-format
 msgid "Method {0} is not yet implemented."
 msgstr "Metod {0} nije još impelemtiran."
 
-#: org/postgresql/PGProperty.java:535 org/postgresql/PGProperty.java:555
+#: org/postgresql/PGProperty.java:537 org/postgresql/PGProperty.java:557
 #, java-format
 msgid "{0} parameter value must be an integer but was: {1}"
 msgstr ""
 
-#: org/postgresql/copy/CopyManager.java:53
+#: org/postgresql/copy/CopyManager.java:49
 #, java-format
 msgid "Requested CopyIn but got {0}"
 msgstr ""
 
-#: org/postgresql/copy/CopyManager.java:64
+#: org/postgresql/copy/CopyManager.java:60
 #, java-format
 msgid "Requested CopyOut but got {0}"
 msgstr ""
 
-#: org/postgresql/copy/CopyManager.java:75
+#: org/postgresql/copy/CopyManager.java:71
 #, java-format
 msgid "Requested CopyDual but got {0}"
 msgstr ""
@@ -97,6 +96,13 @@ msgstr ""
 msgid "Cannot write to copy a byte of value {0}"
 msgstr ""
 
+#: org/postgresql/core/CommandCompleteParser.java:71
+#, fuzzy, java-format
+msgid "Unable to parse the count in command completion tag: {0}."
+msgstr ""
+"Neuspešno prekidanje prebrojavanja ažurivanja u tagu zakompletiranje "
+"komandi: {0}."
+
 #: org/postgresql/core/ConnectionFactory.java:57
 #, java-format
 msgid "A connection could not be made using the requested protocol {0}."
@@ -119,7 +125,7 @@ msgstr ""
 msgid "Expected an EOF from server, got: {0}"
 msgstr "Očekivan EOF od servera, a dobijeno: {0}"
 
-#: org/postgresql/core/Parser.java:1006
+#: org/postgresql/core/Parser.java:1051
 #, java-format
 msgid "Malformed function or procedure escape syntax at offset {0}."
 msgstr "Pogrešna sintaksa u funkciji ili proceduri na poziciji {0}."
@@ -177,23 +183,23 @@ msgstr "Nula bajtovji se ne smeju pojavljivati u identifikatorima."
 #: org/postgresql/core/v3/CompositeParameterList.java:33
 #: org/postgresql/core/v3/SimpleParameterList.java:54
 #: org/postgresql/core/v3/SimpleParameterList.java:65
-#: org/postgresql/jdbc/PgResultSet.java:2757
-#: org/postgresql/jdbc/PgResultSetMetaData.java:494
+#: org/postgresql/jdbc/PgResultSet.java:2755
+#: org/postgresql/jdbc/PgResultSetMetaData.java:388
 #, java-format
 msgid "The column index is out of range: {0}, number of columns: {1}."
 msgstr "Indeks kolone van osega: {0}, broj kolona: {1}."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:109
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:103
 #, fuzzy, java-format
 msgid "Invalid sslmode value: {0}"
 msgstr "Nevažeća dužina toka {0}."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:124
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:118
 #, fuzzy, java-format
 msgid "Invalid targetServerType value: {0}"
 msgstr "Nevažeća dužina toka {0}."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:246
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:239
 #, fuzzy, java-format
 msgid ""
 "Connection to {0} refused. Check that the hostname and port are correct and "
@@ -202,40 +208,40 @@ msgstr ""
 "Konekcija odbijena. Proverite dali je ime domćina (host) koretno i da "
 "postmaster podržava TCP/IP konekcije."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:257
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:250
 #: org/postgresql/core/v3/replication/V3ReplicationProtocol.java:133
 msgid "The connection attempt failed."
 msgstr "Pokušaj konektovanja propao."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:272
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:265
 #, java-format
 msgid "Could not find a server with specified targetServerType: {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:368
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:381
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:361
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:374
 msgid "The server does not support SSL."
 msgstr "Server ne podržava SSL."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:395
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:388
 msgid "An error occurred while setting up the SSL connection."
 msgstr "Greška se dogodila prilikom podešavanja SSL konekcije."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:496
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:523
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:484
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:511
 msgid ""
 "The server requested password-based authentication, but no password was "
 "provided."
 msgstr ""
 "Server zahteva autentifikaciju baziranu na šifri, ali šifra nije prosleđena."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:626
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:614
 msgid ""
 "SCRAM authentication is not supported by this driver. You need JDK >= 8 and "
 "pgjdbc >= 42.2.0 (not \".jre\" versions)"
 msgstr ""
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:650
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:638
 #, java-format
 msgid ""
 "The authentication type {0} is not supported. Check that you have configured "
@@ -246,16 +252,16 @@ msgstr ""
 "conf fajl koji uključuje klijentovu IP adresu ili podmrežu, i da ta mreža "
 "koristi šemu autentifikacije koja je podržana od strane ovog drajvera."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:657
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2550
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2581
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2585
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2653
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:645
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2543
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2576
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2580
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2648
 #: org/postgresql/gss/GssAction.java:126
 msgid "Protocol error.  Session setup failed."
 msgstr "Greška protokola.  Zakazivanje sesije propalo."
 
-#: org/postgresql/core/v3/CopyInImpl.java:47
+#: org/postgresql/core/v3/CopyInImpl.java:49
 msgid "CopyIn copy direction can't receive data"
 msgstr ""
 
@@ -263,29 +269,29 @@ msgstr ""
 msgid "CommandComplete expected COPY but got: "
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:161
+#: org/postgresql/core/v3/QueryExecutorImpl.java:163
 msgid "Tried to obtain lock while already holding it"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:177
+#: org/postgresql/core/v3/QueryExecutorImpl.java:179
 msgid "Tried to break lock on database connection"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:195
+#: org/postgresql/core/v3/QueryExecutorImpl.java:197
 #, fuzzy
 msgid "Interrupted while waiting to obtain lock on database connection"
 msgstr "Prekinut pokušaj konektovanja."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:327
+#: org/postgresql/core/v3/QueryExecutorImpl.java:329
 msgid "Unable to bind parameter values for statement."
 msgstr "Nije moguće naći vrednost vezivnog parametra za izjavu (statement)."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:333
-#: org/postgresql/core/v3/QueryExecutorImpl.java:485
-#: org/postgresql/core/v3/QueryExecutorImpl.java:559
-#: org/postgresql/core/v3/QueryExecutorImpl.java:602
-#: org/postgresql/core/v3/QueryExecutorImpl.java:729
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2372
+#: org/postgresql/core/v3/QueryExecutorImpl.java:335
+#: org/postgresql/core/v3/QueryExecutorImpl.java:487
+#: org/postgresql/core/v3/QueryExecutorImpl.java:561
+#: org/postgresql/core/v3/QueryExecutorImpl.java:604
+#: org/postgresql/core/v3/QueryExecutorImpl.java:731
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2377
 #: org/postgresql/util/StreamWrapper.java:130
 #, fuzzy
 msgid "An I/O error occurred while sending to the backend."
@@ -293,120 +299,120 @@ msgstr ""
 "Ulazno/izlazna greška se dogodila prilikom slanja podataka pozadinskom "
 "procesu."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:534
-#: org/postgresql/core/v3/QueryExecutorImpl.java:576
+#: org/postgresql/core/v3/QueryExecutorImpl.java:536
+#: org/postgresql/core/v3/QueryExecutorImpl.java:578
 #, java-format
 msgid "Expected command status BEGIN, got {0}."
 msgstr "Očekivan status komande je BEGIN, a dobijeno je {0}."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:581
+#: org/postgresql/core/v3/QueryExecutorImpl.java:583
 #: org/postgresql/jdbc/PgResultSet.java:1778
 #, java-format
 msgid "Unexpected command status: {0}."
 msgstr "Neočekivan komandni status: {0}."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:687
+#: org/postgresql/core/v3/QueryExecutorImpl.java:689
 #, fuzzy
 msgid "An error occurred while trying to get the socket timeout."
 msgstr ""
 "Ulazno/izlazna greška se dogodila prilikom slanja podataka pozadinskom "
 "procesu."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:722
-#: org/postgresql/core/v3/QueryExecutorImpl.java:798
+#: org/postgresql/core/v3/QueryExecutorImpl.java:724
+#: org/postgresql/core/v3/QueryExecutorImpl.java:800
 #, java-format
 msgid "Unknown Response Type {0}."
 msgstr "Nepoznat tip odziva {0}."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:745
+#: org/postgresql/core/v3/QueryExecutorImpl.java:747
 #, fuzzy
 msgid "An error occurred while trying to reset the socket timeout."
 msgstr ""
 "Ulazno/izlazna greška se dogodila prilikom slanja podataka pozadinskom "
 "procesu."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:843
+#: org/postgresql/core/v3/QueryExecutorImpl.java:845
 msgid "Database connection failed when starting copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:878
+#: org/postgresql/core/v3/QueryExecutorImpl.java:880
 msgid "Tried to cancel an inactive copy operation"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:917
+#: org/postgresql/core/v3/QueryExecutorImpl.java:919
 msgid "Database connection failed when canceling copy operation"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:933
+#: org/postgresql/core/v3/QueryExecutorImpl.java:935
 msgid "Missing expected error response to copy cancel request"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:937
+#: org/postgresql/core/v3/QueryExecutorImpl.java:939
 #, java-format
 msgid "Got {0} error responses to single copy cancel request"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:952
+#: org/postgresql/core/v3/QueryExecutorImpl.java:954
 msgid "Tried to end inactive copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:967
+#: org/postgresql/core/v3/QueryExecutorImpl.java:969
 msgid "Database connection failed when ending copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:985
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1005
+#: org/postgresql/core/v3/QueryExecutorImpl.java:987
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1007
 msgid "Tried to write to an inactive copy operation"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:998
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1013
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1000
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1015
 msgid "Database connection failed when writing to copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1028
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1030
 msgid "Tried to read from inactive copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1035
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1037
 msgid "Database connection failed when reading from copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1101
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1103
 #, java-format
 msgid "Received CommandComplete ''{0}'' without an active copy operation"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1126
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1128
 #, java-format
 msgid "Got CopyInResponse from server during an active {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1140
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1142
 #, java-format
 msgid "Got CopyOutResponse from server during an active {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1154
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1156
 #, java-format
 msgid "Got CopyBothResponse from server during an active {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1170
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1172
 msgid "Got CopyData without an active copy operation"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1174
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1176
 #, fuzzy, java-format
 msgid "Unexpected copydata from server for {0}"
 msgstr "Očekivan EOF od servera, a dobijeno: {0}"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1234
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1236
 #, java-format
 msgid "Unexpected packet type during copy: {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1524
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1526
 #, java-format
 msgid ""
 "Bind message length {0} too long.  This can be caused by very large or "
@@ -415,22 +421,15 @@ msgstr ""
 "Dužina vezivne poruke {0} prevelika.  Ovo je možda rezultat veoma velike ili "
 "pogrešne dužine specifikacije za InputStream parametre."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2145
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2150
 msgid "Ran out of memory retrieving query results."
 msgstr "Nestalo je memorije prilikom preuzimanja rezultata upita."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2313
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2318
 msgid "The driver currently does not support COPY operations."
 msgstr "Drajver trenutno ne podržava COPY operacije."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2487
-#, fuzzy, java-format
-msgid "Unable to parse the count in command completion tag: {0}."
-msgstr ""
-"Neuspešno prekidanje prebrojavanja ažurivanja u tagu zakompletiranje "
-"komandi: {0}."
-
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2610
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2605
 #, fuzzy, java-format
 msgid ""
 "The server''s client_encoding parameter was changed to {0}. The JDBC driver "
@@ -439,7 +438,7 @@ msgstr ""
 "Serverov client_encoding parametar je promenjen u  {0}.JDBC darajver zahteva "
 "UNICODE client_encoding  za uspešno izvršavanje operacije."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2620
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2615
 #, java-format
 msgid ""
 "The server''s DateStyle parameter was changed to {0}. The JDBC driver "
@@ -448,7 +447,7 @@ msgstr ""
 "Serverov DataStyle parametar promenjen u {0}. JDBC zahteva da DateStyle "
 "počinje sa ISO za uspešno završavanje operacije."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2633
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2628
 #, java-format
 msgid ""
 "The server''s standard_conforming_strings parameter was reported as {0}. The "
@@ -511,19 +510,19 @@ msgstr "DataSource je zatvoren."
 msgid "Unsupported property name: {0}"
 msgstr "Za tip nije podržana vrednost: {0}"
 
-#: org/postgresql/fastpath/Fastpath.java:86
+#: org/postgresql/fastpath/Fastpath.java:84
 #, fuzzy, java-format
 msgid "Fastpath call {0} - No result was returned and we expected a numeric."
 msgstr ""
 "Fastpath poziv {0} - Nikakav rezultat nije vraćen a očekivan je integer."
 
-#: org/postgresql/fastpath/Fastpath.java:163
+#: org/postgresql/fastpath/Fastpath.java:161
 #, java-format
 msgid "Fastpath call {0} - No result was returned and we expected an integer."
 msgstr ""
 "Fastpath poziv {0} - Nikakav rezultat nije vraćen a očekivan je integer."
 
-#: org/postgresql/fastpath/Fastpath.java:171
+#: org/postgresql/fastpath/Fastpath.java:169
 #, fuzzy, java-format
 msgid ""
 "Fastpath call {0} - No result was returned or wrong size while expecting an "
@@ -531,13 +530,13 @@ msgid ""
 msgstr ""
 "Fastpath poziv {0} - Nikakav rezultat nije vraćen a očekivan je integer."
 
-#: org/postgresql/fastpath/Fastpath.java:188
+#: org/postgresql/fastpath/Fastpath.java:186
 #, fuzzy, java-format
 msgid "Fastpath call {0} - No result was returned and we expected a long."
 msgstr ""
 "Fastpath poziv {0} - Nikakav rezultat nije vraćen a očekivan je integer."
 
-#: org/postgresql/fastpath/Fastpath.java:196
+#: org/postgresql/fastpath/Fastpath.java:194
 #, fuzzy, java-format
 msgid ""
 "Fastpath call {0} - No result was returned or wrong size while expecting a "
@@ -545,7 +544,7 @@ msgid ""
 msgstr ""
 "Fastpath poziv {0} - Nikakav rezultat nije vraćen a očekivan je integer."
 
-#: org/postgresql/fastpath/Fastpath.java:308
+#: org/postgresql/fastpath/Fastpath.java:297
 #, java-format
 msgid "The fastpath function {0} is unknown."
 msgstr "Fastpath funkcija {0} je nepoznata."
@@ -615,63 +614,70 @@ msgid "Cannot cast to boolean: \"{0}\""
 msgstr ""
 
 #: org/postgresql/jdbc/EscapedFunctions.java:240
+#: org/postgresql/jdbc/EscapedFunctions2.java:167
 #, java-format
 msgid "{0} function takes four and only four argument."
 msgstr "Funkcija {0} prima četiri i samo četiri parametra."
 
 #: org/postgresql/jdbc/EscapedFunctions.java:270
-#: org/postgresql/jdbc/EscapedFunctions.java:344
-#: org/postgresql/jdbc/EscapedFunctions.java:749
-#: org/postgresql/jdbc/EscapedFunctions.java:787
+#: org/postgresql/jdbc/EscapedFunctions.java:337
+#: org/postgresql/jdbc/EscapedFunctions.java:740
+#: org/postgresql/jdbc/EscapedFunctions2.java:196
+#: org/postgresql/jdbc/EscapedFunctions2.java:263
+#: org/postgresql/jdbc/EscapedFunctions2.java:665
 #, java-format
 msgid "{0} function takes two and only two arguments."
 msgstr "Funkcija {0} prima dva i samo dva parametra."
 
 #: org/postgresql/jdbc/EscapedFunctions.java:288
-#: org/postgresql/jdbc/EscapedFunctions.java:326
-#: org/postgresql/jdbc/EscapedFunctions.java:446
-#: org/postgresql/jdbc/EscapedFunctions.java:461
-#: org/postgresql/jdbc/EscapedFunctions.java:476
-#: org/postgresql/jdbc/EscapedFunctions.java:491
-#: org/postgresql/jdbc/EscapedFunctions.java:506
-#: org/postgresql/jdbc/EscapedFunctions.java:521
-#: org/postgresql/jdbc/EscapedFunctions.java:536
-#: org/postgresql/jdbc/EscapedFunctions.java:551
-#: org/postgresql/jdbc/EscapedFunctions.java:566
-#: org/postgresql/jdbc/EscapedFunctions.java:581
-#: org/postgresql/jdbc/EscapedFunctions.java:596
-#: org/postgresql/jdbc/EscapedFunctions.java:611
-#: org/postgresql/jdbc/EscapedFunctions.java:775
+#: org/postgresql/jdbc/EscapedFunctions.java:441
+#: org/postgresql/jdbc/EscapedFunctions.java:467
+#: org/postgresql/jdbc/EscapedFunctions.java:526
+#: org/postgresql/jdbc/EscapedFunctions.java:728
+#: org/postgresql/jdbc/EscapedFunctions2.java:211
+#: org/postgresql/jdbc/EscapedFunctions2.java:355
+#: org/postgresql/jdbc/EscapedFunctions2.java:381
+#: org/postgresql/jdbc/EscapedFunctions2.java:440
+#: org/postgresql/jdbc/EscapedFunctions2.java:654
 #, java-format
 msgid "{0} function takes one and only one argument."
 msgstr "Funkcija {0} prima jedan i samo jedan parametar."
 
-#: org/postgresql/jdbc/EscapedFunctions.java:310
-#: org/postgresql/jdbc/EscapedFunctions.java:391
+#: org/postgresql/jdbc/EscapedFunctions.java:312
+#: org/postgresql/jdbc/EscapedFunctions.java:386
+#: org/postgresql/jdbc/EscapedFunctions2.java:238
+#: org/postgresql/jdbc/EscapedFunctions2.java:307
 #, java-format
 msgid "{0} function takes two or three arguments."
 msgstr "Funkcija {0} prima dva ili tri parametra."
 
-#: org/postgresql/jdbc/EscapedFunctions.java:416
-#: org/postgresql/jdbc/EscapedFunctions.java:431
-#: org/postgresql/jdbc/EscapedFunctions.java:734
-#: org/postgresql/jdbc/EscapedFunctions.java:764
+#: org/postgresql/jdbc/EscapedFunctions.java:411
+#: org/postgresql/jdbc/EscapedFunctions.java:426
+#: org/postgresql/jdbc/EscapedFunctions.java:693
+#: org/postgresql/jdbc/EscapedFunctions.java:719
+#: org/postgresql/jdbc/EscapedFunctions2.java:645
 #, java-format
 msgid "{0} function doesn''t take any argument."
 msgstr "Funkcija {0} nema parametara."
 
-#: org/postgresql/jdbc/EscapedFunctions.java:627
-#: org/postgresql/jdbc/EscapedFunctions.java:680
+#: org/postgresql/jdbc/EscapedFunctions.java:586
+#: org/postgresql/jdbc/EscapedFunctions.java:639
+#: org/postgresql/jdbc/EscapedFunctions2.java:500
+#: org/postgresql/jdbc/EscapedFunctions2.java:571
 #, java-format
 msgid "{0} function takes three and only three arguments."
 msgstr "Funkcija {0} prima tri i samo tri parametra."
 
-#: org/postgresql/jdbc/EscapedFunctions.java:640
-#: org/postgresql/jdbc/EscapedFunctions.java:661
-#: org/postgresql/jdbc/EscapedFunctions.java:664
-#: org/postgresql/jdbc/EscapedFunctions.java:697
-#: org/postgresql/jdbc/EscapedFunctions.java:710
-#: org/postgresql/jdbc/EscapedFunctions.java:713
+#: org/postgresql/jdbc/EscapedFunctions.java:599
+#: org/postgresql/jdbc/EscapedFunctions.java:620
+#: org/postgresql/jdbc/EscapedFunctions.java:623
+#: org/postgresql/jdbc/EscapedFunctions.java:656
+#: org/postgresql/jdbc/EscapedFunctions.java:669
+#: org/postgresql/jdbc/EscapedFunctions.java:672
+#: org/postgresql/jdbc/EscapedFunctions2.java:510
+#: org/postgresql/jdbc/EscapedFunctions2.java:527
+#: org/postgresql/jdbc/EscapedFunctions2.java:585
+#: org/postgresql/jdbc/EscapedFunctions2.java:597
 #, java-format
 msgid "Interval {0} not yet implemented"
 msgstr "Interval {0} još nije implementiran."
@@ -690,17 +696,17 @@ msgstr "Nije moguće primiti id imena tačke snimanja."
 msgid "Cannot retrieve the name of an unnamed savepoint."
 msgstr "Nije moguće izvaditi ime tačke snimanja koja nema ime."
 
-#: org/postgresql/jdbc/PgArray.java:157 org/postgresql/jdbc/PgArray.java:844
+#: org/postgresql/jdbc/PgArray.java:155 org/postgresql/jdbc/PgArray.java:842
 #, java-format
 msgid "The array index is out of range: {0}"
 msgstr "Indeks niza je van opsega: {0}"
 
-#: org/postgresql/jdbc/PgArray.java:178 org/postgresql/jdbc/PgArray.java:861
+#: org/postgresql/jdbc/PgArray.java:176 org/postgresql/jdbc/PgArray.java:859
 #, java-format
 msgid "The array index is out of range: {0}, number of elements: {1}."
 msgstr "Indeks niza je van opsega: {0}, broj elemenata: {1}."
 
-#: org/postgresql/jdbc/PgArray.java:210
+#: org/postgresql/jdbc/PgArray.java:208
 #: org/postgresql/jdbc/PgResultSet.java:1930
 #: org/postgresql/util/HStoreConverter.java:43
 #: org/postgresql/util/HStoreConverter.java:74
@@ -715,16 +721,16 @@ msgstr ""
 "kojima je baza kreirana.  Npr. Čuvanje 8bit podataka u SQL_ASCII bazi "
 "podataka."
 
-#: org/postgresql/jdbc/PgCallableStatement.java:86
-#: org/postgresql/jdbc/PgCallableStatement.java:96
+#: org/postgresql/jdbc/PgCallableStatement.java:85
+#: org/postgresql/jdbc/PgCallableStatement.java:95
 msgid "A CallableStatement was executed with nothing returned."
 msgstr "CallableStatement je izvršen ali ništa nije vrećeno kao rezultat."
 
-#: org/postgresql/jdbc/PgCallableStatement.java:107
+#: org/postgresql/jdbc/PgCallableStatement.java:106
 msgid "A CallableStatement was executed with an invalid number of parameters"
 msgstr "CallableStatement je izvršen sa nevažećim brojem parametara"
 
-#: org/postgresql/jdbc/PgCallableStatement.java:145
+#: org/postgresql/jdbc/PgCallableStatement.java:144
 #, java-format
 msgid ""
 "A CallableStatement function was executed and the out parameter {0} was of "
@@ -733,7 +739,7 @@ msgstr ""
 "CallableStatement funkcija je izvršena dok je izlazni parametar {0} tipa {1} "
 "a tip {2} je registrovan kao izlazni parametar."
 
-#: org/postgresql/jdbc/PgCallableStatement.java:202
+#: org/postgresql/jdbc/PgCallableStatement.java:206
 msgid ""
 "This statement does not declare an OUT parameter.  Use '{' ?= call ... '}' "
 "to declare one."
@@ -741,12 +747,12 @@ msgstr ""
 "Izraz ne deklariše izlazni parametar. Koristite '{' ?= poziv ... '}' za "
 "deklarisanje."
 
-#: org/postgresql/jdbc/PgCallableStatement.java:246
+#: org/postgresql/jdbc/PgCallableStatement.java:229
 msgid "wasNull cannot be call before fetching a result."
 msgstr "wasNull nemože biti pozvan pre zahvatanja rezultata."
 
-#: org/postgresql/jdbc/PgCallableStatement.java:384
-#: org/postgresql/jdbc/PgCallableStatement.java:403
+#: org/postgresql/jdbc/PgCallableStatement.java:367
+#: org/postgresql/jdbc/PgCallableStatement.java:386
 #, java-format
 msgid ""
 "Parameter of type {0} was registered, but call to get{1} (sqltype={2}) was "
@@ -755,7 +761,7 @@ msgstr ""
 "Parametar tipa {0} je registrovan,ali poziv za get{1} (sql tip={2}) je "
 "izvršen."
 
-#: org/postgresql/jdbc/PgCallableStatement.java:424
+#: org/postgresql/jdbc/PgCallableStatement.java:407
 msgid ""
 "A CallableStatement was declared, but no call to registerOutParameter(1, "
 "<some type>) was made."
@@ -763,28 +769,28 @@ msgstr ""
 "CallableStatement jedeklarisan ali nije bilo poziva registerOutParameter (1, "
 "<neki_tip>)."
 
-#: org/postgresql/jdbc/PgCallableStatement.java:430
+#: org/postgresql/jdbc/PgCallableStatement.java:413
 msgid "No function outputs were registered."
 msgstr "Nije registrovan nikakv izlaz iz funkcije."
 
-#: org/postgresql/jdbc/PgCallableStatement.java:436
+#: org/postgresql/jdbc/PgCallableStatement.java:419
 msgid ""
 "Results cannot be retrieved from a CallableStatement before it is executed."
 msgstr ""
 "Razultat nemože da se primi iz CallableStatement pre nego što se on izvrši."
 
-#: org/postgresql/jdbc/PgCallableStatement.java:703
+#: org/postgresql/jdbc/PgCallableStatement.java:686
 #, fuzzy, java-format
 msgid "Unsupported type conversion to {1}."
 msgstr "Za tip nije podržana vrednost: {0}"
 
-#: org/postgresql/jdbc/PgConnection.java:272
+#: org/postgresql/jdbc/PgConnection.java:241
 #, java-format
 msgid "Unsupported value for stringtype parameter: {0}"
 msgstr "Vrednost za parametar tipa string nije podržana: {0}"
 
 #: org/postgresql/jdbc/PgConnection.java:424
-#: org/postgresql/jdbc/PgPreparedStatement.java:119
+#: org/postgresql/jdbc/PgPreparedStatement.java:107
 #: org/postgresql/jdbc/PgStatement.java:225
 #: org/postgresql/jdbc/TypeInfoCache.java:226
 #: org/postgresql/jdbc/TypeInfoCache.java:371
@@ -796,131 +802,131 @@ msgstr "Vrednost za parametar tipa string nije podržana: {0}"
 msgid "No results were returned by the query."
 msgstr "Nikakav rezultat nije vraćen od strane upita."
 
-#: org/postgresql/jdbc/PgConnection.java:441
+#: org/postgresql/jdbc/PgConnection.java:442
 #: org/postgresql/jdbc/PgStatement.java:254
 msgid "A result was returned when none was expected."
 msgstr "Rezultat vraćen ali nikakav rezultat nije očekivan."
 
-#: org/postgresql/jdbc/PgConnection.java:545
+#: org/postgresql/jdbc/PgConnection.java:547
 msgid "Custom type maps are not supported."
 msgstr "Mape sa korisnički definisanim tipovima nisu podržane."
 
-#: org/postgresql/jdbc/PgConnection.java:587
+#: org/postgresql/jdbc/PgConnection.java:589
 #, java-format
 msgid "Failed to create object for: {0}."
 msgstr "Propao pokušaj kreiranja objekta za: {0}."
 
-#: org/postgresql/jdbc/PgConnection.java:641
+#: org/postgresql/jdbc/PgConnection.java:643
 #, java-format
 msgid "Unable to load the class {0} responsible for the datatype {1}"
 msgstr "Nije moguće učitati kalsu {0} odgovornu za tip podataka {1}"
 
-#: org/postgresql/jdbc/PgConnection.java:693
+#: org/postgresql/jdbc/PgConnection.java:705
 msgid ""
 "Cannot change transaction read-only property in the middle of a transaction."
 msgstr ""
 "Nije moguće izmeniti read-only osobinu transakcije u sred izvršavanja "
 "transakcije."
 
-#: org/postgresql/jdbc/PgConnection.java:756
+#: org/postgresql/jdbc/PgConnection.java:772
 msgid "Cannot commit when autoCommit is enabled."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:767
-#: org/postgresql/jdbc/PgConnection.java:1384
-#: org/postgresql/jdbc/PgConnection.java:1428
+#: org/postgresql/jdbc/PgConnection.java:783
+#: org/postgresql/jdbc/PgConnection.java:1401
+#: org/postgresql/jdbc/PgConnection.java:1445
 #, fuzzy
 msgid "This connection has been closed."
 msgstr "Konekcija je već zatvorena."
 
-#: org/postgresql/jdbc/PgConnection.java:777
+#: org/postgresql/jdbc/PgConnection.java:794
 msgid "Cannot rollback when autoCommit is enabled."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:827
+#: org/postgresql/jdbc/PgConnection.java:844
 msgid ""
 "Cannot change transaction isolation level in the middle of a transaction."
 msgstr ""
 "Nije moguće izmeniti nivo izolacije transakcije u sred izvršavanja "
 "transakcije."
 
-#: org/postgresql/jdbc/PgConnection.java:833
+#: org/postgresql/jdbc/PgConnection.java:850
 #, java-format
 msgid "Transaction isolation level {0} not supported."
 msgstr "Nivo izolacije transakcije {0} nije podržan."
 
-#: org/postgresql/jdbc/PgConnection.java:878
+#: org/postgresql/jdbc/PgConnection.java:895
 msgid "Finalizing a Connection that was never closed:"
 msgstr "Dovršavanje konekcije koja nikada nije zatvorena:"
 
-#: org/postgresql/jdbc/PgConnection.java:945
+#: org/postgresql/jdbc/PgConnection.java:962
 msgid "Unable to translate data into the desired encoding."
 msgstr "Nije moguće prevesti podatke u odabrani encoding format."
 
-#: org/postgresql/jdbc/PgConnection.java:1008
+#: org/postgresql/jdbc/PgConnection.java:1025
 #: org/postgresql/jdbc/PgResultSet.java:1817
-#: org/postgresql/jdbc/PgStatement.java:903
+#: org/postgresql/jdbc/PgStatement.java:908
 msgid "Fetch size must be a value greater to or equal to 0."
 msgstr "Doneta veličina mora biti vrednost veća ili jednaka 0."
 
-#: org/postgresql/jdbc/PgConnection.java:1289
-#: org/postgresql/jdbc/PgConnection.java:1330
+#: org/postgresql/jdbc/PgConnection.java:1306
+#: org/postgresql/jdbc/PgConnection.java:1347
 #, java-format
 msgid "Unable to find server array type for provided name {0}."
 msgstr "Neuspešno nalaženje liste servera za zadato ime {0}."
 
-#: org/postgresql/jdbc/PgConnection.java:1312
+#: org/postgresql/jdbc/PgConnection.java:1329
 #, fuzzy, java-format
 msgid "Invalid elements {0}"
 msgstr "Nevažeće zastavice {0}"
 
-#: org/postgresql/jdbc/PgConnection.java:1348
+#: org/postgresql/jdbc/PgConnection.java:1365
 #, fuzzy, java-format
 msgid "Invalid timeout ({0}<0)."
 msgstr "Nevažeća dužina toka {0}."
 
-#: org/postgresql/jdbc/PgConnection.java:1372
+#: org/postgresql/jdbc/PgConnection.java:1389
 msgid "Validating connection."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1405
+#: org/postgresql/jdbc/PgConnection.java:1422
 #, fuzzy, java-format
 msgid "Failed to set ClientInfo property: {0}"
 msgstr "Propao pokušaj kreiranja objekta za: {0}."
 
-#: org/postgresql/jdbc/PgConnection.java:1415
+#: org/postgresql/jdbc/PgConnection.java:1432
 msgid "ClientInfo property not supported."
 msgstr "ClientInfo property nije podržan."
 
-#: org/postgresql/jdbc/PgConnection.java:1441
+#: org/postgresql/jdbc/PgConnection.java:1458
 msgid "One ore more ClientInfo failed."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1540
+#: org/postgresql/jdbc/PgConnection.java:1559
 #, fuzzy
 msgid "Network timeout must be a value greater than or equal to 0."
 msgstr "Tajm-aut mora biti vrednost veća ili jednaka 0."
 
-#: org/postgresql/jdbc/PgConnection.java:1552
+#: org/postgresql/jdbc/PgConnection.java:1571
 msgid "Unable to set network timeout."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1563
+#: org/postgresql/jdbc/PgConnection.java:1582
 msgid "Unable to get network timeout."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1580
+#: org/postgresql/jdbc/PgConnection.java:1599
 #, java-format
 msgid "Unknown ResultSet holdability setting: {0}."
 msgstr ""
 "Nepoznata ResultSet podešavanja za mogućnost držanja (holdability): {0}."
 
-#: org/postgresql/jdbc/PgConnection.java:1598
-#: org/postgresql/jdbc/PgConnection.java:1619
+#: org/postgresql/jdbc/PgConnection.java:1617
+#: org/postgresql/jdbc/PgConnection.java:1638
 msgid "Cannot establish a savepoint in auto-commit mode."
 msgstr "U auto-commit modu nije moguće podešavanje tački snimanja."
 
-#: org/postgresql/jdbc/PgConnection.java:1685
+#: org/postgresql/jdbc/PgConnection.java:1707
 msgid "Returning autogenerated keys is not supported."
 msgstr "Vraćanje autogenerisanih ključeva nije podržano."
 
@@ -936,47 +942,47 @@ msgstr ""
 msgid "Unable to find name datatype in the system catalogs."
 msgstr "Nije moguće pronaći ime tipa podatka u sistemskom katalogu."
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:323
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:322
 #, fuzzy
 msgid "Unable to find keywords in the system catalogs."
 msgstr "Nije moguće pronaći ime tipa podatka u sistemskom katalogu."
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1105
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1095
 msgid "oid"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1105
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1095
 msgid "proname"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1107
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1558
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1097
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1548
 msgid "typtype"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1110
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1100
 msgid "proargtypes"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1576
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1566
 msgid "adsrc"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1589
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1579
 msgid "attidentity"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1685
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1761
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1675
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1751
 msgid "rolname"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1686
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1762
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1676
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1752
 msgid "relacl"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1692
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1682
 msgid "attacl"
 msgstr ""
 
@@ -985,68 +991,68 @@ msgstr ""
 msgid "The parameter index is out of range: {0}, number of parameters: {1}."
 msgstr "Index parametra je van opsega: {0}, broj parametara je: {1}."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:106
+#: org/postgresql/jdbc/PgPreparedStatement.java:94
+#: org/postgresql/jdbc/PgPreparedStatement.java:115
 #: org/postgresql/jdbc/PgPreparedStatement.java:127
-#: org/postgresql/jdbc/PgPreparedStatement.java:139
-#: org/postgresql/jdbc/PgPreparedStatement.java:1035
+#: org/postgresql/jdbc/PgPreparedStatement.java:1008
 msgid ""
 "Can''t use query methods that take a query string on a PreparedStatement."
 msgstr ""
 "Ne možete da koristite metode za upit koji uzimaju string iz upita u "
 "PreparedStatement-u."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:249
+#: org/postgresql/jdbc/PgPreparedStatement.java:237
 msgid "Unknown Types value."
 msgstr "Nepoznata vrednost za Types."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:382
-#: org/postgresql/jdbc/PgPreparedStatement.java:439
-#: org/postgresql/jdbc/PgPreparedStatement.java:1191
-#: org/postgresql/jdbc/PgPreparedStatement.java:1490
+#: org/postgresql/jdbc/PgPreparedStatement.java:364
+#: org/postgresql/jdbc/PgPreparedStatement.java:421
+#: org/postgresql/jdbc/PgPreparedStatement.java:1164
+#: org/postgresql/jdbc/PgPreparedStatement.java:1472
 #, java-format
 msgid "Invalid stream length {0}."
 msgstr "Nevažeća dužina toka {0}."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:411
+#: org/postgresql/jdbc/PgPreparedStatement.java:393
 #, java-format
 msgid "The JVM claims not to support the {0} encoding."
 msgstr "JVM tvrdi da ne podržava {0} encoding."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:414
+#: org/postgresql/jdbc/PgPreparedStatement.java:396
 #: org/postgresql/jdbc/PgResultSet.java:1122
 #: org/postgresql/jdbc/PgResultSet.java:1156
 msgid "Provided InputStream failed."
 msgstr "Pribaljeni InputStream zakazao."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:460
-#: org/postgresql/jdbc/PgPreparedStatement.java:1096
+#: org/postgresql/jdbc/PgPreparedStatement.java:442
+#: org/postgresql/jdbc/PgPreparedStatement.java:1069
 #, java-format
 msgid "Unknown type {0}."
 msgstr "Nepoznat tip {0}."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:477
+#: org/postgresql/jdbc/PgPreparedStatement.java:459
 msgid "No hstore extension installed."
 msgstr ""
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:619
-#: org/postgresql/jdbc/PgPreparedStatement.java:642
-#: org/postgresql/jdbc/PgPreparedStatement.java:652
-#: org/postgresql/jdbc/PgPreparedStatement.java:664
+#: org/postgresql/jdbc/PgPreparedStatement.java:601
+#: org/postgresql/jdbc/PgPreparedStatement.java:624
+#: org/postgresql/jdbc/PgPreparedStatement.java:634
+#: org/postgresql/jdbc/PgPreparedStatement.java:646
 #, java-format
 msgid "Cannot cast an instance of {0} to type {1}"
 msgstr "Nije moguće kastovati instancu {0} u tip {1}"
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:682
+#: org/postgresql/jdbc/PgPreparedStatement.java:664
 #, java-format
 msgid "Unsupported Types value: {0}"
 msgstr "Za tip nije podržana vrednost: {0}"
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:894
+#: org/postgresql/jdbc/PgPreparedStatement.java:876
 #, java-format
 msgid "Cannot convert an instance of {0} to type {1}"
 msgstr "Nije moguće konvertovati instancu {0} u tip {1}"
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:968
+#: org/postgresql/jdbc/PgPreparedStatement.java:950
 #, java-format
 msgid ""
 "Can''t infer the SQL type to use for an instance of {0}. Use setObject() "
@@ -1055,17 +1061,17 @@ msgstr ""
 "Nije moguće zaključiti SQL tip koji bi se koristio sa instancom {0}. "
 "Koristite setObject() sa zadatim eksplicitnim tipom vrednosti."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:1133
-#: org/postgresql/jdbc/PgPreparedStatement.java:1233
+#: org/postgresql/jdbc/PgPreparedStatement.java:1106
+#: org/postgresql/jdbc/PgPreparedStatement.java:1206
 msgid "Unexpected error writing large object to database."
 msgstr "Neočekivana greška prilikom upisa velikog objekta u bazu podataka."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:1178
+#: org/postgresql/jdbc/PgPreparedStatement.java:1151
 #: org/postgresql/jdbc/PgResultSet.java:1210
 msgid "Provided Reader failed."
 msgstr "Pribavljeni čitač (Reader) zakazao."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:1449
+#: org/postgresql/jdbc/PgPreparedStatement.java:1431
 #: org/postgresql/util/StreamWrapper.java:56
 msgid "Object is too large to send over the protocol."
 msgstr ""
@@ -1082,8 +1088,8 @@ msgstr ""
 #: org/postgresql/jdbc/PgResultSet.java:556
 #: org/postgresql/jdbc/PgResultSet.java:594
 #: org/postgresql/jdbc/PgResultSet.java:624
-#: org/postgresql/jdbc/PgResultSet.java:3014
-#: org/postgresql/jdbc/PgResultSet.java:3058
+#: org/postgresql/jdbc/PgResultSet.java:3012
+#: org/postgresql/jdbc/PgResultSet.java:3057
 #, fuzzy, java-format
 msgid "Cannot convert the column of type {0} to requested type {1}."
 msgstr "Nije moguće konvertovati instancu {0} u tip {1}"
@@ -1096,7 +1102,7 @@ msgstr ""
 "Ne može se koristiti metod relativnog pomeranja prilikom ubacivanja redova."
 
 #: org/postgresql/jdbc/PgResultSet.java:878
-#: org/postgresql/jdbc/PgStatement.java:895
+#: org/postgresql/jdbc/PgStatement.java:900
 #, java-format
 msgid "Invalid fetch direction constant: {0}."
 msgstr "Pogrešna konstanta za direkciju donošenja: {0}."
@@ -1140,8 +1146,8 @@ msgstr ""
 
 #: org/postgresql/jdbc/PgResultSet.java:1119
 #: org/postgresql/jdbc/PgResultSet.java:1754
-#: org/postgresql/jdbc/PgResultSet.java:2422
-#: org/postgresql/jdbc/PgResultSet.java:2443
+#: org/postgresql/jdbc/PgResultSet.java:2420
+#: org/postgresql/jdbc/PgResultSet.java:2441
 #, java-format
 msgid "The JVM claims not to support the encoding: {0}"
 msgstr "JVM tvrdi da ne podržava encoding: {0}"
@@ -1155,7 +1161,7 @@ msgid "Cannot call updateRow() when on the insert row."
 msgstr "Nije moguće pozvati updateRow() prilikom ubacivanja redova."
 
 #: org/postgresql/jdbc/PgResultSet.java:1335
-#: org/postgresql/jdbc/PgResultSet.java:3075
+#: org/postgresql/jdbc/PgResultSet.java:3074
 msgid ""
 "Cannot update the ResultSet because it is either before the start or after "
 "the end of the results."
@@ -1173,27 +1179,27 @@ msgstr "Nije pronađen ključ za tabelu {0}."
 
 #: org/postgresql/jdbc/PgResultSet.java:2017
 #: org/postgresql/jdbc/PgResultSet.java:2022
-#: org/postgresql/jdbc/PgResultSet.java:2809
-#: org/postgresql/jdbc/PgResultSet.java:2815
-#: org/postgresql/jdbc/PgResultSet.java:2840
-#: org/postgresql/jdbc/PgResultSet.java:2846
-#: org/postgresql/jdbc/PgResultSet.java:2870
-#: org/postgresql/jdbc/PgResultSet.java:2875
-#: org/postgresql/jdbc/PgResultSet.java:2891
-#: org/postgresql/jdbc/PgResultSet.java:2912
-#: org/postgresql/jdbc/PgResultSet.java:2923
-#: org/postgresql/jdbc/PgResultSet.java:2936
-#: org/postgresql/jdbc/PgResultSet.java:3063
+#: org/postgresql/jdbc/PgResultSet.java:2807
+#: org/postgresql/jdbc/PgResultSet.java:2813
+#: org/postgresql/jdbc/PgResultSet.java:2838
+#: org/postgresql/jdbc/PgResultSet.java:2844
+#: org/postgresql/jdbc/PgResultSet.java:2868
+#: org/postgresql/jdbc/PgResultSet.java:2873
+#: org/postgresql/jdbc/PgResultSet.java:2889
+#: org/postgresql/jdbc/PgResultSet.java:2910
+#: org/postgresql/jdbc/PgResultSet.java:2921
+#: org/postgresql/jdbc/PgResultSet.java:2934
+#: org/postgresql/jdbc/PgResultSet.java:3062
 #, java-format
 msgid "Bad value for type {0} : {1}"
 msgstr "Pogrešna vrednost za tip {0} : {1}"
 
-#: org/postgresql/jdbc/PgResultSet.java:2595
+#: org/postgresql/jdbc/PgResultSet.java:2593
 #, java-format
 msgid "The column name {0} was not found in this ResultSet."
 msgstr "Ime kolone {0} nije pronadjeno u ResultSet."
 
-#: org/postgresql/jdbc/PgResultSet.java:2731
+#: org/postgresql/jdbc/PgResultSet.java:2729
 msgid ""
 "ResultSet is not updateable.  The query that generated this result set must "
 "select only one table, and must select all primary keys from that table. See "
@@ -1204,42 +1210,42 @@ msgstr ""
 "tabele. Pogledajte API specifikaciju za JDBC 2.1, sekciju 5.6 za više "
 "detalja."
 
-#: org/postgresql/jdbc/PgResultSet.java:2743
+#: org/postgresql/jdbc/PgResultSet.java:2741
 msgid "This ResultSet is closed."
 msgstr "ResultSet je zatvoren."
 
-#: org/postgresql/jdbc/PgResultSet.java:2774
+#: org/postgresql/jdbc/PgResultSet.java:2772
 msgid "ResultSet not positioned properly, perhaps you need to call next."
 msgstr ""
 "ResultSet nije pravilno pozicioniran, možda je potrebno da pozovete next."
 
-#: org/postgresql/jdbc/PgResultSet.java:3095
+#: org/postgresql/jdbc/PgResultSet.java:3094
 msgid "Invalid UUID data."
 msgstr "Nevažeća UUID podatak."
 
-#: org/postgresql/jdbc/PgResultSet.java:3184
-#: org/postgresql/jdbc/PgResultSet.java:3191
-#: org/postgresql/jdbc/PgResultSet.java:3202
-#: org/postgresql/jdbc/PgResultSet.java:3213
-#: org/postgresql/jdbc/PgResultSet.java:3224
-#: org/postgresql/jdbc/PgResultSet.java:3235
-#: org/postgresql/jdbc/PgResultSet.java:3246
-#: org/postgresql/jdbc/PgResultSet.java:3257
-#: org/postgresql/jdbc/PgResultSet.java:3268
-#: org/postgresql/jdbc/PgResultSet.java:3275
-#: org/postgresql/jdbc/PgResultSet.java:3282
-#: org/postgresql/jdbc/PgResultSet.java:3293
-#: org/postgresql/jdbc/PgResultSet.java:3310
-#: org/postgresql/jdbc/PgResultSet.java:3317
-#: org/postgresql/jdbc/PgResultSet.java:3324
-#: org/postgresql/jdbc/PgResultSet.java:3335
-#: org/postgresql/jdbc/PgResultSet.java:3342
-#: org/postgresql/jdbc/PgResultSet.java:3349
-#: org/postgresql/jdbc/PgResultSet.java:3387
-#: org/postgresql/jdbc/PgResultSet.java:3394
-#: org/postgresql/jdbc/PgResultSet.java:3401
-#: org/postgresql/jdbc/PgResultSet.java:3421
-#: org/postgresql/jdbc/PgResultSet.java:3434
+#: org/postgresql/jdbc/PgResultSet.java:3183
+#: org/postgresql/jdbc/PgResultSet.java:3190
+#: org/postgresql/jdbc/PgResultSet.java:3201
+#: org/postgresql/jdbc/PgResultSet.java:3212
+#: org/postgresql/jdbc/PgResultSet.java:3223
+#: org/postgresql/jdbc/PgResultSet.java:3234
+#: org/postgresql/jdbc/PgResultSet.java:3245
+#: org/postgresql/jdbc/PgResultSet.java:3256
+#: org/postgresql/jdbc/PgResultSet.java:3267
+#: org/postgresql/jdbc/PgResultSet.java:3274
+#: org/postgresql/jdbc/PgResultSet.java:3281
+#: org/postgresql/jdbc/PgResultSet.java:3292
+#: org/postgresql/jdbc/PgResultSet.java:3309
+#: org/postgresql/jdbc/PgResultSet.java:3316
+#: org/postgresql/jdbc/PgResultSet.java:3323
+#: org/postgresql/jdbc/PgResultSet.java:3334
+#: org/postgresql/jdbc/PgResultSet.java:3341
+#: org/postgresql/jdbc/PgResultSet.java:3348
+#: org/postgresql/jdbc/PgResultSet.java:3386
+#: org/postgresql/jdbc/PgResultSet.java:3393
+#: org/postgresql/jdbc/PgResultSet.java:3400
+#: org/postgresql/jdbc/PgResultSet.java:3420
+#: org/postgresql/jdbc/PgResultSet.java:3433
 #, fuzzy, java-format
 msgid "conversion to {0} from {1} not supported"
 msgstr "Nivo izolacije transakcije {0} nije podržan."
@@ -1306,34 +1312,34 @@ msgstr ""
 msgid "Maximum number of rows must be a value grater than or equal to 0."
 msgstr "Maksimalni broj redova mora biti vrednosti veće ili jednake 0."
 
-#: org/postgresql/jdbc/PgStatement.java:550
+#: org/postgresql/jdbc/PgStatement.java:555
 msgid "Query timeout must be a value greater than or equals to 0."
 msgstr "Tajm-aut mora biti vrednost veća ili jednaka 0."
 
-#: org/postgresql/jdbc/PgStatement.java:590
+#: org/postgresql/jdbc/PgStatement.java:595
 msgid "The maximum field size must be a value greater than or equal to 0."
 msgstr ""
 "Maksimalna vrednost veličine polja mora biti vrednost veća ili jednaka 0."
 
-#: org/postgresql/jdbc/PgStatement.java:689
+#: org/postgresql/jdbc/PgStatement.java:694
 msgid "This statement has been closed."
 msgstr "Statement je zatvoren."
 
-#: org/postgresql/jdbc/PgStatement.java:1145
-#: org/postgresql/jdbc/PgStatement.java:1173
+#: org/postgresql/jdbc/PgStatement.java:1150
+#: org/postgresql/jdbc/PgStatement.java:1178
 msgid "Returning autogenerated keys by column index is not supported."
 msgstr "Vraćanje autogenerisanih ključeva po kloloni nije podržano."
 
-#: org/postgresql/jdbc/TimestampUtils.java:355
-#: org/postgresql/jdbc/TimestampUtils.java:423
+#: org/postgresql/jdbc/TimestampUtils.java:365
+#: org/postgresql/jdbc/TimestampUtils.java:433
 #, fuzzy, java-format
 msgid "Bad value for type timestamp/date/time: {1}"
 msgstr "Pogrešna vrednost za tip {0} : {1}"
 
-#: org/postgresql/jdbc/TimestampUtils.java:858
-#: org/postgresql/jdbc/TimestampUtils.java:915
-#: org/postgresql/jdbc/TimestampUtils.java:961
-#: org/postgresql/jdbc/TimestampUtils.java:1010
+#: org/postgresql/jdbc/TimestampUtils.java:914
+#: org/postgresql/jdbc/TimestampUtils.java:971
+#: org/postgresql/jdbc/TimestampUtils.java:1017
+#: org/postgresql/jdbc/TimestampUtils.java:1066
 #, fuzzy, java-format
 msgid "Unsupported binary encoding of {0}."
 msgstr "Za tip nije podržana vrednost: {0}"
@@ -1346,31 +1352,31 @@ msgstr ""
 msgid "Invalid or unsupported by client SCRAM mechanisms"
 msgstr ""
 
-#: org/postgresql/jre8/sasl/ScramAuthenticator.java:117
+#: org/postgresql/jre8/sasl/ScramAuthenticator.java:119
 #, fuzzy, java-format
 msgid "Invalid server-first-message: {0}"
 msgstr "Nevažeća dužina toka {0}."
 
-#: org/postgresql/jre8/sasl/ScramAuthenticator.java:147
+#: org/postgresql/jre8/sasl/ScramAuthenticator.java:151
 #, fuzzy, java-format
 msgid "Invalid server-final-message: {0}"
 msgstr "Nevažeća dužina toka {0}."
 
-#: org/postgresql/jre8/sasl/ScramAuthenticator.java:153
+#: org/postgresql/jre8/sasl/ScramAuthenticator.java:157
 #, java-format
 msgid "SCRAM authentication failed, server returned error: {0}"
 msgstr ""
 
-#: org/postgresql/jre8/sasl/ScramAuthenticator.java:160
+#: org/postgresql/jre8/sasl/ScramAuthenticator.java:164
 msgid "Invalid server SCRAM signature"
 msgstr ""
 
-#: org/postgresql/largeobject/LargeObjectManager.java:144
+#: org/postgresql/largeobject/LargeObjectManager.java:136
 msgid "Failed to initialize LargeObject API"
 msgstr "Propao pokušaj inicijalizacije LargeObject API-ja."
 
-#: org/postgresql/largeobject/LargeObjectManager.java:262
-#: org/postgresql/largeobject/LargeObjectManager.java:305
+#: org/postgresql/largeobject/LargeObjectManager.java:254
+#: org/postgresql/largeobject/LargeObjectManager.java:295
 msgid "Large Objects may not be used in auto-commit mode."
 msgstr "Veliki objekti (Large Object) se nemogu koristiti u auto-commit modu."
 
@@ -1404,34 +1410,34 @@ msgstr ""
 msgid "The hostname {0} could not be verified."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:164
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:90
 msgid "The sslfactoryarg property may not be empty."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:180
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:106
 msgid ""
 "The environment variable containing the server's SSL certificate must not be "
 "empty."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:188
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:114
 msgid ""
 "The system property containing the server's SSL certificate must not be "
 "empty."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:195
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:121
 msgid ""
 "The sslfactoryarg property must start with the prefix file:, classpath:, "
 "env:, sys:, or -----BEGIN CERTIFICATE-----."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:207
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:133
 #, fuzzy
 msgid "An error occurred reading the certificate"
 msgstr "Greška se dogodila prilikom podešavanja SSL konekcije."
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:240
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:166
 msgid "No X509TrustManager found"
 msgstr ""
 
@@ -1566,31 +1572,31 @@ msgid ""
 "setSavePoint not allowed while an XA transaction is active."
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:177
-#: org/postgresql/xa/PGXAConnection.java:253
-#: org/postgresql/xa/PGXAConnection.java:347
+#: org/postgresql/xa/PGXAConnection.java:186
+#: org/postgresql/xa/PGXAConnection.java:272
+#: org/postgresql/xa/PGXAConnection.java:381
 #, java-format
 msgid "Invalid flags {0}"
 msgstr "Nevažeće zastavice {0}"
 
-#: org/postgresql/xa/PGXAConnection.java:181
-#: org/postgresql/xa/PGXAConnection.java:257
-#: org/postgresql/xa/PGXAConnection.java:449
+#: org/postgresql/xa/PGXAConnection.java:190
+#: org/postgresql/xa/PGXAConnection.java:276
+#: org/postgresql/xa/PGXAConnection.java:491
 msgid "xid must not be null"
 msgstr "xid ne sme biti null"
 
-#: org/postgresql/xa/PGXAConnection.java:185
+#: org/postgresql/xa/PGXAConnection.java:194
 msgid "Connection is busy with another transaction"
 msgstr "Konekcija je zauzeta sa drugom transakciom."
 
-#: org/postgresql/xa/PGXAConnection.java:194
-#: org/postgresql/xa/PGXAConnection.java:267
+#: org/postgresql/xa/PGXAConnection.java:203
+#: org/postgresql/xa/PGXAConnection.java:286
 msgid "suspend/resume not implemented"
 msgstr "obustavljanje/nastavljanje nije implementirano."
 
-#: org/postgresql/xa/PGXAConnection.java:202
-#: org/postgresql/xa/PGXAConnection.java:209
-#: org/postgresql/xa/PGXAConnection.java:213
+#: org/postgresql/xa/PGXAConnection.java:211
+#: org/postgresql/xa/PGXAConnection.java:218
+#: org/postgresql/xa/PGXAConnection.java:222
 #, java-format
 msgid ""
 "Invalid protocol state requested. Attempted transaction interleaving is not "
@@ -1599,11 +1605,11 @@ msgstr ""
 "Preplitanje transakcija nije implementirano. xid={0}, currentXid={1}, "
 "state={2}, flags={3}"
 
-#: org/postgresql/xa/PGXAConnection.java:224
+#: org/postgresql/xa/PGXAConnection.java:233
 msgid "Error disabling autocommit"
 msgstr "Greška u isključivanju autokomita"
 
-#: org/postgresql/xa/PGXAConnection.java:261
+#: org/postgresql/xa/PGXAConnection.java:280
 #, java-format
 msgid ""
 "tried to call end without corresponding start call. state={0}, start "
@@ -1612,7 +1618,7 @@ msgstr ""
 "Pokušaj pozivanja kraja pre odgovarajućeg početka. state={0}, start xid={1}, "
 "currentXid={2}, preparedXid={3}"
 
-#: org/postgresql/xa/PGXAConnection.java:297
+#: org/postgresql/xa/PGXAConnection.java:326
 #, fuzzy, java-format
 msgid ""
 "Preparing already prepared transaction, the prepared xid {0}, prepare xid={1}"
@@ -1620,12 +1626,12 @@ msgstr ""
 "Greška prilikom povratka na prethodo pripremljenu transakciju. rollback "
 "xid={0}, preparedXid={1}, currentXid={2}"
 
-#: org/postgresql/xa/PGXAConnection.java:300
+#: org/postgresql/xa/PGXAConnection.java:329
 #, java-format
 msgid "Current connection does not have an associated xid. prepare xid={0}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:307
+#: org/postgresql/xa/PGXAConnection.java:336
 #, java-format
 msgid ""
 "Not implemented: Prepare must be issued using the same connection that "
@@ -1635,21 +1641,21 @@ msgstr ""
 "konekcije koja se koristi za startovanje transakcije. currentXid={0}, "
 "prepare xid={1}"
 
-#: org/postgresql/xa/PGXAConnection.java:311
+#: org/postgresql/xa/PGXAConnection.java:340
 #, java-format
 msgid "Prepare called before end. prepare xid={0}, state={1}"
 msgstr "Pripremanje poziva pre kraja. prepare xid={0}, state={1}"
 
-#: org/postgresql/xa/PGXAConnection.java:331
+#: org/postgresql/xa/PGXAConnection.java:360
 #, java-format
 msgid "Error preparing transaction. prepare xid={0}"
 msgstr "Greška u pripremanju transakcije. prepare xid={0}"
 
-#: org/postgresql/xa/PGXAConnection.java:382
+#: org/postgresql/xa/PGXAConnection.java:416
 msgid "Error during recover"
 msgstr "Greška prilikom oporavljanja."
 
-#: org/postgresql/xa/PGXAConnection.java:438
+#: org/postgresql/xa/PGXAConnection.java:480
 #, java-format
 msgid ""
 "Error rolling back prepared transaction. rollback xid={0}, preparedXid={1}, "
@@ -1658,13 +1664,13 @@ msgstr ""
 "Greška prilikom povratka na prethodo pripremljenu transakciju. rollback "
 "xid={0}, preparedXid={1}, currentXid={2}"
 
-#: org/postgresql/xa/PGXAConnection.java:471
+#: org/postgresql/xa/PGXAConnection.java:521
 #, java-format
 msgid ""
 "One-phase commit called for xid {0} but connection was prepared with xid {1}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:479
+#: org/postgresql/xa/PGXAConnection.java:529
 msgid ""
 "Not implemented: one-phase commit must be issued using the same connection "
 "that was used to start it"
@@ -1672,22 +1678,22 @@ msgstr ""
 "Nije implementirano: Commit iz jedne faze mora biti izdat uz korištenje iste "
 "konekcije koja je korištena za startovanje."
 
-#: org/postgresql/xa/PGXAConnection.java:483
+#: org/postgresql/xa/PGXAConnection.java:533
 #, java-format
 msgid "One-phase commit with unknown xid. commit xid={0}, currentXid={1}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:487
+#: org/postgresql/xa/PGXAConnection.java:537
 #, fuzzy, java-format
 msgid "commit called before end. commit xid={0}, state={1}"
 msgstr "commit pozvan pre kraja."
 
-#: org/postgresql/xa/PGXAConnection.java:498
+#: org/postgresql/xa/PGXAConnection.java:548
 #, java-format
 msgid "Error during one-phase commit. commit xid={0}"
 msgstr "Kreška prilikom commit-a iz jedne faze. commit xid={0}"
 
-#: org/postgresql/xa/PGXAConnection.java:517
+#: org/postgresql/xa/PGXAConnection.java:576
 msgid ""
 "Not implemented: 2nd phase commit must be issued using an idle connection. "
 "commit xid={0}, currentXid={1}, state={2], transactionState={3}"
@@ -1696,7 +1702,7 @@ msgstr ""
 "besposlene konekcije. commit xid={0}, currentXid={1}, state={2], "
 "transactionState={3}"
 
-#: org/postgresql/xa/PGXAConnection.java:550
+#: org/postgresql/xa/PGXAConnection.java:609
 #, fuzzy, java-format
 msgid ""
 "Error committing prepared transaction. commit xid={0}, preparedXid={1}, "
@@ -1705,7 +1711,7 @@ msgstr ""
 "Greška prilikom povratka na prethodo pripremljenu transakciju. commit "
 "xid={0}, preparedXid={1}, currentXid={2}"
 
-#: org/postgresql/xa/PGXAConnection.java:567
+#: org/postgresql/xa/PGXAConnection.java:626
 #, java-format
 msgid "Heuristic commit/rollback not supported. forget xid={0}"
 msgstr "Heuristički commit/rollback nije podržan. forget xid={0}"

--- a/pgjdbc/src/main/java/org/postgresql/translation/tr.po
+++ b/pgjdbc/src/main/java/org/postgresql/translation/tr.po
@@ -7,7 +7,6 @@ msgid ""
 msgstr ""
 "Project-Id-Version: jdbc-tr\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-06-05 10:57+0300\n"
 "PO-Revision-Date: 2009-05-31 21:47+0200\n"
 "Last-Translator: Devrim GÜNDÜZ <devrim@gunduz.org>\n"
 "Language-Team: Turkish <pgsql-tr-genel@PostgreSQL.org>\n"
@@ -19,15 +18,15 @@ msgstr ""
 "X-Poedit-Language: Turkish\n"
 "X-Poedit-Country: TURKEY\n"
 
-#: org/postgresql/Driver.java:214
+#: org/postgresql/Driver.java:217
 msgid "Error loading default settings from driverconfig.properties"
 msgstr "driverconfig.properties dosyasından varsayılan ayarları yükleme hatası"
 
-#: org/postgresql/Driver.java:226
+#: org/postgresql/Driver.java:229
 msgid "Properties for the driver contains a non-string value for the key "
 msgstr ""
 
-#: org/postgresql/Driver.java:270
+#: org/postgresql/Driver.java:272
 msgid ""
 "Your security policy has prevented the connection from being attempted.  You "
 "probably need to grant the connect java.net.SocketPermission to the database "
@@ -37,7 +36,7 @@ msgstr ""
 "SocketPermission'a veritabanına ve de bağlanacağı porta bağlantı izni "
 "vermelisiniz."
 
-#: org/postgresql/Driver.java:276 org/postgresql/Driver.java:408
+#: org/postgresql/Driver.java:278 org/postgresql/Driver.java:410
 msgid ""
 "Something unusual has occurred to cause the driver to fail. Please report "
 "this exception."
@@ -45,35 +44,35 @@ msgstr ""
 "Sıradışı bir durum sürücünün hata vermesine sebep oldu. Lütfen bu durumu "
 "geliştiricilere bildirin."
 
-#: org/postgresql/Driver.java:416
+#: org/postgresql/Driver.java:418
 msgid "Connection attempt timed out."
 msgstr "Bağlantı denemesi zaman aşımına uğradı."
 
-#: org/postgresql/Driver.java:429
+#: org/postgresql/Driver.java:431
 msgid "Interrupted while attempting to connect."
 msgstr "Bağlanırken kesildi."
 
-#: org/postgresql/Driver.java:682
+#: org/postgresql/Driver.java:687
 #, java-format
 msgid "Method {0} is not yet implemented."
 msgstr "{0} yöntemi henüz kodlanmadı."
 
-#: org/postgresql/PGProperty.java:535 org/postgresql/PGProperty.java:555
+#: org/postgresql/PGProperty.java:537 org/postgresql/PGProperty.java:557
 #, java-format
 msgid "{0} parameter value must be an integer but was: {1}"
 msgstr ""
 
-#: org/postgresql/copy/CopyManager.java:53
+#: org/postgresql/copy/CopyManager.java:49
 #, java-format
 msgid "Requested CopyIn but got {0}"
 msgstr ""
 
-#: org/postgresql/copy/CopyManager.java:64
+#: org/postgresql/copy/CopyManager.java:60
 #, java-format
 msgid "Requested CopyOut but got {0}"
 msgstr ""
 
-#: org/postgresql/copy/CopyManager.java:75
+#: org/postgresql/copy/CopyManager.java:71
 #, java-format
 msgid "Requested CopyDual but got {0}"
 msgstr ""
@@ -98,6 +97,11 @@ msgstr ""
 msgid "Cannot write to copy a byte of value {0}"
 msgstr ""
 
+#: org/postgresql/core/CommandCompleteParser.java:71
+#, fuzzy, java-format
+msgid "Unable to parse the count in command completion tag: {0}."
+msgstr "Komut tamamlama etiketinde update sayısı yorumlanamıyor: {0}."
+
 #: org/postgresql/core/ConnectionFactory.java:57
 #, java-format
 msgid "A connection could not be made using the requested protocol {0}."
@@ -120,7 +124,7 @@ msgstr ""
 msgid "Expected an EOF from server, got: {0}"
 msgstr "Sunucudan EOF beklendi; ama {0} alındı."
 
-#: org/postgresql/core/Parser.java:1006
+#: org/postgresql/core/Parser.java:1051
 #, java-format
 msgid "Malformed function or procedure escape syntax at offset {0}."
 msgstr "{0} adresinde fonksiyon veya yordamda kaçış söz dizimi geçersiz."
@@ -179,23 +183,23 @@ msgstr "Belirteçlerde sıfır bayt olamaz."
 #: org/postgresql/core/v3/CompositeParameterList.java:33
 #: org/postgresql/core/v3/SimpleParameterList.java:54
 #: org/postgresql/core/v3/SimpleParameterList.java:65
-#: org/postgresql/jdbc/PgResultSet.java:2757
-#: org/postgresql/jdbc/PgResultSetMetaData.java:494
+#: org/postgresql/jdbc/PgResultSet.java:2755
+#: org/postgresql/jdbc/PgResultSetMetaData.java:388
 #, java-format
 msgid "The column index is out of range: {0}, number of columns: {1}."
 msgstr "Sütun gçstergesi kapsam dışıdır: {0}, sütun sayısı: {1}."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:109
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:103
 #, fuzzy, java-format
 msgid "Invalid sslmode value: {0}"
 msgstr "Geçersiz akım uzunluğu {0}."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:124
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:118
 #, fuzzy, java-format
 msgid "Invalid targetServerType value: {0}"
 msgstr "Geçersiz akım uzunluğu {0}."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:246
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:239
 #, fuzzy, java-format
 msgid ""
 "Connection to {0} refused. Check that the hostname and port are correct and "
@@ -204,39 +208,39 @@ msgstr ""
 "Bağlantı reddedildi. Sunucu adı ve portun doğru olup olmadığını ve "
 "postmaster''in TCP/IP bağlantılarını kabul edip etmediğini kontrol ediniz."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:257
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:250
 #: org/postgresql/core/v3/replication/V3ReplicationProtocol.java:133
 msgid "The connection attempt failed."
 msgstr "Bağlantı denemesi başarısız oldu."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:272
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:265
 #, java-format
 msgid "Could not find a server with specified targetServerType: {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:368
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:381
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:361
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:374
 msgid "The server does not support SSL."
 msgstr "Sunucu SSL desteklemiyor."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:395
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:388
 msgid "An error occurred while setting up the SSL connection."
 msgstr "SSL bağlantısı ayarlanırken bir hata oluştu."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:496
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:523
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:484
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:511
 msgid ""
 "The server requested password-based authentication, but no password was "
 "provided."
 msgstr "Sunucu şifre tabanlı yetkilendirme istedi; ancak bir şifre sağlanmadı."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:626
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:614
 msgid ""
 "SCRAM authentication is not supported by this driver. You need JDK >= 8 and "
 "pgjdbc >= 42.2.0 (not \".jre\" versions)"
 msgstr ""
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:650
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:638
 #, java-format
 msgid ""
 "The authentication type {0} is not supported. Check that you have configured "
@@ -248,16 +252,16 @@ msgstr ""
 "ayarlamadığınızı ve sürücü tarafından desteklenen yetkilendirme "
 "yöntemlerinden birisini kullanıp kullanmadığını kontrol ediniz."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:657
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2550
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2581
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2585
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2653
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:645
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2543
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2576
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2580
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2648
 #: org/postgresql/gss/GssAction.java:126
 msgid "Protocol error.  Session setup failed."
 msgstr "Protokol hatası.  Oturum kurulumu başarısız oldu."
 
-#: org/postgresql/core/v3/CopyInImpl.java:47
+#: org/postgresql/core/v3/CopyInImpl.java:49
 msgid "CopyIn copy direction can't receive data"
 msgstr ""
 
@@ -265,144 +269,144 @@ msgstr ""
 msgid "CommandComplete expected COPY but got: "
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:161
+#: org/postgresql/core/v3/QueryExecutorImpl.java:163
 msgid "Tried to obtain lock while already holding it"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:177
+#: org/postgresql/core/v3/QueryExecutorImpl.java:179
 msgid "Tried to break lock on database connection"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:195
+#: org/postgresql/core/v3/QueryExecutorImpl.java:197
 #, fuzzy
 msgid "Interrupted while waiting to obtain lock on database connection"
 msgstr "Bağlanırken kesildi."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:327
+#: org/postgresql/core/v3/QueryExecutorImpl.java:329
 msgid "Unable to bind parameter values for statement."
 msgstr "Komut için parametre değerlei bağlanamadı."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:333
-#: org/postgresql/core/v3/QueryExecutorImpl.java:485
-#: org/postgresql/core/v3/QueryExecutorImpl.java:559
-#: org/postgresql/core/v3/QueryExecutorImpl.java:602
-#: org/postgresql/core/v3/QueryExecutorImpl.java:729
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2372
+#: org/postgresql/core/v3/QueryExecutorImpl.java:335
+#: org/postgresql/core/v3/QueryExecutorImpl.java:487
+#: org/postgresql/core/v3/QueryExecutorImpl.java:561
+#: org/postgresql/core/v3/QueryExecutorImpl.java:604
+#: org/postgresql/core/v3/QueryExecutorImpl.java:731
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2377
 #: org/postgresql/util/StreamWrapper.java:130
 #, fuzzy
 msgid "An I/O error occurred while sending to the backend."
 msgstr "Backend''e gönderirken bir I/O hatası oluştu."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:534
-#: org/postgresql/core/v3/QueryExecutorImpl.java:576
+#: org/postgresql/core/v3/QueryExecutorImpl.java:536
+#: org/postgresql/core/v3/QueryExecutorImpl.java:578
 #, java-format
 msgid "Expected command status BEGIN, got {0}."
 msgstr "BEGIN komut durumunu beklenirken {0} alındı."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:581
+#: org/postgresql/core/v3/QueryExecutorImpl.java:583
 #: org/postgresql/jdbc/PgResultSet.java:1778
 #, java-format
 msgid "Unexpected command status: {0}."
 msgstr "Beklenmeyen komut durumu: {0}."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:687
+#: org/postgresql/core/v3/QueryExecutorImpl.java:689
 #, fuzzy
 msgid "An error occurred while trying to get the socket timeout."
 msgstr "Backend''e gönderirken bir I/O hatası oluştu."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:722
-#: org/postgresql/core/v3/QueryExecutorImpl.java:798
+#: org/postgresql/core/v3/QueryExecutorImpl.java:724
+#: org/postgresql/core/v3/QueryExecutorImpl.java:800
 #, java-format
 msgid "Unknown Response Type {0}."
 msgstr "Bilinmeyen yanıt tipi {0}"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:745
+#: org/postgresql/core/v3/QueryExecutorImpl.java:747
 #, fuzzy
 msgid "An error occurred while trying to reset the socket timeout."
 msgstr "Backend''e gönderirken bir I/O hatası oluştu."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:843
+#: org/postgresql/core/v3/QueryExecutorImpl.java:845
 msgid "Database connection failed when starting copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:878
+#: org/postgresql/core/v3/QueryExecutorImpl.java:880
 msgid "Tried to cancel an inactive copy operation"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:917
+#: org/postgresql/core/v3/QueryExecutorImpl.java:919
 msgid "Database connection failed when canceling copy operation"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:933
+#: org/postgresql/core/v3/QueryExecutorImpl.java:935
 msgid "Missing expected error response to copy cancel request"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:937
+#: org/postgresql/core/v3/QueryExecutorImpl.java:939
 #, java-format
 msgid "Got {0} error responses to single copy cancel request"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:952
+#: org/postgresql/core/v3/QueryExecutorImpl.java:954
 msgid "Tried to end inactive copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:967
+#: org/postgresql/core/v3/QueryExecutorImpl.java:969
 msgid "Database connection failed when ending copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:985
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1005
+#: org/postgresql/core/v3/QueryExecutorImpl.java:987
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1007
 msgid "Tried to write to an inactive copy operation"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:998
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1013
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1000
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1015
 msgid "Database connection failed when writing to copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1028
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1030
 msgid "Tried to read from inactive copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1035
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1037
 msgid "Database connection failed when reading from copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1101
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1103
 #, java-format
 msgid "Received CommandComplete ''{0}'' without an active copy operation"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1126
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1128
 #, java-format
 msgid "Got CopyInResponse from server during an active {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1140
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1142
 #, java-format
 msgid "Got CopyOutResponse from server during an active {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1154
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1156
 #, java-format
 msgid "Got CopyBothResponse from server during an active {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1170
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1172
 msgid "Got CopyData without an active copy operation"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1174
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1176
 #, fuzzy, java-format
 msgid "Unexpected copydata from server for {0}"
 msgstr "Sunucudan EOF beklendi; ama {0} alındı."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1234
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1236
 #, java-format
 msgid "Unexpected packet type during copy: {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1524
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1526
 #, java-format
 msgid ""
 "Bind message length {0} too long.  This can be caused by very large or "
@@ -411,20 +415,15 @@ msgstr ""
 "Bind mesaj uzunluğu ({0}) fazla uzun. Bu durum InputStream yalnış uzunluk "
 "belirtimlerden kaynaklanabilir."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2145
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2150
 msgid "Ran out of memory retrieving query results."
 msgstr "Sorgu sonuçları alınırken bellek yetersiz."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2313
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2318
 msgid "The driver currently does not support COPY operations."
 msgstr "Bu sunucu şu aşamada COPY işlemleri desteklememktedir."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2487
-#, fuzzy, java-format
-msgid "Unable to parse the count in command completion tag: {0}."
-msgstr "Komut tamamlama etiketinde update sayısı yorumlanamıyor: {0}."
-
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2610
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2605
 #, fuzzy, java-format
 msgid ""
 "The server''s client_encoding parameter was changed to {0}. The JDBC driver "
@@ -434,7 +433,7 @@ msgstr ""
 "sürücüsünün doğru çalışması için client_encoding parameteresinin UNICODE "
 "olması gerekir."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2620
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2615
 #, java-format
 msgid ""
 "The server''s DateStyle parameter was changed to {0}. The JDBC driver "
@@ -443,7 +442,7 @@ msgstr ""
 "Sunucunun DateStyle parametresi {0} olarak değiştirildi. JDBC sürücüsü doğru "
 "işlemesi için DateStyle tanımının ISO işle başlamasını gerekir."
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2633
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2628
 #, java-format
 msgid ""
 "The server''s standard_conforming_strings parameter was reported as {0}. The "
@@ -506,36 +505,36 @@ msgstr "DataSource kapatıldı."
 msgid "Unsupported property name: {0}"
 msgstr "Geçersiz Types değeri: {0}"
 
-#: org/postgresql/fastpath/Fastpath.java:86
+#: org/postgresql/fastpath/Fastpath.java:84
 #, fuzzy, java-format
 msgid "Fastpath call {0} - No result was returned and we expected a numeric."
 msgstr "Fastpath call {0} - Integer beklenirken hiçbir sonuç getirilmedi."
 
-#: org/postgresql/fastpath/Fastpath.java:163
+#: org/postgresql/fastpath/Fastpath.java:161
 #, java-format
 msgid "Fastpath call {0} - No result was returned and we expected an integer."
 msgstr "Fastpath call {0} - Integer beklenirken hiçbir sonuç getirilmedi."
 
-#: org/postgresql/fastpath/Fastpath.java:171
+#: org/postgresql/fastpath/Fastpath.java:169
 #, fuzzy, java-format
 msgid ""
 "Fastpath call {0} - No result was returned or wrong size while expecting an "
 "integer."
 msgstr "Fastpath call {0} - Integer beklenirken hiçbir sonuç getirilmedi."
 
-#: org/postgresql/fastpath/Fastpath.java:188
+#: org/postgresql/fastpath/Fastpath.java:186
 #, fuzzy, java-format
 msgid "Fastpath call {0} - No result was returned and we expected a long."
 msgstr "Fastpath call {0} - Integer beklenirken hiçbir sonuç getirilmedi."
 
-#: org/postgresql/fastpath/Fastpath.java:196
+#: org/postgresql/fastpath/Fastpath.java:194
 #, fuzzy, java-format
 msgid ""
 "Fastpath call {0} - No result was returned or wrong size while expecting a "
 "long."
 msgstr "Fastpath call {0} - Integer beklenirken hiçbir sonuç getirilmedi."
 
-#: org/postgresql/fastpath/Fastpath.java:308
+#: org/postgresql/fastpath/Fastpath.java:297
 #, java-format
 msgid "The fastpath function {0} is unknown."
 msgstr "{0} fastpath fonksiyonu bilinmemektedir."
@@ -603,63 +602,70 @@ msgid "Cannot cast to boolean: \"{0}\""
 msgstr ""
 
 #: org/postgresql/jdbc/EscapedFunctions.java:240
+#: org/postgresql/jdbc/EscapedFunctions2.java:167
 #, java-format
 msgid "{0} function takes four and only four argument."
 msgstr "{0} fonksiyonunu yalnız dört parametre alabilir."
 
 #: org/postgresql/jdbc/EscapedFunctions.java:270
-#: org/postgresql/jdbc/EscapedFunctions.java:344
-#: org/postgresql/jdbc/EscapedFunctions.java:749
-#: org/postgresql/jdbc/EscapedFunctions.java:787
+#: org/postgresql/jdbc/EscapedFunctions.java:337
+#: org/postgresql/jdbc/EscapedFunctions.java:740
+#: org/postgresql/jdbc/EscapedFunctions2.java:196
+#: org/postgresql/jdbc/EscapedFunctions2.java:263
+#: org/postgresql/jdbc/EscapedFunctions2.java:665
 #, java-format
 msgid "{0} function takes two and only two arguments."
 msgstr "{0} fonksiyonunu sadece iki parametre alabilir."
 
 #: org/postgresql/jdbc/EscapedFunctions.java:288
-#: org/postgresql/jdbc/EscapedFunctions.java:326
-#: org/postgresql/jdbc/EscapedFunctions.java:446
-#: org/postgresql/jdbc/EscapedFunctions.java:461
-#: org/postgresql/jdbc/EscapedFunctions.java:476
-#: org/postgresql/jdbc/EscapedFunctions.java:491
-#: org/postgresql/jdbc/EscapedFunctions.java:506
-#: org/postgresql/jdbc/EscapedFunctions.java:521
-#: org/postgresql/jdbc/EscapedFunctions.java:536
-#: org/postgresql/jdbc/EscapedFunctions.java:551
-#: org/postgresql/jdbc/EscapedFunctions.java:566
-#: org/postgresql/jdbc/EscapedFunctions.java:581
-#: org/postgresql/jdbc/EscapedFunctions.java:596
-#: org/postgresql/jdbc/EscapedFunctions.java:611
-#: org/postgresql/jdbc/EscapedFunctions.java:775
+#: org/postgresql/jdbc/EscapedFunctions.java:441
+#: org/postgresql/jdbc/EscapedFunctions.java:467
+#: org/postgresql/jdbc/EscapedFunctions.java:526
+#: org/postgresql/jdbc/EscapedFunctions.java:728
+#: org/postgresql/jdbc/EscapedFunctions2.java:211
+#: org/postgresql/jdbc/EscapedFunctions2.java:355
+#: org/postgresql/jdbc/EscapedFunctions2.java:381
+#: org/postgresql/jdbc/EscapedFunctions2.java:440
+#: org/postgresql/jdbc/EscapedFunctions2.java:654
 #, java-format
 msgid "{0} function takes one and only one argument."
 msgstr "{0} fonksiyonunu yalnız tek bir parametre alabilir."
 
-#: org/postgresql/jdbc/EscapedFunctions.java:310
-#: org/postgresql/jdbc/EscapedFunctions.java:391
+#: org/postgresql/jdbc/EscapedFunctions.java:312
+#: org/postgresql/jdbc/EscapedFunctions.java:386
+#: org/postgresql/jdbc/EscapedFunctions2.java:238
+#: org/postgresql/jdbc/EscapedFunctions2.java:307
 #, java-format
 msgid "{0} function takes two or three arguments."
 msgstr "{0} fonksiyonu yalnız iki veya üç argüman alabilir."
 
-#: org/postgresql/jdbc/EscapedFunctions.java:416
-#: org/postgresql/jdbc/EscapedFunctions.java:431
-#: org/postgresql/jdbc/EscapedFunctions.java:734
-#: org/postgresql/jdbc/EscapedFunctions.java:764
+#: org/postgresql/jdbc/EscapedFunctions.java:411
+#: org/postgresql/jdbc/EscapedFunctions.java:426
+#: org/postgresql/jdbc/EscapedFunctions.java:693
+#: org/postgresql/jdbc/EscapedFunctions.java:719
+#: org/postgresql/jdbc/EscapedFunctions2.java:645
 #, java-format
 msgid "{0} function doesn''t take any argument."
 msgstr "{0} fonksiyonu parametre almaz."
 
-#: org/postgresql/jdbc/EscapedFunctions.java:627
-#: org/postgresql/jdbc/EscapedFunctions.java:680
+#: org/postgresql/jdbc/EscapedFunctions.java:586
+#: org/postgresql/jdbc/EscapedFunctions.java:639
+#: org/postgresql/jdbc/EscapedFunctions2.java:500
+#: org/postgresql/jdbc/EscapedFunctions2.java:571
 #, java-format
 msgid "{0} function takes three and only three arguments."
 msgstr "{0} fonksiyonunu sadece üç parametre alabilir."
 
-#: org/postgresql/jdbc/EscapedFunctions.java:640
-#: org/postgresql/jdbc/EscapedFunctions.java:661
-#: org/postgresql/jdbc/EscapedFunctions.java:664
-#: org/postgresql/jdbc/EscapedFunctions.java:697
-#: org/postgresql/jdbc/EscapedFunctions.java:710
-#: org/postgresql/jdbc/EscapedFunctions.java:713
+#: org/postgresql/jdbc/EscapedFunctions.java:599
+#: org/postgresql/jdbc/EscapedFunctions.java:620
+#: org/postgresql/jdbc/EscapedFunctions.java:623
+#: org/postgresql/jdbc/EscapedFunctions.java:656
+#: org/postgresql/jdbc/EscapedFunctions.java:669
+#: org/postgresql/jdbc/EscapedFunctions.java:672
+#: org/postgresql/jdbc/EscapedFunctions2.java:510
+#: org/postgresql/jdbc/EscapedFunctions2.java:527
+#: org/postgresql/jdbc/EscapedFunctions2.java:585
+#: org/postgresql/jdbc/EscapedFunctions2.java:597
 #, java-format
 msgid "Interval {0} not yet implemented"
 msgstr "{0} aralığı henüz kodlanmadı."
@@ -678,17 +684,17 @@ msgstr "Adlandırılmış savepointin id değerine erişilemiyor."
 msgid "Cannot retrieve the name of an unnamed savepoint."
 msgstr "Adı verilmemiş savepointin id değerine erişilemiyor."
 
-#: org/postgresql/jdbc/PgArray.java:157 org/postgresql/jdbc/PgArray.java:844
+#: org/postgresql/jdbc/PgArray.java:155 org/postgresql/jdbc/PgArray.java:842
 #, java-format
 msgid "The array index is out of range: {0}"
 msgstr "Dizi göstergesi kapsam dışıdır: {0}"
 
-#: org/postgresql/jdbc/PgArray.java:178 org/postgresql/jdbc/PgArray.java:861
+#: org/postgresql/jdbc/PgArray.java:176 org/postgresql/jdbc/PgArray.java:859
 #, java-format
 msgid "The array index is out of range: {0}, number of elements: {1}."
 msgstr "Dizin göstergisi kapsam dışıdır: {0}, öğe sayısı: {1}."
 
-#: org/postgresql/jdbc/PgArray.java:210
+#: org/postgresql/jdbc/PgArray.java:208
 #: org/postgresql/jdbc/PgResultSet.java:1930
 #: org/postgresql/util/HStoreConverter.java:43
 #: org/postgresql/util/HStoreConverter.java:74
@@ -703,16 +709,16 @@ msgstr ""
 "rastlamasıdır. Bunun en yaygın örneği 8 bitlik veriyi SQL_ASCII "
 "veritabanında saklamasıdır."
 
-#: org/postgresql/jdbc/PgCallableStatement.java:86
-#: org/postgresql/jdbc/PgCallableStatement.java:96
+#: org/postgresql/jdbc/PgCallableStatement.java:85
+#: org/postgresql/jdbc/PgCallableStatement.java:95
 msgid "A CallableStatement was executed with nothing returned."
 msgstr "CallableStatement çalıştırma sonucunda veri getirilmedi."
 
-#: org/postgresql/jdbc/PgCallableStatement.java:107
+#: org/postgresql/jdbc/PgCallableStatement.java:106
 msgid "A CallableStatement was executed with an invalid number of parameters"
 msgstr "CallableStatement geçersiz sayıda parametre ile çalıştırıldı."
 
-#: org/postgresql/jdbc/PgCallableStatement.java:145
+#: org/postgresql/jdbc/PgCallableStatement.java:144
 #, java-format
 msgid ""
 "A CallableStatement function was executed and the out parameter {0} was of "
@@ -721,7 +727,7 @@ msgstr ""
 "CallableStatement çalıştırıldı, ancak {2} tipi kaydedilmesine rağmen "
 "döndürme parametresi {0} ve tipi {1} idi."
 
-#: org/postgresql/jdbc/PgCallableStatement.java:202
+#: org/postgresql/jdbc/PgCallableStatement.java:206
 msgid ""
 "This statement does not declare an OUT parameter.  Use '{' ?= call ... '}' "
 "to declare one."
@@ -729,12 +735,12 @@ msgstr ""
 "Bu komut OUT parametresi bildirmemektedir.  Bildirmek için '{' ?= call ... "
 "'}' kullanın."
 
-#: org/postgresql/jdbc/PgCallableStatement.java:246
+#: org/postgresql/jdbc/PgCallableStatement.java:229
 msgid "wasNull cannot be call before fetching a result."
 msgstr "wasNull sonuç çekmeden önce çağırılamaz."
 
-#: org/postgresql/jdbc/PgCallableStatement.java:384
-#: org/postgresql/jdbc/PgCallableStatement.java:403
+#: org/postgresql/jdbc/PgCallableStatement.java:367
+#: org/postgresql/jdbc/PgCallableStatement.java:386
 #, java-format
 msgid ""
 "Parameter of type {0} was registered, but call to get{1} (sqltype={2}) was "
@@ -743,7 +749,7 @@ msgstr ""
 "{0} tipinde parametre tanıtıldı, ancak {1} (sqltype={2}) tipinde geri "
 "getirmek için çağrı yapıldı."
 
-#: org/postgresql/jdbc/PgCallableStatement.java:424
+#: org/postgresql/jdbc/PgCallableStatement.java:407
 msgid ""
 "A CallableStatement was declared, but no call to registerOutParameter(1, "
 "<some type>) was made."
@@ -751,27 +757,27 @@ msgstr ""
 "CallableStatement bildirildi ancak registerOutParameter(1, < bir tip>) "
 "tanıtımı yapılmadı."
 
-#: org/postgresql/jdbc/PgCallableStatement.java:430
+#: org/postgresql/jdbc/PgCallableStatement.java:413
 msgid "No function outputs were registered."
 msgstr "Hiçbir fonksiyon çıktısı kaydedilmedi."
 
-#: org/postgresql/jdbc/PgCallableStatement.java:436
+#: org/postgresql/jdbc/PgCallableStatement.java:419
 msgid ""
 "Results cannot be retrieved from a CallableStatement before it is executed."
 msgstr "CallableStatement çalıştırılmadan sonuçlar ondan alınamaz."
 
-#: org/postgresql/jdbc/PgCallableStatement.java:703
+#: org/postgresql/jdbc/PgCallableStatement.java:686
 #, fuzzy, java-format
 msgid "Unsupported type conversion to {1}."
 msgstr "Geçersiz Types değeri: {0}"
 
-#: org/postgresql/jdbc/PgConnection.java:272
+#: org/postgresql/jdbc/PgConnection.java:241
 #, java-format
 msgid "Unsupported value for stringtype parameter: {0}"
 msgstr "strinftype parametresi için destekleneyen değer: {0}"
 
 #: org/postgresql/jdbc/PgConnection.java:424
-#: org/postgresql/jdbc/PgPreparedStatement.java:119
+#: org/postgresql/jdbc/PgPreparedStatement.java:107
 #: org/postgresql/jdbc/PgStatement.java:225
 #: org/postgresql/jdbc/TypeInfoCache.java:226
 #: org/postgresql/jdbc/TypeInfoCache.java:371
@@ -783,129 +789,129 @@ msgstr "strinftype parametresi için destekleneyen değer: {0}"
 msgid "No results were returned by the query."
 msgstr "Sorgudan hiç bir sonuç dönmedi."
 
-#: org/postgresql/jdbc/PgConnection.java:441
+#: org/postgresql/jdbc/PgConnection.java:442
 #: org/postgresql/jdbc/PgStatement.java:254
 msgid "A result was returned when none was expected."
 msgstr "Hiçbir sonuç kebklenimezken sonuç getirildi."
 
-#: org/postgresql/jdbc/PgConnection.java:545
+#: org/postgresql/jdbc/PgConnection.java:547
 msgid "Custom type maps are not supported."
 msgstr "Özel tip eşleştirmeleri desteklenmiyor."
 
-#: org/postgresql/jdbc/PgConnection.java:587
+#: org/postgresql/jdbc/PgConnection.java:589
 #, java-format
 msgid "Failed to create object for: {0}."
 msgstr "{0} için nesne oluşturma hatası."
 
-#: org/postgresql/jdbc/PgConnection.java:641
+#: org/postgresql/jdbc/PgConnection.java:643
 #, java-format
 msgid "Unable to load the class {0} responsible for the datatype {1}"
 msgstr "{1} veri tipinden sorumlu {0} sınıfı yüklenemedi"
 
-#: org/postgresql/jdbc/PgConnection.java:693
+#: org/postgresql/jdbc/PgConnection.java:705
 msgid ""
 "Cannot change transaction read-only property in the middle of a transaction."
 msgstr ""
 "Transaction ortasında geçerli transactionun read-only özellği değiştirilemez."
 
-#: org/postgresql/jdbc/PgConnection.java:756
+#: org/postgresql/jdbc/PgConnection.java:772
 msgid "Cannot commit when autoCommit is enabled."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:767
-#: org/postgresql/jdbc/PgConnection.java:1384
-#: org/postgresql/jdbc/PgConnection.java:1428
+#: org/postgresql/jdbc/PgConnection.java:783
+#: org/postgresql/jdbc/PgConnection.java:1401
+#: org/postgresql/jdbc/PgConnection.java:1445
 #, fuzzy
 msgid "This connection has been closed."
 msgstr "Bağlantı kapatıldı."
 
-#: org/postgresql/jdbc/PgConnection.java:777
+#: org/postgresql/jdbc/PgConnection.java:794
 msgid "Cannot rollback when autoCommit is enabled."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:827
+#: org/postgresql/jdbc/PgConnection.java:844
 msgid ""
 "Cannot change transaction isolation level in the middle of a transaction."
 msgstr ""
 "Transaction ortasında geçerli transactionun transaction isolation level "
 "özellği değiştirilemez."
 
-#: org/postgresql/jdbc/PgConnection.java:833
+#: org/postgresql/jdbc/PgConnection.java:850
 #, java-format
 msgid "Transaction isolation level {0} not supported."
 msgstr "Transaction isolation level {0} desteklenmiyor."
 
-#: org/postgresql/jdbc/PgConnection.java:878
+#: org/postgresql/jdbc/PgConnection.java:895
 msgid "Finalizing a Connection that was never closed:"
 msgstr "Kapatılmamış bağlantı sonlandırılıyor."
 
-#: org/postgresql/jdbc/PgConnection.java:945
+#: org/postgresql/jdbc/PgConnection.java:962
 msgid "Unable to translate data into the desired encoding."
 msgstr "Veri, istenilen dil kodlamasına çevrilemiyor."
 
-#: org/postgresql/jdbc/PgConnection.java:1008
+#: org/postgresql/jdbc/PgConnection.java:1025
 #: org/postgresql/jdbc/PgResultSet.java:1817
-#: org/postgresql/jdbc/PgStatement.java:903
+#: org/postgresql/jdbc/PgStatement.java:908
 msgid "Fetch size must be a value greater to or equal to 0."
 msgstr "Fetch boyutu sıfır veya daha büyük bir değer olmalıdır."
 
-#: org/postgresql/jdbc/PgConnection.java:1289
-#: org/postgresql/jdbc/PgConnection.java:1330
+#: org/postgresql/jdbc/PgConnection.java:1306
+#: org/postgresql/jdbc/PgConnection.java:1347
 #, java-format
 msgid "Unable to find server array type for provided name {0}."
 msgstr "Belirtilen {0} adı için sunucu array tipi bulunamadı."
 
-#: org/postgresql/jdbc/PgConnection.java:1312
+#: org/postgresql/jdbc/PgConnection.java:1329
 #, fuzzy, java-format
 msgid "Invalid elements {0}"
 msgstr "Geçersiz seçenekler {0}"
 
-#: org/postgresql/jdbc/PgConnection.java:1348
+#: org/postgresql/jdbc/PgConnection.java:1365
 #, fuzzy, java-format
 msgid "Invalid timeout ({0}<0)."
 msgstr "Geçersiz akım uzunluğu {0}."
 
-#: org/postgresql/jdbc/PgConnection.java:1372
+#: org/postgresql/jdbc/PgConnection.java:1389
 msgid "Validating connection."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1405
+#: org/postgresql/jdbc/PgConnection.java:1422
 #, fuzzy, java-format
 msgid "Failed to set ClientInfo property: {0}"
 msgstr "{0} için nesne oluşturma hatası."
 
-#: org/postgresql/jdbc/PgConnection.java:1415
+#: org/postgresql/jdbc/PgConnection.java:1432
 msgid "ClientInfo property not supported."
 msgstr "Clientinfo property'si desteklenememktedir."
 
-#: org/postgresql/jdbc/PgConnection.java:1441
+#: org/postgresql/jdbc/PgConnection.java:1458
 msgid "One ore more ClientInfo failed."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1540
+#: org/postgresql/jdbc/PgConnection.java:1559
 #, fuzzy
 msgid "Network timeout must be a value greater than or equal to 0."
 msgstr "Sorgu zaman aşımı değer sıfır veya sıfırdan büyük bir sayı olmalıdır."
 
-#: org/postgresql/jdbc/PgConnection.java:1552
+#: org/postgresql/jdbc/PgConnection.java:1571
 msgid "Unable to set network timeout."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1563
+#: org/postgresql/jdbc/PgConnection.java:1582
 msgid "Unable to get network timeout."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1580
+#: org/postgresql/jdbc/PgConnection.java:1599
 #, java-format
 msgid "Unknown ResultSet holdability setting: {0}."
 msgstr "ResultSet tutabilme ayarı geçersiz: {0}."
 
-#: org/postgresql/jdbc/PgConnection.java:1598
-#: org/postgresql/jdbc/PgConnection.java:1619
+#: org/postgresql/jdbc/PgConnection.java:1617
+#: org/postgresql/jdbc/PgConnection.java:1638
 msgid "Cannot establish a savepoint in auto-commit mode."
 msgstr "Auto-commit biçimde savepoint oluşturulamıyor."
 
-#: org/postgresql/jdbc/PgConnection.java:1685
+#: org/postgresql/jdbc/PgConnection.java:1707
 msgid "Returning autogenerated keys is not supported."
 msgstr "Otomatik üretilen değerlerin getirilmesi desteklenememktedir."
 
@@ -920,47 +926,47 @@ msgstr ""
 msgid "Unable to find name datatype in the system catalogs."
 msgstr "Sistem kataloglarında name veri tipi bulunamıyor."
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:323
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:322
 #, fuzzy
 msgid "Unable to find keywords in the system catalogs."
 msgstr "Sistem kataloglarında name veri tipi bulunamıyor."
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1105
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1095
 msgid "oid"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1105
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1095
 msgid "proname"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1107
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1558
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1097
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1548
 msgid "typtype"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1110
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1100
 msgid "proargtypes"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1576
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1566
 msgid "adsrc"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1589
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1579
 msgid "attidentity"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1685
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1761
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1675
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1751
 msgid "rolname"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1686
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1762
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1676
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1752
 msgid "relacl"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1692
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1682
 msgid "attacl"
 msgstr ""
 
@@ -969,66 +975,66 @@ msgstr ""
 msgid "The parameter index is out of range: {0}, number of parameters: {1}."
 msgstr "Dizin göstergisi kapsam dışıdır: {0}, öğe sayısı: {1}."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:106
+#: org/postgresql/jdbc/PgPreparedStatement.java:94
+#: org/postgresql/jdbc/PgPreparedStatement.java:115
 #: org/postgresql/jdbc/PgPreparedStatement.java:127
-#: org/postgresql/jdbc/PgPreparedStatement.java:139
-#: org/postgresql/jdbc/PgPreparedStatement.java:1035
+#: org/postgresql/jdbc/PgPreparedStatement.java:1008
 msgid ""
 "Can''t use query methods that take a query string on a PreparedStatement."
 msgstr "PreparedStatement ile sorgu satırı alan sorgu yöntemleri kullanılamaz."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:249
+#: org/postgresql/jdbc/PgPreparedStatement.java:237
 msgid "Unknown Types value."
 msgstr "Geçersiz Types değeri."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:382
-#: org/postgresql/jdbc/PgPreparedStatement.java:439
-#: org/postgresql/jdbc/PgPreparedStatement.java:1191
-#: org/postgresql/jdbc/PgPreparedStatement.java:1490
+#: org/postgresql/jdbc/PgPreparedStatement.java:364
+#: org/postgresql/jdbc/PgPreparedStatement.java:421
+#: org/postgresql/jdbc/PgPreparedStatement.java:1164
+#: org/postgresql/jdbc/PgPreparedStatement.java:1472
 #, java-format
 msgid "Invalid stream length {0}."
 msgstr "Geçersiz akım uzunluğu {0}."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:411
+#: org/postgresql/jdbc/PgPreparedStatement.java:393
 #, java-format
 msgid "The JVM claims not to support the {0} encoding."
 msgstr "JVM, {0} dil kodlamasını desteklememektedir."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:414
+#: org/postgresql/jdbc/PgPreparedStatement.java:396
 #: org/postgresql/jdbc/PgResultSet.java:1122
 #: org/postgresql/jdbc/PgResultSet.java:1156
 msgid "Provided InputStream failed."
 msgstr "Sağlanmış InputStream başarısız."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:460
-#: org/postgresql/jdbc/PgPreparedStatement.java:1096
+#: org/postgresql/jdbc/PgPreparedStatement.java:442
+#: org/postgresql/jdbc/PgPreparedStatement.java:1069
 #, java-format
 msgid "Unknown type {0}."
 msgstr "Bilinmeyen tip {0}."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:477
+#: org/postgresql/jdbc/PgPreparedStatement.java:459
 msgid "No hstore extension installed."
 msgstr ""
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:619
-#: org/postgresql/jdbc/PgPreparedStatement.java:642
-#: org/postgresql/jdbc/PgPreparedStatement.java:652
-#: org/postgresql/jdbc/PgPreparedStatement.java:664
+#: org/postgresql/jdbc/PgPreparedStatement.java:601
+#: org/postgresql/jdbc/PgPreparedStatement.java:624
+#: org/postgresql/jdbc/PgPreparedStatement.java:634
+#: org/postgresql/jdbc/PgPreparedStatement.java:646
 #, java-format
 msgid "Cannot cast an instance of {0} to type {1}"
 msgstr "{0} tipi {1} tipine dönüştürülemiyor"
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:682
+#: org/postgresql/jdbc/PgPreparedStatement.java:664
 #, java-format
 msgid "Unsupported Types value: {0}"
 msgstr "Geçersiz Types değeri: {0}"
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:894
+#: org/postgresql/jdbc/PgPreparedStatement.java:876
 #, java-format
 msgid "Cannot convert an instance of {0} to type {1}"
 msgstr "{0} instance, {1} tipine dönüştürülemiyor"
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:968
+#: org/postgresql/jdbc/PgPreparedStatement.java:950
 #, java-format
 msgid ""
 "Can''t infer the SQL type to use for an instance of {0}. Use setObject() "
@@ -1037,17 +1043,17 @@ msgstr ""
 "{0}''nin örneği ile kullanılacak SQL tip bulunamadı. Kullanılacak tip "
 "belirtmek için kesin Types değerleri ile setObject() kullanın."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:1133
-#: org/postgresql/jdbc/PgPreparedStatement.java:1233
+#: org/postgresql/jdbc/PgPreparedStatement.java:1106
+#: org/postgresql/jdbc/PgPreparedStatement.java:1206
 msgid "Unexpected error writing large object to database."
 msgstr "Large object veritabanına yazılırken beklenmeyan hata."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:1178
+#: org/postgresql/jdbc/PgPreparedStatement.java:1151
 #: org/postgresql/jdbc/PgResultSet.java:1210
 msgid "Provided Reader failed."
 msgstr "Sağlanmış InputStream başarısız."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:1449
+#: org/postgresql/jdbc/PgPreparedStatement.java:1431
 #: org/postgresql/util/StreamWrapper.java:56
 msgid "Object is too large to send over the protocol."
 msgstr ""
@@ -1065,8 +1071,8 @@ msgstr ""
 #: org/postgresql/jdbc/PgResultSet.java:556
 #: org/postgresql/jdbc/PgResultSet.java:594
 #: org/postgresql/jdbc/PgResultSet.java:624
-#: org/postgresql/jdbc/PgResultSet.java:3014
-#: org/postgresql/jdbc/PgResultSet.java:3058
+#: org/postgresql/jdbc/PgResultSet.java:3012
+#: org/postgresql/jdbc/PgResultSet.java:3057
 #, fuzzy, java-format
 msgid "Cannot convert the column of type {0} to requested type {1}."
 msgstr "{0} instance, {1} tipine dönüştürülemiyor"
@@ -1078,7 +1084,7 @@ msgid "Can''t use relative move methods while on the insert row."
 msgstr "Insert kaydı üzerinde relative move method kullanılamaz."
 
 #: org/postgresql/jdbc/PgResultSet.java:878
-#: org/postgresql/jdbc/PgStatement.java:895
+#: org/postgresql/jdbc/PgStatement.java:900
 #, java-format
 msgid "Invalid fetch direction constant: {0}."
 msgstr "Getirme yönü değişmezi geçersiz: {0}."
@@ -1121,8 +1127,8 @@ msgstr "Bir satır eklemek için en az bir sütun değerini belirtmelisiniz."
 
 #: org/postgresql/jdbc/PgResultSet.java:1119
 #: org/postgresql/jdbc/PgResultSet.java:1754
-#: org/postgresql/jdbc/PgResultSet.java:2422
-#: org/postgresql/jdbc/PgResultSet.java:2443
+#: org/postgresql/jdbc/PgResultSet.java:2420
+#: org/postgresql/jdbc/PgResultSet.java:2441
 #, java-format
 msgid "The JVM claims not to support the encoding: {0}"
 msgstr "JVM, {0} dil kodlamasını desteklememektedir."
@@ -1136,7 +1142,7 @@ msgid "Cannot call updateRow() when on the insert row."
 msgstr "Insert  kaydı üzerinde updateRow() çağırılamaz."
 
 #: org/postgresql/jdbc/PgResultSet.java:1335
-#: org/postgresql/jdbc/PgResultSet.java:3075
+#: org/postgresql/jdbc/PgResultSet.java:3074
 msgid ""
 "Cannot update the ResultSet because it is either before the start or after "
 "the end of the results."
@@ -1155,27 +1161,27 @@ msgstr "{0} tablosunda primary key yok."
 
 #: org/postgresql/jdbc/PgResultSet.java:2017
 #: org/postgresql/jdbc/PgResultSet.java:2022
-#: org/postgresql/jdbc/PgResultSet.java:2809
-#: org/postgresql/jdbc/PgResultSet.java:2815
-#: org/postgresql/jdbc/PgResultSet.java:2840
-#: org/postgresql/jdbc/PgResultSet.java:2846
-#: org/postgresql/jdbc/PgResultSet.java:2870
-#: org/postgresql/jdbc/PgResultSet.java:2875
-#: org/postgresql/jdbc/PgResultSet.java:2891
-#: org/postgresql/jdbc/PgResultSet.java:2912
-#: org/postgresql/jdbc/PgResultSet.java:2923
-#: org/postgresql/jdbc/PgResultSet.java:2936
-#: org/postgresql/jdbc/PgResultSet.java:3063
+#: org/postgresql/jdbc/PgResultSet.java:2807
+#: org/postgresql/jdbc/PgResultSet.java:2813
+#: org/postgresql/jdbc/PgResultSet.java:2838
+#: org/postgresql/jdbc/PgResultSet.java:2844
+#: org/postgresql/jdbc/PgResultSet.java:2868
+#: org/postgresql/jdbc/PgResultSet.java:2873
+#: org/postgresql/jdbc/PgResultSet.java:2889
+#: org/postgresql/jdbc/PgResultSet.java:2910
+#: org/postgresql/jdbc/PgResultSet.java:2921
+#: org/postgresql/jdbc/PgResultSet.java:2934
+#: org/postgresql/jdbc/PgResultSet.java:3062
 #, java-format
 msgid "Bad value for type {0} : {1}"
 msgstr "{0} veri tipi için geçersiz değer : {1}"
 
-#: org/postgresql/jdbc/PgResultSet.java:2595
+#: org/postgresql/jdbc/PgResultSet.java:2593
 #, java-format
 msgid "The column name {0} was not found in this ResultSet."
 msgstr "Bu ResultSet içinde {0} sütun adı bulunamadı."
 
-#: org/postgresql/jdbc/PgResultSet.java:2731
+#: org/postgresql/jdbc/PgResultSet.java:2729
 msgid ""
 "ResultSet is not updateable.  The query that generated this result set must "
 "select only one table, and must select all primary keys from that table. See "
@@ -1185,41 +1191,41 @@ msgstr ""
 "sorgulamalı ve tablonun tüm primary key alanları belirtmelidir. Daha fazla "
 "bilgi için bk. JDBC 2.1 API Specification, section 5.6."
 
-#: org/postgresql/jdbc/PgResultSet.java:2743
+#: org/postgresql/jdbc/PgResultSet.java:2741
 msgid "This ResultSet is closed."
 msgstr "ResultSet kapalıdır."
 
-#: org/postgresql/jdbc/PgResultSet.java:2774
+#: org/postgresql/jdbc/PgResultSet.java:2772
 msgid "ResultSet not positioned properly, perhaps you need to call next."
 msgstr "ResultSet doğru konumlanmamıştır, next işlemi çağırmanız gerekir."
 
-#: org/postgresql/jdbc/PgResultSet.java:3095
+#: org/postgresql/jdbc/PgResultSet.java:3094
 msgid "Invalid UUID data."
 msgstr "Geçersiz UUID verisi."
 
-#: org/postgresql/jdbc/PgResultSet.java:3184
-#: org/postgresql/jdbc/PgResultSet.java:3191
-#: org/postgresql/jdbc/PgResultSet.java:3202
-#: org/postgresql/jdbc/PgResultSet.java:3213
-#: org/postgresql/jdbc/PgResultSet.java:3224
-#: org/postgresql/jdbc/PgResultSet.java:3235
-#: org/postgresql/jdbc/PgResultSet.java:3246
-#: org/postgresql/jdbc/PgResultSet.java:3257
-#: org/postgresql/jdbc/PgResultSet.java:3268
-#: org/postgresql/jdbc/PgResultSet.java:3275
-#: org/postgresql/jdbc/PgResultSet.java:3282
-#: org/postgresql/jdbc/PgResultSet.java:3293
-#: org/postgresql/jdbc/PgResultSet.java:3310
-#: org/postgresql/jdbc/PgResultSet.java:3317
-#: org/postgresql/jdbc/PgResultSet.java:3324
-#: org/postgresql/jdbc/PgResultSet.java:3335
-#: org/postgresql/jdbc/PgResultSet.java:3342
-#: org/postgresql/jdbc/PgResultSet.java:3349
-#: org/postgresql/jdbc/PgResultSet.java:3387
-#: org/postgresql/jdbc/PgResultSet.java:3394
-#: org/postgresql/jdbc/PgResultSet.java:3401
-#: org/postgresql/jdbc/PgResultSet.java:3421
-#: org/postgresql/jdbc/PgResultSet.java:3434
+#: org/postgresql/jdbc/PgResultSet.java:3183
+#: org/postgresql/jdbc/PgResultSet.java:3190
+#: org/postgresql/jdbc/PgResultSet.java:3201
+#: org/postgresql/jdbc/PgResultSet.java:3212
+#: org/postgresql/jdbc/PgResultSet.java:3223
+#: org/postgresql/jdbc/PgResultSet.java:3234
+#: org/postgresql/jdbc/PgResultSet.java:3245
+#: org/postgresql/jdbc/PgResultSet.java:3256
+#: org/postgresql/jdbc/PgResultSet.java:3267
+#: org/postgresql/jdbc/PgResultSet.java:3274
+#: org/postgresql/jdbc/PgResultSet.java:3281
+#: org/postgresql/jdbc/PgResultSet.java:3292
+#: org/postgresql/jdbc/PgResultSet.java:3309
+#: org/postgresql/jdbc/PgResultSet.java:3316
+#: org/postgresql/jdbc/PgResultSet.java:3323
+#: org/postgresql/jdbc/PgResultSet.java:3334
+#: org/postgresql/jdbc/PgResultSet.java:3341
+#: org/postgresql/jdbc/PgResultSet.java:3348
+#: org/postgresql/jdbc/PgResultSet.java:3386
+#: org/postgresql/jdbc/PgResultSet.java:3393
+#: org/postgresql/jdbc/PgResultSet.java:3400
+#: org/postgresql/jdbc/PgResultSet.java:3420
+#: org/postgresql/jdbc/PgResultSet.java:3433
 #, fuzzy, java-format
 msgid "conversion to {0} from {1} not supported"
 msgstr "Transaction isolation level {0} desteklenmiyor."
@@ -1285,35 +1291,35 @@ msgstr ""
 msgid "Maximum number of rows must be a value grater than or equal to 0."
 msgstr "En büyük getirilecek satır sayısı sıfırdan büyük olmalıdır."
 
-#: org/postgresql/jdbc/PgStatement.java:550
+#: org/postgresql/jdbc/PgStatement.java:555
 msgid "Query timeout must be a value greater than or equals to 0."
 msgstr "Sorgu zaman aşımı değer sıfır veya sıfırdan büyük bir sayı olmalıdır."
 
-#: org/postgresql/jdbc/PgStatement.java:590
+#: org/postgresql/jdbc/PgStatement.java:595
 msgid "The maximum field size must be a value greater than or equal to 0."
 msgstr "En büyük alan boyutu sıfır ya da sıfırdan büyük bir değer olmalı."
 
-#: org/postgresql/jdbc/PgStatement.java:689
+#: org/postgresql/jdbc/PgStatement.java:694
 msgid "This statement has been closed."
 msgstr "Bu komut kapatıldı."
 
-#: org/postgresql/jdbc/PgStatement.java:1145
-#: org/postgresql/jdbc/PgStatement.java:1173
+#: org/postgresql/jdbc/PgStatement.java:1150
+#: org/postgresql/jdbc/PgStatement.java:1178
 msgid "Returning autogenerated keys by column index is not supported."
 msgstr ""
 "Kolonların indexlenmesi ile otomatik olarak oluşturulan anahtarların "
 "döndürülmesi desteklenmiyor."
 
-#: org/postgresql/jdbc/TimestampUtils.java:355
-#: org/postgresql/jdbc/TimestampUtils.java:423
+#: org/postgresql/jdbc/TimestampUtils.java:365
+#: org/postgresql/jdbc/TimestampUtils.java:433
 #, fuzzy, java-format
 msgid "Bad value for type timestamp/date/time: {1}"
 msgstr "{0} veri tipi için geçersiz değer : {1}"
 
-#: org/postgresql/jdbc/TimestampUtils.java:858
-#: org/postgresql/jdbc/TimestampUtils.java:915
-#: org/postgresql/jdbc/TimestampUtils.java:961
-#: org/postgresql/jdbc/TimestampUtils.java:1010
+#: org/postgresql/jdbc/TimestampUtils.java:914
+#: org/postgresql/jdbc/TimestampUtils.java:971
+#: org/postgresql/jdbc/TimestampUtils.java:1017
+#: org/postgresql/jdbc/TimestampUtils.java:1066
 #, fuzzy, java-format
 msgid "Unsupported binary encoding of {0}."
 msgstr "Geçersiz Types değeri: {0}"
@@ -1326,31 +1332,31 @@ msgstr ""
 msgid "Invalid or unsupported by client SCRAM mechanisms"
 msgstr ""
 
-#: org/postgresql/jre8/sasl/ScramAuthenticator.java:117
+#: org/postgresql/jre8/sasl/ScramAuthenticator.java:119
 #, fuzzy, java-format
 msgid "Invalid server-first-message: {0}"
 msgstr "Geçersiz akım uzunluğu {0}."
 
-#: org/postgresql/jre8/sasl/ScramAuthenticator.java:147
+#: org/postgresql/jre8/sasl/ScramAuthenticator.java:151
 #, fuzzy, java-format
 msgid "Invalid server-final-message: {0}"
 msgstr "Geçersiz akım uzunluğu {0}."
 
-#: org/postgresql/jre8/sasl/ScramAuthenticator.java:153
+#: org/postgresql/jre8/sasl/ScramAuthenticator.java:157
 #, java-format
 msgid "SCRAM authentication failed, server returned error: {0}"
 msgstr ""
 
-#: org/postgresql/jre8/sasl/ScramAuthenticator.java:160
+#: org/postgresql/jre8/sasl/ScramAuthenticator.java:164
 msgid "Invalid server SCRAM signature"
 msgstr ""
 
-#: org/postgresql/largeobject/LargeObjectManager.java:144
+#: org/postgresql/largeobject/LargeObjectManager.java:136
 msgid "Failed to initialize LargeObject API"
 msgstr "LArgeObject API ilklendirme hatası"
 
-#: org/postgresql/largeobject/LargeObjectManager.java:262
-#: org/postgresql/largeobject/LargeObjectManager.java:305
+#: org/postgresql/largeobject/LargeObjectManager.java:254
+#: org/postgresql/largeobject/LargeObjectManager.java:295
 msgid "Large Objects may not be used in auto-commit mode."
 msgstr "Auto-commit biçimde large object kullanılamaz."
 
@@ -1384,34 +1390,34 @@ msgstr ""
 msgid "The hostname {0} could not be verified."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:164
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:90
 msgid "The sslfactoryarg property may not be empty."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:180
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:106
 msgid ""
 "The environment variable containing the server's SSL certificate must not be "
 "empty."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:188
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:114
 msgid ""
 "The system property containing the server's SSL certificate must not be "
 "empty."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:195
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:121
 msgid ""
 "The sslfactoryarg property must start with the prefix file:, classpath:, "
 "env:, sys:, or -----BEGIN CERTIFICATE-----."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:207
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:133
 #, fuzzy
 msgid "An error occurred reading the certificate"
 msgstr "SSL bağlantısı ayarlanırken bir hata oluştu."
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:240
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:166
 msgid "No X509TrustManager found"
 msgstr ""
 
@@ -1546,31 +1552,31 @@ msgid ""
 "setSavePoint not allowed while an XA transaction is active."
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:177
-#: org/postgresql/xa/PGXAConnection.java:253
-#: org/postgresql/xa/PGXAConnection.java:347
+#: org/postgresql/xa/PGXAConnection.java:186
+#: org/postgresql/xa/PGXAConnection.java:272
+#: org/postgresql/xa/PGXAConnection.java:381
 #, java-format
 msgid "Invalid flags {0}"
 msgstr "Geçersiz seçenekler {0}"
 
-#: org/postgresql/xa/PGXAConnection.java:181
-#: org/postgresql/xa/PGXAConnection.java:257
-#: org/postgresql/xa/PGXAConnection.java:449
+#: org/postgresql/xa/PGXAConnection.java:190
+#: org/postgresql/xa/PGXAConnection.java:276
+#: org/postgresql/xa/PGXAConnection.java:491
 msgid "xid must not be null"
 msgstr "xid null olamaz"
 
-#: org/postgresql/xa/PGXAConnection.java:185
+#: org/postgresql/xa/PGXAConnection.java:194
 msgid "Connection is busy with another transaction"
 msgstr "Bağlantı, başka bir transaction tarafından meşgul ediliyor"
 
-#: org/postgresql/xa/PGXAConnection.java:194
-#: org/postgresql/xa/PGXAConnection.java:267
+#: org/postgresql/xa/PGXAConnection.java:203
+#: org/postgresql/xa/PGXAConnection.java:286
 msgid "suspend/resume not implemented"
 msgstr "suspend/resume desteklenmiyor"
 
-#: org/postgresql/xa/PGXAConnection.java:202
-#: org/postgresql/xa/PGXAConnection.java:209
-#: org/postgresql/xa/PGXAConnection.java:213
+#: org/postgresql/xa/PGXAConnection.java:211
+#: org/postgresql/xa/PGXAConnection.java:218
+#: org/postgresql/xa/PGXAConnection.java:222
 #, java-format
 msgid ""
 "Invalid protocol state requested. Attempted transaction interleaving is not "
@@ -1579,11 +1585,11 @@ msgstr ""
 "Transaction interleaving desteklenmiyor. xid={0}, currentXid={1}, state={2}, "
 "flags={3}"
 
-#: org/postgresql/xa/PGXAConnection.java:224
+#: org/postgresql/xa/PGXAConnection.java:233
 msgid "Error disabling autocommit"
 msgstr "autocommit'i devre dışı bırakma sırasında hata"
 
-#: org/postgresql/xa/PGXAConnection.java:261
+#: org/postgresql/xa/PGXAConnection.java:280
 #, java-format
 msgid ""
 "tried to call end without corresponding start call. state={0}, start "
@@ -1592,7 +1598,7 @@ msgstr ""
 "start çağırımı olmadan end çağırılmıştır. state={0}, start xid={1}, "
 "currentXid={2}, preparedXid={3}"
 
-#: org/postgresql/xa/PGXAConnection.java:297
+#: org/postgresql/xa/PGXAConnection.java:326
 #, fuzzy, java-format
 msgid ""
 "Preparing already prepared transaction, the prepared xid {0}, prepare xid={1}"
@@ -1600,12 +1606,12 @@ msgstr ""
 "Hazırlanmış transaction rollback hatası. rollback xid={0}, preparedXid={1}, "
 "currentXid={2}"
 
-#: org/postgresql/xa/PGXAConnection.java:300
+#: org/postgresql/xa/PGXAConnection.java:329
 #, java-format
 msgid "Current connection does not have an associated xid. prepare xid={0}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:307
+#: org/postgresql/xa/PGXAConnection.java:336
 #, java-format
 msgid ""
 "Not implemented: Prepare must be issued using the same connection that "
@@ -1614,21 +1620,21 @@ msgstr ""
 "Desteklenmiyor: Prepare, transaction başlatran bağlantı tarafından "
 "çağırmalıdır. currentXid={0}, prepare xid={1}"
 
-#: org/postgresql/xa/PGXAConnection.java:311
+#: org/postgresql/xa/PGXAConnection.java:340
 #, java-format
 msgid "Prepare called before end. prepare xid={0}, state={1}"
 msgstr "Sondan önce prepare çağırılmış. prepare xid={0}, state={1}"
 
-#: org/postgresql/xa/PGXAConnection.java:331
+#: org/postgresql/xa/PGXAConnection.java:360
 #, java-format
 msgid "Error preparing transaction. prepare xid={0}"
 msgstr "Transaction hazırlama hatası. prepare xid={0}"
 
-#: org/postgresql/xa/PGXAConnection.java:382
+#: org/postgresql/xa/PGXAConnection.java:416
 msgid "Error during recover"
 msgstr "Kurtarma sırasında hata"
 
-#: org/postgresql/xa/PGXAConnection.java:438
+#: org/postgresql/xa/PGXAConnection.java:480
 #, java-format
 msgid ""
 "Error rolling back prepared transaction. rollback xid={0}, preparedXid={1}, "
@@ -1637,13 +1643,13 @@ msgstr ""
 "Hazırlanmış transaction rollback hatası. rollback xid={0}, preparedXid={1}, "
 "currentXid={2}"
 
-#: org/postgresql/xa/PGXAConnection.java:471
+#: org/postgresql/xa/PGXAConnection.java:521
 #, java-format
 msgid ""
 "One-phase commit called for xid {0} but connection was prepared with xid {1}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:479
+#: org/postgresql/xa/PGXAConnection.java:529
 msgid ""
 "Not implemented: one-phase commit must be issued using the same connection "
 "that was used to start it"
@@ -1651,22 +1657,22 @@ msgstr ""
 "Desteklenmiyor: one-phase commit, işlevinde başlatan ve bitiren bağlantı "
 "aynı olmalıdır"
 
-#: org/postgresql/xa/PGXAConnection.java:483
+#: org/postgresql/xa/PGXAConnection.java:533
 #, java-format
 msgid "One-phase commit with unknown xid. commit xid={0}, currentXid={1}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:487
+#: org/postgresql/xa/PGXAConnection.java:537
 #, java-format
 msgid "commit called before end. commit xid={0}, state={1}"
 msgstr "commit, sondan önce çağırıldı. commit xid={0}, state={1}"
 
-#: org/postgresql/xa/PGXAConnection.java:498
+#: org/postgresql/xa/PGXAConnection.java:548
 #, java-format
 msgid "Error during one-phase commit. commit xid={0}"
 msgstr "One-phase commit sırasında hata. commit xid={0}"
 
-#: org/postgresql/xa/PGXAConnection.java:517
+#: org/postgresql/xa/PGXAConnection.java:576
 msgid ""
 "Not implemented: 2nd phase commit must be issued using an idle connection. "
 "commit xid={0}, currentXid={1}, state={2], transactionState={3}"
@@ -1674,7 +1680,7 @@ msgstr ""
 "Desteklenmiyor: 2nd phase commit, atıl bir bağlantıdan başlatılmalıdır. "
 "commit xid={0}, currentXid={1}, state={2], transactionState={3}"
 
-#: org/postgresql/xa/PGXAConnection.java:550
+#: org/postgresql/xa/PGXAConnection.java:609
 #, fuzzy, java-format
 msgid ""
 "Error committing prepared transaction. commit xid={0}, preparedXid={1}, "
@@ -1683,7 +1689,7 @@ msgstr ""
 "Hazırlanmış transaction rollback hatası. commit xid={0}, preparedXid={1}, "
 "currentXid={2}"
 
-#: org/postgresql/xa/PGXAConnection.java:567
+#: org/postgresql/xa/PGXAConnection.java:626
 #, java-format
 msgid "Heuristic commit/rollback not supported. forget xid={0}"
 msgstr "Heuristic commit/rollback desteklenmiyor. forget xid={0}"

--- a/pgjdbc/src/main/java/org/postgresql/translation/zh_CN.po
+++ b/pgjdbc/src/main/java/org/postgresql/translation/zh_CN.po
@@ -6,7 +6,6 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PostgreSQL JDBC Driver 8.3\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-06-05 10:57+0300\n"
 "PO-Revision-Date: 2008-01-31 14:34+0800\n"
 "Last-Translator: 郭朝益(ChaoYi, Kuo) <Kuo.ChaoYi@gmail.com>\n"
 "Language-Team: The PostgreSQL Development Team <Kuo.ChaoYi@gmail.com>\n"
@@ -18,56 +17,56 @@ msgstr ""
 "X-Poedit-Country: CHINA\n"
 "X-Poedit-SourceCharset: utf-8\n"
 
-#: org/postgresql/Driver.java:214
+#: org/postgresql/Driver.java:217
 msgid "Error loading default settings from driverconfig.properties"
 msgstr ""
 
-#: org/postgresql/Driver.java:226
+#: org/postgresql/Driver.java:229
 msgid "Properties for the driver contains a non-string value for the key "
 msgstr ""
 
-#: org/postgresql/Driver.java:270
+#: org/postgresql/Driver.java:272
 msgid ""
 "Your security policy has prevented the connection from being attempted.  You "
 "probably need to grant the connect java.net.SocketPermission to the database "
 "server host and port that you wish to connect to."
 msgstr ""
 
-#: org/postgresql/Driver.java:276 org/postgresql/Driver.java:408
+#: org/postgresql/Driver.java:278 org/postgresql/Driver.java:410
 msgid ""
 "Something unusual has occurred to cause the driver to fail. Please report "
 "this exception."
 msgstr "不明的原因导致驱动程序造成失败，请回报这个例外。"
 
-#: org/postgresql/Driver.java:416
+#: org/postgresql/Driver.java:418
 msgid "Connection attempt timed out."
 msgstr "Connection 尝试逾时。"
 
-#: org/postgresql/Driver.java:429
+#: org/postgresql/Driver.java:431
 msgid "Interrupted while attempting to connect."
 msgstr ""
 
-#: org/postgresql/Driver.java:682
+#: org/postgresql/Driver.java:687
 #, java-format
 msgid "Method {0} is not yet implemented."
 msgstr "这个 {0} 方法尚未被实作。"
 
-#: org/postgresql/PGProperty.java:535 org/postgresql/PGProperty.java:555
+#: org/postgresql/PGProperty.java:537 org/postgresql/PGProperty.java:557
 #, java-format
 msgid "{0} parameter value must be an integer but was: {1}"
 msgstr ""
 
-#: org/postgresql/copy/CopyManager.java:53
+#: org/postgresql/copy/CopyManager.java:49
 #, java-format
 msgid "Requested CopyIn but got {0}"
 msgstr ""
 
-#: org/postgresql/copy/CopyManager.java:64
+#: org/postgresql/copy/CopyManager.java:60
 #, java-format
 msgid "Requested CopyOut but got {0}"
 msgstr ""
 
-#: org/postgresql/copy/CopyManager.java:75
+#: org/postgresql/copy/CopyManager.java:71
 #, java-format
 msgid "Requested CopyDual but got {0}"
 msgstr ""
@@ -92,6 +91,11 @@ msgstr ""
 msgid "Cannot write to copy a byte of value {0}"
 msgstr ""
 
+#: org/postgresql/core/CommandCompleteParser.java:71
+#, fuzzy, java-format
+msgid "Unable to parse the count in command completion tag: {0}."
+msgstr "无法解读命令完成标签中的更新计数：{0}。"
+
 #: org/postgresql/core/ConnectionFactory.java:57
 #, java-format
 msgid "A connection could not be made using the requested protocol {0}."
@@ -112,7 +116,7 @@ msgstr ""
 msgid "Expected an EOF from server, got: {0}"
 msgstr ""
 
-#: org/postgresql/core/Parser.java:1006
+#: org/postgresql/core/Parser.java:1051
 #, java-format
 msgid "Malformed function or procedure escape syntax at offset {0}."
 msgstr "不正确的函式或程序 escape 语法于 {0}。"
@@ -168,23 +172,23 @@ msgstr "在标识识别符中不存在零位元组。"
 #: org/postgresql/core/v3/CompositeParameterList.java:33
 #: org/postgresql/core/v3/SimpleParameterList.java:54
 #: org/postgresql/core/v3/SimpleParameterList.java:65
-#: org/postgresql/jdbc/PgResultSet.java:2757
-#: org/postgresql/jdbc/PgResultSetMetaData.java:494
+#: org/postgresql/jdbc/PgResultSet.java:2755
+#: org/postgresql/jdbc/PgResultSetMetaData.java:388
 #, java-format
 msgid "The column index is out of range: {0}, number of columns: {1}."
 msgstr "栏位索引超过许可范围：{0}，栏位数：{1}。"
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:109
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:103
 #, fuzzy, java-format
 msgid "Invalid sslmode value: {0}"
 msgstr "无效的串流长度 {0}."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:124
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:118
 #, fuzzy, java-format
 msgid "Invalid targetServerType value: {0}"
 msgstr "无效的串流长度 {0}."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:246
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:239
 #, fuzzy, java-format
 msgid ""
 "Connection to {0} refused. Check that the hostname and port are correct and "
@@ -192,39 +196,39 @@ msgid ""
 msgstr ""
 "连线被拒，请检查主机名称和埠号，并确定 postmaster 可以接受 TCP/IP 连线。"
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:257
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:250
 #: org/postgresql/core/v3/replication/V3ReplicationProtocol.java:133
 msgid "The connection attempt failed."
 msgstr "尝试连线已失败。"
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:272
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:265
 #, java-format
 msgid "Could not find a server with specified targetServerType: {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:368
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:381
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:361
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:374
 msgid "The server does not support SSL."
 msgstr "服务器不支援 SSL 连线。"
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:395
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:388
 msgid "An error occurred while setting up the SSL connection."
 msgstr "进行 SSL 连线时发生错误。"
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:496
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:523
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:484
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:511
 msgid ""
 "The server requested password-based authentication, but no password was "
 "provided."
 msgstr "服务器要求使用密码验证，但是密码并未提供。"
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:626
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:614
 msgid ""
 "SCRAM authentication is not supported by this driver. You need JDK >= 8 and "
 "pgjdbc >= 42.2.0 (not \".jre\" versions)"
 msgstr ""
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:650
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:638
 #, java-format
 msgid ""
 "The authentication type {0} is not supported. Check that you have configured "
@@ -234,16 +238,16 @@ msgstr ""
 "不支援 {0} 验证类型。请核对您已经组态 pg_hba.conf 文件包含客户端的IP位址或网"
 "路区段，以及驱动程序所支援的验证架构模式已被支援。"
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:657
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2550
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2581
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2585
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2653
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:645
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2543
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2576
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2580
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2648
 #: org/postgresql/gss/GssAction.java:126
 msgid "Protocol error.  Session setup failed."
 msgstr "通讯协定错误，Session 初始化失败。"
 
-#: org/postgresql/core/v3/CopyInImpl.java:47
+#: org/postgresql/core/v3/CopyInImpl.java:49
 msgid "CopyIn copy direction can't receive data"
 msgstr ""
 
@@ -251,163 +255,158 @@ msgstr ""
 msgid "CommandComplete expected COPY but got: "
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:161
+#: org/postgresql/core/v3/QueryExecutorImpl.java:163
 msgid "Tried to obtain lock while already holding it"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:177
+#: org/postgresql/core/v3/QueryExecutorImpl.java:179
 msgid "Tried to break lock on database connection"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:195
+#: org/postgresql/core/v3/QueryExecutorImpl.java:197
 msgid "Interrupted while waiting to obtain lock on database connection"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:327
+#: org/postgresql/core/v3/QueryExecutorImpl.java:329
 msgid "Unable to bind parameter values for statement."
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:333
-#: org/postgresql/core/v3/QueryExecutorImpl.java:485
-#: org/postgresql/core/v3/QueryExecutorImpl.java:559
-#: org/postgresql/core/v3/QueryExecutorImpl.java:602
-#: org/postgresql/core/v3/QueryExecutorImpl.java:729
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2372
+#: org/postgresql/core/v3/QueryExecutorImpl.java:335
+#: org/postgresql/core/v3/QueryExecutorImpl.java:487
+#: org/postgresql/core/v3/QueryExecutorImpl.java:561
+#: org/postgresql/core/v3/QueryExecutorImpl.java:604
+#: org/postgresql/core/v3/QueryExecutorImpl.java:731
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2377
 #: org/postgresql/util/StreamWrapper.java:130
 #, fuzzy
 msgid "An I/O error occurred while sending to the backend."
 msgstr "传送数据至后端时发生 I/O 错误。"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:534
-#: org/postgresql/core/v3/QueryExecutorImpl.java:576
+#: org/postgresql/core/v3/QueryExecutorImpl.java:536
+#: org/postgresql/core/v3/QueryExecutorImpl.java:578
 #, java-format
 msgid "Expected command status BEGIN, got {0}."
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:581
+#: org/postgresql/core/v3/QueryExecutorImpl.java:583
 #: org/postgresql/jdbc/PgResultSet.java:1778
 #, java-format
 msgid "Unexpected command status: {0}."
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:687
+#: org/postgresql/core/v3/QueryExecutorImpl.java:689
 #, fuzzy
 msgid "An error occurred while trying to get the socket timeout."
 msgstr "传送数据至后端时发生 I/O 错误。"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:722
-#: org/postgresql/core/v3/QueryExecutorImpl.java:798
+#: org/postgresql/core/v3/QueryExecutorImpl.java:724
+#: org/postgresql/core/v3/QueryExecutorImpl.java:800
 #, java-format
 msgid "Unknown Response Type {0}."
 msgstr "不明的回应类型 {0}。"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:745
+#: org/postgresql/core/v3/QueryExecutorImpl.java:747
 #, fuzzy
 msgid "An error occurred while trying to reset the socket timeout."
 msgstr "传送数据至后端时发生 I/O 错误。"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:843
+#: org/postgresql/core/v3/QueryExecutorImpl.java:845
 msgid "Database connection failed when starting copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:878
+#: org/postgresql/core/v3/QueryExecutorImpl.java:880
 msgid "Tried to cancel an inactive copy operation"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:917
+#: org/postgresql/core/v3/QueryExecutorImpl.java:919
 msgid "Database connection failed when canceling copy operation"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:933
+#: org/postgresql/core/v3/QueryExecutorImpl.java:935
 msgid "Missing expected error response to copy cancel request"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:937
+#: org/postgresql/core/v3/QueryExecutorImpl.java:939
 #, java-format
 msgid "Got {0} error responses to single copy cancel request"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:952
+#: org/postgresql/core/v3/QueryExecutorImpl.java:954
 msgid "Tried to end inactive copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:967
+#: org/postgresql/core/v3/QueryExecutorImpl.java:969
 msgid "Database connection failed when ending copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:985
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1005
+#: org/postgresql/core/v3/QueryExecutorImpl.java:987
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1007
 msgid "Tried to write to an inactive copy operation"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:998
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1013
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1000
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1015
 msgid "Database connection failed when writing to copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1028
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1030
 msgid "Tried to read from inactive copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1035
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1037
 msgid "Database connection failed when reading from copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1101
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1103
 #, java-format
 msgid "Received CommandComplete ''{0}'' without an active copy operation"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1126
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1128
 #, java-format
 msgid "Got CopyInResponse from server during an active {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1140
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1142
 #, java-format
 msgid "Got CopyOutResponse from server during an active {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1154
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1156
 #, java-format
 msgid "Got CopyBothResponse from server during an active {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1170
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1172
 msgid "Got CopyData without an active copy operation"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1174
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1176
 #, java-format
 msgid "Unexpected copydata from server for {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1234
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1236
 #, java-format
 msgid "Unexpected packet type during copy: {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1524
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1526
 #, java-format
 msgid ""
 "Bind message length {0} too long.  This can be caused by very large or "
 "incorrect length specifications on InputStream parameters."
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2145
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2150
 msgid "Ran out of memory retrieving query results."
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2313
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2318
 msgid "The driver currently does not support COPY operations."
 msgstr "驱动程序目前不支援 COPY 操作。"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2487
-#, fuzzy, java-format
-msgid "Unable to parse the count in command completion tag: {0}."
-msgstr "无法解读命令完成标签中的更新计数：{0}。"
-
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2610
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2605
 #, fuzzy, java-format
 msgid ""
 "The server''s client_encoding parameter was changed to {0}. The JDBC driver "
@@ -416,7 +415,7 @@ msgstr ""
 "这服务器的 client_encoding 参数被改成 {0}，JDBC 驱动程序请求需要 "
 "client_encoding 为 UNICODE 以正确工作。"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2620
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2615
 #, java-format
 msgid ""
 "The server''s DateStyle parameter was changed to {0}. The JDBC driver "
@@ -425,7 +424,7 @@ msgstr ""
 "这服务器的 DateStyle 参数被更改成 {0}，JDBC 驱动程序请求需要 DateStyle 以 "
 "ISO 开头以正确工作。"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2633
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2628
 #, java-format
 msgid ""
 "The server''s standard_conforming_strings parameter was reported as {0}. The "
@@ -488,36 +487,36 @@ msgstr "DataSource 已经被关闭。"
 msgid "Unsupported property name: {0}"
 msgstr "未被支持的类型值：{0}"
 
-#: org/postgresql/fastpath/Fastpath.java:86
+#: org/postgresql/fastpath/Fastpath.java:84
 #, fuzzy, java-format
 msgid "Fastpath call {0} - No result was returned and we expected a numeric."
 msgstr "Fastpath 呼叫 {0} - 没有传回值，且应该传回一个整数。"
 
-#: org/postgresql/fastpath/Fastpath.java:163
+#: org/postgresql/fastpath/Fastpath.java:161
 #, java-format
 msgid "Fastpath call {0} - No result was returned and we expected an integer."
 msgstr "Fastpath 呼叫 {0} - 没有传回值，且应该传回一个整数。"
 
-#: org/postgresql/fastpath/Fastpath.java:171
+#: org/postgresql/fastpath/Fastpath.java:169
 #, fuzzy, java-format
 msgid ""
 "Fastpath call {0} - No result was returned or wrong size while expecting an "
 "integer."
 msgstr "Fastpath 呼叫 {0} - 没有传回值，且应该传回一个整数。"
 
-#: org/postgresql/fastpath/Fastpath.java:188
+#: org/postgresql/fastpath/Fastpath.java:186
 #, fuzzy, java-format
 msgid "Fastpath call {0} - No result was returned and we expected a long."
 msgstr "Fastpath 呼叫 {0} - 没有传回值，且应该传回一个整数。"
 
-#: org/postgresql/fastpath/Fastpath.java:196
+#: org/postgresql/fastpath/Fastpath.java:194
 #, fuzzy, java-format
 msgid ""
 "Fastpath call {0} - No result was returned or wrong size while expecting a "
 "long."
 msgstr "Fastpath 呼叫 {0} - 没有传回值，且应该传回一个整数。"
 
-#: org/postgresql/fastpath/Fastpath.java:308
+#: org/postgresql/fastpath/Fastpath.java:297
 #, java-format
 msgid "The fastpath function {0} is unknown."
 msgstr "不明的 fastpath 函式 {0}。"
@@ -583,63 +582,70 @@ msgid "Cannot cast to boolean: \"{0}\""
 msgstr ""
 
 #: org/postgresql/jdbc/EscapedFunctions.java:240
+#: org/postgresql/jdbc/EscapedFunctions2.java:167
 #, java-format
 msgid "{0} function takes four and only four argument."
 msgstr "{0} 函式取得四个且仅有四个引数。"
 
 #: org/postgresql/jdbc/EscapedFunctions.java:270
-#: org/postgresql/jdbc/EscapedFunctions.java:344
-#: org/postgresql/jdbc/EscapedFunctions.java:749
-#: org/postgresql/jdbc/EscapedFunctions.java:787
+#: org/postgresql/jdbc/EscapedFunctions.java:337
+#: org/postgresql/jdbc/EscapedFunctions.java:740
+#: org/postgresql/jdbc/EscapedFunctions2.java:196
+#: org/postgresql/jdbc/EscapedFunctions2.java:263
+#: org/postgresql/jdbc/EscapedFunctions2.java:665
 #, java-format
 msgid "{0} function takes two and only two arguments."
 msgstr "{0} 函式取得二个且仅有二个引数。"
 
 #: org/postgresql/jdbc/EscapedFunctions.java:288
-#: org/postgresql/jdbc/EscapedFunctions.java:326
-#: org/postgresql/jdbc/EscapedFunctions.java:446
-#: org/postgresql/jdbc/EscapedFunctions.java:461
-#: org/postgresql/jdbc/EscapedFunctions.java:476
-#: org/postgresql/jdbc/EscapedFunctions.java:491
-#: org/postgresql/jdbc/EscapedFunctions.java:506
-#: org/postgresql/jdbc/EscapedFunctions.java:521
-#: org/postgresql/jdbc/EscapedFunctions.java:536
-#: org/postgresql/jdbc/EscapedFunctions.java:551
-#: org/postgresql/jdbc/EscapedFunctions.java:566
-#: org/postgresql/jdbc/EscapedFunctions.java:581
-#: org/postgresql/jdbc/EscapedFunctions.java:596
-#: org/postgresql/jdbc/EscapedFunctions.java:611
-#: org/postgresql/jdbc/EscapedFunctions.java:775
+#: org/postgresql/jdbc/EscapedFunctions.java:441
+#: org/postgresql/jdbc/EscapedFunctions.java:467
+#: org/postgresql/jdbc/EscapedFunctions.java:526
+#: org/postgresql/jdbc/EscapedFunctions.java:728
+#: org/postgresql/jdbc/EscapedFunctions2.java:211
+#: org/postgresql/jdbc/EscapedFunctions2.java:355
+#: org/postgresql/jdbc/EscapedFunctions2.java:381
+#: org/postgresql/jdbc/EscapedFunctions2.java:440
+#: org/postgresql/jdbc/EscapedFunctions2.java:654
 #, java-format
 msgid "{0} function takes one and only one argument."
 msgstr "{0} 函式取得一个且仅有一个引数。"
 
-#: org/postgresql/jdbc/EscapedFunctions.java:310
-#: org/postgresql/jdbc/EscapedFunctions.java:391
+#: org/postgresql/jdbc/EscapedFunctions.java:312
+#: org/postgresql/jdbc/EscapedFunctions.java:386
+#: org/postgresql/jdbc/EscapedFunctions2.java:238
+#: org/postgresql/jdbc/EscapedFunctions2.java:307
 #, java-format
 msgid "{0} function takes two or three arguments."
 msgstr "{0} 函式取得二个或三个引数。"
 
-#: org/postgresql/jdbc/EscapedFunctions.java:416
-#: org/postgresql/jdbc/EscapedFunctions.java:431
-#: org/postgresql/jdbc/EscapedFunctions.java:734
-#: org/postgresql/jdbc/EscapedFunctions.java:764
+#: org/postgresql/jdbc/EscapedFunctions.java:411
+#: org/postgresql/jdbc/EscapedFunctions.java:426
+#: org/postgresql/jdbc/EscapedFunctions.java:693
+#: org/postgresql/jdbc/EscapedFunctions.java:719
+#: org/postgresql/jdbc/EscapedFunctions2.java:645
 #, java-format
 msgid "{0} function doesn''t take any argument."
 msgstr "{0} 函式无法取得任何的引数。"
 
-#: org/postgresql/jdbc/EscapedFunctions.java:627
-#: org/postgresql/jdbc/EscapedFunctions.java:680
+#: org/postgresql/jdbc/EscapedFunctions.java:586
+#: org/postgresql/jdbc/EscapedFunctions.java:639
+#: org/postgresql/jdbc/EscapedFunctions2.java:500
+#: org/postgresql/jdbc/EscapedFunctions2.java:571
 #, java-format
 msgid "{0} function takes three and only three arguments."
 msgstr "{0} 函式取得三个且仅有三个引数。"
 
-#: org/postgresql/jdbc/EscapedFunctions.java:640
-#: org/postgresql/jdbc/EscapedFunctions.java:661
-#: org/postgresql/jdbc/EscapedFunctions.java:664
-#: org/postgresql/jdbc/EscapedFunctions.java:697
-#: org/postgresql/jdbc/EscapedFunctions.java:710
-#: org/postgresql/jdbc/EscapedFunctions.java:713
+#: org/postgresql/jdbc/EscapedFunctions.java:599
+#: org/postgresql/jdbc/EscapedFunctions.java:620
+#: org/postgresql/jdbc/EscapedFunctions.java:623
+#: org/postgresql/jdbc/EscapedFunctions.java:656
+#: org/postgresql/jdbc/EscapedFunctions.java:669
+#: org/postgresql/jdbc/EscapedFunctions.java:672
+#: org/postgresql/jdbc/EscapedFunctions2.java:510
+#: org/postgresql/jdbc/EscapedFunctions2.java:527
+#: org/postgresql/jdbc/EscapedFunctions2.java:585
+#: org/postgresql/jdbc/EscapedFunctions2.java:597
 #, java-format
 msgid "Interval {0} not yet implemented"
 msgstr "隔绝 {0} 尚未被实作。"
@@ -658,17 +664,17 @@ msgstr "无法取得已命名储存点的 id。"
 msgid "Cannot retrieve the name of an unnamed savepoint."
 msgstr "无法取得未命名储存点(Savepoint)的名称。"
 
-#: org/postgresql/jdbc/PgArray.java:157 org/postgresql/jdbc/PgArray.java:844
+#: org/postgresql/jdbc/PgArray.java:155 org/postgresql/jdbc/PgArray.java:842
 #, java-format
 msgid "The array index is out of range: {0}"
 msgstr "阵列索引超过许可范围：{0}"
 
-#: org/postgresql/jdbc/PgArray.java:178 org/postgresql/jdbc/PgArray.java:861
+#: org/postgresql/jdbc/PgArray.java:176 org/postgresql/jdbc/PgArray.java:859
 #, java-format
 msgid "The array index is out of range: {0}, number of elements: {1}."
 msgstr "阵列索引超过许可范围：{0}，元素数量：{1}。"
 
-#: org/postgresql/jdbc/PgArray.java:210
+#: org/postgresql/jdbc/PgArray.java:208
 #: org/postgresql/jdbc/PgResultSet.java:1930
 #: org/postgresql/util/HStoreConverter.java:43
 #: org/postgresql/util/HStoreConverter.java:74
@@ -681,17 +687,17 @@ msgstr ""
 "发现不合法的字元，可能的原因是欲储存的数据中包含数据库的字元集不支援的字码，"
 "其中最常见例子的就是将 8 位元数据存入使用 SQL_ASCII 编码的数据库中。"
 
-#: org/postgresql/jdbc/PgCallableStatement.java:86
-#: org/postgresql/jdbc/PgCallableStatement.java:96
+#: org/postgresql/jdbc/PgCallableStatement.java:85
+#: org/postgresql/jdbc/PgCallableStatement.java:95
 msgid "A CallableStatement was executed with nothing returned."
 msgstr "一个 CallableStatement 执行函式后没有传回值。"
 
-#: org/postgresql/jdbc/PgCallableStatement.java:107
+#: org/postgresql/jdbc/PgCallableStatement.java:106
 #, fuzzy
 msgid "A CallableStatement was executed with an invalid number of parameters"
 msgstr "一个 CallableStatement 已执行包括一个无效的参数数值"
 
-#: org/postgresql/jdbc/PgCallableStatement.java:145
+#: org/postgresql/jdbc/PgCallableStatement.java:144
 #, java-format
 msgid ""
 "A CallableStatement function was executed and the out parameter {0} was of "
@@ -700,25 +706,25 @@ msgstr ""
 "一个 CallableStatement 执行函式后输出的参数类型为 {1} 值为 {0}，但是已注册的"
 "类型是 {2}。"
 
-#: org/postgresql/jdbc/PgCallableStatement.java:202
+#: org/postgresql/jdbc/PgCallableStatement.java:206
 msgid ""
 "This statement does not declare an OUT parameter.  Use '{' ?= call ... '}' "
 "to declare one."
 msgstr "这个 statement 未宣告 OUT 参数，使用 '{' ?= call ... '}' 宣告一个。"
 
-#: org/postgresql/jdbc/PgCallableStatement.java:246
+#: org/postgresql/jdbc/PgCallableStatement.java:229
 msgid "wasNull cannot be call before fetching a result."
 msgstr ""
 
-#: org/postgresql/jdbc/PgCallableStatement.java:384
-#: org/postgresql/jdbc/PgCallableStatement.java:403
+#: org/postgresql/jdbc/PgCallableStatement.java:367
+#: org/postgresql/jdbc/PgCallableStatement.java:386
 #, java-format
 msgid ""
 "Parameter of type {0} was registered, but call to get{1} (sqltype={2}) was "
 "made."
 msgstr "已注册参数类型 {0}，但是又呼叫了get{1}(sqltype={2})。"
 
-#: org/postgresql/jdbc/PgCallableStatement.java:424
+#: org/postgresql/jdbc/PgCallableStatement.java:407
 msgid ""
 "A CallableStatement was declared, but no call to registerOutParameter(1, "
 "<some type>) was made."
@@ -726,27 +732,27 @@ msgstr ""
 "已经宣告 CallableStatement 函式，但是尚未呼叫 registerOutParameter (1, "
 "<some_type>) 。"
 
-#: org/postgresql/jdbc/PgCallableStatement.java:430
+#: org/postgresql/jdbc/PgCallableStatement.java:413
 msgid "No function outputs were registered."
 msgstr ""
 
-#: org/postgresql/jdbc/PgCallableStatement.java:436
+#: org/postgresql/jdbc/PgCallableStatement.java:419
 msgid ""
 "Results cannot be retrieved from a CallableStatement before it is executed."
 msgstr ""
 
-#: org/postgresql/jdbc/PgCallableStatement.java:703
+#: org/postgresql/jdbc/PgCallableStatement.java:686
 #, fuzzy, java-format
 msgid "Unsupported type conversion to {1}."
 msgstr "未被支持的类型值：{0}"
 
-#: org/postgresql/jdbc/PgConnection.java:272
+#: org/postgresql/jdbc/PgConnection.java:241
 #, java-format
 msgid "Unsupported value for stringtype parameter: {0}"
 msgstr "字符类型参数值未被支持：{0}"
 
 #: org/postgresql/jdbc/PgConnection.java:424
-#: org/postgresql/jdbc/PgPreparedStatement.java:119
+#: org/postgresql/jdbc/PgPreparedStatement.java:107
 #: org/postgresql/jdbc/PgStatement.java:225
 #: org/postgresql/jdbc/TypeInfoCache.java:226
 #: org/postgresql/jdbc/TypeInfoCache.java:371
@@ -758,126 +764,126 @@ msgstr "字符类型参数值未被支持：{0}"
 msgid "No results were returned by the query."
 msgstr "查询没有传回任何结果。"
 
-#: org/postgresql/jdbc/PgConnection.java:441
+#: org/postgresql/jdbc/PgConnection.java:442
 #: org/postgresql/jdbc/PgStatement.java:254
 msgid "A result was returned when none was expected."
 msgstr "传回预期之外的结果。"
 
-#: org/postgresql/jdbc/PgConnection.java:545
+#: org/postgresql/jdbc/PgConnection.java:547
 msgid "Custom type maps are not supported."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:587
+#: org/postgresql/jdbc/PgConnection.java:589
 #, java-format
 msgid "Failed to create object for: {0}."
 msgstr "为 {0} 建立对象失败。"
 
-#: org/postgresql/jdbc/PgConnection.java:641
+#: org/postgresql/jdbc/PgConnection.java:643
 #, java-format
 msgid "Unable to load the class {0} responsible for the datatype {1}"
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:693
+#: org/postgresql/jdbc/PgConnection.java:705
 msgid ""
 "Cannot change transaction read-only property in the middle of a transaction."
 msgstr "不能在事物交易过程中改变事物交易唯读属性。"
 
-#: org/postgresql/jdbc/PgConnection.java:756
+#: org/postgresql/jdbc/PgConnection.java:772
 msgid "Cannot commit when autoCommit is enabled."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:767
-#: org/postgresql/jdbc/PgConnection.java:1384
-#: org/postgresql/jdbc/PgConnection.java:1428
+#: org/postgresql/jdbc/PgConnection.java:783
+#: org/postgresql/jdbc/PgConnection.java:1401
+#: org/postgresql/jdbc/PgConnection.java:1445
 #, fuzzy
 msgid "This connection has been closed."
 msgstr "Connection 已经被关闭。"
 
-#: org/postgresql/jdbc/PgConnection.java:777
+#: org/postgresql/jdbc/PgConnection.java:794
 msgid "Cannot rollback when autoCommit is enabled."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:827
+#: org/postgresql/jdbc/PgConnection.java:844
 msgid ""
 "Cannot change transaction isolation level in the middle of a transaction."
 msgstr "不能在事务交易过程中改变事物交易隔绝等级。"
 
-#: org/postgresql/jdbc/PgConnection.java:833
+#: org/postgresql/jdbc/PgConnection.java:850
 #, java-format
 msgid "Transaction isolation level {0} not supported."
 msgstr "不支援交易隔绝等级 {0} 。"
 
-#: org/postgresql/jdbc/PgConnection.java:878
+#: org/postgresql/jdbc/PgConnection.java:895
 msgid "Finalizing a Connection that was never closed:"
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:945
+#: org/postgresql/jdbc/PgConnection.java:962
 msgid "Unable to translate data into the desired encoding."
 msgstr "无法将数据转成目标编码。"
 
-#: org/postgresql/jdbc/PgConnection.java:1008
+#: org/postgresql/jdbc/PgConnection.java:1025
 #: org/postgresql/jdbc/PgResultSet.java:1817
-#: org/postgresql/jdbc/PgStatement.java:903
+#: org/postgresql/jdbc/PgStatement.java:908
 msgid "Fetch size must be a value greater to or equal to 0."
 msgstr "数据读取笔数(fetch size)必须大于或等于 0。"
 
-#: org/postgresql/jdbc/PgConnection.java:1289
-#: org/postgresql/jdbc/PgConnection.java:1330
+#: org/postgresql/jdbc/PgConnection.java:1306
+#: org/postgresql/jdbc/PgConnection.java:1347
 #, java-format
 msgid "Unable to find server array type for provided name {0}."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1312
+#: org/postgresql/jdbc/PgConnection.java:1329
 #, fuzzy, java-format
 msgid "Invalid elements {0}"
 msgstr "无效的旗标 flags {0}"
 
-#: org/postgresql/jdbc/PgConnection.java:1348
+#: org/postgresql/jdbc/PgConnection.java:1365
 #, fuzzy, java-format
 msgid "Invalid timeout ({0}<0)."
 msgstr "无效的串流长度 {0}."
 
-#: org/postgresql/jdbc/PgConnection.java:1372
+#: org/postgresql/jdbc/PgConnection.java:1389
 msgid "Validating connection."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1405
+#: org/postgresql/jdbc/PgConnection.java:1422
 #, fuzzy, java-format
 msgid "Failed to set ClientInfo property: {0}"
 msgstr "为 {0} 建立对象失败。"
 
-#: org/postgresql/jdbc/PgConnection.java:1415
+#: org/postgresql/jdbc/PgConnection.java:1432
 msgid "ClientInfo property not supported."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1441
+#: org/postgresql/jdbc/PgConnection.java:1458
 msgid "One ore more ClientInfo failed."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1540
+#: org/postgresql/jdbc/PgConnection.java:1559
 #, fuzzy
 msgid "Network timeout must be a value greater than or equal to 0."
 msgstr "查询逾时等候时间必须大于或等于 0。"
 
-#: org/postgresql/jdbc/PgConnection.java:1552
+#: org/postgresql/jdbc/PgConnection.java:1571
 msgid "Unable to set network timeout."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1563
+#: org/postgresql/jdbc/PgConnection.java:1582
 msgid "Unable to get network timeout."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1580
+#: org/postgresql/jdbc/PgConnection.java:1599
 #, java-format
 msgid "Unknown ResultSet holdability setting: {0}."
 msgstr "未知的 ResultSet 可适用的设置：{0}。"
 
-#: org/postgresql/jdbc/PgConnection.java:1598
-#: org/postgresql/jdbc/PgConnection.java:1619
+#: org/postgresql/jdbc/PgConnection.java:1617
+#: org/postgresql/jdbc/PgConnection.java:1638
 msgid "Cannot establish a savepoint in auto-commit mode."
 msgstr "在自动确认事物交易模式无法建立储存点(Savepoint)。"
 
-#: org/postgresql/jdbc/PgConnection.java:1685
+#: org/postgresql/jdbc/PgConnection.java:1707
 msgid "Returning autogenerated keys is not supported."
 msgstr ""
 
@@ -891,47 +897,47 @@ msgstr ""
 msgid "Unable to find name datatype in the system catalogs."
 msgstr "在系统 catalog 中找不到名称数据类型(datatype)。"
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:323
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:322
 #, fuzzy
 msgid "Unable to find keywords in the system catalogs."
 msgstr "在系统 catalog 中找不到名称数据类型(datatype)。"
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1105
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1095
 msgid "oid"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1105
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1095
 msgid "proname"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1107
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1558
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1097
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1548
 msgid "typtype"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1110
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1100
 msgid "proargtypes"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1576
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1566
 msgid "adsrc"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1589
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1579
 msgid "attidentity"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1685
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1761
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1675
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1751
 msgid "rolname"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1686
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1762
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1676
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1752
 msgid "relacl"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1692
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1682
 msgid "attacl"
 msgstr ""
 
@@ -940,83 +946,83 @@ msgstr ""
 msgid "The parameter index is out of range: {0}, number of parameters: {1}."
 msgstr "参数索引超出许可范围：{0}，参数总数：{1}。"
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:106
+#: org/postgresql/jdbc/PgPreparedStatement.java:94
+#: org/postgresql/jdbc/PgPreparedStatement.java:115
 #: org/postgresql/jdbc/PgPreparedStatement.java:127
-#: org/postgresql/jdbc/PgPreparedStatement.java:139
-#: org/postgresql/jdbc/PgPreparedStatement.java:1035
+#: org/postgresql/jdbc/PgPreparedStatement.java:1008
 msgid ""
 "Can''t use query methods that take a query string on a PreparedStatement."
 msgstr "在 PreparedStatement 上不能使用获取查询字符的查询方法。"
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:249
+#: org/postgresql/jdbc/PgPreparedStatement.java:237
 msgid "Unknown Types value."
 msgstr "不明的类型值。"
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:382
-#: org/postgresql/jdbc/PgPreparedStatement.java:439
-#: org/postgresql/jdbc/PgPreparedStatement.java:1191
-#: org/postgresql/jdbc/PgPreparedStatement.java:1490
+#: org/postgresql/jdbc/PgPreparedStatement.java:364
+#: org/postgresql/jdbc/PgPreparedStatement.java:421
+#: org/postgresql/jdbc/PgPreparedStatement.java:1164
+#: org/postgresql/jdbc/PgPreparedStatement.java:1472
 #, java-format
 msgid "Invalid stream length {0}."
 msgstr "无效的串流长度 {0}."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:411
+#: org/postgresql/jdbc/PgPreparedStatement.java:393
 #, java-format
 msgid "The JVM claims not to support the {0} encoding."
 msgstr "JVM 声明并不支援 {0} 编码。"
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:414
+#: org/postgresql/jdbc/PgPreparedStatement.java:396
 #: org/postgresql/jdbc/PgResultSet.java:1122
 #: org/postgresql/jdbc/PgResultSet.java:1156
 msgid "Provided InputStream failed."
 msgstr "提供的 InputStream 已失败。"
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:460
-#: org/postgresql/jdbc/PgPreparedStatement.java:1096
+#: org/postgresql/jdbc/PgPreparedStatement.java:442
+#: org/postgresql/jdbc/PgPreparedStatement.java:1069
 #, java-format
 msgid "Unknown type {0}."
 msgstr "不明的类型 {0}"
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:477
+#: org/postgresql/jdbc/PgPreparedStatement.java:459
 msgid "No hstore extension installed."
 msgstr ""
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:619
-#: org/postgresql/jdbc/PgPreparedStatement.java:642
-#: org/postgresql/jdbc/PgPreparedStatement.java:652
-#: org/postgresql/jdbc/PgPreparedStatement.java:664
+#: org/postgresql/jdbc/PgPreparedStatement.java:601
+#: org/postgresql/jdbc/PgPreparedStatement.java:624
+#: org/postgresql/jdbc/PgPreparedStatement.java:634
+#: org/postgresql/jdbc/PgPreparedStatement.java:646
 #, java-format
 msgid "Cannot cast an instance of {0} to type {1}"
 msgstr "不能转换一个 {0} 实例到类型 {1}"
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:682
+#: org/postgresql/jdbc/PgPreparedStatement.java:664
 #, java-format
 msgid "Unsupported Types value: {0}"
 msgstr "未被支持的类型值：{0}"
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:894
+#: org/postgresql/jdbc/PgPreparedStatement.java:876
 #, java-format
 msgid "Cannot convert an instance of {0} to type {1}"
 msgstr "无法转换 {0} 到类型 {1} 的实例"
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:968
+#: org/postgresql/jdbc/PgPreparedStatement.java:950
 #, java-format
 msgid ""
 "Can''t infer the SQL type to use for an instance of {0}. Use setObject() "
 "with an explicit Types value to specify the type to use."
 msgstr ""
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:1133
-#: org/postgresql/jdbc/PgPreparedStatement.java:1233
+#: org/postgresql/jdbc/PgPreparedStatement.java:1106
+#: org/postgresql/jdbc/PgPreparedStatement.java:1206
 msgid "Unexpected error writing large object to database."
 msgstr "将大型对象(large object)写入数据库时发生不明错误。"
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:1178
+#: org/postgresql/jdbc/PgPreparedStatement.java:1151
 #: org/postgresql/jdbc/PgResultSet.java:1210
 msgid "Provided Reader failed."
 msgstr "提供的 Reader 已失败。"
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:1449
+#: org/postgresql/jdbc/PgPreparedStatement.java:1431
 #: org/postgresql/util/StreamWrapper.java:56
 msgid "Object is too large to send over the protocol."
 msgstr ""
@@ -1032,8 +1038,8 @@ msgstr "操作要求可卷动的 ResultSet，但此 ResultSet 是 FORWARD_ONLY�
 #: org/postgresql/jdbc/PgResultSet.java:556
 #: org/postgresql/jdbc/PgResultSet.java:594
 #: org/postgresql/jdbc/PgResultSet.java:624
-#: org/postgresql/jdbc/PgResultSet.java:3014
-#: org/postgresql/jdbc/PgResultSet.java:3058
+#: org/postgresql/jdbc/PgResultSet.java:3012
+#: org/postgresql/jdbc/PgResultSet.java:3057
 #, fuzzy, java-format
 msgid "Cannot convert the column of type {0} to requested type {1}."
 msgstr "无法转换 {0} 到类型 {1} 的实例"
@@ -1045,7 +1051,7 @@ msgid "Can''t use relative move methods while on the insert row."
 msgstr "不能在新增的数据列上使用相对位置 move 方法。"
 
 #: org/postgresql/jdbc/PgResultSet.java:878
-#: org/postgresql/jdbc/PgStatement.java:895
+#: org/postgresql/jdbc/PgStatement.java:900
 #, java-format
 msgid "Invalid fetch direction constant: {0}."
 msgstr "无效的 fetch 方向常数：{0}。"
@@ -1084,8 +1090,8 @@ msgstr ""
 
 #: org/postgresql/jdbc/PgResultSet.java:1119
 #: org/postgresql/jdbc/PgResultSet.java:1754
-#: org/postgresql/jdbc/PgResultSet.java:2422
-#: org/postgresql/jdbc/PgResultSet.java:2443
+#: org/postgresql/jdbc/PgResultSet.java:2420
+#: org/postgresql/jdbc/PgResultSet.java:2441
 #, java-format
 msgid "The JVM claims not to support the encoding: {0}"
 msgstr "JVM 声明并不支援编码：{0} 。"
@@ -1099,7 +1105,7 @@ msgid "Cannot call updateRow() when on the insert row."
 msgstr "不能在新增的数据列上呼叫 deleteRow()。"
 
 #: org/postgresql/jdbc/PgResultSet.java:1335
-#: org/postgresql/jdbc/PgResultSet.java:3075
+#: org/postgresql/jdbc/PgResultSet.java:3074
 msgid ""
 "Cannot update the ResultSet because it is either before the start or after "
 "the end of the results."
@@ -1116,27 +1122,27 @@ msgstr "{0} 数据表中未找到主键(Primary key)。"
 
 #: org/postgresql/jdbc/PgResultSet.java:2017
 #: org/postgresql/jdbc/PgResultSet.java:2022
-#: org/postgresql/jdbc/PgResultSet.java:2809
-#: org/postgresql/jdbc/PgResultSet.java:2815
-#: org/postgresql/jdbc/PgResultSet.java:2840
-#: org/postgresql/jdbc/PgResultSet.java:2846
-#: org/postgresql/jdbc/PgResultSet.java:2870
-#: org/postgresql/jdbc/PgResultSet.java:2875
-#: org/postgresql/jdbc/PgResultSet.java:2891
-#: org/postgresql/jdbc/PgResultSet.java:2912
-#: org/postgresql/jdbc/PgResultSet.java:2923
-#: org/postgresql/jdbc/PgResultSet.java:2936
-#: org/postgresql/jdbc/PgResultSet.java:3063
+#: org/postgresql/jdbc/PgResultSet.java:2807
+#: org/postgresql/jdbc/PgResultSet.java:2813
+#: org/postgresql/jdbc/PgResultSet.java:2838
+#: org/postgresql/jdbc/PgResultSet.java:2844
+#: org/postgresql/jdbc/PgResultSet.java:2868
+#: org/postgresql/jdbc/PgResultSet.java:2873
+#: org/postgresql/jdbc/PgResultSet.java:2889
+#: org/postgresql/jdbc/PgResultSet.java:2910
+#: org/postgresql/jdbc/PgResultSet.java:2921
+#: org/postgresql/jdbc/PgResultSet.java:2934
+#: org/postgresql/jdbc/PgResultSet.java:3062
 #, java-format
 msgid "Bad value for type {0} : {1}"
 msgstr "不良的类型值 {0} : {1}"
 
-#: org/postgresql/jdbc/PgResultSet.java:2595
+#: org/postgresql/jdbc/PgResultSet.java:2593
 #, java-format
 msgid "The column name {0} was not found in this ResultSet."
 msgstr "ResultSet 中找不到栏位名称 {0}。"
 
-#: org/postgresql/jdbc/PgResultSet.java:2731
+#: org/postgresql/jdbc/PgResultSet.java:2729
 msgid ""
 "ResultSet is not updateable.  The query that generated this result set must "
 "select only one table, and must select all primary keys from that table. See "
@@ -1145,42 +1151,42 @@ msgstr ""
 "不可更新的 ResultSet。用来产生这个 ResultSet 的 SQL 命令只能操作一个数据表，"
 "并且必需选择所有主键栏位，详细请参阅 JDBC 2.1 API 规格书 5.6 节。"
 
-#: org/postgresql/jdbc/PgResultSet.java:2743
+#: org/postgresql/jdbc/PgResultSet.java:2741
 msgid "This ResultSet is closed."
 msgstr "这个 ResultSet 已经被关闭。"
 
-#: org/postgresql/jdbc/PgResultSet.java:2774
+#: org/postgresql/jdbc/PgResultSet.java:2772
 msgid "ResultSet not positioned properly, perhaps you need to call next."
 msgstr "查询结果指标位置不正确，您也许需要呼叫 ResultSet 的 next() 方法。"
 
-#: org/postgresql/jdbc/PgResultSet.java:3095
+#: org/postgresql/jdbc/PgResultSet.java:3094
 #, fuzzy
 msgid "Invalid UUID data."
 msgstr "无效的旗标"
 
-#: org/postgresql/jdbc/PgResultSet.java:3184
-#: org/postgresql/jdbc/PgResultSet.java:3191
-#: org/postgresql/jdbc/PgResultSet.java:3202
-#: org/postgresql/jdbc/PgResultSet.java:3213
-#: org/postgresql/jdbc/PgResultSet.java:3224
-#: org/postgresql/jdbc/PgResultSet.java:3235
-#: org/postgresql/jdbc/PgResultSet.java:3246
-#: org/postgresql/jdbc/PgResultSet.java:3257
-#: org/postgresql/jdbc/PgResultSet.java:3268
-#: org/postgresql/jdbc/PgResultSet.java:3275
-#: org/postgresql/jdbc/PgResultSet.java:3282
-#: org/postgresql/jdbc/PgResultSet.java:3293
-#: org/postgresql/jdbc/PgResultSet.java:3310
-#: org/postgresql/jdbc/PgResultSet.java:3317
-#: org/postgresql/jdbc/PgResultSet.java:3324
-#: org/postgresql/jdbc/PgResultSet.java:3335
-#: org/postgresql/jdbc/PgResultSet.java:3342
-#: org/postgresql/jdbc/PgResultSet.java:3349
-#: org/postgresql/jdbc/PgResultSet.java:3387
-#: org/postgresql/jdbc/PgResultSet.java:3394
-#: org/postgresql/jdbc/PgResultSet.java:3401
-#: org/postgresql/jdbc/PgResultSet.java:3421
-#: org/postgresql/jdbc/PgResultSet.java:3434
+#: org/postgresql/jdbc/PgResultSet.java:3183
+#: org/postgresql/jdbc/PgResultSet.java:3190
+#: org/postgresql/jdbc/PgResultSet.java:3201
+#: org/postgresql/jdbc/PgResultSet.java:3212
+#: org/postgresql/jdbc/PgResultSet.java:3223
+#: org/postgresql/jdbc/PgResultSet.java:3234
+#: org/postgresql/jdbc/PgResultSet.java:3245
+#: org/postgresql/jdbc/PgResultSet.java:3256
+#: org/postgresql/jdbc/PgResultSet.java:3267
+#: org/postgresql/jdbc/PgResultSet.java:3274
+#: org/postgresql/jdbc/PgResultSet.java:3281
+#: org/postgresql/jdbc/PgResultSet.java:3292
+#: org/postgresql/jdbc/PgResultSet.java:3309
+#: org/postgresql/jdbc/PgResultSet.java:3316
+#: org/postgresql/jdbc/PgResultSet.java:3323
+#: org/postgresql/jdbc/PgResultSet.java:3334
+#: org/postgresql/jdbc/PgResultSet.java:3341
+#: org/postgresql/jdbc/PgResultSet.java:3348
+#: org/postgresql/jdbc/PgResultSet.java:3386
+#: org/postgresql/jdbc/PgResultSet.java:3393
+#: org/postgresql/jdbc/PgResultSet.java:3400
+#: org/postgresql/jdbc/PgResultSet.java:3420
+#: org/postgresql/jdbc/PgResultSet.java:3433
 #, fuzzy, java-format
 msgid "conversion to {0} from {1} not supported"
 msgstr "不支援交易隔绝等级 {0} 。"
@@ -1246,33 +1252,33 @@ msgstr ""
 msgid "Maximum number of rows must be a value grater than or equal to 0."
 msgstr "最大数据读取笔数必须大于或等于 0。"
 
-#: org/postgresql/jdbc/PgStatement.java:550
+#: org/postgresql/jdbc/PgStatement.java:555
 msgid "Query timeout must be a value greater than or equals to 0."
 msgstr "查询逾时等候时间必须大于或等于 0。"
 
-#: org/postgresql/jdbc/PgStatement.java:590
+#: org/postgresql/jdbc/PgStatement.java:595
 msgid "The maximum field size must be a value greater than or equal to 0."
 msgstr "最大栏位容量必须大于或等于 0。"
 
-#: org/postgresql/jdbc/PgStatement.java:689
+#: org/postgresql/jdbc/PgStatement.java:694
 msgid "This statement has been closed."
 msgstr "这个 statement 已经被关闭。"
 
-#: org/postgresql/jdbc/PgStatement.java:1145
-#: org/postgresql/jdbc/PgStatement.java:1173
+#: org/postgresql/jdbc/PgStatement.java:1150
+#: org/postgresql/jdbc/PgStatement.java:1178
 msgid "Returning autogenerated keys by column index is not supported."
 msgstr ""
 
-#: org/postgresql/jdbc/TimestampUtils.java:355
-#: org/postgresql/jdbc/TimestampUtils.java:423
+#: org/postgresql/jdbc/TimestampUtils.java:365
+#: org/postgresql/jdbc/TimestampUtils.java:433
 #, fuzzy, java-format
 msgid "Bad value for type timestamp/date/time: {1}"
 msgstr "不良的类型值 {0} : {1}"
 
-#: org/postgresql/jdbc/TimestampUtils.java:858
-#: org/postgresql/jdbc/TimestampUtils.java:915
-#: org/postgresql/jdbc/TimestampUtils.java:961
-#: org/postgresql/jdbc/TimestampUtils.java:1010
+#: org/postgresql/jdbc/TimestampUtils.java:914
+#: org/postgresql/jdbc/TimestampUtils.java:971
+#: org/postgresql/jdbc/TimestampUtils.java:1017
+#: org/postgresql/jdbc/TimestampUtils.java:1066
 #, fuzzy, java-format
 msgid "Unsupported binary encoding of {0}."
 msgstr "未被支持的类型值：{0}"
@@ -1285,31 +1291,31 @@ msgstr ""
 msgid "Invalid or unsupported by client SCRAM mechanisms"
 msgstr ""
 
-#: org/postgresql/jre8/sasl/ScramAuthenticator.java:117
+#: org/postgresql/jre8/sasl/ScramAuthenticator.java:119
 #, fuzzy, java-format
 msgid "Invalid server-first-message: {0}"
 msgstr "无效的串流长度 {0}."
 
-#: org/postgresql/jre8/sasl/ScramAuthenticator.java:147
+#: org/postgresql/jre8/sasl/ScramAuthenticator.java:151
 #, fuzzy, java-format
 msgid "Invalid server-final-message: {0}"
 msgstr "无效的串流长度 {0}."
 
-#: org/postgresql/jre8/sasl/ScramAuthenticator.java:153
+#: org/postgresql/jre8/sasl/ScramAuthenticator.java:157
 #, java-format
 msgid "SCRAM authentication failed, server returned error: {0}"
 msgstr ""
 
-#: org/postgresql/jre8/sasl/ScramAuthenticator.java:160
+#: org/postgresql/jre8/sasl/ScramAuthenticator.java:164
 msgid "Invalid server SCRAM signature"
 msgstr ""
 
-#: org/postgresql/largeobject/LargeObjectManager.java:144
+#: org/postgresql/largeobject/LargeObjectManager.java:136
 msgid "Failed to initialize LargeObject API"
 msgstr "初始化 LargeObject API 失败"
 
-#: org/postgresql/largeobject/LargeObjectManager.java:262
-#: org/postgresql/largeobject/LargeObjectManager.java:305
+#: org/postgresql/largeobject/LargeObjectManager.java:254
+#: org/postgresql/largeobject/LargeObjectManager.java:295
 msgid "Large Objects may not be used in auto-commit mode."
 msgstr "大型对象无法被使用在自动确认事物交易模式。"
 
@@ -1343,34 +1349,34 @@ msgstr ""
 msgid "The hostname {0} could not be verified."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:164
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:90
 msgid "The sslfactoryarg property may not be empty."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:180
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:106
 msgid ""
 "The environment variable containing the server's SSL certificate must not be "
 "empty."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:188
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:114
 msgid ""
 "The system property containing the server's SSL certificate must not be "
 "empty."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:195
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:121
 msgid ""
 "The sslfactoryarg property must start with the prefix file:, classpath:, "
 "env:, sys:, or -----BEGIN CERTIFICATE-----."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:207
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:133
 #, fuzzy
 msgid "An error occurred reading the certificate"
 msgstr "进行 SSL 连线时发生错误。"
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:240
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:166
 msgid "No X509TrustManager found"
 msgstr ""
 
@@ -1505,31 +1511,31 @@ msgid ""
 "setSavePoint not allowed while an XA transaction is active."
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:177
-#: org/postgresql/xa/PGXAConnection.java:253
-#: org/postgresql/xa/PGXAConnection.java:347
+#: org/postgresql/xa/PGXAConnection.java:186
+#: org/postgresql/xa/PGXAConnection.java:272
+#: org/postgresql/xa/PGXAConnection.java:381
 #, java-format
 msgid "Invalid flags {0}"
 msgstr "无效的旗标 flags {0}"
 
-#: org/postgresql/xa/PGXAConnection.java:181
-#: org/postgresql/xa/PGXAConnection.java:257
-#: org/postgresql/xa/PGXAConnection.java:449
+#: org/postgresql/xa/PGXAConnection.java:190
+#: org/postgresql/xa/PGXAConnection.java:276
+#: org/postgresql/xa/PGXAConnection.java:491
 msgid "xid must not be null"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:185
+#: org/postgresql/xa/PGXAConnection.java:194
 msgid "Connection is busy with another transaction"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:194
-#: org/postgresql/xa/PGXAConnection.java:267
+#: org/postgresql/xa/PGXAConnection.java:203
+#: org/postgresql/xa/PGXAConnection.java:286
 msgid "suspend/resume not implemented"
 msgstr "暂停(suspend)/再继续(resume)尚未被实作。"
 
-#: org/postgresql/xa/PGXAConnection.java:202
-#: org/postgresql/xa/PGXAConnection.java:209
-#: org/postgresql/xa/PGXAConnection.java:213
+#: org/postgresql/xa/PGXAConnection.java:211
+#: org/postgresql/xa/PGXAConnection.java:218
+#: org/postgresql/xa/PGXAConnection.java:222
 #, java-format
 msgid ""
 "Invalid protocol state requested. Attempted transaction interleaving is not "
@@ -1538,97 +1544,97 @@ msgstr ""
 "事物交易隔绝(Transaction interleaving)未被实作。xid={0}, currentXid={1}, "
 "state={2}, flags={3}"
 
-#: org/postgresql/xa/PGXAConnection.java:224
+#: org/postgresql/xa/PGXAConnection.java:233
 msgid "Error disabling autocommit"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:261
+#: org/postgresql/xa/PGXAConnection.java:280
 #, java-format
 msgid ""
 "tried to call end without corresponding start call. state={0}, start "
 "xid={1}, currentXid={2}, preparedXid={3}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:297
+#: org/postgresql/xa/PGXAConnection.java:326
 #, java-format
 msgid ""
 "Preparing already prepared transaction, the prepared xid {0}, prepare xid={1}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:300
+#: org/postgresql/xa/PGXAConnection.java:329
 #, java-format
 msgid "Current connection does not have an associated xid. prepare xid={0}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:307
+#: org/postgresql/xa/PGXAConnection.java:336
 #, java-format
 msgid ""
 "Not implemented: Prepare must be issued using the same connection that "
 "started the transaction. currentXid={0}, prepare xid={1}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:311
+#: org/postgresql/xa/PGXAConnection.java:340
 #, java-format
 msgid "Prepare called before end. prepare xid={0}, state={1}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:331
+#: org/postgresql/xa/PGXAConnection.java:360
 #, java-format
 msgid "Error preparing transaction. prepare xid={0}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:382
+#: org/postgresql/xa/PGXAConnection.java:416
 msgid "Error during recover"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:438
+#: org/postgresql/xa/PGXAConnection.java:480
 #, java-format
 msgid ""
 "Error rolling back prepared transaction. rollback xid={0}, preparedXid={1}, "
 "currentXid={2}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:471
+#: org/postgresql/xa/PGXAConnection.java:521
 #, java-format
 msgid ""
 "One-phase commit called for xid {0} but connection was prepared with xid {1}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:479
+#: org/postgresql/xa/PGXAConnection.java:529
 msgid ""
 "Not implemented: one-phase commit must be issued using the same connection "
 "that was used to start it"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:483
+#: org/postgresql/xa/PGXAConnection.java:533
 #, java-format
 msgid "One-phase commit with unknown xid. commit xid={0}, currentXid={1}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:487
+#: org/postgresql/xa/PGXAConnection.java:537
 #, java-format
 msgid "commit called before end. commit xid={0}, state={1}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:498
+#: org/postgresql/xa/PGXAConnection.java:548
 #, java-format
 msgid "Error during one-phase commit. commit xid={0}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:517
+#: org/postgresql/xa/PGXAConnection.java:576
 msgid ""
 "Not implemented: 2nd phase commit must be issued using an idle connection. "
 "commit xid={0}, currentXid={1}, state={2], transactionState={3}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:550
+#: org/postgresql/xa/PGXAConnection.java:609
 #, java-format
 msgid ""
 "Error committing prepared transaction. commit xid={0}, preparedXid={1}, "
 "currentXid={2}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:567
+#: org/postgresql/xa/PGXAConnection.java:626
 #, java-format
 msgid "Heuristic commit/rollback not supported. forget xid={0}"
 msgstr ""

--- a/pgjdbc/src/main/java/org/postgresql/translation/zh_TW.po
+++ b/pgjdbc/src/main/java/org/postgresql/translation/zh_TW.po
@@ -6,7 +6,6 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PostgreSQL JDBC Driver 8.3\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-06-05 10:57+0300\n"
 "PO-Revision-Date: 2008-01-21 16:50+0800\n"
 "Last-Translator: 郭朝益(ChaoYi, Kuo) <Kuo.ChaoYi@gmail.com>\n"
 "Language-Team: The PostgreSQL Development Team <Kuo.ChaoYi@gmail.com>\n"
@@ -18,56 +17,56 @@ msgstr ""
 "X-Poedit-Country: TAIWAN\n"
 "X-Poedit-SourceCharset: utf-8\n"
 
-#: org/postgresql/Driver.java:214
+#: org/postgresql/Driver.java:217
 msgid "Error loading default settings from driverconfig.properties"
 msgstr ""
 
-#: org/postgresql/Driver.java:226
+#: org/postgresql/Driver.java:229
 msgid "Properties for the driver contains a non-string value for the key "
 msgstr ""
 
-#: org/postgresql/Driver.java:270
+#: org/postgresql/Driver.java:272
 msgid ""
 "Your security policy has prevented the connection from being attempted.  You "
 "probably need to grant the connect java.net.SocketPermission to the database "
 "server host and port that you wish to connect to."
 msgstr ""
 
-#: org/postgresql/Driver.java:276 org/postgresql/Driver.java:408
+#: org/postgresql/Driver.java:278 org/postgresql/Driver.java:410
 msgid ""
 "Something unusual has occurred to cause the driver to fail. Please report "
 "this exception."
 msgstr "不明的原因導致驅動程式造成失敗，請回報這個例外。"
 
-#: org/postgresql/Driver.java:416
+#: org/postgresql/Driver.java:418
 msgid "Connection attempt timed out."
 msgstr "Connection 嘗試逾時。"
 
-#: org/postgresql/Driver.java:429
+#: org/postgresql/Driver.java:431
 msgid "Interrupted while attempting to connect."
 msgstr ""
 
-#: org/postgresql/Driver.java:682
+#: org/postgresql/Driver.java:687
 #, java-format
 msgid "Method {0} is not yet implemented."
 msgstr "這個 {0} 方法尚未被實作。"
 
-#: org/postgresql/PGProperty.java:535 org/postgresql/PGProperty.java:555
+#: org/postgresql/PGProperty.java:537 org/postgresql/PGProperty.java:557
 #, java-format
 msgid "{0} parameter value must be an integer but was: {1}"
 msgstr ""
 
-#: org/postgresql/copy/CopyManager.java:53
+#: org/postgresql/copy/CopyManager.java:49
 #, java-format
 msgid "Requested CopyIn but got {0}"
 msgstr ""
 
-#: org/postgresql/copy/CopyManager.java:64
+#: org/postgresql/copy/CopyManager.java:60
 #, java-format
 msgid "Requested CopyOut but got {0}"
 msgstr ""
 
-#: org/postgresql/copy/CopyManager.java:75
+#: org/postgresql/copy/CopyManager.java:71
 #, java-format
 msgid "Requested CopyDual but got {0}"
 msgstr ""
@@ -92,6 +91,11 @@ msgstr ""
 msgid "Cannot write to copy a byte of value {0}"
 msgstr ""
 
+#: org/postgresql/core/CommandCompleteParser.java:71
+#, fuzzy, java-format
+msgid "Unable to parse the count in command completion tag: {0}."
+msgstr "無法解讀命令完成標籤中的更新計數：{0}。"
+
 #: org/postgresql/core/ConnectionFactory.java:57
 #, java-format
 msgid "A connection could not be made using the requested protocol {0}."
@@ -112,7 +116,7 @@ msgstr ""
 msgid "Expected an EOF from server, got: {0}"
 msgstr ""
 
-#: org/postgresql/core/Parser.java:1006
+#: org/postgresql/core/Parser.java:1051
 #, java-format
 msgid "Malformed function or procedure escape syntax at offset {0}."
 msgstr "不正確的函式或程序 escape 語法於 {0}。"
@@ -168,23 +172,23 @@ msgstr "在標識識別符中不存在零位元組。"
 #: org/postgresql/core/v3/CompositeParameterList.java:33
 #: org/postgresql/core/v3/SimpleParameterList.java:54
 #: org/postgresql/core/v3/SimpleParameterList.java:65
-#: org/postgresql/jdbc/PgResultSet.java:2757
-#: org/postgresql/jdbc/PgResultSetMetaData.java:494
+#: org/postgresql/jdbc/PgResultSet.java:2755
+#: org/postgresql/jdbc/PgResultSetMetaData.java:388
 #, java-format
 msgid "The column index is out of range: {0}, number of columns: {1}."
 msgstr "欄位索引超過許可範圍：{0}，欄位數：{1}。"
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:109
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:103
 #, fuzzy, java-format
 msgid "Invalid sslmode value: {0}"
 msgstr "無效的串流長度 {0}."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:124
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:118
 #, fuzzy, java-format
 msgid "Invalid targetServerType value: {0}"
 msgstr "無效的串流長度 {0}."
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:246
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:239
 #, fuzzy, java-format
 msgid ""
 "Connection to {0} refused. Check that the hostname and port are correct and "
@@ -192,39 +196,39 @@ msgid ""
 msgstr ""
 "連線被拒，請檢查主機名稱和埠號，並確定 postmaster 可以接受 TCP/IP 連線。"
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:257
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:250
 #: org/postgresql/core/v3/replication/V3ReplicationProtocol.java:133
 msgid "The connection attempt failed."
 msgstr "嘗試連線已失敗。"
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:272
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:265
 #, java-format
 msgid "Could not find a server with specified targetServerType: {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:368
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:381
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:361
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:374
 msgid "The server does not support SSL."
 msgstr "伺服器不支援 SSL 連線。"
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:395
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:388
 msgid "An error occurred while setting up the SSL connection."
 msgstr "進行 SSL 連線時發生錯誤。"
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:496
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:523
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:484
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:511
 msgid ""
 "The server requested password-based authentication, but no password was "
 "provided."
 msgstr "伺服器要求使用密碼驗證，但是密碼並未提供。"
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:626
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:614
 msgid ""
 "SCRAM authentication is not supported by this driver. You need JDK >= 8 and "
 "pgjdbc >= 42.2.0 (not \".jre\" versions)"
 msgstr ""
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:650
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:638
 #, java-format
 msgid ""
 "The authentication type {0} is not supported. Check that you have configured "
@@ -234,16 +238,16 @@ msgstr ""
 "不支援 {0} 驗證型別。請核對您已經組態 pg_hba.conf 檔案包含客戶端的IP位址或網"
 "路區段，以及驅動程式所支援的驗證架構模式已被支援。"
 
-#: org/postgresql/core/v3/ConnectionFactoryImpl.java:657
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2550
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2581
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2585
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2653
+#: org/postgresql/core/v3/ConnectionFactoryImpl.java:645
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2543
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2576
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2580
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2648
 #: org/postgresql/gss/GssAction.java:126
 msgid "Protocol error.  Session setup failed."
 msgstr "通訊協定錯誤，Session 初始化失敗。"
 
-#: org/postgresql/core/v3/CopyInImpl.java:47
+#: org/postgresql/core/v3/CopyInImpl.java:49
 msgid "CopyIn copy direction can't receive data"
 msgstr ""
 
@@ -251,163 +255,158 @@ msgstr ""
 msgid "CommandComplete expected COPY but got: "
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:161
+#: org/postgresql/core/v3/QueryExecutorImpl.java:163
 msgid "Tried to obtain lock while already holding it"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:177
+#: org/postgresql/core/v3/QueryExecutorImpl.java:179
 msgid "Tried to break lock on database connection"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:195
+#: org/postgresql/core/v3/QueryExecutorImpl.java:197
 msgid "Interrupted while waiting to obtain lock on database connection"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:327
+#: org/postgresql/core/v3/QueryExecutorImpl.java:329
 msgid "Unable to bind parameter values for statement."
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:333
-#: org/postgresql/core/v3/QueryExecutorImpl.java:485
-#: org/postgresql/core/v3/QueryExecutorImpl.java:559
-#: org/postgresql/core/v3/QueryExecutorImpl.java:602
-#: org/postgresql/core/v3/QueryExecutorImpl.java:729
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2372
+#: org/postgresql/core/v3/QueryExecutorImpl.java:335
+#: org/postgresql/core/v3/QueryExecutorImpl.java:487
+#: org/postgresql/core/v3/QueryExecutorImpl.java:561
+#: org/postgresql/core/v3/QueryExecutorImpl.java:604
+#: org/postgresql/core/v3/QueryExecutorImpl.java:731
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2377
 #: org/postgresql/util/StreamWrapper.java:130
 #, fuzzy
 msgid "An I/O error occurred while sending to the backend."
 msgstr "傳送資料至後端時發生 I/O 錯誤。"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:534
-#: org/postgresql/core/v3/QueryExecutorImpl.java:576
+#: org/postgresql/core/v3/QueryExecutorImpl.java:536
+#: org/postgresql/core/v3/QueryExecutorImpl.java:578
 #, java-format
 msgid "Expected command status BEGIN, got {0}."
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:581
+#: org/postgresql/core/v3/QueryExecutorImpl.java:583
 #: org/postgresql/jdbc/PgResultSet.java:1778
 #, java-format
 msgid "Unexpected command status: {0}."
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:687
+#: org/postgresql/core/v3/QueryExecutorImpl.java:689
 #, fuzzy
 msgid "An error occurred while trying to get the socket timeout."
 msgstr "傳送資料至後端時發生 I/O 錯誤。"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:722
-#: org/postgresql/core/v3/QueryExecutorImpl.java:798
+#: org/postgresql/core/v3/QueryExecutorImpl.java:724
+#: org/postgresql/core/v3/QueryExecutorImpl.java:800
 #, java-format
 msgid "Unknown Response Type {0}."
 msgstr "不明的回應類型 {0}。"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:745
+#: org/postgresql/core/v3/QueryExecutorImpl.java:747
 #, fuzzy
 msgid "An error occurred while trying to reset the socket timeout."
 msgstr "傳送資料至後端時發生 I/O 錯誤。"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:843
+#: org/postgresql/core/v3/QueryExecutorImpl.java:845
 msgid "Database connection failed when starting copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:878
+#: org/postgresql/core/v3/QueryExecutorImpl.java:880
 msgid "Tried to cancel an inactive copy operation"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:917
+#: org/postgresql/core/v3/QueryExecutorImpl.java:919
 msgid "Database connection failed when canceling copy operation"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:933
+#: org/postgresql/core/v3/QueryExecutorImpl.java:935
 msgid "Missing expected error response to copy cancel request"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:937
+#: org/postgresql/core/v3/QueryExecutorImpl.java:939
 #, java-format
 msgid "Got {0} error responses to single copy cancel request"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:952
+#: org/postgresql/core/v3/QueryExecutorImpl.java:954
 msgid "Tried to end inactive copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:967
+#: org/postgresql/core/v3/QueryExecutorImpl.java:969
 msgid "Database connection failed when ending copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:985
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1005
+#: org/postgresql/core/v3/QueryExecutorImpl.java:987
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1007
 msgid "Tried to write to an inactive copy operation"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:998
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1013
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1000
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1015
 msgid "Database connection failed when writing to copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1028
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1030
 msgid "Tried to read from inactive copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1035
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1037
 msgid "Database connection failed when reading from copy"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1101
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1103
 #, java-format
 msgid "Received CommandComplete ''{0}'' without an active copy operation"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1126
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1128
 #, java-format
 msgid "Got CopyInResponse from server during an active {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1140
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1142
 #, java-format
 msgid "Got CopyOutResponse from server during an active {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1154
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1156
 #, java-format
 msgid "Got CopyBothResponse from server during an active {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1170
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1172
 msgid "Got CopyData without an active copy operation"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1174
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1176
 #, java-format
 msgid "Unexpected copydata from server for {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1234
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1236
 #, java-format
 msgid "Unexpected packet type during copy: {0}"
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:1524
+#: org/postgresql/core/v3/QueryExecutorImpl.java:1526
 #, java-format
 msgid ""
 "Bind message length {0} too long.  This can be caused by very large or "
 "incorrect length specifications on InputStream parameters."
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2145
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2150
 msgid "Ran out of memory retrieving query results."
 msgstr ""
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2313
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2318
 msgid "The driver currently does not support COPY operations."
 msgstr "驅動程式目前不支援 COPY 操作。"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2487
-#, fuzzy, java-format
-msgid "Unable to parse the count in command completion tag: {0}."
-msgstr "無法解讀命令完成標籤中的更新計數：{0}。"
-
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2610
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2605
 #, fuzzy, java-format
 msgid ""
 "The server''s client_encoding parameter was changed to {0}. The JDBC driver "
@@ -416,7 +415,7 @@ msgstr ""
 "這伺服器的 client_encoding 參數被改成 {0}，JDBC 驅動程式請求需要 "
 "client_encoding 為 UNICODE 以正確工作。"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2620
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2615
 #, java-format
 msgid ""
 "The server''s DateStyle parameter was changed to {0}. The JDBC driver "
@@ -425,7 +424,7 @@ msgstr ""
 "這伺服器的 DateStyle 參數被更改成 {0}，JDBC 驅動程式請求需要 DateStyle 以 "
 "ISO 開頭以正確工作。"
 
-#: org/postgresql/core/v3/QueryExecutorImpl.java:2633
+#: org/postgresql/core/v3/QueryExecutorImpl.java:2628
 #, java-format
 msgid ""
 "The server''s standard_conforming_strings parameter was reported as {0}. The "
@@ -488,36 +487,36 @@ msgstr "DataSource 已經被關閉。"
 msgid "Unsupported property name: {0}"
 msgstr "未被支持的型別值：{0}"
 
-#: org/postgresql/fastpath/Fastpath.java:86
+#: org/postgresql/fastpath/Fastpath.java:84
 #, fuzzy, java-format
 msgid "Fastpath call {0} - No result was returned and we expected a numeric."
 msgstr "Fastpath 呼叫 {0} - 沒有傳回值，且應該傳回一個整數。"
 
-#: org/postgresql/fastpath/Fastpath.java:163
+#: org/postgresql/fastpath/Fastpath.java:161
 #, java-format
 msgid "Fastpath call {0} - No result was returned and we expected an integer."
 msgstr "Fastpath 呼叫 {0} - 沒有傳回值，且應該傳回一個整數。"
 
-#: org/postgresql/fastpath/Fastpath.java:171
+#: org/postgresql/fastpath/Fastpath.java:169
 #, fuzzy, java-format
 msgid ""
 "Fastpath call {0} - No result was returned or wrong size while expecting an "
 "integer."
 msgstr "Fastpath 呼叫 {0} - 沒有傳回值，且應該傳回一個整數。"
 
-#: org/postgresql/fastpath/Fastpath.java:188
+#: org/postgresql/fastpath/Fastpath.java:186
 #, fuzzy, java-format
 msgid "Fastpath call {0} - No result was returned and we expected a long."
 msgstr "Fastpath 呼叫 {0} - 沒有傳回值，且應該傳回一個整數。"
 
-#: org/postgresql/fastpath/Fastpath.java:196
+#: org/postgresql/fastpath/Fastpath.java:194
 #, fuzzy, java-format
 msgid ""
 "Fastpath call {0} - No result was returned or wrong size while expecting a "
 "long."
 msgstr "Fastpath 呼叫 {0} - 沒有傳回值，且應該傳回一個整數。"
 
-#: org/postgresql/fastpath/Fastpath.java:308
+#: org/postgresql/fastpath/Fastpath.java:297
 #, java-format
 msgid "The fastpath function {0} is unknown."
 msgstr "不明的 fastpath 函式 {0}。"
@@ -583,63 +582,70 @@ msgid "Cannot cast to boolean: \"{0}\""
 msgstr ""
 
 #: org/postgresql/jdbc/EscapedFunctions.java:240
+#: org/postgresql/jdbc/EscapedFunctions2.java:167
 #, java-format
 msgid "{0} function takes four and only four argument."
 msgstr "{0} 函式取得四個且僅有四個引數。"
 
 #: org/postgresql/jdbc/EscapedFunctions.java:270
-#: org/postgresql/jdbc/EscapedFunctions.java:344
-#: org/postgresql/jdbc/EscapedFunctions.java:749
-#: org/postgresql/jdbc/EscapedFunctions.java:787
+#: org/postgresql/jdbc/EscapedFunctions.java:337
+#: org/postgresql/jdbc/EscapedFunctions.java:740
+#: org/postgresql/jdbc/EscapedFunctions2.java:196
+#: org/postgresql/jdbc/EscapedFunctions2.java:263
+#: org/postgresql/jdbc/EscapedFunctions2.java:665
 #, java-format
 msgid "{0} function takes two and only two arguments."
 msgstr "{0} 函式取得二個且僅有二個引數。"
 
 #: org/postgresql/jdbc/EscapedFunctions.java:288
-#: org/postgresql/jdbc/EscapedFunctions.java:326
-#: org/postgresql/jdbc/EscapedFunctions.java:446
-#: org/postgresql/jdbc/EscapedFunctions.java:461
-#: org/postgresql/jdbc/EscapedFunctions.java:476
-#: org/postgresql/jdbc/EscapedFunctions.java:491
-#: org/postgresql/jdbc/EscapedFunctions.java:506
-#: org/postgresql/jdbc/EscapedFunctions.java:521
-#: org/postgresql/jdbc/EscapedFunctions.java:536
-#: org/postgresql/jdbc/EscapedFunctions.java:551
-#: org/postgresql/jdbc/EscapedFunctions.java:566
-#: org/postgresql/jdbc/EscapedFunctions.java:581
-#: org/postgresql/jdbc/EscapedFunctions.java:596
-#: org/postgresql/jdbc/EscapedFunctions.java:611
-#: org/postgresql/jdbc/EscapedFunctions.java:775
+#: org/postgresql/jdbc/EscapedFunctions.java:441
+#: org/postgresql/jdbc/EscapedFunctions.java:467
+#: org/postgresql/jdbc/EscapedFunctions.java:526
+#: org/postgresql/jdbc/EscapedFunctions.java:728
+#: org/postgresql/jdbc/EscapedFunctions2.java:211
+#: org/postgresql/jdbc/EscapedFunctions2.java:355
+#: org/postgresql/jdbc/EscapedFunctions2.java:381
+#: org/postgresql/jdbc/EscapedFunctions2.java:440
+#: org/postgresql/jdbc/EscapedFunctions2.java:654
 #, java-format
 msgid "{0} function takes one and only one argument."
 msgstr "{0} 函式取得一個且僅有一個引數。"
 
-#: org/postgresql/jdbc/EscapedFunctions.java:310
-#: org/postgresql/jdbc/EscapedFunctions.java:391
+#: org/postgresql/jdbc/EscapedFunctions.java:312
+#: org/postgresql/jdbc/EscapedFunctions.java:386
+#: org/postgresql/jdbc/EscapedFunctions2.java:238
+#: org/postgresql/jdbc/EscapedFunctions2.java:307
 #, java-format
 msgid "{0} function takes two or three arguments."
 msgstr "{0} 函式取得二個或三個引數。"
 
-#: org/postgresql/jdbc/EscapedFunctions.java:416
-#: org/postgresql/jdbc/EscapedFunctions.java:431
-#: org/postgresql/jdbc/EscapedFunctions.java:734
-#: org/postgresql/jdbc/EscapedFunctions.java:764
+#: org/postgresql/jdbc/EscapedFunctions.java:411
+#: org/postgresql/jdbc/EscapedFunctions.java:426
+#: org/postgresql/jdbc/EscapedFunctions.java:693
+#: org/postgresql/jdbc/EscapedFunctions.java:719
+#: org/postgresql/jdbc/EscapedFunctions2.java:645
 #, java-format
 msgid "{0} function doesn''t take any argument."
 msgstr "{0} 函式無法取得任何的引數。"
 
-#: org/postgresql/jdbc/EscapedFunctions.java:627
-#: org/postgresql/jdbc/EscapedFunctions.java:680
+#: org/postgresql/jdbc/EscapedFunctions.java:586
+#: org/postgresql/jdbc/EscapedFunctions.java:639
+#: org/postgresql/jdbc/EscapedFunctions2.java:500
+#: org/postgresql/jdbc/EscapedFunctions2.java:571
 #, java-format
 msgid "{0} function takes three and only three arguments."
 msgstr "{0} 函式取得三個且僅有三個引數。"
 
-#: org/postgresql/jdbc/EscapedFunctions.java:640
-#: org/postgresql/jdbc/EscapedFunctions.java:661
-#: org/postgresql/jdbc/EscapedFunctions.java:664
-#: org/postgresql/jdbc/EscapedFunctions.java:697
-#: org/postgresql/jdbc/EscapedFunctions.java:710
-#: org/postgresql/jdbc/EscapedFunctions.java:713
+#: org/postgresql/jdbc/EscapedFunctions.java:599
+#: org/postgresql/jdbc/EscapedFunctions.java:620
+#: org/postgresql/jdbc/EscapedFunctions.java:623
+#: org/postgresql/jdbc/EscapedFunctions.java:656
+#: org/postgresql/jdbc/EscapedFunctions.java:669
+#: org/postgresql/jdbc/EscapedFunctions.java:672
+#: org/postgresql/jdbc/EscapedFunctions2.java:510
+#: org/postgresql/jdbc/EscapedFunctions2.java:527
+#: org/postgresql/jdbc/EscapedFunctions2.java:585
+#: org/postgresql/jdbc/EscapedFunctions2.java:597
 #, java-format
 msgid "Interval {0} not yet implemented"
 msgstr "隔絕 {0} 尚未被實作。"
@@ -658,17 +664,17 @@ msgstr "無法取得已命名儲存點的 id。"
 msgid "Cannot retrieve the name of an unnamed savepoint."
 msgstr "無法取得未命名儲存點(Savepoint)的名稱。"
 
-#: org/postgresql/jdbc/PgArray.java:157 org/postgresql/jdbc/PgArray.java:844
+#: org/postgresql/jdbc/PgArray.java:155 org/postgresql/jdbc/PgArray.java:842
 #, java-format
 msgid "The array index is out of range: {0}"
 msgstr "陣列索引超過許可範圍：{0}"
 
-#: org/postgresql/jdbc/PgArray.java:178 org/postgresql/jdbc/PgArray.java:861
+#: org/postgresql/jdbc/PgArray.java:176 org/postgresql/jdbc/PgArray.java:859
 #, java-format
 msgid "The array index is out of range: {0}, number of elements: {1}."
 msgstr "陣列索引超過許可範圍：{0}，元素數量：{1}。"
 
-#: org/postgresql/jdbc/PgArray.java:210
+#: org/postgresql/jdbc/PgArray.java:208
 #: org/postgresql/jdbc/PgResultSet.java:1930
 #: org/postgresql/util/HStoreConverter.java:43
 #: org/postgresql/util/HStoreConverter.java:74
@@ -681,17 +687,17 @@ msgstr ""
 "發現不合法的字元，可能的原因是欲儲存的資料中包含資料庫的字元集不支援的字碼，"
 "其中最常見例子的就是將 8 位元資料存入使用 SQL_ASCII 編碼的資料庫中。"
 
-#: org/postgresql/jdbc/PgCallableStatement.java:86
-#: org/postgresql/jdbc/PgCallableStatement.java:96
+#: org/postgresql/jdbc/PgCallableStatement.java:85
+#: org/postgresql/jdbc/PgCallableStatement.java:95
 msgid "A CallableStatement was executed with nothing returned."
 msgstr "一個 CallableStatement 執行函式後沒有傳回值。"
 
-#: org/postgresql/jdbc/PgCallableStatement.java:107
+#: org/postgresql/jdbc/PgCallableStatement.java:106
 #, fuzzy
 msgid "A CallableStatement was executed with an invalid number of parameters"
 msgstr "一個 CallableStatement 已執行包括一個無效的參數數值"
 
-#: org/postgresql/jdbc/PgCallableStatement.java:145
+#: org/postgresql/jdbc/PgCallableStatement.java:144
 #, java-format
 msgid ""
 "A CallableStatement function was executed and the out parameter {0} was of "
@@ -700,25 +706,25 @@ msgstr ""
 "一個 CallableStatement 執行函式後輸出的參數型別為 {1} 值為 {0}，但是已註冊的"
 "型別是 {2}。"
 
-#: org/postgresql/jdbc/PgCallableStatement.java:202
+#: org/postgresql/jdbc/PgCallableStatement.java:206
 msgid ""
 "This statement does not declare an OUT parameter.  Use '{' ?= call ... '}' "
 "to declare one."
 msgstr "這個 statement 未宣告 OUT 參數，使用 '{' ?= call ... '}' 宣告一個。"
 
-#: org/postgresql/jdbc/PgCallableStatement.java:246
+#: org/postgresql/jdbc/PgCallableStatement.java:229
 msgid "wasNull cannot be call before fetching a result."
 msgstr ""
 
-#: org/postgresql/jdbc/PgCallableStatement.java:384
-#: org/postgresql/jdbc/PgCallableStatement.java:403
+#: org/postgresql/jdbc/PgCallableStatement.java:367
+#: org/postgresql/jdbc/PgCallableStatement.java:386
 #, java-format
 msgid ""
 "Parameter of type {0} was registered, but call to get{1} (sqltype={2}) was "
 "made."
 msgstr "已註冊參數型別 {0}，但是又呼叫了get{1}(sqltype={2})。"
 
-#: org/postgresql/jdbc/PgCallableStatement.java:424
+#: org/postgresql/jdbc/PgCallableStatement.java:407
 msgid ""
 "A CallableStatement was declared, but no call to registerOutParameter(1, "
 "<some type>) was made."
@@ -726,27 +732,27 @@ msgstr ""
 "已經宣告 CallableStatement 函式，但是尚未呼叫 registerOutParameter (1, "
 "<some_type>) 。"
 
-#: org/postgresql/jdbc/PgCallableStatement.java:430
+#: org/postgresql/jdbc/PgCallableStatement.java:413
 msgid "No function outputs were registered."
 msgstr ""
 
-#: org/postgresql/jdbc/PgCallableStatement.java:436
+#: org/postgresql/jdbc/PgCallableStatement.java:419
 msgid ""
 "Results cannot be retrieved from a CallableStatement before it is executed."
 msgstr ""
 
-#: org/postgresql/jdbc/PgCallableStatement.java:703
+#: org/postgresql/jdbc/PgCallableStatement.java:686
 #, fuzzy, java-format
 msgid "Unsupported type conversion to {1}."
 msgstr "未被支持的型別值：{0}"
 
-#: org/postgresql/jdbc/PgConnection.java:272
+#: org/postgresql/jdbc/PgConnection.java:241
 #, java-format
 msgid "Unsupported value for stringtype parameter: {0}"
 msgstr "字串型別參數值未被支持：{0}"
 
 #: org/postgresql/jdbc/PgConnection.java:424
-#: org/postgresql/jdbc/PgPreparedStatement.java:119
+#: org/postgresql/jdbc/PgPreparedStatement.java:107
 #: org/postgresql/jdbc/PgStatement.java:225
 #: org/postgresql/jdbc/TypeInfoCache.java:226
 #: org/postgresql/jdbc/TypeInfoCache.java:371
@@ -758,126 +764,126 @@ msgstr "字串型別參數值未被支持：{0}"
 msgid "No results were returned by the query."
 msgstr "查詢沒有傳回任何結果。"
 
-#: org/postgresql/jdbc/PgConnection.java:441
+#: org/postgresql/jdbc/PgConnection.java:442
 #: org/postgresql/jdbc/PgStatement.java:254
 msgid "A result was returned when none was expected."
 msgstr "傳回預期之外的結果。"
 
-#: org/postgresql/jdbc/PgConnection.java:545
+#: org/postgresql/jdbc/PgConnection.java:547
 msgid "Custom type maps are not supported."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:587
+#: org/postgresql/jdbc/PgConnection.java:589
 #, java-format
 msgid "Failed to create object for: {0}."
 msgstr "為 {0} 建立物件失敗。"
 
-#: org/postgresql/jdbc/PgConnection.java:641
+#: org/postgresql/jdbc/PgConnection.java:643
 #, java-format
 msgid "Unable to load the class {0} responsible for the datatype {1}"
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:693
+#: org/postgresql/jdbc/PgConnection.java:705
 msgid ""
 "Cannot change transaction read-only property in the middle of a transaction."
 msgstr "不能在事物交易過程中改變事物交易唯讀屬性。"
 
-#: org/postgresql/jdbc/PgConnection.java:756
+#: org/postgresql/jdbc/PgConnection.java:772
 msgid "Cannot commit when autoCommit is enabled."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:767
-#: org/postgresql/jdbc/PgConnection.java:1384
-#: org/postgresql/jdbc/PgConnection.java:1428
+#: org/postgresql/jdbc/PgConnection.java:783
+#: org/postgresql/jdbc/PgConnection.java:1401
+#: org/postgresql/jdbc/PgConnection.java:1445
 #, fuzzy
 msgid "This connection has been closed."
 msgstr "Connection 已經被關閉。"
 
-#: org/postgresql/jdbc/PgConnection.java:777
+#: org/postgresql/jdbc/PgConnection.java:794
 msgid "Cannot rollback when autoCommit is enabled."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:827
+#: org/postgresql/jdbc/PgConnection.java:844
 msgid ""
 "Cannot change transaction isolation level in the middle of a transaction."
 msgstr "不能在事務交易過程中改變事物交易隔絕等級。"
 
-#: org/postgresql/jdbc/PgConnection.java:833
+#: org/postgresql/jdbc/PgConnection.java:850
 #, java-format
 msgid "Transaction isolation level {0} not supported."
 msgstr "不支援交易隔絕等級 {0} 。"
 
-#: org/postgresql/jdbc/PgConnection.java:878
+#: org/postgresql/jdbc/PgConnection.java:895
 msgid "Finalizing a Connection that was never closed:"
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:945
+#: org/postgresql/jdbc/PgConnection.java:962
 msgid "Unable to translate data into the desired encoding."
 msgstr "無法將資料轉成目標編碼。"
 
-#: org/postgresql/jdbc/PgConnection.java:1008
+#: org/postgresql/jdbc/PgConnection.java:1025
 #: org/postgresql/jdbc/PgResultSet.java:1817
-#: org/postgresql/jdbc/PgStatement.java:903
+#: org/postgresql/jdbc/PgStatement.java:908
 msgid "Fetch size must be a value greater to or equal to 0."
 msgstr "資料讀取筆數(fetch size)必須大於或等於 0。"
 
-#: org/postgresql/jdbc/PgConnection.java:1289
-#: org/postgresql/jdbc/PgConnection.java:1330
+#: org/postgresql/jdbc/PgConnection.java:1306
+#: org/postgresql/jdbc/PgConnection.java:1347
 #, java-format
 msgid "Unable to find server array type for provided name {0}."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1312
+#: org/postgresql/jdbc/PgConnection.java:1329
 #, fuzzy, java-format
 msgid "Invalid elements {0}"
 msgstr "無效的旗標 {0}"
 
-#: org/postgresql/jdbc/PgConnection.java:1348
+#: org/postgresql/jdbc/PgConnection.java:1365
 #, fuzzy, java-format
 msgid "Invalid timeout ({0}<0)."
 msgstr "無效的串流長度 {0}."
 
-#: org/postgresql/jdbc/PgConnection.java:1372
+#: org/postgresql/jdbc/PgConnection.java:1389
 msgid "Validating connection."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1405
+#: org/postgresql/jdbc/PgConnection.java:1422
 #, fuzzy, java-format
 msgid "Failed to set ClientInfo property: {0}"
 msgstr "為 {0} 建立物件失敗。"
 
-#: org/postgresql/jdbc/PgConnection.java:1415
+#: org/postgresql/jdbc/PgConnection.java:1432
 msgid "ClientInfo property not supported."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1441
+#: org/postgresql/jdbc/PgConnection.java:1458
 msgid "One ore more ClientInfo failed."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1540
+#: org/postgresql/jdbc/PgConnection.java:1559
 #, fuzzy
 msgid "Network timeout must be a value greater than or equal to 0."
 msgstr "查詢逾時等候時間必須大於或等於 0。"
 
-#: org/postgresql/jdbc/PgConnection.java:1552
+#: org/postgresql/jdbc/PgConnection.java:1571
 msgid "Unable to set network timeout."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1563
+#: org/postgresql/jdbc/PgConnection.java:1582
 msgid "Unable to get network timeout."
 msgstr ""
 
-#: org/postgresql/jdbc/PgConnection.java:1580
+#: org/postgresql/jdbc/PgConnection.java:1599
 #, java-format
 msgid "Unknown ResultSet holdability setting: {0}."
 msgstr "未知的 ResultSet 可適用的設置：{0}。"
 
-#: org/postgresql/jdbc/PgConnection.java:1598
-#: org/postgresql/jdbc/PgConnection.java:1619
+#: org/postgresql/jdbc/PgConnection.java:1617
+#: org/postgresql/jdbc/PgConnection.java:1638
 msgid "Cannot establish a savepoint in auto-commit mode."
 msgstr "在自動確認事物交易模式無法建立儲存點(Savepoint)。"
 
-#: org/postgresql/jdbc/PgConnection.java:1685
+#: org/postgresql/jdbc/PgConnection.java:1707
 msgid "Returning autogenerated keys is not supported."
 msgstr ""
 
@@ -891,47 +897,47 @@ msgstr ""
 msgid "Unable to find name datatype in the system catalogs."
 msgstr "在系統 catalog 中找不到名稱資料類型(datatype)。"
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:323
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:322
 #, fuzzy
 msgid "Unable to find keywords in the system catalogs."
 msgstr "在系統 catalog 中找不到名稱資料類型(datatype)。"
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1105
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1095
 msgid "oid"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1105
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1095
 msgid "proname"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1107
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1558
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1097
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1548
 msgid "typtype"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1110
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1100
 msgid "proargtypes"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1576
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1566
 msgid "adsrc"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1589
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1579
 msgid "attidentity"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1685
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1761
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1675
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1751
 msgid "rolname"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1686
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1762
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1676
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1752
 msgid "relacl"
 msgstr ""
 
-#: org/postgresql/jdbc/PgDatabaseMetaData.java:1692
+#: org/postgresql/jdbc/PgDatabaseMetaData.java:1682
 msgid "attacl"
 msgstr ""
 
@@ -940,83 +946,83 @@ msgstr ""
 msgid "The parameter index is out of range: {0}, number of parameters: {1}."
 msgstr "參數索引超出許可範圍：{0}，參數總數：{1}。"
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:106
+#: org/postgresql/jdbc/PgPreparedStatement.java:94
+#: org/postgresql/jdbc/PgPreparedStatement.java:115
 #: org/postgresql/jdbc/PgPreparedStatement.java:127
-#: org/postgresql/jdbc/PgPreparedStatement.java:139
-#: org/postgresql/jdbc/PgPreparedStatement.java:1035
+#: org/postgresql/jdbc/PgPreparedStatement.java:1008
 msgid ""
 "Can''t use query methods that take a query string on a PreparedStatement."
 msgstr "在 PreparedStatement 上不能使用獲取查詢字串的查詢方法。"
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:249
+#: org/postgresql/jdbc/PgPreparedStatement.java:237
 msgid "Unknown Types value."
 msgstr "不明的型別值。"
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:382
-#: org/postgresql/jdbc/PgPreparedStatement.java:439
-#: org/postgresql/jdbc/PgPreparedStatement.java:1191
-#: org/postgresql/jdbc/PgPreparedStatement.java:1490
+#: org/postgresql/jdbc/PgPreparedStatement.java:364
+#: org/postgresql/jdbc/PgPreparedStatement.java:421
+#: org/postgresql/jdbc/PgPreparedStatement.java:1164
+#: org/postgresql/jdbc/PgPreparedStatement.java:1472
 #, java-format
 msgid "Invalid stream length {0}."
 msgstr "無效的串流長度 {0}."
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:411
+#: org/postgresql/jdbc/PgPreparedStatement.java:393
 #, java-format
 msgid "The JVM claims not to support the {0} encoding."
 msgstr "JVM 聲明並不支援 {0} 編碼。"
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:414
+#: org/postgresql/jdbc/PgPreparedStatement.java:396
 #: org/postgresql/jdbc/PgResultSet.java:1122
 #: org/postgresql/jdbc/PgResultSet.java:1156
 msgid "Provided InputStream failed."
 msgstr "提供的 InputStream 已失敗。"
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:460
-#: org/postgresql/jdbc/PgPreparedStatement.java:1096
+#: org/postgresql/jdbc/PgPreparedStatement.java:442
+#: org/postgresql/jdbc/PgPreparedStatement.java:1069
 #, java-format
 msgid "Unknown type {0}."
 msgstr "不明的型別 {0}"
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:477
+#: org/postgresql/jdbc/PgPreparedStatement.java:459
 msgid "No hstore extension installed."
 msgstr ""
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:619
-#: org/postgresql/jdbc/PgPreparedStatement.java:642
-#: org/postgresql/jdbc/PgPreparedStatement.java:652
-#: org/postgresql/jdbc/PgPreparedStatement.java:664
+#: org/postgresql/jdbc/PgPreparedStatement.java:601
+#: org/postgresql/jdbc/PgPreparedStatement.java:624
+#: org/postgresql/jdbc/PgPreparedStatement.java:634
+#: org/postgresql/jdbc/PgPreparedStatement.java:646
 #, java-format
 msgid "Cannot cast an instance of {0} to type {1}"
 msgstr "不能轉換一個 {0} 實例到型別 {1}"
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:682
+#: org/postgresql/jdbc/PgPreparedStatement.java:664
 #, java-format
 msgid "Unsupported Types value: {0}"
 msgstr "未被支持的型別值：{0}"
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:894
+#: org/postgresql/jdbc/PgPreparedStatement.java:876
 #, java-format
 msgid "Cannot convert an instance of {0} to type {1}"
 msgstr "無法轉換 {0} 到類型 {1} 的實例"
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:968
+#: org/postgresql/jdbc/PgPreparedStatement.java:950
 #, java-format
 msgid ""
 "Can''t infer the SQL type to use for an instance of {0}. Use setObject() "
 "with an explicit Types value to specify the type to use."
 msgstr ""
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:1133
-#: org/postgresql/jdbc/PgPreparedStatement.java:1233
+#: org/postgresql/jdbc/PgPreparedStatement.java:1106
+#: org/postgresql/jdbc/PgPreparedStatement.java:1206
 msgid "Unexpected error writing large object to database."
 msgstr "將大型物件(large object)寫入資料庫時發生不明錯誤。"
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:1178
+#: org/postgresql/jdbc/PgPreparedStatement.java:1151
 #: org/postgresql/jdbc/PgResultSet.java:1210
 msgid "Provided Reader failed."
 msgstr "提供的 Reader 已失敗。"
 
-#: org/postgresql/jdbc/PgPreparedStatement.java:1449
+#: org/postgresql/jdbc/PgPreparedStatement.java:1431
 #: org/postgresql/util/StreamWrapper.java:56
 msgid "Object is too large to send over the protocol."
 msgstr ""
@@ -1032,8 +1038,8 @@ msgstr "操作要求可捲動的 ResultSet，但此 ResultSet 是 FORWARD_ONLY�
 #: org/postgresql/jdbc/PgResultSet.java:556
 #: org/postgresql/jdbc/PgResultSet.java:594
 #: org/postgresql/jdbc/PgResultSet.java:624
-#: org/postgresql/jdbc/PgResultSet.java:3014
-#: org/postgresql/jdbc/PgResultSet.java:3058
+#: org/postgresql/jdbc/PgResultSet.java:3012
+#: org/postgresql/jdbc/PgResultSet.java:3057
 #, fuzzy, java-format
 msgid "Cannot convert the column of type {0} to requested type {1}."
 msgstr "無法轉換 {0} 到類型 {1} 的實例"
@@ -1045,7 +1051,7 @@ msgid "Can''t use relative move methods while on the insert row."
 msgstr "不能在新增的資料列上使用相對位置 move 方法。"
 
 #: org/postgresql/jdbc/PgResultSet.java:878
-#: org/postgresql/jdbc/PgStatement.java:895
+#: org/postgresql/jdbc/PgStatement.java:900
 #, java-format
 msgid "Invalid fetch direction constant: {0}."
 msgstr "無效的 fetch 方向常數：{0}。"
@@ -1084,8 +1090,8 @@ msgstr ""
 
 #: org/postgresql/jdbc/PgResultSet.java:1119
 #: org/postgresql/jdbc/PgResultSet.java:1754
-#: org/postgresql/jdbc/PgResultSet.java:2422
-#: org/postgresql/jdbc/PgResultSet.java:2443
+#: org/postgresql/jdbc/PgResultSet.java:2420
+#: org/postgresql/jdbc/PgResultSet.java:2441
 #, java-format
 msgid "The JVM claims not to support the encoding: {0}"
 msgstr "JVM 聲明並不支援編碼：{0} 。"
@@ -1099,7 +1105,7 @@ msgid "Cannot call updateRow() when on the insert row."
 msgstr "不能在新增的資料列上呼叫 deleteRow()。"
 
 #: org/postgresql/jdbc/PgResultSet.java:1335
-#: org/postgresql/jdbc/PgResultSet.java:3075
+#: org/postgresql/jdbc/PgResultSet.java:3074
 msgid ""
 "Cannot update the ResultSet because it is either before the start or after "
 "the end of the results."
@@ -1116,27 +1122,27 @@ msgstr "{0} 資料表中未找到主鍵(Primary key)。"
 
 #: org/postgresql/jdbc/PgResultSet.java:2017
 #: org/postgresql/jdbc/PgResultSet.java:2022
-#: org/postgresql/jdbc/PgResultSet.java:2809
-#: org/postgresql/jdbc/PgResultSet.java:2815
-#: org/postgresql/jdbc/PgResultSet.java:2840
-#: org/postgresql/jdbc/PgResultSet.java:2846
-#: org/postgresql/jdbc/PgResultSet.java:2870
-#: org/postgresql/jdbc/PgResultSet.java:2875
-#: org/postgresql/jdbc/PgResultSet.java:2891
-#: org/postgresql/jdbc/PgResultSet.java:2912
-#: org/postgresql/jdbc/PgResultSet.java:2923
-#: org/postgresql/jdbc/PgResultSet.java:2936
-#: org/postgresql/jdbc/PgResultSet.java:3063
+#: org/postgresql/jdbc/PgResultSet.java:2807
+#: org/postgresql/jdbc/PgResultSet.java:2813
+#: org/postgresql/jdbc/PgResultSet.java:2838
+#: org/postgresql/jdbc/PgResultSet.java:2844
+#: org/postgresql/jdbc/PgResultSet.java:2868
+#: org/postgresql/jdbc/PgResultSet.java:2873
+#: org/postgresql/jdbc/PgResultSet.java:2889
+#: org/postgresql/jdbc/PgResultSet.java:2910
+#: org/postgresql/jdbc/PgResultSet.java:2921
+#: org/postgresql/jdbc/PgResultSet.java:2934
+#: org/postgresql/jdbc/PgResultSet.java:3062
 #, java-format
 msgid "Bad value for type {0} : {1}"
 msgstr "不良的型別值 {0} : {1}"
 
-#: org/postgresql/jdbc/PgResultSet.java:2595
+#: org/postgresql/jdbc/PgResultSet.java:2593
 #, java-format
 msgid "The column name {0} was not found in this ResultSet."
 msgstr "ResultSet 中找不到欄位名稱 {0}。"
 
-#: org/postgresql/jdbc/PgResultSet.java:2731
+#: org/postgresql/jdbc/PgResultSet.java:2729
 msgid ""
 "ResultSet is not updateable.  The query that generated this result set must "
 "select only one table, and must select all primary keys from that table. See "
@@ -1145,42 +1151,42 @@ msgstr ""
 "不可更新的 ResultSet。用來產生這個 ResultSet 的 SQL 命令只能操作一個資料表，"
 "並且必需選擇所有主鍵欄位，詳細請參閱 JDBC 2.1 API 規格書 5.6 節。"
 
-#: org/postgresql/jdbc/PgResultSet.java:2743
+#: org/postgresql/jdbc/PgResultSet.java:2741
 msgid "This ResultSet is closed."
 msgstr "這個 ResultSet 已經被關閉。"
 
-#: org/postgresql/jdbc/PgResultSet.java:2774
+#: org/postgresql/jdbc/PgResultSet.java:2772
 msgid "ResultSet not positioned properly, perhaps you need to call next."
 msgstr "查詢結果指標位置不正確，您也許需要呼叫 ResultSet 的 next() 方法。"
 
-#: org/postgresql/jdbc/PgResultSet.java:3095
+#: org/postgresql/jdbc/PgResultSet.java:3094
 #, fuzzy
 msgid "Invalid UUID data."
 msgstr "無效的旗標"
 
-#: org/postgresql/jdbc/PgResultSet.java:3184
-#: org/postgresql/jdbc/PgResultSet.java:3191
-#: org/postgresql/jdbc/PgResultSet.java:3202
-#: org/postgresql/jdbc/PgResultSet.java:3213
-#: org/postgresql/jdbc/PgResultSet.java:3224
-#: org/postgresql/jdbc/PgResultSet.java:3235
-#: org/postgresql/jdbc/PgResultSet.java:3246
-#: org/postgresql/jdbc/PgResultSet.java:3257
-#: org/postgresql/jdbc/PgResultSet.java:3268
-#: org/postgresql/jdbc/PgResultSet.java:3275
-#: org/postgresql/jdbc/PgResultSet.java:3282
-#: org/postgresql/jdbc/PgResultSet.java:3293
-#: org/postgresql/jdbc/PgResultSet.java:3310
-#: org/postgresql/jdbc/PgResultSet.java:3317
-#: org/postgresql/jdbc/PgResultSet.java:3324
-#: org/postgresql/jdbc/PgResultSet.java:3335
-#: org/postgresql/jdbc/PgResultSet.java:3342
-#: org/postgresql/jdbc/PgResultSet.java:3349
-#: org/postgresql/jdbc/PgResultSet.java:3387
-#: org/postgresql/jdbc/PgResultSet.java:3394
-#: org/postgresql/jdbc/PgResultSet.java:3401
-#: org/postgresql/jdbc/PgResultSet.java:3421
-#: org/postgresql/jdbc/PgResultSet.java:3434
+#: org/postgresql/jdbc/PgResultSet.java:3183
+#: org/postgresql/jdbc/PgResultSet.java:3190
+#: org/postgresql/jdbc/PgResultSet.java:3201
+#: org/postgresql/jdbc/PgResultSet.java:3212
+#: org/postgresql/jdbc/PgResultSet.java:3223
+#: org/postgresql/jdbc/PgResultSet.java:3234
+#: org/postgresql/jdbc/PgResultSet.java:3245
+#: org/postgresql/jdbc/PgResultSet.java:3256
+#: org/postgresql/jdbc/PgResultSet.java:3267
+#: org/postgresql/jdbc/PgResultSet.java:3274
+#: org/postgresql/jdbc/PgResultSet.java:3281
+#: org/postgresql/jdbc/PgResultSet.java:3292
+#: org/postgresql/jdbc/PgResultSet.java:3309
+#: org/postgresql/jdbc/PgResultSet.java:3316
+#: org/postgresql/jdbc/PgResultSet.java:3323
+#: org/postgresql/jdbc/PgResultSet.java:3334
+#: org/postgresql/jdbc/PgResultSet.java:3341
+#: org/postgresql/jdbc/PgResultSet.java:3348
+#: org/postgresql/jdbc/PgResultSet.java:3386
+#: org/postgresql/jdbc/PgResultSet.java:3393
+#: org/postgresql/jdbc/PgResultSet.java:3400
+#: org/postgresql/jdbc/PgResultSet.java:3420
+#: org/postgresql/jdbc/PgResultSet.java:3433
 #, fuzzy, java-format
 msgid "conversion to {0} from {1} not supported"
 msgstr "不支援交易隔絕等級 {0} 。"
@@ -1246,33 +1252,33 @@ msgstr ""
 msgid "Maximum number of rows must be a value grater than or equal to 0."
 msgstr "最大資料讀取筆數必須大於或等於 0。"
 
-#: org/postgresql/jdbc/PgStatement.java:550
+#: org/postgresql/jdbc/PgStatement.java:555
 msgid "Query timeout must be a value greater than or equals to 0."
 msgstr "查詢逾時等候時間必須大於或等於 0。"
 
-#: org/postgresql/jdbc/PgStatement.java:590
+#: org/postgresql/jdbc/PgStatement.java:595
 msgid "The maximum field size must be a value greater than or equal to 0."
 msgstr "最大欄位容量必須大於或等於 0。"
 
-#: org/postgresql/jdbc/PgStatement.java:689
+#: org/postgresql/jdbc/PgStatement.java:694
 msgid "This statement has been closed."
 msgstr "這個 statement 已經被關閉。"
 
-#: org/postgresql/jdbc/PgStatement.java:1145
-#: org/postgresql/jdbc/PgStatement.java:1173
+#: org/postgresql/jdbc/PgStatement.java:1150
+#: org/postgresql/jdbc/PgStatement.java:1178
 msgid "Returning autogenerated keys by column index is not supported."
 msgstr ""
 
-#: org/postgresql/jdbc/TimestampUtils.java:355
-#: org/postgresql/jdbc/TimestampUtils.java:423
+#: org/postgresql/jdbc/TimestampUtils.java:365
+#: org/postgresql/jdbc/TimestampUtils.java:433
 #, fuzzy, java-format
 msgid "Bad value for type timestamp/date/time: {1}"
 msgstr "不良的型別值 {0} : {1}"
 
-#: org/postgresql/jdbc/TimestampUtils.java:858
-#: org/postgresql/jdbc/TimestampUtils.java:915
-#: org/postgresql/jdbc/TimestampUtils.java:961
-#: org/postgresql/jdbc/TimestampUtils.java:1010
+#: org/postgresql/jdbc/TimestampUtils.java:914
+#: org/postgresql/jdbc/TimestampUtils.java:971
+#: org/postgresql/jdbc/TimestampUtils.java:1017
+#: org/postgresql/jdbc/TimestampUtils.java:1066
 #, fuzzy, java-format
 msgid "Unsupported binary encoding of {0}."
 msgstr "未被支持的型別值：{0}"
@@ -1285,31 +1291,31 @@ msgstr ""
 msgid "Invalid or unsupported by client SCRAM mechanisms"
 msgstr ""
 
-#: org/postgresql/jre8/sasl/ScramAuthenticator.java:117
+#: org/postgresql/jre8/sasl/ScramAuthenticator.java:119
 #, fuzzy, java-format
 msgid "Invalid server-first-message: {0}"
 msgstr "無效的串流長度 {0}."
 
-#: org/postgresql/jre8/sasl/ScramAuthenticator.java:147
+#: org/postgresql/jre8/sasl/ScramAuthenticator.java:151
 #, fuzzy, java-format
 msgid "Invalid server-final-message: {0}"
 msgstr "無效的串流長度 {0}."
 
-#: org/postgresql/jre8/sasl/ScramAuthenticator.java:153
+#: org/postgresql/jre8/sasl/ScramAuthenticator.java:157
 #, java-format
 msgid "SCRAM authentication failed, server returned error: {0}"
 msgstr ""
 
-#: org/postgresql/jre8/sasl/ScramAuthenticator.java:160
+#: org/postgresql/jre8/sasl/ScramAuthenticator.java:164
 msgid "Invalid server SCRAM signature"
 msgstr ""
 
-#: org/postgresql/largeobject/LargeObjectManager.java:144
+#: org/postgresql/largeobject/LargeObjectManager.java:136
 msgid "Failed to initialize LargeObject API"
 msgstr "初始化 LargeObject API 失敗"
 
-#: org/postgresql/largeobject/LargeObjectManager.java:262
-#: org/postgresql/largeobject/LargeObjectManager.java:305
+#: org/postgresql/largeobject/LargeObjectManager.java:254
+#: org/postgresql/largeobject/LargeObjectManager.java:295
 msgid "Large Objects may not be used in auto-commit mode."
 msgstr "大型物件無法被使用在自動確認事物交易模式。"
 
@@ -1343,34 +1349,34 @@ msgstr ""
 msgid "The hostname {0} could not be verified."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:164
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:90
 msgid "The sslfactoryarg property may not be empty."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:180
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:106
 msgid ""
 "The environment variable containing the server's SSL certificate must not be "
 "empty."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:188
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:114
 msgid ""
 "The system property containing the server's SSL certificate must not be "
 "empty."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:195
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:121
 msgid ""
 "The sslfactoryarg property must start with the prefix file:, classpath:, "
 "env:, sys:, or -----BEGIN CERTIFICATE-----."
 msgstr ""
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:207
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:133
 #, fuzzy
 msgid "An error occurred reading the certificate"
 msgstr "進行 SSL 連線時發生錯誤。"
 
-#: org/postgresql/ssl/SingleCertValidatingFactory.java:240
+#: org/postgresql/ssl/SingleCertValidatingFactory.java:166
 msgid "No X509TrustManager found"
 msgstr ""
 
@@ -1505,31 +1511,31 @@ msgid ""
 "setSavePoint not allowed while an XA transaction is active."
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:177
-#: org/postgresql/xa/PGXAConnection.java:253
-#: org/postgresql/xa/PGXAConnection.java:347
+#: org/postgresql/xa/PGXAConnection.java:186
+#: org/postgresql/xa/PGXAConnection.java:272
+#: org/postgresql/xa/PGXAConnection.java:381
 #, java-format
 msgid "Invalid flags {0}"
 msgstr "無效的旗標 {0}"
 
-#: org/postgresql/xa/PGXAConnection.java:181
-#: org/postgresql/xa/PGXAConnection.java:257
-#: org/postgresql/xa/PGXAConnection.java:449
+#: org/postgresql/xa/PGXAConnection.java:190
+#: org/postgresql/xa/PGXAConnection.java:276
+#: org/postgresql/xa/PGXAConnection.java:491
 msgid "xid must not be null"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:185
+#: org/postgresql/xa/PGXAConnection.java:194
 msgid "Connection is busy with another transaction"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:194
-#: org/postgresql/xa/PGXAConnection.java:267
+#: org/postgresql/xa/PGXAConnection.java:203
+#: org/postgresql/xa/PGXAConnection.java:286
 msgid "suspend/resume not implemented"
 msgstr "暫停(suspend)/再繼續(resume)尚未被實作。"
 
-#: org/postgresql/xa/PGXAConnection.java:202
-#: org/postgresql/xa/PGXAConnection.java:209
-#: org/postgresql/xa/PGXAConnection.java:213
+#: org/postgresql/xa/PGXAConnection.java:211
+#: org/postgresql/xa/PGXAConnection.java:218
+#: org/postgresql/xa/PGXAConnection.java:222
 #, java-format
 msgid ""
 "Invalid protocol state requested. Attempted transaction interleaving is not "
@@ -1538,97 +1544,97 @@ msgstr ""
 "事物交易隔絕(Transaction interleaving)未被實作。xid={0}, currentXid={1}, "
 "state={2}, flags={3}"
 
-#: org/postgresql/xa/PGXAConnection.java:224
+#: org/postgresql/xa/PGXAConnection.java:233
 msgid "Error disabling autocommit"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:261
+#: org/postgresql/xa/PGXAConnection.java:280
 #, java-format
 msgid ""
 "tried to call end without corresponding start call. state={0}, start "
 "xid={1}, currentXid={2}, preparedXid={3}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:297
+#: org/postgresql/xa/PGXAConnection.java:326
 #, java-format
 msgid ""
 "Preparing already prepared transaction, the prepared xid {0}, prepare xid={1}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:300
+#: org/postgresql/xa/PGXAConnection.java:329
 #, java-format
 msgid "Current connection does not have an associated xid. prepare xid={0}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:307
+#: org/postgresql/xa/PGXAConnection.java:336
 #, java-format
 msgid ""
 "Not implemented: Prepare must be issued using the same connection that "
 "started the transaction. currentXid={0}, prepare xid={1}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:311
+#: org/postgresql/xa/PGXAConnection.java:340
 #, java-format
 msgid "Prepare called before end. prepare xid={0}, state={1}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:331
+#: org/postgresql/xa/PGXAConnection.java:360
 #, java-format
 msgid "Error preparing transaction. prepare xid={0}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:382
+#: org/postgresql/xa/PGXAConnection.java:416
 msgid "Error during recover"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:438
+#: org/postgresql/xa/PGXAConnection.java:480
 #, java-format
 msgid ""
 "Error rolling back prepared transaction. rollback xid={0}, preparedXid={1}, "
 "currentXid={2}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:471
+#: org/postgresql/xa/PGXAConnection.java:521
 #, java-format
 msgid ""
 "One-phase commit called for xid {0} but connection was prepared with xid {1}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:479
+#: org/postgresql/xa/PGXAConnection.java:529
 msgid ""
 "Not implemented: one-phase commit must be issued using the same connection "
 "that was used to start it"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:483
+#: org/postgresql/xa/PGXAConnection.java:533
 #, java-format
 msgid "One-phase commit with unknown xid. commit xid={0}, currentXid={1}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:487
+#: org/postgresql/xa/PGXAConnection.java:537
 #, java-format
 msgid "commit called before end. commit xid={0}, state={1}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:498
+#: org/postgresql/xa/PGXAConnection.java:548
 #, java-format
 msgid "Error during one-phase commit. commit xid={0}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:517
+#: org/postgresql/xa/PGXAConnection.java:576
 msgid ""
 "Not implemented: 2nd phase commit must be issued using an idle connection. "
 "commit xid={0}, currentXid={1}, state={2], transactionState={3}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:550
+#: org/postgresql/xa/PGXAConnection.java:609
 #, java-format
 msgid ""
 "Error committing prepared transaction. commit xid={0}, preparedXid={1}, "
 "currentXid={2}"
 msgstr ""
 
-#: org/postgresql/xa/PGXAConnection.java:567
+#: org/postgresql/xa/PGXAConnection.java:626
 #, java-format
 msgid "Heuristic commit/rollback not supported. forget xid={0}"
 msgstr ""


### PR DESCRIPTION
This makes repeated executions of `mvn -Ptranslate compile` produce empty diffs
[ci skip]