### PR TITLE
Support custom 'options' connection property

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ where:
  * **host** (Optional) is the server address to connect. This could be a DNS or IP address, or it could be *localhost* or *127.0.0.1* for the local computer. To specify an IPv6 address your must enclose the host parameter with square brackets (jdbc:postgresql://[::1]:5740/accounting). Defaults to `localhost`.
  * **port** (Optional) is the port number listening on the host. Defaults to `5432`.
  * **database** (Optional) is the database name. Defaults to the same name as the *user name* used in the connection.
- * **propertyX** (Optional) is one or more option connection properties. For more information see *Connection properties*. 
+ * **propertyX** (Optional) is one or more option connection properties. For more information see *Connection properties*.
 
 #### Connection Properties
 In addition to the standard connection parameters the driver supports a number of additional properties which can be used to specify additional driver behaviour specific to PostgreSQL™. These properties may be specified in either the connection URL or an additional Properties object parameter to DriverManager.getConnection.
@@ -109,6 +109,7 @@ In addition to the standard connection parameters the driver supports a number o
 | ----------------------------- | ------- | :-----: | ------------- |
 | user                          | String  | null    | The database user on whose behalf the connection is being made. |
 | password                      | String  | null    | The database user's password. |
+| options                       | String  | null    | Command-line options to send to the server at connection start. |
 | ssl                           | Boolean | false   | Control use of SSL (true value causes SSL to be required) |
 | sslfactory                    | String  | null    | Provide a SSLSocketFactory class when using SSL. |
 | sslfactoryarg (deprecated)    | String  | null    | Argument forwarded to constructor of SSLSocketFactory class. |
@@ -149,7 +150,7 @@ In addition to the standard connection parameters the driver supports a number o
 | preferQueryMode               | String  | extended | Specifies which mode is used to execute queries to database, possible values: extended, extendedForPrepared, extendedCacheEverything, simple |
 | reWriteBatchedInserts         | Boolean | false  | Enable optimization to rewrite and collapse compatible INSERT statements that are batched. |
 
-## Contributing 
+## Contributing
 For information on how to contribute to the project see the [Contributing Guidelines](CONTRIBUTING.md)
 
 ----------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ In addition to the standard connection parameters the driver supports a number o
 | ----------------------------- | ------- | :-----: | ------------- |
 | user                          | String  | null    | The database user on whose behalf the connection is being made. |
 | password                      | String  | null    | The database user's password. |
-| options                       | String  | null    | Command-line options to send to the server at connection start. |
+| options                       | String  | null    | Specify 'options' connection initialization parameter. |
 | ssl                           | Boolean | false   | Control use of SSL (true value causes SSL to be required) |
 | sslfactory                    | String  | null    | Provide a SSLSocketFactory class when using SSL. |
 | sslfactoryarg (deprecated)    | String  | null    | Argument forwarded to constructor of SSLSocketFactory class. |

--- a/docs/documentation/head/connect.md
+++ b/docs/documentation/head/connect.md
@@ -54,6 +54,9 @@ URL or an additional `Properties` object parameter to `DriverManager.getConnecti
 The following examples illustrate the use of both methods to establish a SSL
 connection.
 
+If a property is specified both in URL and in `Properties` object, the value from
+`Properties` object is ignored.
+
 ```java
 String url = "jdbc:postgresql://localhost/test";
 Properties props = new Properties();
@@ -68,11 +71,20 @@ Connection conn = DriverManager.getConnection(url);
 
 * **user** = String
 
-	The database user on whose behalf the connection is being made. 
+	The database user on whose behalf the connection is being made.
 
 * **password** = String
 
-	The database user's password. 
+	The database user's password.
+
+* **options** = String
+
+	Command-line options to send to the server at connection start.
+
+	The value of this property may contain spaces or other special characters,
+	and it should be properly encoded if provided in the connection URL. Spaces
+	are considered to separate command-line arguments, unless escaped with
+	a backslash (`\`); `\\` represents a literal backslash.
 
 * **ssl** = boolean
 

--- a/docs/documentation/head/connect.md
+++ b/docs/documentation/head/connect.md
@@ -79,7 +79,7 @@ Connection conn = DriverManager.getConnection(url);
 
 * **options** = String
 
-	Command-line options to send to the server at connection start.
+	Specify 'options' connection initialization parameter.
 
 	The value of this property may contain spaces or other special characters,
 	and it should be properly encoded if provided in the connection URL. Spaces

--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -56,10 +56,10 @@ public enum PGProperty {
       false, "3"),
 
   /**
-   * Specify command-line options to send to the server at connection start.
-   * The value of this parameter may contain spaces and other special characters or their URL representation
+   * Specify 'options' connection initialization parameter.
+   * The value of this parameter may contain spaces and other special characters or their URL representation.
    */
-  OPTIONS("options", null, "Command-line options to send to the server at connection start."),
+  OPTIONS("options", null, "Specify 'options' connection initialization parameter."),
 
   /**
    * <p>Logger level of the driver. Allowed values: {@code OFF}, {@code DEBUG} or {@code TRACE}.</p>

--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -56,6 +56,12 @@ public enum PGProperty {
       false, "3"),
 
   /**
+   * Specify command-line options to send to the server at connection start.
+   * The value of this parameter may contain spaces and other special characters or their URL representation
+   */
+  OPTIONS("options", null, "Command-line options to send to the server at connection start."),
+
+  /**
    * <p>Logger level of the driver. Allowed values: {@code OFF}, {@code DEBUG} or {@code TRACE}.</p>
    *
    * <p>This enable the {@link java.util.logging.Logger} of the driver based on the following mapping

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java
@@ -339,6 +339,12 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
     if (currentSchema != null) {
       paramList.add(new String[]{"search_path", currentSchema});
     }
+
+    String options = PGProperty.OPTIONS.get(info);
+    if (options != null) {
+      paramList.add(new String[]{"options", options});
+    }
+
     return paramList;
   }
 

--- a/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
+++ b/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
@@ -233,6 +233,21 @@ public abstract class BaseDataSource implements CommonDataSource, Referenceable 
   }
 
   /**
+   * @return command line options for this connection
+   */
+  public String getOptions() {
+    return PGProperty.OPTIONS.get(properties);
+  }
+
+  /**
+   * Set command line options for this connection
+   * @param options string to set options to
+   */
+  public void setOptions(String options) {
+    PGProperty.OPTIONS.set(properties, options);
+  }
+
+  /**
    * @return login timeout
    * @see PGProperty#LOGIN_TIMEOUT
    */

--- a/pgjdbc/src/test/java/org/postgresql/test/TestUtil.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/TestUtil.java
@@ -69,6 +69,11 @@ public class TestUtil {
       protocolVersion = "&protocolVersion=" + getProtocolVersion();
     }
 
+    String options = "";
+    if (getOptions() != null) {
+      options = "&options=" + getOptions();
+    }
+
     String binaryTransfer = "";
     if (getBinaryTransfer() != null && !getBinaryTransfer().equals("")) {
       binaryTransfer = "&binaryTransfer=" + getBinaryTransfer();
@@ -96,6 +101,7 @@ public class TestUtil {
         + logLevel
         + logFile
         + protocolVersion
+        + options
         + binaryTransfer
         + receiveBufferSize
         + sendBufferSize
@@ -125,6 +131,10 @@ public class TestUtil {
 
   public static int getProtocolVersion() {
     return Integer.parseInt(System.getProperty("protocolVersion", "0"));
+  }
+
+  public static String getOptions() {
+    return System.getProperty("options");
   }
 
   /*

--- a/pgjdbc/src/test/java/org/postgresql/test/core/OptionsPropertyTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/core/OptionsPropertyTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2004, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.test.core;
+
+import org.postgresql.PGProperty;
+import org.postgresql.test.TestUtil;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.Properties;
+
+public class OptionsPropertyTest {
+  private static final String schemaName = "options_property_test";
+  private static final String optionsValue = "-c search_path=" + schemaName;
+
+  @Before
+  public void setUp() throws Exception {
+    Connection con = TestUtil.openDB();
+    Statement stmt = con.createStatement();
+    stmt.execute("DROP SCHEMA IF EXISTS " + schemaName + ";");
+    stmt.execute("CREATE SCHEMA " + schemaName + ";");
+    stmt.close();
+    TestUtil.closeDB(con);
+  }
+
+  @Test
+  public void testOptionsInProperties() throws Exception {
+    Properties props = new Properties();
+    props.setProperty(PGProperty.OPTIONS.getName(), optionsValue);
+
+    Connection con = TestUtil.openDB(props);
+    Statement stmt = con.createStatement();
+    stmt.execute("SHOW search_path");
+
+    ResultSet rs = stmt.getResultSet();
+    if (!rs.next()) {
+      Assert.fail("'options' connection initialization parameter should be passed to the database.");
+    }
+    Assert.assertEquals("'options' connection initialization parameter should be passed to the database.", schemaName, rs.getString(1));
+
+    stmt.close();
+    TestUtil.closeDB(con);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    Connection con = TestUtil.openDB();
+    Statement stmt = con.createStatement();
+    stmt.execute("DROP SCHEMA " + schemaName + ";");
+    stmt.close();
+    TestUtil.closeDB(con);
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/Jdbc2TestSuite.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/Jdbc2TestSuite.java
@@ -16,6 +16,7 @@ import org.postgresql.jdbc.DeepBatchedInsertStatementTest;
 import org.postgresql.jdbc.PrimitiveArraySupportTest;
 import org.postgresql.test.core.JavaVersionTest;
 import org.postgresql.test.core.NativeQueryBindLengthTest;
+import org.postgresql.test.core.OptionsPropertyTest;
 import org.postgresql.test.util.ExpressionPropertiesTest;
 import org.postgresql.test.util.LruCacheTest;
 import org.postgresql.test.util.ServerVersionParseTest;
@@ -61,6 +62,7 @@ import org.junit.runners.Suite;
         ReaderInputStreamTest.class,
         ServerVersionParseTest.class,
         ServerVersionTest.class,
+        OptionsPropertyTest.class,
 
         TypeCacheDLLStressTest.class,
 


### PR DESCRIPTION
Add support for custom `options` connection property. The property is [described in PostgreSQL documentation](https://www.postgresql.org/docs/8.2/libpq-envars.html); the motivation for its introduction was discussed in https://github.com/pgjdbc/pgjdbc/issues/222 (which is closed by this PR).

Implementation is straightforward: a new `PGProperty` is introduced to store `options` parameter value. It works the same way as any other `PGProperty`, thus it can be passed either in URL or in `Properties` object.

The documentation is updated to mention new connection property. Also, a note is added that when some property is present both in URL and in `Properties` object, the first one is prioritized.

`TestUtil` is updated so that it reads `options` property provided by testing environment.

A new `OptionsPropertyTest` is added.

### All Submissions:
* [x] Have you followed the guidelines in our [Contributing](CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### New Feature Submissions:
1. [x] Does your submission pass tests?
2. [x] Does mvn checkstyle:check pass?

### Changes to Existing Features:
* [x] Does this preserve the existing behaviour? If not, please explain.
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?