### PR TITLE
Metadata queries improvment

### DIFF
--- a/pgjdbc/pom.xml
+++ b/pgjdbc/pom.xml
@@ -34,6 +34,7 @@
     <jdbc.specification.version.nodot>42</jdbc.specification.version.nodot>
     <skip.assembly>false</skip.assembly>
     <checkstyle.version>8.29</checkstyle.version>
+	  <parsedVersion.osgiVersion>${project.version}</parsedVersion.osgiVersion>
   </properties>
 
   <dependencies>

--- a/pgjdbc/pom.xml
+++ b/pgjdbc/pom.xml
@@ -34,7 +34,6 @@
     <jdbc.specification.version.nodot>42</jdbc.specification.version.nodot>
     <skip.assembly>false</skip.assembly>
     <checkstyle.version>8.29</checkstyle.version>
-	  <parsedVersion.osgiVersion>${project.version}</parsedVersion.osgiVersion>
   </properties>
 
   <dependencies>

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
@@ -2424,6 +2424,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
       }
 
       sql = "SELECT "
+                + "    tmp.TABLE_CAT, "
                 + "    tmp.TABLE_SCHEM, "
                 + "    tmp.TABLE_NAME, "
                 + "    tmp.NON_UNIQUE, "

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseMetaDataTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseMetaDataTest.java
@@ -658,30 +658,30 @@ public class DatabaseMetaDataTest {
     rs.close();
   }
 
-	/**
-	 * Order defined at https://docs.oracle.com/javase/8/docs/api/java/sql/DatabaseMetaData.html#getIndexInfo-java.lang.String-java.lang.String-java.lang.String-boolean-boolean-
-	 * @throws SQLException
-	 */
-	@Test
+  /**
+   * Order defined at
+   * https://docs.oracle.com/javase/8/docs/api/java/sql/DatabaseMetaData.html#getIndexInfo-java.lang.String-java.lang.String-java.lang.String-boolean-boolean-
+   */
+  @Test
   public void testIndexInfoColumnOrder() throws SQLException {
-	  DatabaseMetaData dbmd = con.getMetaData();
-	  assertNotNull(dbmd);
-	  ResultSet rs = dbmd.getIndexInfo(null, null, "metadatatest", false, false);
-	  assertEquals(rs.findColumn("TABLE_CAT"), 1);
-	  assertEquals(rs.findColumn("TABLE_SCHEM"), 2);
-	  assertEquals(rs.findColumn("TABLE_NAME"), 3);
-	  assertEquals(rs.findColumn("NON_UNIQUE"), 4);
-	  assertEquals(rs.findColumn("INDEX_QUALIFIER"), 5);
-	  assertEquals(rs.findColumn("INDEX_NAME"), 6);
-	  assertEquals(rs.findColumn("TYPE"), 7);
-	  assertEquals(rs.findColumn("ORDINAL_POSITION"), 8);
-	  assertEquals(rs.findColumn("COLUMN_NAME"), 9);
-	  assertEquals(rs.findColumn("ASC_OR_DESC"), 10);
-	  assertEquals(rs.findColumn("CARDINALITY"), 11);
-	  assertEquals(rs.findColumn("PAGES"), 12);
-	  assertEquals(rs.findColumn("FILTER_CONDITION"), 13);
+    DatabaseMetaData dbmd = con.getMetaData();
+    assertNotNull(dbmd);
+    ResultSet rs = dbmd.getIndexInfo(null, null, "metadatatest", false, false);
+    assertEquals(rs.findColumn("TABLE_CAT"), 1);
+    assertEquals(rs.findColumn("TABLE_SCHEM"), 2);
+    assertEquals(rs.findColumn("TABLE_NAME"), 3);
+    assertEquals(rs.findColumn("NON_UNIQUE"), 4);
+    assertEquals(rs.findColumn("INDEX_QUALIFIER"), 5);
+    assertEquals(rs.findColumn("INDEX_NAME"), 6);
+    assertEquals(rs.findColumn("TYPE"), 7);
+    assertEquals(rs.findColumn("ORDINAL_POSITION"), 8);
+    assertEquals(rs.findColumn("COLUMN_NAME"), 9);
+    assertEquals(rs.findColumn("ASC_OR_DESC"), 10);
+    assertEquals(rs.findColumn("CARDINALITY"), 11);
+    assertEquals(rs.findColumn("PAGES"), 12);
+    assertEquals(rs.findColumn("FILTER_CONDITION"), 13);
 
-	  rs.close();
+    rs.close();
   }
 
   @Test

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseMetaDataTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseMetaDataTest.java
@@ -658,6 +658,32 @@ public class DatabaseMetaDataTest {
     rs.close();
   }
 
+	/**
+	 * Order defined at https://docs.oracle.com/javase/8/docs/api/java/sql/DatabaseMetaData.html#getIndexInfo-java.lang.String-java.lang.String-java.lang.String-boolean-boolean-
+	 * @throws SQLException
+	 */
+	@Test
+  public void testIndexInfoColumnOrder() throws SQLException {
+	  DatabaseMetaData dbmd = con.getMetaData();
+	  assertNotNull(dbmd);
+	  ResultSet rs = dbmd.getIndexInfo(null, null, "metadatatest", false, false);
+	  assertEquals(rs.findColumn("TABLE_CAT"), 1);
+	  assertEquals(rs.findColumn("TABLE_SCHEM"), 2);
+	  assertEquals(rs.findColumn("TABLE_NAME"), 3);
+	  assertEquals(rs.findColumn("NON_UNIQUE"), 4);
+	  assertEquals(rs.findColumn("INDEX_QUALIFIER"), 5);
+	  assertEquals(rs.findColumn("INDEX_NAME"), 6);
+	  assertEquals(rs.findColumn("TYPE"), 7);
+	  assertEquals(rs.findColumn("ORDINAL_POSITION"), 8);
+	  assertEquals(rs.findColumn("COLUMN_NAME"), 9);
+	  assertEquals(rs.findColumn("ASC_OR_DESC"), 10);
+	  assertEquals(rs.findColumn("CARDINALITY"), 11);
+	  assertEquals(rs.findColumn("PAGES"), 12);
+	  assertEquals(rs.findColumn("FILTER_CONDITION"), 13);
+
+	  rs.close();
+  }
+
   @Test
   public void testNotNullDomainColumn() throws SQLException {
     DatabaseMetaData dbmd = con.getMetaData();


### PR DESCRIPTION
When dealing with large PostrgeSQL databases of thousands of schemas, tens of thousands of tables and millions of indexes particular PgDatabaseMetaData methods have suboptimal implementation.
The pattern that was utilized in implementation used inner query on pg_catalog.pg_index in order to retrieve keys (information_schema._pg_expandarray(i.indkey) AS keys). Such implementation forced full table scan on pg_catalog.pg_index prior to filtering result set on schema and table name.
The optimization idea was to get rid of inner querry in order to let querry planner to avoid full table scan and filter out pg_catalog.pg_index rows prior to executing (information_schema._pg_expandarray(i.indkey) AS keys).

This optimization was tested on database AWS RDS db.t3.large having:
~2000000 rows in pg_catalog.pg_index
~3000000 rows in pg_catalog.pg_class
~8000 rows in pg_catalog.pg_namespace
~14000000 rows in pg_catalog.pg_attribute

One of optimized methods was PgDatabaseMetaData.getIndexInfo which call time on given database dropped from ~13s to ~600ms.

Missing column added.
### All Submissions:

* [ ] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Does mvn checkstyle:check pass ?
3. [ ] Have you added your new test classes to an existing test suite in alphabetical order?

### Changes to Existing Features:

* [ ] Does this break existing behaviour? If so please explain.
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
