### PR TITLE
refactor: remove unused method encode3to4 from Base64

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/util/Base64.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/Base64.java
@@ -195,25 +195,6 @@ public class Base64 {
 
 
   /**
-   * Encodes up to the first three bytes of array <var>threeBytes</var> and returns a four-byte
-   * array in Base64 notation. The actual number of significant bytes in your array is given by
-   * <var>numSigBytes</var>. The array <var>threeBytes</var> needs only be as big as
-   * <var>numSigBytes</var>. Code can reuse a byte array by passing a four-byte array as
-   * <var>b4</var>.
-   *
-   * @param b4 A reusable byte array to reduce array instantiation
-   * @param threeBytes the array to convert
-   * @param numSigBytes the number of significant bytes in your array
-   * @return four byte array in Base64 notation.
-   * @since 1.5.1
-   */
-  private static byte[] encode3to4(byte[] b4, byte[] threeBytes, int numSigBytes) {
-    encode3to4(threeBytes, 0, numSigBytes, b4, 0);
-    return b4;
-  } // end encode3to4
-
-
-  /**
    * Encodes up to three bytes of the array <var>source</var> and writes the resulting four Base64
    * bytes to <var>destination</var>. The source and destination arrays can be manipulated anywhere
    * along their length by specifying <var>srcOffset</var> and <var>destOffset</var>. This method


### PR DESCRIPTION
The method encode3to4(byte[], byte[], int) from Base64 has never been
used since [1].

[1] 034c2c3fecd39cd1513914d577921913c9810aa6

Signed-off-by: Mykola Nikishov <mn@mn.com.ua>