### PR TITLE
Invert order of declaring oid vs Array.newInstance to help compilers

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgArray.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgArray.java
@@ -194,12 +194,12 @@ public class PgArray implements java.sql.Array {
       pos += 4;
     }
     if (dimensions == 0) {
-      return java.lang.reflect.Array.newInstance(elementOidToClass(elementOid), 0);
+      return newTypedArray(elementOid, 0);
     }
     if (count > 0) {
       dims[0] = Math.min(count, dims[0]);
     }
-    Object arr = java.lang.reflect.Array.newInstance(elementOidToClass(elementOid), dims);
+    Object arr = newTypedArray(elementOid, dims);
     try {
       storeValues((Object[]) arr, elementOid, dims, pos, 0, index);
     } catch (IOException ioe) {
@@ -378,27 +378,27 @@ public class PgArray implements java.sql.Array {
     return pos;
   }
 
-  private Class<?> elementOidToClass(int oid) throws SQLException {
+  private Object newTypedArray(final int oid, final int... dimensions) throws SQLException {
     switch (oid) {
       case Oid.INT2:
-        return Short.class;
+        return java.lang.reflect.Array.newInstance(Short.class, dimensions);
       case Oid.INT4:
-        return Integer.class;
+        return java.lang.reflect.Array.newInstance(Integer.class, dimensions);
       case Oid.INT8:
-        return Long.class;
+        return java.lang.reflect.Array.newInstance(Long.class, dimensions);
       case Oid.FLOAT4:
-        return Float.class;
+        return java.lang.reflect.Array.newInstance(Float.class, dimensions);
       case Oid.FLOAT8:
-        return Double.class;
+        return java.lang.reflect.Array.newInstance(Double.class, dimensions);
       case Oid.TEXT:
       case Oid.VARCHAR:
-        return String.class;
+        return java.lang.reflect.Array.newInstance(String.class, dimensions);
       case Oid.BOOL:
-        return Boolean.class;
+        return java.lang.reflect.Array.newInstance(Boolean.class, dimensions);
       default:
         ArrayAssistant arrElemBuilder = ArrayAssistantRegistry.getAssistant(oid);
         if (arrElemBuilder != null) {
-          return arrElemBuilder.baseType();
+          return arrElemBuilder.makeTypedArray(dimensions);
         }
 
         throw org.postgresql.Driver.notImplemented(this.getClass(), "readBinaryArray(data,oid)");
@@ -568,8 +568,10 @@ public class PgArray implements java.sql.Array {
 
       if (dims > 1 || useObjects) {
         ret = oa = (dims > 1
-            ? (Object[]) java.lang.reflect.Array
-                .newInstance(useObjects ? Boolean.class : boolean.class, dimsLength)
+            ? ((Object[]) (useObjects
+                  ? java.lang.reflect.Array.newInstance(Boolean.class, dimsLength)
+                  : java.lang.reflect.Array.newInstance(boolean.class, dimsLength)
+              ))
             : new Boolean[count]);
       } else {
         ret = pa = new boolean[count];
@@ -593,8 +595,11 @@ public class PgArray implements java.sql.Array {
       if (dims > 1 || useObjects) {
         ret =
             oa = (dims > 1
-                ? (Object[]) java.lang.reflect.Array
-                    .newInstance(useObjects ? Short.class : short.class, dimsLength)
+                ?
+                ((Object[]) (useObjects
+                    ? java.lang.reflect.Array.newInstance(Short.class, dimsLength)
+                    : java.lang.reflect.Array.newInstance(short.class, dimsLength)
+                ))
                 : new Short[count]);
       } else {
         ret = pa = new short[count];
@@ -617,8 +622,10 @@ public class PgArray implements java.sql.Array {
       if (dims > 1 || useObjects) {
         ret =
             oa = (dims > 1
-                ? (Object[]) java.lang.reflect.Array
-                    .newInstance(useObjects ? Integer.class : int.class, dimsLength)
+                ? ((Object[]) (useObjects
+                      ? java.lang.reflect.Array.newInstance(Integer.class, dimsLength)
+                      : java.lang.reflect.Array.newInstance(int.class, dimsLength)
+            ))
                 : new Integer[count]);
       } else {
         ret = pa = new int[count];
@@ -641,8 +648,11 @@ public class PgArray implements java.sql.Array {
       if (dims > 1 || useObjects) {
         ret =
             oa = (dims > 1
-                ? (Object[]) java.lang.reflect.Array
-                    .newInstance(useObjects ? Long.class : long.class, dimsLength)
+                  ?
+                ((Object[]) (useObjects
+                    ? java.lang.reflect.Array.newInstance(Long.class, dimsLength)
+                    : java.lang.reflect.Array.newInstance(long.class, dimsLength)
+                ))
                 : new Long[count]);
       } else {
         ret = pa = new long[count];
@@ -676,8 +686,10 @@ public class PgArray implements java.sql.Array {
       if (dims > 1 || useObjects) {
         ret =
             oa = (dims > 1
-                ? (Object[]) java.lang.reflect.Array
-                    .newInstance(useObjects ? Float.class : float.class, dimsLength)
+                ? ((Object[]) (useObjects
+                  ? java.lang.reflect.Array.newInstance(Float.class, dimsLength)
+                  : java.lang.reflect.Array.newInstance(float.class, dimsLength)
+            ))
                 : new Float[count]);
       } else {
         ret = pa = new float[count];
@@ -699,8 +711,10 @@ public class PgArray implements java.sql.Array {
 
       if (dims > 1 || useObjects) {
         ret = oa = (dims > 1
-            ? (Object[]) java.lang.reflect.Array
-                .newInstance(useObjects ? Double.class : double.class, dimsLength)
+            ? ((Object[]) (useObjects
+                  ? java.lang.reflect.Array.newInstance(Double.class, dimsLength)
+                  : java.lang.reflect.Array.newInstance(double.class, dimsLength)
+            ))
             : new Double[count]);
       } else {
         ret = pa = new double[count];
@@ -764,8 +778,8 @@ public class PgArray implements java.sql.Array {
 
       Object[] oa = null;
       ret = oa = (dims > 1)
-          ? (Object[]) java.lang.reflect.Array.newInstance(arrAssistant.baseType(), dimsLength)
-          : (Object[]) java.lang.reflect.Array.newInstance(arrAssistant.baseType(), count);
+          ? (Object[]) arrAssistant.makeTypedArray(dimsLength)
+          : (Object[]) arrAssistant.makeTypedArray(count);
 
       for (; count > 0; count--) {
         Object v = input.get(index++);

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/UUIDArrayAssistant.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/UUIDArrayAssistant.java
@@ -25,4 +25,9 @@ public class UUIDArrayAssistant implements ArrayAssistant {
   public Object buildElement(String literal) {
     return UUID.fromString(literal);
   }
+
+  @Override
+  public Object makeTypedArray(final int... dimensions) {
+    return java.lang.reflect.Array.newInstance(UUID.class, dimensions);
+  }
 }

--- a/pgjdbc/src/main/java/org/postgresql/jdbc2/ArrayAssistant.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc2/ArrayAssistant.java
@@ -36,4 +36,11 @@ public interface ArrayAssistant {
    * @return array element
    */
   Object buildElement(String literal);
+
+  /**
+   * Allocate an array of the custom type and requested dimensions
+   * @param dimensions the array dimensions
+   * @return a new array
+   */
+  Object makeTypedArray(int... dimensions);
 }


### PR DESCRIPTION
## What is this?

The primary intention here is to make the PostgreSQL JDBC driver easier to run
on the SubstrateVM.

This patch alone is not sufficient, I'll send more. It's self-contained and quite simple.

### How does this work?

When building with GraalVM and including pgjdbc, the driver will get compiled
to native code; this process requires particular care with Reflection, including
use of `java.lang.reflect.Array.newInstance` will require users to enable various
additional flags at compile time.

By inverting some logic as in the attached patch, the compiler is able to better
predict what kind of types exactly will be necessary to support at runtime;
this is a far better solution than setting ad-hoc flags, as it allows for use
without necessarily knowing all such compile time flags, and also allows for
optimal dead code elimination as the GraalVM compiler might be able to apply
more specific optimisations than when forced with user overrides.

I didn't verify performance in non-Graal compilers, but I would expect
this to possibly help any other JVM as well, as the method could be more
easily recognized, and therefore compiled to better performing code.

### Drawbacks

I added a new method in `org.postgresql.jdbc2.ArrayAssistant`. I don't know if that's acceptable, please let me know: my personal opinion is to not expect lots of people having implemented that interface in custom extensions.


### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests? I'll need help from Trevis.
2. [x] Does mvn checkstyle:check pass ?

### Changes to Existing Features:

* [ ] Does this break existing behaviour? If so please explain. See Drawbacks above.
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable? Not Applicable.
* [x] Have you successfully run tests with your changes locally?