### PR TITLE
Refactor cleanup. GraalVM native-image compatible

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/v3/Portal.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/Portal.java
@@ -25,10 +25,10 @@ class Portal implements ResultCursor {
   }
 
   public void close() {
-    if (cleanupRef != null) {
-      cleanupRef.clear();
-      cleanupRef.enqueue();
-      cleanupRef = null;
+    if (portalResourcesCleaner != null && cleanupReference != null) {
+      portalResourcesCleaner.registerClosedObject(cleanupReference);
+      cleanupReference = null;
+      portalResourcesCleaner = null;
     }
   }
 
@@ -44,8 +44,9 @@ class Portal implements ResultCursor {
     return query;
   }
 
-  void setCleanupRef(PhantomReference<?> cleanupRef) {
-    this.cleanupRef = cleanupRef;
+  void setReferenceCleanup(PhantomReference<Portal> cleanupReference, ServerResourcesCleaner<Portal> serverResourcesCleaner) {
+    this.cleanupReference = cleanupReference;
+    this.portalResourcesCleaner = serverResourcesCleaner;
   }
 
   public String toString() {
@@ -61,5 +62,6 @@ class Portal implements ResultCursor {
   private final SimpleQuery query;
   private final String portalName;
   private final byte[] encodedName;
-  private PhantomReference<?> cleanupRef;
+  private ServerResourcesCleaner<Portal> portalResourcesCleaner;
+  private PhantomReference<Portal> cleanupReference;
 }

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -44,8 +44,6 @@ import org.postgresql.util.ServerErrorMessage;
 
 import java.io.IOException;
 import java.lang.ref.PhantomReference;
-import java.lang.ref.Reference;
-import java.lang.ref.ReferenceQueue;
 import java.net.Socket;
 import java.net.SocketException;
 import java.net.SocketTimeoutException;
@@ -56,7 +54,6 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Deque;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
@@ -64,6 +61,7 @@ import java.util.Set;
 import java.util.TimeZone;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
 
 /**
  * QueryExecutor implementation for the V3 protocol.
@@ -1847,67 +1845,48 @@ public class QueryExecutorImpl extends QueryExecutorBase {
     pendingDescribePortalQueue.add(query);
   }
 
-  //
-  // Garbage collection of parsed statements.
-  //
-  // When a statement is successfully parsed, registerParsedQuery is called.
-  // This creates a PhantomReference referring to the "owner" of the statement
-  // (the originating Query object) and inserts that reference as a key in
-  // parsedQueryMap. The values of parsedQueryMap are the corresponding allocated
-  // statement names. The originating Query object also holds a reference to the
-  // PhantomReference.
-  //
-  // When the owning Query object is closed, it enqueues and clears the associated
-  // PhantomReference.
-  //
-  // If the owning Query object becomes unreachable (see java.lang.ref javadoc) before
-  // being closed, the corresponding PhantomReference is enqueued on
-  // parsedQueryCleanupQueue. In the Sun JVM, phantom references are only enqueued
-  // when a GC occurs, so this is not necessarily prompt but should eventually happen.
-  //
-  // Periodically (currently, just before query execution), the parsedQueryCleanupQueue
-  // is polled. For each enqueued PhantomReference we find, we remove the corresponding
-  // entry from parsedQueryMap, obtaining the name of the underlying statement in the
-  // process. Then we send a message to the backend to deallocate that statement.
-  //
 
-  private final HashMap<PhantomReference<SimpleQuery>, String> parsedQueryMap =
-      new HashMap<PhantomReference<SimpleQuery>, String>();
-  private final ReferenceQueue<SimpleQuery> parsedQueryCleanupQueue =
-      new ReferenceQueue<SimpleQuery>();
+  /**
+   * Garbage collection of parsed statements. See {@link ServerResourcesCleaner}.
+   */
+
+  private final ServerResourcesCleaner<SimpleQuery> queryServerResourcesCleaner = new ServerResourcesCleaner<SimpleQuery>() {
+    @Override
+    protected void onReferenceCleanup(String statementName) throws IOException {
+      sendCloseStatement(statementName);
+    }
+  };
 
   private void registerParsedQuery(SimpleQuery query, String statementName) {
     if (statementName == null) {
       return;
     }
 
-    PhantomReference<SimpleQuery> cleanupRef =
-        new PhantomReference<SimpleQuery>(query, parsedQueryCleanupQueue);
-    parsedQueryMap.put(cleanupRef, statementName);
-    query.setCleanupRef(cleanupRef);
+    PhantomReference<SimpleQuery> reference = queryServerResourcesCleaner.registerObject(query, statementName);
+    query.setReferenceCleanup(reference, queryServerResourcesCleaner);
   }
 
   private void processDeadParsedQueries() throws IOException {
-    Reference<? extends SimpleQuery> deadQuery;
-    while ((deadQuery = parsedQueryCleanupQueue.poll()) != null) {
-      String statementName = parsedQueryMap.remove(deadQuery);
-      sendCloseStatement(statementName);
-      deadQuery.clear();
-    }
+    queryServerResourcesCleaner.processDeadObjects();
   }
 
-  //
-  // Essentially the same strategy is used for the cleanup of portals.
-  // Note that each Portal holds a reference to the corresponding Query
-  // that generated it, so the Query won't be collected (and the statement
-  // closed) until all the Portals are, too. This is required by the mechanics
-  // of the backend protocol: when a statement is closed, all dependent portals
-  // are also closed.
-  //
 
-  private final HashMap<PhantomReference<Portal>, String> openPortalMap =
-      new HashMap<PhantomReference<Portal>, String>();
-  private final ReferenceQueue<Portal> openPortalCleanupQueue = new ReferenceQueue<Portal>();
+  /**
+   * Garbage collection of portals. See {@link ServerResourcesCleaner}.
+   *
+   * <p>Note that each Portal holds a reference to the corresponding Query that
+   * generated it, so the Query won't be collected (and the statement closed)
+   * until all the Portals are, too. This is required by the mechanics of the
+   * backend protocol: when a statement is closed, all dependent portals are
+   * also closed.
+   */
+
+  private final ServerResourcesCleaner<Portal> portalServerResourcesCleaner = new ServerResourcesCleaner<Portal>() {
+    @Override
+    protected void onReferenceCleanup(String portalName) throws IOException {
+      sendClosePortal(portalName);
+    }
+  };
 
   private static final Portal UNNAMED_PORTAL = new Portal(null, "unnamed");
 
@@ -1917,20 +1896,14 @@ public class QueryExecutorImpl extends QueryExecutorBase {
     }
 
     String portalName = portal.getPortalName();
-    PhantomReference<Portal> cleanupRef =
-        new PhantomReference<Portal>(portal, openPortalCleanupQueue);
-    openPortalMap.put(cleanupRef, portalName);
-    portal.setCleanupRef(cleanupRef);
+    PhantomReference<Portal> reference = portalServerResourcesCleaner.registerObject(portal, portalName);
+    portal.setReferenceCleanup(reference, portalServerResourcesCleaner);
   }
 
   private void processDeadPortals() throws IOException {
-    Reference<? extends Portal> deadPortal;
-    while ((deadPortal = openPortalCleanupQueue.poll()) != null) {
-      String portalName = openPortalMap.remove(deadPortal);
-      sendClosePortal(portalName);
-      deadPortal.clear();
-    }
+    portalServerResourcesCleaner.processDeadObjects();
   }
+
 
   protected void processResults(ResultHandler handler, int flags) throws IOException {
     boolean noResults = (flags & QueryExecutor.QUERY_NO_RESULTS) != 0;

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/ServerResourcesCleaner.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/ServerResourcesCleaner.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2018, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.core.v3;
+
+import java.io.IOException;
+import java.lang.ref.PhantomReference;
+import java.lang.ref.Reference;
+import java.lang.ref.ReferenceQueue;
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+
+/**
+ * This class serves as a base, generic class, to track and eventually close
+ * (deallocate) server-side resources such as prepared queries or portals.
+ *
+ * <p>At the driver level, these resources may be cleaned either automatically
+ * (if freed by the JVM) or when their close() method is called. In either
+ * case, a {@link PhantomReference} to the resource ("owner") is used.
+ *
+ * <p>If the resource object becomes unreachable (see {@link Reference}) before
+ * being closed, the corresponding PhantomReference is automatically added to a
+ * ReferenceQueue, which will be later inspected by the driver to instruct the
+ * server to deallocate related resources. Note that reference enqueuing may
+ * happen at a later point than the resource deallocation (some JVMs will only
+ * do this at a GC event, for example).
+ *
+ * <p>If the resource is freed by calling its close() method, it is placed on a
+ * internal queue of closed resources, and the driver will call the logic to
+ * deallocate those server-side.
+ *
+ * <p>This class encapsulates this logic and aides in creating simple concrete
+ * implementations for {@link SimpleQuery} and {@link Portal}. Typically these
+ * implementations may periodically call this class methods to traverse both
+ * the VM deallocated resources, as well as those closed, and call the
+ * appropriate server-side deallcation method (to be provided by subclasses).
+ *
+ * @author Alvaro Hernandez aht@ongres.com
+ *
+ */
+public abstract class ServerResourcesCleaner<T>  {
+  private final Map<PhantomReference<T>, String> referenceNameMap = new ConcurrentHashMap<PhantomReference<T>, String>();
+  private final ReferenceQueue<T> referenceQueue = new ReferenceQueue<T>();
+  private final Queue<PhantomReference<T>> closedQueue = new ConcurrentLinkedQueue<PhantomReference<T>>();
+
+  public PhantomReference<T> registerObject(T object, String name) {
+    PhantomReference<T> reference = new PhantomReference<T>(object, referenceQueue);
+    referenceNameMap.put(reference, name);
+
+    return reference;
+  }
+
+  public void registerClosedObject(PhantomReference<T> reference) {
+    closedQueue.add(reference);
+  }
+
+  public void processDeadObjects() throws IOException {
+    Reference<? extends T> deadObject;
+    while ((deadObject = referenceQueue.poll()) != null) {
+      cleanDeadObjectReference(deadObject);
+    }
+
+    while ((deadObject = closedQueue.poll()) != null) {
+      cleanDeadObjectReference(deadObject);
+    }
+  }
+
+  private void cleanDeadObjectReference(Reference<? extends T> deadObject) throws IOException {
+    String name = referenceNameMap.remove(deadObject);
+    if (null == name) {
+      return; // name has already been processed
+    }
+
+    onReferenceCleanup(name);
+    deadObject.clear();
+  }
+
+  protected abstract void onReferenceCleanup(String name) throws IOException;
+}

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/SimpleQuery.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/SimpleQuery.java
@@ -284,19 +284,16 @@ class SimpleQuery implements Query {
     return getNativeSql().isEmpty();
   }
 
-  void setCleanupRef(PhantomReference<?> cleanupRef) {
-    if (this.cleanupRef != null) {
-      this.cleanupRef.clear();
-      this.cleanupRef.enqueue();
-    }
-    this.cleanupRef = cleanupRef;
+  void setReferenceCleanup(PhantomReference<SimpleQuery> cleanupReference, ServerResourcesCleaner<SimpleQuery> serverResourcesCleaner) {
+    this.cleanupReference = cleanupReference;
+    this.simpleQueryResourcesCleaner = serverResourcesCleaner;
   }
 
   void unprepare() {
-    if (cleanupRef != null) {
-      cleanupRef.clear();
-      cleanupRef.enqueue();
-      cleanupRef = null;
+    if (simpleQueryResourcesCleaner != null && cleanupReference != null) {
+      simpleQueryResourcesCleaner.registerClosedObject(cleanupReference);
+      cleanupReference = null;
+      simpleQueryResourcesCleaner = null;
     }
     if (this.unspecifiedParams != null) {
       this.unspecifiedParams.clear();
@@ -359,7 +356,8 @@ class SimpleQuery implements Query {
   private boolean portalDescribed;
   private boolean statementDescribed;
   private final boolean sanitiserDisabled;
-  private PhantomReference<?> cleanupRef;
+  private ServerResourcesCleaner<SimpleQuery> simpleQueryResourcesCleaner;
+  private PhantomReference<SimpleQuery> cleanupReference;
   private int[] preparedTypes;
   private BitSet unspecifiedParams;
   private short deallocateEpoch;


### PR DESCRIPTION
Code in QueryExecutorImpl used to clean server-side resoures such as
statements or portals have been refactored. Main goals are:

- Avoid code duplication and make code more readable. In particular,
  there were two usages conflated to the same data structure and
  procedure: use the queue internal to the PhantomReference to queue
  resources to be later cleaned up at the server. However, reasons for
  resources to be added there could be significantly different: either
  the JVM marking them as unreachable, or the user calling close() on
  them. These two scenarios have been separated and the code factored
  into external class ServerResourcesCleaner.

- Add GraalVM's native-image compatibility. The only showstopper for
  this was the usage of Reference.enqueue() and .clear() methods that
  are not implemented in SVM. By avoiding them, this patch enables
  generation of native images that include the pgjdbc driver as a
  dependency.

### All Submissions:

* [X] Have you followed the guidelines in our [Contributing](CONTRIBUTING.md) document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests? Not tested
2. [X] Does mvn checkstyle:check pass ?

### Changes to Existing Features:

* [X] Does this break existing behaviour? If so please explain. It shouldn't.
* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully run tests with your changes locally? No, left for Travis