### PR TITLE
Fix execution with big decimal in simple query mode.

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/v3/SimpleParameterList.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/SimpleParameterList.java
@@ -250,6 +250,8 @@ class SimpleParameterList implements V3ParameterList {
         p.append("::date");
       } else if (paramType == Oid.INTERVAL) {
         p.append("::interval");
+      } else if (paramType == Oid.NUMERIC) {
+        p.append("::numeric");
       }
       return p.toString();
     }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc42/PreparedStatementTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc42/PreparedStatementTest.java
@@ -5,20 +5,26 @@
 
 package org.postgresql.test.jdbc42;
 
+import org.postgresql.PGProperty;
 import org.postgresql.test.TestUtil;
 import org.postgresql.test.jdbc2.BaseTest4;
 
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.math.BigDecimal;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
 import java.time.LocalTime;
+import java.util.Properties;
 
 
 public class PreparedStatementTest extends BaseTest4 {
+  protected void updateProperties(Properties props) {
+    PGProperty.PREFER_QUERY_MODE.set(props, "simple");
+  }
 
   @Override
   public void setUp() throws Exception {
@@ -34,6 +40,19 @@ public class PreparedStatementTest extends BaseTest4 {
     TestUtil.dropTable(con, "timetztable");
     TestUtil.dropTable(con, "timetable");
     super.tearDown();
+  }
+
+  @Test
+  public void testSetNumber() throws SQLException {
+    PreparedStatement pstmt = con.prepareStatement("SELECT ? * 2");
+
+    pstmt.setBigDecimal(1, new BigDecimal("1.6"));
+    ResultSet rs = pstmt.executeQuery();
+    rs.next();
+    BigDecimal d = rs.getBigDecimal(1);
+    pstmt.close();
+
+    Assert.assertEquals(new BigDecimal("3.2"), d);
   }
 
   @Test


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
Yes.
2. [x] Does mvn checkstyle:check pass ?
Yes.

### Changes to Existing Features:

* [x] Does this break existing behaviour? If so please explain.
Nop.
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
Big decimal is set as string without cast, which is parsed as T_String instead of T_Float in postgres, resulting improper operator match thus conversion error.
* [x] Have you written new tests for your core changes, as applicable?
Yes, see enclosed.
* [x] Have you successfully run tests with your changes locally?
mvn test passed in local env.
