### PR TITLE
Explicit check for null URL

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/Driver.java
+++ b/pgjdbc/src/main/java/org/postgresql/Driver.java
@@ -29,6 +29,7 @@ import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.util.ArrayList;
 import java.util.Enumeration;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
 import java.util.logging.Formatter;
@@ -465,6 +466,7 @@ public class Driver implements java.sql.Driver {
    */
   @Override
   public boolean acceptsURL(String url) {
+	Objects.requireNonNull(url, "Non-Null URL required");
     return parseURL(url, null) != null;
   }
 

--- a/pgjdbc/src/main/java/org/postgresql/Driver.java
+++ b/pgjdbc/src/main/java/org/postgresql/Driver.java
@@ -466,7 +466,7 @@ public class Driver implements java.sql.Driver {
    */
   @Override
   public boolean acceptsURL(String url) {
-	Objects.requireNonNull(url, "Non-Null URL required");
+    Objects.requireNonNull(url, "Non-null URL is required");
     return parseURL(url, null) != null;
   }
 


### PR DESCRIPTION
If there is a misconfiguration in a J2EE server (e.g. tomcat), a null URL can be passed to the driver. Lacking an explicit null check, the eventual `NullPointerException` is ambiguous and looks like a driver bug. Hence, I'm adding an explicit null check.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

