### PR TITLE
fix: prevent crash when ReadyForQuery has no corresponding portal (#1425)

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -2284,7 +2284,11 @@ public class QueryExecutorImpl extends QueryExecutorBase {
             // identify that "update" did not return any results
             executeRequest.query.setFields(null);
 
-            pendingDescribePortalQueue.removeFirst();
+            if (!pendingDescribePortalQueue.isEmpty()) {
+              pendingDescribePortalQueue.removeFirst();
+            } else {
+              LOGGER.log(Level.WARNING, " <=BE ReadyForQuery with no corresponding pending Describe portal message");
+            }
             if (!pendingExecuteQueue.isEmpty()) {
               if (getTransactionState() == TransactionState.IDLE) {
                 handler.secureProgress();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes to Existing Features:

* [ ] Does this break existing behaviour? If so please explain.
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
