### PR TITLE
fix: Correct typo in CopyManager comment

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/copy/CopyManager.java
+++ b/pgjdbc/src/main/java/org/postgresql/copy/CopyManager.java
@@ -95,7 +95,7 @@ public class CopyManager {
       if (cp.isActive()) {
         cp.cancelCopy();
       }
-      try { // read until excausted or operation cancelled SQLException
+      try { // read until exhausted or operation cancelled SQLException
         while ((buf = cp.readFromCopy()) != null) {
         }
       } catch (SQLException sqlEx) {
@@ -130,7 +130,7 @@ public class CopyManager {
       if (cp.isActive()) {
         cp.cancelCopy();
       }
-      try { // read until excausted or operation cancelled SQLException
+      try { // read until exhausted or operation cancelled SQLException
         while ((buf = cp.readFromCopy()) != null) {
         }
       } catch (SQLException sqlEx) {


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the guidelines in our [Contributing](CONTRIBUTING.md) document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

Fixes a typo of "excausted" => "exhausted".