### PR TITLE
Fix Markdown formatting issue

### DIFF
--- a/docs/documentation/92/query.md
+++ b/docs/documentation/92/query.md
@@ -76,7 +76,7 @@ exhausted the next block of rows is retrieved by repositioning the cursor.
 * The `Connection` must not be in autocommit mode. The backend closes cursors at
 	the end of transactions, so in autocommit mode the backend will have
 	closed the cursor before anything can be fetched from it.
-*The `Statement` must be created with a `ResultSet` type of `ResultSet.TYPE_FORWARD_ONLY`.
+* The `Statement` must be created with a `ResultSet` type of `ResultSet.TYPE_FORWARD_ONLY`.
 	This is the default, so no code will need to be rewritten to take advantage
 	of this, but it also means that you cannot scroll backwards or otherwise
 	jump around in the `ResultSet`.

--- a/docs/documentation/93/query.md
+++ b/docs/documentation/93/query.md
@@ -76,7 +76,7 @@ exhausted the next block of rows is retrieved by repositioning the cursor.
 * The `Connection` must not be in autocommit mode. The backend closes cursors at
 	the end of transactions, so in autocommit mode the backend will have
 	closed the cursor before anything can be fetched from it.
-*The `Statement` must be created with a `ResultSet` type of `ResultSet.TYPE_FORWARD_ONLY`.
+* The `Statement` must be created with a `ResultSet` type of `ResultSet.TYPE_FORWARD_ONLY`.
 	This is the default, so no code will need to be rewritten to take advantage
 	of this, but it also means that you cannot scroll backwards or otherwise
 	jump around in the `ResultSet`.

--- a/docs/documentation/94/query.md
+++ b/docs/documentation/94/query.md
@@ -76,7 +76,7 @@ exhausted the next block of rows is retrieved by repositioning the cursor.
 * The `Connection` must not be in autocommit mode. The backend closes cursors at
 	the end of transactions, so in autocommit mode the backend will have
 	closed the cursor before anything can be fetched from it.
-*The `Statement` must be created with a `ResultSet` type of `ResultSet.TYPE_FORWARD_ONLY`.
+* The `Statement` must be created with a `ResultSet` type of `ResultSet.TYPE_FORWARD_ONLY`.
 	This is the default, so no code will need to be rewritten to take advantage
 	of this, but it also means that you cannot scroll backwards or otherwise
 	jump around in the `ResultSet`.

--- a/docs/documentation/head/query.md
+++ b/docs/documentation/head/query.md
@@ -81,7 +81,7 @@ exhausted the next block of rows is retrieved by repositioning the cursor.
 * The `Connection` must not be in autocommit mode. The backend closes cursors at
 	the end of transactions, so in autocommit mode the backend will have
 	closed the cursor before anything can be fetched from it.
-*The `Statement` must be created with a `ResultSet` type of `ResultSet.TYPE_FORWARD_ONLY`.
+* The `Statement` must be created with a `ResultSet` type of `ResultSet.TYPE_FORWARD_ONLY`.
 	This is the default, so no code will need to be rewritten to take advantage
 	of this, but it also means that you cannot scroll backwards or otherwise
 	jump around in the `ResultSet`.


### PR DESCRIPTION
Fixes a Markdown formatting issue in the `query.md` section on restrictions with cursor-based `ResultSet`s.