### PR TITLE
Added support for single-attribute SQLData implementations.

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
@@ -691,7 +691,7 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
    * At this time, only single attribute SQLData is supported.
    */
   private Object getSQLDataAttribute(SQLData in) throws SQLException {
-    Vector<Object> attributes = new Vector<>();
+    Vector<Object> attributes = new Vector<Object>();
     in.writeSQL(new SQLOutputImpl(attributes, connection.getTypeMap())); // TODO: connection.getTypeMapNoCopy() once pull request #1378 is merged
     int size = attributes.size();
     if (size == 1) {

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
@@ -684,9 +684,9 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
     Vector<Object> attributes = new Vector<>();
     in.writeSQL(new SQLOutputImpl(attributes, connection.getTypeMapNoCopy()));
     int size = attributes.size();
-    if(size == 1) {
+    if (size == 1) {
       return attributes.get(0);
-    } else if(size == 0) {
+    } else if (size == 0) {
       throw new PSQLException(GT.tr(
           "No attributes written by SQLData instance of {0}",
           in.getClass().getName()), PSQLState.DATA_ERROR);


### PR DESCRIPTION
This alleviates a lot of the explicit casting that had to be done for DOMAIN and ENUM.

Our example, where "com.aoindustries.net"."Email" is a DOMAIN (that enforces the same rules as our
com.aoindustries.net.Email class in Java).  The Java type implements SQLData, the PostgreSQL type is a DOMAIN,
both implement the same rules, and conversion between them should be as seemless as possible.

Before:
    "INSERT INTO ticket.\"Ticket\" (...) VALUES (?,?,?,?,?,?,?,?,?::\"com.aoindustries.net\".\"Email\",?,?,?,?,?,?,?,?,?,?)",

After:
    "INSERT INTO ticket.\"Ticket\" (...) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)"

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [x] Does mvn checkstyle:check pass ?

### Changes to Existing Features:

* [ ] Does this break existing behaviour? If so please explain.
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
