### PR TITLE
Fix NPE in PGXAConnection$ConnectionHandler.invoke() of .equals(null)

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/xa/PGXAConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/xa/PGXAConnection.java
@@ -134,9 +134,9 @@ public class PGXAConnection extends PGPooledConnection implements XAConnection, 
          * If the argument to equals-method is also a wrapper, present the original unwrapped
          * connection to the underlying equals method.
          */
-        if (method.getName().equals("equals")) {
+        if (method.getName().equals("equals") && args.length == 1) {
           Object arg = args[0];
-          if (Proxy.isProxyClass(arg.getClass())) {
+          if (arg != null && Proxy.isProxyClass(arg.getClass())) {
             InvocationHandler h = Proxy.getInvocationHandler(arg);
             if (h instanceof ConnectionHandler) {
               // unwrap argument

--- a/pgjdbc/src/test/java/org/postgresql/test/xa/XADataSourceTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/xa/XADataSourceTest.java
@@ -191,6 +191,8 @@ public class XADataSourceTest {
   @Test
   public void testWrapperEquals() throws Exception {
     assertTrue("Wrappers should be equal", conn.equals(conn));
+    assertFalse("Wrapper should be unequal to null", conn.equals(null));
+    assertFalse("Wrapper should be unequal to unrelated object", conn.equals("dummy string object"));
   }
 
   @Test


### PR DESCRIPTION
The PGXAConnection inner class call-filtering proxy ConnectionHandler
special cases calls to equals() by testing if the argument is itself
a proxy that should be unwrapped.

However it fails to test if the argument is null before calling getClass()
on it, resulting in an NPE like

java.lang.NullPointerException: null
at org.postgresql.xa.PGXAConnection$ConnectionHandler.invoke(PGXAConnection.java:139)

Fix by testing for null. While we're at it, also defensively check to ensure
there's exactly one argument to .equals. It's not sensible to pass more and
will error later anyway.

### All Submissions:

* [ ] Have you followed the guidelines in our [Contributing](CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Does mvn checkstyle:check pass ?

### Changes to Existing Features:

* [ ] Does this break existing behaviour? If so please explain.
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?