### PR TITLE
WIP: implement PgConnection.createClob/createBlob/createNClob

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgBlob.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgBlob.java
@@ -9,9 +9,13 @@ import org.postgresql.largeobject.LargeObject;
 
 import java.sql.SQLException;
 
-public class PgBlob extends AbstractBlobClob implements java.sql.Blob {
+class PgBlob extends AbstractBlobClob implements java.sql.Blob {
 
-  public PgBlob(org.postgresql.core.BaseConnection conn, long oid) throws SQLException {
+  PgBlob(org.postgresql.core.BaseConnection conn) throws SQLException {
+    super(conn);
+  }
+
+  PgBlob(org.postgresql.core.BaseConnection conn, long oid) throws SQLException {
     super(conn, oid);
   }
 

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgClob.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgClob.java
@@ -5,62 +5,153 @@
 
 package org.postgresql.jdbc;
 
+import org.postgresql.util.GT;
+import org.postgresql.util.LimitedReader;
+import org.postgresql.util.PSQLException;
+import org.postgresql.util.PSQLState;
+
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
 import java.io.Reader;
+import java.io.StringWriter;
+import java.io.Writer;
 import java.nio.charset.Charset;
 import java.sql.Clob;
+import java.sql.NClob;
 import java.sql.SQLException;
 
-public class PgClob extends AbstractBlobClob implements java.sql.Clob {
+class PgClob extends AbstractBlobClob implements Clob, NClob {
 
-  public PgClob(org.postgresql.core.BaseConnection conn, long oid) throws java.sql.SQLException {
+  PgClob(org.postgresql.core.BaseConnection conn) throws java.sql.SQLException {
+    super(conn);
+  }
+
+  PgClob(org.postgresql.core.BaseConnection conn, long oid) throws java.sql.SQLException {
     super(conn, oid);
   }
 
-  public synchronized Reader getCharacterStream(long pos, long length) throws SQLException {
-    checkFreed();
-    throw org.postgresql.Driver.notImplemented(this.getClass(), "getCharacterStream(long, long)");
+  private int getBufferSize(long length) {
+    return (int) Math.min(length * 1.2, 64000);
   }
 
+  @Override
   public synchronized int setString(long pos, String str) throws SQLException {
-    checkFreed();
-    throw org.postgresql.Driver.notImplemented(this.getClass(), "setString(long,str)");
+    // TODO: pos>0 check
+    return setString(pos, str, 0, str.length());
   }
 
+  private long measureBytes(long numCharacters) throws SQLException {
+    if (numCharacters == 0) {
+      return 0;
+    }
+    // TODO: offload to backend somehow?
+    Reader characterStream = getCharacterStream(1, numCharacters);
+    int bufferSize = (int) (numCharacters < 8192 ? numCharacters * 1.2 : numCharacters);
+    char[] tmp = new char[bufferSize];
+    int read;
+    long len = 0;
+    try {
+      while ((read = characterStream.read(tmp)) != -1) {
+        len = len + read;
+      }
+    } catch (IOException e) {
+      throw new PSQLException(GT.tr("Unable to skip {0} characters, large object oid is {1}",
+          numCharacters, getOid()),
+          PSQLState.UNEXPECTED_ERROR, e);
+    }
+    return len;
+  }
+
+
+  @Override
   public synchronized int setString(long pos, String str, int offset, int len) throws SQLException {
-    checkFreed();
-    throw org.postgresql.Driver.notImplemented(this.getClass(), "setString(long,String,int,int)");
+    // TODO: add pos>0 check and error message
+    Writer writer = setCharacterStream(pos);
+    try {
+      writer.write(str, offset, len);
+      return len;
+    } catch (IOException e) {
+      throw new SQLException();
+    } finally {
+      try {
+        writer.close();
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
+
+    }
   }
 
+  @Override
   public synchronized java.io.OutputStream setAsciiStream(long pos) throws SQLException {
-    checkFreed();
-    throw org.postgresql.Driver.notImplemented(this.getClass(), "setAsciiStream(long)");
+    return setBinaryStream(pos);
   }
 
+  @Override
   public synchronized java.io.Writer setCharacterStream(long pos) throws SQLException {
-    checkFreed();
-    throw org.postgresql.Driver.notImplemented(this.getClass(), "setCharacteStream(long)");
+    Charset connectionCharset = Charset.forName(conn.getEncoding().name());
+    return new OutputStreamWriter(setBinaryStream(measureBytes(pos - 1) + 1), connectionCharset);
   }
 
+  @Override
   public synchronized InputStream getAsciiStream() throws SQLException {
     return getBinaryStream();
   }
 
+  @Override
   public synchronized Reader getCharacterStream() throws SQLException {
     Charset connectionCharset = Charset.forName(conn.getEncoding().name());
     return new InputStreamReader(getBinaryStream(), connectionCharset);
   }
 
-  public synchronized String getSubString(long i, int j) throws SQLException {
-    assertPosition(i, j);
-    getLo(false).seek((int) i - 1);
-    return new String(getLo(false).read(j));
+  @Override
+  public synchronized Reader getCharacterStream(long pos, long length) throws SQLException {
+    Reader characterStream = getCharacterStream();
+    // TODO: add pos>0 check and error message
+    try {
+      // TODO: offload to backend somehow?
+      characterStream.skip(pos - 1);
+    } catch (IOException e) {
+      throw new PSQLException(GT.tr("Unable to skip {0} bytes, large object oid is {1}",
+          pos - 1, getOid()),
+          PSQLState.COMMUNICATION_ERROR, e);
+    }
+    return new LimitedReader(characterStream, getBufferSize(length), length);
+  }
+
+  @Override
+  public synchronized String getSubString(long pos, int length) throws SQLException {
+    StringWriter sw = new StringWriter();
+    Reader reader = null;
+    try {
+      reader = getCharacterStream(pos, length);
+      char[] buffer = new char[Math.min(8192, length)];
+      int len;
+      while ((len = reader.read(buffer)) != -1) {
+        sw.write(buffer, 0, len);
+      }
+    } catch (IOException e) {
+      throw new PSQLException(GT.tr("Error while reading large object oid {0} at character {1}",
+          getOid(), sw.getBuffer().length()),
+          PSQLState.COMMUNICATION_ERROR, e);
+    } finally {
+      try {
+        reader.close();
+      } catch (IOException e) {
+        throw new PSQLException(GT.tr("Unable to release large object oid {0} reader",
+            getOid()),
+            PSQLState.UNEXPECTED_ERROR, e);
+      }
+    }
+    return sw.toString();
   }
 
   /**
    * For now, this is not implemented.
    */
+  @Override
   public synchronized long position(String pattern, long start) throws SQLException {
     checkFreed();
     throw org.postgresql.Driver.notImplemented(this.getClass(), "position(String,long)");
@@ -69,6 +160,7 @@ public class PgClob extends AbstractBlobClob implements java.sql.Clob {
   /**
    * This should be simply passing the byte value of the pattern Blob.
    */
+  @Override
   public synchronized long position(Clob pattern, long start) throws SQLException {
     checkFreed();
     throw org.postgresql.Driver.notImplemented(this.getClass(), "position(Clob,start)");

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
@@ -1266,19 +1266,19 @@ public class PgConnection implements BaseConnection {
   @Override
   public Clob createClob() throws SQLException {
     checkClosed();
-    throw org.postgresql.Driver.notImplemented(this.getClass(), "createClob()");
+    return new PgClob(this);
   }
 
   @Override
   public Blob createBlob() throws SQLException {
     checkClosed();
-    throw org.postgresql.Driver.notImplemented(this.getClass(), "createBlob()");
+    return new PgBlob(this);
   }
 
   @Override
   public NClob createNClob() throws SQLException {
     checkClosed();
-    throw org.postgresql.Driver.notImplemented(this.getClass(), "createNClob()");
+    return new PgClob(this);
   }
 
   @Override

--- a/pgjdbc/src/main/java/org/postgresql/util/LimitedReader.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/LimitedReader.java
@@ -31,6 +31,9 @@ public class LimitedReader extends BufferedReader {
 
   @Override
   public int read(char[] cbuf, int off, int len) throws IOException {
+    if (position == maxLength) {
+      return -1;
+    }
     if (position + len > maxLength) {
       len = (int) (maxLength - position);
     }

--- a/pgjdbc/src/main/java/org/postgresql/util/LimitedReader.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/LimitedReader.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2018, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.util;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.Reader;
+
+public class LimitedReader extends BufferedReader {
+  private final long maxLength;
+  private long position;
+  private long markPosition;
+
+  public LimitedReader(Reader in, int sz, long maxLength) {
+    super(in, sz);
+    this.maxLength = maxLength;
+  }
+
+  @Override
+  public int read() throws IOException {
+    if (position == maxLength) {
+      return -1;
+    }
+    int read = super.read();
+    position++;
+    return read;
+  }
+
+  @Override
+  public int read(char[] cbuf, int off, int len) throws IOException {
+    if (position + len > maxLength) {
+      len = (int) (maxLength - position);
+    }
+    int read = super.read(cbuf, off, len);
+    position += read;
+    return read;
+  }
+
+  @Override
+  public void mark(int readAheadLimit) throws IOException {
+    super.mark(readAheadLimit);
+    markPosition = position;
+  }
+
+  @Override
+  public void reset() throws IOException {
+    position = markPosition;
+    super.reset();
+  }
+
+  @Override
+  public long skip(long n) throws IOException {
+    if (n == 0) {
+      return 0;
+    }
+    if (position + n > maxLength) {
+      n = (int) (maxLength - position);
+    }
+    long skip = super.skip(n);
+    position += skip;
+    return skip;
+  }
+
+  @Override
+  public String readLine() {
+    throw new UnsupportedOperationException("LimitedReader.readLine");
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc4/ClobTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc4/ClobTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2018, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.test.jdbc4;
+
+import org.postgresql.test.TestUtil;
+import org.postgresql.test.jdbc2.BaseTest4;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.sql.Clob;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class ClobTest extends BaseTest4 {
+  Clob clob;
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    TestUtil.createTable(con, "testclob", "id int4,lo oid");
+    con.setAutoCommit(false);
+    clob = con.createClob();
+  }
+
+  @Override
+  public void tearDown() throws SQLException {
+    TestUtil.dropTable(con, "testclob");
+    super.tearDown();
+  }
+
+  private void insertClob(int id, Clob clob) throws SQLException {
+    PreparedStatement insertClob =
+        con.prepareStatement("insert into testclob(id, lo) values(?, ?)");
+    insertClob.setInt(1, id);
+    insertClob.setClob(2, clob);
+    insertClob.execute();
+    TestUtil.closeQuietly(insertClob);
+  }
+
+  private void checkClobContents(String value, Clob clob) throws SQLException {
+    int id = 42;
+    insertClob(id, clob);
+    clob.free();
+
+    PreparedStatement ps = con.prepareStatement("select lo from testclob where id=?");
+    ps.setInt(1, id);
+    ResultSet rs = ps.executeQuery();
+    rs.next();
+    Clob dbClob = rs.getClob(1);
+    String dbValue = dbClob.getSubString(1, (int) dbClob.length());
+    dbClob.free();
+    Assert.assertEquals(value, dbValue);
+  }
+
+  @Test
+  public void setString() throws SQLException {
+    String value = "Привет, clob";
+    clob.setString(1, value);
+
+    checkClobContents(value, clob);
+  }
+
+  @Test
+  public void setStringOffsLen() throws SQLException {
+    String value = "Привет, clob";
+    clob.setString(1, value, 1, 3);
+
+    checkClobContents(value.substring(1, 1 + 3), clob);
+  }
+
+  @Test
+  public void setAsciiStream() throws SQLException, IOException {
+    String value = "Привет, clob";
+    OutputStream os = clob.setAsciiStream(1); // index is 1-based
+    os.write(value.getBytes("UTF-8"));
+    os.close();
+    checkClobContents(value, clob);
+  }
+
+  @Test
+  public void setAsciiStreamOffs() throws SQLException, IOException {
+    String prefix = "Привет, ";
+    byte[] prefixBytes = prefix.getBytes("UTF-8");
+    OutputStream os = clob.setAsciiStream(1);
+    os.write((prefix + ", clob").getBytes("UTF-8"));
+    os.close();
+
+    // Append value to the tail
+    String suffix = "клоб";
+    byte[] suffixBytes = suffix.getBytes("UTF-8");
+    os = clob.setAsciiStream(prefixBytes.length + 1); // index is 1-based
+    os.write(suffixBytes);
+    os.close();
+
+    checkClobContents(prefix + suffix, clob);
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc4/Jdbc4TestSuite.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc4/Jdbc4TestSuite.java
@@ -21,6 +21,7 @@ import org.junit.runners.Suite;
         ClientInfoTest.class,
         PGCopyInputStreamTest.class,
         BlobTest.class,
+        ClobTest.class,
         BinaryStreamTest.class,
         CharacterStreamTest.class,
         UUIDTest.class,


### PR DESCRIPTION
fixes #1102

TODO:
- [ ] add argument verification
- [ ] more tests
- [ ] automatic `lo_unlink` when lob was created and not passed to a prepared statement
- [ ] check if Hibernate works with the new implementation

Note: createBlob/createClob are not supported in autocommit mode as JDBC says 

> * A <code>Blob</code> object is valid for the duration of the
> * transaction in which is was created.

@ vladmihalcea, does Hibernate use `autoCommit==true` at all?
If so does it call `connection.createClob` / `connection.createBlob` in `autoCommit` mode?

Relevant hackers thread:
https://www.postgresql.org/message-id/17891.1246301879@sss.pgh.pa.us

>Yeah, it would be more useful probably to fix that than to add
>decoration to the LO facility.  Making LO more usable is just going to
>encourage people to bump into its other limitations (32-bit OIDs,
>32-bit object size, finite maximum size of pg_largeobject, lack of
>dead-object cleanup, etc etc).
>			regards, tom lane

