### PR TITLE
PGCopyOutputStream remove CopyIn interface and internal buffering

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/copy/PGCopyOutputStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/copy/PGCopyOutputStream.java
@@ -86,6 +86,7 @@ public class PGCopyOutputStream extends OutputStream {
   }
 
   public void flush() throws IOException {
+    checkClosed();
     try {
       op.flushCopy();
     } catch (SQLException e) {

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/CopyTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/CopyTest.java
@@ -125,7 +125,7 @@ public class CopyTest {
   @Test
   public void testCopyInAsOutputStream() throws SQLException, IOException {
     String sql = "COPY copytest FROM STDIN";
-    OutputStream os = new PGCopyOutputStream((PGConnection) con, sql, 1000);
+    OutputStream os = new PGCopyOutputStream((PGConnection) con, sql);
     for (String anOrigData : origData) {
       byte[] buf = anOrigData.getBytes();
       os.write(buf);


### PR DESCRIPTION
Removes CopyIn interface methods from PGCopyOutputsream and internal buffering of writes. Also removes constructors that provided buffer sizes.

*__BREAKING CHANGE__* :bomb: 

### All Submissions:

* [X] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes to Existing Features:

* [X] Does this break existing behaviour? If so please explain.
* [X] Have you added an explanation of what your changes do and why you'd like us to include them?

### Explanation
See this mailing thread for a user report on this: https://www.postgresql.org/message-id/25bf5fc6-1dd0-0944-61e7-0eae6c6614c7%40gmail.com

PGCopyOutputStream handling of close() and endCopy() seem odd and not particularly useful. The class is an OutputStream which also implements CopyIn (interface for representing a COPY FROM STDIN) and adds some buffering but I'm not sure either of those last two makes sense.

Couple thoughts after going through the code a bit:

* Calling `CopyIn.endCopy()` prior to closing the stream will lead to an error when calling `close()` (which you're supposed to do for all streams).
* It wraps/delegates to an internal CopyIn operation but also clears the delegate after a successful `close()` so you can't actually call any of the CopyIn methods after you've closed the operation.
* Specifically `getHandledRowCount()` seems kind of useless as you can't call it before the operation is completed (because it comes from the server) and you can't call it after the operation completes because the delegate will be null (NPE).

Anything that fixes these things is likely a breaking change in some manner. That said, might as well make it worthwhile of  so here's what I'm thinking:

* Remove CopyIn interface from PGCopyOutputStream and associated public methods. It's primarily an OutputStream, not a CopyIn so having two ways to interact with it does not make sense. If anyone wants access to the getXyz(...) methods then they can create a CopyIn and use it to create the PGCopyOutputStream:

```java
CopyIn op = connection.getCopyAPI().copyIn(sql);
try (PGCopyOutputStream out = new PGCopyOutputStream(op)) {
   // Do I/O stuff here with out as an OutputStream
}
// Can access op to get state after I'm done:
long rowCount = op.getHandledRowCount();
```

* Remove the buffering. If anyone wants it added they can wrap in a BufferedOutputStream:

```java
try (BufferedOutputStream out = new BufferedOutputStream(new PGCopyOutputStream(op))) {
   // Do I/O stuff
}
```

It's definitely a breaking change. I'm wondering if it's worth it as the existing behavior doesn't seem usable. Could maybe split it to only remove the CopyIn stuff and leave the buffering in case people are relying on it? Though my vote would be to remove that too and just add it to the release notes.

Thoughts?