### PR TITLE
Fix Network Performance of PgDatabaseMetaData.getTypeInfo() method

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
@@ -9,6 +9,7 @@ import org.postgresql.core.BaseStatement;
 import org.postgresql.core.Field;
 import org.postgresql.core.Oid;
 import org.postgresql.core.ServerVersion;
+import org.postgresql.core.TypeInfo;
 import org.postgresql.util.ByteConverter;
 import org.postgresql.util.GT;
 import org.postgresql.util.JdbcBlackHole;
@@ -2291,6 +2292,11 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
               connection.encodeString(Integer.toString(java.sql.DatabaseMetaData.typeNullable));
     byte[] bSearchable =
               connection.encodeString(Integer.toString(java.sql.DatabaseMetaData.typeSearchable));
+
+    TypeInfo ti = connection.getTypeInfo();
+    if (ti instanceof TypeInfoCache) {
+      ((TypeInfoCache) ti).cacheSQLTypes();
+    }
 
     while (rs.next()) {
       byte[][] tuple = new byte[19][];

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
@@ -24,8 +24,12 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class TypeInfoCache implements TypeInfo {
+
+  private static final Logger LOGGER = Logger.getLogger(TypeInfoCache.class.getName());
 
   // pgname (String) -> java.sql.Types (Integer)
   private Map<String, Integer> pgNameToSQLType;
@@ -189,6 +193,8 @@ public class TypeInfoCache implements TypeInfo {
     if (i != null) {
       return i;
     }
+
+    LOGGER.log(Level.FINEST, "querying SQL typecode for pg type '{0}'", pgTypeName);
 
     if (getTypeInfoStatement == null) {
       // There's no great way of telling what's an array type.

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseMetaDataCacheTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseMetaDataCacheTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2004, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.test.jdbc2;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.postgresql.core.TypeInfo;
+import org.postgresql.jdbc.PgConnection;
+import org.postgresql.test.TestUtil;
+import org.postgresql.util.TestLogHandler;
+
+import java.sql.SQLException;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.LogManager;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+import java.util.regex.Pattern;
+
+import static org.junit.Assert.assertEquals;
+
+/*
+ * Tests for caching of DatabaseMetadata
+ *
+ */
+public class DatabaseMetaDataCacheTest {
+  private PgConnection con;
+  private TestLogHandler log;
+  private Logger driverLogger;
+  private Level driverLogLevel;
+
+  private static final Pattern SQL_TYPE_QUERY_LOG_FILTER = Pattern.compile("querying SQL typecode for pg type");
+
+  @Before
+  public void setUp() throws Exception {
+    con = (PgConnection)TestUtil.openDB();
+    log = new TestLogHandler();
+    driverLogger = LogManager.getLogManager().getLogger("org.postgresql");
+    driverLogger.addHandler(log);
+    driverLogLevel = driverLogger.getLevel();
+    driverLogger.setLevel(Level.ALL);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    TestUtil.closeDB(con);
+    driverLogger.removeHandler(log);
+    driverLogger.setLevel(driverLogLevel);
+    log = null;
+  }
+
+  @Test
+  public void testGetSQLTypeQueryCache() throws SQLException {
+    TypeInfo ti = con.getTypeInfo();
+
+    List<LogRecord> typeQueries = log.getRecordsMatching(SQL_TYPE_QUERY_LOG_FILTER);
+    assertEquals(0, typeQueries.size());
+
+    ti.getSQLType("box");  // this must be a type not in the hardcoded 'types' list
+    typeQueries = log.getRecordsMatching(SQL_TYPE_QUERY_LOG_FILTER);
+    assertEquals(1, typeQueries.size());
+
+    ti.getSQLType("box");  // this time it should be retrieved from the cache
+    typeQueries = log.getRecordsMatching(SQL_TYPE_QUERY_LOG_FILTER);
+    assertEquals(1, typeQueries.size());
+  }
+
+  @Test
+  public void testGetTypeInfoUsesCache() throws SQLException {
+    con.getMetaData().getTypeInfo();
+    List<LogRecord> typeQueries = log.getRecordsMatching(SQL_TYPE_QUERY_LOG_FILTER);
+    assertEquals("DatabaseMetadata.getTypeInfo() resulted in individual queries for SQL typecodes", 0, typeQueries.size());
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseMetaDataCacheTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseMetaDataCacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, PostgreSQL Global Development Group
+ * Copyright (c) 2020, PostgreSQL Global Development Group
  * See the LICENSE file in the project root for more information.
  */
 

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseMetaDataCacheTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseMetaDataCacheTest.java
@@ -34,6 +34,7 @@ public class DatabaseMetaDataCacheTest {
   private Level driverLogLevel;
 
   private static final Pattern SQL_TYPE_QUERY_LOG_FILTER = Pattern.compile("querying SQL typecode for pg type");
+  private static final Pattern SQL_TYPE_CACHE_LOG_FILTER = Pattern.compile("caching all SQL typecodes");
 
   @Before
   public void setUp() throws Exception {
@@ -72,7 +73,11 @@ public class DatabaseMetaDataCacheTest {
   @Test
   public void testGetTypeInfoUsesCache() throws SQLException {
     con.getMetaData().getTypeInfo();
+
+    List<LogRecord> typeCacheQuery = log.getRecordsMatching(SQL_TYPE_CACHE_LOG_FILTER);
+    assertEquals("PgDatabaseMetadata.getTypeInfo() did not cache SQL typecodes", 1, typeCacheQuery.size());
+
     List<LogRecord> typeQueries = log.getRecordsMatching(SQL_TYPE_QUERY_LOG_FILTER);
-    assertEquals("DatabaseMetadata.getTypeInfo() resulted in individual queries for SQL typecodes", 0, typeQueries.size());
+    assertEquals("PgDatabaseMetadata.getTypeInfo() resulted in individual queries for SQL typecodes", 0, typeQueries.size());
   }
 }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseMetaDataCacheTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseMetaDataCacheTest.java
@@ -5,13 +5,16 @@
 
 package org.postgresql.test.jdbc2;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+
 import org.postgresql.core.TypeInfo;
 import org.postgresql.jdbc.PgConnection;
 import org.postgresql.test.TestUtil;
 import org.postgresql.util.TestLogHandler;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
 import java.sql.SQLException;
 import java.util.List;
@@ -20,8 +23,6 @@ import java.util.logging.LogManager;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
-
-import static org.junit.Assert.assertEquals;
 
 /*
  * Tests for caching of DatabaseMetadata

--- a/pgjdbc/src/test/java/org/postgresql/util/TestLogHandler.java
+++ b/pgjdbc/src/test/java/org/postgresql/util/TestLogHandler.java
@@ -1,0 +1,34 @@
+package org.postgresql.util;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Handler;
+import java.util.logging.LogRecord;
+import java.util.regex.Pattern;
+
+public class TestLogHandler extends Handler {
+  public List<LogRecord> records = new ArrayList<>();
+
+  @Override
+  public void publish(LogRecord record) {
+    records.add(record);
+  }
+
+  @Override
+  public void flush() {
+  }
+
+  @Override
+  public void close() throws SecurityException {
+  }
+
+  public List<LogRecord> getRecordsMatching(Pattern messagePattern) {
+    ArrayList<LogRecord> matches = new ArrayList<>();
+    for (LogRecord r: this.records) {
+      if (messagePattern.matcher(r.getMessage()).find()) {
+        matches.add(r);
+      }
+    }
+    return matches;
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/util/TestLogHandler.java
+++ b/pgjdbc/src/test/java/org/postgresql/util/TestLogHandler.java
@@ -7,7 +7,7 @@ import java.util.logging.LogRecord;
 import java.util.regex.Pattern;
 
 public class TestLogHandler extends Handler {
-  public List<LogRecord> records = new ArrayList<>();
+  public List<LogRecord> records = new ArrayList<LogRecord>();
 
   @Override
   public void publish(LogRecord record) {
@@ -23,7 +23,7 @@ public class TestLogHandler extends Handler {
   }
 
   public List<LogRecord> getRecordsMatching(Pattern messagePattern) {
-    ArrayList<LogRecord> matches = new ArrayList<>();
+    ArrayList<LogRecord> matches = new ArrayList<LogRecord>();
     for (LogRecord r: this.records) {
       if (messagePattern.matcher(r.getMessage()).find()) {
         matches.add(r);

--- a/pgjdbc/src/test/java/org/postgresql/util/TestLogHandler.java
+++ b/pgjdbc/src/test/java/org/postgresql/util/TestLogHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, PostgreSQL Global Development Group
+ * Copyright (c) 2020, PostgreSQL Global Development Group
  * See the LICENSE file in the project root for more information.
  */
 

--- a/pgjdbc/src/test/java/org/postgresql/util/TestLogHandler.java
+++ b/pgjdbc/src/test/java/org/postgresql/util/TestLogHandler.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2004, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
 package org.postgresql.util;
 
 import java.util.ArrayList;


### PR DESCRIPTION
This PR is our proposed fix for https://github.com/pgjdbc/pgjdbc/issues/1342

It adds a `TypeInfoCache.cacheSQLTypes()` method, which is called by `PgDatabaseMetaData.getTypeInfo()` to pre-populate the `pgNameToSQLType` cache, prior to calling `TypeInfoCache.getSQLType()` for each required type. It includes some refactoring so that we don't have to duplicate SQL and logic between `cacheSQLTypes()` and `getSQLType()`.

We've added a new `DatabaseMetaDataCacheTest` test suite. As the driver classes are tightly-coupled, the simplest way we found to check whether the cache is used is to inspect the debug log in the tests - not ideal - open to better suggestions :)

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes to Existing Features:

* [x] Does this break existing behaviour? (**No**)
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
