### PR TITLE
Fix typos detected by github.com/client9/misspell

### DIFF
--- a/docs/community/mailinglist.html
+++ b/docs/community/mailinglist.html
@@ -74,7 +74,7 @@ nav: ../
 						<p>
 							This mailing list is for people interested in carefully monitoring
 							the development process.  The mailing list was active until the code
-							base was transfered to GitHub in late 2012. Every commit to this earlier
+							base was transferred to GitHub in late 2012. Every commit to this earlier
 							CVS repository sent out an email with the log message and links to diffs.
 							So the archive of this list, <a href="http://lists.pgfoundry.org/mailman/listinfo/jdbc-commits" target="_blank">pgfoundry site</a>,
 							holds the history of activity with the driver prior to 2013.

--- a/docs/development/website.html
+++ b/docs/development/website.html
@@ -27,7 +27,7 @@ nav: ../
 							The website is produced with <a href="http://jekyllrb.com" target="_blank">Jekyll</a>.
 							It allows you to build a reasonably good looking website that is
 							easy to maintain and modular in nature. Templates are used from the _layout
-							and _includes directories which are then used in conjuction with content that
+							and _includes directories which are then used in conjunction with content that
 							is created with <a href="http://daringfireball.net/projects/markdown/" target="_blank">Markdown</a>,
 							<a href="http://textile.sitemonks.com/" target="_blank">Textile</a>, or
 							just standard HTML for input. Using Markdown or Textile allows the content

--- a/docs/documentation/92/escaped-functions.md
+++ b/docs/documentation/92/escaped-functions.md
@@ -15,7 +15,7 @@ The driver supports the nesting and the mixing of escaped functions and escaped
 values. The appendix C of the JDBC specification describes the functions.
 
 Some functions in the following tables are translated but not reported as supported
-because they are duplicating or changing ther order of the arguments. While this
+because they are duplicating or changing their order of the arguments. While this
 is harmless for literal values or columns, it will cause problems when using
 prepared statements. For example "`{fn right(?,?)}`" will be translated to "`substring(? from (length(?)+1-?))`".
 As you can see the translated SQL requires more parameters than before the

--- a/docs/documentation/93/escaped-functions.md
+++ b/docs/documentation/93/escaped-functions.md
@@ -15,7 +15,7 @@ The driver supports the nesting and the mixing of escaped functions and escaped
 values. The appendix C of the JDBC specification describes the functions.
 
 Some functions in the following tables are translated but not reported as supported
-because they are duplicating or changing ther order of the arguments. While this
+because they are duplicating or changing their order of the arguments. While this
 is harmless for literal values or columns, it will cause problems when using
 prepared statements. For example "`{fn right(?,?)}`" will be translated to "`substring(? from (length(?)+1-?))`".
 As you can see the translated SQL requires more parameters than before the

--- a/docs/documentation/94/connect.md
+++ b/docs/documentation/94/connect.md
@@ -235,7 +235,7 @@ connection.
 	Enable optimization to rewrite and collapse compatible INSERT statements that are batched.
 	If enabled, pgjdbc rewrites batch of `insert into ... values(?, ?)` into `insert into ... values(?, ?), (?, ?), ...`
 	That reduces per-statement overhead. The drawback is if one of the statements fail, the whole batch fails.
-	The default value is `false`. The option is avaliable since 9.4.1208
+	The default value is `false`. The option is available since 9.4.1208
 
 * `loginTimeout = int`
 

--- a/docs/documentation/94/escaped-functions.md
+++ b/docs/documentation/94/escaped-functions.md
@@ -15,7 +15,7 @@ The driver supports the nesting and the mixing of escaped functions and escaped
 values. The appendix C of the JDBC specification describes the functions.
 
 Some functions in the following tables are translated but not reported as supported
-because they are duplicating or changing ther order of the arguments. While this
+because they are duplicating or changing their order of the arguments. While this
 is harmless for literal values or columns, it will cause problems when using
 prepared statements. For example "`{fn right(?,?)}`" will be translated to "`substring(? from (length(?)+1-?))`".
 As you can see the translated SQL requires more parameters than before the

--- a/docs/documentation/changelog.md
+++ b/docs/documentation/changelog.md
@@ -1071,7 +1071,7 @@ Author:Craig Ringer <craig@2ndquadrant.com>
 Author: cchantep <chantepie@altern.org>
 Date:   Thu Dec 12 15:54:55 2013 +0100
 
-    Base table more usefull than "" as basic table name
+    Base table more useful than "" as basic table name
 
 
     fixed driver fails to find foreign tables fix from plalg@hotmail.com
@@ -1597,7 +1597,7 @@ Date:   Fri Sep 30 10:08:17 2011 +0000
 Author: Dave Cramer <davec@fastcrypt.com>
 Date:   Tue Sep 27 11:15:23 2011 +0000
 
-    more jdk 1.4 compatability issues fixed from Mike Fowler
+    more jdk 1.4 compatibility issues fixed from Mike Fowler
 
 Author: Dave Cramer <davec@fastcrypt.com>
 Date:   Mon Sep 26 15:16:05 2011 +0000
@@ -2020,20 +2020,20 @@ Date:   Mon Jan 28 16:52:56 2013 -0500
 Author: Fiona Tay
 Date:   Sun Jan 20 23:46:31 2013 -0800
 
-    Fix spelling of occured in error message
+    Fix spelling of occurred in error message
     - An error occurred while setting up the SSL connection
 
 Author: Fiona Tay
 Date:   Sun Jan 20 23:45:26 2013 -0800
 
-    Fix spelling of occured in error message
+    Fix spelling of occurred in error message
     - Something unusual has occurred to cause the driver to fail
 
 Author: Fiona Tay
 Date:   Sun Jan 20 23:44:02 2013 -0800
 
-    Fix spelling of occured in error message
-     - An I/O error occured while sending to the backend.
+    Fix spelling of occurred in error message
+     - An I/O error occurred while sending to the backend.
 
 Author: Dave Cramer
 Date:   Fri Jan 11 11:38:17 2013 -0800
@@ -2127,7 +2127,7 @@ Date:   Fri Jan 11 05:43:24 2013 -0800
 
     Merge pull request #25 from rkrzewski/backend_pid
     
-    Expose PID of the backend process serving a paricular JDBC connection
+    Expose PID of the backend process serving a particular JDBC connection
 
 Author: Dave Cramer
 Date:   Fri Jan 11 05:41:51 2013 -0800

--- a/docs/documentation/head/thread.md
+++ b/docs/documentation/head/thread.md
@@ -16,5 +16,5 @@ as such any concurrent requests to the process would have to be serialized.
 The driver makes no guarantees that methods on connections are synchronized. 
 It will be up to the caller to synchronize calls to the driver.
 
-A noteable exception is org/postgresql/jdbc/TimestampUtils.java which is threadsafe.
+A notable exception is org/postgresql/jdbc/TimestampUtils.java which is threadsafe.
  

--- a/pgjdbc/src/main/java/org/postgresql/copy/CopyIn.java
+++ b/pgjdbc/src/main/java/org/postgresql/copy/CopyIn.java
@@ -33,7 +33,7 @@ public interface CopyIn extends CopyOperation {
   void flushCopy() throws SQLException;
 
   /**
-   * Finishes copy operation succesfully.
+   * Finishes copy operation successfully.
    *
    * @return number of updated rows for server 8.2 or newer (see getHandledRowCount())
    * @throws SQLException if the operation fails.

--- a/pgjdbc/src/main/java/org/postgresql/copy/CopyOperation.java
+++ b/pgjdbc/src/main/java/org/postgresql/copy/CopyOperation.java
@@ -42,7 +42,7 @@ public interface CopyOperation {
   void cancelCopy() throws SQLException;
 
   /**
-   * After succesful end of copy, returns the number of database records handled in that operation.
+   * After successful end of copy, returns the number of database records handled in that operation.
    * Only implemented in PostgreSQL server version 8.2 and up. Otherwise, returns -1.
    *
    * @return number of handled rows or -1

--- a/pgjdbc/src/main/java/org/postgresql/core/VisibleBufferedInputStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/VisibleBufferedInputStream.java
@@ -162,7 +162,7 @@ public class VisibleBufferedInputStream extends InputStream {
   }
 
   /**
-   * Moves bytes from the buffer to the begining of the destination buffer. Also sets the index and
+   * Moves bytes from the buffer to the beginning of the destination buffer. Also sets the index and
    * endIndex variables.
    *
    * @param dest The destination buffer.

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -311,7 +311,7 @@ public class QueryExecutorImpl extends QueryExecutorBase {
         // There are three causes of this error, an
         // invalid total Bind message length, a
         // BinaryStream that cannot provide the amount
-        // of data claimed by the length arugment, and
+        // of data claimed by the length argument, and
         // a BinaryStream that throws an Exception
         // when reading.
         //
@@ -414,7 +414,7 @@ public class QueryExecutorImpl extends QueryExecutorBase {
   // the server is sending.
   //
   // Our message size estimation is coarse, and disregards asynchronous
-  // notifications, warnings/info/debug messages, etc, so the repsonse size may be
+  // notifications, warnings/info/debug messages, etc, so the response size may be
   // quite different from the 250 bytes assumed here even for queries that don't
   // return data.
   //

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/SimpleQuery.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/SimpleQuery.java
@@ -119,7 +119,7 @@ class SimpleQuery implements Query {
   }
 
   void setPrepareTypes(int[] paramTypes) {
-    // Remember which parameters were unspecified since the parameters will be overriden later by
+    // Remember which parameters were unspecified since the parameters will be overridden later by
     // ParameterDescription message
     for (int i = 0; i < paramTypes.length; i++) {
       int paramType = paramTypes[i];

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
@@ -1557,7 +1557,7 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
 
     primaryKeys = new ArrayList<PrimaryKey>();
 
-    // this is not stricty jdbc spec, but it will make things much faster if used
+    // this is not strictly jdbc spec, but it will make things much faster if used
     // the user has to select oid, * from table and then we will just use oid
 
 

--- a/pgjdbc/src/main/java/org/postgresql/largeobject/LargeObject.java
+++ b/pgjdbc/src/main/java/org/postgresql/largeobject/LargeObject.java
@@ -44,7 +44,7 @@ public class LargeObject
     //#endif
     /* hi, checkstyle */ {
   /**
-   * Indicates a seek from the begining of a file.
+   * Indicates a seek from the beginning of a file.
    */
   public static final int SEEK_SET = 0;
 
@@ -279,7 +279,7 @@ public class LargeObject
    * <p>This is similar to the fseek() call in the standard C library. It allows you to have random
    * access to the large object.</p>
    *
-   * @param pos position within object from begining
+   * @param pos position within object from beginning
    * @throws SQLException if a database-access error occurs.
    */
   public void seek(int pos) throws SQLException {

--- a/pgjdbc/src/main/java/org/postgresql/replication/fluent/ChainedCommonStreamBuilder.java
+++ b/pgjdbc/src/main/java/org/postgresql/replication/fluent/ChainedCommonStreamBuilder.java
@@ -37,7 +37,7 @@ public interface ChainedCommonStreamBuilder<T extends ChainedCommonStreamBuilder
   T withStatusInterval(int time, TimeUnit format);
 
   /**
-   * Specify start position from wich backend will start stream changes. If parameter will not
+   * Specify start position from which backend will start stream changes. If parameter will not
    * specify, streaming starts from restart_lsn. For more details see pg_replication_slots
    * description.
    *

--- a/pgjdbc/src/main/java/org/postgresql/ssl/jdbc4/LibPQFactory.java
+++ b/pgjdbc/src/main/java/org/postgresql/ssl/jdbc4/LibPQFactory.java
@@ -66,7 +66,7 @@ public class LibPQFactory extends WrappedFactory implements HostnameVerifier {
       sslmode = PGProperty.SSL_MODE.get(info);
       SSLContext ctx = SSLContext.getInstance("TLS"); // or "SSL" ?
 
-      // Determinig the default file location
+      // Determining the default file location
       String pathsep = System.getProperty("file.separator");
       String defaultdir;
       boolean defaultfile = false;

--- a/pgjdbc/src/main/java/org/postgresql/util/Base64.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/Base64.java
@@ -217,7 +217,7 @@ public class Base64 {
    * Encodes up to three bytes of the array <var>source</var> and writes the resulting four Base64
    * bytes to <var>destination</var>. The source and destination arrays can be manipulated anywhere
    * along their length by specifying <var>srcOffset</var> and <var>destOffset</var>. This method
-   * does not check to make sure your arrays are large enough to accomodate <var>srcOffset</var> + 3
+   * does not check to make sure your arrays are large enough to accommodate <var>srcOffset</var> + 3
    * for the <var>source</var> array or <var>destOffset</var> + 4 for the <var>destination</var>
    * array. The actual number of significant bytes in your array is given by <var>numSigBytes</var>.
    *
@@ -403,7 +403,7 @@ public class Base64 {
    * Decodes four bytes from array <var>source</var> and writes the resulting bytes (up to three of
    * them) to <var>destination</var>. The source and destination arrays can be manipulated anywhere
    * along their length by specifying <var>srcOffset</var> and <var>destOffset</var>. This method
-   * does not check to make sure your arrays are large enough to accomodate <var>srcOffset</var> + 4
+   * does not check to make sure your arrays are large enough to accommodate <var>srcOffset</var> + 4
    * for the <var>source</var> array or <var>destOffset</var> + 3 for the <var>destination</var>
    * array. This method returns the actual number of bytes that were converted from the Base64
    * encoding.

--- a/pgjdbc/src/test/java/org/postgresql/test/TestUtil.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/TestUtil.java
@@ -255,10 +255,10 @@ public class TestUtil {
   }
 
   /**
-   * Get a connection using a priviliged user mostly for tests that the ability to load C functions
+   * Get a connection using a privileged user mostly for tests that the ability to load C functions
    * now as of 4/14.
    *
-   * @return connection using a priviliged user mostly for tests that the ability to load C
+   * @return connection using a privileged user mostly for tests that the ability to load C
    *         functions now as of 4/14
    */
   public static Connection openPrivilegedDB() throws Exception {
@@ -782,7 +782,7 @@ public class TestUtil {
 
   public static void recreateLogicalReplicationSlot(Connection connection, String slotName, String outputPlugin)
       throws SQLException, InterruptedException, TimeoutException {
-    //drop previos slot
+    //drop previous slot
     dropReplicationSlot(connection, slotName);
 
     PreparedStatement stm = null;
@@ -798,7 +798,7 @@ public class TestUtil {
 
   public static void recreatePhysicalReplicationSlot(Connection connection, String slotName)
       throws SQLException, InterruptedException, TimeoutException {
-    //drop previos slot
+    //drop previous slot
     dropReplicationSlot(connection, slotName);
 
     PreparedStatement stm = null;

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseEncodingTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseEncodingTest.java
@@ -260,7 +260,7 @@ public class DatabaseEncodingTest {
         // Seven-byte illegal sequences
         {(byte) 0xfe}, // Can't have a seven-byte sequence.
 
-        // Eigth-byte illegal sequences
+        // Eighth-byte illegal sequences
         {(byte) 0xff}, // Can't have an eight-byte sequence.
     };
 

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/NotifyTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/NotifyTest.java
@@ -111,7 +111,7 @@ public class NotifyTest {
     PGNotification[] notifications = ((org.postgresql.PGConnection) conn).getNotifications(500);
     long endMillis = System.currentTimeMillis();
     long runtime = endMillis - startMillis;
-    assertNull("There have been notifications, althought none have been expected.",notifications);
+    assertNull("There have been notifications, although none have been expected.",notifications);
     Assert.assertTrue("We didn't wait long enough! runtime=" + runtime, runtime > 450);
 
     stmt.close();
@@ -229,7 +229,7 @@ public class NotifyTest {
       ((org.postgresql.PGConnection) conn).getNotifications(40000);
       Assert.fail("The getNotifications(...) call didn't return when the socket closed.");
     } catch (SQLException e) {
-      // We expected thta
+      // We expected that
     }
 
     stmt.close();

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PreparedStatementTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PreparedStatementTest.java
@@ -1228,7 +1228,7 @@ public class PreparedStatementTest extends BaseTest4 {
 
   /**
    * When we have parameters of unknown type and it's not using the unnamed statement, we issue a
-   * protocol level statment describe message for the V3 protocol. This test just makes sure that
+   * protocol level statement describe message for the V3 protocol. This test just makes sure that
    * works.
    */
   @Test

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/optional/ConnectionPoolTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/optional/ConnectionPoolTest.java
@@ -157,7 +157,7 @@ public class ConnectionPoolTest extends BaseDataSourceTest {
   /**
    * Makes sure that if you get two connection wrappers from the same PooledConnection, they are
    * different, even though the represent the same physical connection. See JDBC 2.0 Optional
-   * Pacakge spec section 6.2.2
+   * Package spec section 6.2.2
    */
   @Test
   public void testPoolNewWrapper() {

--- a/pgjdbc/src/test/java/org/postgresql/test/ssl/SingleCertValidatingFactoryTestSuite.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/ssl/SingleCertValidatingFactoryTestSuite.java
@@ -33,7 +33,7 @@ public class SingleCertValidatingFactoryTestSuite {
   private static String IS_ENABLED_PROP_NAME = "testsinglecertfactory";
 
   /**
-   * <p>This method returns the paramaters that JUnit will use when constructing this class for
+   * <p>This method returns the parameters that JUnit will use when constructing this class for
    * testing. It returns a collection of arrays, each containing a single value for the JDBC URL to
    * test against.</p>
    *
@@ -97,7 +97,7 @@ public class SingleCertValidatingFactoryTestSuite {
   }
 
   /**
-   * Helper method to create a connection using the additional properites specified in the "info"
+   * Helper method to create a connection using the additional properties specified in the "info"
    * paramater.
    *
    * @param info The additional properties to use when creating a connection
@@ -279,7 +279,7 @@ public class SingleCertValidatingFactoryTestSuite {
    * <p>Connect using SSL and attempt to validate the server's certificate against the proper pre
    * shared certificate. The certificate is specified as an environment variable.</p>
    *
-   * <p>Note: To execute this test succesfully you need to set the value of the environment variable
+   * <p>Note: To execute this test successfully you need to set the value of the environment variable
    * DATASOURCE_SSL_CERT prior to running the test.</p>
    *
    * <p>Here's one way to do it: $ DATASOURCE_SSL_CERT=$(cat certdir/goodroot.crt) ant clean test</p>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes to Existing Features:

Fixing typos is sometimes very hard. It's not so easy to visually review them. Recently, I discovered a very useful tool for it, [misspell](https://github.com/client9/misspell). 

This pull request fixes minor typos detected by [misspell](https://github.com/client9/misspell) except for the false positives. If you would like me to work on other files as well, let me know. 

### before

```
$ misspell . | grep -v /translation/
docs/community/mailinglist.html:77:16: "transfered" is a misspelling of "transferred"
docs/development/website.html:30:56: "conjuction" is a misspelling of "conjunction"
docs/documentation/92/escaped-functions.md:18:41: "ther" is a misspelling of "there"
docs/documentation/93/escaped-functions.md:18:41: "ther" is a misspelling of "there"
docs/documentation/94/escaped-functions.md:18:41: "ther" is a misspelling of "there"
docs/documentation/94/connect.md:238:45: "avaliable" is a misspelling of "available"
docs/documentation/head/thread.md:19:2: "noteable" is a misspelling of "notable"
pgjdbc/src/main/checkstyle/checks.xml:242:98: "guarentee" is a misspelling of "guarantee"
pgjdbc/src/main/checkstyle/checks.xml:242:108: "seperated" is a misspelling of "separated"
pgjdbc/src/main/checkstyle/checks.xml:242:125: "useage" is a misspelling of "usage"
pgjdbc/src/main/java/org/postgresql/copy/CopyIn.java:36:29: "succesfully" is a misspelling of "successfully"
pgjdbc/src/main/java/org/postgresql/copy/CopyOperation.java:45:11: "succesful" is a misspelling of "successful"
docs/documentation/changelog.md:1074:20: "usefull" is a misspelling of "useful"
docs/documentation/changelog.md:1600:17: "compatability" is a misspelling of "compatibility"
docs/documentation/changelog.md:2023:20: "occured" is a misspelling of "occurred"
docs/documentation/changelog.md:2029:20: "occured" is a misspelling of "occurred"
docs/documentation/changelog.md:2035:20: "occured" is a misspelling of "occurred"
docs/documentation/changelog.md:2036:20: "occured" is a misspelling of "occurred"
docs/documentation/changelog.md:2130:48: "paricular" is a misspelling of "particular"
pgjdbc/src/main/java/org/postgresql/core/VisibleBufferedInputStream.java:165:40: "begining" is a misspelling of "beginning"
pgjdbc/src/main/java/org/postgresql/core/v3/SimpleQuery.java:122:79: "overriden" is a misspelling of "overridden"
pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java:314:41: "arugment" is a misspelling of "argument"
pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java:417:62: "repsonse" is a misspelling of "response"
pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java:1560:19: "stricty" is a misspelling of "strictly"
pgjdbc/src/main/java/org/postgresql/replication/fluent/ChainedCommonStreamBuilder.java:40:33: "wich" is a misspelling of "which"
pgjdbc/src/main/java/org/postgresql/largeobject/LargeObject.java:47:31: "begining" is a misspelling of "beginning"
pgjdbc/src/main/java/org/postgresql/largeobject/LargeObject.java:282:44: "begining" is a misspelling of "beginning"
pgjdbc/src/main/java/org/postgresql/ssl/jdbc4/LibPQFactory.java:69:9: "Determinig" is a misspelling of "Determining"
pgjdbc/src/main/java/org/postgresql/util/Base64.java:220:65: "accomodate" is a misspelling of "accommodate"
pgjdbc/src/main/java/org/postgresql/util/Base64.java:406:65: "accomodate" is a misspelling of "accommodate"
pgjdbc/src/test/java/org/postgresql/test/TestUtil.java:258:30: "priviliged" is a misspelling of "privileged"
pgjdbc/src/test/java/org/postgresql/test/TestUtil.java:261:32: "priviliged" is a misspelling of "privileged"
pgjdbc/src/test/java/org/postgresql/test/TestUtil.java:785:11: "previos" is a misspelling of "previous"
pgjdbc/src/test/java/org/postgresql/test/TestUtil.java:801:11: "previos" is a misspelling of "previous"
pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseEncodingTest.java:263:11: "Eigth" is a misspelling of "Eighth"
pgjdbc/src/test/java/org/postgresql/test/jdbc2/NotifyTest.java:114:47: "althought" is a misspelling of "although"
pgjdbc/src/test/java/org/postgresql/test/jdbc2/NotifyTest.java:232:21: "thta" is a misspelling of "that"
pgjdbc/src/test/java/org/postgresql/test/jdbc2/PreparedStatementTest.java:1231:20: "statment" is a misspelling of "statement"
pgjdbc/src/test/java/org/postgresql/test/jdbc2/optional/ConnectionPoolTest.java:160:5: "Pacakge" is a misspelling of "Package"
pgjdbc/src/test/java/org/postgresql/test/ssl/SingleCertValidatingFactoryTestSuite.java:36:32: "paramaters" is a misspelling of "parameters"
pgjdbc/src/test/java/org/postgresql/test/ssl/SingleCertValidatingFactoryTestSuite.java:100:63: "properites" is a misspelling of "properties"
pgjdbc/src/test/java/org/postgresql/test/ssl/SingleCertValidatingFactoryTestSuite.java:282:35: "succesfully" is a misspelling of "successfully"
```

#### after

```
$ misspell . | grep -v /translation/
pgjdbc/src/main/checkstyle/checks.xml:242:98: "guarentee" is a misspelling of "guarantee"
pgjdbc/src/main/checkstyle/checks.xml:242:108: "seperated" is a misspelling of "separated"
pgjdbc/src/main/checkstyle/checks.xml:242:125: "useage" is a misspelling of "usage"
```

---
* [ ] Does this break existing behaviour? If so please explain.
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?