### PR TITLE
Allow setFlushedLSN(lsn) and setAppliedLSN(lsn) from outside main loop

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/v3/replication/V3PGReplicationStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/replication/V3PGReplicationStream.java
@@ -35,9 +35,9 @@ public class V3PGReplicationStream implements PGReplicationStream {
   /**
    * Last receive LSN + payload size.
    */
-  private LogSequenceNumber lastReceiveLSN = LogSequenceNumber.INVALID_LSN;
-  private LogSequenceNumber lastAppliedLSN = LogSequenceNumber.INVALID_LSN;
-  private LogSequenceNumber lastFlushedLSN = LogSequenceNumber.INVALID_LSN;
+  private volatile LogSequenceNumber lastReceiveLSN = LogSequenceNumber.INVALID_LSN;
+  private volatile LogSequenceNumber lastAppliedLSN = LogSequenceNumber.INVALID_LSN;
+  private volatile LogSequenceNumber lastFlushedLSN = LogSequenceNumber.INVALID_LSN;
 
   /**
    * @param copyDual         bidirectional copy protocol

--- a/pgjdbc/src/main/java/org/postgresql/replication/PGReplicationStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/replication/PGReplicationStream.java
@@ -58,11 +58,11 @@ public interface PGReplicationStream
   ByteBuffer readPending() throws SQLException;
 
   /**
-   * Parameter updates by execute {@link PGReplicationStream#read()} method.</p>
+   * <p>Parameter updates by execute {@link PGReplicationStream#read()} method.</p>
    *
-   * It is safe to call this method in a thread different than the main thread. However, usually this
+   * <p>It is safe to call this method in a thread different than the main thread. However, usually this
    * method is called in the main thread after a successful {@link PGReplicationStream#read()} or
-   * {@link PGReplicationStream#readPending()}, to get the LSN corresponding to the received record.
+   * {@link PGReplicationStream#readPending()}, to get the LSN corresponding to the received record.</p>
    *
    * @return not null LSN position that was receive last time via {@link PGReplicationStream#read()}
    *     method
@@ -70,31 +70,31 @@ public interface PGReplicationStream
   LogSequenceNumber getLastReceiveLSN();
 
   /**
-   * Last flushed lsn send in update message to backend. Parameter updates only via {@link
+   * <p>Last flushed lsn send in update message to backend. Parameter updates only via {@link
    * PGReplicationStream#setFlushedLSN(LogSequenceNumber)}</p>
    *
-   * It is safe to call this method in a thread different than the main thread.
+   * <p>It is safe to call this method in a thread different than the main thread.</p>
    *
    * @return not null location of the last WAL flushed to disk in the standby.
    */
   LogSequenceNumber getLastFlushedLSN();
 
   /**
-   * Last applied lsn send in update message to backed. Parameter updates only via {@link
+   * <p>Last applied lsn send in update message to backed. Parameter updates only via {@link
    * PGReplicationStream#setAppliedLSN(LogSequenceNumber)}</p>
    *
-   * It is safe to call this method in a thread different than the main thread.
+   * <p>It is safe to call this method in a thread different than the main thread.</p>
    *
    * @return not null location of the last WAL applied in the standby.
    */
   LogSequenceNumber getLastAppliedLSN();
 
   /**
-   * Set flushed LSN. It parameter will be send to backend on next update status iteration. Flushed
+   * <p>Set flushed LSN. It parameter will be send to backend on next update status iteration. Flushed
    * LSN position help backend define which wal can be recycle.</p>
    *
-   * It is safe to call this method in a thread different than the main thread. The updated value
-   * will be sent to the backend in the next status update run.
+   * <p>It is safe to call this method in a thread different than the main thread. The updated value
+   * will be sent to the backend in the next status update run.</p>
    *
    * @param flushed not null location of the last WAL flushed to disk in the standby.
    * @see PGReplicationStream#forceUpdateStatus()
@@ -102,11 +102,11 @@ public interface PGReplicationStream
   void setFlushedLSN(LogSequenceNumber flushed);
 
   /**
-   * Parameter used only physical replication and define which lsn already was apply on standby.
+   * <p>Parameter used only physical replication and define which lsn already was apply on standby.
    * Feedback will send to backend on next update status iteration.</p>
    *
-   * It is safe to call this method in a thread different than the main thread. The updated value
-   * will be sent to the backend in the next status update run.
+   * <p>It is safe to call this method in a thread different than the main thread. The updated value
+   * will be sent to the backend in the next status update run.</p>
    *
    * @param applied not null location of the last WAL applied in the standby.
    * @see PGReplicationStream#forceUpdateStatus()

--- a/pgjdbc/src/main/java/org/postgresql/replication/PGReplicationStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/replication/PGReplicationStream.java
@@ -58,7 +58,7 @@ public interface PGReplicationStream
   ByteBuffer readPending() throws SQLException;
 
   /**
-   * Parameter updates by execute {@link PGReplicationStream#read()} method.
+   * Parameter updates by execute {@link PGReplicationStream#read()} method.</p>
    *
    * It is safe to call this method in a thread different than the main thread. However, usually this
    * method is called in the main thread after a successful {@link PGReplicationStream#read()} or
@@ -71,7 +71,7 @@ public interface PGReplicationStream
 
   /**
    * Last flushed lsn send in update message to backend. Parameter updates only via {@link
-   * PGReplicationStream#setFlushedLSN(LogSequenceNumber)}
+   * PGReplicationStream#setFlushedLSN(LogSequenceNumber)}</p>
    *
    * It is safe to call this method in a thread different than the main thread.
    *
@@ -81,7 +81,7 @@ public interface PGReplicationStream
 
   /**
    * Last applied lsn send in update message to backed. Parameter updates only via {@link
-   * PGReplicationStream#setAppliedLSN(LogSequenceNumber)}
+   * PGReplicationStream#setAppliedLSN(LogSequenceNumber)}</p>
    *
    * It is safe to call this method in a thread different than the main thread.
    *
@@ -91,7 +91,7 @@ public interface PGReplicationStream
 
   /**
    * Set flushed LSN. It parameter will be send to backend on next update status iteration. Flushed
-   * LSN position help backend define which wal can be recycle.
+   * LSN position help backend define which wal can be recycle.</p>
    *
    * It is safe to call this method in a thread different than the main thread. The updated value
    * will be sent to the backend in the next status update run.
@@ -103,7 +103,7 @@ public interface PGReplicationStream
 
   /**
    * Parameter used only physical replication and define which lsn already was apply on standby.
-   * Feedback will send to backend on next update status iteration.
+   * Feedback will send to backend on next update status iteration.</p>
    *
    * It is safe to call this method in a thread different than the main thread. The updated value
    * will be sent to the backend in the next status update run.


### PR DESCRIPTION
Hi,

**TL;DR version**

Marking the fields holding the sequence numbers as `volatile` will allow the API user to call `setFlushedLSN(lsn)` and `setAppliedLSN(lsn)` (and also the getters) from a thread different than the thread doing the main loop. This is useful when doing a blocking `read()`, as it allows another thread to actually acknowledge an event as flushed/applied.

Without this change, one cannot combine `read()` and parallel processing+acknowledging of WAL events, as there is no guarantee that the updated values will be seen by the main replication loop.

**long version**

I'm working on a logical replication consumer implementation which forwards replication event to a queue service (RabbitMQ in this instance). The flow is as following:

1. The main loop consuming the replication events uses `read()` to collect replication events. This is a blocking call, it only returns when a new replication event is read.
2. The replication events, together with their corresponding LSN, are pushed to a `BlockingQueue` (https://docs.oracle.com/javase/7/docs/api/java/util/concurrent/BlockingQueue.html)
3. One or more threads consume this queue and send the replication events to RabbitMQ, following certain policies.
4. From the moment RabbitMQ confirms, we can acknowledge to PostgreSQL, if all previous events were also confirmed by RabbitMQ.

In this flow, replication events are independent from each other. Therefore, it is correct to have multiple active threads in (3) above.

The main replication loop is as following:

    final PGReplicationStream stream = ...;
    final BlockingQueue queue = ...;

    while (true) {
        final ByteBuffer bb = stream.read(); // this blocks
        final Item = new Item(bb, stream.getLastReceivedLSN());

        queue.put(item); // this might also block if the queue is full
    }

The main RabbitMQ loops is/are as following:

    final PGReplicationStream stream = ...; // the same stream as above
    final BlockingQueue queue = ...; // the same queue as above
    final RabbitMQClient client = ...;

    while (true) {
        final Item item = queue.take(); // this might block

        // send to RabbitMQ
        final boolean OK = client.send(item.getBuffer());

        // acknowledge to PostgreSQL
        if (OK && all previous events were also OK) { // this typically happens asynchronously
            stream.setFlushedLSN(item.getLSN());
        }
    }

The change is in this pull request is related to `stream.setFlushedLSN(item.getLSN())` in the code snippet above. Without declaring the LSN members as `volatile`, there is no guarantee that the replication main loop will (ever) notice the update, as it could continue to use its cached value.