### PR TITLE
upgrade maven-checkstyle-plugin to 3.1.0

### DIFF
--- a/pgjdbc/pom.xml
+++ b/pgjdbc/pom.xml
@@ -329,7 +329,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-checkstyle-plugin</artifactId>
-          <version>3.0.0</version>
+          <version>3.1.0</version>
           <dependencies>
             <dependency>
               <groupId>com.puppycrawl.tools</groupId>


### PR DESCRIPTION
Identified at https://github.com/checkstyle/checkstyle/pull/7088

Checkstyle is looking to remove some deprecated methods and our CI noticed that you are not on the latest maven-checkstyle-plugin which is still using some deprecated methods.