### PR TITLE
feat: Expose `ByteStreamWriter` in CopyManager

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/copy/CopyIn.java
+++ b/pgjdbc/src/main/java/org/postgresql/copy/CopyIn.java
@@ -5,6 +5,8 @@
 
 package org.postgresql.copy;
 
+import org.postgresql.util.ByteStreamWriter;
+
 import java.sql.SQLException;
 
 /**
@@ -21,6 +23,14 @@ public interface CopyIn extends CopyOperation {
    * @throws SQLException if the operation fails
    */
   void writeToCopy(byte[] buf, int off, int siz) throws SQLException;
+
+  /**
+   * Writes a ByteStreamWriter to an open and writable copy operation.
+   *
+   * @param from the source of bytes, e.g. a ByteBufferByteStreamWriter
+   * @throws SQLException if the operation fails
+   */
+  void writeToCopy(ByteStreamWriter from) throws SQLException;
 
   /**
    * Force any buffered output to be sent over the network to the backend. In general this is a

--- a/pgjdbc/src/main/java/org/postgresql/copy/CopyManager.java
+++ b/pgjdbc/src/main/java/org/postgresql/copy/CopyManager.java
@@ -8,6 +8,7 @@ package org.postgresql.copy;
 import org.postgresql.core.BaseConnection;
 import org.postgresql.core.Encoding;
 import org.postgresql.core.QueryExecutor;
+import org.postgresql.util.ByteStreamWriter;
 import org.postgresql.util.GT;
 import org.postgresql.util.PSQLException;
 import org.postgresql.util.PSQLState;
@@ -220,6 +221,28 @@ public class CopyManager {
           cp.writeToCopy(buf, 0, len);
         }
       }
+      return cp.endCopy();
+    } finally { // see to it that we do not leave the connection locked
+      if (cp.isActive()) {
+        cp.cancelCopy();
+      }
+    }
+  }
+
+  /**
+   * Use COPY FROM STDIN for very fast copying from an ByteStreamWriter into a database table.
+   *
+   * @param sql  COPY FROM STDIN statement
+   * @param from the source of bytes, e.g. a ByteBufferByteStreamWriter
+   * @return number of rows updated for server 8.2 or newer; -1 for older
+   * @throws SQLException on database usage issues
+   * @throws IOException  upon input stream or database connection failure
+   */
+  public long copyIn(String sql, ByteStreamWriter from)
+      throws SQLException, IOException {
+    CopyIn cp = copyIn(sql);
+    try {
+      cp.writeToCopy(from);
       return cp.endCopy();
     } finally { // see to it that we do not leave the connection locked
       if (cp.isActive()) {

--- a/pgjdbc/src/main/java/org/postgresql/copy/PGCopyOutputStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/copy/PGCopyOutputStream.java
@@ -6,6 +6,7 @@
 package org.postgresql.copy;
 
 import org.postgresql.PGConnection;
+import org.postgresql.util.ByteStreamWriter;
 import org.postgresql.util.GT;
 
 import java.io.IOException;
@@ -138,6 +139,10 @@ public class PGCopyOutputStream extends OutputStream implements CopyIn {
       System.arraycopy(buf, off, copyBuffer, at, siz);
       at += siz;
     }
+  }
+
+  public void writeToCopy(ByteStreamWriter from) throws SQLException {
+    op.writeToCopy(from);
   }
 
   public int getFormat() {

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/CopyDualImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/CopyDualImpl.java
@@ -6,6 +6,7 @@
 package org.postgresql.core.v3;
 
 import org.postgresql.copy.CopyDual;
+import org.postgresql.util.ByteStreamWriter;
 import org.postgresql.util.PSQLException;
 
 import java.sql.SQLException;
@@ -17,6 +18,10 @@ public class CopyDualImpl extends CopyOperationImpl implements CopyDual {
 
   public void writeToCopy(byte[] data, int off, int siz) throws SQLException {
     queryExecutor.writeToCopy(this, data, off, siz);
+  }
+
+  public void writeToCopy(ByteStreamWriter from) throws SQLException {
+    queryExecutor.writeToCopy(this, from);
   }
 
   public void flushCopy() throws SQLException {

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/CopyInImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/CopyInImpl.java
@@ -6,6 +6,7 @@
 package org.postgresql.core.v3;
 
 import org.postgresql.copy.CopyIn;
+import org.postgresql.util.ByteStreamWriter;
 import org.postgresql.util.GT;
 import org.postgresql.util.PSQLException;
 import org.postgresql.util.PSQLState;
@@ -35,6 +36,10 @@ public class CopyInImpl extends CopyOperationImpl implements CopyIn {
 
   public void writeToCopy(byte[] data, int off, int siz) throws SQLException {
     queryExecutor.writeToCopy(this, data, off, siz);
+  }
+
+  public void writeToCopy(ByteStreamWriter from) throws SQLException {
+    queryExecutor.writeToCopy(this, from);
   }
 
   public void flushCopy() throws SQLException {

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/CopyTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/CopyTest.java
@@ -18,6 +18,7 @@ import org.postgresql.copy.CopyOut;
 import org.postgresql.copy.PGCopyOutputStream;
 import org.postgresql.core.ServerVersion;
 import org.postgresql.test.TestUtil;
+import org.postgresql.util.ByteBufferByteStreamWriter;
 import org.postgresql.util.PSQLState;
 
 import org.junit.After;
@@ -31,6 +32,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.io.StringReader;
+import java.nio.ByteBuffer;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -206,6 +208,14 @@ public class CopyTest {
   public void testCopyInFromReader() throws SQLException, IOException {
     String sql = "COPY copytest FROM STDIN";
     copyAPI.copyIn(sql, new StringReader(new String(getData(origData))), 3);
+    int rowCount = getCount();
+    assertEquals(dataRows, rowCount);
+  }
+
+  @Test
+  public void testCopyInFromByteStreamWriter() throws SQLException, IOException {
+    String sql = "COPY copytest FROM STDIN";
+    copyAPI.copyIn(sql, new ByteBufferByteStreamWriter(ByteBuffer.wrap(getData(origData))));
     int rowCount = getCount();
     assertEquals(dataRows, rowCount);
   }


### PR DESCRIPTION
Continuing https://github.com/pgjdbc/pgjdbc/pull/953, let's expose the garbageless writer to the COPY protocol as well.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [x] Does mvn checkstyle:check pass?
3. [x] Have you added your new test classes to an existing test suite in alphabetical order?

### Changes to Existing Features:

* [ ] Does this break existing behaviour? If so please explain.
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
