### PR TITLE
fix JDBC function-call syntax for PG11.

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -437,7 +437,10 @@ public enum PGProperty {
           + "to the database specified in the dbname parameter, "
           + "which will allow the connection to be used for logical replication "
           + "from that database. "
-          + "(backend >= 9.4)");
+          + "(backend >= 9.4)"),
+
+  REWRITE_CALL_PROCEDURE("reWriteCallProcedure", "true",
+      "Enable rewriting CALL statetements written in function-call syntax.");
 
   private final String name;
   private final String defaultValue;

--- a/pgjdbc/src/main/java/org/postgresql/core/CachedQueryCreateAction.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/CachedQueryCreateAction.java
@@ -44,7 +44,7 @@ class CachedQueryCreateAction implements LruCache.CreateAction<Object, CachedQue
     if (key instanceof CallableQueryKey) {
       JdbcCallParseInfo callInfo =
           Parser.modifyJdbcCall(parsedSql, queryExecutor.getStandardConformingStrings(),
-              queryExecutor.getServerVersionNum(), queryExecutor.getProtocolVersion());
+              queryExecutor.getServerVersionNum(), queryExecutor.getProtocolVersion(), queryExecutor.isReWriteCallProcedureEnabled());
       parsedSql = callInfo.getSql();
       isFunction = callInfo.isFunction();
     } else {

--- a/pgjdbc/src/main/java/org/postgresql/core/Parser.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/Parser.java
@@ -902,7 +902,7 @@ public class Parser {
    * @throws SQLException if given SQL is malformed
    */
   public static JdbcCallParseInfo modifyJdbcCall(String jdbcSql, boolean stdStrings,
-      int serverVersion, int protocolVersion) throws SQLException {
+      int serverVersion, int protocolVersion, boolean reWriteCallProcedure) throws SQLException {
     // Mini-parser for JDBC function-call syntax (only)
     // TODO: Merge with escape processing (and parameter parsing?) so we only parse each query once.
     // RE: frequently used statements are cached (see {@link org.postgresql.jdbc.PgConnection#borrowQuery}), so this "merge" is not that important.
@@ -1056,8 +1056,8 @@ public class Parser {
     String prefix = "select * from ";
     String suffix = " as result";
     if (serverVersion >= 110000) {
-        prefix = "call ";
-        suffix = "";
+      prefix = "call ";
+      suffix = "";
     }
 
     String s = jdbcSql.substring(startIndex, endIndex);
@@ -1097,11 +1097,11 @@ public class Parser {
       }
     }
 
-    if (!suffix.isEmpty())
-       sql = sb.append(suffix).toString();
-    else
-       sql = sb.toString();
-
+    if (!suffix.isEmpty()) {
+      sql = sb.append(suffix).toString();
+    } else {
+      sql = sb.toString();
+    }
     return new JdbcCallParseInfo(sql, isFunction);
   }
 

--- a/pgjdbc/src/main/java/org/postgresql/core/Parser.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/Parser.java
@@ -1055,6 +1055,10 @@ public class Parser {
 
     String prefix = "select * from ";
     String suffix = " as result";
+    if (serverVersion >= 110000) {
+        prefix = "call ";
+        suffix = "";
+    }
 
     String s = jdbcSql.substring(startIndex, endIndex);
     int prefixLength = prefix.length();
@@ -1093,7 +1097,11 @@ public class Parser {
       }
     }
 
-    sql = sb.append(suffix).toString();
+    if (!suffix.isEmpty())
+       sql = sb.append(suffix).toString();
+    else
+       sql = sb.toString();
+
     return new JdbcCallParseInfo(sql, isFunction);
   }
 

--- a/pgjdbc/src/main/java/org/postgresql/core/QueryExecutor.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/QueryExecutor.java
@@ -182,6 +182,8 @@ public interface QueryExecutor extends TypeTransferModeRegistry {
 
   boolean isReWriteBatchedInsertsEnabled();
 
+  boolean isReWriteCallProcedureEnabled();
+
   CachedQuery createQuery(String sql, boolean escapeProcessing, boolean isParameterized,
       String... columnNames)
       throws SQLException;

--- a/pgjdbc/src/main/java/org/postgresql/core/QueryExecutorBase.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/QueryExecutorBase.java
@@ -38,6 +38,7 @@ public abstract class QueryExecutorBase implements QueryExecutor {
   private int serverVersionNum = 0;
   private TransactionState transactionState;
   private final boolean reWriteBatchedInserts;
+  private final boolean reWriteCallProcedure;
   private final boolean columnSanitiserDisabled;
   private final PreferQueryMode preferQueryMode;
   private AutoSave autoSave;
@@ -59,6 +60,7 @@ public abstract class QueryExecutorBase implements QueryExecutor {
     this.database = database;
     this.cancelSignalTimeout = cancelSignalTimeout;
     this.reWriteBatchedInserts = PGProperty.REWRITE_BATCHED_INSERTS.getBoolean(info);
+    this.reWriteCallProcedure = PGProperty.REWRITE_CALL_PROCEDURE.getBoolean(info);
     this.columnSanitiserDisabled = PGProperty.DISABLE_COLUMN_SANITISER.getBoolean(info);
     String preferMode = PGProperty.PREFER_QUERY_MODE.get(info);
     this.preferQueryMode = PreferQueryMode.of(preferMode);
@@ -264,6 +266,11 @@ public abstract class QueryExecutorBase implements QueryExecutor {
   @Override
   public boolean isReWriteBatchedInsertsEnabled() {
     return this.reWriteBatchedInserts;
+  }
+
+  @Override
+  public boolean isReWriteCallProcedureEnabled() {
+    return this.reWriteCallProcedure;
   }
 
   @Override

--- a/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
+++ b/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
@@ -1351,6 +1351,14 @@ public abstract class BaseDataSource implements CommonDataSource, Referenceable 
     PGProperty.REWRITE_BATCHED_INSERTS.set(properties, reWrite);
   }
 
+  public boolean getReWriteCallProcedure() {
+    return PGProperty.REWRITE_CALL_PROCEDURE.getBoolean(properties);
+  }
+
+  public void setReWriteCallProcedure(boolean reWrite) {
+    PGProperty.REWRITE_CALL_PROCEDURE.set(properties, reWrite);
+  }
+
   //#if mvn.project.property.postgresql.jdbc.spec >= "JDBC4.1"
   public java.util.logging.Logger getParentLogger() {
     return Logger.getLogger("org.postgresql");

--- a/pgjdbc/src/test/java/org/postgresql/core/ParserTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/core/ParserTest.java
@@ -141,6 +141,12 @@ public class ParserTest {
     assertEquals("select * from pack_getValue(?) as result", Parser.modifyJdbcCall("{ ? = call pack_getValue()}", true, ServerVersion.v9_6.getVersionNum(), 3).getSql());
     assertEquals("select * from pack_getValue(?,?,?,?)  as result", Parser.modifyJdbcCall("{ ? = call pack_getValue(?,?,?) }", true, ServerVersion.v9_6.getVersionNum(), 3).getSql());
     assertEquals("select * from lower(?,?) as result", Parser.modifyJdbcCall("{ ? = call lower(?)}", true, ServerVersion.v9_6.getVersionNum(), 3).getSql());
+
+    assertEquals("call pack_getValue(?)", Parser.modifyJdbcCall("{ ? = call pack_getValue}", true, ServerVersion.v11.getVersionNum(), 3).getSql());
+    assertEquals("call pack_getValue(?,?) ", Parser.modifyJdbcCall("{ ? = call pack_getValue(?) }", true, ServerVersion.v11.getVersionNum(), 3).getSql());
+    assertEquals("call pack_getValue(?)", Parser.modifyJdbcCall("{ ? = call pack_getValue()}", true, ServerVersion.v11.getVersionNum(), 3).getSql());
+    assertEquals("call pack_getValue(?,?,?,?) ", Parser.modifyJdbcCall("{ ? = call pack_getValue(?,?,?) }", true, ServerVersion.v11.getVersionNum(), 3).getSql());
+    assertEquals("call lower(?,?)", Parser.modifyJdbcCall("{ ? = call lower(?)}", true, ServerVersion.v11.getVersionNum(), 3).getSql());
   }
 
   @Test

--- a/pgjdbc/src/test/java/org/postgresql/core/ParserTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/core/ParserTest.java
@@ -136,17 +136,17 @@ public class ParserTest {
 
   @Test
   public void testModifyJdbcCall() throws SQLException {
-    assertEquals("select * from pack_getValue(?) as result", Parser.modifyJdbcCall("{ ? = call pack_getValue}", true, ServerVersion.v9_6.getVersionNum(), 3).getSql());
-    assertEquals("select * from pack_getValue(?,?)  as result", Parser.modifyJdbcCall("{ ? = call pack_getValue(?) }", true, ServerVersion.v9_6.getVersionNum(), 3).getSql());
-    assertEquals("select * from pack_getValue(?) as result", Parser.modifyJdbcCall("{ ? = call pack_getValue()}", true, ServerVersion.v9_6.getVersionNum(), 3).getSql());
-    assertEquals("select * from pack_getValue(?,?,?,?)  as result", Parser.modifyJdbcCall("{ ? = call pack_getValue(?,?,?) }", true, ServerVersion.v9_6.getVersionNum(), 3).getSql());
-    assertEquals("select * from lower(?,?) as result", Parser.modifyJdbcCall("{ ? = call lower(?)}", true, ServerVersion.v9_6.getVersionNum(), 3).getSql());
+    assertEquals("select * from pack_getValue(?) as result", Parser.modifyJdbcCall("{ ? = call pack_getValue}", true, ServerVersion.v9_6.getVersionNum(), 3, false).getSql());
+    assertEquals("select * from pack_getValue(?,?)  as result", Parser.modifyJdbcCall("{ ? = call pack_getValue(?) }", true, ServerVersion.v9_6.getVersionNum(), 3, false).getSql());
+    assertEquals("select * from pack_getValue(?) as result", Parser.modifyJdbcCall("{ ? = call pack_getValue()}", true, ServerVersion.v9_6.getVersionNum(), 3, false).getSql());
+    assertEquals("select * from pack_getValue(?,?,?,?)  as result", Parser.modifyJdbcCall("{ ? = call pack_getValue(?,?,?) }", true, ServerVersion.v9_6.getVersionNum(), 3, false).getSql());
+    assertEquals("select * from lower(?,?) as result", Parser.modifyJdbcCall("{ ? = call lower(?)}", true, ServerVersion.v9_6.getVersionNum(), 3, false).getSql());
 
-    assertEquals("call pack_getValue(?)", Parser.modifyJdbcCall("{ ? = call pack_getValue}", true, ServerVersion.v11.getVersionNum(), 3).getSql());
-    assertEquals("call pack_getValue(?,?) ", Parser.modifyJdbcCall("{ ? = call pack_getValue(?) }", true, ServerVersion.v11.getVersionNum(), 3).getSql());
-    assertEquals("call pack_getValue(?)", Parser.modifyJdbcCall("{ ? = call pack_getValue()}", true, ServerVersion.v11.getVersionNum(), 3).getSql());
-    assertEquals("call pack_getValue(?,?,?,?) ", Parser.modifyJdbcCall("{ ? = call pack_getValue(?,?,?) }", true, ServerVersion.v11.getVersionNum(), 3).getSql());
-    assertEquals("call lower(?,?)", Parser.modifyJdbcCall("{ ? = call lower(?)}", true, ServerVersion.v11.getVersionNum(), 3).getSql());
+    assertEquals("call pack_getValue(?)", Parser.modifyJdbcCall("{ ? = call pack_getValue}", true, ServerVersion.v11.getVersionNum(), 3, false).getSql());
+    assertEquals("call pack_getValue(?,?) ", Parser.modifyJdbcCall("{ ? = call pack_getValue(?) }", true, ServerVersion.v11.getVersionNum(), 3, false).getSql());
+    assertEquals("call pack_getValue(?)", Parser.modifyJdbcCall("{ ? = call pack_getValue()}", true, ServerVersion.v11.getVersionNum(), 3, false).getSql());
+    assertEquals("call pack_getValue(?,?,?,?) ", Parser.modifyJdbcCall("{ ? = call pack_getValue(?,?,?) }", true, ServerVersion.v11.getVersionNum(), 3, false).getSql());
+    assertEquals("call lower(?,?)", Parser.modifyJdbcCall("{ ? = call lower(?)}", true, ServerVersion.v11.getVersionNum(), 3, false).getSql());
   }
 
   @Test


### PR DESCRIPTION
JDBC converts CALL to SELECT * FROM AS RESULT becasue PostgreSQL did not
support procedure, but support function.
However, since procedure was supported in PG11, so JDBC does not convert CALL
in JDBC function-call syntax after this version.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Does mvn checkstyle:check pass ?

### Changes to Existing Features:

* [ ] Does this break existing behaviour? If so please explain.
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
