### PR TITLE
Cleanup PGProperty, sort values, and add some missing to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ In addition to the standard connection parameters the driver supports a number o
 | sslpasswordcallback           | String  | null    | The name of a class (for use in [Class.forName(String)](https://docs.oracle.com/javase/6/docs/api/java/lang/Class.html#forName%28java.lang.String%29)) that implements javax.security.auth.callback.CallbackHandler and can handle PasswordCallback for the ssl password. |
 | sslpassword                   | String  | null    | The password for the client's ssl key (ignored if sslpasswordcallback is set) |
 | sendBufferSize                | Integer | -1      | Socket write buffer size |
-| recvBufferSize                | Integer | -1      | Socket read buffer size  |
+| receiveBufferSize             | Integer | -1      | Socket read buffer size  |
 | loggerLevel                   | String  | null    | Logger level of the driver using java.util.logging. Allowed values: OFF, DEBUG or TRACE. |
 | loggerFile                    | String  | null    | File name output of the Logger, if set, the Logger will use a FileHandler to write to a specified file. If the parameter is not set or the file can't be created the ConsoleHandler will be used instead. |
 | allowEncodingChanges          | Boolean | false   | Allow for changes in client_encoding |

--- a/docs/documentation/92/connect.md
+++ b/docs/documentation/92/connect.md
@@ -111,7 +111,7 @@ connection.
 * `sendBufferSize = int`
 	Sets SO_SNDBUF on the connection stream
 	
-* `recvBufferSize = int`
+* `receiveBufferSize = int`
 	Sets SO_RCVBUF on the connection stream
 	
 * `protocolVersion = String`

--- a/docs/documentation/93/connect.md
+++ b/docs/documentation/93/connect.md
@@ -111,7 +111,7 @@ connection.
 * `sendBufferSize = int`
 	Sets SO_SNDBUF on the connection stream
 	
-* `recvBufferSize = int`
+* `receiveBufferSize = int`
 	Sets SO_RCVBUF on the connection stream
 	
 * `protocolVersion = String`

--- a/docs/documentation/94/connect.md
+++ b/docs/documentation/94/connect.md
@@ -118,12 +118,8 @@ connection.
 
 	Sets SO_SNDBUF on the connection stream
 	
-* `recvBufferSize = int`
+* `receiveBufferSize = int`
 
-	Sets SO_RCVBUF on the connection stream
-
-* `receiveBufferSize = int`  
-	
 	Sets SO_RCVBUF on the connection stream
 
 * `protocolVersion = String`

--- a/docs/documentation/head/connect.md
+++ b/docs/documentation/head/connect.md
@@ -235,6 +235,20 @@ Connection conn = DriverManager.getConnection(url);
 	A comma separated list of types to disable binary transfer. Either OID numbers or names.
 	Overrides values in the driver default set and values set with binaryTransferEnable.
 
+* **databaseMetadataCacheFields** = int
+
+	Specifies the maximum number of fields to be cached per connection.
+	A value of 0 disables the cache.
+
+	Defaults to 65536.
+
+* **databaseMetadataCacheFieldsMiB** = int
+
+	Specifies the maximum size (in megabytes) of fields to be cached per connection.
+	A value of 0 disables the cache.
+
+	Defaults to 5.
+
 * **prepareThreshold** = int
 
 	Determine the number of `PreparedStatement` executions required before

--- a/docs/documentation/head/connect.md
+++ b/docs/documentation/head/connect.md
@@ -158,14 +158,6 @@ Connection conn = DriverManager.getConnection(url);
 
 	If provided will be used by ConsoleCallbackHandler
 
-* **sendBufferSize** = int
-
-	Sets SO_SNDBUF on the connection stream
-
-* **recvBufferSize** = int
-
-	Sets SO_RCVBUF on the connection stream
-
 * **protocolVersion** = int
 
 	The driver supports the V3 frontend/backend protocols. The V3 protocol was introduced in 7.4 and

--- a/docs/documentation/head/connect.md
+++ b/docs/documentation/head/connect.md
@@ -220,6 +220,12 @@ Connection conn = DriverManager.getConnection(url);
      
     The default is 'false'
 
+* **binaryTransfer** = boolean
+
+	Use binary format for sending and receiving data if possible.
+
+	The default is 'true'
+
 * **binaryTransferEnable** = String
 
 	A comma separated list of types to enable binary transfer. Either OID numbers or names.

--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -710,6 +710,15 @@ public enum PGProperty {
   }
 
   /**
+   * Returns whether this parameter is required.
+   *
+   * @return whether this parameter is required
+   */
+  public boolean isRequired() {
+    return required;
+  }
+
+  /**
    * Returns the description for this connection parameter.
    *
    * @return the description for this connection parameter

--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -12,6 +12,8 @@ import org.postgresql.util.PSQLState;
 
 import java.sql.Connection;
 import java.sql.DriverPropertyInfo;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
 
 /**
@@ -679,6 +681,15 @@ public enum PGProperty {
     this.choices = choices;
   }
 
+  private static final Map<String, PGProperty> PROPS_BY_NAME = new HashMap<String, PGProperty>();
+  static {
+    for (PGProperty prop : PGProperty.values()) {
+      if (PROPS_BY_NAME.put(prop.getName(), prop) != null) {
+        throw new IllegalStateException("Duplicate PGProperty name: " + prop.getName());
+      }
+    }
+  }
+
   /**
    * Returns the name of the connection parameter. The name is the key that must be used in JDBC URL
    * or in Driver properties
@@ -838,12 +849,7 @@ public enum PGProperty {
   }
 
   public static PGProperty forName(String name) {
-    for (PGProperty property : PGProperty.values()) {
-      if (property.getName().equals(name)) {
-        return property;
-      }
-    }
-    return null;
+    return PROPS_BY_NAME.get(name);
   }
 
   /**

--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -23,44 +23,66 @@ public enum PGProperty {
   /**
    * Database name to connect to (may be specified directly in the JDBC URL).
    */
-  PG_DBNAME("PGDBNAME", null,
-      "Database name to connect to (may be specified directly in the JDBC URL)", true),
+  PG_DBNAME(
+    "PGDBNAME",
+    null,
+    "Database name to connect to (may be specified directly in the JDBC URL)",
+    true),
 
   /**
    * Hostname of the PostgreSQL server (may be specified directly in the JDBC URL).
    */
-  PG_HOST("PGHOST", null,
-      "Hostname of the PostgreSQL server (may be specified directly in the JDBC URL)", false),
+  PG_HOST(
+    "PGHOST",
+    null,
+    "Hostname of the PostgreSQL server (may be specified directly in the JDBC URL)",
+    false),
 
   /**
    * Port of the PostgreSQL server (may be specified directly in the JDBC URL).
    */
-  PG_PORT("PGPORT", null,
-      "Port of the PostgreSQL server (may be specified directly in the JDBC URL)"),
+  PG_PORT(
+    "PGPORT",
+    null,
+    "Port of the PostgreSQL server (may be specified directly in the JDBC URL)"),
 
   /**
    * Username to connect to the database as.
    */
-  USER("user", null, "Username to connect to the database as.", true),
+  USER(
+    "user",
+    null,
+    "Username to connect to the database as.",
+    true),
 
   /**
    * Password to use when authenticating.
    */
-  PASSWORD("password", null, "Password to use when authenticating.", false),
+  PASSWORD(
+    "password",
+    null,
+    "Password to use when authenticating.",
+    false),
 
   /**
    * Force use of a particular protocol version when connecting, if set, disables protocol version
    * fallback.
    */
-  PROTOCOL_VERSION("protocolVersion", null,
-      "Force use of a particular protocol version when connecting, currently only version 3 is supported.",
-      false, "3"),
+  PROTOCOL_VERSION(
+    "protocolVersion",
+    null,
+    "Force use of a particular protocol version when connecting, currently only version 3 is supported.",
+    false,
+    new String[] {"3"}),
 
   /**
    * Specify 'options' connection initialization parameter.
    * The value of this parameter may contain spaces and other special characters or their URL representation.
    */
-  OPTIONS("options", null, "Specify 'options' connection initialization parameter."),
+  OPTIONS(
+    "options",
+    null,
+    "Specify 'options' connection initialization parameter."),
 
   /**
    * <p>Logger level of the driver. Allowed values: {@code OFF}, {@code DEBUG} or {@code TRACE}.</p>
@@ -77,7 +99,12 @@ public enum PGProperty {
    * {@code -Djava.util.logging.config.file=myfile} or if your are using an application server
    * you should use the appropriate logging subsystem.</p>
    */
-  LOGGER_LEVEL("loggerLevel", null, "Logger level of the driver", false, "OFF", "DEBUG", "TRACE"),
+  LOGGER_LEVEL(
+    "loggerLevel",
+    null,
+    "Logger level of the driver",
+    false,
+    new String[] {"OFF", "DEBUG", "TRACE"}),
 
   /**
    * <p>File name output of the Logger, if set, the Logger will use a
@@ -86,109 +113,147 @@ public enum PGProperty {
    *
    * <p>Parameter should be use together with {@link PGProperty#LOGGER_LEVEL}</p>
    */
-  LOGGER_FILE("loggerFile", null, "File name output of the Logger"),
+  LOGGER_FILE(
+    "loggerFile",
+    null,
+    "File name output of the Logger"),
 
   /**
    * Sets the default threshold for enabling server-side prepare. A value of {@code -1} stands for
    * forceBinary
    */
-  PREPARE_THRESHOLD("prepareThreshold", "5",
-      "Statement prepare threshold. A value of {@code -1} stands for forceBinary"),
+  PREPARE_THRESHOLD(
+    "prepareThreshold",
+    "5",
+    "Statement prepare threshold. A value of {@code -1} stands for forceBinary"),
 
   /**
    * Specifies the maximum number of entries in cache of prepared statements. A value of {@code 0}
    * disables the cache.
    */
-  PREPARED_STATEMENT_CACHE_QUERIES("preparedStatementCacheQueries", "256",
-      "Specifies the maximum number of entries in per-connection cache of prepared statements. A value of {@code 0} disables the cache."),
+  PREPARED_STATEMENT_CACHE_QUERIES(
+    "preparedStatementCacheQueries",
+    "256",
+    "Specifies the maximum number of entries in per-connection cache of prepared statements. A value of {@code 0} disables the cache."),
 
   /**
    * Specifies the maximum size (in megabytes) of the prepared statement cache. A value of {@code 0}
    * disables the cache.
    */
-  PREPARED_STATEMENT_CACHE_SIZE_MIB("preparedStatementCacheSizeMiB", "5",
-      "Specifies the maximum size (in megabytes) of a per-connection prepared statement cache. A value of {@code 0} disables the cache."),
+  PREPARED_STATEMENT_CACHE_SIZE_MIB(
+    "preparedStatementCacheSizeMiB",
+    "5",
+    "Specifies the maximum size (in megabytes) of a per-connection prepared statement cache. A value of {@code 0} disables the cache."),
 
   /**
    * Specifies the maximum number of fields to be cached per connection. A value of {@code 0} disables the cache.
    */
-  DATABASE_METADATA_CACHE_FIELDS("databaseMetadataCacheFields", "65536",
-          "Specifies the maximum number of fields to be cached per connection. A value of {@code 0} disables the cache."),
+  DATABASE_METADATA_CACHE_FIELDS(
+    "databaseMetadataCacheFields",
+    "65536",
+    "Specifies the maximum number of fields to be cached per connection. A value of {@code 0} disables the cache."),
 
   /**
    * Specifies the maximum size (in megabytes) of fields to be cached per connection. A value of {@code 0} disables the cache.
    */
-  DATABASE_METADATA_CACHE_FIELDS_MIB("databaseMetadataCacheFieldsMiB", "5",
-          "Specifies the maximum size (in megabytes) of fields to be cached per connection. A value of {@code 0} disables the cache."),
+  DATABASE_METADATA_CACHE_FIELDS_MIB(
+    "databaseMetadataCacheFieldsMiB",
+    "5",
+    "Specifies the maximum size (in megabytes) of fields to be cached per connection. A value of {@code 0} disables the cache."),
 
   /**
    * Default parameter for {@link java.sql.Statement#getFetchSize()}. A value of {@code 0} means
    * that need fetch all rows at once
    */
-  DEFAULT_ROW_FETCH_SIZE("defaultRowFetchSize", "0",
-      "Positive number of rows that should be fetched from the database when more rows are needed for ResultSet by each fetch iteration"),
+  DEFAULT_ROW_FETCH_SIZE(
+    "defaultRowFetchSize",
+    "0",
+    "Positive number of rows that should be fetched from the database when more rows are needed for ResultSet by each fetch iteration"),
 
   /**
    * Use binary format for sending and receiving data if possible.
    */
-  BINARY_TRANSFER("binaryTransfer", "true",
-      "Use binary format for sending and receiving data if possible"),
+  BINARY_TRANSFER(
+    "binaryTransfer",
+    "true",
+    "Use binary format for sending and receiving data if possible"),
 
   /**
    * Puts this connection in read-only mode.
    */
-  READ_ONLY("readOnly", "false", "Puts this connection in read-only mode"),
+  READ_ONLY(
+    "readOnly",
+    "false",
+    "Puts this connection in read-only mode"),
 
   /**
    * Comma separated list of types to enable binary transfer. Either OID numbers or names
    */
-  BINARY_TRANSFER_ENABLE("binaryTransferEnable", "",
-      "Comma separated list of types to enable binary transfer. Either OID numbers or names"),
+  BINARY_TRANSFER_ENABLE(
+    "binaryTransferEnable",
+    "",
+    "Comma separated list of types to enable binary transfer. Either OID numbers or names"),
 
   /**
    * Comma separated list of types to disable binary transfer. Either OID numbers or names.
    * Overrides values in the driver default set and values set with binaryTransferEnable.
    */
-  BINARY_TRANSFER_DISABLE("binaryTransferDisable", "",
-      "Comma separated list of types to disable binary transfer. Either OID numbers or names. Overrides values in the driver default set and values set with binaryTransferEnable."),
+  BINARY_TRANSFER_DISABLE(
+    "binaryTransferDisable",
+    "",
+    "Comma separated list of types to disable binary transfer. Either OID numbers or names. Overrides values in the driver default set and values set with binaryTransferEnable."),
 
   /**
    * Bind String to either {@code unspecified} or {@code varchar}. Default is {@code varchar} for
    * 8.0+ backends.
    */
-  STRING_TYPE("stringtype", null,
-      "The type to bind String parameters as (usually 'varchar', 'unspecified' allows implicit casting to other types)",
-      false, "unspecified", "varchar"),
+  STRING_TYPE(
+    "stringtype",
+    null,
+    "The type to bind String parameters as (usually 'varchar', 'unspecified' allows implicit casting to other types)",
+    false,
+    new String[] {"unspecified", "varchar"}),
 
   /**
    * Specifies the length to return for types of unknown length.
    */
-  UNKNOWN_LENGTH("unknownLength", Integer.toString(Integer.MAX_VALUE),
-      "Specifies the length to return for types of unknown length"),
+  UNKNOWN_LENGTH(
+    "unknownLength",
+    Integer.toString(Integer.MAX_VALUE),
+    "Specifies the length to return for types of unknown length"),
 
   /**
    * When connections that are not explicitly closed are garbage collected, log the stacktrace from
    * the opening of the connection to trace the leak source.
    */
-  LOG_UNCLOSED_CONNECTIONS("logUnclosedConnections", "false",
-      "When connections that are not explicitly closed are garbage collected, log the stacktrace from the opening of the connection to trace the leak source"),
+  LOG_UNCLOSED_CONNECTIONS(
+    "logUnclosedConnections",
+    "false",
+    "When connections that are not explicitly closed are garbage collected, log the stacktrace from the opening of the connection to trace the leak source"),
 
   /**
    * Whether to include full server error detail in exception messages.
    */
-  LOG_SERVER_ERROR_DETAIL("logServerErrorDetail", "true",
-      "Include full server error detail in exception messages. If disabled then only the error itself will be included."),
+  LOG_SERVER_ERROR_DETAIL(
+    "logServerErrorDetail",
+    "true",
+    "Include full server error detail in exception messages. If disabled then only the error itself will be included."),
 
   /**
    * Enable optimization that disables column name sanitiser.
    */
-  DISABLE_COLUMN_SANITISER("disableColumnSanitiser", "false",
-      "Enable optimization that disables column name sanitiser"),
+  DISABLE_COLUMN_SANITISER(
+    "disableColumnSanitiser",
+    "false",
+    "Enable optimization that disables column name sanitiser"),
 
   /**
    * Control use of SSL: empty or {@code true} values imply {@code sslmode==verify-full}
    */
-  SSL("ssl", null, "Control use of SSL (any non-null value causes SSL to be required)"),
+  SSL(
+    "ssl",
+    null,
+    "Control use of SSL (any non-null value causes SSL to be required)"),
 
   /**
    * Parameter governing the use of SSL. The allowed values are {@code disable}, {@code allow},
@@ -196,73 +261,100 @@ public enum PGProperty {
    * If {@code ssl} property is empty or set to {@code true} it implies {@code verify-full}.
    * Default mode is "require"
    */
-  SSL_MODE("sslmode", null, "Parameter governing the use of SSL", false,
-      "disable", "allow", "prefer", "require", "verify-ca", "verify-full"),
+  SSL_MODE(
+    "sslmode",
+    null,
+    "Parameter governing the use of SSL",
+    false,
+    new String[] {"disable", "allow", "prefer", "require", "verify-ca", "verify-full"}),
 
   /**
    * Classname of the SSL Factory to use (instance of {@code javax.net.ssl.SSLSocketFactory}).
    */
-  SSL_FACTORY("sslfactory", null, "Provide a SSLSocketFactory class when using SSL."),
+  SSL_FACTORY(
+    "sslfactory",
+    null,
+    "Provide a SSLSocketFactory class when using SSL."),
 
   /**
    * The String argument to give to the constructor of the SSL Factory.
    * @deprecated use {@code ..Factory(Properties)} constructor.
    */
   @Deprecated
-  SSL_FACTORY_ARG("sslfactoryarg", null,
-      "Argument forwarded to constructor of SSLSocketFactory class."),
+  SSL_FACTORY_ARG(
+    "sslfactoryarg",
+    null,
+    "Argument forwarded to constructor of SSLSocketFactory class."),
 
   /**
    * Classname of the SSL HostnameVerifier to use (instance of {@code
    * javax.net.ssl.HostnameVerifier}).
    */
-  SSL_HOSTNAME_VERIFIER("sslhostnameverifier", null,
-      "A class, implementing javax.net.ssl.HostnameVerifier that can verify the server"),
+  SSL_HOSTNAME_VERIFIER(
+    "sslhostnameverifier",
+    null,
+    "A class, implementing javax.net.ssl.HostnameVerifier that can verify the server"),
 
   /**
    * File containing the SSL Certificate. Default will be the file {@code postgresql.crt} in {@code
    * $HOME/.postgresql} (*nix) or {@code %APPDATA%\postgresql} (windows).
    */
-  SSL_CERT("sslcert", null, "The location of the client's SSL certificate"),
+  SSL_CERT(
+    "sslcert",
+    null,
+    "The location of the client's SSL certificate"),
 
   /**
    * File containing the SSL Key. Default will be the file {@code postgresql.pk8} in {@code
    * $HOME/.postgresql} (*nix) or {@code %APPDATA%\postgresql} (windows).
    */
-  SSL_KEY("sslkey", null, "The location of the client's PKCS#8 SSL key"),
+  SSL_KEY(
+    "sslkey",
+    null,
+    "The location of the client's PKCS#8 SSL key"),
 
   /**
    * File containing the root certificate when validating server ({@code sslmode} = {@code
    * verify-ca} or {@code verify-full}). Default will be the file {@code root.crt} in {@code
    * $HOME/.postgresql} (*nix) or {@code %APPDATA%\postgresql} (windows).
    */
-  SSL_ROOT_CERT("sslrootcert", null,
-      "The location of the root certificate for authenticating the server."),
+  SSL_ROOT_CERT(
+    "sslrootcert",
+    null,
+    "The location of the root certificate for authenticating the server."),
 
   /**
    * The SSL password to use in the default CallbackHandler.
    */
-  SSL_PASSWORD("sslpassword", null,
-      "The password for the client's ssl key (ignored if sslpasswordcallback is set)"),
+  SSL_PASSWORD(
+    "sslpassword",
+    null,
+    "The password for the client's ssl key (ignored if sslpasswordcallback is set)"),
 
   /**
    * The classname instantiating {@code javax.security.auth.callback.CallbackHandler} to use.
    */
-  SSL_PASSWORD_CALLBACK("sslpasswordcallback", null,
-      "A class, implementing javax.security.auth.callback.CallbackHandler that can handle PassworCallback for the ssl password."),
+  SSL_PASSWORD_CALLBACK(
+    "sslpasswordcallback",
+    null,
+    "A class, implementing javax.security.auth.callback.CallbackHandler that can handle PassworCallback for the ssl password."),
 
   /**
    * Enable or disable TCP keep-alive. The default is {@code false}.
    */
-  TCP_KEEP_ALIVE("tcpKeepAlive", "false",
-      "Enable or disable TCP keep-alive. The default is {@code false}."),
+  TCP_KEEP_ALIVE(
+    "tcpKeepAlive",
+    "false",
+    "Enable or disable TCP keep-alive. The default is {@code false}."),
 
   /**
    * Specify how long to wait for establishment of a database connection. The timeout is specified
    * in seconds.
    */
-  LOGIN_TIMEOUT("loginTimeout", "0",
-      "Specify how long to wait for establishment of a database connection."),
+  LOGIN_TIMEOUT(
+    "loginTimeout",
+    "0",
+    "Specify how long to wait for establishment of a database connection."),
 
   /**
    * <p>The timeout value used for socket connect operations. If connecting to the server takes longer
@@ -270,7 +362,10 @@ public enum PGProperty {
    *
    * <p>The timeout is specified in seconds and a value of zero means that it is disabled.</p>
    */
-  CONNECT_TIMEOUT("connectTimeout", "10", "The timeout value used for socket connect operations."),
+  CONNECT_TIMEOUT(
+    "connectTimeout",
+    "10",
+    "The timeout value used for socket connect operations."),
 
   /**
    * The timeout value used for socket read operations. If reading from the server takes longer than
@@ -278,7 +373,10 @@ public enum PGProperty {
    * timeout and a method of detecting network problems. The timeout is specified in seconds and a
    * value of zero means that it is disabled.
    */
-  SOCKET_TIMEOUT("socketTimeout", "0", "The timeout value used for socket read operations."),
+  SOCKET_TIMEOUT(
+    "socketTimeout",
+    "0",
+    "The timeout value used for socket read operations."),
 
   /**
    * Cancel command is sent out of band over its own connection, so cancel message can itself get
@@ -286,68 +384,97 @@ public enum PGProperty {
    * This property controls "connect timeout" and "socket timeout" used for cancel commands.
    * The timeout is specified in seconds. Default value is 10 seconds.
    */
-  CANCEL_SIGNAL_TIMEOUT("cancelSignalTimeout", "10", "The timeout that is used for sending cancel command."),
+  CANCEL_SIGNAL_TIMEOUT(
+    "cancelSignalTimeout",
+    "10",
+    "The timeout that is used for sending cancel command."),
 
   /**
    * Socket factory used to create socket. A null value, which is the default, means system default.
    */
-  SOCKET_FACTORY("socketFactory", null, "Specify a socket factory for socket creation"),
+  SOCKET_FACTORY(
+    "socketFactory",
+    null,
+    "Specify a socket factory for socket creation"),
 
   /**
    * The String argument to give to the constructor of the Socket Factory.
    * @deprecated use {@code ..Factory(Properties)} constructor.
    */
   @Deprecated
-  SOCKET_FACTORY_ARG("socketFactoryArg", null,
-      "Argument forwarded to constructor of SocketFactory class."),
+  SOCKET_FACTORY_ARG(
+    "socketFactoryArg",
+    null,
+    "Argument forwarded to constructor of SocketFactory class."),
 
   /**
    * Socket read buffer size (SO_RECVBUF). A value of {@code -1}, which is the default, means system
    * default.
    */
-  RECEIVE_BUFFER_SIZE("receiveBufferSize", "-1", "Socket read buffer size"),
+  RECEIVE_BUFFER_SIZE(
+    "receiveBufferSize",
+    "-1",
+    "Socket read buffer size"),
 
   /**
    * Socket write buffer size (SO_SNDBUF). A value of {@code -1}, which is the default, means system
    * default.
    */
-  SEND_BUFFER_SIZE("sendBufferSize", "-1", "Socket write buffer size"),
+  SEND_BUFFER_SIZE(
+    "sendBufferSize",
+    "-1",
+    "Socket write buffer size"),
 
   /**
    * Assume the server is at least that version.
    */
-  ASSUME_MIN_SERVER_VERSION("assumeMinServerVersion", null,
-      "Assume the server is at least that version"),
+  ASSUME_MIN_SERVER_VERSION(
+    "assumeMinServerVersion",
+    null,
+    "Assume the server is at least that version"),
 
   /**
    * The application name (require server version &gt;= 9.0).
    */
-  APPLICATION_NAME("ApplicationName", DriverInfo.DRIVER_NAME, "Name of the Application (backend >= 9.0)"),
+  APPLICATION_NAME(
+    "ApplicationName",
+    DriverInfo.DRIVER_NAME,
+    "Name of the Application (backend >= 9.0)"),
 
   /**
    * Flag to enable/disable obtaining a GSS credential via JAAS login before authenticating.
    * Useful if setting system property javax.security.auth.useSubjectCredsOnly=false
    * or using native GSS with system property sun.security.jgss.native=true
    */
-  JAAS_LOGIN("jaasLogin", "true", "Login with JAAS before doing GSSAPI authentication"),
+  JAAS_LOGIN(
+    "jaasLogin",
+    "true",
+    "Login with JAAS before doing GSSAPI authentication"),
 
   /**
    * Specifies the name of the JAAS system or application login configuration.
    */
-  JAAS_APPLICATION_NAME("jaasApplicationName", null,
-      "Specifies the name of the JAAS system or application login configuration."),
+  JAAS_APPLICATION_NAME(
+    "jaasApplicationName",
+    null,
+    "Specifies the name of the JAAS system or application login configuration."),
 
   /**
    * The Kerberos service name to use when authenticating with GSSAPI. This is equivalent to libpq's
    * PGKRBSRVNAME environment variable.
    */
-  KERBEROS_SERVER_NAME("kerberosServerName", null,
-      "The Kerberos service name to use when authenticating with GSSAPI."),
+  KERBEROS_SERVER_NAME(
+    "kerberosServerName",
+    null,
+    "The Kerberos service name to use when authenticating with GSSAPI."),
 
   /**
    * Use SPNEGO in SSPI authentication requests.
    */
-  USE_SPNEGO("useSpnego", "false", "Use SPNEGO in SSPI authentication requests"),
+  USE_SPNEGO(
+    "useSpnego",
+    "false",
+    "Use SPNEGO in SSPI authentication requests"),
 
   /**
    * Force one of
@@ -357,13 +484,21 @@ public enum PGProperty {
    * </ul>
    * to be used when the server requests Kerberos or SSPI authentication.
    */
-  GSS_LIB("gsslib", "auto", "Force SSSPI or GSSAPI", false, "auto", "sspi", "gssapi"),
+  GSS_LIB(
+    "gsslib",
+    "auto",
+    "Force SSSPI or GSSAPI",
+    false,
+    new String[] {"auto", "sspi", "gssapi"}),
 
   /**
    * Specifies the name of the SSPI service class that forms the service class part of the SPN. The
    * default, {@code POSTGRES}, is almost always correct.
    */
-  SSPI_SERVICE_CLASS("sspiServiceClass", "POSTGRES", "The Windows SSPI service class for SPN"),
+  SSPI_SERVICE_CLASS(
+    "sspiServiceClass",
+    "POSTGRES",
+    "The Windows SSPI service class for SPN"),
 
   /**
    * When using the V3 protocol the driver monitors changes in certain server configuration
@@ -371,22 +506,36 @@ public enum PGProperty {
    * by the driver and should not be altered. If the driver detects a change it will abort the
    * connection.
    */
-  ALLOW_ENCODING_CHANGES("allowEncodingChanges", "false", "Allow for changes in client_encoding"),
+  ALLOW_ENCODING_CHANGES(
+    "allowEncodingChanges",
+    "false",
+    "Allow for changes in client_encoding"),
 
   /**
    * Specify the schema (or several schema separated by commas) to be set in the search-path. This schema will be used to resolve
    * unqualified object names used in statements over this connection.
    */
-  CURRENT_SCHEMA("currentSchema", null, "Specify the schema (or several schema separated by commas) to be set in the search-path"),
+  CURRENT_SCHEMA(
+    "currentSchema",
+    null,
+    "Specify the schema (or several schema separated by commas) to be set in the search-path"),
 
-  TARGET_SERVER_TYPE("targetServerType", "any", "Specifies what kind of server to connect", false,
-      "any", "master", "slave", "secondary",  "preferSlave", "preferSecondary"),
+  TARGET_SERVER_TYPE(
+    "targetServerType",
+    "any",
+    "Specifies what kind of server to connect",
+    false,
+    new String[] {"any", "master", "slave", "secondary",  "preferSlave", "preferSecondary"}),
 
-  LOAD_BALANCE_HOSTS("loadBalanceHosts", "false",
-      "If disabled hosts are connected in the given order. If enabled hosts are chosen randomly from the set of suitable candidates"),
+  LOAD_BALANCE_HOSTS(
+    "loadBalanceHosts",
+    "false",
+    "If disabled hosts are connected in the given order. If enabled hosts are chosen randomly from the set of suitable candidates"),
 
-  HOST_RECHECK_SECONDS("hostRecheckSeconds", "10",
-      "Specifies period (seconds) after which the host status is checked again in case it has changed"),
+  HOST_RECHECK_SECONDS(
+    "hostRecheckSeconds",
+    "10",
+    "Specifies period (seconds) after which the host status is checked again in case it has changed"),
 
   /**
    * <p>Specifies which mode is used to execute queries to database: simple means ('Q' execute, no parse, no bind, text mode only),
@@ -395,11 +544,13 @@ public enum PGProperty {
    *
    * <p>This mode is meant for debugging purposes and/or for cases when extended protocol cannot be used (e.g. logical replication protocol)</p>
    */
-  PREFER_QUERY_MODE("preferQueryMode", "extended",
-      "Specifies which mode is used to execute queries to database: simple means ('Q' execute, no parse, no bind, text mode only), "
-          + "extended means always use bind/execute messages, extendedForPrepared means extended for prepared statements only, "
-          + "extendedCacheEverything means use extended protocol and try cache every statement (including Statement.execute(String sql)) in a query cache.", false,
-      "extended", "extendedForPrepared", "extendedCacheEverything", "simple"),
+  PREFER_QUERY_MODE(
+    "preferQueryMode",
+    "extended",
+    "Specifies which mode is used to execute queries to database: simple means ('Q' execute, no parse, no bind, text mode only), "
+        + "extended means always use bind/execute messages, extendedForPrepared means extended for prepared statements only, "
+        + "extendedCacheEverything means use extended protocol and try cache every statement (including Statement.execute(String sql)) in a query cache.", false,
+    new String[] {"extended", "extendedForPrepared", "extendedCacheEverything", "simple"}),
 
   /**
    * Specifies what the driver should do if a query fails. In {@code autosave=always} mode, JDBC driver sets a savepoint before each query,
@@ -407,29 +558,39 @@ public enum PGProperty {
    * In {@code autosave=conservative} mode, savepoint is set for each query, however the rollback is done only for rare cases
    * like 'cached statement cannot change return type' or 'statement XXX is not valid' so JDBC driver rollsback and retries
    */
-  AUTOSAVE("autosave", "never",
-      "Specifies what the driver should do if a query fails. In autosave=always mode, JDBC driver sets a savepoint before each query, "
-          + "and rolls back to that savepoint in case of failure. In autosave=never mode (default), no savepoint dance is made ever. "
-          + "In autosave=conservative mode, safepoint is set for each query, however the rollback is done only for rare cases"
-          + " like 'cached statement cannot change return type' or 'statement XXX is not valid' so JDBC driver rollsback and retries", false,
-      "always", "never", "conservative"),
+  AUTOSAVE(
+    "autosave",
+    "never",
+    "Specifies what the driver should do if a query fails. In autosave=always mode, JDBC driver sets a savepoint before each query, "
+        + "and rolls back to that savepoint in case of failure. In autosave=never mode (default), no savepoint dance is made ever. "
+        + "In autosave=conservative mode, safepoint is set for each query, however the rollback is done only for rare cases"
+        + " like 'cached statement cannot change return type' or 'statement XXX is not valid' so JDBC driver rollsback and retries", false,
+    new String[] {"always", "never", "conservative"}),
 
   /**
    *
    */
-  CLEANUP_SAVEPOINTS("cleanupSavepoints", "false","Determine whether SAVEPOINTS used in AUTOSAVE will be released per query or not",
-      false, "true", "false"),
+  CLEANUP_SAVEPOINTS(
+    "cleanupSavepoints",
+    "false",
+    "Determine whether SAVEPOINTS used in AUTOSAVE will be released per query or not",
+    false,
+    new String[] {"true", "false"}),
   /**
    * Configure optimization to enable batch insert re-writing.
    */
-  REWRITE_BATCHED_INSERTS("reWriteBatchedInserts", "false",
-      "Enable optimization to rewrite and collapse compatible INSERT statements that are batched."),
+  REWRITE_BATCHED_INSERTS(
+    "reWriteBatchedInserts",
+    "false",
+    "Enable optimization to rewrite and collapse compatible INSERT statements that are batched."),
 
   /**
    * Enable mode to filter out the names of database objects for which the current user has no privileges
    * granted from appearing in the DatabaseMetaData returned by the driver.
    */
-  HIDE_UNPRIVILEGED_OBJECTS("hideUnprivilegedObjects", "false",
+  HIDE_UNPRIVILEGED_OBJECTS(
+    "hideUnprivilegedObjects",
+    "false",
     "Enable hiding of database objects for which the current user has no privileges granted from the DatabaseMetaData"),
 
   /**
@@ -442,16 +603,19 @@ public enum PGProperty {
    * <p>Parameter should be use together with {@link PGProperty#ASSUME_MIN_SERVER_VERSION} with
    * parameter &gt;= 9.4 (backend &gt;= 9.4)</p>
    */
-  REPLICATION("replication", null,
-      "Connection parameter passed in startup message, one of 'true' or 'database' "
-          + "Passing 'true' tells the backend to go into walsender mode, "
-          + "wherein a small set of replication commands can be issued instead of SQL statements. "
-          + "Only the simple query protocol can be used in walsender mode. "
-          + "Passing 'database' as the value instructs walsender to connect "
-          + "to the database specified in the dbname parameter, "
-          + "which will allow the connection to be used for logical replication "
-          + "from that database. "
-          + "(backend >= 9.4)"),
+  REPLICATION(
+    "replication",
+    null,
+    "Connection parameter passed in startup message, one of 'true' or 'database' "
+      + "Passing 'true' tells the backend to go into walsender mode, "
+      + "wherein a small set of replication commands can be issued instead of SQL statements. "
+      + "Only the simple query protocol can be used in walsender mode. "
+      + "Passing 'database' as the value instructs walsender to connect "
+      + "to the database specified in the dbname parameter, "
+      + "which will allow the connection to be used for logical replication "
+      + "from that database. "
+      + "(backend >= 9.4)"),
+  ;
 
   /**
    * Specifies how the driver transforms JDBC escape call syntax into underlying SQL, for invoking procedures or functions. (backend &gt;= 11)
@@ -459,30 +623,38 @@ public enum PGProperty {
    * In {@code escapeSyntaxCallMode=callIfNoReturn} mode, the driver uses a CALL statement (allowing procedure invocation) if there is no return parameter specified, otherwise the driver uses a SELECT statement.
    * In {@code escapeSyntaxCallMode=call} mode, the driver always uses a CALL statement (allowing procedure invocation only).
    */
-  ESCAPE_SYNTAX_CALL_MODE("escapeSyntaxCallMode", "select",
-      "Specifies how the driver transforms JDBC escape call syntax into underlying SQL, for invoking procedures or functions. (backend >= 11)"
-          + "In escapeSyntaxCallMode=select mode (the default), the driver always uses a SELECT statement (allowing function invocation only)."
-          + "In escapeSyntaxCallMode=callIfNoReturn mode, the driver uses a CALL statement (allowing procedure invocation) if there is no return parameter specified, otherwise the driver uses a SELECT statement."
-          + "In escapeSyntaxCallMode=call mode, the driver always uses a CALL statement (allowing procedure invocation only).",
-      false, "select", "callIfNoReturn", "call"),
+  ESCAPE_SYNTAX_CALL_MODE(
+    "escapeSyntaxCallMode",
+    "select",
+    "Specifies how the driver transforms JDBC escape call syntax into underlying SQL, for invoking procedures or functions. (backend >= 11)"
+      + "In escapeSyntaxCallMode=select mode (the default), the driver always uses a SELECT statement (allowing function invocation only)."
+      + "In escapeSyntaxCallMode=callIfNoReturn mode, the driver uses a CALL statement (allowing procedure invocation) if there is no return parameter specified, otherwise the driver uses a SELECT statement."
+      + "In escapeSyntaxCallMode=call mode, the driver always uses a CALL statement (allowing procedure invocation only).",
+    false,
+    new String[] {"select", "callIfNoReturn", "call"}),
 
   /**
    * Connection parameter to control behavior when
    * {@link Connection#setReadOnly(boolean)} is set to {@code true}.
    */
-  READ_ONLY_MODE("readOnlyMode", "transaction",
-      "Controls the behavior when a connection is set to be read only, one of 'ignore', 'transaction', or 'always' "
-          + "When 'ignore', setting readOnly has no effect. "
-          + "When 'transaction' setting readOnly to 'true' will cause transactions to BEGIN READ ONLY if autocommit is 'false'. "
-          + "When 'always' setting readOnly to 'true' will set the session to READ ONLY if autoCommit is 'true' "
-          + "and the transaction to BEGIN READ ONLY if autocommit is 'false'.",
-      false, "ignore", "transaction", "always"),
+  READ_ONLY_MODE(
+    "readOnlyMode",
+    "transaction",
+    "Controls the behavior when a connection is set to be read only, one of 'ignore', 'transaction', or 'always' "
+      + "When 'ignore', setting readOnly has no effect. "
+      + "When 'transaction' setting readOnly to 'true' will cause transactions to BEGIN READ ONLY if autocommit is 'false'. "
+      + "When 'always' setting readOnly to 'true' will set the session to READ ONLY if autoCommit is 'true' "
+      + "and the transaction to BEGIN READ ONLY if autocommit is 'false'.",
+    false,
+    new String[] {"ignore", "transaction", "always"}),
 
   /**
    * Specifies size of buffer during fetching result set. Can be specified as specified size or
    * percent of heap memory.
    */
-  MAX_RESULT_BUFFER("maxResultBuffer", null,
+  MAX_RESULT_BUFFER(
+    "maxResultBuffer",
+    null,
     "Specifies size of buffer during fetching result set. Can be specified as specified size or percent of heap memory.");
 
   private final String name;
@@ -499,8 +671,7 @@ public enum PGProperty {
     this(name, defaultValue, description, required, (String[]) null);
   }
 
-  PGProperty(String name, String defaultValue, String description, boolean required,
-      String... choices) {
+  PGProperty(String name, String defaultValue, String description, boolean required, String[] choices) {
     this.name = name;
     this.defaultValue = defaultValue;
     this.required = required;

--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -664,6 +664,7 @@ public enum PGProperty {
   private final boolean required;
   private final String description;
   private final String[] choices;
+  private final boolean deprecated;
 
   PGProperty(String name, String defaultValue, String description) {
     this(name, defaultValue, description, false);
@@ -679,6 +680,11 @@ public enum PGProperty {
     this.required = required;
     this.description = description;
     this.choices = choices;
+    try {
+      this.deprecated = PGProperty.class.getField(name()).getAnnotation(Deprecated.class) != null;
+    } catch (NoSuchFieldException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   private static final Map<String, PGProperty> PROPS_BY_NAME = new HashMap<String, PGProperty>();
@@ -734,6 +740,15 @@ public enum PGProperty {
    */
   public String[] getChoices() {
     return choices;
+  }
+
+  /**
+   * Returns whether this connection parameter is deprecated.
+   *
+   * @return whether this connection parameter is deprecated
+   */
+  public boolean isDeprecated() {
+    return deprecated;
   }
 
   /**

--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -23,129 +23,114 @@ import java.util.Properties;
 public enum PGProperty {
 
   /**
-   * Database name to connect to (may be specified directly in the JDBC URL).
+   * When using the V3 protocol the driver monitors changes in certain server configuration
+   * parameters that should not be touched by end users. The {@code client_encoding} setting is set
+   * by the driver and should not be altered. If the driver detects a change it will abort the
+   * connection.
    */
-  PG_DBNAME(
-    "PGDBNAME",
-    null,
-    "Database name to connect to (may be specified directly in the JDBC URL)",
-    true),
+  ALLOW_ENCODING_CHANGES(
+    "allowEncodingChanges",
+    "false",
+    "Allow for changes in client_encoding"),
 
   /**
-   * Hostname of the PostgreSQL server (may be specified directly in the JDBC URL).
+   * The application name (require server version &gt;= 9.0).
    */
-  PG_HOST(
-    "PGHOST",
-    null,
-    "Hostname of the PostgreSQL server (may be specified directly in the JDBC URL)",
-    false),
+  APPLICATION_NAME(
+    "ApplicationName",
+    DriverInfo.DRIVER_NAME,
+    "Name of the Application (backend >= 9.0)"),
 
   /**
-   * Port of the PostgreSQL server (may be specified directly in the JDBC URL).
+   * Specifies what the driver should do if a query fails. In {@code autosave=always} mode, JDBC driver sets a savepoint before each query,
+   * and rolls back to that savepoint in case of failure. In {@code autosave=never} mode (default), no savepoint dance is made ever.
+   * In {@code autosave=conservative} mode, savepoint is set for each query, however the rollback is done only for rare cases
+   * like 'cached statement cannot change return type' or 'statement XXX is not valid' so JDBC driver rollsback and retries
    */
-  PG_PORT(
-    "PGPORT",
-    null,
-    "Port of the PostgreSQL server (may be specified directly in the JDBC URL)"),
-
-  /**
-   * Username to connect to the database as.
-   */
-  USER(
-    "user",
-    null,
-    "Username to connect to the database as.",
-    true),
-
-  /**
-   * Password to use when authenticating.
-   */
-  PASSWORD(
-    "password",
-    null,
-    "Password to use when authenticating.",
-    false),
-
-  /**
-   * Force use of a particular protocol version when connecting, if set, disables protocol version
-   * fallback.
-   */
-  PROTOCOL_VERSION(
-    "protocolVersion",
-    null,
-    "Force use of a particular protocol version when connecting, currently only version 3 is supported.",
+  AUTOSAVE(
+    "autosave",
+    "never",
+    "Specifies what the driver should do if a query fails. In autosave=always mode, JDBC driver sets a savepoint before each query, "
+        + "and rolls back to that savepoint in case of failure. In autosave=never mode (default), no savepoint dance is made ever. "
+        + "In autosave=conservative mode, safepoint is set for each query, however the rollback is done only for rare cases"
+        + " like 'cached statement cannot change return type' or 'statement XXX is not valid' so JDBC driver rollsback and retries",
     false,
-    new String[] {"3"}),
+    new String[] {"always", "never", "conservative"}),
 
   /**
-   * Specify 'options' connection initialization parameter.
-   * The value of this parameter may contain spaces and other special characters or their URL representation.
+   * Assume the server is at least that version.
    */
-  OPTIONS(
-    "options",
+  ASSUME_MIN_SERVER_VERSION(
+    "assumeMinServerVersion",
     null,
-    "Specify 'options' connection initialization parameter."),
+    "Assume the server is at least that version"),
+
 
   /**
-   * <p>Logger level of the driver. Allowed values: {@code OFF}, {@code DEBUG} or {@code TRACE}.</p>
-   *
-   * <p>This enable the {@link java.util.logging.Logger} of the driver based on the following mapping
-   * of levels:</p>
-   * <ul>
-   *     <li>FINE -&gt; DEBUG</li>
-   *     <li>FINEST -&gt; TRACE</li>
-   * </ul>
-   *
-   * <p><b>NOTE:</b> The recommended approach to enable java.util.logging is using a
-   * {@code logging.properties} configuration file with the property
-   * {@code -Djava.util.logging.config.file=myfile} or if your are using an application server
-   * you should use the appropriate logging subsystem.</p>
+   * Use binary format for sending and receiving data if possible.
    */
-  LOGGER_LEVEL(
-    "loggerLevel",
-    null,
-    "Logger level of the driver",
+  BINARY_TRANSFER(
+    "binaryTransfer",
+    "true",
+    "Use binary format for sending and receiving data if possible"),
+
+  /**
+   * Comma separated list of types to disable binary transfer. Either OID numbers or names.
+   * Overrides values in the driver default set and values set with binaryTransferEnable.
+   */
+  BINARY_TRANSFER_DISABLE(
+    "binaryTransferDisable",
+    "",
+    "Comma separated list of types to disable binary transfer. Either OID numbers or names. Overrides values in the driver default set and values set with binaryTransferEnable."),
+
+  /**
+   * Comma separated list of types to enable binary transfer. Either OID numbers or names
+   */
+  BINARY_TRANSFER_ENABLE(
+    "binaryTransferEnable",
+    "",
+    "Comma separated list of types to enable binary transfer. Either OID numbers or names"),
+
+  /**
+   * Cancel command is sent out of band over its own connection, so cancel message can itself get
+   * stuck.
+   * This property controls "connect timeout" and "socket timeout" used for cancel commands.
+   * The timeout is specified in seconds. Default value is 10 seconds.
+   */
+  CANCEL_SIGNAL_TIMEOUT(
+    "cancelSignalTimeout",
+    "10",
+    "The timeout that is used for sending cancel command."),
+
+  /**
+   * Determine whether SAVEPOINTS used in AUTOSAVE will be released per query or not
+   */
+  CLEANUP_SAVEPOINTS(
+    "cleanupSavepoints",
+    "false",
+    "Determine whether SAVEPOINTS used in AUTOSAVE will be released per query or not",
     false,
-    new String[] {"OFF", "DEBUG", "TRACE"}),
+    new String[] {"true", "false"}),
 
   /**
-   * <p>File name output of the Logger, if set, the Logger will use a
-   * {@link java.util.logging.FileHandler} to write to a specified file. If the parameter is not set
-   * or the file can't be created the {@link java.util.logging.ConsoleHandler} will be used instead.</p>
+   * <p>The timeout value used for socket connect operations. If connecting to the server takes longer
+   * than this value, the connection is broken.</p>
    *
-   * <p>Parameter should be use together with {@link PGProperty#LOGGER_LEVEL}</p>
+   * <p>The timeout is specified in seconds and a value of zero means that it is disabled.</p>
    */
-  LOGGER_FILE(
-    "loggerFile",
+  CONNECT_TIMEOUT(
+    "connectTimeout",
+    "10",
+    "The timeout value used for socket connect operations."),
+
+  /**
+   * Specify the schema (or several schema separated by commas) to be set in the search-path. This schema will be used to resolve
+   * unqualified object names used in statements over this connection.
+   */
+  CURRENT_SCHEMA(
+    "currentSchema",
     null,
-    "File name output of the Logger"),
-
-  /**
-   * Sets the default threshold for enabling server-side prepare. A value of {@code -1} stands for
-   * forceBinary
-   */
-  PREPARE_THRESHOLD(
-    "prepareThreshold",
-    "5",
-    "Statement prepare threshold. A value of {@code -1} stands for forceBinary"),
-
-  /**
-   * Specifies the maximum number of entries in cache of prepared statements. A value of {@code 0}
-   * disables the cache.
-   */
-  PREPARED_STATEMENT_CACHE_QUERIES(
-    "preparedStatementCacheQueries",
-    "256",
-    "Specifies the maximum number of entries in per-connection cache of prepared statements. A value of {@code 0} disables the cache."),
-
-  /**
-   * Specifies the maximum size (in megabytes) of the prepared statement cache. A value of {@code 0}
-   * disables the cache.
-   */
-  PREPARED_STATEMENT_CACHE_SIZE_MIB(
-    "preparedStatementCacheSizeMiB",
-    "5",
-    "Specifies the maximum size (in megabytes) of a per-connection prepared statement cache. A value of {@code 0} disables the cache."),
+    "Specify the schema (or several schema separated by commas) to be set in the search-path"),
 
   /**
    * Specifies the maximum number of fields to be cached per connection. A value of {@code 0} disables the cache.
@@ -173,56 +158,140 @@ public enum PGProperty {
     "Positive number of rows that should be fetched from the database when more rows are needed for ResultSet by each fetch iteration"),
 
   /**
-   * Use binary format for sending and receiving data if possible.
+   * Enable optimization that disables column name sanitiser.
    */
-  BINARY_TRANSFER(
-    "binaryTransfer",
-    "true",
-    "Use binary format for sending and receiving data if possible"),
-
-  /**
-   * Puts this connection in read-only mode.
-   */
-  READ_ONLY(
-    "readOnly",
+  DISABLE_COLUMN_SANITISER(
+    "disableColumnSanitiser",
     "false",
-    "Puts this connection in read-only mode"),
+    "Enable optimization that disables column name sanitiser"),
 
   /**
-   * Comma separated list of types to enable binary transfer. Either OID numbers or names
+   * Specifies how the driver transforms JDBC escape call syntax into underlying SQL, for invoking procedures or functions. (backend &gt;= 11)
+   * In {@code escapeSyntaxCallMode=select} mode (the default), the driver always uses a SELECT statement (allowing function invocation only).
+   * In {@code escapeSyntaxCallMode=callIfNoReturn} mode, the driver uses a CALL statement (allowing procedure invocation) if there is no return parameter specified, otherwise the driver uses a SELECT statement.
+   * In {@code escapeSyntaxCallMode=call} mode, the driver always uses a CALL statement (allowing procedure invocation only).
    */
-  BINARY_TRANSFER_ENABLE(
-    "binaryTransferEnable",
-    "",
-    "Comma separated list of types to enable binary transfer. Either OID numbers or names"),
-
-  /**
-   * Comma separated list of types to disable binary transfer. Either OID numbers or names.
-   * Overrides values in the driver default set and values set with binaryTransferEnable.
-   */
-  BINARY_TRANSFER_DISABLE(
-    "binaryTransferDisable",
-    "",
-    "Comma separated list of types to disable binary transfer. Either OID numbers or names. Overrides values in the driver default set and values set with binaryTransferEnable."),
-
-  /**
-   * Bind String to either {@code unspecified} or {@code varchar}. Default is {@code varchar} for
-   * 8.0+ backends.
-   */
-  STRING_TYPE(
-    "stringtype",
-    null,
-    "The type to bind String parameters as (usually 'varchar', 'unspecified' allows implicit casting to other types)",
+  ESCAPE_SYNTAX_CALL_MODE(
+    "escapeSyntaxCallMode",
+    "select",
+    "Specifies how the driver transforms JDBC escape call syntax into underlying SQL, for invoking procedures or functions. (backend >= 11)"
+      + "In escapeSyntaxCallMode=select mode (the default), the driver always uses a SELECT statement (allowing function invocation only)."
+      + "In escapeSyntaxCallMode=callIfNoReturn mode, the driver uses a CALL statement (allowing procedure invocation) if there is no return parameter specified, otherwise the driver uses a SELECT statement."
+      + "In escapeSyntaxCallMode=call mode, the driver always uses a CALL statement (allowing procedure invocation only).",
     false,
-    new String[] {"unspecified", "varchar"}),
+    new String[] {"select", "callIfNoReturn", "call"}),
 
   /**
-   * Specifies the length to return for types of unknown length.
+   * Force one of
+   * <ul>
+   * <li>SSPI (Windows transparent single-sign-on)</li>
+   * <li>GSSAPI (Kerberos, via JSSE)</li>
+   * </ul>
+   * to be used when the server requests Kerberos or SSPI authentication.
    */
-  UNKNOWN_LENGTH(
-    "unknownLength",
-    Integer.toString(Integer.MAX_VALUE),
-    "Specifies the length to return for types of unknown length"),
+  GSS_LIB(
+    "gsslib",
+    "auto",
+    "Force SSSPI or GSSAPI",
+    false,
+    new String[] {"auto", "sspi", "gssapi"}),
+
+  /**
+   * Enable mode to filter out the names of database objects for which the current user has no privileges
+   * granted from appearing in the DatabaseMetaData returned by the driver.
+   */
+  HIDE_UNPRIVILEGED_OBJECTS(
+    "hideUnprivilegedObjects",
+    "false",
+    "Enable hiding of database objects for which the current user has no privileges granted from the DatabaseMetaData"),
+
+  HOST_RECHECK_SECONDS(
+    "hostRecheckSeconds",
+    "10",
+    "Specifies period (seconds) after which the host status is checked again in case it has changed"),
+
+  /**
+   * Specifies the name of the JAAS system or application login configuration.
+   */
+  JAAS_APPLICATION_NAME(
+    "jaasApplicationName",
+    null,
+    "Specifies the name of the JAAS system or application login configuration."),
+
+  /**
+   * Flag to enable/disable obtaining a GSS credential via JAAS login before authenticating.
+   * Useful if setting system property javax.security.auth.useSubjectCredsOnly=false
+   * or using native GSS with system property sun.security.jgss.native=true
+   */
+  JAAS_LOGIN(
+    "jaasLogin",
+    "true",
+    "Login with JAAS before doing GSSAPI authentication"),
+
+  /**
+   * The Kerberos service name to use when authenticating with GSSAPI. This is equivalent to libpq's
+   * PGKRBSRVNAME environment variable.
+   */
+  KERBEROS_SERVER_NAME(
+    "kerberosServerName",
+    null,
+    "The Kerberos service name to use when authenticating with GSSAPI."),
+
+  LOAD_BALANCE_HOSTS(
+    "loadBalanceHosts",
+    "false",
+    "If disabled hosts are connected in the given order. If enabled hosts are chosen randomly from the set of suitable candidates"),
+
+  /**
+   * <p>File name output of the Logger, if set, the Logger will use a
+   * {@link java.util.logging.FileHandler} to write to a specified file. If the parameter is not set
+   * or the file can't be created the {@link java.util.logging.ConsoleHandler} will be used instead.</p>
+   *
+   * <p>Parameter should be use together with {@link PGProperty#LOGGER_LEVEL}</p>
+   */
+  LOGGER_FILE(
+    "loggerFile",
+    null,
+    "File name output of the Logger"),
+
+  /**
+   * <p>Logger level of the driver. Allowed values: {@code OFF}, {@code DEBUG} or {@code TRACE}.</p>
+   *
+   * <p>This enable the {@link java.util.logging.Logger} of the driver based on the following mapping
+   * of levels:</p>
+   * <ul>
+   *     <li>FINE -&gt; DEBUG</li>
+   *     <li>FINEST -&gt; TRACE</li>
+   * </ul>
+   *
+   * <p><b>NOTE:</b> The recommended approach to enable java.util.logging is using a
+   * {@code logging.properties} configuration file with the property
+   * {@code -Djava.util.logging.config.file=myfile} or if your are using an application server
+   * you should use the appropriate logging subsystem.</p>
+   */
+  LOGGER_LEVEL(
+    "loggerLevel",
+    null,
+    "Logger level of the driver",
+    false,
+    new String[] {"OFF", "DEBUG", "TRACE"}),
+
+  /**
+   * Specify how long to wait for establishment of a database connection. The timeout is specified
+   * in seconds.
+   */
+  LOGIN_TIMEOUT(
+    "loginTimeout",
+    "0",
+    "Specify how long to wait for establishment of a database connection."),
+
+  /**
+   * Whether to include full server error detail in exception messages.
+   */
+  LOG_SERVER_ERROR_DETAIL(
+    "logServerErrorDetail",
+    "true",
+    "Include full server error detail in exception messages. If disabled then only the error itself will be included."),
 
   /**
    * When connections that are not explicitly closed are garbage collected, log the stacktrace from
@@ -234,20 +303,211 @@ public enum PGProperty {
     "When connections that are not explicitly closed are garbage collected, log the stacktrace from the opening of the connection to trace the leak source"),
 
   /**
-   * Whether to include full server error detail in exception messages.
+   * Specifies size of buffer during fetching result set. Can be specified as specified size or
+   * percent of heap memory.
    */
-  LOG_SERVER_ERROR_DETAIL(
-    "logServerErrorDetail",
-    "true",
-    "Include full server error detail in exception messages. If disabled then only the error itself will be included."),
+  MAX_RESULT_BUFFER(
+    "maxResultBuffer",
+    null,
+    "Specifies size of buffer during fetching result set. Can be specified as specified size or percent of heap memory."),
 
   /**
-   * Enable optimization that disables column name sanitiser.
+   * Specify 'options' connection initialization parameter.
+   * The value of this parameter may contain spaces and other special characters or their URL representation.
    */
-  DISABLE_COLUMN_SANITISER(
-    "disableColumnSanitiser",
+  OPTIONS(
+    "options",
+    null,
+    "Specify 'options' connection initialization parameter."),
+
+  /**
+   * Password to use when authenticating.
+   */
+  PASSWORD(
+    "password",
+    null,
+    "Password to use when authenticating.",
+    false),
+
+  /**
+   * Database name to connect to (may be specified directly in the JDBC URL).
+   */
+  PG_DBNAME(
+    "PGDBNAME",
+    null,
+    "Database name to connect to (may be specified directly in the JDBC URL)",
+    true),
+
+  /**
+   * Hostname of the PostgreSQL server (may be specified directly in the JDBC URL).
+   */
+  PG_HOST(
+    "PGHOST",
+    null,
+    "Hostname of the PostgreSQL server (may be specified directly in the JDBC URL)",
+    false),
+
+  /**
+   * Port of the PostgreSQL server (may be specified directly in the JDBC URL).
+   */
+  PG_PORT(
+    "PGPORT",
+    null,
+    "Port of the PostgreSQL server (may be specified directly in the JDBC URL)"),
+
+  /**
+   * <p>Specifies which mode is used to execute queries to database: simple means ('Q' execute, no parse, no bind, text mode only),
+   * extended means always use bind/execute messages, extendedForPrepared means extended for prepared statements only,
+   * extendedCacheEverything means use extended protocol and try cache every statement (including Statement.execute(String sql)) in a query cache.</p>
+   *
+   * <p>This mode is meant for debugging purposes and/or for cases when extended protocol cannot be used (e.g. logical replication protocol)</p>
+   */
+  PREFER_QUERY_MODE(
+    "preferQueryMode",
+    "extended",
+    "Specifies which mode is used to execute queries to database: simple means ('Q' execute, no parse, no bind, text mode only), "
+        + "extended means always use bind/execute messages, extendedForPrepared means extended for prepared statements only, "
+        + "extendedCacheEverything means use extended protocol and try cache every statement (including Statement.execute(String sql)) in a query cache.", false,
+    new String[] {"extended", "extendedForPrepared", "extendedCacheEverything", "simple"}),
+
+  /**
+   * Specifies the maximum number of entries in cache of prepared statements. A value of {@code 0}
+   * disables the cache.
+   */
+  PREPARED_STATEMENT_CACHE_QUERIES(
+    "preparedStatementCacheQueries",
+    "256",
+    "Specifies the maximum number of entries in per-connection cache of prepared statements. A value of {@code 0} disables the cache."),
+
+  /**
+   * Specifies the maximum size (in megabytes) of the prepared statement cache. A value of {@code 0}
+   * disables the cache.
+   */
+  PREPARED_STATEMENT_CACHE_SIZE_MIB(
+    "preparedStatementCacheSizeMiB",
+    "5",
+    "Specifies the maximum size (in megabytes) of a per-connection prepared statement cache. A value of {@code 0} disables the cache."),
+
+  /**
+   * Sets the default threshold for enabling server-side prepare. A value of {@code -1} stands for
+   * forceBinary
+   */
+  PREPARE_THRESHOLD(
+    "prepareThreshold",
+    "5",
+    "Statement prepare threshold. A value of {@code -1} stands for forceBinary"),
+
+  /**
+   * Force use of a particular protocol version when connecting, if set, disables protocol version
+   * fallback.
+   */
+  PROTOCOL_VERSION(
+    "protocolVersion",
+    null,
+    "Force use of a particular protocol version when connecting, currently only version 3 is supported.",
+    false,
+    new String[] {"3"}),
+
+  /**
+   * Puts this connection in read-only mode.
+   */
+  READ_ONLY(
+    "readOnly",
     "false",
-    "Enable optimization that disables column name sanitiser"),
+    "Puts this connection in read-only mode"),
+
+  /**
+   * Connection parameter to control behavior when
+   * {@link Connection#setReadOnly(boolean)} is set to {@code true}.
+   */
+  READ_ONLY_MODE(
+    "readOnlyMode",
+    "transaction",
+    "Controls the behavior when a connection is set to be read only, one of 'ignore', 'transaction', or 'always' "
+      + "When 'ignore', setting readOnly has no effect. "
+      + "When 'transaction' setting readOnly to 'true' will cause transactions to BEGIN READ ONLY if autocommit is 'false'. "
+      + "When 'always' setting readOnly to 'true' will set the session to READ ONLY if autoCommit is 'true' "
+      + "and the transaction to BEGIN READ ONLY if autocommit is 'false'.",
+    false,
+    new String[] {"ignore", "transaction", "always"}),
+
+  /**
+   * Socket read buffer size (SO_RECVBUF). A value of {@code -1}, which is the default, means system
+   * default.
+   */
+  RECEIVE_BUFFER_SIZE(
+    "receiveBufferSize",
+    "-1",
+    "Socket read buffer size"),
+
+  /**
+   * <p>Connection parameter passed in the startup message. This parameter accepts two values; "true"
+   * and "database". Passing "true" tells the backend to go into walsender mode, wherein a small set
+   * of replication commands can be issued instead of SQL statements. Only the simple query protocol
+   * can be used in walsender mode. Passing "database" as the value instructs walsender to connect
+   * to the database specified in the dbname parameter, which will allow the connection to be used
+   * for logical replication from that database.</p>
+   * <p>Parameter should be use together with {@link PGProperty#ASSUME_MIN_SERVER_VERSION} with
+   * parameter &gt;= 9.4 (backend &gt;= 9.4)</p>
+   */
+  REPLICATION(
+    "replication",
+    null,
+    "Connection parameter passed in startup message, one of 'true' or 'database' "
+      + "Passing 'true' tells the backend to go into walsender mode, "
+      + "wherein a small set of replication commands can be issued instead of SQL statements. "
+      + "Only the simple query protocol can be used in walsender mode. "
+      + "Passing 'database' as the value instructs walsender to connect "
+      + "to the database specified in the dbname parameter, "
+      + "which will allow the connection to be used for logical replication "
+      + "from that database. "
+      + "(backend >= 9.4)"),
+
+  /**
+   * Configure optimization to enable batch insert re-writing.
+   */
+  REWRITE_BATCHED_INSERTS(
+    "reWriteBatchedInserts",
+    "false",
+    "Enable optimization to rewrite and collapse compatible INSERT statements that are batched."),
+
+  /**
+   * Socket write buffer size (SO_SNDBUF). A value of {@code -1}, which is the default, means system
+   * default.
+   */
+  SEND_BUFFER_SIZE(
+    "sendBufferSize",
+    "-1",
+    "Socket write buffer size"),
+
+  /**
+   * Socket factory used to create socket. A null value, which is the default, means system default.
+   */
+  SOCKET_FACTORY(
+    "socketFactory",
+    null,
+    "Specify a socket factory for socket creation"),
+
+  /**
+   * The String argument to give to the constructor of the Socket Factory.
+   * @deprecated use {@code ..Factory(Properties)} constructor.
+   */
+  @Deprecated
+  SOCKET_FACTORY_ARG(
+    "socketFactoryArg",
+    null,
+    "Argument forwarded to constructor of SocketFactory class."),
+
+  /**
+   * The timeout value used for socket read operations. If reading from the server takes longer than
+   * this value, the connection is closed. This can be used as both a brute force global query
+   * timeout and a method of detecting network problems. The timeout is specified in seconds and a
+   * value of zero means that it is disabled.
+   */
+  SOCKET_TIMEOUT(
+    "socketTimeout",
+    "0",
+    "The timeout value used for socket read operations."),
 
   /**
    * Control use of SSL: empty or {@code true} values imply {@code sslmode==verify-full}
@@ -258,17 +518,13 @@ public enum PGProperty {
     "Control use of SSL (any non-null value causes SSL to be required)"),
 
   /**
-   * Parameter governing the use of SSL. The allowed values are {@code disable}, {@code allow},
-   * {@code prefer}, {@code require}, {@code verify-ca}, {@code verify-full}.
-   * If {@code ssl} property is empty or set to {@code true} it implies {@code verify-full}.
-   * Default mode is "require"
+   * File containing the SSL Certificate. Default will be the file {@code postgresql.crt} in {@code
+   * $HOME/.postgresql} (*nix) or {@code %APPDATA%\postgresql} (windows).
    */
-  SSL_MODE(
-    "sslmode",
+  SSL_CERT(
+    "sslcert",
     null,
-    "Parameter governing the use of SSL",
-    false,
-    new String[] {"disable", "allow", "prefer", "require", "verify-ca", "verify-full"}),
+    "The location of the client's SSL certificate"),
 
   /**
    * Classname of the SSL Factory to use (instance of {@code javax.net.ssl.SSLSocketFactory}).
@@ -298,15 +554,6 @@ public enum PGProperty {
     "A class, implementing javax.net.ssl.HostnameVerifier that can verify the server"),
 
   /**
-   * File containing the SSL Certificate. Default will be the file {@code postgresql.crt} in {@code
-   * $HOME/.postgresql} (*nix) or {@code %APPDATA%\postgresql} (windows).
-   */
-  SSL_CERT(
-    "sslcert",
-    null,
-    "The location of the client's SSL certificate"),
-
-  /**
    * File containing the SSL Key. Default will be the file {@code postgresql.pk8} in {@code
    * $HOME/.postgresql} (*nix) or {@code %APPDATA%\postgresql} (windows).
    */
@@ -316,14 +563,17 @@ public enum PGProperty {
     "The location of the client's PKCS#8 SSL key"),
 
   /**
-   * File containing the root certificate when validating server ({@code sslmode} = {@code
-   * verify-ca} or {@code verify-full}). Default will be the file {@code root.crt} in {@code
-   * $HOME/.postgresql} (*nix) or {@code %APPDATA%\postgresql} (windows).
+   * Parameter governing the use of SSL. The allowed values are {@code disable}, {@code allow},
+   * {@code prefer}, {@code require}, {@code verify-ca}, {@code verify-full}.
+   * If {@code ssl} property is empty or set to {@code true} it implies {@code verify-full}.
+   * Default mode is "require"
    */
-  SSL_ROOT_CERT(
-    "sslrootcert",
+  SSL_MODE(
+    "sslmode",
     null,
-    "The location of the root certificate for authenticating the server."),
+    "Parameter governing the use of SSL",
+    false,
+    new String[] {"disable", "allow", "prefer", "require", "verify-ca", "verify-full"}),
 
   /**
    * The SSL password to use in the default CallbackHandler.
@@ -342,156 +592,14 @@ public enum PGProperty {
     "A class, implementing javax.security.auth.callback.CallbackHandler that can handle PassworCallback for the ssl password."),
 
   /**
-   * Enable or disable TCP keep-alive. The default is {@code false}.
+   * File containing the root certificate when validating server ({@code sslmode} = {@code
+   * verify-ca} or {@code verify-full}). Default will be the file {@code root.crt} in {@code
+   * $HOME/.postgresql} (*nix) or {@code %APPDATA%\postgresql} (windows).
    */
-  TCP_KEEP_ALIVE(
-    "tcpKeepAlive",
-    "false",
-    "Enable or disable TCP keep-alive. The default is {@code false}."),
-
-  /**
-   * Specify how long to wait for establishment of a database connection. The timeout is specified
-   * in seconds.
-   */
-  LOGIN_TIMEOUT(
-    "loginTimeout",
-    "0",
-    "Specify how long to wait for establishment of a database connection."),
-
-  /**
-   * <p>The timeout value used for socket connect operations. If connecting to the server takes longer
-   * than this value, the connection is broken.</p>
-   *
-   * <p>The timeout is specified in seconds and a value of zero means that it is disabled.</p>
-   */
-  CONNECT_TIMEOUT(
-    "connectTimeout",
-    "10",
-    "The timeout value used for socket connect operations."),
-
-  /**
-   * The timeout value used for socket read operations. If reading from the server takes longer than
-   * this value, the connection is closed. This can be used as both a brute force global query
-   * timeout and a method of detecting network problems. The timeout is specified in seconds and a
-   * value of zero means that it is disabled.
-   */
-  SOCKET_TIMEOUT(
-    "socketTimeout",
-    "0",
-    "The timeout value used for socket read operations."),
-
-  /**
-   * Cancel command is sent out of band over its own connection, so cancel message can itself get
-   * stuck.
-   * This property controls "connect timeout" and "socket timeout" used for cancel commands.
-   * The timeout is specified in seconds. Default value is 10 seconds.
-   */
-  CANCEL_SIGNAL_TIMEOUT(
-    "cancelSignalTimeout",
-    "10",
-    "The timeout that is used for sending cancel command."),
-
-  /**
-   * Socket factory used to create socket. A null value, which is the default, means system default.
-   */
-  SOCKET_FACTORY(
-    "socketFactory",
+  SSL_ROOT_CERT(
+    "sslrootcert",
     null,
-    "Specify a socket factory for socket creation"),
-
-  /**
-   * The String argument to give to the constructor of the Socket Factory.
-   * @deprecated use {@code ..Factory(Properties)} constructor.
-   */
-  @Deprecated
-  SOCKET_FACTORY_ARG(
-    "socketFactoryArg",
-    null,
-    "Argument forwarded to constructor of SocketFactory class."),
-
-  /**
-   * Socket read buffer size (SO_RECVBUF). A value of {@code -1}, which is the default, means system
-   * default.
-   */
-  RECEIVE_BUFFER_SIZE(
-    "receiveBufferSize",
-    "-1",
-    "Socket read buffer size"),
-
-  /**
-   * Socket write buffer size (SO_SNDBUF). A value of {@code -1}, which is the default, means system
-   * default.
-   */
-  SEND_BUFFER_SIZE(
-    "sendBufferSize",
-    "-1",
-    "Socket write buffer size"),
-
-  /**
-   * Assume the server is at least that version.
-   */
-  ASSUME_MIN_SERVER_VERSION(
-    "assumeMinServerVersion",
-    null,
-    "Assume the server is at least that version"),
-
-  /**
-   * The application name (require server version &gt;= 9.0).
-   */
-  APPLICATION_NAME(
-    "ApplicationName",
-    DriverInfo.DRIVER_NAME,
-    "Name of the Application (backend >= 9.0)"),
-
-  /**
-   * Flag to enable/disable obtaining a GSS credential via JAAS login before authenticating.
-   * Useful if setting system property javax.security.auth.useSubjectCredsOnly=false
-   * or using native GSS with system property sun.security.jgss.native=true
-   */
-  JAAS_LOGIN(
-    "jaasLogin",
-    "true",
-    "Login with JAAS before doing GSSAPI authentication"),
-
-  /**
-   * Specifies the name of the JAAS system or application login configuration.
-   */
-  JAAS_APPLICATION_NAME(
-    "jaasApplicationName",
-    null,
-    "Specifies the name of the JAAS system or application login configuration."),
-
-  /**
-   * The Kerberos service name to use when authenticating with GSSAPI. This is equivalent to libpq's
-   * PGKRBSRVNAME environment variable.
-   */
-  KERBEROS_SERVER_NAME(
-    "kerberosServerName",
-    null,
-    "The Kerberos service name to use when authenticating with GSSAPI."),
-
-  /**
-   * Use SPNEGO in SSPI authentication requests.
-   */
-  USE_SPNEGO(
-    "useSpnego",
-    "false",
-    "Use SPNEGO in SSPI authentication requests"),
-
-  /**
-   * Force one of
-   * <ul>
-   * <li>SSPI (Windows transparent single-sign-on)</li>
-   * <li>GSSAPI (Kerberos, via JSSE)</li>
-   * </ul>
-   * to be used when the server requests Kerberos or SSPI authentication.
-   */
-  GSS_LIB(
-    "gsslib",
-    "auto",
-    "Force SSSPI or GSSAPI",
-    false,
-    new String[] {"auto", "sspi", "gssapi"}),
+    "The location of the root certificate for authenticating the server."),
 
   /**
    * Specifies the name of the SSPI service class that forms the service class part of the SPN. The
@@ -503,24 +611,15 @@ public enum PGProperty {
     "The Windows SSPI service class for SPN"),
 
   /**
-   * When using the V3 protocol the driver monitors changes in certain server configuration
-   * parameters that should not be touched by end users. The {@code client_encoding} setting is set
-   * by the driver and should not be altered. If the driver detects a change it will abort the
-   * connection.
+   * Bind String to either {@code unspecified} or {@code varchar}. Default is {@code varchar} for
+   * 8.0+ backends.
    */
-  ALLOW_ENCODING_CHANGES(
-    "allowEncodingChanges",
-    "false",
-    "Allow for changes in client_encoding"),
-
-  /**
-   * Specify the schema (or several schema separated by commas) to be set in the search-path. This schema will be used to resolve
-   * unqualified object names used in statements over this connection.
-   */
-  CURRENT_SCHEMA(
-    "currentSchema",
+  STRING_TYPE(
+    "stringtype",
     null,
-    "Specify the schema (or several schema separated by commas) to be set in the search-path"),
+    "The type to bind String parameters as (usually 'varchar', 'unspecified' allows implicit casting to other types)",
+    false,
+    new String[] {"unspecified", "varchar"}),
 
   TARGET_SERVER_TYPE(
     "targetServerType",
@@ -529,135 +628,40 @@ public enum PGProperty {
     false,
     new String[] {"any", "master", "slave", "secondary",  "preferSlave", "preferSecondary"}),
 
-  LOAD_BALANCE_HOSTS(
-    "loadBalanceHosts",
+  /**
+   * Enable or disable TCP keep-alive. The default is {@code false}.
+   */
+  TCP_KEEP_ALIVE(
+    "tcpKeepAlive",
     "false",
-    "If disabled hosts are connected in the given order. If enabled hosts are chosen randomly from the set of suitable candidates"),
-
-  HOST_RECHECK_SECONDS(
-    "hostRecheckSeconds",
-    "10",
-    "Specifies period (seconds) after which the host status is checked again in case it has changed"),
+    "Enable or disable TCP keep-alive. The default is {@code false}."),
 
   /**
-   * <p>Specifies which mode is used to execute queries to database: simple means ('Q' execute, no parse, no bind, text mode only),
-   * extended means always use bind/execute messages, extendedForPrepared means extended for prepared statements only,
-   * extendedCacheEverything means use extended protocol and try cache every statement (including Statement.execute(String sql)) in a query cache.</p>
-   *
-   * <p>This mode is meant for debugging purposes and/or for cases when extended protocol cannot be used (e.g. logical replication protocol)</p>
+   * Specifies the length to return for types of unknown length.
    */
-  PREFER_QUERY_MODE(
-    "preferQueryMode",
-    "extended",
-    "Specifies which mode is used to execute queries to database: simple means ('Q' execute, no parse, no bind, text mode only), "
-        + "extended means always use bind/execute messages, extendedForPrepared means extended for prepared statements only, "
-        + "extendedCacheEverything means use extended protocol and try cache every statement (including Statement.execute(String sql)) in a query cache.", false,
-    new String[] {"extended", "extendedForPrepared", "extendedCacheEverything", "simple"}),
+  UNKNOWN_LENGTH(
+    "unknownLength",
+    Integer.toString(Integer.MAX_VALUE),
+    "Specifies the length to return for types of unknown length"),
 
   /**
-   * Specifies what the driver should do if a query fails. In {@code autosave=always} mode, JDBC driver sets a savepoint before each query,
-   * and rolls back to that savepoint in case of failure. In {@code autosave=never} mode (default), no savepoint dance is made ever.
-   * In {@code autosave=conservative} mode, savepoint is set for each query, however the rollback is done only for rare cases
-   * like 'cached statement cannot change return type' or 'statement XXX is not valid' so JDBC driver rollsback and retries
+   * Username to connect to the database as.
    */
-  AUTOSAVE(
-    "autosave",
-    "never",
-    "Specifies what the driver should do if a query fails. In autosave=always mode, JDBC driver sets a savepoint before each query, "
-        + "and rolls back to that savepoint in case of failure. In autosave=never mode (default), no savepoint dance is made ever. "
-        + "In autosave=conservative mode, safepoint is set for each query, however the rollback is done only for rare cases"
-        + " like 'cached statement cannot change return type' or 'statement XXX is not valid' so JDBC driver rollsback and retries", false,
-    new String[] {"always", "never", "conservative"}),
-
-  /**
-   *
-   */
-  CLEANUP_SAVEPOINTS(
-    "cleanupSavepoints",
-    "false",
-    "Determine whether SAVEPOINTS used in AUTOSAVE will be released per query or not",
-    false,
-    new String[] {"true", "false"}),
-  /**
-   * Configure optimization to enable batch insert re-writing.
-   */
-  REWRITE_BATCHED_INSERTS(
-    "reWriteBatchedInserts",
-    "false",
-    "Enable optimization to rewrite and collapse compatible INSERT statements that are batched."),
-
-  /**
-   * Enable mode to filter out the names of database objects for which the current user has no privileges
-   * granted from appearing in the DatabaseMetaData returned by the driver.
-   */
-  HIDE_UNPRIVILEGED_OBJECTS(
-    "hideUnprivilegedObjects",
-    "false",
-    "Enable hiding of database objects for which the current user has no privileges granted from the DatabaseMetaData"),
-
-  /**
-   * <p>Connection parameter passed in the startup message. This parameter accepts two values; "true"
-   * and "database". Passing "true" tells the backend to go into walsender mode, wherein a small set
-   * of replication commands can be issued instead of SQL statements. Only the simple query protocol
-   * can be used in walsender mode. Passing "database" as the value instructs walsender to connect
-   * to the database specified in the dbname parameter, which will allow the connection to be used
-   * for logical replication from that database.</p>
-   * <p>Parameter should be use together with {@link PGProperty#ASSUME_MIN_SERVER_VERSION} with
-   * parameter &gt;= 9.4 (backend &gt;= 9.4)</p>
-   */
-  REPLICATION(
-    "replication",
+  USER(
+    "user",
     null,
-    "Connection parameter passed in startup message, one of 'true' or 'database' "
-      + "Passing 'true' tells the backend to go into walsender mode, "
-      + "wherein a small set of replication commands can be issued instead of SQL statements. "
-      + "Only the simple query protocol can be used in walsender mode. "
-      + "Passing 'database' as the value instructs walsender to connect "
-      + "to the database specified in the dbname parameter, "
-      + "which will allow the connection to be used for logical replication "
-      + "from that database. "
-      + "(backend >= 9.4)"),
+    "Username to connect to the database as.",
+    true),
+
+  /**
+   * Use SPNEGO in SSPI authentication requests.
+   */
+  USE_SPNEGO(
+    "useSpnego",
+    "false",
+    "Use SPNEGO in SSPI authentication requests"),
+
   ;
-
-  /**
-   * Specifies how the driver transforms JDBC escape call syntax into underlying SQL, for invoking procedures or functions. (backend &gt;= 11)
-   * In {@code escapeSyntaxCallMode=select} mode (the default), the driver always uses a SELECT statement (allowing function invocation only).
-   * In {@code escapeSyntaxCallMode=callIfNoReturn} mode, the driver uses a CALL statement (allowing procedure invocation) if there is no return parameter specified, otherwise the driver uses a SELECT statement.
-   * In {@code escapeSyntaxCallMode=call} mode, the driver always uses a CALL statement (allowing procedure invocation only).
-   */
-  ESCAPE_SYNTAX_CALL_MODE(
-    "escapeSyntaxCallMode",
-    "select",
-    "Specifies how the driver transforms JDBC escape call syntax into underlying SQL, for invoking procedures or functions. (backend >= 11)"
-      + "In escapeSyntaxCallMode=select mode (the default), the driver always uses a SELECT statement (allowing function invocation only)."
-      + "In escapeSyntaxCallMode=callIfNoReturn mode, the driver uses a CALL statement (allowing procedure invocation) if there is no return parameter specified, otherwise the driver uses a SELECT statement."
-      + "In escapeSyntaxCallMode=call mode, the driver always uses a CALL statement (allowing procedure invocation only).",
-    false,
-    new String[] {"select", "callIfNoReturn", "call"}),
-
-  /**
-   * Connection parameter to control behavior when
-   * {@link Connection#setReadOnly(boolean)} is set to {@code true}.
-   */
-  READ_ONLY_MODE(
-    "readOnlyMode",
-    "transaction",
-    "Controls the behavior when a connection is set to be read only, one of 'ignore', 'transaction', or 'always' "
-      + "When 'ignore', setting readOnly has no effect. "
-      + "When 'transaction' setting readOnly to 'true' will cause transactions to BEGIN READ ONLY if autocommit is 'false'. "
-      + "When 'always' setting readOnly to 'true' will set the session to READ ONLY if autoCommit is 'true' "
-      + "and the transaction to BEGIN READ ONLY if autocommit is 'false'.",
-    false,
-    new String[] {"ignore", "transaction", "always"}),
-
-  /**
-   * Specifies size of buffer during fetching result set. Can be specified as specified size or
-   * percent of heap memory.
-   */
-  MAX_RESULT_BUFFER(
-    "maxResultBuffer",
-    null,
-    "Specifies size of buffer during fetching result set. Can be specified as specified size or percent of heap memory.");
 
   private final String name;
   private final String defaultValue;

--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -710,6 +710,15 @@ public enum PGProperty {
   }
 
   /**
+   * Returns the description for this connection parameter.
+   *
+   * @return the description for this connection parameter
+   */
+  public String getDescription() {
+    return description;
+  }
+
+  /**
    * Returns the available values for this connection parameter.
    *
    * @return the available values for this connection parameter or null


### PR DESCRIPTION
Alternative to #1504 (I'll close that one out in a min in favor of this). This PR is rebased atop the latest additions for new properties and docs. It passes checkstyle and tests. Should not have any end user change as the only thing modified is the declaration order of the PGProperty enums and I can't imagine the previous sort order being used for anything (it was effectively random anyway).

Summary of PGProperty changes:

* misc: Remove variadic constructor for PGProperty values and split across multiple lines - Longer term we're going to need to add some more structured information to the PGProperty enum so this commit gets rid of the convenience variadic constructor as it'd just be confusing down the road.
* perf: Cache PGProperty values in a map by name - I noticed one of the methods does a loop through all the values to find one matching by name. This commit builds a static cache on class load so the lookups are always O(1). It also does a sanity check that no two entries have the same name.
* misc: Add PGProperty.getDescription() - Eventually required for automated docs.
* misc: Add PGProperty.isRequired() - Eventually required for automated docs.
* misc: Add PGProperty.isDeprecated() - Eventually required for automated docs. This is done via reflection of the @Deprecated annotation so should work for any future deprecations as well.
* misc: Sort PGProperty enum values - This should eliminate most future merge conflicts as long as they continue to maintain the sort order for new values.

Stepping through the docs I noticed the following properties were either not documented or incorrectly referenced:

* docs: Correct receiveBufferSize and remove duplicate sendBufferSize
* docs: Add missing binaryTransfer property to head docs
* docs: Add missing databaseMetadataCacheFields and databaseMetadataCacheFieldsMiB to head docs

This PR does **not** go through the connection property docs themselves to sort things. There's too many changes that I don't think it's worth the effort. Better to go straight to creating automated docs based on the info that we now have in the enum. I'm going to open a separate issue to track automating the doc generation.