### PR TITLE
fix: NPE as a result of calling executeQuery twice on a statement 

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
@@ -1852,14 +1852,24 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
 
   public void close() throws SQLException {
     try {
-      // release resources held (memory for tuples)
-      rows = null;
-      if (cursor != null) {
-        cursor.close();
-        cursor = null;
-      }
+      closeInternally();
     } finally {
       ((PgStatement) statement).checkCompletion();
+    }
+  }
+
+  /*
+  used by PgStatement.closeForNextExecution to avoid
+  closing the firstUnclosedResult twice.
+  checkCompletion above modifies firstUnclosedResult
+  fixes issue #684
+   */
+  protected void closeInternally() throws SQLException {
+    // release resources held (memory for tuples)
+    rows = null;
+    if (cursor != null) {
+      cursor.close();
+      cursor = null;
     }
   }
 

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgStatement.java
@@ -125,7 +125,7 @@ public class PgStatement implements Statement, BaseStatement {
   /**
    * The first unclosed result.
    */
-  protected ResultWrapper firstUnclosedResult = null;
+  protected volatile ResultWrapper firstUnclosedResult = null;
 
   /**
    * Results returned by a statement that wants generated keys.
@@ -327,9 +327,9 @@ public class PgStatement implements Statement, BaseStatement {
     // Close any existing resultsets associated with this statement.
     synchronized (this) {
       while (firstUnclosedResult != null) {
-        ResultSet rs = firstUnclosedResult.getResultSet();
+        PgResultSet rs = (PgResultSet)firstUnclosedResult.getResultSet();
         if (rs != null) {
-          rs.close();
+          rs.closeInternally();
         }
         firstUnclosedResult = firstUnclosedResult.getNext();
       }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc4/jdbc41/CloseOnCompletionTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc4/jdbc41/CloseOnCompletionTest.java
@@ -15,6 +15,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -88,5 +89,13 @@ public class CloseOnCompletionTest {
 
     stmt.executeUpdate(TestUtil.insertSQL("table1", "1"));
     assertFalse(stmt.isClosed());
+  }
+
+  @Test
+  public void testExecuteTwice() throws SQLException {
+    PreparedStatement s = conn.prepareStatement("SELECT 1");
+    s.closeOnCompletion();
+    s.executeQuery();
+    s.executeQuery();
   }
 }


### PR DESCRIPTION
fixes issue #684

