### PR TITLE
Expose parameter status messages (GUC_REPORT) to the user

### DIFF
--- a/docs/documentation/head/ext.md
+++ b/docs/documentation/head/ext.md
@@ -16,6 +16,7 @@ next: geometric.html
 * [Large Objects](largeobjects.html)
 * [Listen / Notify](listennotify.html)
 * [Server Prepared Statements](server-prepare.html)
+* [Parameter Status Messages](parameterstatus.html)
 * [Physical and Logical replication API](replication.html)
 * [Arrays](arrays.html)
 

--- a/docs/documentation/head/parameterstatus.md
+++ b/docs/documentation/head/parameterstatus.md
@@ -1,0 +1,63 @@
+---
+layout: default_docs
+title: Physical and Logical replication API
+header: Chapter 9. PostgreSQL™ Extensions to the JDBC API
+resource: media
+previoustitle: Parameter Status Messages
+previous: server-prepare.html
+nexttitle: Physical and Logical replication API
+next: replication.html
+---
+
+# Parameter Status Messages
+
+PostgreSQL supports server parameters, also called server variables or,
+internally, Grand Unified Configuration (GUC) variables. These variables are
+manipulated by the `SET` command, `postgresql.conf`, `ALTER SYSTEM SET`, `ALTER
+USER SET`, `ALTER DATABASE SET`, the `set_config(...)` SQL-callable function,
+etc. See [the PostgreSQL manual](https://www.postgresql.org/docs/current/config-setting.html).
+
+For a subset of these variables the server will *automatically report changes
+to the value to the client driver and application*. These variables are known
+internally as `GUC_REPORT` variables after the name of the flag that enables
+the functionality.
+
+The server keeps track of all the variable scopes and reports when a variable
+reverts to a prior value, so the client doesn't have to guess what the current
+value is and whether some server-side function could've changed it.  Whenever
+the value changes, no matter why or how it changes, the server reports the new
+effective value in a *Parameter Status* protocol message to the client.  PgJDBC
+uses many of these reports internally.
+
+As of PgJDBC 42.2.6, it also exposes the parameter status information to user
+applications via the PGConnection extensions interface.
+
+## Methods
+
+Two methods on `org.postgresql.PGConnection` provide the client interface to
+reported parameters. Parameter names are case-insensitive and case-preserving.
+
+* `Map PGConnection.getParameterStatuses()` - return a map of all reported
+  parameters and their values.
+
+* `String PGConnection.getParameterStatus()` - shorthand to retrieve one
+  value by name, or null if no value has been reported.
+
+See the `PGConnection` JavaDoc for details.
+
+## Example
+
+If you're working directly with a `java.sql.Connection` you can
+
+    import org.postgresql.PGConnection;
+
+    void my_function(Connection conn) {
+
+        System.out.println("My application name is " +
+            ((PGConnection)conn).getParameterStatus("application_name"));
+
+    }
+
+## Other client drivers
+
+The `libpq` equivalent is the `PQparameterStatus(...)` API function.

--- a/docs/documentation/head/replication.md
+++ b/docs/documentation/head/replication.md
@@ -3,8 +3,8 @@ layout: default_docs
 title: Physical and Logical replication API
 header: Chapter 9. PostgreSQL™ Extensions to the JDBC API
 resource: media
-previoustitle: Server Prepared Statements
-previous: server-prepare.html
+previoustitle: Parameter Status Messages
+previous: parameterstatus.html
 nexttitle: Arrays
 next: arrays.html
 ---

--- a/docs/documentation/head/server-prepare.md
+++ b/docs/documentation/head/server-prepare.md
@@ -5,8 +5,8 @@ header: Chapter 9. PostgreSQL™ Extensions to the JDBC API
 resource: media
 previoustitle: Listen / Notify
 previous: listennotify.html
-nexttitle: Physical and Logical replication API
-next: replication.html
+nexttitle: Parameter Status Messages
+next: parameterstatus.html
 ---
 
 ### Motivation

--- a/pgjdbc/src/main/java/org/postgresql/PGConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGConnection.java
@@ -17,6 +17,8 @@ import java.sql.Array;
 import java.sql.SQLException;
 import java.sql.Statement;
 
+import java.util.Map;
+
 /**
  * This interface defines the public PostgreSQL extensions to java.sql.Connection. All Connections
  * returned by the PostgreSQL driver implement PGConnection.
@@ -236,4 +238,76 @@ public interface PGConnection {
    * @return replication API for the current connection
    */
   PGReplicationConnection getReplicationAPI();
+
+  /**
+   * <p>Returns the current values of all parameters reported by the server.</p>
+   *
+   * <p>PostgreSQL reports values for a subset of parameters (GUCs) to the client
+   * at connect-time, then sends update messages whenever the values change
+   * during a session. PgJDBC records the latest values and exposes it to client
+   * applications via <code>getParameterStatuses()</code>.</p>
+   *
+   * <p>PgJDBC exposes individual accessors for some of these parameters as
+   * listed below. They are more backwarrds-compatible and should be preferred
+   * where possible.</p>
+   *
+   * <p>Not all parameters are reported, only those marked
+   * <code>GUC_REPORT</code> in the source code. The <code>pg_settings</code>
+   * view does not expose information about which parameters are reportable.
+   * PgJDBC's map will only contain the parameters the server reports values
+   * for, so you cannot use this method as a substitute for running a
+   * <code>SHOW paramname;</code> or <code>SELECT
+   * current_setting('paramname');</code> query for arbitrary parameters.</p>
+   *
+   * <p>Parameter names are <i>case-insensitive</i> and <i>case-preserving</i>
+   * in this map, like in PostgreSQL itself. So <code>DateStyle</code> and
+   * <code>datestyle</code> are the same key.</p>
+   *
+   * <p>
+   *  As of PostgreSQL 11 the reportable parameter list, and related PgJDBC
+   *  interfaces or accesors, are:
+   * </p>
+   *
+   * <ul>
+   *  <li>
+   *    <code>application_name</code> -
+   *    {@link java.sql.Connection#getClientInfo()},
+   *    {@link java.sql.Connection#setClientInfo(java.util.Properties)}
+   *    and <code>ApplicationName</code> connection property.
+   *  </li>
+   *  <li>
+   *    <code>client_encoding</code> - PgJDBC always sets this to <code>UTF8</code>.
+   *    See <code>allowEncodingChanges</code> connection property.
+   *  </li>
+   *  <li><code>DateStyle</code> - PgJDBC requires this to always be set to <code>ISO</code></li>
+   *  <li><code>standard_conforming_strings</code> - indirectly via {@link #escapeLiteral(String)}</li>
+   *  <li>
+   *    <code>TimeZone</code> - set from JDK timezone see {@link java.util.TimeZone#getDefault()}
+   *    and {@link java.util.TimeZone#setDefault(TimeZone)}
+   *  </li>
+   *  <li><code>integer_datetimes</code></li>
+   *  <li><code>IntervalStyle</code></li>
+   *  <li><code>server_encoding</code></li>
+   *  <li><code>server_version</code></li>
+   *  <li><code>is_superuser</code> </li>
+   *  <li><code>session_authorization</code></li>
+   * </ul>
+   *
+   * <p>Note that some PgJDBC operations will change server parameters
+   * automatically.</p>
+   *
+   * @return unmodifiable map of case-insensitive parameter names to parameter values
+   * @since 42.2.6
+   */
+  Map<String,String> getParameterStatuses();
+
+  /**
+   * Shorthand for getParameterStatuses().get(...) .
+   *
+   * @param parameterName case-insensitive parameter name
+   * @return parameter value if defined, or null if no parameter known
+   * @see #getParameterStatuses
+   * @since 42.2.6
+   */
+  String getParameterStatus(String parameterName);
 }

--- a/pgjdbc/src/main/java/org/postgresql/core/QueryExecutor.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/QueryExecutor.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.sql.SQLException;
 import java.sql.SQLWarning;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.TimeZone;
 
@@ -452,4 +453,9 @@ public interface QueryExecutor extends TypeTransferModeRegistry {
   void setNetworkTimeout(int milliseconds) throws IOException;
 
   int getNetworkTimeout() throws IOException;
+
+  // Expose parameter status to PGConnection
+  Map<String,String> getParameterStatuses();
+
+  String getParameterStatus(String parameterName);
 }

--- a/pgjdbc/src/main/java/org/postgresql/core/QueryExecutorBase.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/QueryExecutorBase.java
@@ -19,7 +19,10 @@ import java.io.IOException;
 import java.sql.SQLException;
 import java.sql.SQLWarning;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Map;
 import java.util.Properties;
+import java.util.TreeMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -51,6 +54,10 @@ public abstract class QueryExecutorBase implements QueryExecutor {
 
   private final LruCache<Object, CachedQuery> statementCache;
   private final CachedQueryCreateAction cachedQueryCreateAction;
+
+  // For getParameterStatuses(), GUC_REPORT tracking
+  private final TreeMap<String,String> parameterStatuses
+      = new TreeMap<String,String>(String.CASE_INSENSITIVE_ORDER);
 
   protected QueryExecutorBase(PGStream pgStream, String user,
       String database, int cancelSignalTimeout, Properties info) throws SQLException {
@@ -388,5 +395,43 @@ public abstract class QueryExecutorBase implements QueryExecutor {
 
   protected boolean hasNotifications() {
     return notifications.size() > 0;
+  }
+
+  @Override
+  public final Map<String,String> getParameterStatuses() {
+    return Collections.unmodifiableMap(parameterStatuses);
+  }
+
+  @Override
+  public final String getParameterStatus(String parameterName) {
+    return parameterStatuses.get(parameterName);
+  }
+
+  /**
+   * Update the parameter status map in response to a new ParameterStatus
+   * wire protocol message.
+   *
+   * <p>The server sends ParameterStatus messages when GUC_REPORT settings are
+   * initially assigned and whenever they change.</p>
+   *
+   * <p>A future version may invoke a client-defined listener class at this point,
+   * so this should be the only access path.</p>
+   *
+   * <p>Keys are case-insensitive and case-preserving.</p>
+   *
+   * <p>The server doesn't provide a way to report deletion of a reportable
+   * parameter so we don't expose one here.</p>
+   *
+   * @param parameterName case-insensitive case-preserving name of parameter to create or update
+   * @param parameterStatus new value of parameter
+   * @see org.postgresql.PGConnection#getParameterStatuses
+   * @see org.postgresql.PGConnection#getParameterStatus
+   */
+  protected void onParameterStatus(String parameterName, String parameterStatus) {
+    if (parameterName == null || parameterName.equals("")) {
+      throw new IllegalStateException("attempt to set GUC_REPORT parameter with null or empty-string name");
+    }
+
+    parameterStatuses.put(parameterName, parameterStatus);
   }
 }

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -2621,6 +2621,11 @@ public class QueryExecutorImpl extends QueryExecutorBase {
       LOGGER.log(Level.FINEST, " <=BE ParameterStatus({0} = {1})", new Object[]{name, value});
     }
 
+    /* Update client-visible parameter status map for getParameterStatuses() */
+    if (name != null && !name.equals("")) {
+      onParameterStatus(name, value);
+    }
+
     if (name.equals("client_encoding")) {
       if (allowEncodingChanges) {
         if (!value.equalsIgnoreCase("UTF8") && !value.equalsIgnoreCase("UTF-8")) {

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
@@ -1726,4 +1726,15 @@ public class PgConnection implements BaseConnection {
     }
     return ps;
   }
+
+  @Override
+  public final Map<String,String> getParameterStatuses() {
+    return queryExecutor.getParameterStatuses();
+  }
+
+  @Override
+  public final String getParameterStatus(String parameterName) {
+    return queryExecutor.getParameterStatus(parameterName);
+  }
+
 }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/Jdbc2TestSuite.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/Jdbc2TestSuite.java
@@ -122,7 +122,8 @@ import org.junit.runners.Suite;
         CopyLargeFileTest.class,
         ServerErrorTest.class,
         UpsertTest.class,
-        OuterJoinSyntaxTest.class
+        OuterJoinSyntaxTest.class,
+        ParameterStatusTest.class
 })
 public class Jdbc2TestSuite {
 }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ParameterStatusTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ParameterStatusTest.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright (c) 2019, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.test.jdbc2;
+
+import org.postgresql.PGConnection;
+import org.postgresql.core.ServerVersion;
+import org.postgresql.test.TestUtil;
+
+import org.hamcrest.core.StringStartsWith;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.sql.Statement;
+import java.util.Map;
+import java.util.TimeZone;
+import java.util.logging.Logger;
+
+/**
+ * Test JDBC extension API for server reported parameter status messages.
+ *
+ * <p>This test covers client interface for server ParameterStatus messages
+ * (GUC_REPORT) parameters via PGConnection.getParameterStatuses() and
+ * PGConnection.getParameterStatus().</p>
+ */
+public class ParameterStatusTest extends BaseTest4 {
+
+  private final TimeZone tzPlus0800 = TimeZone.getTimeZone("GMT+8:00");
+  private final Logger logger = Logger.getLogger(ParameterStatusTest.class.getName());
+
+  @Test
+  public void expectedInitialParameters() throws Exception {
+    TimeZone.setDefault(tzPlus0800);
+    con = TestUtil.openDB();
+
+    Map<String,String> params = ((PGConnection)con).getParameterStatuses();
+
+    // PgJDBC forces the following parameters
+    Assert.assertEquals("UTF8", params.get("client_encoding"));
+    Assert.assertNotNull(params.get("DateStyle"));
+    Assert.assertThat(params.get("DateStyle"), StringStartsWith.startsWith("ISO"));
+
+    // PgJDBC sets TimeZone via Java's TimeZone.getDefault()
+    // Pg reports POSIX timezones which are negated, so:
+    Assert.assertEquals("GMT-08:00", params.get("TimeZone"));
+
+    // Must be reported. All these exist in 8.2 or above, and we don't bother
+    // with test coverage older than that.
+    Assert.assertNotNull(params.get("integer_datetimes"));
+    Assert.assertNotNull(params.get("is_superuser"));
+    Assert.assertNotNull(params.get("server_encoding"));
+    Assert.assertNotNull(params.get("server_version"));
+    Assert.assertNotNull(params.get("session_authorization"));
+    Assert.assertNotNull(params.get("standard_conforming_strings"));
+
+    if (TestUtil.haveMinimumServerVersion(con, ServerVersion.v8_4)) {
+      Assert.assertNotNull(params.get("IntervalStyle"));
+    } else {
+      Assert.assertNull(params.get("IntervalStyle"));
+    }
+
+    // TestUtil forces "ApplicationName=Driver Tests"
+    // if application_name is supported (9.0 or newer)
+    if (TestUtil.haveMinimumServerVersion(con, ServerVersion.v9_0)) {
+      Assert.assertEquals("Driver Tests", params.get("application_name"));
+    } else {
+      Assert.assertNull(params.get("application_name"));
+    }
+
+    // Not reported
+    Assert.assertNull(params.get("nonexistent"));
+    Assert.assertNull(params.get("enable_hashjoin"));
+
+    TestUtil.closeDB(con);
+  }
+
+  @Test
+  public void reportUpdatedParameters() throws Exception {
+    con = TestUtil.openDB();
+
+    if (!TestUtil.haveMinimumServerVersion(con, ServerVersion.v9_0)) {
+      /* This test uses application_name which was added in 9.0 */
+      return;
+    }
+
+    con.setAutoCommit(false);
+    Statement stmt = con.createStatement();
+
+    stmt.executeUpdate("SET application_name = 'pgjdbc_ParameterStatusTest2';");
+    stmt.close();
+
+    // Parameter status should be reported before the ReadyForQuery so we will
+    // have already processed it
+    Assert.assertEquals("pgjdbc_ParameterStatusTest2", ((PGConnection)con).getParameterStatus("application_name"));
+
+    TestUtil.closeDB(con);
+  }
+
+  // Run a txn-level SET then a txn-level SET LOCAL so we can make sure we keep
+  // track of the right GUC value at each point.
+  private void transactionalParametersCommon() throws Exception {
+    Statement stmt = con.createStatement();
+
+    // Initial value assigned by TestUtil
+    Assert.assertEquals("Driver Tests", ((PGConnection)con).getParameterStatus("application_name"));
+
+    // PgJDBC begins an explicit txn here due to autocommit=off so the effect
+    // should be lost on rollback but retained on commit per the docs.
+    stmt.executeUpdate("SET application_name = 'pgjdbc_ParameterStatusTestTxn';");
+    Assert.assertEquals("pgjdbc_ParameterStatusTestTxn", ((PGConnection)con).getParameterStatus("application_name"));
+
+    // SET LOCAL is always txn scoped so the effect here will always be
+    // unwound on txn end.
+    stmt.executeUpdate("SET LOCAL application_name = 'pgjdbc_ParameterStatusTestLocal';");
+    Assert.assertEquals("pgjdbc_ParameterStatusTestLocal", ((PGConnection)con).getParameterStatus("application_name"));
+
+    stmt.close();
+  }
+
+  @Test
+  public void transactionalParametersRollback() throws Exception {
+    con = TestUtil.openDB();
+
+    if (!TestUtil.haveMinimumServerVersion(con, ServerVersion.v9_0)) {
+      /* This test uses application_name which was added in 9.0 */
+      return;
+    }
+
+    con.setAutoCommit(false);
+
+    transactionalParametersCommon();
+
+    // SET unwinds on ROLLBACK
+    con.rollback();
+
+    Assert.assertEquals("Driver Tests", ((PGConnection)con).getParameterStatus("application_name"));
+
+    TestUtil.closeDB(con);
+  }
+
+  @Test
+  public void transactionalParametersCommit() throws Exception {
+    con = TestUtil.openDB();
+
+    if (!TestUtil.haveMinimumServerVersion(con, ServerVersion.v9_0)) {
+      /* This test uses application_name which was added in 9.0 */
+      return;
+    }
+
+    con.setAutoCommit(false);
+
+    transactionalParametersCommon();
+
+    // SET is retained on commit but SET LOCAL is unwound
+    con.commit();
+
+    Assert.assertEquals("pgjdbc_ParameterStatusTestTxn", ((PGConnection)con).getParameterStatus("application_name"));
+
+    TestUtil.closeDB(con);
+  }
+
+  @Test
+  public void transactionalParametersAutocommit() throws Exception {
+    con = TestUtil.openDB();
+
+    if (!TestUtil.haveMinimumServerVersion(con, ServerVersion.v9_0)) {
+      /* This test uses application_name which was added in 9.0 */
+      return;
+    }
+
+    con.setAutoCommit(true);
+    Statement stmt = con.createStatement();
+
+    // A SET LOCAL in autocommit should have no visible effect as we report the reset value too
+    Assert.assertEquals("Driver Tests", ((PGConnection)con).getParameterStatus("application_name"));
+    stmt.executeUpdate("SET LOCAL application_name = 'pgjdbc_ParameterStatusTestLocal';");
+    Assert.assertEquals("Driver Tests", ((PGConnection)con).getParameterStatus("application_name"));
+
+    stmt.close();
+    TestUtil.closeDB(con);
+  }
+
+  @Test(expected = UnsupportedOperationException.class)
+  public void parameterMapReadOnly() throws Exception {
+    try {
+      con = TestUtil.openDB();
+      Map params = ((PGConnection)con).getParameterStatuses();
+      params.put("DateStyle", "invalid");
+      Assert.fail("Attempt to write to exposed parameters map must throw");
+    } finally {
+      TestUtil.closeDB(con);
+    }
+  }
+
+  @Test
+  public void parameterMapIsView() throws Exception {
+    con = TestUtil.openDB();
+
+    if (!TestUtil.haveMinimumServerVersion(con, ServerVersion.v9_0)) {
+      /* This test uses application_name which was added in 9.0 */
+      return;
+    }
+
+    Map params = ((PGConnection)con).getParameterStatuses();
+
+    Statement stmt = con.createStatement();
+
+    Assert.assertEquals("Driver Tests", params.get("application_name"));
+    stmt.executeUpdate("SET application_name = 'pgjdbc_paramstatus_view';");
+    Assert.assertEquals("pgjdbc_paramstatus_view", params.get("application_name"));
+
+    stmt.close();
+    TestUtil.closeDB(con);
+  }
+
+}

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/StatementTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/StatementTest.java
@@ -730,11 +730,21 @@ public class StatementTest {
     Statement stmt2 = con.createStatement();
     while (System.currentTimeMillis() < deadLine) {
       try {
-        stmt.execute("select 1");
+        // This usually won't time out but scheduler jitter, server load
+        // etc can cause a timeout.
+        stmt.executeQuery("select 1;");
       } catch (SQLException e) {
-        // ignore "statement cancelled"
+        // Expect "57014 query_canceled" (en-msg is "canceling statement due to statement timeout")
+        // but anything else is fatal. We can't differentiate other causes of statement cancel like
+        // "canceling statement due to user request" without error message matching though, and we
+        // don't want to do that.
+        Assert.assertEquals(
+            "Query is expected to be cancelled via st.close(), got " + e.getMessage(),
+            PSQLState.QUERY_CANCELED.getState(),
+            e.getSQLState());
       }
-      stmt2.executeQuery("select 1");
+      // Must never time out.
+      stmt2.executeQuery("select 1;");
     }
   }
 


### PR DESCRIPTION
Add a new `Map PGConnection.getParameterStatuses()` method that tracks the
latest values of all `GUC_REPORT` parameters reported by the server in
`ParameterStatus` protocol messages from the server. The map is read-only. A
convenience `PGConnection.getParameterStatus(String)` wrapper is also provided.

This provides a PgJDBC equivalent to the `PQparameterStatus(...)` `libpq` API
function.

Extensions may define custom GUCs that are set as `GUC_REPORT` when they
`DefineCustomStringVariable(...)` etc. This feature will properly handle such
GUCs, allowing applications to generate parameter status change messages in
their extensions and have them available to the JDBC driver without needing
round trips.

No assumptions are made about which server GUCs are `GUC_REPORT` or their
names, so it'll work (with possible test case tweaks) on current and future
server versions.

Github issue pgjdbc/pgjdbc#1428

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Does mvn checkstyle:check pass ?

### Changes to Existing Features:

* [ ] Does this break existing behaviour? **no**
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?