### PR TITLE
Fix TestUtil.dropXyz(...) object not exists errors

### DIFF
--- a/pgjdbc/src/test/java/org/postgresql/test/TestUtil.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/TestUtil.java
@@ -375,17 +375,15 @@ public class TestUtil {
   public static void dropSchema(Connection con, String schema) throws SQLException {
     Statement stmt = con.createStatement();
     try {
-      String sql = "DROP SCHEMA " + schema + " CASCADE ";
-
-      stmt.executeUpdate(sql);
-    } catch (SQLException ex) {
-      // Since every create schema issues a drop schema
-      // it's easy to get a schema doesn't exist error.
-      // we want to ignore these, but if we're in a
-      // transaction then we've got trouble
-      if (!con.getAutoCommit()) {
-        throw ex;
+      if (con.getAutoCommit()) {
+        // Not in a transaction so ignore error for missing object
+        stmt.executeUpdate("DROP SCHEMA IF EXISTS " + schema + " CASCADE");
+      } else {
+        // In a transaction so do not ignore errors for missing object
+        stmt.executeUpdate("DROP SCHEMA " + schema + " CASCADE");
       }
+    } finally {
+      closeQuietly(stmt);
     }
   }
 
@@ -482,15 +480,17 @@ public class TestUtil {
    */
   public static void dropDomain(Connection con, String name)
       throws SQLException {
-    Statement st = con.createStatement();
+    Statement stmt = con.createStatement();
     try {
-      st.executeUpdate("drop domain " + name + " cascade");
-    } catch (SQLException ex) {
-      if (!con.getAutoCommit()) {
-        throw ex;
+      if (con.getAutoCommit()) {
+        // Not in a transaction so ignore error for missing object
+        stmt.executeUpdate("DROP DOMAIN IF EXISTS " + name + " CASCADE");
+      } else {
+        // In a transaction so do not ignore errors for missing object
+        stmt.executeUpdate("DROP DOMAIN " + name + " CASCADE");
       }
     } finally {
-      closeQuietly(st);
+      closeQuietly(stmt);
     }
   }
 
@@ -519,12 +519,15 @@ public class TestUtil {
   public static void dropSequence(Connection con, String sequence) throws SQLException {
     Statement stmt = con.createStatement();
     try {
-      String sql = "DROP SEQUENCE " + sequence;
-      stmt.executeUpdate(sql);
-    } catch (SQLException sqle) {
-      if (!con.getAutoCommit()) {
-        throw sqle;
+      if (con.getAutoCommit()) {
+        // Not in a transaction so ignore error for missing object
+        stmt.executeUpdate("DROP SEQUENCE IF EXISTS " + sequence);
+      } else {
+        // In a transaction so do not ignore errors for missing object
+        stmt.executeUpdate("DROP SEQUENCE " + sequence);
       }
+    } finally {
+      closeQuietly(stmt);
     }
   }
 
@@ -534,16 +537,15 @@ public class TestUtil {
   public static void dropTable(Connection con, String table) throws SQLException {
     Statement stmt = con.createStatement();
     try {
-      String sql = "DROP TABLE " + table + " CASCADE ";
-      stmt.executeUpdate(sql);
-    } catch (SQLException ex) {
-      // Since every create table issues a drop table
-      // it's easy to get a table doesn't exist error.
-      // we want to ignore these, but if we're in a
-      // transaction then we've got trouble
-      if (!con.getAutoCommit()) {
-        throw ex;
+      if (con.getAutoCommit()) {
+        // Not in a transaction so ignore error for missing object
+        stmt.executeUpdate("DROP TABLE IF EXISTS " + table + " CASCADE ");
+      } else {
+        // In a transaction so do not ignore errors for missing object
+        stmt.executeUpdate("DROP TABLE " + table + " CASCADE ");
       }
+    } finally {
+      closeQuietly(stmt);
     }
   }
 
@@ -553,12 +555,15 @@ public class TestUtil {
   public static void dropType(Connection con, String type) throws SQLException {
     Statement stmt = con.createStatement();
     try {
-      String sql = "DROP TYPE " + type + " CASCADE";
-      stmt.executeUpdate(sql);
-    } catch (SQLException ex) {
-      if (!con.getAutoCommit()) {
-        throw ex;
+      if (con.getAutoCommit()) {
+        // Not in a transaction so ignore error for missing object
+        stmt.executeUpdate("DROP TYPE IF EXISTS " + type + " CASCADE");
+      } else {
+        // In a transaction so do not ignore errors for missing object
+        stmt.executeUpdate("DROP TYPE " + type + " CASCADE");
       }
+    } finally {
+      closeQuietly(stmt);
     }
   }
 

--- a/pgjdbc/src/test/java/org/postgresql/test/TestUtil.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/TestUtil.java
@@ -457,16 +457,26 @@ public class TestUtil {
    * @param name String
    * @param values String
    */
+  public static void createCompositeType(Connection con, String name, String values) throws SQLException {
+    createCompositeType(con, name, values, true);
+  }
 
-  public static void createCompositeType(Connection con, String name, String values)
+  /**
+   * Helper creates an composite type.
+   *
+   * @param con Connection
+   * @param name String
+   * @param values String
+   */
+  public static void createCompositeType(Connection con, String name, String values, boolean shouldDrop)
       throws SQLException {
     Statement st = con.createStatement();
     try {
-      dropType(con, name);
-
-
-      // Now create the table
-      st.executeUpdate("create type " + name + " as (" + values + ")");
+      if (shouldDrop) {
+        dropType(con, name);
+      }
+      // Now create the type
+      st.executeUpdate("CREATE TYPE " + name + " AS (" + values + ")");
     } finally {
       closeQuietly(st);
     }

--- a/pgjdbc/src/test/java/org/postgresql/test/TestUtil.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/TestUtil.java
@@ -521,10 +521,10 @@ public class TestUtil {
     try {
       if (con.getAutoCommit()) {
         // Not in a transaction so ignore error for missing object
-        stmt.executeUpdate("DROP SEQUENCE IF EXISTS " + sequence);
+        stmt.executeUpdate("DROP SEQUENCE IF EXISTS " + sequence + " CASCADE");
       } else {
         // In a transaction so do not ignore errors for missing object
-        stmt.executeUpdate("DROP SEQUENCE " + sequence);
+        stmt.executeUpdate("DROP SEQUENCE " + sequence + " CASCADE");
       }
     } finally {
       closeQuietly(stmt);

--- a/pgjdbc/src/test/java/org/postgresql/test/TestUtil.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/TestUtil.java
@@ -242,7 +242,7 @@ public class TestUtil {
     return p;
   }
 
-  public static void initDriver() throws Exception {
+  public static void initDriver() {
     synchronized (TestUtil.class) {
       if (initialized) {
         return;
@@ -281,7 +281,7 @@ public class TestUtil {
    * @return connection using a privileged user mostly for tests that the ability to load C
    *         functions now as of 4/14
    */
-  public static Connection openPrivilegedDB() throws Exception {
+  public static Connection openPrivilegedDB() throws SQLException {
     initDriver();
     Properties properties = new Properties();
     properties.setProperty("user", getPrivilegedUser());
@@ -295,7 +295,7 @@ public class TestUtil {
    *
    * @return connection
    */
-  public static Connection openDB() throws Exception {
+  public static Connection openDB() throws SQLException {
     return openDB(new Properties());
   }
 
@@ -303,7 +303,7 @@ public class TestUtil {
    * Helper - opens a connection with the allowance for passing additional parameters, like
    * "compatible".
    */
-  public static Connection openDB(Properties props) throws Exception {
+  public static Connection openDB(Properties props) throws SQLException {
     initDriver();
 
     // Allow properties to override the user name.

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseMetaDataTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseMetaDataTest.java
@@ -52,8 +52,10 @@ public class DatabaseMetaDataTest {
     TestUtil.createTable(con, "\"a'\"", "a int4");
     TestUtil.createTable(con, "arraytable", "a numeric(5,2)[], b varchar(100)[]");
     TestUtil.createTable(con, "intarraytable", "a int4[], b int4[][]");
-    TestUtil.createCompositeType(con, "custom", "i int");
-    TestUtil.createCompositeType(con, "_custom", "f float");
+    TestUtil.dropType(con, "custom");
+    TestUtil.dropType(con, "_custom");
+    TestUtil.createCompositeType(con, "custom", "i int", false);
+    TestUtil.createCompositeType(con, "_custom", "f float", false);
 
 
     // 8.2 does not support arrays of composite types
@@ -107,7 +109,7 @@ public class DatabaseMetaDataTest {
     stmt.execute("DROP FUNCTION f1(int, varchar)");
     stmt.execute("DROP FUNCTION f2(int, varchar)");
     stmt.execute("DROP FUNCTION f3(int, varchar)");
-    TestUtil.dropType(con, "domaintable");
+    TestUtil.dropTable(con, "domaintable");
     TestUtil.dropDomain(con, "nndom");
 
     TestUtil.closeDB(con);


### PR DESCRIPTION
- [x] - Tests pass
- [x] - Checkstyle pass

While testing some update to a VM for testing pgjdbc I noticed a bunch of errors in the server error logs for trying to drop missing objects as the test SQL was not using `... IF EXISTS ...`.

The first commit in the PR changes a bunch of the `dropXYZ(...)` methods in `TestUtil` to use `... DROP EXISTS ...` if the connection is not in a transaction. This matches the behavior in the comments around the drop statements. This also changes the method to *not* skip over non-transactional exceptions in the drop statements that are not due to missing objects such as a connection error or a dependency on the dropped object.

That last one (dependencies) lead to a bunch of broken tests that were previously passing because they were ignoring those errors. Here's an example:

```
testForeignKeysToUniqueIndexes(org.postgresql.test.jdbc2.DatabaseMetaDataTest)  Time elapsed: 0.017 sec  <<< ERROR!
org.postgresql.util.PSQLException: ERROR: cannot drop sequence sercoltest_b_seq because other objects depend on it
  Detail: default for table sercoltest column b depends on sequence sercoltest_b_seq
  Hint: Use DROP ... CASCADE to drop the dependent objects too.
	at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2440)
	at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2183)
	at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:308)
	at org.postgresql.jdbc.PgStatement.executeInternal(PgStatement.java:441)
	at org.postgresql.jdbc.PgStatement.execute(PgStatement.java:365)
	at org.postgresql.jdbc.PgStatement.executeWithFlags(PgStatement.java:307)
	at org.postgresql.jdbc.PgStatement.executeCachedSql(PgStatement.java:293)
	at org.postgresql.jdbc.PgStatement.executeWithFlags(PgStatement.java:270)
	at org.postgresql.jdbc.PgStatement.executeUpdate(PgStatement.java:244)
	at org.postgresql.test.TestUtil.dropSequence(TestUtil.java:524)
	at org.postgresql.test.jdbc2.DatabaseMetaDataTest.setUp(DatabaseMetaDataTest.java:48)
```

The rest of the commits fix the dependency related drop errors. This is done through either adding missing `... CASCADE ...` clauses or explicitly ordering the drops so they happen in the right order.
