### PR TITLE
Fix ResultSet.getBigDecimal(int columnIndex, int scale) when scale is -1

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
@@ -35,6 +35,7 @@ import java.io.Reader;
 import java.io.UnsupportedEncodingException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.math.RoundingMode;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.sql.Array;
@@ -2937,7 +2938,7 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
       return val;
     }
     try {
-      return val.setScale(scale);
+      return val.setScale(scale, RoundingMode.HALF_EVEN);
     } catch (ArithmeticException e) {
       throw new PSQLException(
           GT.tr("Bad value for type {0} : {1}", "BigDecimal", val),

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
@@ -187,7 +187,7 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
       case Types.NUMERIC:
       case Types.DECIMAL:
         return getNumeric(columnIndex,
-            (field.getMod() == -1) ? -1 : ((field.getMod() - 4) & 0xffff), true);
+            (field.getMod() == -1) ? null : ((field.getMod() - 4) & 0xffff), true);
       case Types.REAL:
         return getFloat(columnIndex);
       case Types.FLOAT:
@@ -400,7 +400,7 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
 
 
   public java.math.BigDecimal getBigDecimal(int columnIndex) throws SQLException {
-    return getBigDecimal(columnIndex, -1);
+    return getBigDecimal(columnIndex, null);
   }
 
 
@@ -2251,7 +2251,7 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
    * @return The parsed number.
    * @throws SQLException If an error occurs while fetching column.
    * @throws NumberFormatException If the number is invalid or the out of range for fast parsing.
-   *         The value must then be parsed by {@link #toBigDecimal(String, int)}.
+   *         The value must then be parsed by {@link #toBigDecimal(String, Integer)}.
    */
   private BigDecimal getFastBigDecimal(int columnIndex) throws SQLException, NumberFormatException {
 
@@ -2348,11 +2348,15 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
   }
 
   public BigDecimal getBigDecimal(int columnIndex, int scale) throws SQLException {
+    return getBigDecimal(columnIndex, (Integer) scale);
+  }
+
+  private BigDecimal getBigDecimal(int columnIndex, Integer scale) throws SQLException {
     connection.getLogger().log(Level.FINEST, "  getBigDecimal columnIndex: {0}", columnIndex);
     return (BigDecimal) getNumeric(columnIndex, scale, false);
   }
 
-  private Number getNumeric(int columnIndex, int scale, boolean allowNaN) throws SQLException {
+  private Number getNumeric(int columnIndex, Integer scale, boolean allowNaN) throws SQLException {
     checkResultSet(columnIndex);
     if (wasNullFlag) {
       return null;
@@ -2925,7 +2929,7 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
     }
   }
 
-  public BigDecimal toBigDecimal(String s, int scale) throws SQLException {
+  private BigDecimal toBigDecimal(String s, Integer scale) throws SQLException {
     if (s == null) {
       return null;
     }
@@ -2933,8 +2937,8 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
     return scaleBigDecimal(val, scale);
   }
 
-  private BigDecimal scaleBigDecimal(BigDecimal val, int scale) throws PSQLException {
-    if (scale == -1) {
+  private BigDecimal scaleBigDecimal(BigDecimal val, Integer scale) throws PSQLException {
+    if (scale == null) {
       return val;
     }
     try {

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PreparedStatementTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PreparedStatementTest.java
@@ -956,6 +956,8 @@ public class PreparedStatementTest extends BaseTest4 {
         rs.getBigDecimal(2, 0));
     assertNull("rs.getBigDecimal(scale=0)", rs.getBigDecimal(3, 0));
     assertTrue("rs.getBigDecimal after rs.getLong", rs.wasNull());
+    assertEquals("maxInt as rs.getBigDecimal(scale=-1)",
+        BigDecimal.valueOf(maxInt).setScale(-1, BigDecimal.ROUND_HALF_EVEN), rs.getBigDecimal(1, -1));
     assertEquals("maxInt as rs.getBigDecimal(scale=1)",
         BigDecimal.valueOf(maxInt).setScale(1, BigDecimal.ROUND_HALF_EVEN), rs.getBigDecimal(1, 1));
     assertEquals("minInt as rs.getBigDecimal(scale=1)",

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PreparedStatementTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PreparedStatementTest.java
@@ -968,6 +968,18 @@ public class PreparedStatementTest extends BaseTest4 {
   }
 
   @Test
+  public void testBigDecimalWithScale() throws SQLException {
+    final String bigDecimalString = "1.1234";
+    PreparedStatement pstmt = con.prepareStatement("select " + bigDecimalString);
+    ResultSet rs = pstmt.executeQuery();
+    assertTrue(rs.next());
+    assertEquals("rs.getBigDecimal(scale=2)",
+        new BigDecimal(bigDecimalString).setScale(2, BigDecimal.ROUND_HALF_EVEN), rs.getBigDecimal(1, 2));
+    rs.close();
+    pstmt.close();
+  }
+
+  @Test
   public void testSetSmallIntFloat() throws SQLException {
     PreparedStatement pstmt = con.prepareStatement(
         "CREATE temp TABLE small_int (max_val int4, min_val int4, null_val int4)");


### PR DESCRIPTION
Other JDBC drivers do not ignore the scale when its value is -1 and reading:
https://docs.oracle.com/javase/7/docs/api/java/sql/ResultSet.html#getBigDecimal(int,%20int)
I do not see that the scale should be ignored when scale is -1.