### PR TITLE
Make LogSequenceNumber implement Comparable<LogSequenceNumber>

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/replication/LogSequenceNumber.java
+++ b/pgjdbc/src/main/java/org/postgresql/replication/LogSequenceNumber.java
@@ -105,14 +105,14 @@ public final class LogSequenceNumber implements Comparable<LogSequenceNumber> {
   public String toString() {
     return "LSN{" + asString() + '}';
   }
-  
+
   @Override
   public int compareTo(LogSequenceNumber o) {
     if (value == o.value) {
       return 0;
     }
     //Unsigned comparison
-    return value + Long.MIN_VALUE < o.value+Long.MIN_VALUE ? -1 : 1;
+    return value + Long.MIN_VALUE < o.value + Long.MIN_VALUE ? -1 : 1;
   }
 
 }

--- a/pgjdbc/src/main/java/org/postgresql/replication/LogSequenceNumber.java
+++ b/pgjdbc/src/main/java/org/postgresql/replication/LogSequenceNumber.java
@@ -10,7 +10,7 @@ import java.nio.ByteBuffer;
 /**
  * LSN (Log Sequence Number) data which is a pointer to a location in the XLOG.
  */
-public final class LogSequenceNumber {
+public final class LogSequenceNumber implements Comparable<LogSequenceNumber> {
   /**
    * Zero is used indicate an invalid pointer. Bootstrap skips the first possible WAL segment,
    * initializing the first WAL page at XLOG_SEG_SIZE, so no XLOG record can begin at zero.
@@ -105,4 +105,14 @@ public final class LogSequenceNumber {
   public String toString() {
     return "LSN{" + asString() + '}';
   }
+  
+  @Override
+  public int compareTo(LogSequenceNumber o) {
+    if (value == o.value) {
+      return 0;
+    }
+    //Unsigned comparison
+    return value + Long.MIN_VALUE < o.value+Long.MIN_VALUE ? -1 : 1;
+  }
+
 }

--- a/pgjdbc/src/test/java/org/postgresql/replication/LogSequenceNumberTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/replication/LogSequenceNumberTest.java
@@ -96,4 +96,49 @@ public class LogSequenceNumberTest {
 
     assertThat(first.hashCode(), equalTo(second.hashCode()));
   }
+  
+  @Test
+  public void testCompareToSameValue() throws Exception {
+    LogSequenceNumber first = LogSequenceNumber.valueOf("0/15D690F8");
+    LogSequenceNumber second = LogSequenceNumber.valueOf("0/15D690F8");
+
+    assertThat(first.compareTo(second), equalTo(0));
+    assertThat(second.compareTo(first), equalTo(0));
+  }
+  
+  @Test
+  public void testCompareToPositiveValues() throws Exception {
+    LogSequenceNumber first = LogSequenceNumber.valueOf(1234);
+    LogSequenceNumber second = LogSequenceNumber.valueOf(4321);
+
+    assertThat(first.compareTo(second), equalTo(-1));
+    assertThat(second.compareTo(first), equalTo(1));
+  }
+
+  @Test
+  public void testCompareToNegativeValues() throws Exception {
+    LogSequenceNumber first = LogSequenceNumber.valueOf(0x8000000000000000L);
+    LogSequenceNumber second = LogSequenceNumber.valueOf(0x8000000000000001L);
+
+    assertThat(first.compareTo(second), equalTo(-1));
+    assertThat(second.compareTo(first), equalTo(1));
+  }
+
+  @Test
+  public void testCompareToMixedSign() throws Exception {
+    LogSequenceNumber first = LogSequenceNumber.valueOf(1);
+    LogSequenceNumber second = LogSequenceNumber.valueOf(0x8000000000000001L);
+
+    assertThat(first.compareTo(second), equalTo(-1));
+    assertThat(second.compareTo(first), equalTo(1));
+  }
+  
+  @Test
+  public void testCompareToWithInvalid() throws Exception {
+    LogSequenceNumber first = LogSequenceNumber.INVALID_LSN;
+    LogSequenceNumber second = LogSequenceNumber.valueOf(1);
+
+    assertThat(first.compareTo(second), equalTo(-1));
+    assertThat(second.compareTo(first), equalTo(1));
+  }
 }

--- a/pgjdbc/src/test/java/org/postgresql/replication/LogSequenceNumberTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/replication/LogSequenceNumberTest.java
@@ -96,7 +96,7 @@ public class LogSequenceNumberTest {
 
     assertThat(first.hashCode(), equalTo(second.hashCode()));
   }
-  
+
   @Test
   public void testCompareToSameValue() throws Exception {
     LogSequenceNumber first = LogSequenceNumber.valueOf("0/15D690F8");
@@ -105,7 +105,7 @@ public class LogSequenceNumberTest {
     assertThat(first.compareTo(second), equalTo(0));
     assertThat(second.compareTo(first), equalTo(0));
   }
-  
+
   @Test
   public void testCompareToPositiveValues() throws Exception {
     LogSequenceNumber first = LogSequenceNumber.valueOf(1234);
@@ -132,7 +132,7 @@ public class LogSequenceNumberTest {
     assertThat(first.compareTo(second), equalTo(-1));
     assertThat(second.compareTo(first), equalTo(1));
   }
-  
+
   @Test
   public void testCompareToWithInvalid() throws Exception {
     LogSequenceNumber first = LogSequenceNumber.INVALID_LSN;


### PR DESCRIPTION
Regarding #1493:

added a Java 6 - compatible `compareTo` implementation for `LogSequenceNumber`, so it implements `Comparable<LogSequenceNumber>`.