### PR TITLE
Fixing LocalTime rounding (losing precision)

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/TimestampUtils.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/TimestampUtils.java
@@ -54,7 +54,7 @@ public class TimestampUtils {
   private static final Duration ONE_MICROSECOND = Duration.ofNanos(1000);
   // LocalTime.MAX is 23:59:59.999_999_999, and it wraps to 24:00:00 when nanos exceed 999_999_499
   // since PostgreSQL has microsecond resolution only
-  private static final LocalTime MAX_TIME = LocalTime.MAX.minus(Duration.ofMillis(500));
+  private static final LocalTime MAX_TIME = LocalTime.MAX.minus(Duration.ofNanos(500));
   private static final OffsetDateTime MAX_OFFSET_DATETIME = OffsetDateTime.MAX.minus(Duration.ofMillis(500));
   private static final LocalDateTime MAX_LOCAL_DATETIME = LocalDateTime.MAX.minus(Duration.ofMillis(500));
   // low value for dates is   4713 BC

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/TimestampUtilsTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/TimestampUtilsTest.java
@@ -7,6 +7,8 @@ package org.postgresql.jdbc;
 
 import static org.junit.Assert.assertEquals;
 
+import org.postgresql.core.Provider;
+
 import org.junit.Test;
 
 import java.sql.SQLException;
@@ -17,7 +19,7 @@ public class TimestampUtilsTest {
 
   @Test
   public void testToStringOfLocalTime() {
-    TimestampUtils timestampUtils = new TimestampUtils(true, TimeZone::getDefault);
+    TimestampUtils timestampUtils = createTimestampUtils();
 
     assertEquals("00:00:00", timestampUtils.toString(LocalTime.parse("00:00:00")));
     assertEquals("00:00:00.1", timestampUtils.toString(LocalTime.parse("00:00:00.1")));
@@ -40,7 +42,7 @@ public class TimestampUtilsTest {
 
   @Test
   public void testToLocalTime() throws SQLException {
-    TimestampUtils timestampUtils = new TimestampUtils(true, TimeZone::getDefault);
+    TimestampUtils timestampUtils = createTimestampUtils();
 
     assertEquals(LocalTime.parse("00:00:00"), timestampUtils.toLocalTime("00:00:00"));
 
@@ -58,9 +60,15 @@ public class TimestampUtilsTest {
     assertEquals(LocalTime.parse("23:59:59.99999999"), timestampUtils.toLocalTime("23:59:59.99999999")); // 990 NanoSeconds
     assertEquals(LocalTime.parse("23:59:59.999999998"), timestampUtils.toLocalTime("23:59:59.999999998")); // 998 NanoSeconds
     assertEquals(LocalTime.parse("23:59:59.999999999"), timestampUtils.toLocalTime("24:00:00"));
+  }
 
-    assertEquals(LocalTime.parse("23:59:59.999999999"), timestampUtils.toLocalTime(timestampUtils.toString(LocalTime.parse("23:59:59.999999500"))));
-
+  private TimestampUtils createTimestampUtils() {
+    return  new TimestampUtils(true, new Provider<TimeZone>() {
+      @Override
+      public TimeZone get() {
+        return TimeZone.getDefault();
+      }
+    });
   }
 
 }

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/TimestampUtilsTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/TimestampUtilsTest.java
@@ -1,0 +1,34 @@
+package org.postgresql.jdbc;
+
+import org.junit.Test;
+
+import java.time.LocalTime;
+import java.util.TimeZone;
+
+import static org.junit.Assert.*;
+
+public class TimestampUtilsTest {
+
+  @Test
+  public void testToStringOfLocalTime() {
+    TimestampUtils timestampUtils = new TimestampUtils(true, TimeZone::getDefault);
+
+    assertEquals("00:00:00", timestampUtils.toString(LocalTime.parse("00:00:00")));
+    assertEquals("00:00:00.1", timestampUtils.toString(LocalTime.parse("00:00:00.1")));
+    assertEquals("00:00:00.12", timestampUtils.toString(LocalTime.parse("00:00:00.12")));
+    assertEquals("00:00:00.123", timestampUtils.toString(LocalTime.parse("00:00:00.123")));
+    assertEquals("00:00:00.1234", timestampUtils.toString(LocalTime.parse("00:00:00.1234")));
+    assertEquals("00:00:00.12345", timestampUtils.toString(LocalTime.parse("00:00:00.12345")));
+    assertEquals("00:00:00.123456", timestampUtils.toString(LocalTime.parse("00:00:00.123456")));
+
+    assertEquals("00:00:00.999999", timestampUtils.toString(LocalTime.parse("00:00:00.999999")));
+    assertEquals("00:00:00.999999", timestampUtils.toString(LocalTime.parse("00:00:00.999999499")));
+    assertEquals("00:00:01", timestampUtils.toString(LocalTime.parse("00:00:00.999999500")));
+
+    assertEquals("23:59:59", timestampUtils.toString(LocalTime.parse("23:59:59")));
+    assertEquals("23:59:59.999999", timestampUtils.toString(LocalTime.parse("23:59:59.999999")));
+    assertEquals("23:59:59.999999", timestampUtils.toString(LocalTime.parse("23:59:59.999999499")));
+    assertEquals("24:00:00", timestampUtils.toString(LocalTime.parse("23:59:59.999999500")));
+  }
+
+}

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/TimestampUtilsTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/TimestampUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, PostgreSQL Global Development Group
+ * Copyright (c) 2019, PostgreSQL Global Development Group
  * See the LICENSE file in the project root for more information.
  */
 

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/TimestampUtilsTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/TimestampUtilsTest.java
@@ -2,10 +2,11 @@ package org.postgresql.jdbc;
 
 import org.junit.Test;
 
+import java.sql.SQLException;
 import java.time.LocalTime;
 import java.util.TimeZone;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 public class TimestampUtilsTest {
 
@@ -22,13 +23,36 @@ public class TimestampUtilsTest {
     assertEquals("00:00:00.123456", timestampUtils.toString(LocalTime.parse("00:00:00.123456")));
 
     assertEquals("00:00:00.999999", timestampUtils.toString(LocalTime.parse("00:00:00.999999")));
-    assertEquals("00:00:00.999999", timestampUtils.toString(LocalTime.parse("00:00:00.999999499")));
-    assertEquals("00:00:01", timestampUtils.toString(LocalTime.parse("00:00:00.999999500")));
+    assertEquals("00:00:00.999999", timestampUtils.toString(LocalTime.parse("00:00:00.999999499"))); // 499 NanoSeconds
+    assertEquals("00:00:01", timestampUtils.toString(LocalTime.parse("00:00:00.999999500"))); // 500 NanoSeconds
 
     assertEquals("23:59:59", timestampUtils.toString(LocalTime.parse("23:59:59")));
-    assertEquals("23:59:59.999999", timestampUtils.toString(LocalTime.parse("23:59:59.999999")));
-    assertEquals("23:59:59.999999", timestampUtils.toString(LocalTime.parse("23:59:59.999999499")));
-    assertEquals("24:00:00", timestampUtils.toString(LocalTime.parse("23:59:59.999999500")));
+    assertEquals("23:59:59.999999", timestampUtils.toString(LocalTime.parse("23:59:59.999999"))); // 0 NanoSeconds
+    assertEquals("23:59:59.999999", timestampUtils.toString(LocalTime.parse("23:59:59.999999499"))); // 499 NanoSeconds
+    assertEquals("24:00:00", timestampUtils.toString(LocalTime.parse("23:59:59.999999500")));// 500 NanoSeconds
+    assertEquals("24:00:00", timestampUtils.toString(LocalTime.parse("23:59:59.999999999")));// 999 NanoSeconds
+  }
+
+  @Test
+  public void testToLocalTime() throws SQLException {
+    TimestampUtils timestampUtils = new TimestampUtils(true, TimeZone::getDefault);
+
+    assertEquals(LocalTime.parse("00:00:00"), timestampUtils.toLocalTime("00:00:00"));
+
+    assertEquals(LocalTime.parse("00:00:00.1"), timestampUtils.toLocalTime("00:00:00.1"));
+    assertEquals(LocalTime.parse("00:00:00.12"), timestampUtils.toLocalTime("00:00:00.12"));
+    assertEquals(LocalTime.parse("00:00:00.123"), timestampUtils.toLocalTime("00:00:00.123"));
+    assertEquals(LocalTime.parse("00:00:00.1234"), timestampUtils.toLocalTime("00:00:00.1234"));
+    assertEquals(LocalTime.parse("00:00:00.12345"), timestampUtils.toLocalTime("00:00:00.12345"));
+    assertEquals(LocalTime.parse("00:00:00.123456"), timestampUtils.toLocalTime("00:00:00.123456"));
+    assertEquals(LocalTime.parse("00:00:00.999999"), timestampUtils.toLocalTime("00:00:00.999999"));
+
+    assertEquals(LocalTime.parse("23:59:59"), timestampUtils.toLocalTime("23:59:59"));
+    assertEquals(LocalTime.parse("23:59:59.999999"), timestampUtils.toLocalTime("23:59:59.999999")); // 0 NanoSeconds
+    assertEquals(LocalTime.parse("23:59:59.9999999"), timestampUtils.toLocalTime("23:59:59.9999999")); // 900 NanoSeconds
+    assertEquals(LocalTime.parse("23:59:59.99999999"), timestampUtils.toLocalTime("23:59:59.99999999")); // 990 NanoSeconds
+    assertEquals(LocalTime.parse("23:59:59.999999998"), timestampUtils.toLocalTime("23:59:59.999999998")); // 998 NanoSeconds
+    assertEquals(LocalTime.parse("23:59:59.999999999"), timestampUtils.toLocalTime("24:00:00"));
   }
 
 }

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/TimestampUtilsTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/TimestampUtilsTest.java
@@ -12,7 +12,9 @@ import org.postgresql.core.Provider;
 import org.junit.Test;
 
 import java.sql.SQLException;
+//#if mvn.project.property.postgresql.jdbc.spec >= "JDBC4.2"
 import java.time.LocalTime;
+//#endif
 import java.util.TimeZone;
 
 public class TimestampUtilsTest {

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/TimestampUtilsTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/TimestampUtilsTest.java
@@ -1,12 +1,17 @@
+/*
+ * Copyright (c) 2003, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
 package org.postgresql.jdbc;
+
+import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 
 import java.sql.SQLException;
 import java.time.LocalTime;
 import java.util.TimeZone;
-
-import static org.junit.Assert.assertEquals;
 
 public class TimestampUtilsTest {
 
@@ -53,6 +58,9 @@ public class TimestampUtilsTest {
     assertEquals(LocalTime.parse("23:59:59.99999999"), timestampUtils.toLocalTime("23:59:59.99999999")); // 990 NanoSeconds
     assertEquals(LocalTime.parse("23:59:59.999999998"), timestampUtils.toLocalTime("23:59:59.999999998")); // 998 NanoSeconds
     assertEquals(LocalTime.parse("23:59:59.999999999"), timestampUtils.toLocalTime("24:00:00"));
+
+    assertEquals(LocalTime.parse("23:59:59.999999999"), timestampUtils.toLocalTime(timestampUtils.toString(LocalTime.parse("23:59:59.999999500"))));
+
   }
 
 }

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/TimestampUtilsTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/TimestampUtilsTest.java
@@ -17,6 +17,7 @@ import java.util.TimeZone;
 
 public class TimestampUtilsTest {
 
+  //#if mvn.project.property.postgresql.jdbc.spec >= "JDBC4.2"
   @Test
   public void testToStringOfLocalTime() {
     TimestampUtils timestampUtils = createTimestampUtils();
@@ -70,5 +71,6 @@ public class TimestampUtilsTest {
       }
     });
   }
+  //#endif
 
 }


### PR DESCRIPTION
When converting the Java `LocalTime` to PostgreSQL `time` value we have to consider the following:
- Java `LocalTime` has nano and `time` has micro precision
- PostgreSQL `time` max value is `24:00:00` while `LocalTime` is `23:59:59.999999999`

Conversion logic:
- truncate and round up when nanos >= 500
- rounding up all >=  `23:59:59.999999500`  to `24:00:00`

The current code intends to do this but it has a bug where it rounds too much. This PR fixes it.

I've added test for `toLocalTime()` which demostrates that these two methods are asymmetrical, you can lose/change information if you store and retrieve the time.
Example: 
```
timestampUtils.toLocalTime(timestampUtils.toString(LocalTime.parse("23:59:59.999999500")))) -> LocalTime.parse("23:59:59.999999999")
```

I'm open to suggestions on how can this be consolidated and if there's anything hidden to consider with this kind of change.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [x] Does mvn checkstyle:check pass ?
3. [ ] Have you added your new test classes to an existing test suite?

### Changes to Existing Features:

* [ ] Does this break existing behaviour? If so please explain.
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
