### PR TITLE
fix: improper indentation for javadoc

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/copy/CopyOut.java
+++ b/pgjdbc/src/main/java/org/postgresql/copy/CopyOut.java
@@ -22,7 +22,7 @@ public interface CopyOut extends CopyOperation {
    * @param block {@code true} if need wait data from server otherwise {@code false} and will read
    *              pending message from server
    * @return byte array received from server, if pending message from server absent and use no
-   * blocking mode return null
+   *         blocking mode return null
    * @throws SQLException if something goes wrong for example socket timeout
    */
   byte[] readFromCopy(boolean block) throws SQLException;


### PR DESCRIPTION
This PR is being created because of violations found in CheckStyle's regression of Orekit during implementation of a bug fix.
PR: checkstyle/checkstyle#6529
Issue: checkstyle/checkstyle#6516

A bug was found in identifying javadocs where certain type of javadocs were missed from validation. The change produced new violations in Orekit as seen below:

````
[INFO] --- maven-checkstyle-plugin:3.0.0:check (default-cli) @ postgresql ---
[INFO] Starting audit...
[ERROR] /pipeline/source/.ci-temp/pgjdbc/pgjdbc/src/main/java/org/postgresql/copy/CopyOut.java:25: Line continuation have incorrect indentation level, expected level should be 4. [JavadocTagContinuationIndentation]
Audit done.
````

You can either accept this PR and not have an issue when you upgrade CS with this fix in the future,
or make your own change/fix later when you do upgrade CS.
Please let us know which way you intend to go.

Feel free to ask any questions.
Thanks.