### PR TITLE
fix: Incorrect return value for bytes [128-255] in stream.read

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/copy/PGCopyInputStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/copy/PGCopyInputStream.java
@@ -76,7 +76,7 @@ public class PGCopyInputStream extends InputStream implements CopyOut {
 
   public int read() throws IOException {
     checkClosed();
-    return gotBuf() ? buf[at++] : -1;
+    return gotBuf() ? (buf[at++] & 0xFF)  : -1;
   }
 
   public int read(byte[] buf) throws IOException {

--- a/pgjdbc/src/main/java/org/postgresql/util/ReaderInputStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/ReaderInputStream.java
@@ -113,7 +113,7 @@ public class ReaderInputStream extends InputStream {
     while (res != -1) {
       res = read(oneByte);
       if (res > 0) {
-        return oneByte[0];
+        return (oneByte[0] & 0xFF);
       }
     }
     return -1;


### PR DESCRIPTION
fixes #1344 