### PR TITLE
Using LinkedHashMap in HStoreConverter

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/util/HStoreConverter.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/HStoreConverter.java
@@ -10,13 +10,13 @@ import org.postgresql.core.Encoding;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.sql.SQLException;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 
 public class HStoreConverter {
   public static Map<String, String> fromBytes(byte[] b, Encoding encoding) throws SQLException {
-    Map<String, String> m = new HashMap<String, String>();
+    Map<String, String> m = new LinkedHashMap<String, String>();
     int pos = 0;
     int numElements = ByteConverter.int4(b, pos);
     pos += 4;
@@ -110,7 +110,7 @@ public class HStoreConverter {
   }
 
   public static Map<String, String> fromString(String s) {
-    Map<String, String> m = new HashMap<String, String>();
+    Map<String, String> m = new LinkedHashMap<String, String>();
     int pos = 0;
     StringBuilder sb = new StringBuilder();
     while (pos < s.length()) {


### PR DESCRIPTION
This lets the map return the keys in the same order as in the given HStore value.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

Hey @davecramer, a minor improvement to `HStoreConverter`, so it returns maps with the same iteration order as parsed HStore values. Not sure whether/how I should test this?

Thanks!