### PR TITLE
docs: Add note to GitHub PR templates about test suites

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,6 +9,7 @@
 
 1. [ ] Does your submission pass tests?
 2. [ ] Does mvn checkstyle:check pass ?
+3. [ ] Have you added your new test classes to an existing test suite?
 
 ### Changes to Existing Features:
 


### PR DESCRIPTION
Adds a note to the GitHub PR template to verify that any new test files have been added to an existing test suite to ensure they are actually included in automated CI testing.

If anybody has a better suggestion for the wording feel free to replace. The point is to remind contributors that that any new test additions must be included somewhere to actually run.