### PR TITLE
Add method alias's for each property which didn't use the conventiona…

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
+++ b/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
@@ -26,6 +26,7 @@ import java.sql.SQLException;
 import java.util.Properties;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
 import javax.naming.NamingException;
 import javax.naming.RefAddr;
 import javax.naming.Reference;
@@ -63,7 +64,9 @@ public abstract class BaseDataSource implements CommonDataSource, Referenceable 
     try {
       Class.forName("org.postgresql.Driver");
     } catch (ClassNotFoundException e) {
-      throw new IllegalStateException("BaseDataSource is unable to load org.postgresql.Driver. Please check if you have proper PostgreSQL JDBC Driver jar on the classpath", e);
+      throw new IllegalStateException(
+        "BaseDataSource is unable to load org.postgresql.Driver. Please check if you have proper PostgreSQL JDBC Driver jar on the classpath",
+        e);
     }
   }
 
@@ -84,7 +87,7 @@ public abstract class BaseDataSource implements CommonDataSource, Referenceable 
    * properties serverName, databaseName, and portNumber. The user to connect as is identified by
    * the arguments user and password, which override the DataSource properties by the same name.
    *
-   * @param user user
+   * @param user     user
    * @param password password
    * @return A valid database connection.
    * @throws SQLException Occurs when the database connection cannot be established.
@@ -93,12 +96,13 @@ public abstract class BaseDataSource implements CommonDataSource, Referenceable 
     try {
       Connection con = DriverManager.getConnection(getUrl(), user, password);
       if (LOGGER.isLoggable(Level.FINE)) {
-        LOGGER.log(Level.FINE, "Created a {0} for {1} at {2}", new Object[]{getDescription(), user, getUrl()});
+        LOGGER.log(Level.FINE, "Created a {0} for {1} at {2}",
+            new Object[] {getDescription(), user, getUrl()});
       }
       return con;
     } catch (SQLException e) {
       LOGGER.log(Level.FINE, "Failed to create a {0} for {1} at {2}: {3}",
-          new Object[]{getDescription(), user, getUrl(), e});
+          new Object[] {getDescription(), user, getUrl(), e});
       throw e;
     }
   }
@@ -113,6 +117,7 @@ public abstract class BaseDataSource implements CommonDataSource, Referenceable 
 
   /**
    * This implementation don't use a LogWriter.
+   *
    * @param printWriter Not used
    */
   @Override
@@ -241,6 +246,7 @@ public abstract class BaseDataSource implements CommonDataSource, Referenceable 
 
   /**
    * Set command line options for this connection
+   *
    * @param options string to set options to
    */
   public void setOptions(String options) {
@@ -1087,7 +1093,7 @@ public abstract class BaseDataSource implements CommonDataSource, Referenceable 
     url.append("/").append(URLCoder.encode(databaseName));
 
     StringBuilder query = new StringBuilder(100);
-    for (PGProperty property: PGProperty.values()) {
+    for (PGProperty property : PGProperty.values()) {
       if (property.isPresent(properties)) {
         if (query.length() != 0) {
           query.append("&");
@@ -1124,7 +1130,7 @@ public abstract class BaseDataSource implements CommonDataSource, Referenceable 
 
     Properties p = org.postgresql.Driver.parseURL(url, null);
 
-    if (p == null ) {
+    if (p == null) {
       throw new IllegalArgumentException("URL invalid " + url);
     }
     for (PGProperty property : PGProperty.values()) {
@@ -1150,7 +1156,7 @@ public abstract class BaseDataSource implements CommonDataSource, Referenceable 
       return getProperty(pgProperty);
     } else {
       throw new PSQLException(GT.tr("Unsupported property name: {0}", name),
-          PSQLState.INVALID_PARAMETER_VALUE);
+        PSQLState.INVALID_PARAMETER_VALUE);
     }
   }
 
@@ -1160,7 +1166,7 @@ public abstract class BaseDataSource implements CommonDataSource, Referenceable 
       setProperty(pgProperty, value);
     } else {
       throw new PSQLException(GT.tr("Unsupported property name: {0}", name),
-          PSQLState.INVALID_PARAMETER_VALUE);
+        PSQLState.INVALID_PARAMETER_VALUE);
     }
   }
 
@@ -1314,6 +1320,7 @@ public abstract class BaseDataSource implements CommonDataSource, Referenceable 
 
   /**
    * see PGProperty#CLEANUP_SAVEPOINTS
+   *
    * @return boolean indicating property set
    */
   public boolean getCleanupSavepoints() {
@@ -1322,6 +1329,7 @@ public abstract class BaseDataSource implements CommonDataSource, Referenceable 
 
   /**
    * see PGProperty#CLEANUP_SAVEPOINTS
+   *
    * @param cleanupSavepoints will cleanup savepoints after a successful transaction
    */
   public void setCleanupSavepoints(boolean cleanupSavepoints) {
@@ -1355,143 +1363,115 @@ public abstract class BaseDataSource implements CommonDataSource, Referenceable 
    * which expect normal java bean getters / setters to exist for the property names.
    */
 
-  public boolean isSsl()
-  {
+  public boolean isSsl() {
     return getSsl();
   }
 
-  public String getSslfactoryarg()
-  {
+  public String getSslfactoryarg() {
     return getSslFactoryArg();
   }
 
-  public void setSslfactoryarg(final String arg)
-  {
+  public void setSslfactoryarg(final String arg) {
     setSslFactoryArg(arg);
   }
 
-  public String getSslcert()
-  {
+  public String getSslcert() {
     return getSslCert();
   }
 
-  public void setSslcert(final String file)
-  {
+  public void setSslcert(final String file) {
     setSslCert(file);
   }
 
-  public String getSslmode()
-  {
+  public String getSslmode() {
     return getSslMode();
   }
 
-  public void setSslmode(final String mode)
-  {
+  public void setSslmode(final String mode) {
     setSslMode(mode);
   }
 
-  public String getSslhostnameverifier()
-  {
+  public String getSslhostnameverifier() {
     return getSslHostnameVerifier();
   }
 
-  public void setSslhostnameverifier(final String className)
-  {
+  public void setSslhostnameverifier(final String className) {
     setSslHostnameVerifier(className);
   }
 
-  public String getSslkey()
-  {
+  public String getSslkey() {
     return getSslKey();
   }
 
-  public void setSslkey(final String file)
-  {
+  public void setSslkey(final String file) {
     setSslKey(file);
   }
 
-  public String getSslrootcert()
-  {
+  public String getSslrootcert() {
     return getSslRootCert();
   }
 
-  public void setSslrootcert(final String file)
-  {
+  public void setSslrootcert(final String file) {
     setSslRootCert(file);
   }
 
-  public String getSslpasswordcallback()
-  {
+  public String getSslpasswordcallback() {
     return getSslPasswordCallback();
   }
 
-  public void setSslpasswordcallback(final String className)
-  {
+  public void setSslpasswordcallback(final String className) {
     setSslPasswordCallback(className);
   }
 
-  public String getSslpassword()
-  {
+  public String getSslpassword() {
     return getSslPassword();
   }
 
-  public void setSslpassword(final String sslpassword)
-  {
+  public void setSslpassword(final String sslpassword) {
     setSslPassword(sslpassword);
   }
 
-  public int getRecvBufferSize()
-  {
+  public int getRecvBufferSize() {
     return getReceiveBufferSize();
   }
 
-  public void setRecvBufferSize(final int nbytes)
-  {
+  public void setRecvBufferSize(final int nbytes) {
     setReceiveBufferSize(nbytes);
   }
 
-  public boolean isAllowEncodingChanges()
-  {
+  public boolean isAllowEncodingChanges() {
     return getAllowEncodingChanges();
   }
 
-  public boolean isLogUnclosedConnections()
-  {
+  public boolean isLogUnclosedConnections() {
     return getLogUnclosedConnections();
   }
 
-  public boolean isTcpKeepAlive()
-  {
+  public boolean isTcpKeepAlive() {
     return getTcpKeepAlive();
   }
 
-  public boolean isReadOnly()
-  {
+  public boolean isReadOnly() {
     return getReadOnly();
   }
 
-  public boolean isDisableColumnSanitiser()
-  {
+  public boolean isDisableColumnSanitiser() {
     return getDisableColumnSanitiser();
   }
 
-  public boolean isLoadBalanceHosts()
-  {
+  public boolean isLoadBalanceHosts() {
     return getLoadBalanceHosts();
   }
 
-  public boolean isCleanupSavePoints()
-  {
+  public boolean isCleanupSavePoints() {
     return getCleanupSavepoints();
   }
 
-  public void setCleanupSavePoints(final boolean cleanupSavepoints)
-  {
+  public void setCleanupSavePoints(final boolean cleanupSavepoints) {
     setCleanupSavepoints(cleanupSavepoints);
   }
 
-  public boolean isReWriteBatchedInserts()
-  {
+  public boolean isReWriteBatchedInserts() {
     return getReWriteBatchedInserts();
   }
 }

--- a/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
+++ b/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
@@ -1349,4 +1349,149 @@ public abstract class BaseDataSource implements CommonDataSource, Referenceable 
     return Logger.getLogger("org.postgresql");
   }
   //#endif
+
+  /*
+   * Alias methods below, these are to help with ease-of-use with other database tools / frameworks
+   * which expect normal java bean getters / setters to exist for the property names.
+   */
+
+  public boolean isSsl()
+  {
+    return getSsl();
+  }
+
+  public String getSslfactoryarg()
+  {
+    return getSslFactoryArg();
+  }
+
+  public void setSslfactoryarg(final String arg)
+  {
+    setSslFactoryArg(arg);
+  }
+
+  public String getSslcert()
+  {
+    return getSslCert();
+  }
+
+  public void setSslcert(final String file)
+  {
+    setSslCert(file);
+  }
+
+  public String getSslmode()
+  {
+    return getSslMode();
+  }
+
+  public void setSslmode(final String mode)
+  {
+    setSslMode(mode);
+  }
+
+  public String getSslhostnameverifier()
+  {
+    return getSslHostnameVerifier();
+  }
+
+  public void setSslhostnameverifier(final String className)
+  {
+    setSslHostnameVerifier(className);
+  }
+
+  public String getSslkey()
+  {
+    return getSslKey();
+  }
+
+  public void setSslkey(final String file)
+  {
+    setSslKey(file);
+  }
+
+  public String getSslrootcert()
+  {
+    return getSslRootCert();
+  }
+
+  public void setSslrootcert(final String file)
+  {
+    setSslRootCert(file);
+  }
+
+  public String getSslpasswordcallback()
+  {
+    return getSslPasswordCallback();
+  }
+
+  public void setSslpasswordcallback(final String className)
+  {
+    setSslPasswordCallback(className);
+  }
+
+  public String getSslpassword()
+  {
+    return getSslPassword();
+  }
+
+  public void setSslpassword(final String sslpassword)
+  {
+    setSslPassword(sslpassword);
+  }
+
+  public int getRecvBufferSize()
+  {
+    return getReceiveBufferSize();
+  }
+
+  public void setRecvBufferSize(final int nbytes)
+  {
+    setReceiveBufferSize(nbytes);
+  }
+
+  public boolean isAllowEncodingChanges()
+  {
+    return getAllowEncodingChanges();
+  }
+
+  public boolean isLogUnclosedConnections()
+  {
+    return getLogUnclosedConnections();
+  }
+
+  public boolean isTcpKeepAlive()
+  {
+    return getTcpKeepAlive();
+  }
+
+  public boolean isReadOnly()
+  {
+    return getReadOnly();
+  }
+
+  public boolean isDisableColumnSanitiser()
+  {
+    return getDisableColumnSanitiser();
+  }
+
+  public boolean isLoadBalanceHosts()
+  {
+    return getLoadBalanceHosts();
+  }
+
+  public boolean isCleanupSavePoints()
+  {
+    return getCleanupSavepoints();
+  }
+
+  public void setCleanupSavePoints(final boolean cleanupSavepoints)
+  {
+    setCleanupSavepoints(cleanupSavepoints);
+  }
+
+  public boolean isReWriteBatchedInserts()
+  {
+    return getReWriteBatchedInserts();
+  }
 }


### PR DESCRIPTION
…l Java bean method naming for the specific property name.

This allows other libraries like connection pools to properly set any properties by the property names through their own interface when you may not have direct access to the jdbc datasource.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes to Existing Features:

* [ ] Does this break existing behaviour? If so please explain.
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
