### PR TITLE
chore: add MissingDeprecated checkstyle rule

### DIFF
--- a/pgjdbc/pom.xml
+++ b/pgjdbc/pom.xml
@@ -33,7 +33,7 @@
     <jdbc.specification.version>4.2</jdbc.specification.version>
     <jdbc.specification.version.nodot>42</jdbc.specification.version.nodot>
     <skip.assembly>false</skip.assembly>
-    <checkstyle.version>8.5</checkstyle.version>
+    <checkstyle.version>8.16</checkstyle.version>
   </properties>
 
   <dependencies>
@@ -297,7 +297,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-checkstyle-plugin</artifactId>
-          <version>2.17</version>
+          <version>3.0.0</version>
           <dependencies>
             <dependency>
               <groupId>com.puppycrawl.tools</groupId>

--- a/pgjdbc/src/main/checkstyle/checks.xml
+++ b/pgjdbc/src/main/checkstyle/checks.xml
@@ -209,6 +209,7 @@
     <!--<module name="SummaryJavadoc">-->
     <!--<property name="forbiddenSummaryFragments" value="^@return the *|^This method returns |^A [{]@code [a-zA-Z0-9]+[}]( is a )"/>-->
     <!--</module>-->
+    <module name="MissingDeprecated"/>
     <module name="JavadocParagraph"/>
     <!--<module name="AtclauseOrder">-->
     <!--<property name="tagOrder" value="@param, @return, @throws, @deprecated"/>-->

--- a/pgjdbc/src/test/java/org/postgresql/test/.gitignore
+++ b/pgjdbc/src/test/java/org/postgresql/test/.gitignore
@@ -1,1 +1,0 @@
-VersionInfo.java


### PR DESCRIPTION
add [MissingDeprecated checkstyle rule](http://checkstyle.sourceforge.net/config_annotation.html#MissingDeprecated)
update checkstyle.

This check is used to verify that both the Deprecated annotation and the `@deprecated` javadoc tag are present when either one is present. Both ways of flagging deprecation serve their own purpose. The Deprecated annotation is used for compilers and development tools. The deprecated javadoc tag is used to document why something is deprecated and what, if any, alternatives exist.
