### PR TITLE
fix: method returns empty array instead of null

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
@@ -2325,8 +2325,9 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
   public byte[] getBytes(int columnIndex) throws SQLException {
     connection.getLogger().log(Level.FINEST, "  getBytes columnIndex: {0}", columnIndex);
     checkResultSet(columnIndex);
+    byte[] arr = new byte[0];
     if (wasNullFlag) {
-      return null;
+      return arr;
     }
 
     if (isBinary(columnIndex)) {


### PR DESCRIPTION
Method returns null instead of empty array for `PgResultSet`
relates to Fix huntbugs warnings [#586](https://github.com/pgjdbc/pgjdbc/issues/586)