### PR TITLE
Mshajarrazip issue1136

### DIFF
--- a/docs/documentation/94/resultset.md
+++ b/docs/documentation/94/resultset.md
@@ -17,3 +17,9 @@ The following must be considered when using the `ResultSet` interface:
 	it.
 * Once you make another query with the `Statement` used to create a `ResultSet`,
 	the currently open `ResultSet` instance is closed automatically.
+* When PreparedStatement API is used, `ResultSet` switches to binary mode after 
+	5 query executions (this is set by the `prepareThreshold` 
+	connection property - see [Server Prepared Statements](server-prepare.md)). 
+	This may cause unexpected behavior when some methods are called. For example, 
+	methods such as `getString()` on double type may yield a slightly different 
+	representation after query execution exceeds the set `prepareThreshold`. 

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -213,6 +213,11 @@ public class QueryExecutorImpl extends QueryExecutorBase {
   // Query parsing
   //
 
+  /**
+   * Stores the original SQL text for display in error message. 
+   */
+  private String SQLtext; 
+  
   public Query createSimpleQuery(String sql) throws SQLException {
     List<NativeQuery> queries = Parser.parseJdbcSql(sql,
         getStandardConformingStrings(), false, true,
@@ -272,6 +277,8 @@ public class QueryExecutorImpl extends QueryExecutorBase {
 
   public synchronized void execute(Query query, ParameterList parameters, ResultHandler handler,
       int maxRows, int fetchSize, int flags) throws SQLException {
+	
+	SQLtext = query.getNativeSql();
     waitOnLock();
     if (LOGGER.isLoggable(Level.FINEST)) {
       LOGGER.log(Level.FINEST, "  simple execute, handler={0}, maxRows={1}, fetchSize={2}, flags={3}",
@@ -306,7 +313,7 @@ public class QueryExecutorImpl extends QueryExecutorBase {
         } else {
           sendSync();
         }
-        processResults(handler, flags);
+        processResults(handler, flags); 
         estimatedReceiveBufferBytes = 0;
       } catch (PGBindException se) {
         // There are three causes of this error, an
@@ -2465,7 +2472,7 @@ public class QueryExecutorImpl extends QueryExecutorBase {
       LOGGER.log(Level.FINEST, " <=BE ErrorMessage({0})", errorMsg.toString());
     }
 
-    PSQLException error = new PSQLException(errorMsg);
+    PSQLException error = new PSQLException(errorMsg, SQLtext);
     if (transactionFailCause == null) {
       transactionFailCause = error;
     } else {

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2004, PostgreSQL Global Development Group
  * See the LICENSE file in the project root for more information.
  */

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright (c) 2004, PostgreSQL Global Development Group
  * See the LICENSE file in the project root for more information.
  */

--- a/pgjdbc/src/main/java/org/postgresql/util/PSQLException.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/PSQLException.java
@@ -23,6 +23,11 @@ public class PSQLException extends SQLException {
     super(serverError.toString(), serverError.getSQLState());
     this.serverError = serverError;
   }
+  
+  public PSQLException(ServerErrorMessage serverError, String SQLtext) {
+	    super(serverError.toString(SQLtext), serverError.getSQLState());
+	    this.serverError = serverError;
+	  }
 
   public ServerErrorMessage getServerErrorMessage() {
     return serverError;

--- a/pgjdbc/src/main/java/org/postgresql/util/ServerErrorMessage.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/ServerErrorMessage.java
@@ -143,74 +143,89 @@ public class ServerErrorMessage implements Serializable {
     return Integer.parseInt(s);
   }
 
+  public String toString(String SQLtext) {
+	    // Now construct the message from what the server sent
+	    // The general format is:
+	    // SEVERITY: Message \n
+	    // Detail: \n
+	    // Hint: \n
+	    // Position: \n
+	    // Where: \n
+	    // Internal Query: \n
+	    // Internal Position: \n
+	    // Location: File:Line:Routine \n
+	    // SQLState: \n
+	    //
+	    // Normally only the message and detail is included.
+	    // If INFO level logging is enabled then detail, hint, position and where are
+	    // included. If DEBUG level logging is enabled then all information
+	    // is included.
+
+	    StringBuilder totalMessage = new StringBuilder();
+	    String message = mesgParts.get(SEVERITY);
+	    if (message != null) {
+	      totalMessage.append(message).append(": ");
+	    }
+	    message = mesgParts.get(MESSAGE);
+	    if (message != null) {
+	      totalMessage.append(message);
+	    }
+	    message = mesgParts.get(DETAIL);
+	    if (message != null) {
+	      totalMessage.append("\n  ").append(GT.tr("Detail: {0}", message));
+	    }
+
+	    message = mesgParts.get(HINT);
+	    if (message != null) {
+	    	totalMessage.append("\n  ").append(GT.tr("Hint: {0}", message));
+	    }
+	    
+	    message = mesgParts.get(POSITION);
+	    if (message != null) {
+	    	if (SQLtext.equals("")) {
+	    		totalMessage.append("\n  ").append(GT.tr("Position: {0}", message));
+	    	} else {
+	    		totalMessage.append("\n  ").append(SQLtext); 
+	    		totalMessage.append("\n  ");
+	    		int pos = Integer.parseInt(message);
+	    		while (pos-- != 0) {
+	    			totalMessage.append(" ");
+	    		}
+	    		totalMessage.append("^");
+	    	}
+	    }
+	    
+	    message = mesgParts.get(WHERE);
+	    if (message != null) {
+	      totalMessage.append("\n  ").append(GT.tr("Where: {0}", message));
+	    }
+
+	    if (LOGGER.isLoggable(Level.FINEST)) {
+	      String internalQuery = mesgParts.get(INTERNAL_QUERY);
+	      if (internalQuery != null) {
+	        totalMessage.append("\n  ").append(GT.tr("Internal Query: {0}", internalQuery));
+	      }
+	      String internalPosition = mesgParts.get(INTERNAL_POSITION);
+	      if (internalPosition != null) {
+	        totalMessage.append("\n  ").append(GT.tr("Internal Position: {0}", internalPosition));
+	      }
+
+	      String file = mesgParts.get(FILE);
+	      String line = mesgParts.get(LINE);
+	      String routine = mesgParts.get(ROUTINE);
+	      if (file != null || line != null || routine != null) {
+	        totalMessage.append("\n  ").append(GT.tr("Location: File: {0}, Routine: {1}, Line: {2}",
+	            file, routine, line));
+	      }
+	      message = mesgParts.get(SQLSTATE);
+	      if (message != null) {
+	        totalMessage.append("\n  ").append(GT.tr("Server SQLState: {0}", message));
+	      }
+	    }
+
+	    return totalMessage.toString();
+  }
   public String toString() {
-    // Now construct the message from what the server sent
-    // The general format is:
-    // SEVERITY: Message \n
-    // Detail: \n
-    // Hint: \n
-    // Position: \n
-    // Where: \n
-    // Internal Query: \n
-    // Internal Position: \n
-    // Location: File:Line:Routine \n
-    // SQLState: \n
-    //
-    // Normally only the message and detail is included.
-    // If INFO level logging is enabled then detail, hint, position and where are
-    // included. If DEBUG level logging is enabled then all information
-    // is included.
-
-    StringBuilder totalMessage = new StringBuilder();
-    String message = mesgParts.get(SEVERITY);
-    if (message != null) {
-      totalMessage.append(message).append(": ");
-    }
-    message = mesgParts.get(MESSAGE);
-    if (message != null) {
-      totalMessage.append(message);
-    }
-    message = mesgParts.get(DETAIL);
-    if (message != null) {
-      totalMessage.append("\n  ").append(GT.tr("Detail: {0}", message));
-    }
-
-    message = mesgParts.get(HINT);
-    if (message != null) {
-      totalMessage.append("\n  ").append(GT.tr("Hint: {0}", message));
-    }
-    message = mesgParts.get(POSITION);
-    if (message != null) {
-      totalMessage.append("\n  ").append(GT.tr("Position: {0}", message));
-    }
-    message = mesgParts.get(WHERE);
-    if (message != null) {
-      totalMessage.append("\n  ").append(GT.tr("Where: {0}", message));
-    }
-
-    if (LOGGER.isLoggable(Level.FINEST)) {
-      String internalQuery = mesgParts.get(INTERNAL_QUERY);
-      if (internalQuery != null) {
-        totalMessage.append("\n  ").append(GT.tr("Internal Query: {0}", internalQuery));
-      }
-      String internalPosition = mesgParts.get(INTERNAL_POSITION);
-      if (internalPosition != null) {
-        totalMessage.append("\n  ").append(GT.tr("Internal Position: {0}", internalPosition));
-      }
-
-      String file = mesgParts.get(FILE);
-      String line = mesgParts.get(LINE);
-      String routine = mesgParts.get(ROUTINE);
-      if (file != null || line != null || routine != null) {
-        totalMessage.append("\n  ").append(GT.tr("Location: File: {0}, Routine: {1}, Line: {2}",
-            file, routine, line));
-      }
-      message = mesgParts.get(SQLSTATE);
-      if (message != null) {
-        totalMessage.append("\n  ").append(GT.tr("Server SQLState: {0}", message));
-      }
-    }
-
-    return totalMessage.toString();
+	  	return toString("");
   }
 }

--- a/pgjdbc/src/main/java/org/postgresql/util/ServerErrorMessage.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/ServerErrorMessage.java
@@ -182,9 +182,7 @@ public class ServerErrorMessage implements Serializable {
 	    
 	    message = mesgParts.get(POSITION);
 	    if (message != null) {
-	    	if (SQLtext.equals("")) {
-	    		totalMessage.append("\n  ").append(GT.tr("Position: {0}", message));
-	    	} else {
+	    	if (!SQLtext.equals("")) {
 	    		totalMessage.append("\n  ").append(SQLtext); 
 	    		totalMessage.append("\n  ");
 	    		int pos = Integer.parseInt(message);
@@ -193,6 +191,7 @@ public class ServerErrorMessage implements Serializable {
 	    		}
 	    		totalMessage.append("^");
 	    	}
+	    	totalMessage.append("\n  ").append(GT.tr("Position: {0}", message));
 	    }
 	    
 	    message = mesgParts.get(WHERE);
@@ -225,7 +224,9 @@ public class ServerErrorMessage implements Serializable {
 
 	    return totalMessage.toString();
   }
+  
   public String toString() {
 	  	return toString("");
   }
+  
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Does mvn checkstyle:check pass ?

### Changes to Existing Features:

* [ ] Does this break existing behaviour? If so please explain.
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully run tests with your changes locally?

------------------------
This adds SQL text to the SQLException error message. Changes made to code:

1) In `org/postgresql/core/v3/QueryExecutorImpl.java:219`, I added a new private member called `SQLtext` to store the original SQL text in query. This is initialized when QueryExecutorImpl.execute() is called (line 281), when the Query object is first passed to be processed. 

```
  /**
   * Stores the original SQL text for display in error message. 
   */
  private String SQLtext; 
```

2) The error message is parsed by the toString() method based on the server error message, defined in org.postgresql.util.ServerErrorMessage, so I overload the method by adding a parameter for SQLtext and have the old one return the new one, initialized to an empty string. In the new ServerErrorMessage.toString(String SQLtext), the SQL text is added to the error message if POSITION is returned by the server. 

```
	    message = mesgParts.get(POSITION);
	    if (message != null) {
	    	if (!SQLtext.equals("")) {
	    		totalMessage.append("\n  ").append(SQLtext); 
	    		totalMessage.append("\n  ");
	    		int pos = Integer.parseInt(message);
	    		while (pos-- != 0) {
	    			totalMessage.append(" ");
	    		}
	    		totalMessage.append("^");
	    	}
	    	totalMessage.append("\n  ").append(GT.tr("Position: {0}", message));
	    }
```

3) ServerErrorMessage.toString() is used in the constructor of PSQLException like this:

```
public PSQLException(ServerErrorMessage serverError) {
    super(serverError.toString(), serverError.getSQLState());
    this.serverError = serverError;
  }
```

So to bind the SQLtext to the error message, I created a new constructor that uses the new overloading method:

```
  public PSQLException(ServerErrorMessage serverError, String SQLtext) {
	    super(serverError.toString(SQLtext), serverError.getSQLState());
	    this.serverError = serverError;
	  }
```

The output is as follows:

```
org.postgresql.util.PSQLException: ERROR: syntax error at or near "x"
  select 'abc' as a x
                     ^
  Position: 19
	at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2475)
	at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2218)
	at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:316)
	at org.postgresql.jdbc.PgStatement.executeInternal(PgStatement.java:445)
	at org.postgresql.jdbc.PgStatement.execute(PgStatement.java:369)
	at org.postgresql.jdbc.PgStatement.executeWithFlags(PgStatement.java:311)
	at org.postgresql.jdbc.PgStatement.executeCachedSql(PgStatement.java:297)
	at org.postgresql.jdbc.PgStatement.executeWithFlags(PgStatement.java:274)
	at org.postgresql.jdbc.PgStatement.executeQuery(PgStatement.java:225)
	at org.postgresql.test.jdbc2.ClientEncodingTest.checkConnectionSanity(ClientEncodingTest.java:73)
	at org.postgresql.test.jdbc2.ClientEncodingTest.setEncodingAscii(ClientEncodingTest.java:68)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runners.Suite.runChild(Suite.java:128)
	at org.junit.runners.Suite.runChild(Suite.java:27)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.eclipse.jdt.internal.junit4.runner.JUnit4TestReference.run(JUnit4TestReference.java:89)
	at org.eclipse.jdt.internal.junit.runner.TestExecution.run(TestExecution.java:41)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:541)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:763)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.run(RemoteTestRunner.java:463)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.main(RemoteTestRunner.java:209)


```


