### PR TITLE
Fix interval overflow

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/util/PGInterval.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/PGInterval.java
@@ -17,10 +17,10 @@ import java.util.StringTokenizer;
 public class PGInterval extends PGobject implements Serializable, Cloneable {
 
   private int years;
-  private byte months;
-  private byte days;
-  private byte hours;
-  private byte minutes;
+  private int months;
+  private int days;
+  private int hours;
+  private int minutes;
   private int wholeSeconds;
   private int microSeconds;
 
@@ -280,7 +280,7 @@ public class PGInterval extends PGobject implements Serializable, Cloneable {
    * @param months months to set
    */
   public void setMonths(int months) {
-    this.months = (byte) months;
+    this.months = months;
   }
 
   /**
@@ -298,7 +298,7 @@ public class PGInterval extends PGobject implements Serializable, Cloneable {
    * @param days days to set
    */
   public void setDays(int days) {
-    this.days = (byte)days;
+    this.days = days;
   }
 
   /**
@@ -316,7 +316,7 @@ public class PGInterval extends PGobject implements Serializable, Cloneable {
    * @param hours hours to set
    */
   public void setHours(int hours) {
-    this.hours = (byte)hours;
+    this.hours = hours;
   }
 
   /**
@@ -334,7 +334,7 @@ public class PGInterval extends PGobject implements Serializable, Cloneable {
    * @param minutes minutes to set
    */
   public void setMinutes(int minutes) {
-    this.minutes = (byte)minutes;
+    this.minutes = minutes;
   }
 
   /**

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/IntervalTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/IntervalTest.java
@@ -174,6 +174,15 @@ public class IntervalTest {
     assertEquals(-15, pgi.getHours());
     assertEquals(57, pgi.getMinutes());
     assertEquals(-12.1, pgi.getSeconds(), 0);
+
+    // Unjustified interval test
+    pgi = new PGInterval("@ 0 years 0 mons 0 days 900 hours 0 mins 0.00 secs");
+    assertEquals(0, pgi.getYears());
+    assertEquals(0, pgi.getMonths());
+    assertEquals(0, pgi.getDays());
+    assertEquals(900, pgi.getHours());
+    assertEquals(0, pgi.getMinutes());
+    assertEquals(0, pgi.getSeconds(), 0);
   }
 
   private Calendar getStartCalendar() {


### PR DESCRIPTION
I noticed issues with interval after upgrading to 42.2.9 from 42.2.8. It appears #1612 is the cause due to overloading issues. Some of the units were changed from int to byte. But I don't believe this is sound because intervals in postgres aren't guaranteed to be justified. For example, it's valid to have hour values greater than 24 hours:

```sql
select interval '900 hours';
-- 0 years 0 mons 0 days 900 hours 0 mins 0.00 secs

select justify_interval(interval '900 hours');
-- 0 years 1 mons 7 days 12 hours 0 mins 0.00 secs
```

I have unjustified intervals in my DB which is how I discovered this.