### PR TITLE
fix:Test Case HostSpecTest , tests testShouldResolveWithEmptySocksPro…

### DIFF
--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/Jdbc2TestSuite.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/Jdbc2TestSuite.java
@@ -18,6 +18,7 @@ import org.postgresql.test.core.JavaVersionTest;
 import org.postgresql.test.core.NativeQueryBindLengthTest;
 import org.postgresql.test.core.OptionsPropertyTest;
 import org.postgresql.test.util.ExpressionPropertiesTest;
+import org.postgresql.test.util.HostSpecTest;
 import org.postgresql.test.util.LruCacheTest;
 import org.postgresql.test.util.ServerVersionParseTest;
 import org.postgresql.test.util.ServerVersionTest;
@@ -45,23 +46,11 @@ import org.junit.runners.Suite;
         ColumnSanitiserDisabledTest.class,
         ColumnSanitiserEnabledTest.class,
         LruCacheTest.class,
+        HostSpecTest.class,
         ReaderInputStreamTest.class,
         ServerVersionParseTest.class,
         ServerVersionTest.class,
 
-        DriverTest.class,
-        ConnectionTest.class,
-        DatabaseMetaDataTest.class,
-        DatabaseMetaDataPropertiesTest.class,
-        SearchPathLookupTest.class,
-        EncodingTest.class,
-        ExpressionPropertiesTest.class,
-        ColumnSanitiserDisabledTest.class,
-        ColumnSanitiserEnabledTest.class,
-        LruCacheTest.class,
-        ReaderInputStreamTest.class,
-        ServerVersionParseTest.class,
-        ServerVersionTest.class,
         OptionsPropertyTest.class,
 
         TypeCacheDLLStressTest.class,

--- a/pgjdbc/src/test/java/org/postgresql/test/util/HostSpecTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/util/HostSpecTest.java
@@ -36,14 +36,14 @@ public class HostSpecTest {
   public void testShouldResolveWithEmptySocksProxyHost() throws Exception {
     System.setProperty("socksProxyHost", "");
     HostSpec hostSpec = new HostSpec("localhost", 5432);
-    assertFalse(hostSpec.shouldResolve());
+    assertTrue(hostSpec.shouldResolve());
   }
 
   @Test
   public void testShouldResolveWithWhiteSpaceSocksProxyHost() throws Exception {
     System.setProperty("socksProxyHost", " ");
     HostSpec hostSpec = new HostSpec("localhost", 5432);
-    assertFalse(hostSpec.shouldResolve());
+    assertTrue(hostSpec.shouldResolve());
   }
 
   @Test


### PR DESCRIPTION
…xyHost and testShouldResolveWithWhiteSpaceSocksProxyHost

Added HostSpecTest to Jdbc2TestSuite and removed duplicates from same

Fixes #1423 
