### PR TITLE
perf: fix 1ms per async CopyAPI (regression since 42.2.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Added
 
 ### Fixed
+- Fixed async copy performance regression [PR 1314](https://github.com/pgjdbc/pgjdbc/pull/1314)
 
 ## [42.2.5] (2018-08-27)
+### Known issues
+- 1ms per async copy call [issue 1312](https://github.com/pgjdbc/pgjdbc/issues/1312)
+
 ### Changed
 - `ssl=true` implies `sslmode=verify-full`, that is it requires valid server certificate [cdeeaca4](https://github.com/pgjdbc/pgjdbc/commit/cdeeaca47dc3bc6f727c79a582c9e4123099526e)
 

--- a/docs/_posts/2018-08-27-42.2.5-release.md
+++ b/docs/_posts/2018-08-27-42.2.5-release.md
@@ -7,6 +7,9 @@ version: 42.2.5
 ---
 **Notable changes**
 
+### Known issues
+- 1ms per async copy call [issue 1312](https://github.com/pgjdbc/pgjdbc/issues/1312)
+
 ### Changed
 - `ssl=true` implies `sslmode=verify-full`, that is it requires valid server certificate [cdeeaca4](https://github.com/pgjdbc/pgjdbc/commit/cdeeaca47dc3bc6f727c79a582c9e4123099526e)
 

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/CopyDualImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/CopyDualImpl.java
@@ -28,11 +28,7 @@ public class CopyDualImpl extends CopyOperationImpl implements CopyDual {
   }
 
   public byte[] readFromCopy() throws SQLException {
-    if (received.isEmpty()) {
-      queryExecutor.readFromCopy(this, true);
-    }
-
-    return received.poll();
+    return readFromCopy(true);
   }
 
   @Override

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/replication/V3ReplicationProtocol.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/replication/V3ReplicationProtocol.java
@@ -129,6 +129,8 @@ public class V3ReplicationProtocol implements ReplicationProtocol {
       }
 
       pgStream.getSocket().setSoTimeout(minimalTimeOut);
+      // Use blocking 1ms reads for `available()` checks
+      pgStream.setMinStreamAvailableCheckDelay(0);
     } catch (IOException ioe) {
       throw new PSQLException(GT.tr("The connection attempt failed."),
           PSQLState.CONNECTION_UNABLE_TO_CONNECT, ioe);


### PR DESCRIPTION
Let's see what breaks