### PR TITLE
fix: issue 1482 where the port was being added to the GSSAPI service name

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/sspi/SSPIClient.java
+++ b/pgjdbc/src/main/java/org/postgresql/sspi/SSPIClient.java
@@ -103,8 +103,13 @@ public class SSPIClient implements ISSPIClient {
     final HostSpec hs = pgStream.getHostSpec();
 
     try {
+      /*
+      The GSSAPI implementation does not use the port in the service name.
+      Force the port number to 0
+      Fixes issue 1482
+      */
       return NTDSAPIWrapper.instance.DsMakeSpn(spnServiceClass, hs.getHost(), null,
-          (short) hs.getPort(), null);
+          (short) 0, null);
     } catch (LastErrorException ex) {
       throw new PSQLException("SSPI setup failed to determine SPN",
           PSQLState.CONNECTION_UNABLE_TO_CONNECT, ex);


### PR DESCRIPTION
PostgreSQL does not use the port in the service name which is consistent with the GSSAPI docs