### PR TITLE
Add an apache karaf feature for the PostgreSQL JDBC driver to fix #1552

### DIFF
--- a/pgjdbc/pom.xml
+++ b/pgjdbc/pom.xml
@@ -301,6 +301,27 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.karaf.tooling</groupId>
+        <artifactId>karaf-maven-plugin</artifactId>
+        <version>4.2.5</version>
+        <extensions>true</extensions>
+        <configuration>
+          <startLevel>80</startLevel>
+          <includeTransitiveDependency>false</includeTransitiveDependency>
+          <aggregateFeatures>false</aggregateFeatures>
+          <includeProjectArtifact>true</includeProjectArtifact>
+        </configuration>
+        <executions>
+          <execution>
+            <id>generate-features-file</id>
+            <phase>package</phase>
+            <goals>
+              <goal>features-generate-descriptor</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
 
     <pluginManagement>

--- a/pgjdbc/src/main/feature/feature.xml
+++ b/pgjdbc/src/main/feature/feature.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<features xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
+  <feature name="postgresql" description="PostgreSQL JDBC driver karaf feature" version="${project.version}">
+    <feature>transaction-api</feature>
+  </feature>
+</features>


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [X] Does your submission pass tests?
2. [X] Does mvn checkstyle:check pass ?

### Changes to Existing Features:

* [ ] Have you written new tests for your core changes, as applicable?
* [X] Have you successfully run tests with your changes locally?

An explanation of the changes:

1. A karaf-maven-plugin configuraion added to the <build> of the pgjdbc POM
2. A template feature.xml file pulling in the karaf built-in feature transaction-api, which contains all of the postgresql OSGi bundle's runtime dependencies
3. The result of the build is a maven attachment to the jar artifact with type "xml" and classifier "features"

How to use the feature
1. From a maven project for an OSGi bundle that needs postgresql JDBC as a runtime dependency in apache karaf, add the following maven dependency:
    ```
        <dependency>
            <groupId>org.postgresql</groupId>
            <artifactId>postgresql</artifactId>
            <version>42.2.7</version>
            <type>xml</type>
            <classifier>features</classifier>
        </dependency>
    ```
2. Alternatively, it's also possible to add a feature dependency to "postgresql" in the template feature.xml file (i.e. src/main/feature/feature.xml):
    ```
    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
    <features xmlns="http://karaf.apache.org/xmlns/features/v1.4.0" name="authservice.bundle">
        <repository>mvn:org.postgresql/postgresql/42.2.7-SNAPSHOT/xml/features</repository>
        <feature name="${karaf-feature-name}">
            <feature>postgresql</feature>
        </feature>
    </features>
    ```
    (preferences vary. I prefer to use maven dependencies. It is possible to use maven properties inside the karaf feature files)

Test procedure:
1. Download and start the newest stable version of apache karaf, using the [Apache Karaf Quick Start guide](https://karaf.apache.org/manual/latest/quick-start.html) (basically download the binary tar.gz or .zip, unpack it and run the startup script
2. After starting karaf you will be presented with the karaf command shell prompt
3. In the karaf command shell prompt, load the most recent version of the karaf "feature repository" (the XML file maven attachment created by this pull request)
    ```
    feature:repo-add mvn:org.postgresql/postgresql/LATEST/xml/features
    ```
4. In the karaf command shell prompt, load the postgresql feature
    ```
    feature:install postgresql
    ```
5. At this stage, if you don't get any error messages the bundle has loaded and started
6. It is possible to list all OSGi bundles loaded and started by this feature, with the command
    ```
    bundle:list
    ```
7. It is possible to examine the capabilities of the postgresql, with the command:
    ```
    bundle:capabilities org.postgresql.jdbc42
    ```

Here's an example of running the commands in karaf on my development system:
```
karaf@root()> feature:repo-add mvn:org.postgresql/postgresql/LATEST/xml/features
Adding feature url mvn:org.postgresql/postgresql/LATEST/xml/features
karaf@root()> feature:install postgresql
karaf@root()> bundle:list
START LEVEL 100 , List Threshold: 50
ID │ State  │ Lvl │ Version         │ Name
───┼────────┼─────┼─────────────────┼──────────────────────
23 │ Active │  80 │ 4.2.6           │ Apache Karaf :: OSGi Services :: Event
45 │ Active │  80 │ 3.0.0           │ Expression Language 3.0 API
46 │ Active │  80 │ 1.2.0           │ CDI APIs
47 │ Active │  80 │ 1.2             │ javax.interceptor API
48 │ Active │  80 │ 1.2             │ javax.transaction API
49 │ Active │  80 │ 1.0.0.2         │ Apache ServiceMix :: Bundles :: javax.inject
50 │ Active │  80 │ 0.4.3           │ pax-transx-tm-api
51 │ Active │  80 │ 42.2.7.SNAPSHOT │ PostgreSQL JDBC Driver JDBC42
52 │ Active │  80 │ 0               │ wrap_file__home_sb_.m2_repository_com_github_waffle_waffle-jna_1.9.1_waffle-jna-1.9.1.jar
53 │ Active │  80 │ 0               │ wrap_file__home_sb_.m2_repository_com_ongres_scram_client_2.0_client-2.0.jar
karaf@root()> bundle:capabilities org.postgresql.jdbc42
org.postgresql.jdbc42 [51] provides:
------------------------------------
osgi.wiring.bundle; org.postgresql.jdbc42 42.2.7.SNAPSHOT [UNUSED]
osgi.wiring.host; org.postgresql.jdbc42 42.2.7.SNAPSHOT [UNUSED]
osgi.identity; org.postgresql.jdbc42 42.2.7.SNAPSHOT [UNUSED]
osgi.wiring.package; org.postgresql 42.2.7.SNAPSHOT [UNUSED]
osgi.wiring.package; org.postgresql.copy 42.2.7.SNAPSHOT [UNUSED]
osgi.wiring.package; org.postgresql.core 42.2.7.SNAPSHOT [UNUSED]
osgi.wiring.package; org.postgresql.core.v3 42.2.7.SNAPSHOT [UNUSED]
osgi.wiring.package; org.postgresql.core.v3.replication 42.2.7.SNAPSHOT [UNUSED]
osgi.wiring.package; org.postgresql.ds 42.2.7.SNAPSHOT [UNUSED]
osgi.wiring.package; org.postgresql.ds.common 42.2.7.SNAPSHOT [UNUSED]
osgi.wiring.package; org.postgresql.fastpath 42.2.7.SNAPSHOT [UNUSED]
osgi.wiring.package; org.postgresql.geometric 42.2.7.SNAPSHOT [UNUSED]
osgi.wiring.package; org.postgresql.gss 42.2.7.SNAPSHOT [UNUSED]
osgi.wiring.package; org.postgresql.hostchooser 42.2.7.SNAPSHOT [UNUSED]
osgi.wiring.package; org.postgresql.jdbc 42.2.7.SNAPSHOT [UNUSED]
osgi.wiring.package; org.postgresql.jdbc2 42.2.7.SNAPSHOT [UNUSED]
osgi.wiring.package; org.postgresql.jdbc2.optional 42.2.7.SNAPSHOT [UNUSED]
osgi.wiring.package; org.postgresql.jdbc3 42.2.7.SNAPSHOT [UNUSED]
osgi.wiring.package; org.postgresql.jre7.sasl 42.2.7.SNAPSHOT [UNUSED]
osgi.wiring.package; org.postgresql.largeobject 42.2.7.SNAPSHOT [UNUSED]
osgi.wiring.package; org.postgresql.osgi 42.2.7.SNAPSHOT [UNUSED]
osgi.wiring.package; org.postgresql.replication 42.2.7.SNAPSHOT [UNUSED]
osgi.wiring.package; org.postgresql.replication.fluent 42.2.7.SNAPSHOT [UNUSED]
osgi.wiring.package; org.postgresql.replication.fluent.logical 42.2.7.SNAPSHOT [UNUSED]
osgi.wiring.package; org.postgresql.replication.fluent.physical 42.2.7.SNAPSHOT [UNUSED]
osgi.wiring.package; org.postgresql.ssl 42.2.7.SNAPSHOT [UNUSED]
osgi.wiring.package; org.postgresql.ssl.jdbc4 42.2.7.SNAPSHOT [UNUSED]
osgi.wiring.package; org.postgresql.sspi 42.2.7.SNAPSHOT [UNUSED]
osgi.wiring.package; org.postgresql.translation 42.2.7.SNAPSHOT [UNUSED]
osgi.wiring.package; org.postgresql.util 42.2.7.SNAPSHOT [UNUSED]
osgi.wiring.package; org.postgresql.xa 42.2.7.SNAPSHOT [UNUSED]
karaf@root()>
```
