### PR TITLE
Add statement timeout support

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -437,7 +437,17 @@ public enum PGProperty {
           + "to the database specified in the dbname parameter, "
           + "which will allow the connection to be used for logical replication "
           + "from that database. "
-          + "(backend >= 9.4)");
+          + "(backend >= 9.4)"),
+
+  /**
+   * Sets the STATEMENT_TIMEOUT property in postgresql to the number of milliseconds a query
+   * can execute before it's terminated by the server. If the query is terminated a SQLException is
+   * thrown with the message 'ERROR: canceling statement due to statement timeout'
+   */
+  STATEMENT_TIMEOUT("statementTimeout", null, "Sets the STATEMENT_TIMEOUT property in "
+    + "postgresql to the number of milliseconds a query can execute before "
+    + "it's terminated by the server. If the query is terminated a SQLException is "
+    + "thrown with the message 'ERROR: canceling statement due to statement timeout'");
 
   private final String name;
   private final String defaultValue;

--- a/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
+++ b/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
@@ -1069,6 +1069,14 @@ public abstract class BaseDataSource implements CommonDataSource, Referenceable 
     return PGProperty.LOGGER_FILE.get(exprProps);
   }
 
+  public void setStatementTimeout(String statementTimeout) {
+    PGProperty.STATEMENT_TIMEOUT.set(properties, statementTimeout);
+  }
+
+  public String getStatementTimeout() {
+    return PGProperty.STATEMENT_TIMEOUT.get(properties);
+  }
+
   /**
    * @param loggerFile File output of the Logger.
    * @see PGProperty#LOGGER_LEVEL

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
@@ -253,6 +253,10 @@ public class PgConnection implements BaseConnection {
       }
     });
 
+    if (PGProperty.STATEMENT_TIMEOUT.isPresent(info)) {
+      execSQLUpdate("set statement_timeout=" + PGProperty.STATEMENT_TIMEOUT.getInt(info));
+    }
+
     // Initialize common queries.
     // isParameterized==true so full parse is performed and the engine knows the query
     // is not a compound query with ; inside, so it could use parse/bind/exec messages

--- a/pgjdbc/src/test/java/org/postgresql/test/TestUtil.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/TestUtil.java
@@ -94,6 +94,11 @@ public class TestUtil {
       ssl = "&ssl=" + getSSL();
     }
 
+    String statementTimeout = "";
+    if (getStatementTimeout() != null) {
+      statementTimeout = "&statementTimeout=" + getStatementTimeout();
+    }
+
     return "jdbc:postgresql://"
         + hostport + "/"
         + database
@@ -105,7 +110,8 @@ public class TestUtil {
         + binaryTransfer
         + receiveBufferSize
         + sendBufferSize
-        + ssl;
+        + ssl
+        + statementTimeout;
   }
 
   /*
@@ -214,6 +220,10 @@ public class TestUtil {
 
   public static String getSSL() {
     return System.getProperty("ssl");
+  }
+
+  public static String getStatementTimeout() {
+    return System.getProperty("statementTimeout");
   }
 
   static {

--- a/pgjdbc/src/test/java/org/postgresql/test/core/StatementTimeoutTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/core/StatementTimeoutTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2004, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.test.core;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Properties;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.postgresql.PGProperty;
+import org.postgresql.test.TestUtil;
+
+public class StatementTimeoutTest {
+  private static final String schemaName = "statement_timeout_test";
+  private static final String optionsValue = "500";
+
+  @Before
+  public void setUp() throws Exception {
+    Connection con = TestUtil.openDB();
+    Statement stmt = con.createStatement();
+    stmt.execute("DROP SCHEMA IF EXISTS " + schemaName + ";");
+    stmt.execute("CREATE SCHEMA " + schemaName + ";");
+    stmt.close();
+    TestUtil.closeDB(con);
+  }
+
+  @Test
+  public void testOptionsInProperties() throws Exception {
+    System.setProperty("statementTimeout", optionsValue);
+
+    Connection con = TestUtil.openDB();
+    Statement stmt = con.createStatement();
+
+    try {
+      stmt.execute("SELECT pg_sleep(1)");
+      Assert.fail("This should have failed, since the timeout is 500 milliseconds and we sleep for 1000");
+    } catch (SQLException e) {
+      Assert.assertEquals("ERROR: canceling statement due to statement timeout", e.getMessage());
+    }
+
+    stmt.close();
+    TestUtil.closeDB(con);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    Connection con = TestUtil.openDB();
+    Statement stmt = con.createStatement();
+    stmt.execute("DROP SCHEMA " + schemaName + ";");
+    stmt.close();
+    TestUtil.closeDB(con);
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/test/core/StatementTimeoutTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/core/StatementTimeoutTest.java
@@ -5,17 +5,16 @@
 
 package org.postgresql.test.core;
 
-import java.sql.Connection;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
-import java.util.Properties;
+import org.postgresql.test.TestUtil;
+
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.postgresql.PGProperty;
-import org.postgresql.test.TestUtil;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
 
 public class StatementTimeoutTest {
   private static final String schemaName = "statement_timeout_test";


### PR DESCRIPTION
…s a url property in the jdbc connection string, named statementTimeout

An attempt to fix issue #1495

I'm not sure that the strategy of issuing an execSQLUpdate in the PgConnection constructor
is the correct way to implement this, will be happy to rework this into something better if needed. 

The new test class is maybe also in the wrong location, if so, please advice where i should move it?

### All Submissions:

* [ x ] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [ x ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ x ] Does your submission pass tests?
2. [ x ] Does mvn checkstyle:check pass ?

### Changes to Existing Features:

* [ ] Does this break existing behaviour? If so please explain.
* [ x ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ x ] Have you written new tests for your core changes, as applicable?
* [ x ] Have you successfully run tests with your changes locally?
