### PR TITLE
Cleanup PGProperty enum and Connection Property Docs

### DIFF
--- a/docs/documentation/head/connect.md
+++ b/docs/documentation/head/connect.md
@@ -69,110 +69,6 @@ String url = "jdbc:postgresql://localhost/test?user=fred&password=secret&ssl=tru
 Connection conn = DriverManager.getConnection(url);
 ```
 
-* **user** = String
-
-	The database user on whose behalf the connection is being made.
-
-* **password** = String
-
-	The database user's password.
-
-* **options** = String
-
-	Specify 'options' connection initialization parameter.
-
-	The value of this property may contain spaces or other special characters,
-	and it should be properly encoded if provided in the connection URL. Spaces
-	are considered to separate command-line arguments, unless escaped with
-	a backslash (`\`); `\\` represents a literal backslash.
-
-* **ssl** = boolean
-
-	Connect using SSL. The driver must have been compiled with SSL support.
-	This property does not need a value associated with it. The mere presence
-	of it specifies a SSL connection. However, for compatibility with future
-	versions, the value "true" is preferred. For more information see [Chapter
-	4, *Using SSL*](ssl.html).
- 
-* **sslfactory** = String
-
-	The provided value is a class name to use as the `SSLSocketFactory` when
-	establishing a SSL connection. For more information see the section
-	called [“Custom SSLSocketFactory”](ssl-factory.html). 
-
-* **sslfactoryarg** (deprecated) = String
-
-	This value is an optional argument to the constructor of the sslfactory
-	class provided above. For more information see the section called [“Custom SSLSocketFactory”](ssl-factory.html). 
-
-* **sslmode** = String
-
-	possible values include `disable`, `allow`, `prefer`, `require`, `verify-ca` and `verify-full`
-	. `require`, `allow` and `prefer` all default to a non validating SSL factory and do not check the
-	validity of the certificate or the host name. `verify-ca` validates the certificate, but does not
-	verify the hostname. `verify-full`  will validate that the certificate is correct and verify the
-	host connected to has the same hostname as the certificate.
-
-	Setting these will necessitate storing the server certificate on the client machine see
-	["Configuring the client"](ssl-client.html) for details.
-
-* **sslcert** = String
-
-	Provide the full path for the certificate file. Defaults to /defaultdir/postgresql.crt
-
-	*Note:* defaultdir is ${user.home}/.postgresql/ in *nix systems and %appdata%/postgresql/ on windows 
-
-* **sslkey** = String
-
-	Provide the full path for the key file. Defaults to /defaultdir/postgresql.pk8. 
-	
-	*Note:* The key file **must** be in [DER format](https://wiki.openssl.org/index.php/DER). A PEM key can be converted to DER format using the openssl command:
-	
-	`openssl pkcs8 -topk8 -inform PEM -in my.key -outform DER -out my.key.der`
-
-* **sslrootcert** = String
-
-	File name of the SSL root certificate. Defaults to defaultdir/root.crt
-
-* **sslhostnameverifier** = String
-
-	Class name of hostname verifier. Defaults to using `org.postgresql.ssl.PGjdbcHostnameVerifier`
-
-* **sslpasswordcallback** = String
-
-	Class name of the SSL password provider. Defaults to `org.postgresql.ssl.jdbc4.LibPQFactory.ConsoleCallbackHandler`
-
-* **sslpassword** = String
-
-	If provided will be used by ConsoleCallbackHandler
-
-* **sendBufferSize** = int
-
-	Sets SO_SNDBUF on the connection stream
-
-* **recvBufferSize** = int
-
-	Sets SO_RCVBUF on the connection stream
-
-* **protocolVersion** = int
-
-	The driver supports the V3 frontend/backend protocols. The V3 protocol was introduced in 7.4 and
-	the driver will by default try to	connect using the V3 protocol.
- 
-* **loggerLevel** = String
-
-	Logger level of the driver. Allowed values: <code>OFF</code>, <code>DEBUG</code> or <code>TRACE</code>.
-	This enable the <code>java.util.logging.Logger</code> Level of the driver based on the following mapping
-	of levels: DEBUG -&gt; FINE, TRACE -&gt; FINEST. This property is intended for debug the driver and
-	not for general SQL query debug.
-
-* **loggerFile** = String
-
-	File name output of the Logger. If set, the Logger will use a <code>java.util.logging.FileHandler</code>
-	to write to a specified file. If the parameter is not set or the file can’t be created the
-	<code>java.util.logging.ConsoleHandler</code> will be used instead. This parameter should be use
-	together with loggerLevel.
- 
 * **allowEncodingChanges** = boolean
 
 	When using the V3 protocol the driver monitors changes in certain server
@@ -187,6 +83,146 @@ Connection conn = DriverManager.getConnection(url);
 	for now there is this URL parameter. Enable this only if you need to
 	override the client encoding when doing a copy.
 
+* **ApplicationName** = String
+
+	Specifies the name of the application that is using the connection.
+	This allows a database administrator to see what applications are
+	connected to the server and what resources they are using through views like pg_stat_activity.
+
+* **assumeMinServerVersion** = String
+
+	Assume that the server is at least the given version,
+	thus enabling to some optimization at connection time instead of trying to be version blind.
+
+* **autosave** = String
+
+    Specifies what the driver should do if a query fails. In `autosave=always` mode, JDBC driver sets a savepoint before each query,
+    and rolls back to that savepoint in case of failure. In `autosave=never` mode (default), no savepoint dance is made ever.
+    In `autosave=conservative` mode, savepoint is set for each query, however the rollback is done only for rare cases
+    like 'cached statement cannot change return type' or 'statement XXX is not valid' so JDBC driver rollsback and retries
+
+    The default is `never`
+
+* **binaryTransferDisable** = String
+
+	A comma separated list of types to disable binary transfer. Either OID numbers or names.
+	Overrides values in the driver default set and values set with binaryTransferEnable.
+
+* **binaryTransferEnable** = String
+
+	A comma separated list of types to enable binary transfer. Either OID numbers or names.
+
+* **cancelSignalTimeout** = int
+
+  Cancel command is sent out of band over its own connection, so cancel message can itself get
+  stuck. This property controls "connect timeout" and "socket timeout" used for cancel commands.
+  The timeout is specified in seconds. Default value is 10 seconds.
+
+* **cleanupSavePoints** = boolean
+
+    Determines if the SAVEPOINT created in autosave mode is released prior to the statement. This is
+    done to avoid running out of shared buffers on the server in the case where 1000's of queries are
+    performed.
+
+    The default is 'false'
+
+* **connectTimeout** = int
+
+	The timeout value used for socket connect operations. If connecting to the server
+	takes longer than this value, the connection is broken.
+	The timeout is specified in seconds and a value of zero means that it 	is disabled.
+
+* **currentSchema** = String
+
+	Specify the schema to be set in the search-path.
+	This schema will be used to resolve unqualified object names used in statements over this connection.
+
+* **defaultRowFetchSize** = int
+
+	Determine the number of rows fetched in `ResultSet`
+	by one fetch with trip to the database. Limiting the number of rows are fetch with
+	each trip to the database allow avoids unnecessary memory consumption
+	and as a consequence `OutOfMemoryException`.
+
+	The default is zero, meaning that in `ResultSet` will be fetch all rows at once.
+	Negative number is not available.
+
+* **disableColumnSanitiser** = boolean
+
+	Setting this to true disables column name sanitiser.
+	The sanitiser folds columns in the resultset to lowercase.
+	The default is to sanitise the columns (off).
+
+* **gsslib** = String
+
+	Force either SSPI (Windows transparent single-sign-on) or GSSAPI (Kerberos, via JSSE)
+	to be used when the server requests Kerberos or SSPI authentication.
+	Permissible values are auto (default, see below), sspi (force SSPI) or gssapi (force GSSAPI-JSSE).
+
+	If this parameter is auto, SSPI is attempted if the server requests SSPI authentication,
+	the JDBC client is running on Windows, and the Waffle libraries required
+	for SSPI are on the CLASSPATH. Otherwise Kerberos/GSSAPI via JSSE is used.
+	Note that this behaviour does not exactly match that of libpq, which uses
+	Windows' SSPI libraries for Kerberos (GSSAPI) requests by default when on Windows.
+
+	gssapi mode forces JSSE's GSSAPI to be used even if SSPI is available, matching the pre-9.4 behaviour.
+
+	On non-Windows platforms or where SSPI is unavailable, forcing sspi mode will fail with a PSQLException.
+
+        To use SSPI with PgJDBC you must ensure that
+        [the `waffle-jna` library](https://mvnrepository.com/artifact/com.github.waffle/waffle-jna/)
+	and its dependencies are present on the `CLASSPATH`. PgJDBC does *not*
+        bundle `waffle-jna` in the PgJDBC jar.
+
+	Since: 9.4
+
+* **hostRecheckSeconds** = int
+
+	Controls how long in seconds the knowledge about a host state
+	is cached in JVM wide global cache. The default value is 10 seconds.
+
+* **jaasApplicationName** = String
+
+	Specifies the name of the JAAS system or application login configuration.
+
+* **jaasLogin** = boolean
+
+	Specifies whether to perform a JAAS login before authenticating with GSSAPI.
+	If set to `true` (the default), the driver will attempt to obtain GSS credentials
+	using the configured JAAS login module(s) (e.g. `Krb5LoginModule`) before
+	authenticating. To skip the JAAS login, for example if the native GSS
+	implementation is being used to obtain credentials, set this to `false`.
+
+* **kerberosServerName** = String
+
+	The Kerberos service name to use when authenticating with GSSAPI. This
+	is equivalent to libpq's PGKRBSRVNAME environment variable and defaults
+	to "postgres".
+
+* **loadBalanceHosts** = boolean
+
+	In default mode (disabled) hosts are connected in the given order.
+	If enabled hosts are chosen randomly from the set of suitable candidates.
+
+* **loggerFile** = String
+
+	File name output of the Logger. If set, the Logger will use a <code>java.util.logging.FileHandler</code>
+	to write to a specified file. If the parameter is not set or the file can’t be created the
+	<code>java.util.logging.ConsoleHandler</code> will be used instead. This parameter should be use
+	together with loggerLevel.
+
+* **loggerLevel** = String
+
+	Logger level of the driver. Allowed values: <code>OFF</code>, <code>DEBUG</code> or <code>TRACE</code>.
+	This enable the <code>java.util.logging.Logger</code> Level of the driver based on the following mapping
+	of levels: DEBUG -&gt; FINE, TRACE -&gt; FINEST. This property is intended for debug the driver and
+	not for general SQL query debug.
+
+* **loginTimeout** = int
+
+	Specify how long to wait for establishment of a database connection. The
+	timeout is specified in seconds.
+
 * **logUnclosedConnections** = boolean
 
 	Clients may leak `Connection` objects by failing to call its `close()`
@@ -199,47 +235,35 @@ Connection conn = DriverManager.getConnection(url);
 	method is reached without having been closed the stacktrace is printed
 	to the log.
 	
-* **autosave** = String
+* **options** = String
 
-    Specifies what the driver should do if a query fails. In `autosave=always` mode, JDBC driver sets a savepoint before each query,
-    and rolls back to that savepoint in case of failure. In `autosave=never` mode (default), no savepoint dance is made ever.
-    In `autosave=conservative` mode, savepoint is set for each query, however the rollback is done only for rare cases
-    like 'cached statement cannot change return type' or 'statement XXX is not valid' so JDBC driver rollsback and retries
+	Specify 'options' connection initialization parameter.
 
-    The default is `never` 
+	The value of this property may contain spaces or other special characters,
+	and it should be properly encoded if provided in the connection URL. Spaces
+	are considered to separate command-line arguments, unless escaped with
+	a backslash (`\`); `\\` represents a literal backslash.
 
-* **cleanupSavePoints** = boolean
+* **password** = String
 
-    Determines if the SAVEPOINT created in autosave mode is released prior to the statement. This is
-    done to avoid running out of shared buffers on the server in the case where 1000's of queries are
-    performed.
-     
-    The default is 'false'
+	The database user's password.
 
-* **binaryTransferEnable** = String
+* **preferQueryMode** = String
 
-	A comma separated list of types to enable binary transfer. Either OID numbers or names.
+    Specifies which mode is used to execute queries to database: simple means ('Q' execute, no parse, no bind, text mode only),
+    extended means always use bind/execute messages, extendedForPrepared means extended for prepared statements only,
+    extendedCacheEverything means use extended protocol and try cache every statement
+    (including Statement.execute(String sql)) in a query cache.
+    extended | extendedForPrepared | extendedCacheEverything | simple
 
-* **binaryTransferDisable** = String
-
-	A comma separated list of types to disable binary transfer. Either OID numbers or names.
-	Overrides values in the driver default set and values set with binaryTransferEnable.
-
-* **prepareThreshold** = int
-
-	Determine the number of `PreparedStatement` executions required before
-	switching over to use server side prepared statements. The default is
-	five, meaning start using server side prepared statements on the fifth
-	execution of the same `PreparedStatement` object. More information on
-	server side prepared statements is available in the section called
-	[“Server Prepared Statements”](server-prepare.html).
+    The default is extended
 
 * **preparedStatementCacheQueries** = int
 
 	Determine the number of queries that are cached in each connection.
 	The default is 256, meaning if you use more than 256 different queries
 	in `prepareStatement()` calls, the least recently used ones
-	will be discarded. The cache allows application to benefit from 
+	will be discarded. The cache allows application to benefit from
 	[“Server Prepared Statements”](server-prepare.html)
 	(see `prepareThreshold`) even if the prepared statement is
 	closed after each execution. The value of 0 disables the cache.
@@ -255,36 +279,63 @@ Connection conn = DriverManager.getConnection(url);
 	The main aim of this setting is to prevent `OutOfMemoryError`.
 	The value of 0 disables the cache.
 
-* **preferQueryMode** = String
+* **prepareThreshold** = int
 
-    Specifies which mode is used to execute queries to database: simple means ('Q' execute, no parse, no bind, text mode only), 
-    extended means always use bind/execute messages, extendedForPrepared means extended for prepared statements only, 
-    extendedCacheEverything means use extended protocol and try cache every statement 
-    (including Statement.execute(String sql)) in a query cache.
-    extended | extendedForPrepared | extendedCacheEverything | simple
+	Determine the number of `PreparedStatement` executions required before
+	switching over to use server side prepared statements. The default is
+	five, meaning start using server side prepared statements on the fifth
+	execution of the same `PreparedStatement` object. More information on
+	server side prepared statements is available in the section called
+	[“Server Prepared Statements”](server-prepare.html).
 
-    The default is extended
+* **protocolVersion** = int
 
-* **defaultRowFetchSize** = int
+	The driver supports the V3 frontend/backend protocols. The V3 protocol was introduced in 7.4 and
+	the driver will by default try to	connect using the V3 protocol.
 
-	Determine the number of rows fetched in `ResultSet`
-	by one fetch with trip to the database. Limiting the number of rows are fetch with 
-	each trip to the database allow avoids unnecessary memory consumption 
-	and as a consequence `OutOfMemoryException`.
+* **readOnly** = boolean
 
-	The default is zero, meaning that in `ResultSet` will be fetch all rows at once. 
-	Negative number is not available.
+	Put the connection in read-only mode
 
-* **loginTimeout** = int
+* **receiveBufferSize** = int
 
-	Specify how long to wait for establishment of a database connection. The
-	timeout is specified in seconds. 
+	Sets SO_RCVBUF on the connection stream
 
-* **connectTimeout** = int
+* **recvBufferSize** = int
 
-	The timeout value used for socket connect operations. If connecting to the server
-	takes longer than this value, the connection is broken. 
-	The timeout is specified in seconds and a value of zero means that it 	is disabled.
+	Sets SO_RCVBUF on the connection stream
+
+* **replication** = String
+
+   Connection parameter passed in the startup message. This parameter accepts two values; "true"
+   and `database`. Passing `true` tells the backend to go into walsender mode, wherein a small set
+   of replication commands can be issued instead of SQL statements. Only the simple query protocol
+   can be used in walsender mode. Passing "database" as the value instructs walsender to connect
+   to the database specified in the dbname parameter, which will allow the connection to be used
+   for logical replication from that database. <p>Parameter should be use together with
+   `assumeMinServerVersion` with parameter >= 9.4 (backend >= 9.4)</p>
+
+* **reWriteBatchedInserts** = boolean
+
+	This will change batch inserts from insert into foo (col1, col2, col3) values (1,2,3) into
+	insert into foo (col1, col2, col3) values (1,2,3), (4,5,6) this provides 2-3x performance improvement
+
+* **sendBufferSize** = int
+
+	Sets SO_SNDBUF on the connection stream
+
+* **socketFactory** = String
+
+	The provided value is a class name to use as the `SocketFactory` when establishing a socket connection.
+	This may be used to create unix sockets instead of normal sockets. The class name specified by `socketFactory`
+	must extend `javax.net.SocketFactory` and be available to the driver's classloader.
+	This class must have a zero argument constructor or a single argument constructor taking a String argument.
+	This argument may optionally be supplied by `socketFactoryArg`.
+
+* **socketFactoryArg** (deprecated) = String
+
+	This value is an optional argument to the constructor of the socket factory
+	class provided above.
 
 * **socketTimeout** = int
 
@@ -294,12 +345,94 @@ Connection conn = DriverManager.getConnection(url);
 	detecting network problems. The timeout is specified in seconds and a
 	value of zero means that it is disabled.
 
-* **cancelSignalTimeout** = int
+* **ssl** = boolean
 
-  Cancel command is sent out of band over its own connection, so cancel message can itself get
-  stuck. This property controls "connect timeout" and "socket timeout" used for cancel commands.
-  The timeout is specified in seconds. Default value is 10 seconds.
+	Connect using SSL. The driver must have been compiled with SSL support.
+	This property does not need a value associated with it. The mere presence
+	of it specifies a SSL connection. However, for compatibility with future
+	versions, the value "true" is preferred. For more information see [Chapter
+	4, *Using SSL*](ssl.html).
 
+* **sslcert** = String
+
+	Provide the full path for the certificate file. Defaults to /defaultdir/postgresql.crt
+
+	*Note:* defaultdir is ${user.home}/.postgresql/ in *nix systems and %appdata%/postgresql/ on windows
+
+* **sslfactoryarg** (deprecated) = String
+
+	This value is an optional argument to the constructor of the sslfactory
+	class provided above. For more information see the section called [“Custom SSLSocketFactory”](ssl-factory.html).
+
+* **sslhostnameverifier** = String
+
+	Class name of hostname verifier. Defaults to using `org.postgresql.ssl.PGjdbcHostnameVerifier`
+
+* **sslfactory** = String
+
+	The provided value is a class name to use as the `SSLSocketFactory` when
+	establishing a SSL connection. For more information see the section
+	called [“Custom SSLSocketFactory”](ssl-factory.html).
+
+* **sslkey** = String
+
+	Provide the full path for the key file. Defaults to /defaultdir/postgresql.pk8.
+
+	*Note:* The key file **must** be in [DER format](https://wiki.openssl.org/index.php/DER). A PEM key can be converted to DER format using the openssl command:
+
+	`openssl pkcs8 -topk8 -inform PEM -in my.key -outform DER -out my.key.der`
+
+* **sslmode** = String
+
+	possible values include `disable`, `allow`, `prefer`, `require`, `verify-ca` and `verify-full`
+	. `require`, `allow` and `prefer` all default to a non validating SSL factory and do not check the
+	validity of the certificate or the host name. `verify-ca` validates the certificate, but does not
+	verify the hostname. `verify-full`  will validate that the certificate is correct and verify the
+	host connected to has the same hostname as the certificate.
+
+	Setting these will necessitate storing the server certificate on the client machine see
+	["Configuring the client"](ssl-client.html) for details.
+
+* **sslpasswordcallback** = String
+
+	Class name of the SSL password provider. Defaults to `org.postgresql.ssl.jdbc4.LibPQFactory.ConsoleCallbackHandler`
+
+* **sslpassword** = String
+
+	If provided will be used by ConsoleCallbackHandler
+
+* **sslrootcert** = String
+
+	File name of the SSL root certificate. Defaults to defaultdir/root.crt
+
+* **sspiServiceClass** = String
+
+	Specifies the name of the Windows SSPI service class that forms the service
+	class part of the SPN. The default, POSTGRES, is almost always correct.
+
+	See: SSPI authentication (Pg docs) Service Principal Names (MSDN), DsMakeSpn (MSDN) Configuring SSPI (Pg wiki).
+
+	This parameter is ignored on non-Windows platforms.
+
+* **stringtype** = String
+
+	Specify the type to use when binding `PreparedStatement` parameters set
+	via `setString()`. If `stringtype` is set to `VARCHAR` (the default), such
+	parameters will be sent to the server as varchar parameters. If `stringtype`
+	is set to `unspecified`, parameters will be sent to the server as untyped
+	values, and the server will attempt to infer an appropriate type. This
+	is useful if you have an existing application that uses `setString()` to
+	set parameters that are actually some other type, such as integers, and
+	you are unable to change the application to use an appropriate method
+	such as `setInt()`.
+
+* **targetServerType** = String
+
+	Allows opening connections to only servers with required state,
+	the allowed values are any, master, slave, secondary, preferSlave and preferSecondary.
+	The master/slave distinction is currently done by observing if the server allows writes.
+	The value preferSecondary tries to connect to secondary if any are available,
+	otherwise allows falls back to connecting also to master.
 
 * **tcpKeepAlive** = boolean
 
@@ -314,170 +447,31 @@ Connection conn = DriverManager.getConnection(url);
 	about what they would like to see. This parameter specifies the length
 	to return for types of unknown length.
 
-* **stringtype** = String
+* **user** = String
 
-	Specify the type to use when binding `PreparedStatement` parameters set
-	via `setString()`. If `stringtype` is set to `VARCHAR` (the default), such
-	parameters will be sent to the server as varchar parameters. If `stringtype`
-	is set to `unspecified`, parameters will be sent to the server as untyped
-	values, and the server will attempt to infer an appropriate type. This
-	is useful if you have an existing application that uses `setString()` to
-	set parameters that are actually some other type, such as integers, and
-	you are unable to change the application to use an appropriate method
-	such as `setInt()`.
-
-* **kerberosServerName** = String
-
-	The Kerberos service name to use when authenticating with GSSAPI. This
-	is equivalent to libpq's PGKRBSRVNAME environment variable and defaults
-	to "postgres".
-
-* **jaasApplicationName** = String
-
-	Specifies the name of the JAAS system or application login configuration.
-
-* **jaasLogin** = boolean
-
-	Specifies whether to perform a JAAS login before authenticating with GSSAPI.
-	If set to `true` (the default), the driver will attempt to obtain GSS credentials
-	using the configured JAAS login module(s) (e.g. `Krb5LoginModule`) before
-	authenticating. To skip the JAAS login, for example if the native GSS
-	implementation is being used to obtain credentials, set this to `false`.
-
-* **ApplicationName** = String
-
-	Specifies the name of the application that is using the connection. 
-	This allows a database administrator to see what applications are 
-	connected to the server and what resources they are using through views like pg_stat_activity.
-
-* **gsslib** = String
-
-	Force either SSPI (Windows transparent single-sign-on) or GSSAPI (Kerberos, via JSSE)
-	to be used when the server requests Kerberos or SSPI authentication. 
-	Permissible values are auto (default, see below), sspi (force SSPI) or gssapi (force GSSAPI-JSSE).
-
-	If this parameter is auto, SSPI is attempted if the server requests SSPI authentication, 
-	the JDBC client is running on Windows, and the Waffle libraries required 
-	for SSPI are on the CLASSPATH. Otherwise Kerberos/GSSAPI via JSSE is used. 
-	Note that this behaviour does not exactly match that of libpq, which uses 
-	Windows' SSPI libraries for Kerberos (GSSAPI) requests by default when on Windows.
-
-	gssapi mode forces JSSE's GSSAPI to be used even if SSPI is available, matching the pre-9.4 behaviour.
-
-	On non-Windows platforms or where SSPI is unavailable, forcing sspi mode will fail with a PSQLException.
-
-        To use SSPI with PgJDBC you must ensure that
-        [the `waffle-jna` library](https://mvnrepository.com/artifact/com.github.waffle/waffle-jna/)
-	and its dependencies are present on the `CLASSPATH`. PgJDBC does *not*
-        bundle `waffle-jna` in the PgJDBC jar.
-
-	Since: 9.4
-
-* **sspiServiceClass** = String
-
-	Specifies the name of the Windows SSPI service class that forms the service 
-	class part of the SPN. The default, POSTGRES, is almost always correct.
-
-	See: SSPI authentication (Pg docs) Service Principal Names (MSDN), DsMakeSpn (MSDN) Configuring SSPI (Pg wiki).
-
-	This parameter is ignored on non-Windows platforms.
+	The database user on whose behalf the connection is being made.
 
 * **useSpnego** = boolean
 
 	Use SPNEGO in SSPI authentication requests
 
-* **sendBufferSize** = int
-
-	Sets SO_SNDBUF on the connection stream
-
-* **receiveBufferSize** = int
-
-	Sets SO_RCVBUF on the connection stream
-
-* **readOnly** = boolean
-
-	Put the connection in read-only mode
-
-* **disableColumnSanitiser** = boolean
-
-	Setting this to true disables column name sanitiser. 
-	The sanitiser folds columns in the resultset to lowercase. 
-	The default is to sanitise the columns (off).
-
-* **assumeMinServerVersion** = String
-
-	Assume that the server is at least the given version, 
-	thus enabling to some optimization at connection time instead of trying to be version blind.
-
-* **currentSchema** = String
-
-	Specify the schema to be set in the search-path. 
-	This schema will be used to resolve unqualified object names used in statements over this connection.
-
-* **targetServerType** = String
-
-	Allows opening connections to only servers with required state, 
-	the allowed values are any, master, slave, secondary, preferSlave and preferSecondary. 
-	The master/slave distinction is currently done by observing if the server allows writes. 
-	The value preferSecondary tries to connect to secondary if any are available, 
-	otherwise allows falls back to connecting also to master.
-
-* **hostRecheckSeconds** = int
-
-	Controls how long in seconds the knowledge about a host state 
-	is cached in JVM wide global cache. The default value is 10 seconds.
-
-* **loadBalanceHosts** = boolean
-
-	In default mode (disabled) hosts are connected in the given order. 
-	If enabled hosts are chosen randomly from the set of suitable candidates.
-
-* **socketFactory** = String
-
-	The provided value is a class name to use as the `SocketFactory` when establishing a socket connection. 
-	This may be used to create unix sockets instead of normal sockets. The class name specified by `socketFactory` 
-	must extend `javax.net.SocketFactory` and be available to the driver's classloader.
-	This class must have a zero argument constructor or a single argument constructor taking a String argument. 
-	This argument may optionally be supplied by `socketFactoryArg`.
-
-* **socketFactoryArg** (deprecated) = String
-
-	This value is an optional argument to the constructor of the socket factory
-	class provided above. 
-
-* **reWriteBatchedInserts** = boolean
-
-	This will change batch inserts from insert into foo (col1, col2, col3) values (1,2,3) into 
-	insert into foo (col1, col2, col3) values (1,2,3), (4,5,6) this provides 2-3x performance improvement
-
-* **replication** = String
-
-   Connection parameter passed in the startup message. This parameter accepts two values; "true"
-   and `database`. Passing `true` tells the backend to go into walsender mode, wherein a small set
-   of replication commands can be issued instead of SQL statements. Only the simple query protocol
-   can be used in walsender mode. Passing "database" as the value instructs walsender to connect
-   to the database specified in the dbname parameter, which will allow the connection to be used
-   for logical replication from that database. <p>Parameter should be use together with 
-   `assumeMinServerVersion` with parameter >= 9.4 (backend >= 9.4)</p>
-    
-    
 <a name="connection-failover"></a>
 ## Connection Fail-over
 
 To support simple connection fail-over it is possible to define multiple endpoints
 (host and port pairs) in the connection url separated by commas.
-The driver will try to once connect to each of them in order until the connection succeeds. 
+The driver will try to once connect to each of them in order until the connection succeeds.
 If none succeed, a normal connection exception is thrown.
 
 The syntax for the connection url is:
 
 `jdbc:postgresql://host1:port1,host2:port2/database`
 
-The simple connection fail-over is useful when running against a high availability 
-postgres installation that has identical data on each node. 
+The simple connection fail-over is useful when running against a high availability
+postgres installation that has identical data on each node.
 For example streaming replication postgres or postgres-xc cluster.
 
-For example an application can create two connection pools. 
+For example an application can create two connection pools.
 One data source is for writes, another for reads. The write pool limits connections only to master node:
 
 `jdbc:postgresql://node1,node2,node3/accounting?targetServerType=master`.

--- a/docs/documentation/head/connect.md
+++ b/docs/documentation/head/connect.md
@@ -118,7 +118,7 @@ Connection conn = DriverManager.getConnection(url);
   stuck. This property controls "connect timeout" and "socket timeout" used for cancel commands.
   The timeout is specified in seconds. Default value is 10 seconds.
 
-* **cleanupSavePoints** = boolean
+* **cleanupSavepoints** = boolean
 
     Determines if the SAVEPOINT created in autosave mode is released prior to the statement. This is
     done to avoid running out of shared buffers on the server in the case where 1000's of queries are

--- a/docs/documentation/head/connect.md
+++ b/docs/documentation/head/connect.md
@@ -301,10 +301,6 @@ Connection conn = DriverManager.getConnection(url);
 
 	Sets SO_RCVBUF on the connection stream
 
-* **recvBufferSize** = int
-
-	Sets SO_RCVBUF on the connection stream
-
 * **replication** = String
 
    Connection parameter passed in the startup message. This parameter accepts two values; "true"

--- a/docs/documentation/head/connect.md
+++ b/docs/documentation/head/connect.md
@@ -103,6 +103,12 @@ Connection conn = DriverManager.getConnection(url);
 
     The default is `never`
 
+* **binaryTransfer** = boolean
+
+	Use binary format for sending and receiving data if possible.
+
+	Defaults to true.
+
 * **binaryTransferDisable** = String
 
 	A comma separated list of types to disable binary transfer. Either OID numbers or names.
@@ -136,6 +142,20 @@ Connection conn = DriverManager.getConnection(url);
 
 	Specify the schema to be set in the search-path.
 	This schema will be used to resolve unqualified object names used in statements over this connection.
+
+* **databaseMetadataCacheFields** = int
+
+	Specifies the maximum number of fields to be cached per connection.
+	A value of 0 disables the cache.
+
+	Defaults to 65536.
+
+* **databaseMetadataCacheFieldsMiB** = int
+
+	Specifies the maximum size (in megabytes) of fields to be cached per connection.
+	A value of 0 disables the cache.
+
+	Defaults to 5.
 
 * **defaultRowFetchSize** = int
 

--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -649,6 +649,15 @@ public enum PGProperty {
   }
 
   /**
+   * Returns whether this parameter is required.
+   *
+   * @return whether this parameter is required
+   */
+  public boolean isRequired() {
+    return required;
+  }
+
+  /**
    * Returns the description for this connection parameter.
    *
    * @return the description for this connection parameter

--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -649,6 +649,15 @@ public enum PGProperty {
   }
 
   /**
+   * Returns the description for this connection parameter.
+   *
+   * @return the description for this connection parameter
+   */
+  public String getDescription() {
+    return description;
+  }
+
+  /**
    * Returns the available values for this connection parameter.
    *
    * @return the available values for this connection parameter or null

--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -11,6 +11,8 @@ import org.postgresql.util.PSQLException;
 import org.postgresql.util.PSQLState;
 
 import java.sql.DriverPropertyInfo;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
 
 /**
@@ -618,6 +620,15 @@ public enum PGProperty {
     this.choices = choices;
   }
 
+  private static final Map<String, PGProperty> PROPS_BY_NAME = new HashMap<String, PGProperty>();
+  static {
+    for (PGProperty prop : PGProperty.values()) {
+      if (PROPS_BY_NAME.put(prop.getName(), prop) != null) {
+        throw new IllegalStateException("Duplicate PGProperty name: " + prop.getName());
+      }
+    }
+  }
+
   /**
    * Returns the name of the connection parameter. The name is the key that must be used in JDBC URL
    * or in Driver properties
@@ -777,12 +788,7 @@ public enum PGProperty {
   }
 
   public static PGProperty forName(String name) {
-    for (PGProperty property : PGProperty.values()) {
-      if (property.getName().equals(name)) {
-        return property;
-      }
-    }
-    return null;
+    return PROPS_BY_NAME.get(name);
   }
 
   /**

--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -603,6 +603,7 @@ public enum PGProperty {
   private final boolean required;
   private final String description;
   private final String[] choices;
+  private final boolean deprecated;
 
   PGProperty(String name, String defaultValue, String description) {
     this(name, defaultValue, description, false);
@@ -618,6 +619,11 @@ public enum PGProperty {
     this.required = required;
     this.description = description;
     this.choices = choices;
+    try {
+      this.deprecated = PGProperty.class.getField(name()).getAnnotation(Deprecated.class) != null;
+    } catch (NoSuchFieldException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   private static final Map<String, PGProperty> PROPS_BY_NAME = new HashMap<String, PGProperty>();
@@ -673,6 +679,15 @@ public enum PGProperty {
    */
   public String[] getChoices() {
     return choices;
+  }
+
+  /**
+   * Returns whether this connection parameter is deprecated.
+   *
+   * @return whether this connection parameter is deprecated
+   */
+  public boolean isDeprecated() {
+    return deprecated;
   }
 
   /**

--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -22,44 +22,66 @@ public enum PGProperty {
   /**
    * Database name to connect to (may be specified directly in the JDBC URL).
    */
-  PG_DBNAME("PGDBNAME", null,
-      "Database name to connect to (may be specified directly in the JDBC URL)", true),
+  PG_DBNAME(
+    "PGDBNAME",
+    null,
+    "Database name to connect to (may be specified directly in the JDBC URL)",
+    true),
 
   /**
    * Hostname of the PostgreSQL server (may be specified directly in the JDBC URL).
    */
-  PG_HOST("PGHOST", null,
-      "Hostname of the PostgreSQL server (may be specified directly in the JDBC URL)", false),
+  PG_HOST(
+    "PGHOST",
+    null,
+    "Hostname of the PostgreSQL server (may be specified directly in the JDBC URL)",
+    false),
 
   /**
    * Port of the PostgreSQL server (may be specified directly in the JDBC URL).
    */
-  PG_PORT("PGPORT", null,
-      "Port of the PostgreSQL server (may be specified directly in the JDBC URL)"),
+  PG_PORT(
+    "PGPORT",
+    null,
+    "Port of the PostgreSQL server (may be specified directly in the JDBC URL)"),
 
   /**
    * Username to connect to the database as.
    */
-  USER("user", null, "Username to connect to the database as.", true),
+  USER(
+    "user",
+    null,
+    "Username to connect to the database as.",
+    true),
 
   /**
    * Password to use when authenticating.
    */
-  PASSWORD("password", null, "Password to use when authenticating.", false),
+  PASSWORD(
+    "password",
+    null,
+    "Password to use when authenticating.",
+    false),
 
   /**
    * Force use of a particular protocol version when connecting, if set, disables protocol version
    * fallback.
    */
-  PROTOCOL_VERSION("protocolVersion", null,
-      "Force use of a particular protocol version when connecting, currently only version 3 is supported.",
-      false, "3"),
+  PROTOCOL_VERSION(
+    "protocolVersion",
+    null,
+    "Force use of a particular protocol version when connecting, currently only version 3 is supported.",
+    false,
+    new String[] {"3"}),
 
   /**
    * Specify 'options' connection initialization parameter.
    * The value of this parameter may contain spaces and other special characters or their URL representation.
    */
-  OPTIONS("options", null, "Specify 'options' connection initialization parameter."),
+  OPTIONS(
+    "options",
+    null,
+    "Specify 'options' connection initialization parameter."),
 
   /**
    * <p>Logger level of the driver. Allowed values: {@code OFF}, {@code DEBUG} or {@code TRACE}.</p>
@@ -76,7 +98,12 @@ public enum PGProperty {
    * {@code -Djava.util.logging.config.file=myfile} or if your are using an application server
    * you should use the appropriate logging subsystem.</p>
    */
-  LOGGER_LEVEL("loggerLevel", null, "Logger level of the driver", false, "OFF", "DEBUG", "TRACE"),
+  LOGGER_LEVEL(
+    "loggerLevel",
+    null,
+    "Logger level of the driver",
+    false,
+    new String[] {"OFF", "DEBUG", "TRACE"}),
 
   /**
    * <p>File name output of the Logger, if set, the Logger will use a
@@ -85,103 +112,139 @@ public enum PGProperty {
    *
    * <p>Parameter should be use together with {@link PGProperty#LOGGER_LEVEL}</p>
    */
-  LOGGER_FILE("loggerFile", null, "File name output of the Logger"),
+  LOGGER_FILE(
+    "loggerFile",
+    null,
+    "File name output of the Logger"),
 
   /**
    * Sets the default threshold for enabling server-side prepare. A value of {@code -1} stands for
    * forceBinary
    */
-  PREPARE_THRESHOLD("prepareThreshold", "5",
-      "Statement prepare threshold. A value of {@code -1} stands for forceBinary"),
+  PREPARE_THRESHOLD(
+    "prepareThreshold",
+    "5",
+    "Statement prepare threshold. A value of {@code -1} stands for forceBinary"),
 
   /**
    * Specifies the maximum number of entries in cache of prepared statements. A value of {@code 0}
    * disables the cache.
    */
-  PREPARED_STATEMENT_CACHE_QUERIES("preparedStatementCacheQueries", "256",
-      "Specifies the maximum number of entries in per-connection cache of prepared statements. A value of {@code 0} disables the cache."),
+  PREPARED_STATEMENT_CACHE_QUERIES(
+    "preparedStatementCacheQueries",
+    "256",
+    "Specifies the maximum number of entries in per-connection cache of prepared statements. A value of {@code 0} disables the cache."),
 
   /**
    * Specifies the maximum size (in megabytes) of the prepared statement cache. A value of {@code 0}
    * disables the cache.
    */
-  PREPARED_STATEMENT_CACHE_SIZE_MIB("preparedStatementCacheSizeMiB", "5",
-      "Specifies the maximum size (in megabytes) of a per-connection prepared statement cache. A value of {@code 0} disables the cache."),
+  PREPARED_STATEMENT_CACHE_SIZE_MIB(
+    "preparedStatementCacheSizeMiB",
+    "5",
+    "Specifies the maximum size (in megabytes) of a per-connection prepared statement cache. A value of {@code 0} disables the cache."),
 
   /**
    * Specifies the maximum number of fields to be cached per connection. A value of {@code 0} disables the cache.
    */
-  DATABASE_METADATA_CACHE_FIELDS("databaseMetadataCacheFields", "65536",
-          "Specifies the maximum number of fields to be cached per connection. A value of {@code 0} disables the cache."),
+  DATABASE_METADATA_CACHE_FIELDS(
+    "databaseMetadataCacheFields",
+    "65536",
+    "Specifies the maximum number of fields to be cached per connection. A value of {@code 0} disables the cache."),
 
   /**
    * Specifies the maximum size (in megabytes) of fields to be cached per connection. A value of {@code 0} disables the cache.
    */
-  DATABASE_METADATA_CACHE_FIELDS_MIB("databaseMetadataCacheFieldsMiB", "5",
-          "Specifies the maximum size (in megabytes) of fields to be cached per connection. A value of {@code 0} disables the cache."),
+  DATABASE_METADATA_CACHE_FIELDS_MIB(
+    "databaseMetadataCacheFieldsMiB",
+    "5",
+    "Specifies the maximum size (in megabytes) of fields to be cached per connection. A value of {@code 0} disables the cache."),
 
   /**
    * Default parameter for {@link java.sql.Statement#getFetchSize()}. A value of {@code 0} means
    * that need fetch all rows at once
    */
-  DEFAULT_ROW_FETCH_SIZE("defaultRowFetchSize", "0",
-      "Positive number of rows that should be fetched from the database when more rows are needed for ResultSet by each fetch iteration"),
+  DEFAULT_ROW_FETCH_SIZE(
+    "defaultRowFetchSize",
+    "0",
+    "Positive number of rows that should be fetched from the database when more rows are needed for ResultSet by each fetch iteration"),
 
   /**
    * Use binary format for sending and receiving data if possible.
    */
-  BINARY_TRANSFER("binaryTransfer", "true",
-      "Use binary format for sending and receiving data if possible"),
+  BINARY_TRANSFER(
+    "binaryTransfer",
+    "true",
+    "Use binary format for sending and receiving data if possible"),
 
   /**
    * Puts this connection in read-only mode.
    */
-  READ_ONLY("readOnly", "false", "Puts this connection in read-only mode"),
+  READ_ONLY(
+    "readOnly",
+    "false",
+    "Puts this connection in read-only mode"),
 
   /**
    * Comma separated list of types to enable binary transfer. Either OID numbers or names
    */
-  BINARY_TRANSFER_ENABLE("binaryTransferEnable", "",
-      "Comma separated list of types to enable binary transfer. Either OID numbers or names"),
+  BINARY_TRANSFER_ENABLE(
+    "binaryTransferEnable",
+    "",
+    "Comma separated list of types to enable binary transfer. Either OID numbers or names"),
 
   /**
    * Comma separated list of types to disable binary transfer. Either OID numbers or names.
    * Overrides values in the driver default set and values set with binaryTransferEnable.
    */
-  BINARY_TRANSFER_DISABLE("binaryTransferDisable", "",
-      "Comma separated list of types to disable binary transfer. Either OID numbers or names. Overrides values in the driver default set and values set with binaryTransferEnable."),
+  BINARY_TRANSFER_DISABLE(
+    "binaryTransferDisable",
+    "",
+    "Comma separated list of types to disable binary transfer. Either OID numbers or names. Overrides values in the driver default set and values set with binaryTransferEnable."),
 
   /**
    * Bind String to either {@code unspecified} or {@code varchar}. Default is {@code varchar} for
    * 8.0+ backends.
    */
-  STRING_TYPE("stringtype", null,
-      "The type to bind String parameters as (usually 'varchar', 'unspecified' allows implicit casting to other types)",
-      false, "unspecified", "varchar"),
+  STRING_TYPE(
+    "stringtype",
+    null,
+    "The type to bind String parameters as (usually 'varchar', 'unspecified' allows implicit casting to other types)",
+    false,
+    new String[] {"unspecified", "varchar"}),
 
   /**
    * Specifies the length to return for types of unknown length.
    */
-  UNKNOWN_LENGTH("unknownLength", Integer.toString(Integer.MAX_VALUE),
-      "Specifies the length to return for types of unknown length"),
+  UNKNOWN_LENGTH(
+    "unknownLength",
+    Integer.toString(Integer.MAX_VALUE),
+    "Specifies the length to return for types of unknown length"),
 
   /**
    * When connections that are not explicitly closed are garbage collected, log the stacktrace from
    * the opening of the connection to trace the leak source.
    */
-  LOG_UNCLOSED_CONNECTIONS("logUnclosedConnections", "false",
-      "When connections that are not explicitly closed are garbage collected, log the stacktrace from the opening of the connection to trace the leak source"),
+  LOG_UNCLOSED_CONNECTIONS(
+    "logUnclosedConnections",
+    "false",
+    "When connections that are not explicitly closed are garbage collected, log the stacktrace from the opening of the connection to trace the leak source"),
 
   /**
    * Enable optimization that disables column name sanitiser.
    */
-  DISABLE_COLUMN_SANITISER("disableColumnSanitiser", "false",
-      "Enable optimization that disables column name sanitiser"),
+  DISABLE_COLUMN_SANITISER(
+    "disableColumnSanitiser",
+    "false",
+    "Enable optimization that disables column name sanitiser"),
 
   /**
    * Control use of SSL: empty or {@code true} values imply {@code sslmode==verify-full}
    */
-  SSL("ssl", null, "Control use of SSL (any non-null value causes SSL to be required)"),
+  SSL(
+    "ssl",
+    null,
+    "Control use of SSL (any non-null value causes SSL to be required)"),
 
   /**
    * Parameter governing the use of SSL. The allowed values are {@code disable}, {@code allow},
@@ -189,73 +252,100 @@ public enum PGProperty {
    * If {@code ssl} property is empty or set to {@code true} it implies {@code verify-full}.
    * Default mode is "require"
    */
-  SSL_MODE("sslmode", null, "Parameter governing the use of SSL", false,
-      "disable", "allow", "prefer", "require", "verify-ca", "verify-full"),
+  SSL_MODE(
+    "sslmode",
+    null,
+    "Parameter governing the use of SSL",
+    false,
+    new String[] {"disable", "allow", "prefer", "require", "verify-ca", "verify-full"}),
 
   /**
    * Classname of the SSL Factory to use (instance of {@code javax.net.ssl.SSLSocketFactory}).
    */
-  SSL_FACTORY("sslfactory", null, "Provide a SSLSocketFactory class when using SSL."),
+  SSL_FACTORY(
+    "sslfactory",
+    null,
+    "Provide a SSLSocketFactory class when using SSL."),
 
   /**
    * The String argument to give to the constructor of the SSL Factory.
    * @deprecated use {@code ..Factory(Properties)} constructor.
    */
   @Deprecated
-  SSL_FACTORY_ARG("sslfactoryarg", null,
-      "Argument forwarded to constructor of SSLSocketFactory class."),
+  SSL_FACTORY_ARG(
+    "sslfactoryarg",
+    null,
+    "Argument forwarded to constructor of SSLSocketFactory class."),
 
   /**
    * Classname of the SSL HostnameVerifier to use (instance of {@code
    * javax.net.ssl.HostnameVerifier}).
    */
-  SSL_HOSTNAME_VERIFIER("sslhostnameverifier", null,
-      "A class, implementing javax.net.ssl.HostnameVerifier that can verify the server"),
+  SSL_HOSTNAME_VERIFIER(
+    "sslhostnameverifier",
+    null,
+    "A class, implementing javax.net.ssl.HostnameVerifier that can verify the server"),
 
   /**
    * File containing the SSL Certificate. Default will be the file {@code postgresql.crt} in {@code
    * $HOME/.postgresql} (*nix) or {@code %APPDATA%\postgresql} (windows).
    */
-  SSL_CERT("sslcert", null, "The location of the client's SSL certificate"),
+  SSL_CERT(
+    "sslcert",
+    null,
+    "The location of the client's SSL certificate"),
 
   /**
    * File containing the SSL Key. Default will be the file {@code postgresql.pk8} in {@code
    * $HOME/.postgresql} (*nix) or {@code %APPDATA%\postgresql} (windows).
    */
-  SSL_KEY("sslkey", null, "The location of the client's PKCS#8 SSL key"),
+  SSL_KEY(
+    "sslkey",
+    null,
+    "The location of the client's PKCS#8 SSL key"),
 
   /**
    * File containing the root certificate when validating server ({@code sslmode} = {@code
    * verify-ca} or {@code verify-full}). Default will be the file {@code root.crt} in {@code
    * $HOME/.postgresql} (*nix) or {@code %APPDATA%\postgresql} (windows).
    */
-  SSL_ROOT_CERT("sslrootcert", null,
-      "The location of the root certificate for authenticating the server."),
+  SSL_ROOT_CERT(
+    "sslrootcert",
+    null,
+    "The location of the root certificate for authenticating the server."),
 
   /**
    * The SSL password to use in the default CallbackHandler.
    */
-  SSL_PASSWORD("sslpassword", null,
-      "The password for the client's ssl key (ignored if sslpasswordcallback is set)"),
+  SSL_PASSWORD(
+    "sslpassword",
+    null,
+    "The password for the client's ssl key (ignored if sslpasswordcallback is set)"),
 
   /**
    * The classname instantiating {@code javax.security.auth.callback.CallbackHandler} to use.
    */
-  SSL_PASSWORD_CALLBACK("sslpasswordcallback", null,
-      "A class, implementing javax.security.auth.callback.CallbackHandler that can handle PassworCallback for the ssl password."),
+  SSL_PASSWORD_CALLBACK(
+    "sslpasswordcallback",
+    null,
+    "A class, implementing javax.security.auth.callback.CallbackHandler that can handle PassworCallback for the ssl password."),
 
   /**
    * Enable or disable TCP keep-alive. The default is {@code false}.
    */
-  TCP_KEEP_ALIVE("tcpKeepAlive", "false",
-      "Enable or disable TCP keep-alive. The default is {@code false}."),
+  TCP_KEEP_ALIVE(
+    "tcpKeepAlive",
+    "false",
+    "Enable or disable TCP keep-alive. The default is {@code false}."),
 
   /**
    * Specify how long to wait for establishment of a database connection. The timeout is specified
    * in seconds.
    */
-  LOGIN_TIMEOUT("loginTimeout", "0",
-      "Specify how long to wait for establishment of a database connection."),
+  LOGIN_TIMEOUT(
+    "loginTimeout",
+    "0",
+    "Specify how long to wait for establishment of a database connection."),
 
   /**
    * <p>The timeout value used for socket connect operations. If connecting to the server takes longer
@@ -263,7 +353,10 @@ public enum PGProperty {
    *
    * <p>The timeout is specified in seconds and a value of zero means that it is disabled.</p>
    */
-  CONNECT_TIMEOUT("connectTimeout", "10", "The timeout value used for socket connect operations."),
+  CONNECT_TIMEOUT(
+    "connectTimeout",
+    "10",
+    "The timeout value used for socket connect operations."),
 
   /**
    * The timeout value used for socket read operations. If reading from the server takes longer than
@@ -271,7 +364,10 @@ public enum PGProperty {
    * timeout and a method of detecting network problems. The timeout is specified in seconds and a
    * value of zero means that it is disabled.
    */
-  SOCKET_TIMEOUT("socketTimeout", "0", "The timeout value used for socket read operations."),
+  SOCKET_TIMEOUT(
+    "socketTimeout",
+    "0",
+    "The timeout value used for socket read operations."),
 
   /**
    * Cancel command is sent out of band over its own connection, so cancel message can itself get
@@ -279,7 +375,10 @@ public enum PGProperty {
    * This property controls "connect timeout" and "socket timeout" used for cancel commands.
    * The timeout is specified in seconds. Default value is 10 seconds.
    */
-  CANCEL_SIGNAL_TIMEOUT("cancelSignalTimeout", "10", "The timeout that is used for sending cancel command."),
+  CANCEL_SIGNAL_TIMEOUT(
+    "cancelSignalTimeout",
+    "10",
+    "The timeout that is used for sending cancel command."),
 
   /**
    * Socket factory used to create socket. A null value, which is the default, means system default.
@@ -291,56 +390,79 @@ public enum PGProperty {
    * @deprecated use {@code ..Factory(Properties)} constructor.
    */
   @Deprecated
-  SOCKET_FACTORY_ARG("socketFactoryArg", null,
-      "Argument forwarded to constructor of SocketFactory class."),
+  SOCKET_FACTORY_ARG(
+    "socketFactoryArg",
+    null,
+    "Argument forwarded to constructor of SocketFactory class."),
 
   /**
    * Socket read buffer size (SO_RECVBUF). A value of {@code -1}, which is the default, means system
    * default.
    */
-  RECEIVE_BUFFER_SIZE("receiveBufferSize", "-1", "Socket read buffer size"),
+  RECEIVE_BUFFER_SIZE(
+    "receiveBufferSize",
+    "-1",
+    "Socket read buffer size"),
 
   /**
    * Socket write buffer size (SO_SNDBUF). A value of {@code -1}, which is the default, means system
    * default.
    */
-  SEND_BUFFER_SIZE("sendBufferSize", "-1", "Socket write buffer size"),
+  SEND_BUFFER_SIZE(
+    "sendBufferSize",
+    "-1",
+    "Socket write buffer size"),
 
   /**
    * Assume the server is at least that version.
    */
-  ASSUME_MIN_SERVER_VERSION("assumeMinServerVersion", null,
-      "Assume the server is at least that version"),
+  ASSUME_MIN_SERVER_VERSION(
+    "assumeMinServerVersion",
+    null,
+    "Assume the server is at least that version"),
 
   /**
    * The application name (require server version &gt;= 9.0).
    */
-  APPLICATION_NAME("ApplicationName", DriverInfo.DRIVER_NAME, "Name of the Application (backend >= 9.0)"),
+  APPLICATION_NAME(
+    "ApplicationName",
+    DriverInfo.DRIVER_NAME,
+    "Name of the Application (backend >= 9.0)"),
 
   /**
    * Flag to enable/disable obtaining a GSS credential via JAAS login before authenticating.
    * Useful if setting system property javax.security.auth.useSubjectCredsOnly=false
    * or using native GSS with system property sun.security.jgss.native=true
    */
-  JAAS_LOGIN("jaasLogin", "true", "Login with JAAS before doing GSSAPI authentication"),
+  JAAS_LOGIN(
+    "jaasLogin",
+    "true",
+    "Login with JAAS before doing GSSAPI authentication"),
 
   /**
    * Specifies the name of the JAAS system or application login configuration.
    */
-  JAAS_APPLICATION_NAME("jaasApplicationName", null,
-      "Specifies the name of the JAAS system or application login configuration."),
+  JAAS_APPLICATION_NAME(
+    "jaasApplicationName",
+    null,
+    "Specifies the name of the JAAS system or application login configuration."),
 
   /**
    * The Kerberos service name to use when authenticating with GSSAPI. This is equivalent to libpq's
    * PGKRBSRVNAME environment variable.
    */
-  KERBEROS_SERVER_NAME("kerberosServerName", null,
-      "The Kerberos service name to use when authenticating with GSSAPI."),
+  KERBEROS_SERVER_NAME(
+    "kerberosServerName",
+    null,
+    "The Kerberos service name to use when authenticating with GSSAPI."),
 
   /**
    * Use SPNEGO in SSPI authentication requests.
    */
-  USE_SPNEGO("useSpnego", "false", "Use SPNEGO in SSPI authentication requests"),
+  USE_SPNEGO(
+    "useSpnego",
+    "false",
+    "Use SPNEGO in SSPI authentication requests"),
 
   /**
    * Force one of
@@ -350,13 +472,21 @@ public enum PGProperty {
    * </ul>
    * to be used when the server requests Kerberos or SSPI authentication.
    */
-  GSS_LIB("gsslib", "auto", "Force SSSPI or GSSAPI", false, "auto", "sspi", "gssapi"),
+  GSS_LIB(
+    "gsslib",
+    "auto",
+    "Force SSSPI or GSSAPI",
+    false,
+    new String[] {"auto", "sspi", "gssapi"}),
 
   /**
    * Specifies the name of the SSPI service class that forms the service class part of the SPN. The
    * default, {@code POSTGRES}, is almost always correct.
    */
-  SSPI_SERVICE_CLASS("sspiServiceClass", "POSTGRES", "The Windows SSPI service class for SPN"),
+  SSPI_SERVICE_CLASS(
+    "sspiServiceClass",
+    "POSTGRES",
+    "The Windows SSPI service class for SPN"),
 
   /**
    * When using the V3 protocol the driver monitors changes in certain server configuration
@@ -364,22 +494,36 @@ public enum PGProperty {
    * by the driver and should not be altered. If the driver detects a change it will abort the
    * connection.
    */
-  ALLOW_ENCODING_CHANGES("allowEncodingChanges", "false", "Allow for changes in client_encoding"),
+  ALLOW_ENCODING_CHANGES(
+    "allowEncodingChanges",
+    "false",
+    "Allow for changes in client_encoding"),
 
   /**
    * Specify the schema to be set in the search-path. This schema will be used to resolve
    * unqualified object names used in statements over this connection.
    */
-  CURRENT_SCHEMA("currentSchema", null, "Specify the schema to be set in the search-path"),
+  CURRENT_SCHEMA(
+    "currentSchema",
+    null,
+    "Specify the schema to be set in the search-path"),
 
-  TARGET_SERVER_TYPE("targetServerType", "any", "Specifies what kind of server to connect", false,
-      "any", "master", "slave", "secondary",  "preferSlave", "preferSecondary"),
+  TARGET_SERVER_TYPE(
+    "targetServerType",
+    "any",
+    "Specifies what kind of server to connect",
+    false,
+    new String[] {"any", "master", "slave", "secondary",  "preferSlave", "preferSecondary"}),
 
-  LOAD_BALANCE_HOSTS("loadBalanceHosts", "false",
-      "If disabled hosts are connected in the given order. If enabled hosts are chosen randomly from the set of suitable candidates"),
+  LOAD_BALANCE_HOSTS(
+    "loadBalanceHosts",
+    "false",
+    "If disabled hosts are connected in the given order. If enabled hosts are chosen randomly from the set of suitable candidates"),
 
-  HOST_RECHECK_SECONDS("hostRecheckSeconds", "10",
-      "Specifies period (seconds) after which the host status is checked again in case it has changed"),
+  HOST_RECHECK_SECONDS(
+    "hostRecheckSeconds",
+    "10",
+    "Specifies period (seconds) after which the host status is checked again in case it has changed"),
 
   /**
    * <p>Specifies which mode is used to execute queries to database: simple means ('Q' execute, no parse, no bind, text mode only),
@@ -388,11 +532,13 @@ public enum PGProperty {
    *
    * <p>This mode is meant for debugging purposes and/or for cases when extended protocol cannot be used (e.g. logical replication protocol)</p>
    */
-  PREFER_QUERY_MODE("preferQueryMode", "extended",
-      "Specifies which mode is used to execute queries to database: simple means ('Q' execute, no parse, no bind, text mode only), "
-          + "extended means always use bind/execute messages, extendedForPrepared means extended for prepared statements only, "
-          + "extendedCacheEverything means use extended protocol and try cache every statement (including Statement.execute(String sql)) in a query cache.", false,
-      "extended", "extendedForPrepared", "extendedCacheEverything", "simple"),
+  PREFER_QUERY_MODE(
+    "preferQueryMode",
+    "extended",
+    "Specifies which mode is used to execute queries to database: simple means ('Q' execute, no parse, no bind, text mode only), "
+        + "extended means always use bind/execute messages, extendedForPrepared means extended for prepared statements only, "
+        + "extendedCacheEverything means use extended protocol and try cache every statement (including Statement.execute(String sql)) in a query cache.", false,
+    new String[] {"extended", "extendedForPrepared", "extendedCacheEverything", "simple"}),
 
   /**
    * Specifies what the driver should do if a query fails. In {@code autosave=always} mode, JDBC driver sets a savepoint before each query,
@@ -400,23 +546,31 @@ public enum PGProperty {
    * In {@code autosave=conservative} mode, savepoint is set for each query, however the rollback is done only for rare cases
    * like 'cached statement cannot change return type' or 'statement XXX is not valid' so JDBC driver rollsback and retries
    */
-  AUTOSAVE("autosave", "never",
-      "Specifies what the driver should do if a query fails. In autosave=always mode, JDBC driver sets a savepoint before each query, "
-          + "and rolls back to that savepoint in case of failure. In autosave=never mode (default), no savepoint dance is made ever. "
-          + "In autosave=conservative mode, safepoint is set for each query, however the rollback is done only for rare cases"
-          + " like 'cached statement cannot change return type' or 'statement XXX is not valid' so JDBC driver rollsback and retries", false,
-      "always", "never", "conservative"),
+  AUTOSAVE(
+    "autosave",
+    "never",
+    "Specifies what the driver should do if a query fails. In autosave=always mode, JDBC driver sets a savepoint before each query, "
+        + "and rolls back to that savepoint in case of failure. In autosave=never mode (default), no savepoint dance is made ever. "
+        + "In autosave=conservative mode, safepoint is set for each query, however the rollback is done only for rare cases"
+        + " like 'cached statement cannot change return type' or 'statement XXX is not valid' so JDBC driver rollsback and retries", false,
+    new String[] {"always", "never", "conservative"}),
 
   /**
    *
    */
-  CLEANUP_SAVEPOINTS("cleanupSavepoints", "false","Determine whether SAVEPOINTS used in AUTOSAVE will be released per query or not",
-      false, "true", "false"),
+  CLEANUP_SAVEPOINTS(
+    "cleanupSavepoints",
+    "false",
+    "Determine whether SAVEPOINTS used in AUTOSAVE will be released per query or not",
+    false,
+    new String[] {"true", "false"}),
   /**
    * Configure optimization to enable batch insert re-writing.
    */
-  REWRITE_BATCHED_INSERTS("reWriteBatchedInserts", "false",
-      "Enable optimization to rewrite and collapse compatible INSERT statements that are batched."),
+  REWRITE_BATCHED_INSERTS(
+    "reWriteBatchedInserts",
+    "false",
+    "Enable optimization to rewrite and collapse compatible INSERT statements that are batched."),
 
   /**
    * <p>Connection parameter passed in the startup message. This parameter accepts two values; "true"
@@ -428,16 +582,19 @@ public enum PGProperty {
    * <p>Parameter should be use together with {@link PGProperty#ASSUME_MIN_SERVER_VERSION} with
    * parameter &gt;= 9.4 (backend &gt;= 9.4)</p>
    */
-  REPLICATION("replication", null,
-      "Connection parameter passed in startup message, one of 'true' or 'database' "
-          + "Passing 'true' tells the backend to go into walsender mode, "
-          + "wherein a small set of replication commands can be issued instead of SQL statements. "
-          + "Only the simple query protocol can be used in walsender mode. "
-          + "Passing 'database' as the value instructs walsender to connect "
-          + "to the database specified in the dbname parameter, "
-          + "which will allow the connection to be used for logical replication "
-          + "from that database. "
-          + "(backend >= 9.4)");
+  REPLICATION(
+    "replication",
+    null,
+    "Connection parameter passed in startup message, one of 'true' or 'database' "
+      + "Passing 'true' tells the backend to go into walsender mode, "
+      + "wherein a small set of replication commands can be issued instead of SQL statements. "
+      + "Only the simple query protocol can be used in walsender mode. "
+      + "Passing 'database' as the value instructs walsender to connect "
+      + "to the database specified in the dbname parameter, "
+      + "which will allow the connection to be used for logical replication "
+      + "from that database. "
+      + "(backend >= 9.4)"),
+  ;
 
   private final String name;
   private final String defaultValue;
@@ -453,8 +610,7 @@ public enum PGProperty {
     this(name, defaultValue, description, required, (String[]) null);
   }
 
-  PGProperty(String name, String defaultValue, String description, boolean required,
-      String... choices) {
+  PGProperty(String name, String defaultValue, String description, boolean required, String[] choices) {
     this.name = name;
     this.defaultValue = defaultValue;
     this.required = required;


### PR DESCRIPTION
This PR is a series of commits to clean up the connection property docs pages and the related PGProperty enum. The net change moves things around quite a bit so may be easier to review the individual commits. Net result should be change to driver behavior as it's just reordering, addition of new getters, and doc updates.

* a85f3282 misc: Remove variadic constructor for PGProperty values and split across multiple lines - Longer term we're going to need to add some more structured information to the PGProperty enum so this commit gets rid of the convenience variadic constructor as it'd just be confusing down the road.
* 468d4817 perf: Cache PGProperty values in a map by name - I noticed one of the methods does a loop through all the values to find one matching by name. This commit builds a static cache on class load so the lookups are always O(1). It also does a sanity check that no two entries have the same name.
* 4196bfff misc: Add PGProperty.getDescription() - Eventually required for automated docs.
* dacc8aa6 misc: Add PGProperty.isRequired() - Eventually required for automated docs.
* aa63169a misc: Add PGProperty.isDeprecated() - Eventually required for automated docs. This is done via reflection of the `@Deprecated` annotation so should work for any future deprecations as well.
* 70834a30 docs: Sort connection properties by name - This is for the docs page itself. Nothing else changes in this commit and any bogus or misspelled properties are still retained. Just the order changes.
7c23cd5d fix: Correct cleanupSavepoints connection property in docs. - Docs version had a capital "P" for "Points" which would be silently ignored.
b8bb42fa docs: Remove non-existent connection property recvBufferSize
b789a4f6 docs: Add descriptions for missing connection properties - Adds descriptions for a couple properties that were in PGProperty but not in the docs.


Passes all travis tests and checkstyle too.