### PR TITLE
Cleanup encoding

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/Encoding.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/Encoding.java
@@ -87,20 +87,32 @@ public class Encoding {
   }
 
   /**
-   * Use the charset passed as parameter.
+   * Subclasses may use this constructor if they know in advance of their ASCII number
+   * compatibility.
    *
    * @param encoding charset name to use
+   * @param fastASCIINumbers whether this encoding is compatible with ASCII numbers.
    */
-  protected Encoding(String encoding) {
+  protected Encoding(String encoding, boolean fastASCIINumbers) {
     if (encoding == null) {
       throw new NullPointerException("Null encoding charset not supported");
     }
     this.encoding = encoding;
-    this.fastASCIINumbers = testAsciiNumbers(encoding);
+    this.fastASCIINumbers = fastASCIINumbers;
     if (LOGGER.isLoggable(Level.FINEST)) {
       LOGGER.log(Level.FINEST, "Creating new Encoding {0} with fastASCIINumbers {1}",
           new Object[]{encoding, fastASCIINumbers});
     }
+  }
+
+  /**
+   * Use the charset passed as parameter and tests at creation time whether the specified encoding
+   * is compatible with ASCII numbers.
+   *
+   * @param encoding charset name to use
+   */
+  protected Encoding(String encoding) {
+    this(encoding, testAsciiNumbers(encoding));
   }
 
   /**
@@ -122,7 +134,7 @@ public class Encoding {
    */
   public static Encoding getJVMEncoding(String jvmEncoding) {
     if ("UTF-8".equals(jvmEncoding)) {
-      return new UTF8Encoding(jvmEncoding);
+      return new UTF8Encoding();
     }
     if (Charset.isSupported(jvmEncoding)) {
       return new Encoding(jvmEncoding);

--- a/pgjdbc/src/main/java/org/postgresql/core/Encoding.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/Encoding.java
@@ -96,7 +96,7 @@ public class Encoding {
       throw new NullPointerException("Null encoding charset not supported");
     }
     this.encoding = encoding;
-    fastASCIINumbers = testAsciiNumbers();
+    this.fastASCIINumbers = testAsciiNumbers(encoding);
     if (LOGGER.isLoggable(Level.FINEST)) {
       LOGGER.log(Level.FINEST, "Creating new Encoding {0} with fastASCIINumbers {1}",
           new Object[]{encoding, fastASCIINumbers});
@@ -256,19 +256,17 @@ public class Encoding {
    *
    * @return If faster ASCII number parsing can be used with this encoding.
    */
-  private boolean testAsciiNumbers() {
+  private static boolean testAsciiNumbers(String encoding) {
     // TODO: test all postgres supported encoding to see if there are
     // any which do _not_ have ascii numbers in same location
     // at least all the encoding listed in the encodings hashmap have
     // working ascii numbers
     try {
       String test = "-0123456789";
-      byte[] bytes = encode(test);
+      byte[] bytes = test.getBytes(encoding);
       String res = new String(bytes, "US-ASCII");
       return test.equals(res);
     } catch (java.io.UnsupportedEncodingException e) {
-      return false;
-    } catch (IOException e) {
       return false;
     }
   }

--- a/pgjdbc/src/main/java/org/postgresql/core/Encoding.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/Encoding.java
@@ -251,7 +251,7 @@ public class Encoding {
   }
 
   /**
-   * Checks weather this encoding is compatible with ASCII for the number characters '-' and
+   * Checks whether this encoding is compatible with ASCII for the number characters '-' and
    * '0'..'9'. Where compatible means that they are encoded with exactly same values.
    *
    * @return If faster ASCII number parsing can be used with this encoding.

--- a/pgjdbc/src/main/java/org/postgresql/core/UTF8Encoding.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/UTF8Encoding.java
@@ -17,8 +17,8 @@ class UTF8Encoding extends Encoding {
 
   private char[] decoderArray = new char[1024];
 
-  UTF8Encoding(String jvmEncoding) {
-    super(jvmEncoding);
+  UTF8Encoding() {
+    super("UTF-8", true);
   }
 
   // helper for decode

--- a/pgjdbc/src/main/java/org/postgresql/util/ObjectFactory.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/ObjectFactory.java
@@ -23,7 +23,7 @@ public class ObjectFactory {
    *
    * @param classname name of the class to instantiate
    * @param info parameter to pass as Properties
-   * @param tryString weather to look for a single String argument constructor
+   * @param tryString whether to look for a single String argument constructor
    * @param stringarg parameter to pass as String
    * @return the instantiated class
    * @throws ClassNotFoundException if something goes wrong


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [X] Does your submission pass tests?
2. [X] Does mvn checkstyle:check pass ?

### Changes to Existing Features:

* [ ] Does this break existing behaviour? If so please explain.

- No it's only internals that are changing.

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?

* [ ] Have you written new tests for your core changes, as applicable?

* [X] Have you successfully run tests with your changes locally?

-----

Was taking a look at the internals of the string decoder to see what would be involved in supporting a "*Use system decoder if longer than X...*  (as a possible alternative to #1433) and noticed a couple minor things to clean up.

PR is split into three commits:

1. Typo correction for `s/weather/whether/`
2. Change the internal test function to validate if a given encoding is "ASCII Number Compatible" to be static.
3. Add a new `protected` (so internal only) constructor to Encoding that allows callers to specify if they're ASCII compatible. This allows the `UTF8Encoding` class to skip the ASCII number compatibility test on every construction as we know it'll always pass. I doubt it's a measurable difference but why not right?

That third commit also removes the `encoding` parameter to `UTF8Encoding`'s constructor as the only valid value is `"UTF-8"` anyway. The only invocation of the constructor in `Encoding` is with `"UTF-8"` as a parameter and anything else wouldn't make any sense.

I've got a separate PR built atop this one that splits out `Encoding` further to make it an interface rather than a class and moves the majority of it's logic to a new `EncodingCore` internal class. All of that is in the hopes of simplifying the injection of connection level properties to customize the used encoding. If that idea pans out I'll push a separate PR for it.