### PR TITLE
fix: Always use . as decimal separator in PGInterval.

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/util/PGInterval.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/PGInterval.java
@@ -8,6 +8,7 @@ package org.postgresql.util;
 import java.io.Serializable;
 import java.sql.SQLException;
 import java.text.DecimalFormat;
+import java.text.NumberFormat;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
@@ -243,6 +244,9 @@ public class PGInterval extends PGobject implements Serializable, Cloneable {
    * @return String represented interval
    */
   public String getValue() {
+    DecimalFormat df = (DecimalFormat) NumberFormat.getInstance(Locale.US);
+    df.applyPattern("0.0#####");
+
     return String.format(
       Locale.ROOT,
       "%d years %d mons %d days %d hours %d mins %s secs",
@@ -251,7 +255,7 @@ public class PGInterval extends PGobject implements Serializable, Cloneable {
       days,
       hours,
       minutes,
-      new DecimalFormat("0.0#####").format(getSeconds())
+      df.format(getSeconds())
     );
   }
 

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/IntervalTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/IntervalTest.java
@@ -25,6 +25,7 @@ import java.sql.Statement;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
+import java.util.Locale;
 
 public class IntervalTest {
   private Connection conn;
@@ -334,6 +335,20 @@ public class IntervalTest {
     PGInterval copy = new PGInterval(orig.getValue());
 
     assertEquals(orig, copy);
+  }
+
+  @Test
+  public void testGetValueForSmallValueWithCommaAsDecimalSeparatorInDefaultLocale() throws SQLException {
+    Locale originalLocale = Locale.getDefault();
+    Locale.setDefault(Locale.GERMANY);
+    try {
+      PGInterval orig = new PGInterval("0.0001 seconds");
+      PGInterval copy = new PGInterval(orig.getValue());
+
+      assertEquals(orig, copy);
+    } finally {
+      Locale.setDefault(originalLocale);
+    }
   }
 
   @Test


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
