### PR TITLE
fix: null pointer exception from PgResultSetMetaData when there's no column metadata

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSetMetaData.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSetMetaData.java
@@ -113,7 +113,8 @@ public class PgResultSetMetaData implements ResultSetMetaData, PGResultSetMetaDa
   public int isNullable(int column) throws SQLException {
     fetchFieldMetaData();
     Field field = getField(column);
-    return field.getMetadata().nullable;
+    FieldMetadata metadata = field.getMetadata();
+    return metadata == null ? ResultSetMetaData.columnNullable : metadata.nullable;
   }
 
   /**
@@ -151,7 +152,8 @@ public class PgResultSetMetaData implements ResultSetMetaData, PGResultSetMetaDa
       return "";
     }
     fetchFieldMetaData();
-    return field.getMetadata().columnName;
+    FieldMetadata metadata = field.getMetadata();
+    return metadata == null ? "" : metadata.columnName;
   }
 
   public String getSchemaName(int column) throws SQLException {
@@ -268,7 +270,8 @@ public class PgResultSetMetaData implements ResultSetMetaData, PGResultSetMetaDa
   public String getBaseSchemaName(int column) throws SQLException {
     fetchFieldMetaData();
     Field field = getField(column);
-    return field.getMetadata().schemaName;
+    FieldMetadata metadata = field.getMetadata();
+    return metadata == null ? "" : metadata.schemaName;
   }
 
   public int getPrecision(int column) throws SQLException {
@@ -288,7 +291,8 @@ public class PgResultSetMetaData implements ResultSetMetaData, PGResultSetMetaDa
   public String getBaseTableName(int column) throws SQLException {
     fetchFieldMetaData();
     Field field = getField(column);
-    return field.getMetadata().tableName;
+    FieldMetadata metadata = field.getMetadata();
+    return metadata == null ? "" : metadata.tableName;
   }
 
   /**

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/NoColumnMetadataIssue1613.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/NoColumnMetadataIssue1613.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2019, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.jdbc;
+
+import static org.junit.Assert.assertTrue;
+
+import org.postgresql.test.TestUtil;
+import org.postgresql.test.jdbc2.BaseTest4;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.sql.ResultSet;
+import java.sql.Statement;
+
+/**
+ * If the SQL query has no column metadata, the driver shouldn't break by a null pointer exception.
+ * It should return the result correctly.
+ *
+ * @author Ivy (ivyyiyideng@gmail.com)
+ *
+ */
+public class NoColumnMetadataIssue1613 extends BaseTest4 {
+  @Override
+  @Before
+  public void setUp() throws Exception {
+    super.setUp();
+    TestUtil.createTempTable(con, "test_no_column_metadata","id int");
+  }
+
+  @Test
+  public void shouldBeNoNPE() throws Exception {
+    Statement statement = con.createStatement();
+    statement.executeQuery("INSERT INTO test_no_column_metadata values (1)");
+    ResultSet rs = statement.executeQuery("SELECT x FROM test_no_column_metadata x");
+    assertTrue(rs.next());
+  }
+}


### PR DESCRIPTION
As described in https://github.com/pgjdbc/pgjdbc/issues/1613 and a previous PR https://github.com/pgjdbc/pgjdbc/pull/663, the driver throws null pointer exception when building the results for queries without column metadata, e.g. `SELECT <x> FROM <table name> <x>`,  where `<x>` is not a column name but an alias of the table. It should just return the whole table. (There might be other queries that can also reproduce this issue.)

However the above PR only fix one place where `field.getMetadata()` is null. There are four more places might cause the NPE. 
In this minor fix, we return "" as the columnName, schemaName, tableName if the metadata is null, and `ResultSetMetaData.columnNullable` for nullable.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Does mvn checkstyle:check pass ?
3. [ ] Have you added your new test classes to an existing test suite in alphabetical order?

### Changes to Existing Features:

* [ ] Does this break existing behaviour? If so please explain.
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

