### PR TITLE
style: remove extra empty lines

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/PGStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/PGStream.java
@@ -489,7 +489,6 @@ public class PGStream implements Closeable, Flushable {
     }
   }
 
-
   /**
    * Copy data from an input stream to the connection.
    *

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/BatchedQuery.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/BatchedQuery.java
@@ -8,7 +8,6 @@ package org.postgresql.core.v3;
 import org.postgresql.core.NativeQuery;
 import org.postgresql.core.ParameterList;
 
-
 /**
  * Purpose of this object is to support batched query re write behaviour. Responsibility for
  * tracking the batch size and implement the clean up of the query fragments after the batch execute

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -1731,8 +1731,6 @@ public class QueryExecutorImpl extends QueryExecutorBase {
     pgStream.sendChar(0); // statement name terminator
   }
 
-
-
   // sendOneQuery sends a single statement via the extended query protocol.
   // Per the FE/BE docs this is essentially the same as how a simple query runs
   // (except that it generates some extra acknowledgement messages, and we
@@ -2745,7 +2743,6 @@ public class QueryExecutorImpl extends QueryExecutorBase {
   private long nextUniqueID = 1;
   private final boolean allowEncodingChanges;
   private final boolean cleanupSavePoints;
-
 
   /**
    * <p>The estimated server response size since we last consumed the input stream from the server, in

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/SimpleParameterList.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/SimpleParameterList.java
@@ -24,7 +24,6 @@ import java.io.InputStream;
 import java.sql.SQLException;
 import java.util.Arrays;
 
-
 /**
  * Parameter list for a single-statement V3 query.
  *

--- a/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
+++ b/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
@@ -481,7 +481,6 @@ public abstract class BaseDataSource implements CommonDataSource, Referenceable 
     return PGProperty.CANCEL_SIGNAL_TIMEOUT.getIntNoCheck(properties);
   }
 
-
   /**
    * @param enabled if SSL is enabled
    * @see PGProperty#SSL

--- a/pgjdbc/src/main/java/org/postgresql/hostchooser/CandidateHost.java
+++ b/pgjdbc/src/main/java/org/postgresql/hostchooser/CandidateHost.java
@@ -7,7 +7,6 @@ package org.postgresql.hostchooser;
 
 import org.postgresql.util.HostSpec;
 
-
 /**
  * Candidate host to be connected.
  */

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/AbstractBlobClob.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/AbstractBlobClob.java
@@ -31,7 +31,6 @@ public abstract class AbstractBlobClob {
   private boolean currentLoIsWriteable;
   private boolean support64bit;
 
-
   /**
    * We create separate LargeObjects for methods that use streams so they won't interfere with each
    * other.
@@ -191,7 +190,6 @@ public abstract class AbstractBlobClob {
       return buffer[idx++];
     }
   }
-
 
   /**
    * This is simply passing the byte value of the pattern Blob.

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/EscapedFunctions.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/EscapedFunctions.java
@@ -107,12 +107,10 @@ public class EscapedFunctions {
   public static final String SQL_TSI_WEEK = "WEEK";
   public static final String SQL_TSI_YEAR = "YEAR";
 
-
   // system functions
   public static final String DATABASE = "database";
   public static final String IFNULL = "ifnull";
   public static final String USER = "user";
-
 
   /**
    * storage for functions implementations.
@@ -624,7 +622,6 @@ public class EscapedFunctions {
           PSQLState.SYNTAX_ERROR);
     }
   }
-
 
   /**
    * time stamp diff.

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/EscapedFunctions2.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/EscapedFunctions2.java
@@ -557,7 +557,6 @@ public final class EscapedFunctions2 {
     return interval.regionMatches(true, 0, SQL_TSI_ROOT, 0, SQL_TSI_ROOT.length());
   }
 
-
   /**
    * time stamp diff
    *

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
@@ -2431,7 +2431,6 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
     return true;
   }
 
-
   /* lots of unsupported stuff... */
   public boolean ownUpdatesAreVisible(int type) throws SQLException {
     return true;

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
@@ -1389,7 +1389,6 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
     return new PgParameterMetaData(conn, oids);
   }
 
-
   //#if mvn.project.property.postgresql.jdbc.spec >= "JDBC4.2"
   public void setObject(int parameterIndex, Object x, java.sql.SQLType targetSqlType,
       int scaleOrLength) throws SQLException {

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
@@ -667,7 +667,6 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
     return getObjectImpl(findColumn(columnName), map);
   }
 
-
   /*
    * This checks against map for the type of column i, and if found returns an object based on that
    * mapping. The class must implement the SQLData interface.
@@ -709,7 +708,6 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
 
     return rowOffset + currentRow + 1;
   }
-
 
   // This one needs some thought, as not all ResultSets come from a statement
   public Statement getStatement() throws SQLException {

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/TimestampUtils.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/TimestampUtils.java
@@ -37,7 +37,6 @@ import java.util.HashMap;
 import java.util.SimpleTimeZone;
 import java.util.TimeZone;
 
-
 /**
  * Misc utils for handling time and date values.
  */
@@ -1002,7 +1001,6 @@ public class TimestampUtils {
 
     return convertToTime(millis, tz); // Ensure date part is 1970-01-01
   }
-
 
   //#if mvn.project.property.postgresql.jdbc.spec >= "JDBC4.2"
   /**

--- a/pgjdbc/src/main/java/org/postgresql/largeobject/BlobInputStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/largeobject/BlobInputStream.java
@@ -111,7 +111,6 @@ public class BlobInputStream extends InputStream {
     }
   }
 
-
   /**
    * <p>Closes this input stream and releases any system resources associated with the stream.</p>
    *

--- a/pgjdbc/src/main/java/org/postgresql/largeobject/BlobOutputStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/largeobject/BlobOutputStream.java
@@ -86,7 +86,6 @@ public class BlobOutputStream extends OutputStream {
     }
   }
 
-
   /**
    * Flushes this output stream and forces any buffered output bytes to be written out. The general
    * contract of <code>flush</code> is that calling it is an indication that, if any bytes

--- a/pgjdbc/src/main/java/org/postgresql/sspi/SSPIClient.java
+++ b/pgjdbc/src/main/java/org/postgresql/sspi/SSPIClient.java
@@ -46,7 +46,6 @@ public class SSPIClient implements ISSPIClient {
   private WindowsSecurityContextImpl sspiContext;
   private String targetName;
 
-
   /**
    * <p>Instantiate an SSPIClient for authentication of a connection.</p>
    *

--- a/pgjdbc/src/main/java/org/postgresql/util/Base64.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/Base64.java
@@ -58,7 +58,6 @@ public class Base64 {
 
   /* ******** P U B L I C F I E L D S ******** */
 
-
   /**
    * No options specified. Value is zero.
    */
@@ -69,12 +68,10 @@ public class Base64 {
    */
   public static final int ENCODE = 1;
 
-
   /**
    * Specify decoding.
    */
   public static final int DECODE = 0;
-
 
   /**
    * Don't break lines when encoding (violates strict Base64 specification).
@@ -84,30 +81,25 @@ public class Base64 {
 
   /* ******** P R I V A T E F I E L D S ******** */
 
-
   /**
    * Maximum line length (76) of Base64 output.
    */
   private static final int MAX_LINE_LENGTH = 76;
-
 
   /**
    * The equals sign (=) as a byte.
    */
   private static final byte EQUALS_SIGN = (byte) '=';
 
-
   /**
    * The new line character (\n) as a byte.
    */
   private static final byte NEW_LINE = (byte) '\n';
 
-
   /**
    * Preferred encoding.
    */
   private static final String PREFERRED_ENCODING = "UTF-8";
-
 
   /**
    * The 64 valid Base64 values.
@@ -137,7 +129,6 @@ public class Base64 {
     }
     ALPHABET = bytes;
   }
-
 
   /**
    * Translates a Base64 value to either its 6-bit reconstruction value or a negative number
@@ -183,7 +174,6 @@ public class Base64 {
   private static final byte WHITE_SPACE_ENC = -5; // Indicates white space in encoding
   private static final byte EQUALS_SIGN_ENC = -1; // Indicates equals sign in encoding
 
-
   /**
    * Defeats instantiation.
    */
@@ -192,7 +182,6 @@ public class Base64 {
 
 
   /* ******** E N C O D I N G M E T H O D S ******** */
-
 
   /**
    * Encodes up to three bytes of the array <var>source</var> and writes the resulting four Base64
@@ -265,7 +254,6 @@ public class Base64 {
     return encodeBytes(source, 0, source.length, NO_OPTIONS);
   } // end encodeBytes
 
-
   /**
    * <p>Encodes a byte array into Base64 notation.</p>
    *
@@ -292,7 +280,6 @@ public class Base64 {
     return encodeBytes(source, 0, source.length, options);
   } // end encodeBytes
 
-
   /**
    * Encodes a byte array into Base64 notation. Does not GZip-compress data.
    *
@@ -305,7 +292,6 @@ public class Base64 {
   public static String encodeBytes(byte[] source, int off, int len) {
     return encodeBytes(source, off, len, NO_OPTIONS);
   } // end encodeBytes
-
 
   /**
    * <p>Encodes a byte array into Base64 notation.</p>
@@ -379,7 +365,6 @@ public class Base64 {
 
   /* ******** D E C O D I N G M E T H O D S ******** */
 
-
   /**
    * Decodes four bytes from array <var>source</var> and writes the resulting bytes (up to three of
    * them) to <var>destination</var>. The source and destination arrays can be manipulated anywhere
@@ -449,7 +434,6 @@ public class Base64 {
     }
   } // end decodeToBytes
 
-
   /**
    * Very low-level access to decoding ASCII characters in the form of a byte array. Does not
    * support automatically gunzipping or any other "fancy" features.
@@ -500,7 +484,6 @@ public class Base64 {
     System.arraycopy(outBuff, 0, out, 0, outBuffPosn);
     return out;
   } // end decode
-
 
   /**
    * Decodes data from Base64 notation, automatically detecting gzip-compressed data and

--- a/pgjdbc/src/main/java/org/postgresql/util/PGtokenizer.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/PGtokenizer.java
@@ -9,7 +9,6 @@ package org.postgresql.util;
 import java.util.ArrayList;
 import java.util.List;
 
-
 /**
  * This class is used to tokenize the text output of org.postgres. It's mainly used by the geometric
  * classes, but is useful in parsing any output from custom data types output from org.postgresql.

--- a/pgjdbc/src/test/java/org/postgresql/test/TestUtil.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/TestUtil.java
@@ -397,7 +397,6 @@ public class TestUtil {
     }
   }
 
-
   /*
    * Helper - creates a test table for use by a test
    */

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc3/Jdbc3BlobTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc3/Jdbc3BlobTest.java
@@ -239,7 +239,6 @@ public class Jdbc3BlobTest {
     readWriteStream(1, data);
   }
 
-
   /**
    * Reads then writes data to the blob via a stream.
    */

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc42/Jdbc42CallableStatementTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc42/Jdbc42CallableStatementTest.java
@@ -22,7 +22,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-
 /**
  * Tests for JDBC 4.2 features in {@link org.postgresql.jdbc.PgCallableStatement}.
  */


### PR DESCRIPTION
This PR is created because of violations found during regression testing after implementing (checkstyle)[https://github.com/checkstyle/checkstyle] ability to check multiple lines with comments and javadocs.
Issue: https://github.com/checkstyle/checkstyle/issues/5981
PR: https://github.com/checkstyle/checkstyle/pull/6388

Checkstyle PR changes produce new violations in pjdbc code, which are fixed in this PR.
