### PR TITLE
Metadata queries improvements.

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
@@ -2126,17 +2126,17 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
     }
 
     sql += " AND i.indisprimary ";
-    sql = "SELECT " +
-			"       result.TABLE_CAT, " +
-			"       result.TABLE_SCHEM, " +
-			"       result.TABLE_NAME, " +
-			"       result.COLUMN_NAME, " +
-			"       result.KEY_SEQ, " +
-			"       result.PK_NAME " +
-			"FROM " +
-			"     (" + sql +" ) result" +
-			" where " +
-			" result.A_ATTNUM = (result.KEYS).x ";
+    sql = "SELECT "
+            + "       result.TABLE_CAT, "
+            + "       result.TABLE_SCHEM, "
+            + "       result.TABLE_NAME, "
+            + "       result.COLUMN_NAME, "
+            + "       result.KEY_SEQ, "
+            + "       result.PK_NAME "
+            + "FROM "
+            + "     (" + sql + " ) result"
+            + " where "
+            + " result.A_ATTNUM = (result.KEYS).x ";
     sql += " ORDER BY result.table_name, result.pk_name, result.key_seq";
 
     return createMetaDataStatement().executeQuery(sql);
@@ -2411,41 +2411,42 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
         sql += " AND n.nspname = " + escapeQuotes(schema);
       }
 
-		sql += " AND ct.relname = " + escapeQuotes(tableName);
+      sql += " AND ct.relname = " + escapeQuotes(tableName);
 
-		if (unique) {
-			sql += " AND i.indisunique ";
-		}
+      if (unique) {
+        sql += " AND i.indisunique ";
+      }
 
-		sql = "SELECT " +
-				"    tmp.TABLE_SCHEM, " +
-				"    tmp.TABLE_NAME, " +
-				"    tmp.NON_UNIQUE, " +
-				"    tmp.INDEX_QUALIFIER, " +
-				"    tmp.INDEX_NAME, " +
-				"    tmp.TYPE, " +
-				"    tmp.ORDINAL_POSITION, " +
-				"    trim(both '\"' from pg_catalog.pg_get_indexdef(tmp.CI_OID, tmp.ORDINAL_POSITION, false)) AS COLUMN_NAME, " +
-				(connection.haveMinimumServerVersion(ServerVersion.v9_6)
-						? "  CASE tmp.AM_NAME "
-						+ "    WHEN 'btree' THEN CASE tmp.I_INDOPTION[tmp.ORDINAL_POSITION - 1] & 1 "
-						+ "      WHEN 1 THEN 'D' "
-						+ "      ELSE 'A' "
-						+ "    END "
-						+ "    ELSE NULL "
-						+ "  END AS ASC_OR_DESC, "
-						: "  CASE tmp.AM_CANORDER "
-						+ "    WHEN true THEN CASE tmp.I_INDOPTION[tmp.ORDINAL_POSITION - 1] & 1 "
-						+ "      WHEN 1 THEN 'D' "
-						+ "      ELSE 'A' "
-						+ "    END "
-						+ "    ELSE NULL "
-						+ "  END AS ASC_OR_DESC, ") +
-				"    tmp.CARDINALITY, " +
-				"    tmp.PAGES, " +
-				"    tmp.FILTER_CONDITION " +
-				"FROM ("+ sql
-				+ ") AS tmp";
+      sql = "SELECT "
+                + "    tmp.TABLE_SCHEM, "
+                + "    tmp.TABLE_NAME, "
+                + "    tmp.NON_UNIQUE, "
+                + "    tmp.INDEX_QUALIFIER, "
+                + "    tmp.INDEX_NAME, "
+                + "    tmp.TYPE, "
+                + "    tmp.ORDINAL_POSITION, "
+                + "    trim(both '\"' from pg_catalog.pg_get_indexdef(tmp.CI_OID, tmp.ORDINAL_POSITION, false)) AS COLUMN_NAME, "
+                + (connection.haveMinimumServerVersion(ServerVersion.v9_6)
+                        ? "  CASE tmp.AM_NAME "
+                        + "    WHEN 'btree' THEN CASE tmp.I_INDOPTION[tmp.ORDINAL_POSITION - 1] & 1 "
+                        + "      WHEN 1 THEN 'D' "
+                        + "      ELSE 'A' "
+                        + "    END "
+                        + "    ELSE NULL "
+                        + "  END AS ASC_OR_DESC, "
+                        : "  CASE tmp.AM_CANORDER "
+                        + "    WHEN true THEN CASE tmp.I_INDOPTION[tmp.ORDINAL_POSITION - 1] & 1 "
+                        + "      WHEN 1 THEN 'D' "
+                        + "      ELSE 'A' "
+                        + "    END "
+                        + "    ELSE NULL "
+                        + "  END AS ASC_OR_DESC, ")
+                + "    tmp.CARDINALITY, "
+                + "    tmp.PAGES, "
+                + "    tmp.FILTER_CONDITION "
+                + "FROM ("
+                + sql
+                + ") AS tmp";
     } else {
       String select;
       String from;
@@ -2481,11 +2482,11 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
             + " WHERE ct.oid=i.indrelid AND ci.oid=i.indexrelid AND a.attrelid=ci.oid AND ci.relam=am.oid "
             + where;
 
-		sql += " AND ct.relname = " + escapeQuotes(tableName);
+      sql += " AND ct.relname = " + escapeQuotes(tableName);
 
-		if (unique) {
-			sql += " AND i.indisunique ";
-		}
+      if (unique) {
+        sql += " AND i.indisunique ";
+      }
     }
 
     sql += " ORDER BY NON_UNIQUE, TYPE, INDEX_NAME, ORDINAL_POSITION ";


### PR DESCRIPTION
When dealing with large PostrgeSQL databases of thousands of schemas, tens of thousands of tables and millions of indexes particular PgDatabaseMetaData methods have suboptimal implementation.
The pattern that was utilized in implementation used inner query on pg_catalog.pg_index in order to retrieve keys (information_schema._pg_expandarray(i.indkey) AS keys). Such implementation forced full table scan on pg_catalog.pg_index prior to filtering result set on schema and table name.
The optimization idea was to get rid of inner querry in order to let querry planner to avoid full table scan and filter out pg_catalog.pg_index rows prior to executing (information_schema._pg_expandarray(i.indkey) AS keys).

This optimization was tested on database AWS RDS db.t3.large having:
~2000000 rows in pg_catalog.pg_index
~3000000 rows in pg_catalog.pg_class
~8000 rows in pg_catalog.pg_namespace
~14000000 rows in pg_catalog.pg_attribute

One of optimized methods was PgDatabaseMetaData.getIndexInfo which call time on given database dropped from ~13s to ~600ms.

### All Submissions:

* [ ] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Does mvn checkstyle:check pass ?
3. [ ] Have you added your new test classes to an existing test suite in alphabetical order?

### Changes to Existing Features:

* [ ] Does this break existing behaviour? If so please explain.
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
