### PR TITLE
Add core type delimiters into cache for array type OIDs.

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
@@ -114,16 +114,16 @@ public class TypeInfoCache implements TypeInfo {
   public TypeInfoCache(BaseConnection conn, int unknownLength) {
     this.conn = conn;
     this.unknownLength = unknownLength;
-    oidToPgName = new HashMap<Integer, String>();
-    pgNameToOid = new HashMap<String, Integer>();
-    pgNameToJavaClass = new HashMap<String, String>();
-    pgNameToPgObject = new HashMap<String, Class<? extends PGobject>>();
-    pgArrayToPgType = new HashMap<Integer, Integer>();
-    arrayOidToDelimiter = new HashMap<Integer, Character>();
+    oidToPgName = new HashMap<Integer, String>((int) Math.round(types.length * 1.5));
+    pgNameToOid = new HashMap<String, Integer>((int) Math.round(types.length * 1.5));
+    pgNameToJavaClass = new HashMap<String, String>((int) Math.round(types.length * 1.5));
+    pgNameToPgObject = new HashMap<String, Class<? extends PGobject>>((int) Math.round(types.length * 1.5));
+    pgArrayToPgType = new HashMap<Integer, Integer>((int) Math.round(types.length * 1.5));
+    arrayOidToDelimiter = new HashMap<Integer, Character>((int) Math.round(types.length * 2.5));
 
     // needs to be synchronized because the iterator is returned
     // from getPGTypeNamesWithSQLTypes()
-    pgNameToSQLType = Collections.synchronizedMap(new HashMap<String, Integer>());
+    pgNameToSQLType = Collections.synchronizedMap(new HashMap<String, Integer>((int) Math.round(types.length * 1.5)));
 
     for (Object[] type : types) {
       String pgTypeName = (String) type[0];

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
@@ -152,6 +152,7 @@ public class TypeInfoCache implements TypeInfo {
     //
     Character delim = ',';
     arrayOidToDelimiter.put(oid, delim);
+    arrayOidToDelimiter.put(arrayOid, delim);
 
     String pgArrayTypeName = pgTypeName + "[]";
     pgNameToJavaClass.put(pgArrayTypeName, "java.sql.Array");


### PR DESCRIPTION
In addition to caching the underlying core type mapped to a comma,
cache their array equivalent types to avoid querying from the server.

Fixes #1415.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Does mvn checkstyle:check pass ?

### Changes to Existing Features:

* [x] Does this break existing behaviour? If so please explain.
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
