### PR TITLE
docs: document SocketFactory(Properties)

### DIFF
--- a/docs/documentation/head/connect.md
+++ b/docs/documentation/head/connect.md
@@ -461,8 +461,9 @@ Connection conn = DriverManager.getConnection(url);
 	The provided value is a class name to use as the `SocketFactory` when establishing a socket connection. 
 	This may be used to create unix sockets instead of normal sockets. The class name specified by `socketFactory` 
 	must extend `javax.net.SocketFactory` and be available to the driver's classloader.
-	This class must have a zero argument constructor or a single argument constructor taking a String argument. 
-	This argument may optionally be supplied by `socketFactoryArg`.
+	This class must have a zero-argument constructor, a single-argument constructor taking a String argument, or
+	a single-argument constructor taking a Properties argument. The Properties object will contain all the
+	connection parameters. The String argument will have the value of the `socketFactoryArg` connection parameter.
 
 * **socketFactoryArg** (deprecated) = String
 


### PR DESCRIPTION
Document that in addition to the no-args and the deprecated String arg
constructors, a SocketFactory can, like the SSLSocketFactory
constructor, accept a Properties object, as the there otherwise is no
documented, non-deprecated way of customizing the factory.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->