### PR TITLE
test: fix wrong secondaryPort2 build property

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -5,10 +5,10 @@
 
 server=localhost
 port=5432
-secondaryServer=localhost
-secondaryPort=5433
+secondaryServer1=localhost
+secondaryPort1=5433
 secondaryServer2=localhost
-secondaryServerPort2=5434
+secondaryPort2=5434
 database=test
 username=test
 password=test

--- a/pgjdbc/src/test/java/org/postgresql/test/hostchooser/MultiHostsConnectionTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/hostchooser/MultiHostsConnectionTest.java
@@ -46,7 +46,7 @@ public class MultiHostsConnectionTest {
   private static final String user = TestUtil.getUser();
   private static final String password = TestUtil.getPassword();
   private static final String master1 = TestUtil.getServer() + ":" + TestUtil.getPort();
-  private static final String secondary1 = getSecondaryServer() + ":" + getSecondaryPort();
+  private static final String secondary1 = getSecondaryServer1() + ":" + getSecondaryPort1();
   private static final String secondary2 = getSecondaryServer2() + ":" + getSecondaryPort2();
   private static final String fake1 = "127.127.217.217:1";
 
@@ -95,7 +95,7 @@ public class MultiHostsConnectionTest {
 
     Properties props = userAndPassword();
 
-    return DriverManager.getConnection(TestUtil.getURL(getSecondaryServer(), getSecondaryPort()), props);
+    return DriverManager.getConnection(TestUtil.getURL(getSecondaryServer1(), getSecondaryPort1()), props);
   }
 
   private static Properties userAndPassword() {
@@ -106,12 +106,12 @@ public class MultiHostsConnectionTest {
     return props;
   }
 
-  private static String getSecondaryServer() {
-    return System.getProperty("secondaryServer", TestUtil.getServer());
+  private static String getSecondaryServer1() {
+    return System.getProperty("secondaryServer1", TestUtil.getServer());
   }
 
-  private static int getSecondaryPort() {
-    return Integer.parseInt(System.getProperty("secondaryPort", String.valueOf(TestUtil.getPort() + 1)));
+  private static int getSecondaryPort1() {
+    return Integer.parseInt(System.getProperty("secondaryPort1", String.valueOf(TestUtil.getPort() + 1)));
   }
 
   private static Connection openSecondaryDB2() throws Exception {


### PR DESCRIPTION
The `secondaryServerPort2` is misspelled in the `build.properties` file and do not match with the one used in `MultiHostsConnectionTest.java`. Also make `secondaryServer1` and `secondaryPort1` consistent in the naming.