### PR TITLE
fix: time '24:00:00' should not wrap to '00:00:00' when received in binary mode

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/TimestampUtils.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/TimestampUtils.java
@@ -1281,7 +1281,10 @@ public class TimestampUtils {
       int offset = tz.getRawOffset();
       millis += offset;
       // 2) Truncate year, month, day. Day is always 86400 seconds, no matter what leap seconds are
-      millis = millis % ONEDAY;
+      if (millis != ONEDAY) {
+        // Note: we do allow 24:00:00, so we don't wrap 86400000 to 0
+        millis = millis % ONEDAY;
+      }
       // 2) Now millis is 1970 1 Jan 15:40 UTC, however we need that in GMT+02:00, so subtract some
       // offset
       millis -= offset;
@@ -1294,7 +1297,14 @@ public class TimestampUtils {
     cal.set(Calendar.ERA, GregorianCalendar.AD);
     cal.set(Calendar.YEAR, 1970);
     cal.set(Calendar.MONTH, 0);
-    cal.set(Calendar.DAY_OF_MONTH, 1);
+    // We allow 24:00:00, however all the other dates go with 1970-01-01
+    if (cal.get(Calendar.DAY_OF_MONTH) != 2
+        || cal.get(Calendar.HOUR_OF_DAY) != 0
+        || cal.get(Calendar.MINUTE) != 0
+        || cal.get(Calendar.SECOND) != 0
+        || cal.get(Calendar.MILLISECOND) != 0) {
+      cal.set(Calendar.DAY_OF_MONTH, 1);
+    }
 
     return new Time(cal.getTimeInMillis());
   }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc42/SetObject310Test.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc42/SetObject310Test.java
@@ -11,12 +11,14 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 
 import org.postgresql.test.TestUtil;
+import org.postgresql.test.jdbc2.BaseTest4;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
-import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -38,11 +40,13 @@ import java.time.format.SignStyle;
 import java.time.temporal.ChronoField;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.TimeZone;
 
-public class SetObject310Test {
+@RunWith(Parameterized.class)
+public class SetObject310Test extends BaseTest4 {
   private static final TimeZone saveTZ = TimeZone.getDefault();
 
   public static final DateTimeFormatter LOCAL_TIME_FORMATTER =
@@ -65,11 +69,22 @@ public class SetObject310Test {
           .withResolverStyle(ResolverStyle.LENIENT)
           .withChronology(IsoChronology.INSTANCE);
 
-  private Connection con;
+  public SetObject310Test(BaseTest4.BinaryMode binaryMode) {
+    setBinaryMode(binaryMode);
+  }
+
+  @Parameterized.Parameters(name = "binary = {0}")
+  public static Iterable<Object[]> data() {
+    Collection<Object[]> ids = new ArrayList<Object[]>();
+    for (BaseTest4.BinaryMode binaryMode : BaseTest4.BinaryMode.values()) {
+      ids.add(new Object[]{binaryMode});
+    }
+    return ids;
+  }
 
   @Before
   public void setUp() throws Exception {
-    con = TestUtil.openDB();
+    super.setUp();
     TestUtil.createTable(con, "table1", "timestamp_without_time_zone_column timestamp without time zone,"
             + "timestamp_with_time_zone_column timestamp with time zone,"
             + "date_column date,"
@@ -82,7 +97,7 @@ public class SetObject310Test {
   public void tearDown() throws SQLException {
     TimeZone.setDefault(saveTZ);
     TestUtil.dropTable(con, "table1");
-    TestUtil.closeDB(con);
+    super.tearDown();
   }
 
   private void insert(Object data, String columnName, Integer type) throws SQLException {


### PR DESCRIPTION
Note: 24:00:00 was fine when received in text mode

This fixes #1385