### PR TITLE
Fixes `LocalDateTime` handling of BC dates

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/TimestampUtils.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/TimestampUtils.java
@@ -836,7 +836,7 @@ public class TimestampUtils {
   }
 
   private static void appendDate(StringBuilder sb, LocalDate localDate) {
-    int year = Math.abs(localDate.getYear()); // year is negative for BC dates
+    int year = localDate.get(ChronoField.YEAR_OF_ERA);
     int month = localDate.getMonthValue();
     int day = localDate.getDayOfMonth();
     appendDate(sb, year, month, day);

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc42/SetObject310Test.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc42/SetObject310Test.java
@@ -29,8 +29,12 @@ import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.time.chrono.IsoChronology;
 import java.time.chrono.IsoEra;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.ResolverStyle;
+import java.time.format.SignStyle;
 import java.time.temporal.ChronoField;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -39,6 +43,26 @@ import java.util.TimeZone;
 
 public class SetObject310Test {
   private static final TimeZone saveTZ = TimeZone.getDefault();
+
+  public static final DateTimeFormatter LOCAL_TIME_FORMATTER =
+      new DateTimeFormatterBuilder()
+          .parseCaseInsensitive()
+          .appendValue(ChronoField.YEAR_OF_ERA, 4, 10, SignStyle.EXCEEDS_PAD)
+          .appendLiteral('-')
+          .appendValue(ChronoField.MONTH_OF_YEAR, 2)
+          .appendLiteral('-')
+          .appendValue(ChronoField.DAY_OF_MONTH, 2)
+          .appendLiteral(' ')
+          .append(DateTimeFormatter.ISO_LOCAL_TIME)
+          .optionalStart()
+          .appendOffset("+HH:mm", "+00")
+          .optionalEnd()
+          .optionalStart()
+          .appendLiteral(' ')
+          .appendPattern("GG")
+          .toFormatter()
+          .withResolverStyle(ResolverStyle.LENIENT)
+          .withChronology(IsoChronology.INSTANCE);
 
   private Connection con;
 
@@ -313,8 +337,7 @@ public class SetObject310Test {
     bcDates.add(LocalDateTime.parse("0997-06-30T23:59:59.999999").with(ChronoField.ERA, IsoEra.BCE.getValue()));
 
     for (LocalDateTime bcDate : bcDates) {
-      // -1997-06-30T23:59:59.999999 -> 1997-06-30 23:59:59.999999 BC
-      String expected = bcDate.toString().substring(1).replace('T', ' ') + " BC";
+      String expected = LOCAL_TIME_FORMATTER.format(bcDate);
       localTimestamps(ZoneOffset.UTC, bcDate, expected);
     }
   }


### PR DESCRIPTION
The assertion in `SetObject310Test.testSetLocalDateTimeBc`  is

>   // -1997-06-30T23:59:59.999999 -> 1997-06-30 23:59:59.999999 BC

This is incorrect.  It is actually `-1996  == 1997 BC` because there is no year zero in AD/BC.

I used a `DateTimeFormatter` in the test to prove my case. This “fix” for this method is to fix `TimeStampUtils.appendDate` and stop using the proleptic year (aka `YEAR`) and start using the year of the era (aka `YEAR_OF_ERA`).

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Does mvn checkstyle:check pass ?

### Changes to Existing Features:

* [x] Does this break existing behaviour? If so please explain.

> BC `LocalDateTime` handling was previously incorrect as it didn't handle proleptic year conversion correctly. 

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?