### PR TITLE
Fix test case by changing executeQuery to execute

### DIFF
--- a/pgjdbc/src/test/java/org/postgresql/jdbc/NoColumnMetadataIssue1613Test.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/NoColumnMetadataIssue1613Test.java
@@ -23,7 +23,7 @@ import java.sql.Statement;
  * @author Ivy (ivyyiyideng@gmail.com)
  *
  */
-public class NoColumnMetadataIssue1613 extends BaseTest4 {
+public class NoColumnMetadataIssue1613Test extends BaseTest4 {
   @Override
   @Before
   public void setUp() throws Exception {
@@ -34,7 +34,7 @@ public class NoColumnMetadataIssue1613 extends BaseTest4 {
   @Test
   public void shouldBeNoNPE() throws Exception {
     Statement statement = con.createStatement();
-    statement.executeQuery("INSERT INTO test_no_column_metadata values (1)");
+    statement.execute("INSERT INTO test_no_column_metadata values (1)");
     ResultSet rs = statement.executeQuery("SELECT x FROM test_no_column_metadata x");
     assertTrue(rs.next());
   }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/Jdbc2TestSuite.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/Jdbc2TestSuite.java
@@ -13,6 +13,7 @@ import org.postgresql.core.ParserTest;
 import org.postgresql.core.ReturningParserTest;
 import org.postgresql.core.v3.V3ParameterListTests;
 import org.postgresql.jdbc.DeepBatchedInsertStatementTest;
+import org.postgresql.jdbc.NoColumnMetadataIssue1613Test;
 import org.postgresql.jdbc.PgSQLXMLTest;
 import org.postgresql.jdbc.PrimitiveArraySupportTest;
 import org.postgresql.test.core.JavaVersionTest;
@@ -73,6 +74,7 @@ import org.junit.runners.Suite;
     LruCacheTest.class,
     MiscTest.class,
     NativeQueryBindLengthTest.class,
+    NoColumnMetadataIssue1613Test.class,
     NotifyTest.class,
     OidToStringTest.class,
     OidValueOfTest.class,


### PR DESCRIPTION
"query has no results" error was being thrown since executeQuery is expecting a result set.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [x] Does mvn checkstyle:check pass ?
3. [ ] Have you added your new test classes to an existing test suite in alphabetical order?

### Changes to Existing Features:

* [ ] Does this break existing behaviour? If so please explain.
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
