### PR TITLE
Fix test suite order

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,7 +9,7 @@
 
 1. [ ] Does your submission pass tests?
 2. [ ] Does mvn checkstyle:check pass ?
-3. [ ] Have you added your new test classes to an existing test suite?
+3. [ ] Have you added your new test classes to an existing test suite in alphabetical order?
 
 ### Changes to Existing Features:
 

--- a/pgjdbc/src/test/java/org/postgresql/test/extensions/ExtensionsTestSuite.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/extensions/ExtensionsTestSuite.java
@@ -12,7 +12,9 @@ import org.junit.runners.Suite;
  * Executes all known tests for PostgreSQL extensions supported by JDBC driver
  */
 @RunWith(Suite.class)
-@Suite.SuiteClasses(HStoreTest.class)
+@Suite.SuiteClasses({
+    HStoreTest.class,
+})
 public class ExtensionsTestSuite {
 }
 

--- a/pgjdbc/src/test/java/org/postgresql/test/hostchooser/MultiHostTestSuite.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/hostchooser/MultiHostTestSuite.java
@@ -12,6 +12,8 @@ import org.junit.runners.Suite;
  * Executes multi host tests (aka master/slave connectivity selection).
  */
 @RunWith(Suite.class)
-@Suite.SuiteClasses(MultiHostsConnectionTest.class)
+@Suite.SuiteClasses({
+    MultiHostsConnectionTest.class,
+})
 public class MultiHostTestSuite {
 }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/optional/OptionalTestSuite.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/optional/OptionalTestSuite.java
@@ -15,13 +15,15 @@ import org.junit.runners.Suite;
  * @author Aaron Mulder (ammulder@chariotsolutions.com)
  */
 @RunWith(Suite.class)
-@Suite.SuiteClasses({SimpleDataSourceTest.class,
-        SimpleDataSourceWithUrlTest.class,
-        SimpleDataSourceWithSetURLTest.class,
+@Suite.SuiteClasses({
+        BaseDataSourceFailoverUrlsTest.class,
+        CaseOptimiserDataSourceTest.class,
         ConnectionPoolTest.class,
         PoolingDataSourceTest.class,
-        CaseOptimiserDataSourceTest.class,
-        BaseDataSourceFailoverUrlsTest.class})
+        SimpleDataSourceTest.class,
+        SimpleDataSourceWithSetURLTest.class,
+        SimpleDataSourceWithUrlTest.class,
+})
 public class OptionalTestSuite {
 
 }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc42/Jdbc42TestSuite.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc42/Jdbc42TestSuite.java
@@ -15,10 +15,10 @@ import org.junit.runners.Suite.SuiteClasses;
     GetObject310InfinityTests.class,
     GetObject310Test.class,
     Jdbc42CallableStatementTest.class,
+    LargeCountJdbc42Test.class,
     PreparedStatementTest.class,
     SetObject310Test.class,
     SimpleJdbc42Test.class,
-    LargeCountJdbc42Test.class
 })
 public class Jdbc42TestSuite {
 

--- a/pgjdbc/src/test/java/org/postgresql/test/jre8/core/Jre8TestSuite.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jre8/core/Jre8TestSuite.java
@@ -13,6 +13,8 @@ import org.junit.runners.Suite;
  *         Twitter: @codefinger
  */
 @RunWith(Suite.class)
-@Suite.SuiteClasses({SocksProxyTest.class})
+@Suite.SuiteClasses({
+    SocksProxyTest.class,
+})
 public class Jre8TestSuite {
 }

--- a/pgjdbc/src/test/java/org/postgresql/test/osgi/OsgiTestSuite.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/osgi/OsgiTestSuite.java
@@ -10,7 +10,9 @@ import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 @RunWith(Suite.class)
-@SuiteClasses({PGDataSourceFactoryTest.class})
+@SuiteClasses({
+    PGDataSourceFactoryTest.class,
+})
 public class OsgiTestSuite {
 
 }

--- a/pgjdbc/src/test/java/org/postgresql/test/ssl/SslTestSuite.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/ssl/SslTestSuite.java
@@ -11,9 +11,9 @@ import org.junit.runners.Suite;
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
     CommonNameVerifierTest.class,
+    LazyKeyManagerTest.class,
     LibPQFactoryHostNameTest.class,
     SslTest.class,
-    LazyKeyManagerTest.class,
 })
 public class SslTestSuite {
 }

--- a/pgjdbc/src/test/java/org/postgresql/test/xa/XATestSuite.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/xa/XATestSuite.java
@@ -9,6 +9,8 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
 @RunWith(Suite.class)
-@Suite.SuiteClasses(XADataSourceTest.class)
+@Suite.SuiteClasses({
+    XADataSourceTest.class,
+})
 public class XATestSuite {
 }


### PR DESCRIPTION
Fixes sort order for some test suites so we have cleaner diffs down the road.

Would be nice to have a checkstyle rule or equivalent to enforce this but at the moment we don't run any style checks on src/test/ anyway so I've just added a few words to the PR template.