### PR TITLE
refactor: Clean up loading of reading of keydata file in LazyKeyManager

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/ssl/LazyKeyManager.java
+++ b/pgjdbc/src/main/java/org/postgresql/ssl/LazyKeyManager.java
@@ -9,7 +9,6 @@ import org.postgresql.util.GT;
 import org.postgresql.util.PSQLException;
 import org.postgresql.util.PSQLState;
 
-import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -160,9 +159,19 @@ public class LazyKeyManager implements X509KeyManager {
     return (alias == null ? new String[]{} : new String[]{alias});
   }
 
+  private static byte[] readFileFully(String path) throws IOException {
+    RandomAccessFile raf = new RandomAccessFile(path, "r");
+    try {
+      byte[] ret = new byte[(int) raf.length()];
+      raf.readFully(ret);
+      return ret;
+    } finally {
+      raf.close();
+    }
+  }
+
   @Override
   public PrivateKey getPrivateKey(String alias) {
-    RandomAccessFile raf = null;
     try {
       if (key == null && keyfile != null) {
         // If keyfile is null, we do not load the key
@@ -173,8 +182,9 @@ public class LazyKeyManager implements X509KeyManager {
           }
         }
 
+        byte[] keydata;
         try {
-          raf = new RandomAccessFile(new File(keyfile), "r"); // NOSONAR
+          keydata = readFileFully(keyfile);
         } catch (FileNotFoundException ex) {
           if (!defaultfile) {
             // It is not an error if there is no file at the default location
@@ -182,10 +192,6 @@ public class LazyKeyManager implements X509KeyManager {
           }
           return null;
         }
-        byte[] keydata = new byte[(int) raf.length()];
-        raf.readFully(keydata);
-        raf.close();
-        raf = null;
 
         KeyFactory kf = KeyFactory.getInstance(cert[0].getPublicKey().getAlgorithm());
         try {
@@ -241,13 +247,6 @@ public class LazyKeyManager implements X509KeyManager {
         }
       }
     } catch (IOException ioex) {
-      if (raf != null) {
-        try {
-          raf.close();
-        } catch (IOException ex) {
-        }
-      }
-
       error = new PSQLException(GT.tr("Could not read SSL key file {0}.", keyfile),
           PSQLState.CONNECTION_FAILURE, ioex);
     } catch (NoSuchAlgorithmException ex) {


### PR DESCRIPTION
The old code does ensure that the RAF is closed though it's a bit difficult to reason about it as it happens in two different places depending on where an exception occurs. I took a peek at it after seeing #1371.

This PR refactors loading of keyfile data in LazyKeyManager a bit so that IO happens in a separate method and there is only one close operation. This also has the positive side effect of removing one of the `// NOSONAR` tags.