### PR TITLE
Fix #1390 `LocalDateTime` string serialization

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/TimestampUtils.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/TimestampUtils.java
@@ -830,9 +830,8 @@ public class TimestampUtils {
       return "-infinity";
     }
 
-    // LocalDateTime is always passed with time zone so backend can decide between timestamp and timestamptz
-    ZonedDateTime zonedDateTime = localDateTime.atZone(getDefaultTz().toZoneId());
-    return toString(zonedDateTime.toOffsetDateTime());
+    OffsetDateTime offsetDateTime = localDateTime.atOffset(ZoneOffset.UTC);
+    return toString(offsetDateTime);
   }
 
   private static void appendDate(StringBuilder sb, LocalDate localDate) {

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc42/SetObject310Test.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc42/SetObject310Test.java
@@ -11,12 +11,14 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 
 import org.postgresql.test.TestUtil;
+import org.postgresql.test.jdbc2.BaseTest4;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
-import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -38,10 +40,12 @@ import java.time.format.SignStyle;
 import java.time.temporal.ChronoField;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.TimeZone;
 
-public class SetObject310Test {
+@RunWith(Parameterized.class)
+public class SetObject310Test extends BaseTest4 {
   private static final TimeZone saveTZ = TimeZone.getDefault();
 
   public static final DateTimeFormatter LOCAL_TIME_FORMATTER =
@@ -64,11 +68,22 @@ public class SetObject310Test {
           .withResolverStyle(ResolverStyle.LENIENT)
           .withChronology(IsoChronology.INSTANCE);
 
-  private Connection con;
+  public SetObject310Test(BaseTest4.BinaryMode binaryMode) {
+    setBinaryMode(binaryMode);
+  }
+
+  @Parameterized.Parameters(name = "binary = {0}")
+  public static Iterable<Object[]> data() {
+    Collection<Object[]> ids = new ArrayList<Object[]>();
+    for (BaseTest4.BinaryMode binaryMode : BaseTest4.BinaryMode.values()) {
+      ids.add(new Object[]{binaryMode});
+    }
+    return ids;
+  }
 
   @Before
   public void setUp() throws Exception {
-    con = TestUtil.openDB();
+    super.setUp();
     TestUtil.createTable(con, "table1", "timestamp_without_time_zone_column timestamp without time zone,"
             + "timestamp_with_time_zone_column timestamp with time zone,"
             + "date_column date,"
@@ -81,7 +96,7 @@ public class SetObject310Test {
   public void tearDown() throws SQLException {
     TimeZone.setDefault(saveTZ);
     TestUtil.dropTable(con, "table1");
-    TestUtil.closeDB(con);
+    super.tearDown();
   }
 
   private void insert(Object data, String columnName, Integer type) throws SQLException {

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc42/SetObject310Test.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc42/SetObject310Test.java
@@ -199,7 +199,7 @@ public class SetObject310Test {
       ZoneId zone = ZoneId.of(zoneId);
       for (String date : datesToTest) {
         LocalDateTime localDateTime = LocalDateTime.parse(date);
-        String expected = localDateTime.atZone(zone)
+        String expected = localDateTime
             .format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
             .replace('T', ' ');
         localTimestamps(zone, localDateTime, expected);


### PR DESCRIPTION
This is a proposed fix for #1390.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Does mvn checkstyle:check pass ?

### Changes to Existing Features:

* [x] Does this break existing behaviour? If so please explain.

Yes, `LocalDateTime` is now inserted and retrieved without regard for any current time zone. Which, in my interpretation, is the correct thing to do.

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
