### PR TITLE
chore: use openjdk7 to boostrap Travis CI images for JDK 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -172,7 +172,7 @@ matrix:
         - MCENTRAL=Y
         - COVERAGE=Y
         - TZ=UTC
-    - jdk: openjdk6
+    - jdk: openjdk7
       sudo: required
       addons:
         postgresql: "9.1"
@@ -240,7 +240,7 @@ matrix:
         - PG_VERSION=9.2
         - ZULU_JDK=7
     - stage: release_prev
-      jdk: openjdk6
+      jdk: openjdk7
       sudo: required
       addons:
         postgresql: "9.1"


### PR DESCRIPTION
In fact, Zulu JDK 6 is used for Java 6, so `jdk: openjdk7` does not matter much
