### PR TITLE
fix: improper relative cursor movement

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
@@ -873,7 +873,12 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
     }
 
     // have to add 1 since absolute expects a 1-based index
-    return absolute(currentRow + 1 + rows);
+    int index = currentRow + 1 + rows;
+    if (index < 0) {
+      beforeFirst();
+      return false;
+    }
+    return absolute(index);
   }
 
 

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ResultSetTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ResultSetTest.java
@@ -181,6 +181,49 @@ public class ResultSetTest extends BaseTest4 {
   }
 
   @Test
+  public void testRelative() throws SQLException {
+    Statement stmt =
+        con.createStatement(ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet.CONCUR_READ_ONLY);
+    ResultSet rs = stmt.executeQuery("SELECT * FROM testrs");
+
+    assertTrue(!rs.relative(0));
+    assertEquals(0, rs.getRow());
+    assertTrue(rs.isBeforeFirst());
+
+    assertTrue(rs.relative(2));
+    assertEquals(2, rs.getRow());
+
+    assertTrue(rs.relative(1));
+    assertEquals(3, rs.getRow());
+
+    assertTrue(rs.relative(0));
+    assertEquals(3, rs.getRow());
+
+    assertTrue(!rs.relative(-3));
+    assertEquals(0, rs.getRow());
+    assertTrue(rs.isBeforeFirst());
+
+    assertTrue(rs.relative(4));
+    assertEquals(4, rs.getRow());
+
+    assertTrue(rs.relative(-1));
+    assertEquals(3, rs.getRow());
+
+    assertTrue(!rs.relative(6));
+    assertEquals(0, rs.getRow());
+    assertTrue(rs.isAfterLast());
+
+    assertTrue(rs.relative(-4));
+    assertEquals(3, rs.getRow());
+
+    assertTrue(!rs.relative(-6));
+    assertEquals(0, rs.getRow());
+    assertTrue(rs.isBeforeFirst());
+
+    stmt.close();
+  }
+
+  @Test
   public void testEmptyResult() throws SQLException {
     Statement stmt =
         con.createStatement(ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet.CONCUR_READ_ONLY);


### PR DESCRIPTION
Fix a wrong relative cursor movement when a new calculated index is
negative (beyond the first row). According to the java-doc, in this
case the position leaves before the first row. Current implementation
of the 'relative' method delegates the movement to the 'absolute' method
which treats a negative index with respect to the end of the result set.

Example: assume we have next result set `{1, 2, *3, 4, 5, 6}` and we are
on the 3rd position. Move relative to `-6` which means a new index is 
`-3 (3 - 6)`. I expect the result set will be on the zero position with 
before-first status but actually we are on the 4th position (3rd from the end).
