### PR TITLE
remove receiving EOF from backend after cancel …

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/QueryExecutorBase.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/QueryExecutorBase.java
@@ -185,7 +185,6 @@ public abstract class QueryExecutorBase implements QueryExecutor {
       cancelStream.sendInteger4(cancelPid);
       cancelStream.sendInteger4(cancelKey);
       cancelStream.flush();
-      cancelStream.receiveEOF();
     } catch (IOException e) {
       // Safe to ignore.
       LOGGER.log(Level.FINEST, "Ignoring exception on cancel request:", e);

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/StatementTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/StatementTest.java
@@ -903,7 +903,7 @@ public class StatementTest {
     }
   }
 
-  @Test(timeout = 20000)
+  @Test(timeout = 2000)
   public void testFastCloses() throws SQLException {
     ExecutorService executor = Executors.newSingleThreadExecutor();
     con.createStatement().execute("SET SESSION client_min_messages = 'NOTICE'");


### PR DESCRIPTION
since according to protocol the server closes the connection immediately once cancel is sent (connection reset exception is always thrown) and that was slowing the close considerably (the 1000 close used to take 22 seconds because of this now it takes 1-1.5 seconds on my machine. I also changed the timeout of the test from 20 seconds to 2 seconds.

quote:

> The server will process this [cancel] request and then close the connection. For security reasons, no direct reply is made to the cancel request message

." https://www.postgresql.org/docs/current/protocol-flow.html

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [x] Does mvn checkstyle:check pass ?
3. [ ] Have you added your new test classes to an existing test suite in alphabetical order?

### Changes to Existing Features:

* [ ] Does this break existing behaviour? If so please explain.
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
