### PR TITLE
Make ConnectTimeout test accept NoRouteToHostException

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/QueryExecutorBase.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/QueryExecutorBase.java
@@ -344,6 +344,10 @@ public abstract class QueryExecutorBase implements QueryExecutor {
   }
 
   protected boolean willHealViaReparse(SQLException e) {
+    if (e == null || e.getSQLState() == null) {
+      return false;
+    }
+
     // "prepared statement \"S_2\" does not exist"
     if (PSQLState.INVALID_SQL_STATEMENT_NAME.getState().equals(e.getSQLState())) {
       return true;

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ConnectTimeoutTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ConnectTimeoutTest.java
@@ -10,9 +10,11 @@ import static org.junit.Assert.fail;
 
 import org.postgresql.test.TestUtil;
 
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.net.NoRouteToHostException;
 import java.net.SocketTimeoutException;
 import java.sql.DriverManager;
 import java.sql.SQLException;
@@ -41,11 +43,27 @@ public class ConnectTimeoutTest {
     try {
       DriverManager.getConnection(UNREACHABLE_URL, props);
     } catch (SQLException e) {
-      assertTrue("Unexpected " + e.toString(),
-          e.getCause() instanceof SocketTimeoutException);
       final long interval = System.currentTimeMillis() - startTime;
       final long connectTimeoutMillis = CONNECT_TIMEOUT * 1000;
       final long maxDeviation = connectTimeoutMillis / 10;
+
+      /*
+       * If the platform fast-fails the unroutable address connection then this
+       * test may not time out, instead throwing
+       * java.net.NoRouteToHostException. The test has failed in that the connection
+       * attempt did not time out.
+       *
+       * We treat this as a skipped test, as the test didn't really "succeed"
+       * in testing the original behaviour, but it didn't fail either.
+       */
+      Assume.assumeTrue("Host fast-failed connection to unreachable address "
+                        + UNREACHABLE_HOST + " after " + interval + " ms, "
+                        + " before timeout should have triggered.",
+                        e.getCause() instanceof NoRouteToHostException
+                        && interval < connectTimeoutMillis );
+
+      assertTrue("Unexpected " + e.toString() + " with cause " + e.getCause(),
+          e.getCause() instanceof SocketTimeoutException);
       // check that it was not a default system timeout, an approximate value is used
       assertTrue(Math.abs(interval - connectTimeoutMillis) < maxDeviation);
       return;


### PR DESCRIPTION
The `ConnectTimeout` test expects an exception of type `SocketTimeoutException` when connecting to the unroutable address `10.255.255.1`. But at least on my host (Fedora 30, OpenJDK 1.8.0_212) the connection attempt actually throws `java.net.NoRouteToHostException`.

That is an entirely reasonable exception to throw in this case, but not the intent of the test.

I think the test is intended to time out while connecting to the unreachable address. But it relies on highly platform-dependent behaviour. In particular if there's any sort of negative caching in place the test may fast-fail:

```
~/.../2Q/pgjdbc (miscfix *%)$ time ping -c 1 10.255.255.1
PING 10.255.255.1 (10.255.255.1) 56(84) bytes of data.
From 61.245.136.1 icmp_seq=1 Packet filtered

--- 10.255.255.1 ping statistics ---
1 packets transmitted, 0 received, +1 errors, 100% packet loss, time 0ms


real	0m0.122s
user	0m0.003s
sys	0m0.018s
```

rendering the test useless for the intended purpose.

I propose to treat this as a skipped test, per the associated pull request.

(I've also included a trivial fix for a normally-unreachable NPE I hit during testing here).