### PR TITLE
Fix logging level

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/ssl/PGjdbcHostnameVerifier.java
+++ b/pgjdbc/src/main/java/org/postgresql/ssl/PGjdbcHostnameVerifier.java
@@ -152,7 +152,7 @@ public class PGjdbcHostnameVerifier implements HostnameVerifier {
       anyDnsSan |= sanType == TYPE_DNS_NAME;
       if (verifyHostName(canonicalHostname, san)) {
         if (LOGGER.isLoggable(Level.FINEST)) {
-          LOGGER.log(Level.SEVERE,
+          LOGGER.log(Level.FINEST,
               GT.tr("Server name validation pass for {0}, subjectAltName {1}", hostname, san));
         }
         return true;


### PR DESCRIPTION
Perhaps I'm missing something, but I don't think successful hostname validation should log on SEVERE/ERROR.