### PR TITLE
New targetServerType parameter value: preferMaster

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ In addition to the standard connection parameters the driver supports a number o
 | disableColumnSanitiser        | Boolean | false   | Enable optimization that disables column name sanitiser |
 | assumeMinServerVersion        | String  | null    | Assume the server is at least that version |
 | currentSchema                 | String  | null    | Specify the schema to be set in the search-path |
-| targetServerType              | String  | any     | Specifies what kind of server to connect, possible values: any, master, slave (deprecated), secondary, preferSlave (deprecated), preferSecondary |
+| targetServerType              | String  | any     | Specifies what kind of server to connect, possible values: any, master, slave (deprecated), secondary, preferMaster, preferSlave (deprecated), preferSecondary |
 | hostRecheckSeconds            | Integer | 10      | Specifies period (seconds) after which the host status is checked again in case it has changed |
 | loadBalanceHosts              | Boolean | false   | If disabled hosts are connected in the given order. If enabled hosts are chosen randomly from the set of suitable candidates |
 | socketFactory                 | String  | null    | Specify a socket factory for socket creation |

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ In addition to the standard connection parameters the driver supports a number o
 | disableColumnSanitiser        | Boolean | false   | Enable optimization that disables column name sanitiser |
 | assumeMinServerVersion        | String  | null    | Assume the server is at least that version |
 | currentSchema                 | String  | null    | Specify the schema to be set in the search-path |
-| targetServerType              | String  | any     | Specifies what kind of server to connect, possible values: any, master, slave (deprecated), secondary, preferMaster, preferSlave (deprecated), preferSecondary |
+| targetServerType              | String  | any     | Specifies what kind of server to connect, possible values: any, master, slave (deprecated), secondary, preferPrimary, preferSlave (deprecated), preferSecondary |
 | hostRecheckSeconds            | Integer | 10      | Specifies period (seconds) after which the host status is checked again in case it has changed |
 | loadBalanceHosts              | Boolean | false   | If disabled hosts are connected in the given order. If enabled hosts are chosen randomly from the set of suitable candidates |
 | socketFactory                 | String  | null    | Specify a socket factory for socket creation |

--- a/docs/documentation/head/connect.md
+++ b/docs/documentation/head/connect.md
@@ -418,11 +418,11 @@ Connection conn = DriverManager.getConnection(url);
 
 	Allows opening connections to only servers with required state, 
 	the allowed values are any, master, slave (deprecated), secondary,
-	preferMaster, preferSlave (deprecated) and preferSecondary. 
+	preferPrimary, preferSlave (deprecated) and preferSecondary. 
 	The master/secondary distinction is currently done by observing if the server allows writes. 
 	The value preferSecondary tries to connect to secondary if any are available, 
 	otherwise allows falls back to connecting also to master.
-	The value preferMaster tries to connect to master if it is available, 
+	The value preferPrimary tries to connect to master if it is available, 
 	otherwise allows falls back to connecting to a secondary.
 
 * **hostRecheckSeconds** = int

--- a/docs/documentation/head/connect.md
+++ b/docs/documentation/head/connect.md
@@ -417,10 +417,13 @@ Connection conn = DriverManager.getConnection(url);
 * **targetServerType** = String
 
 	Allows opening connections to only servers with required state, 
-	the allowed values are any, master, slave, secondary, preferSlave and preferSecondary. 
-	The master/slave distinction is currently done by observing if the server allows writes. 
+	the allowed values are any, master, slave (deprecated), secondary,
+	preferMaster, preferSlave (deprecated) and preferSecondary. 
+	The master/secondary distinction is currently done by observing if the server allows writes. 
 	The value preferSecondary tries to connect to secondary if any are available, 
 	otherwise allows falls back to connecting also to master.
+	The value preferMaster tries to connect to master if it is available, 
+	otherwise allows falls back to connecting to a secondary.
 
 * **hostRecheckSeconds** = int
 

--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -373,7 +373,7 @@ public enum PGProperty {
   CURRENT_SCHEMA("currentSchema", null, "Specify the schema to be set in the search-path"),
 
   TARGET_SERVER_TYPE("targetServerType", "any", "Specifies what kind of server to connect", false,
-      "any", "master", "slave", "secondary",  "preferSlave", "preferSecondary"),
+      "any", "master", "slave", "secondary", "preferMaster", "preferSlave", "preferSecondary"),
 
   LOAD_BALANCE_HOSTS("loadBalanceHosts", "false",
       "If disabled hosts are connected in the given order. If enabled hosts are chosen randomly from the set of suitable candidates"),

--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -373,7 +373,7 @@ public enum PGProperty {
   CURRENT_SCHEMA("currentSchema", null, "Specify the schema to be set in the search-path"),
 
   TARGET_SERVER_TYPE("targetServerType", "any", "Specifies what kind of server to connect", false,
-      "any", "master", "slave", "secondary", "preferMaster", "preferSlave", "preferSecondary"),
+      "any", "master", "slave", "secondary", "preferPrimary", "preferMaster", "preferSlave", "preferSecondary"),
 
   LOAD_BALANCE_HOSTS("loadBalanceHosts", "false",
       "If disabled hosts are connected in the given order. If enabled hosts are chosen randomly from the set of suitable candidates"),

--- a/pgjdbc/src/main/java/org/postgresql/hostchooser/HostRequirement.java
+++ b/pgjdbc/src/main/java/org/postgresql/hostchooser/HostRequirement.java
@@ -24,6 +24,11 @@ public enum HostRequirement {
       return status == HostStatus.Secondary || status == HostStatus.ConnectOK;
     }
   },
+  preferMaster {
+    public boolean allowConnectingTo(HostStatus status) {
+      return status != HostStatus.ConnectFail;
+    }
+  },
   preferSecondary {
     public boolean allowConnectingTo(HostStatus status) {
       return status != HostStatus.ConnectFail;

--- a/pgjdbc/src/main/java/org/postgresql/hostchooser/HostRequirement.java
+++ b/pgjdbc/src/main/java/org/postgresql/hostchooser/HostRequirement.java
@@ -24,7 +24,7 @@ public enum HostRequirement {
       return status == HostStatus.Secondary || status == HostStatus.ConnectOK;
     }
   },
-  preferMaster {
+  preferPrimary {
     public boolean allowConnectingTo(HostStatus status) {
       return status != HostStatus.ConnectFail;
     }

--- a/pgjdbc/src/main/java/org/postgresql/hostchooser/MultiHostChooser.java
+++ b/pgjdbc/src/main/java/org/postgresql/hostchooser/MultiHostChooser.java
@@ -56,7 +56,7 @@ class MultiHostChooser implements HostChooser {
   }
 
   private Iterator<CandidateHost> candidateIterator() {
-    if (targetServerType != HostRequirement.preferSecondary && targetServerType != HostRequirement.preferMaster) {
+    if (targetServerType != HostRequirement.preferSecondary && targetServerType != HostRequirement.preferPrimary) {
       return getCandidateHosts(targetServerType).iterator();
     }
 
@@ -66,7 +66,7 @@ class MultiHostChooser implements HostChooser {
     } else {
       preferredTargetServerType = HostRequirement.master;
     }
-    // preferSecondary and preferMaster try to find secondary/master hosts first
+    // preferSecondary and preferPrimary try to find secondary/master hosts first
     // Note: sort does not work here since there are "unknown" hosts,
     // and that "unknown" might turn out to be unwanted master/secondary, so we should discard that
     // if other secondaries/masters exist

--- a/pgjdbc/src/main/java/org/postgresql/hostchooser/MultiHostChooser.java
+++ b/pgjdbc/src/main/java/org/postgresql/hostchooser/MultiHostChooser.java
@@ -60,16 +60,17 @@ class MultiHostChooser implements HostChooser {
       return getCandidateHosts(targetServerType).iterator();
     }
 
-    List<CandidateHost> any = getCandidateHosts(HostRequirement.any);
     final HostRequirement preferredTargetServerType;
-    if (targetServerType == HostRequirement.preferSecondary)
+    if (targetServerType == HostRequirement.preferSecondary) {
       preferredTargetServerType = HostRequirement.secondary;
-    else
+    } else {
       preferredTargetServerType = HostRequirement.master;
+    }
     // preferSecondary and preferMaster try to find secondary/master hosts first
     // Note: sort does not work here since there are "unknown" hosts,
     // and that "unknown" might turn out to be unwanted master/secondary, so we should discard that
     // if other secondaries/masters exist
+    List<CandidateHost> any = getCandidateHosts(HostRequirement.any);
     List<CandidateHost> preferredHosts = getCandidateHosts(preferredTargetServerType);
 
     if (preferredHosts.isEmpty()) {

--- a/pgjdbc/src/test/java/org/postgresql/test/hostchooser/MultiHostsConnectionTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/hostchooser/MultiHostsConnectionTest.java
@@ -9,11 +9,16 @@ import static java.lang.Integer.parseInt;
 import static java.util.Arrays.asList;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
-import static org.postgresql.hostchooser.HostRequirement.*;
+import static org.postgresql.hostchooser.HostRequirement.any;
+import static org.postgresql.hostchooser.HostRequirement.master;
+import static org.postgresql.hostchooser.HostRequirement.preferMaster;
+import static org.postgresql.hostchooser.HostRequirement.preferSecondary;
+import static org.postgresql.hostchooser.HostRequirement.secondary;
 import static org.postgresql.hostchooser.HostStatus.Master;
 import static org.postgresql.hostchooser.HostStatus.Secondary;
 import static org.postgresql.test.TestUtil.closeDB;
@@ -33,7 +38,11 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.*;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
 
 public class MultiHostsConnectionTest {
 
@@ -189,6 +198,7 @@ public class MultiHostsConnectionTest {
     if (status == null) {
       assertNull(hostStatusMap.get(spec));
     } else {
+      assertNotNull(hostStatusMap.get(spec));
       assertEquals(host + "=" + status, hostStatusMap.get(spec).toString());
     }
   }
@@ -279,7 +289,7 @@ public class MultiHostsConnectionTest {
     assertGlobalState(master1, "Master");
     assertGlobalState(secondary1, "Secondary"); // tried as it was unknown
 
-    getConnection(preferMaster, true, fake1, master1, secondary1);
+    getConnection(preferMaster, true, fake1, secondary1, master1);
     assertRemote(masterIP);
     assertGlobalState(fake1, "ConnectFail");
     assertGlobalState(master1, "Master");
@@ -379,7 +389,7 @@ public class MultiHostsConnectionTest {
       }
     }
     assertEquals("Never connected to all secondary hosts", new HashSet<String>(asList(secondaryIP, secondaryIP2)),
-      connectedHosts);
+        connectedHosts);
 
     // connect to secondary when there's no master
     getConnection(preferMaster, true, true, fake1, secondary1);


### PR DESCRIPTION
Allows a new `preferMaster` value for `targetServerType` parameter, which forces the driver to preferably connect to a master host. The behaiviour is basically the inverse of `preferSecondary` value and the usecases are described in the mailing list: https://www.postgresql.org/message-id/VI1PR05MB5295AE43EF9525EACC9E57ECBC750%40VI1PR05MB5295.eurprd05.prod.outlook.com

Also updated the documentation and readme for the parameter.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Does mvn checkstyle:check pass ?

### Changes to Existing Features:

* [ ] Does this break existing behaviour? If so please explain.
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?