### PR TITLE
Perform ssl handshake after socket timeout and buffer size settings

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java
@@ -90,9 +90,6 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
 
     PGStream newStream = new PGStream(socketFactory, hostSpec, connectTimeout);
 
-    // Construct and send an ssl startup packet if requested.
-    newStream = enableSSL(newStream, sslMode, info, connectTimeout);
-
     // Set the socket timeout if the "socketTimeout" property has been set.
     int socketTimeout = PGProperty.SOCKET_TIMEOUT.getInt(info);
     if (socketTimeout > 0) {
@@ -133,6 +130,9 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
       LOGGER.log(Level.FINE, "Receive Buffer Size is {0}", newStream.getSocket().getReceiveBufferSize());
       LOGGER.log(Level.FINE, "Send Buffer Size is {0}", newStream.getSocket().getSendBufferSize());
     }
+
+    // Construct and send an ssl startup packet if requested.
+    newStream = enableSSL(newStream, sslMode, info, connectTimeout);
 
     List<String[]> paramList = getParametersForStartup(user, database, info);
     sendStartupPacket(newStream, paramList);


### PR DESCRIPTION
Currently ```setSoTimeout```, ```setKeepAlive```, ```setReceiveBufferSize``` and ```setSendBufferSize``` are called after ```enableSSL```. In such a case SSL handshake uses only ```CONNECT_TIMEOUT``` and ignores other socket settings.

After few network splits we have found a lot of connections in next state for a very long time:
```
#15680 daemon prio=5 os_prio=0 cpu=47.27ms elapsed=76351.16s tid=0x00007f4abc0029e0 nid=0x4a93 runnable  [0x00007f4b4b7f6000]
   java.lang.Thread.State: RUNNABLE
        at java.net.SocketInputStream.socketRead0(java.base@11.0.3-internal/Native Method)
        at java.net.SocketInputStream.socketRead(java.base@11.0.3-internal/SocketInputStream.java:115)
        at java.net.SocketInputStream.read(java.base@11.0.3-internal/SocketInputStream.java:168)
        at java.net.SocketInputStream.read(java.base@11.0.3-internal/SocketInputStream.java:140)
        at sun.security.ssl.SSLSocketInputRecord.read(java.base@11.0.3-internal/SSLSocketInputRecord.java:448)
        at sun.security.ssl.SSLSocketInputRecord.decodeInputRecord(java.base@11.0.3-internal/SSLSocketInputRecord.java:237)
        at sun.security.ssl.SSLSocketInputRecord.decode(java.base@11.0.3-internal/SSLSocketInputRecord.java:190)
        at sun.security.ssl.SSLTransport.decode(java.base@11.0.3-internal/SSLTransport.java:108)
        at sun.security.ssl.SSLSocketImpl.decode(java.base@11.0.3-internal/SSLSocketImpl.java:1152)
        at sun.security.ssl.SSLSocketImpl.readHandshakeRecord(java.base@11.0.3-internal/SSLSocketImpl.java:1063)
        at sun.security.ssl.SSLSocketImpl.startHandshake(java.base@11.0.3-internal/SSLSocketImpl.java:402)
        - locked <0x00000007f901bae0> (a sun.security.ssl.TransportContext)
        at org.postgresql.ssl.MakeSSL.convert(MakeSSL.java:62)
        at org.postgresql.core.v3.ConnectionFactoryImpl.enableSSL(ConnectionFactoryImpl.java:389)
        at org.postgresql.core.v3.ConnectionFactoryImpl.openConnectionImpl(ConnectionFactoryImpl.java:160)
        at org.postgresql.core.ConnectionFactory.openConnection(ConnectionFactory.java:49)
        at org.postgresql.jdbc.PgConnection.<init>(PgConnection.java:195)
        at org.postgresql.Driver.makeConnection(Driver.java:452)
        at org.postgresql.Driver.connect(Driver.java:254)
        at com.zaxxer.hikari.util.DriverDataSource.getConnection(DriverDataSource.java:117)
        at com.zaxxer.hikari.util.DriverDataSource.getConnection(DriverDataSource.java:123)
        at com.zaxxer.hikari.pool.PoolBase.newConnection(PoolBase.java:375)
        at com.zaxxer.hikari.pool.PoolBase.newPoolEntry(PoolBase.java:204)
        at com.zaxxer.hikari.pool.HikariPool.createPoolEntry(HikariPool.java:445)
        at com.zaxxer.hikari.pool.HikariPool.access$200(HikariPool.java:72)
        at com.zaxxer.hikari.pool.HikariPool$PoolEntryCreator.call(HikariPool.java:632)
        at com.zaxxer.hikari.pool.HikariPool$PoolEntryCreator.call(HikariPool.java:618)
        at java.util.concurrent.FutureTask.run(java.base@11.0.3-internal/FutureTask.java:264)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@11.0.3-internal/ThreadPoolExecutor.java:1128)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@11.0.3-internal/ThreadPoolExecutor.java:628)
        at java.lang.Thread.run(java.base@11.0.3-internal/Thread.java:834)
```

It caused because ```sockettimeout``` was not applied to the connection at the moment of a network partition. 

Env:
* ```PostgreSQL 10.10 (Ubuntu 10.10-103) on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 4.8.4-2ubuntu1~14.04.4) 4.8.4, 64-bit```
* ```OpenJDK 64-Bit Server VM AdoptOpenJDK (build 11.0.3+7, mixed mode)```
* ```postgresql-42.2.2.jar```

Workaround:
* Use ```LOGIN_TIMEOUT```.


### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests? 
2. [x] Does mvn checkstyle:check pass ?
3. [ ] Have you added your new test classes to an existing test suite? 

### Changes to Existing Features:

* [ ] Does this break existing behaviour? If so please explain.
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
