### PR TITLE
fix: #1431: memory leak in UTF8 string decoding

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/UTF8Encoding.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/UTF8Encoding.java
@@ -15,10 +15,11 @@ class UTF8Encoding extends Encoding {
   private static final int MIN_4_BYTES = 0x10000;
   private static final int MAX_CODE_POINT = 0x10ffff;
 
-  private char[] decoderArray = new char[1024];
+  private char[] decoderArray;
 
   UTF8Encoding(String jvmEncoding) {
     super(jvmEncoding);
+    decoderArray = new char[Integer.parseInt(System.getProperty("PG_UTF8_ENC_BYTES", String.valueOf(1024)))];
   }
 
   // helper for decode
@@ -83,7 +84,7 @@ class UTF8Encoding extends Encoding {
   public synchronized String decode(byte[] data, int offset, int length) throws IOException {
     char[] cdata = decoderArray;
     if (cdata.length < length) {
-      cdata = decoderArray = new char[length];
+      cdata = new char[length];
     }
 
     int in = offset;


### PR DESCRIPTION
The decoderArray used in decoding UTF8 strings is now kept constant to 1024 bytes.
If the input size is larger than 1024 bytes, then only the cdata is allocated
to a larger value instead of increasing the size of decodeArray.
This helps keeping the size/memory to a constant.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Does mvn checkstyle:check pass ?

### Changes to Existing Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
