### PR TITLE
fix: PgSQLXML setCharacterStream() results in null value 

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgSQLXML.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgSQLXML.java
@@ -175,6 +175,7 @@ public class PgSQLXML implements SQLXML {
   public synchronized Writer setCharacterStream() throws SQLException {
     checkFreed();
     initialize();
+    active = true;
     stringWriter = new StringWriter();
     return stringWriter;
   }

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/PgSQLXMLTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/PgSQLXMLTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2004, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.jdbc;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.postgresql.test.TestUtil;
+import org.postgresql.test.jdbc2.BaseTest4;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.Writer;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLXML;
+import java.sql.Statement;
+
+public class PgSQLXMLTest extends BaseTest4 {
+
+  @Override
+  @Before
+  public void setUp() throws Exception {
+    super.setUp();
+    TestUtil.createTempTable(con, "xmltab","x xml");
+  }
+
+  @Test
+  public void setCharacterStream() throws  Exception {
+    String exmplar = "<x>value</x>";
+    SQLXML pgSQLXML = con.createSQLXML();
+    Writer writer = pgSQLXML.setCharacterStream();
+    writer.write(exmplar);
+    PreparedStatement preparedStatement = con.prepareStatement("insert into xmltab values (?)");
+    preparedStatement.setSQLXML(1,pgSQLXML);
+    preparedStatement.execute();
+
+    Statement statement = con.createStatement();
+    ResultSet rs = statement.executeQuery("select * from xmltab");
+    assertTrue(rs.next());
+    SQLXML result = rs.getSQLXML(1);
+    assertNotNull(result);
+    assertEquals(exmplar, result.getString());
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/PgSQLXMLTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/PgSQLXMLTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, PostgreSQL Global Development Group
+ * Copyright (c) 2019, PostgreSQL Global Development Group
  * See the LICENSE file in the project root for more information.
  */
 

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/Jdbc2TestSuite.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/Jdbc2TestSuite.java
@@ -13,6 +13,7 @@ import org.postgresql.core.ParserTest;
 import org.postgresql.core.ReturningParserTest;
 import org.postgresql.core.v3.V3ParameterListTests;
 import org.postgresql.jdbc.DeepBatchedInsertStatementTest;
+import org.postgresql.jdbc.PgSQLXMLTest;
 import org.postgresql.jdbc.PrimitiveArraySupportTest;
 import org.postgresql.test.core.JavaVersionTest;
 import org.postgresql.test.core.LogServerMessagePropertyTest;
@@ -82,6 +83,7 @@ import org.junit.runners.Suite;
     PGPropertyTest.class,
     PGTimestampTest.class,
     PGTimeTest.class,
+    PgSQLXMLTest.class,
     PreparedStatementTest.class,
     PrimitiveArraySupportTest.class,
     QuotationTest.class,


### PR DESCRIPTION
fixes Issue #731
