### PR TITLE
fix: DatabaseMetaData.getFunctions should not limit the search to the search_path if the schema is provided

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
@@ -1038,6 +1038,9 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
           + " WHERE p.pronamespace=n.oid ";
     if (schemaPattern != null && !schemaPattern.isEmpty()) {
       sql += " AND n.nspname LIKE " + escapeQuotes(schemaPattern);
+    } else {
+      /* limit to current schema if no schema given */
+      sql += "and pg_function_is_visible(p.oid)";
     }
     if (procedureNamePattern != null && !procedureNamePattern.isEmpty()) {
       sql += " AND p.proname LIKE " + escapeQuotes(procedureNamePattern);
@@ -2679,9 +2682,15 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
         + "FROM pg_catalog.pg_proc p "
         + "INNER JOIN pg_catalog.pg_namespace n ON p.pronamespace=n.oid "
         + "LEFT JOIN pg_catalog.pg_description d ON p.oid=d.objoid "
-        + "WHERE pg_function_is_visible(p.oid) ";
+        + "WHERE true  ";
+    /*
+    if the user provides a schema then search inside the schema for it
+     */
     if (schemaPattern != null && !schemaPattern.isEmpty()) {
       sql += " AND n.nspname LIKE " + escapeQuotes(schemaPattern);
+    } else {
+      /* if no schema is provided then limit the search inside the search_path */
+      sql += "and pg_function_is_visible(p.oid)";
     }
     if (functionNamePattern != null && !functionNamePattern.isEmpty()) {
       sql += " AND p.proname LIKE " + escapeQuotes(functionNamePattern);

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc4/DatabaseMetaDataTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc4/DatabaseMetaDataTest.java
@@ -104,11 +104,20 @@ public class DatabaseMetaDataTest {
     int count = assertGetFunctionRS(rs);
     assertThat( count, is(1));
 
-    conn.setSchema("hasfunctions");
+    Statement statement = conn.createStatement();
+    statement.execute("set search_path=hasfunctions");
+
     rs = dbmd.getFunctions("", "","addfunction");
     assertThat( assertGetFunctionRS(rs), is(1) );
 
-    conn.setSchema("public");
+    statement.execute("set search_path=nofunctions");
+
+    rs = dbmd.getFunctions("", "","addfunction");
+    assertFalse(rs.next());
+
+    statement.execute("reset search_path");
+    statement.close();
+
     rs = dbmd.getFunctions("", "nofunctions",null);
     assertFalse(rs.next());
 
@@ -120,11 +129,19 @@ public class DatabaseMetaDataTest {
     ResultSet rs = dbmd.getProcedures("", "hasfunctions",null);
     assertTrue(rs.next());
 
-    conn.setSchema("hasfunctions");
-    rs = dbmd.getProcedures("", "",null);
+
+    Statement statement = conn.createStatement();
+    statement.execute("set search_path=hasfunctions");
+
+    rs = dbmd.getProcedures("", "","addfunction");
     assertTrue(rs.next());
 
-    conn.setSchema("public");
+    statement.execute("set search_path=nofunctions");
+    rs = dbmd.getProcedures("", "","addfunction");
+    assertFalse(rs.next());
+
+    statement.execute("reset search_path");
+    statement.close();
     rs = dbmd.getProcedures("", "nofunctions",null);
     assertFalse(rs.next());
 


### PR DESCRIPTION
Currently getFunctions adds pg_function_is_visible to the sql looking for functions in all cases. If the user provides a schema but it is not on the search path no functions will be found. This seems counter-intuitive.

With this PR if the user provides a schema then that schema will be searched. If the schema is empty or null then the search path will be searched for the function.