### PR TITLE
Fix: Issue #1577. It is currently possible to leak information into logs from errors

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/Driver.java
+++ b/pgjdbc/src/main/java/org/postgresql/Driver.java
@@ -56,6 +56,7 @@ import java.util.logging.StreamHandler;
  */
 public class Driver implements java.sql.Driver {
 
+  public static boolean logDetail = true;
   private static Driver registeredDriver;
   private static final Logger PARENT_LOGGER = Logger.getLogger("org.postgresql");
   private static final Logger LOGGER = Logger.getLogger("org.postgresql.Driver");
@@ -244,6 +245,10 @@ public class Driver implements java.sql.Driver {
     try {
       // Setup java.util.logging.Logger using connection properties.
       setupLoggerFromProperties(props);
+
+      if ( PGProperty.LOG_DETAIL.get(info).equalsIgnoreCase("false") ) {
+        logDetail = false;
+      }
 
       LOGGER.log(Level.FINE, "Connecting with URL: {0}", url);
 

--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -437,7 +437,10 @@ public enum PGProperty {
           + "to the database specified in the dbname parameter, "
           + "which will allow the connection to be used for logical replication "
           + "from that database. "
-          + "(backend >= 9.4)");
+          + "(backend >= 9.4)"),
+
+  LOG_DETAIL("log_detail", "true", "If set then the DETAIL information provided by the server is"
+    +       "included in the logs, if false the DETAIL information will be omitted");
 
   private final String name;
   private final String defaultValue;

--- a/pgjdbc/src/main/java/org/postgresql/util/ServerErrorMessage.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/ServerErrorMessage.java
@@ -80,7 +80,11 @@ public class ServerErrorMessage implements Serializable {
   }
 
   public String getDetail() {
-    return mesgParts.get(DETAIL);
+    if (org.postgresql.Driver.logDetail == true) {
+      return mesgParts.get(DETAIL);
+    } else {
+      return "";
+    }
   }
 
   public String getHint() {

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PGPropertyTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PGPropertyTest.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 import java.beans.BeanInfo;
 import java.beans.Introspector;
 import java.beans.PropertyDescriptor;
+import java.sql.Connection;
 import java.sql.DriverPropertyInfo;
 import java.util.ArrayList;
 import java.util.Map;
@@ -290,5 +291,21 @@ public class PGPropertyTest {
     assertFalse("user", PGProperty.USER.isPresent(parsed));
     assertFalse("password", PGProperty.PASSWORD.isPresent(parsed));
     assertEquals("APPLICATION_NAME", applicationName, PGProperty.APPLICATION_NAME.get(parsed));
+  }
+
+  @Test
+  public void testLogDetailFalse() throws Exception {
+    Properties props = new Properties();
+    PGProperty.USER.set(props,TestUtil.getUser());
+    PGProperty.PASSWORD.set(props, TestUtil.getPassword());
+    PGProperty.PG_DBNAME.set(props, TestUtil.getDatabase());
+    PGProperty.PG_HOST.set(props, TestUtil.getServer());
+    PGProperty.PG_PORT.set(props, TestUtil.getPort());
+    PGProperty.LOG_DETAIL.set(props,"false");
+
+    Connection con = TestUtil.openDB(props);
+
+    assertFalse(Driver.logDetail);
+
   }
 }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ServerErrorTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ServerErrorTest.java
@@ -95,4 +95,43 @@ public class ServerErrorTest extends BaseTest4 {
     stmt.close();
   }
 
+  @Test
+  public void testLogDetail() throws Exception {
+    Statement stmt = con.createStatement();
+    stmt.executeUpdate("INSERT INTO testerr (id, val) VALUES (1, 1)");
+    try {
+      stmt.executeUpdate("INSERT INTO testerr (id, val) VALUES (1, 1)");
+      fail("Should have thrown a duplicate key exception.");
+    } catch (SQLException sqle) {
+      ServerErrorMessage err = ((PSQLException) sqle).getServerErrorMessage();
+      assertEquals("public", err.getSchema());
+      assertEquals("testerr", err.getTable());
+      assertEquals("testerr_pk", err.getConstraint());
+      assertEquals("Key (id)=(1) already exists.", err.getDetail());
+      assertNull(err.getDatatype());
+      assertNull(err.getColumn());
+    }
+    stmt.close();
+  }
+
+  @Test
+  public void testLogDetailFalse() throws Exception {
+    org.postgresql.Driver.logDetail = false;
+    Statement stmt = con.createStatement();
+    stmt.executeUpdate("INSERT INTO testerr (id, val) VALUES (1, 1)");
+    try {
+      stmt.executeUpdate("INSERT INTO testerr (id, val) VALUES (1, 1)");
+      fail("Should have thrown a duplicate key exception.");
+    } catch (SQLException sqle) {
+      ServerErrorMessage err = ((PSQLException) sqle).getServerErrorMessage();
+      assertEquals("public", err.getSchema());
+      assertEquals("testerr", err.getTable());
+      assertEquals("testerr_pk", err.getConstraint());
+      assertEquals("", err.getDetail());
+      assertNull(err.getDatatype());
+      assertNull(err.getColumn());
+    }
+    stmt.close();
+  }
+
 }


### PR DESCRIPTION
The server will send parameter values in the DETAIL server error message
Adding a log_detail property which if set to false will omit the DETAIL part of the
ServerErrorMessage.
While this won't stop all data from leaking it does provide a first pass.

Note this setting once set will be set for all connections in the JVM as this is a static
variable in the Driver.

### All Submissions:

* [ ] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Does mvn checkstyle:check pass ?
3. [ ] Have you added your new test classes to an existing test suite?

### Changes to Existing Features:

* [ ] Does this break existing behaviour? If so please explain.
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
