### PR TITLE
Fix: Fixes the issue with getting out of sync in the copy

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/PGStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/PGStream.java
@@ -25,6 +25,7 @@ import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.SocketTimeoutException;
 import java.sql.SQLException;
+import java.util.concurrent.TimeUnit;
 
 import javax.net.SocketFactory;
 
@@ -128,7 +129,7 @@ public class PGStream implements Closeable, Flushable {
     if (pgInput.available() > 0) {
       return true;
     }
-    long now = System.nanoTime() / 1000000;
+    long now = TimeUnit.NANOSECONDS.toMillis(System.nanoTime());
 
     if (now < nextStreamAvailableCheckTime && minStreamAvailableCheckDelay != 0) {
       // Do not use ".peek" too often

--- a/pgjdbc/src/main/java/org/postgresql/core/VisibleBufferedInputStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/VisibleBufferedInputStream.java
@@ -8,6 +8,7 @@ package org.postgresql.core;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.SocketTimeoutException;
 
 /**
  * A faster version of BufferedInputStream. Does no synchronisation and allows direct access to the
@@ -137,7 +138,12 @@ public class VisibleBufferedInputStream extends InputStream {
       }
       canFit = buffer.length - endIndex;
     }
-    int read = wrapped.read(buffer, endIndex, canFit);
+    int read = 0;
+    try {
+      read = wrapped.read(buffer, endIndex, canFit);
+    } catch (SocketTimeoutException e) {
+      // ignore
+    }
     if (read < 0) {
       return false;
     }
@@ -211,7 +217,12 @@ public class VisibleBufferedInputStream extends InputStream {
 
     // then directly from wrapped stream
     do {
-      int r = wrapped.read(to, off, len);
+      int r;
+      try {
+        r = wrapped.read(to, off, len);
+      } catch (SocketTimeoutException e) {
+        return read;
+      }
       if (r <= 0) {
         return (read == 0) ? r : read;
       }

--- a/pgjdbc/src/main/java/org/postgresql/core/VisibleBufferedInputStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/VisibleBufferedInputStream.java
@@ -144,7 +144,7 @@ public class VisibleBufferedInputStream extends InputStream {
     } catch (SocketTimeoutException e) {
       // ignore
     }
-    if (read < 0) {
+    if (read <= 0) {
       return false;
     }
     endIndex += read;

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -61,6 +61,7 @@ import java.util.List;
 import java.util.Properties;
 import java.util.Set;
 import java.util.TimeZone;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -719,7 +720,7 @@ public class QueryExecutorImpl extends QueryExecutorBase {
     long startTime = 0;
     int oldTimeout = 0;
     if (useTimeout) {
-      startTime = System.nanoTime() / 1000;
+      startTime = TimeUnit.NANOSECONDS.toMillis(System.nanoTime());
       try {
         oldTimeout = pgStream.getSocket().getSoTimeout();
       } catch (SocketException e) {
@@ -749,7 +750,7 @@ public class QueryExecutorImpl extends QueryExecutorBase {
             SQLWarning warning = receiveNoticeResponse();
             addWarning(warning);
             if (useTimeout) {
-              long newTimeMillis = System.nanoTime() / 1000;
+              long newTimeMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime());
               timeoutMillis += startTime - newTimeMillis; // Overflows after 49 days, ignore that
               startTime = newTimeMillis;
               if (timeoutMillis == 0) {

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -61,7 +61,6 @@ import java.util.List;
 import java.util.Properties;
 import java.util.Set;
 import java.util.TimeZone;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -1088,207 +1087,207 @@ public class QueryExecutorImpl extends QueryExecutorBase {
   CopyOperationImpl processCopyResults(CopyOperationImpl op, boolean block)
       throws SQLException, IOException {
 
-      boolean endReceiving = false;
-      SQLException error = null;
-      SQLException errors = null;
-      int len;
+    boolean endReceiving = false;
+    SQLException error = null;
+    SQLException errors = null;
+    int len;
 
-      while (!endReceiving && (block || pgStream.hasMessagePending())) {
+    while (!endReceiving && (block || pgStream.hasMessagePending())) {
 
-        // There is a bug in the server's implementation of the copy
-        // protocol. It returns command complete immediately upon
-        // receiving the EOF marker in the binary protocol,
-        // potentially before we've issued CopyDone. When we are not
-        // blocking, we don't think we are done, so we hold off on
-        // processing command complete and any subsequent messages
-        // until we actually are done with the copy.
-        //
-        if (!block) {
-          int c = pgStream.peekChar();
-          if (c == 'C') {
-            // CommandComplete
-            LOGGER.log(Level.FINEST, " <=BE CommandStatus, Ignored until CopyDone");
-            break;
-          }
+      // There is a bug in the server's implementation of the copy
+      // protocol. It returns command complete immediately upon
+      // receiving the EOF marker in the binary protocol,
+      // potentially before we've issued CopyDone. When we are not
+      // blocking, we don't think we are done, so we hold off on
+      // processing command complete and any subsequent messages
+      // until we actually are done with the copy.
+      //
+      if (!block) {
+        int c = pgStream.peekChar();
+        if (c == 'C') {
+          // CommandComplete
+          LOGGER.log(Level.FINEST, " <=BE CommandStatus, Ignored until CopyDone");
+          break;
         }
+      }
 
-        int c = pgStream.receiveChar();
-        switch (c) {
+      int c = pgStream.receiveChar();
+      switch (c) {
 
-          case 'A': // Asynchronous Notify
+        case 'A': // Asynchronous Notify
 
-            LOGGER.log(Level.FINEST, " <=BE Asynchronous Notification while copying");
+          LOGGER.log(Level.FINEST, " <=BE Asynchronous Notification while copying");
 
-            receiveAsyncNotify();
-            break;
+          receiveAsyncNotify();
+          break;
 
-          case 'N': // Notice Response
+        case 'N': // Notice Response
 
-            LOGGER.log(Level.FINEST, " <=BE Notification while copying");
+          LOGGER.log(Level.FINEST, " <=BE Notification while copying");
 
-            addWarning(receiveNoticeResponse());
-            break;
+          addWarning(receiveNoticeResponse());
+          break;
 
-          case 'C': // Command Complete
+        case 'C': // Command Complete
 
-            String status = receiveCommandStatus();
+          String status = receiveCommandStatus();
 
-            try {
-              if (op == null) {
-                throw new PSQLException(GT
-                    .tr("Received CommandComplete ''{0}'' without an active copy operation", status),
-                    PSQLState.OBJECT_NOT_IN_STATE);
-              }
-              op.handleCommandStatus(status);
-            } catch (SQLException se) {
-              error = se;
-            }
-
-            block = true;
-            break;
-
-          case 'E': // ErrorMessage (expected response to CopyFail)
-
-            error = receiveErrorResponse();
-            // We've received the error and we now expect to receive
-            // Ready for query, but we must block because it might still be
-            // on the wire and not here yet.
-            block = true;
-            break;
-
-          case 'G': // CopyInResponse
-
-            LOGGER.log(Level.FINEST, " <=BE CopyInResponse");
-
-            if (op != null) {
-              error = new PSQLException(GT.tr("Got CopyInResponse from server during an active {0}",
-                  op.getClass().getName()), PSQLState.OBJECT_NOT_IN_STATE);
-            }
-
-            op = new CopyInImpl();
-            initCopy(op);
-            endReceiving = true;
-            break;
-
-          case 'H': // CopyOutResponse
-
-            LOGGER.log(Level.FINEST, " <=BE CopyOutResponse");
-
-            if (op != null) {
-              error = new PSQLException(GT.tr("Got CopyOutResponse from server during an active {0}",
-                  op.getClass().getName()), PSQLState.OBJECT_NOT_IN_STATE);
-            }
-
-            op = new CopyOutImpl();
-            initCopy(op);
-            endReceiving = true;
-            break;
-
-          case 'W': // CopyBothResponse
-
-            LOGGER.log(Level.FINEST, " <=BE CopyBothResponse");
-
-            if (op != null) {
-              error = new PSQLException(GT.tr("Got CopyBothResponse from server during an active {0}",
-                  op.getClass().getName()), PSQLState.OBJECT_NOT_IN_STATE);
-            }
-
-            op = new CopyDualImpl();
-            initCopy(op);
-            endReceiving = true;
-            break;
-
-          case 'd': // CopyData
-
-            LOGGER.log(Level.FINEST, " <=BE CopyData");
-
-            len = pgStream.receiveInteger4() - 4;
-
-            assert len > 0 : "Copy Data length must be greater than 4";
-
-            byte[] buf = pgStream.receive(len);
+          try {
             if (op == null) {
-              error = new PSQLException(GT.tr("Got CopyData without an active copy operation"),
-                  PSQLState.OBJECT_NOT_IN_STATE);
-            } else if (!(op instanceof CopyOut)) {
-              error = new PSQLException(
-                  GT.tr("Unexpected copydata from server for {0}", op.getClass().getName()),
-                  PSQLState.COMMUNICATION_ERROR);
-            } else {
-              op.handleCopydata(buf);
-            }
-            endReceiving = true;
-            break;
-
-          case 'c': // CopyDone (expected after all copydata received)
-
-            LOGGER.log(Level.FINEST, " <=BE CopyDone");
-
-            len = pgStream.receiveInteger4() - 4;
-            if (len > 0) {
-              pgStream.receive(len); // not in specification; should never appear
-            }
-
-            if (!(op instanceof CopyOut)) {
-              error = new PSQLException("Got CopyDone while not copying from server",
+              throw new PSQLException(GT
+                  .tr("Received CommandComplete ''{0}'' without an active copy operation", status),
                   PSQLState.OBJECT_NOT_IN_STATE);
             }
-
-            // keep receiving since we expect a CommandComplete
-            block = true;
-            break;
-          case 'S': // Parameter Status
-            try {
-              receiveParameterStatus();
-            } catch (SQLException e) {
-              error = e;
-              endReceiving = true;
-            }
-            break;
-
-          case 'Z': // ReadyForQuery: After FE:CopyDone => BE:CommandComplete
-
-            receiveRFQ();
-            if (hasLock(op)) {
-              unlock(op);
-            }
-            op = null;
-            endReceiving = true;
-            break;
-
-          // If the user sends a non-copy query, we've got to handle some additional things.
-          //
-          case 'T': // Row Description (response to Describe)
-            LOGGER.log(Level.FINEST, " <=BE RowDescription (during copy ignored)");
-
-            skipMessage();
-            break;
-
-          case 'D': // DataRow
-            LOGGER.log(Level.FINEST, " <=BE DataRow (during copy ignored)");
-
-            skipMessage();
-            break;
-
-          default:
-            throw new IOException(
-                GT.tr("Unexpected packet type during copy: {0}", Integer.toString(c)));
-        }
-
-        // Collect errors into a neat chain for completeness
-        if (error != null) {
-          if (errors != null) {
-            error.setNextException(errors);
+            op.handleCommandStatus(status);
+          } catch (SQLException se) {
+            error = se;
           }
-          errors = error;
-          error = null;
-        }
+
+          block = true;
+          break;
+
+        case 'E': // ErrorMessage (expected response to CopyFail)
+
+          error = receiveErrorResponse();
+          // We've received the error and we now expect to receive
+          // Ready for query, but we must block because it might still be
+          // on the wire and not here yet.
+          block = true;
+          break;
+
+        case 'G': // CopyInResponse
+
+          LOGGER.log(Level.FINEST, " <=BE CopyInResponse");
+
+          if (op != null) {
+            error = new PSQLException(GT.tr("Got CopyInResponse from server during an active {0}",
+                op.getClass().getName()), PSQLState.OBJECT_NOT_IN_STATE);
+          }
+
+          op = new CopyInImpl();
+          initCopy(op);
+          endReceiving = true;
+          break;
+
+        case 'H': // CopyOutResponse
+
+          LOGGER.log(Level.FINEST, " <=BE CopyOutResponse");
+
+          if (op != null) {
+            error = new PSQLException(GT.tr("Got CopyOutResponse from server during an active {0}",
+                op.getClass().getName()), PSQLState.OBJECT_NOT_IN_STATE);
+          }
+
+          op = new CopyOutImpl();
+          initCopy(op);
+          endReceiving = true;
+          break;
+
+        case 'W': // CopyBothResponse
+
+          LOGGER.log(Level.FINEST, " <=BE CopyBothResponse");
+
+          if (op != null) {
+            error = new PSQLException(GT.tr("Got CopyBothResponse from server during an active {0}",
+                op.getClass().getName()), PSQLState.OBJECT_NOT_IN_STATE);
+          }
+
+          op = new CopyDualImpl();
+          initCopy(op);
+          endReceiving = true;
+          break;
+
+        case 'd': // CopyData
+
+          LOGGER.log(Level.FINEST, " <=BE CopyData");
+
+          len = pgStream.receiveInteger4() - 4;
+
+          assert len > 0 : "Copy Data length must be greater than 4";
+
+          byte[] buf = pgStream.receive(len);
+          if (op == null) {
+            error = new PSQLException(GT.tr("Got CopyData without an active copy operation"),
+                PSQLState.OBJECT_NOT_IN_STATE);
+          } else if (!(op instanceof CopyOut)) {
+            error = new PSQLException(
+                GT.tr("Unexpected copydata from server for {0}", op.getClass().getName()),
+                PSQLState.COMMUNICATION_ERROR);
+          } else {
+            op.handleCopydata(buf);
+          }
+          endReceiving = true;
+          break;
+
+        case 'c': // CopyDone (expected after all copydata received)
+
+          LOGGER.log(Level.FINEST, " <=BE CopyDone");
+
+          len = pgStream.receiveInteger4() - 4;
+          if (len > 0) {
+            pgStream.receive(len); // not in specification; should never appear
+          }
+
+          if (!(op instanceof CopyOut)) {
+            error = new PSQLException("Got CopyDone while not copying from server",
+                PSQLState.OBJECT_NOT_IN_STATE);
+          }
+
+          // keep receiving since we expect a CommandComplete
+          block = true;
+          break;
+        case 'S': // Parameter Status
+          try {
+            receiveParameterStatus();
+          } catch (SQLException e) {
+            error = e;
+            endReceiving = true;
+          }
+          break;
+
+        case 'Z': // ReadyForQuery: After FE:CopyDone => BE:CommandComplete
+
+          receiveRFQ();
+          if (hasLock(op)) {
+            unlock(op);
+          }
+          op = null;
+          endReceiving = true;
+          break;
+
+        // If the user sends a non-copy query, we've got to handle some additional things.
+        //
+        case 'T': // Row Description (response to Describe)
+          LOGGER.log(Level.FINEST, " <=BE RowDescription (during copy ignored)");
+
+          skipMessage();
+          break;
+
+        case 'D': // DataRow
+          LOGGER.log(Level.FINEST, " <=BE DataRow (during copy ignored)");
+
+          skipMessage();
+          break;
+
+        default:
+          throw new IOException(
+              GT.tr("Unexpected packet type during copy: {0}", Integer.toString(c)));
       }
 
-      if (errors != null) {
-        throw errors;
+      // Collect errors into a neat chain for completeness
+      if (error != null) {
+        if (errors != null) {
+          error.setNextException(errors);
+        }
+        errors = error;
+        error = null;
       }
-      return op;
+    }
+
+    if (errors != null) {
+      throw errors;
+    }
+    return op;
   }
 
   /*

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -1075,8 +1075,6 @@ public class QueryExecutorImpl extends QueryExecutorBase {
     }
   }
 
-  AtomicBoolean processingCopyResults = new AtomicBoolean(false);
-
   /**
    * Handles copy sub protocol responses from server. Unlocks at end of sub protocol, so operations
    * on pgStream or QueryExecutor are not allowed in a method after calling this!
@@ -1090,16 +1088,6 @@ public class QueryExecutorImpl extends QueryExecutorBase {
   CopyOperationImpl processCopyResults(CopyOperationImpl op, boolean block)
       throws SQLException, IOException {
 
-    /*
-    *  This is a hack as we should not end up here, but sometimes do with large copy operations.
-     */
-    if ( processingCopyResults.compareAndSet(false,true) == false ) {
-      LOGGER.log(Level.INFO, "Ignoring request to process copy results, already processing");
-      return null;
-    }
-
-    // put this all in a try, finally block and reset the processingCopyResults in the finally clause
-    try {
       boolean endReceiving = false;
       SQLException error = null;
       SQLException errors = null;
@@ -1301,13 +1289,6 @@ public class QueryExecutorImpl extends QueryExecutorBase {
         throw errors;
       }
       return op;
-
-    } finally {
-      /*
-      reset here in the finally block to make sure it really is cleared
-       */
-      processingCopyResults.set(false);
-    }
   }
 
   /*


### PR DESCRIPTION
protocol manifesting as "Unexpected packet type error"
We were incorrectly ignoring SocketTimeout issues and not returning the correct
number of bytes read. This also remove the hack which attempted to
synchronize reads by putting an atomic guard ahead of the reads.

Final fix by @hyunkshinft

