### PR TITLE
fix: #1677 NumberFormatException when fetching PGInterval with small value

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/util/PGInterval.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/PGInterval.java
@@ -240,12 +240,16 @@ public class PGInterval extends PGobject implements Serializable, Cloneable {
    * @return String represented interval
    */
   public String getValue() {
-    return years + " years "
-        + months + " mons "
-        + days + " days "
-        + hours + " hours "
-        + minutes + " mins "
-        + wholeSeconds + '.' + microSeconds + " secs";
+    return String.format(
+      Locale.ROOT,
+      "%d years %d mons %d days %d hours %d mins %f secs",
+      years,
+      months,
+      days,
+      hours,
+      minutes,
+      wholeSeconds + microSeconds / 1e6d
+    );
   }
 
   /**

--- a/pgjdbc/src/main/java/org/postgresql/util/PGInterval.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/PGInterval.java
@@ -9,6 +9,7 @@ import java.io.Serializable;
 import java.sql.SQLException;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.Locale;
 import java.util.StringTokenizer;
 
 /**
@@ -367,20 +368,10 @@ public class PGInterval extends PGobject implements Serializable, Cloneable {
    * @param seconds seconds to set
    */
   public void setSeconds(double seconds) {
-    String str = Double.toString(seconds);
+    String str = String.format(Locale.ROOT,"%.6f",seconds);
     int decimal = str.indexOf('.');
-    if (decimal > 0) {
-
-      /* how many 10's do we need to multiply by to get microseconds */
-      String micSeconds = str.substring(decimal + 1);
-      int power = 6 - micSeconds.length();
-
-      microSeconds = Integer.parseInt(micSeconds) * (int)Math.pow(10,power);
-      wholeSeconds = Integer.parseInt(str.substring(0,decimal));
-    } else {
-      microSeconds = 0;
-      wholeSeconds = Integer.parseInt(str);
-    }
+    microSeconds = Integer.parseInt(str.substring(decimal + 1));
+    wholeSeconds = Integer.parseInt(str.substring(0,decimal));
     if ( seconds < 0 ) {
       microSeconds = -microSeconds;
     }

--- a/pgjdbc/src/main/java/org/postgresql/util/PGInterval.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/PGInterval.java
@@ -19,6 +19,8 @@ import java.util.concurrent.TimeUnit;
  */
 public class PGInterval extends PGobject implements Serializable, Cloneable {
 
+  private static final int MICROS_IN_SECOND = 1000000;
+
   private int years;
   private int months;
   private int days;
@@ -250,9 +252,7 @@ public class PGInterval extends PGobject implements Serializable, Cloneable {
       days,
       hours,
       minutes,
-      new DecimalFormat("0.0#####").format(
-        wholeSeconds + (double) microSeconds / TimeUnit.SECONDS.toMicros(1)
-      )
+      new DecimalFormat("0.0#####").format(getSeconds())
     );
   }
 
@@ -352,14 +352,7 @@ public class PGInterval extends PGobject implements Serializable, Cloneable {
    * @return seconds represented by this interval
    */
   public double getSeconds() {
-    if ( microSeconds < 0) {
-      if ( wholeSeconds == 0 ) {
-        return Double.parseDouble("-0." + -microSeconds);
-      } else {
-        return Double.parseDouble("" + wholeSeconds + '.' + -microSeconds);
-      }
-    }
-    return Double.parseDouble("" + wholeSeconds + '.' + microSeconds );
+    return wholeSeconds + (double) microSeconds / MICROS_IN_SECOND;
   }
 
   public int getWholeSeconds() {
@@ -376,13 +369,8 @@ public class PGInterval extends PGobject implements Serializable, Cloneable {
    * @param seconds seconds to set
    */
   public void setSeconds(double seconds) {
-    String str = String.format(Locale.ROOT,"%.6f",seconds);
-    int decimal = str.indexOf('.');
-    microSeconds = Integer.parseInt(str.substring(decimal + 1));
-    wholeSeconds = Integer.parseInt(str.substring(0,decimal));
-    if ( seconds < 0 ) {
-      microSeconds = -microSeconds;
-    }
+    wholeSeconds = (int) seconds;
+    microSeconds = (int) Math.round((seconds - wholeSeconds) * MICROS_IN_SECOND);
   }
 
   /**

--- a/pgjdbc/src/main/java/org/postgresql/util/PGInterval.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/PGInterval.java
@@ -7,10 +7,12 @@ package org.postgresql.util;
 
 import java.io.Serializable;
 import java.sql.SQLException;
+import java.text.DecimalFormat;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
 import java.util.StringTokenizer;
+import java.util.concurrent.TimeUnit;
 
 /**
  * This implements a class that handles the PostgreSQL interval type.
@@ -242,13 +244,15 @@ public class PGInterval extends PGobject implements Serializable, Cloneable {
   public String getValue() {
     return String.format(
       Locale.ROOT,
-      "%d years %d mons %d days %d hours %d mins %f secs",
+      "%d years %d mons %d days %d hours %d mins %s secs",
       years,
       months,
       days,
       hours,
       minutes,
-      wholeSeconds + microSeconds / 1e6d
+      new DecimalFormat("0.0#####").format(
+        wholeSeconds + (double) microSeconds / TimeUnit.SECONDS.toMicros(1)
+      )
     );
   }
 

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/IntervalTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/IntervalTest.java
@@ -328,6 +328,14 @@ public class IntervalTest {
     stmt.close();
   }
 
+  @Test
+  public void testGetValueForSmallValue() throws SQLException {
+    PGInterval orig = new PGInterval("0.0001 seconds");
+    PGInterval copy = new PGInterval(orig.getValue());
+
+    assertEquals(orig, copy);
+  }
+
   private java.sql.Date makeDate(int y, int m, int d) {
     return new java.sql.Date(y - 1900, m - 1, d);
   }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/IntervalTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/IntervalTest.java
@@ -305,6 +305,29 @@ public class IntervalTest {
     assertEquals(-4, pgi.getHours());
   }
 
+  @Test
+  public void testSmallValue() throws SQLException {
+    PreparedStatement pstmt = conn.prepareStatement("INSERT INTO testinterval VALUES (?)");
+    pstmt.setObject(1, new PGInterval("0.0001 seconds"));
+    pstmt.executeUpdate();
+    pstmt.close();
+
+    Statement stmt = conn.createStatement();
+    ResultSet rs = stmt.executeQuery("SELECT v FROM testinterval");
+    assertTrue(rs.next());
+    PGInterval pgi = (PGInterval) rs.getObject(1);
+    assertEquals(0, pgi.getYears());
+    assertEquals(0, pgi.getMonths());
+    assertEquals(0, pgi.getDays());
+    assertEquals(0, pgi.getHours());
+    assertEquals(0, pgi.getMinutes());
+    assertEquals(0, pgi.getWholeSeconds());
+    assertEquals(100, pgi.getMicroSeconds());
+    assertFalse(rs.next());
+    rs.close();
+    stmt.close();
+  }
+
   private java.sql.Date makeDate(int y, int m, int d) {
     return new java.sql.Date(y - 1900, m - 1, d);
   }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/IntervalTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/IntervalTest.java
@@ -336,6 +336,20 @@ public class IntervalTest {
     assertEquals(orig, copy);
   }
 
+  @Test
+  public void testGetSecondsForSmallValue() throws SQLException {
+    PGInterval pgi = new PGInterval("0.000001 seconds");
+
+    assertEquals(0.000001, pgi.getSeconds(), 0.000000001);
+  }
+
+  @Test
+  public void testMicroSecondsAreRoundedToNearest() throws SQLException {
+    PGInterval pgi = new PGInterval("0.0000007 seconds");
+
+    assertEquals(1, pgi.getMicroSeconds());
+  }
+
   private java.sql.Date makeDate(int y, int m, int d) {
     return new java.sql.Date(y - 1900, m - 1, d);
   }


### PR DESCRIPTION
Prevents getting a string with scientific notation by using an explicit format string. Uses a fixed precision which makes testing for the presence of decimal point and calculating a coefficient to get to microseconds unnecessary.

Fixes: #1677 

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes to Existing Features:

* [ ] Does this break existing behaviour? If so please explain.
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
