### PR TITLE
feat: add way to distinguish base and partitioned tables in PgDatabaseMetaData.getTables

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
@@ -1284,7 +1284,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
              + " END "
              + " WHEN false THEN CASE c.relkind "
              + " WHEN 'r' THEN 'TABLE' "
-             + " WHEN 'p' THEN 'TABLE' "
+             + " WHEN 'p' THEN 'PARTITIONED TABLE' "
              + " WHEN 'i' THEN 'INDEX' "
              + " WHEN 'S' THEN 'SEQUENCE' "
              + " WHEN 'v' THEN 'VIEW' "
@@ -1339,9 +1339,12 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
     tableTypeClauses = new HashMap<String, Map<String, String>>();
     Map<String, String> ht = new HashMap<String, String>();
     tableTypeClauses.put("TABLE", ht);
-    ht.put("SCHEMAS",
-        "c.relkind IN ('r','p') AND n.nspname !~ '^pg_' AND n.nspname <> 'information_schema'");
-    ht.put("NOSCHEMAS", "c.relkind IN ('r','p') AND c.relname !~ '^pg_'");
+    ht.put("SCHEMAS", "c.relkind = 'r' AND n.nspname !~ '^pg_' AND n.nspname <> 'information_schema'");
+    ht.put("NOSCHEMAS", "c.relkind = 'r' AND c.relname !~ '^pg_'");
+    ht = new HashMap<String, String>();
+    tableTypeClauses.put("PARTITIONED TABLE", ht);
+    ht.put("SCHEMAS", "c.relkind = 'p' AND n.nspname !~ '^pg_' AND n.nspname <> 'information_schema'");
+    ht.put("NOSCHEMAS", "c.relkind = 'p' AND c.relname !~ '^pg_'");
     ht = new HashMap<String, String>();
     tableTypeClauses.put("VIEW", ht);
     ht.put("SCHEMAS",

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseMetaDataTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseMetaDataTest.java
@@ -29,6 +29,7 @@ import java.sql.Statement;
 import java.sql.Types;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -758,11 +759,27 @@ public class DatabaseMetaDataTest {
 
   @Test
   public void testTableTypes() throws SQLException {
-    // At the moment just test that no exceptions are thrown KJ
+    final List<String> expectedTableTypes = new ArrayList<String>(Arrays.asList("FOREIGN TABLE", "INDEX",
+        "MATERIALIZED VIEW", "PARTITIONED TABLE", "SEQUENCE", "SYSTEM INDEX", "SYSTEM TABLE", "SYSTEM TOAST INDEX",
+        "SYSTEM TOAST TABLE", "SYSTEM VIEW", "TABLE", "TEMPORARY INDEX", "TEMPORARY SEQUENCE", "TEMPORARY TABLE",
+        "TEMPORARY VIEW", "TYPE", "VIEW"));
+    final List<String> foundTableTypes = new ArrayList<String>();
+
+    // Test that no exceptions are thrown
     DatabaseMetaData dbmd = con.getMetaData();
     assertNotNull(dbmd);
+
+    // Test that the table types returned are the same as those expected
     ResultSet rs = dbmd.getTableTypes();
+    while (rs.next()) {
+      String tableType = new String(rs.getBytes(1));
+      foundTableTypes.add(tableType);
+    }
     rs.close();
+    Collections.sort(expectedTableTypes);
+    Collections.sort(foundTableTypes);
+    Assert.assertEquals("The table types received from DatabaseMetaData should match the 17 expected types",
+        true, foundTableTypes.equals(expectedTableTypes));
   }
 
   @Test

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseMetaDataTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseMetaDataTest.java
@@ -1270,7 +1270,7 @@ public class DatabaseMetaDataTest {
         stmt.execute(
             "CREATE TABLE measurement (logdate date not null,peaktemp int,unitsales int ) PARTITION BY RANGE (logdate);");
         DatabaseMetaData dbmd = con.getMetaData();
-        ResultSet rs = dbmd.getTables("", "", "measurement", new String[]{"TABLE"});
+        ResultSet rs = dbmd.getTables("", "", "measurement", new String[]{"PARTITIONED TABLE"});
         assertTrue(rs.next());
         assertEquals("measurement", rs.getString("table_name"));
 


### PR DESCRIPTION
There is currently no way to distinguish between base tables and
partitioned tables in the response from `PgDatabadeMetaData.getTables`.
Fix this by adding `PARTITIONED TABLE` to the `tableTypeClauses` map and
thus the `TABLE_TYPE` field in the query in `getTables`. Also update a test
(`testPartitionedTables`) that was using `TABLE_TYPE` of `TABLE` to grab
partitioned tables.

This should close #1590. However, perhaps this could be considered a
breaking change for anyone using `getTables` and expecting partitioned
tables to show up for `.getTables(s, s1, s2, new String[]{"TABLE"})`?

### All Submissions:

* [✓] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [✓] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [✓] Does your submission pass tests?
2. [✓] Does mvn checkstyle:check pass ?

### Changes to Existing Features:

* [✓] Does this break existing behaviour? If so please explain.

As above: 
> perhaps this could be considered a breaking change for anyone using `getTables` and expecting partitioned tables to show up for `.getTables(s, s1, s2, new String[]{"TABLE"})`?

* [✓] Have you added an explanation of what your changes do and why you'd like us to include them?
* [✓] Have you successfully run tests with your changes locally?
