### PR TITLE
feat: Extend ReplicationCreateSlotBuilder DSL to support temporary replications slots

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/replication/fluent/AbstractCreateSlotBuilder.java
+++ b/pgjdbc/src/main/java/org/postgresql/replication/fluent/AbstractCreateSlotBuilder.java
@@ -5,16 +5,41 @@
 
 package org.postgresql.replication.fluent;
 
+import org.postgresql.core.BaseConnection;
+import org.postgresql.core.ServerVersion;
+import org.postgresql.util.GT;
+
+import java.sql.SQLFeatureNotSupportedException;
+
 public abstract class AbstractCreateSlotBuilder<T extends ChainedCommonCreateSlotBuilder<T>>
     implements ChainedCommonCreateSlotBuilder<T> {
 
   protected String slotName;
+  protected boolean temporaryOption = false;
+  protected BaseConnection connection;
+
+  protected AbstractCreateSlotBuilder(BaseConnection connection) {
+    this.connection = connection;
+  }
 
   protected abstract T self();
 
   @Override
   public T withSlotName(String slotName) {
     this.slotName = slotName;
+    return self();
+  }
+
+  @Override
+  public T withTemporaryOption() throws SQLFeatureNotSupportedException {
+
+    if (!connection.haveMinimumServerVersion(ServerVersion.v10)) {
+      throw new SQLFeatureNotSupportedException(
+          GT.tr("Server does not support temporary replication slots")
+      );
+    }
+
+    this.temporaryOption = true;
     return self();
   }
 }

--- a/pgjdbc/src/main/java/org/postgresql/replication/fluent/ChainedCommonCreateSlotBuilder.java
+++ b/pgjdbc/src/main/java/org/postgresql/replication/fluent/ChainedCommonCreateSlotBuilder.java
@@ -6,6 +6,7 @@
 package org.postgresql.replication.fluent;
 
 import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
 
 /**
  * Fluent interface for specify common parameters for create Logical and Physical replication slot.
@@ -21,6 +22,17 @@ public interface ChainedCommonCreateSlotBuilder<T extends ChainedCommonCreateSlo
    * @return T a slot builder
    */
   T withSlotName(String slotName);
+
+  /**
+   * <p>Temporary slots are not saved to disk and are automatically dropped on error or when
+   * the session has finished.</p>
+   *
+   * <p>This feature is only supported by PostgreSQL versions &gt;= 10.</p>
+   *
+   * @return T a slot builder
+   * @throws SQLFeatureNotSupportedException thrown if PostgreSQL version is less than 10.
+   */
+  T withTemporaryOption() throws SQLFeatureNotSupportedException;
 
   /**
    * Create slot with specified parameters in database.

--- a/pgjdbc/src/main/java/org/postgresql/replication/fluent/logical/LogicalCreateSlotBuilder.java
+++ b/pgjdbc/src/main/java/org/postgresql/replication/fluent/logical/LogicalCreateSlotBuilder.java
@@ -15,10 +15,9 @@ public class LogicalCreateSlotBuilder
     extends AbstractCreateSlotBuilder<ChainedLogicalCreateSlotBuilder>
     implements ChainedLogicalCreateSlotBuilder {
   private String outputPlugin;
-  private BaseConnection connection;
 
   public LogicalCreateSlotBuilder(BaseConnection connection) {
-    this.connection = connection;
+    super(connection);
   }
 
   @Override
@@ -45,7 +44,12 @@ public class LogicalCreateSlotBuilder
 
     Statement statement = connection.createStatement();
     try {
-      statement.execute(String.format("CREATE_REPLICATION_SLOT %s LOGICAL %s", slotName, outputPlugin));
+      statement.execute(String.format(
+              "CREATE_REPLICATION_SLOT %s %s LOGICAL %s",
+              slotName,
+              temporaryOption ? "TEMPORARY" : "",
+              outputPlugin
+      ));
     } finally {
       statement.close();
     }

--- a/pgjdbc/src/main/java/org/postgresql/replication/fluent/physical/PhysicalCreateSlotBuilder.java
+++ b/pgjdbc/src/main/java/org/postgresql/replication/fluent/physical/PhysicalCreateSlotBuilder.java
@@ -14,10 +14,9 @@ import java.sql.Statement;
 public class PhysicalCreateSlotBuilder
     extends AbstractCreateSlotBuilder<ChainedPhysicalCreateSlotBuilder>
     implements ChainedPhysicalCreateSlotBuilder {
-  private BaseConnection connection;
 
   public PhysicalCreateSlotBuilder(BaseConnection connection) {
-    this.connection = connection;
+    super(connection);
   }
 
   @Override
@@ -33,7 +32,11 @@ public class PhysicalCreateSlotBuilder
 
     Statement statement = connection.createStatement();
     try {
-      statement.execute(String.format("CREATE_REPLICATION_SLOT %s PHYSICAL", slotName));
+      statement.execute(String.format(
+              "CREATE_REPLICATION_SLOT %s %s PHYSICAL",
+              slotName,
+              temporaryOption ? "TEMPORARY" : ""
+      ));
     } finally {
       statement.close();
     }

--- a/pgjdbc/src/test/java/org/postgresql/replication/ReplicationSlotTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/replication/ReplicationSlotTest.java
@@ -7,6 +7,8 @@ package org.postgresql.replication;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeFalse;
+import static org.junit.Assume.assumeTrue;
 
 import org.postgresql.PGConnection;
 import org.postgresql.PGProperty;
@@ -91,20 +93,14 @@ public class ReplicationSlotTest {
   }
 
   @Test
-  public void testCreateTemporaryPhysicalSlot() throws Exception {
+  public void testCreateTemporaryPhysicalSlotPg10AndHigher()
+      throws SQLException {
+    assumeTrue(TestUtil.haveMinimumServerVersion(replConnection, ServerVersion.v10));
+
     BaseConnection baseConnection = (BaseConnection) replConnection;
 
-    slotName = "pgjdbc_test_create_temporary_physical_replication_slot";
+    String slotName = "pgjdbc_test_create_temporary_physical_replication_slot_pg_10_or_higher";
 
-    if (TestUtil.haveMinimumServerVersion(baseConnection, ServerVersion.v10)) {
-      createTemporaryPhysicalSlotPg10AndHigher(baseConnection, slotName);
-    } else {
-      createTemporaryPhysicalSlotPgLowerThan10(baseConnection, slotName);
-    }
-  }
-
-  private void createTemporaryPhysicalSlotPg10AndHigher(BaseConnection baseConnection, String slotName)
-      throws SQLException {
     try {
 
       baseConnection
@@ -123,11 +119,18 @@ public class ReplicationSlotTest {
 
     boolean result = isSlotTemporary(slotName);
 
-    assertThat(result, CoreMatchers.equalTo(true));
+    assertThat("Slot is not temporary", result, CoreMatchers.equalTo(true));
   }
 
-  private void createTemporaryPhysicalSlotPgLowerThan10(BaseConnection baseConnection, String slotName)
+  @Test
+  public void testCreateTemporaryPhysicalSlotPgLowerThan10()
       throws SQLException {
+    assumeFalse(TestUtil.haveMinimumServerVersion(replConnection, ServerVersion.v10));
+
+    BaseConnection baseConnection = (BaseConnection) replConnection;
+
+    String slotName = "pgjdbc_test_create_temporary_physical_replication_slot_pg_lower_than_10";
+
     try {
 
       baseConnection
@@ -221,20 +224,14 @@ public class ReplicationSlotTest {
   }
 
   @Test
-  public void testCreateTemporaryLogicalSlot() throws Exception {
+  public void testCreateTemporaryLogicalSlotPg10AndHigher()
+      throws SQLException {
+    assumeTrue(TestUtil.haveMinimumServerVersion(replConnection, ServerVersion.v10));
+
     BaseConnection baseConnection = (BaseConnection) replConnection;
 
-    slotName = "pgjdbc_test_create_temporary_logical_replication_slot";
+    String slotName = "pgjdbc_test_create_temporary_logical_replication_slot_pg_10_or_higher";
 
-    if (TestUtil.haveMinimumServerVersion(baseConnection, ServerVersion.v10)) {
-      createTemporaryLogicalSlotPg10AndHigher(baseConnection, slotName);
-    } else {
-      createTemporaryLogicalSlotPgLowerThan10(baseConnection, slotName);
-    }
-  }
-
-  private void createTemporaryLogicalSlotPg10AndHigher(BaseConnection baseConnection, String slotName)
-      throws SQLException {
     try {
 
       baseConnection
@@ -254,11 +251,18 @@ public class ReplicationSlotTest {
 
     boolean result = isSlotTemporary(slotName);
 
-    assertThat(result, CoreMatchers.equalTo(true));
+    assertThat("Slot is not temporary", result, CoreMatchers.equalTo(true));
   }
 
-  private void createTemporaryLogicalSlotPgLowerThan10(BaseConnection baseConnection, String slotName)
+  @Test
+  public void testCreateTemporaryLogicalSlotPgLowerThan10()
       throws SQLException {
+    assumeFalse(TestUtil.haveMinimumServerVersion(replConnection, ServerVersion.v10));
+
+    BaseConnection baseConnection = (BaseConnection) replConnection;
+
+    String slotName = "pgjdbc_test_create_temporary_logical_replication_slot_pg_lower_than_10";
+
     try {
 
       baseConnection


### PR DESCRIPTION
With Postgres 10 it is possible to create temporary replication slots.
The Postgres JDBC Driver provides a DSL to create replication slots, but there was no option to declare the slot as temporary.
This PR extends the DSL by a withTemporaryOption method.

BREAKING CHANGE: AbstractCreateSlotBuilder has no parameterless constructor anymore
Closes https://github.com/pgjdbc/pgjdbc/issues/1305

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Does mvn checkstyle:check pass ?

### Changes to Existing Features:

* [x] Does this break existing behaviour? If so please explain.
The `AbstractCreateSlotBuilder` constructor now has a `BaseConnection` parameter which is required to check the server version in the new `withTemporaryOption` method.

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?