### PR TITLE
fix: Revert inet to return as a string and handle values with net masks

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
@@ -39,8 +39,6 @@ import org.postgresql.util.PSQLException;
 import org.postgresql.util.PSQLState;
 
 import java.io.IOException;
-import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.sql.Array;
 import java.sql.Blob;
 import java.sql.CallableStatement;
@@ -548,15 +546,6 @@ public class PgConnection implements BaseConnection {
         // Handle the type (requires SQLInput & SQLOutput classes to be implemented)
         throw new PSQLException(GT.tr("Custom type maps are not supported."),
             PSQLState.NOT_IMPLEMENTED);
-      }
-    }
-
-    if (type.equals("inet")) {
-      try {
-        return InetAddress.getByName(value);
-      } catch (UnknownHostException e) {
-        throw new PSQLException(GT.tr("IP address {0} of a host could not be determined", value),
-          PSQLState.CONNECTION_FAILURE, e);
       }
     }
 

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc4/jdbc41/GetObjectTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc4/jdbc41/GetObjectTest.java
@@ -22,6 +22,7 @@ import org.postgresql.geometric.PGpolygon;
 import org.postgresql.test.TestUtil;
 import org.postgresql.util.PGInterval;
 import org.postgresql.util.PGmoney;
+import org.postgresql.util.PGobject;
 
 import org.junit.After;
 import org.junit.Before;
@@ -938,42 +939,48 @@ public class GetObjectTest {
     }
   }
 
-  /**
-   * Test the behavior getObject for inet columns.
-   */
-  @Test
-  public void testGetInet4Address() throws SQLException, UnknownHostException {
+  private void testInet(String inet, InetAddress expectedAddr, String expectedText) throws SQLException, UnknownHostException {
+    PGobject expectedObj = new PGobject();
+    expectedObj.setType("inet");
+    expectedObj.setValue(expectedText);
     Statement stmt = conn.createStatement();
-    String expected = "192.168.100.128";
-    stmt.executeUpdate(TestUtil.insertSQL("table1","inet_column","'" + expected + "'"));
-
-    ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("table1", "inet_column"));
+    ResultSet rs = stmt.executeQuery("SELECT '" + inet + "'::inet AS inet_column");
     try {
       assertTrue(rs.next());
-      assertEquals(InetAddress.getByName(expected), rs.getObject("inet_column", InetAddress.class));
-      assertEquals(InetAddress.getByName(expected), rs.getObject(1, InetAddress.class));
+      assertEquals("The string value of the inet should match when fetched via getString(...)", expectedText, rs.getString(1));
+      assertEquals("The string value of the inet should match when fetched via getString(...)", expectedText, rs.getString("inet_column"));
+      assertEquals("The object value of the inet should match when fetched via getObject(...)", expectedObj, rs.getObject(1));
+      assertEquals("The object value of the inet should match when fetched via getObject(...)", expectedObj, rs.getObject("inet_column"));
+      assertEquals("The InetAddress value should match when fetched via getObject(..., InetAddress.class)", expectedAddr, rs.getObject("inet_column", InetAddress.class));
+      assertEquals("The InetAddress value should match when fetched via getObject(..., InetAddress.class)", expectedAddr, rs.getObject(1, InetAddress.class));
     } finally {
       rs.close();
+      stmt.close();
     }
   }
 
   /**
-   * Test the behavior getObject for inet columns.
+   * Test the behavior getObject for ipv4 inet columns.
+   */
+  @Test
+  public void testGetInet4Address() throws SQLException, UnknownHostException {
+    String inet = "192.168.100.128";
+    InetAddress addr = InetAddress.getByName(inet);
+    testInet(inet, addr, inet);
+    testInet(inet + "/16", addr, inet + "/16");
+    testInet(inet + "/32", addr, inet);
+  }
+
+  /**
+   * Test the behavior getObject for ipv6 inet columns.
    */
   @Test
   public void testGetInet6Address() throws SQLException, UnknownHostException {
-    Statement stmt = conn.createStatement();
-    String expected = "2001:4f8:3:ba:2e0:81ff:fe22:d1f1";
-    stmt.executeUpdate(TestUtil.insertSQL("table1","inet_column","'" + expected + "'"));
-
-    ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("table1", "inet_column"));
-    try {
-      assertTrue(rs.next());
-      assertEquals(InetAddress.getByName(expected), rs.getObject("inet_column", InetAddress.class));
-      assertEquals(InetAddress.getByName(expected), rs.getObject(1, InetAddress.class));
-    } finally {
-      rs.close();
-    }
+    String inet = "2001:4f8:3:ba:2e0:81ff:fe22:d1f1";
+    InetAddress addr = InetAddress.getByName(inet);
+    testInet(inet, addr, inet);
+    testInet(inet + "/16", addr, inet + "/16");
+    testInet(inet + "/128", addr, inet);
   }
 
 }


### PR DESCRIPTION
Reverts inet type columns to default to returning their value as the text representation returned by the backend rather than parsing them as InetAddress values. This ensures that the mask value is not lost.

Also corrects the getObject(..., InetAddress.class) handling to split out the net mask and return only the address portion.

I've also updated the tests for inet data types to clean it up a bit, explicitly test getString() / getObject(), and add some additional edge cases (ex: "10.20.30.40/32" gets round tripped by the server to strip out the /32).

When (if?) we change the default return type to give a PGInet that test should fail and need to be updated. As I tend to lean toward backwards compatibility, I think we should leave the default as a text and if anything provide PGInet as a separate class that anyone who wants can use. Could consider using something similar to handle mac data types too.

Closes #1567 

See also #1134 for related discussion.

### All Submissions:

* [X] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [X] Does your submission pass tests?
2. [X] Does mvn checkstyle:check pass ?
3. [X] Have you added your new test classes to an existing test suite?

### Changes to Existing Features:

* [X] Does this break existing behaviour? If so please explain.

Yes. It reverts `inet` data type handling to return a `String` instead of `InetAddress` by default.

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you written new tests for your core changes, as applicable?
* [X] Have you successfully run tests with your changes locally?
