### PR TITLE
fix: Update error message for COPY commands executed using JDBC API

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -71,6 +71,7 @@ import java.util.logging.Logger;
 public class QueryExecutorImpl extends QueryExecutorBase {
 
   private static final Logger LOGGER = Logger.getLogger(QueryExecutorImpl.class.getName());
+  private static final String COPY_ERROR_MESSAGE = "COPY commands are only supported using the CopyManager API.";
 
   /**
    * TimeZone of the current connection (TimeZone backend parameter).
@@ -2352,8 +2353,7 @@ public class QueryExecutorImpl extends QueryExecutorBase {
           // We'll send a CopyFail message for COPY FROM STDIN so that
           // server does not wait for the data.
 
-          byte[] buf =
-              Utils.encodeUTF8("The JDBC driver currently does not support COPY operations.");
+          byte[] buf = Utils.encodeUTF8(COPY_ERROR_MESSAGE);
           pgStream.sendChar('f');
           pgStream.sendInteger4(buf.length + 4 + 1);
           pgStream.send(buf);
@@ -2370,7 +2370,7 @@ public class QueryExecutorImpl extends QueryExecutorBase {
           // In case of CopyOutResponse, we cannot abort data transfer,
           // so just throw an error and ignore CopyData messages
           handler.handleError(
-              new PSQLException(GT.tr("The driver currently does not support COPY operations."),
+              new PSQLException(GT.tr(COPY_ERROR_MESSAGE),
                   PSQLState.NOT_IMPLEMENTED));
           break;
 


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the guidelines in our [Contributing](CONTRIBUTING.md) document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

This updates the error message for COPY to STDIN / STDOUT commands that are *not* executed using the CopyManager API, i.e. via a regular `Statement.executeQuery("COPY ... TO STDOUT ...")`. The revised text for the error message is: 

     COPY commands are only supported using the CopyManager API.

If anybody has a better suggestion feel free to chime in. I figure it's enough that someone who does run into the error can then search for "CopyManager" in the context of pgjdbc and hopefully find more info.

This PR does *not* update or remove the old value from the translation files. There's quite a few translations for the old message as it was in the code base for many years. I was considering updating the old message key for the old text so they continue to operate but decided that it's better to have the new / correct english text show up instead.

Separately, we should look into adding more about the CopyManager interface to either the core README or the jdbc.postgresql.org website as I don't think either covers that API.