### PR TITLE
fix: allow DatabaseMetaData.getColumns to describe an unset scale

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
@@ -1633,7 +1633,12 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
         }
       }
       tuple[6] = connection.encodeString(Integer.toString(columnSize));
-      tuple[8] = connection.encodeString(Integer.toString(decimalDigits));
+      // Give null for an unset scale on Decimal and Numeric columns
+      if (((sqlType == Types.NUMERIC) || (sqlType == Types.DECIMAL)) && (typeMod == -1)) {
+        tuple[8] = null;
+      } else {
+        tuple[8] = connection.encodeString(Integer.toString(decimalDigits));
+      }
 
       // Everything is base 10 unless we override later.
       tuple[9] = connection.encodeString("10");

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc42/DatabaseMetaDataTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc42/DatabaseMetaDataTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2007, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.test.jdbc42;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.postgresql.test.TestUtil;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+
+public class DatabaseMetaDataTest {
+
+  private Connection conn;
+
+  @Before
+  public void setUp() throws Exception {
+    conn = TestUtil.openDB();
+    TestUtil.createTable(conn, "decimaltest", "a decimal, b decimal(10, 5)");
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    TestUtil.dropTable(conn, "decimaltest");
+    TestUtil.closeDB(conn);
+  }
+
+  @Test
+  public void testGetColumnsForNullScale() throws Exception {
+    DatabaseMetaData dbmd = conn.getMetaData();
+
+    ResultSet rs = dbmd.getColumns("%", "%", "decimaltest", "%");
+    assertTrue(rs.next());
+    assertEquals("a", rs.getString("COLUMN_NAME"));
+    assertEquals(0, rs.getInt("DECIMAL_DIGITS"));
+    assertTrue(rs.wasNull());
+
+    assertTrue(rs.next());
+    assertEquals("b", rs.getString("COLUMN_NAME"));
+    assertEquals(5, rs.getInt("DECIMAL_DIGITS"));
+    assertFalse(rs.wasNull());
+
+    assertTrue(!rs.next());
+  }
+}


### PR DESCRIPTION
fix: allow DatabaseMetaData.getColumns to describe an unset scale

getColumns returns a 0 for the scale of a Decimal or Numeric column when the
scale is 0, and when the scale is null. The caller can then not differentiate
between a 0 or a null without another query.

This change replaces the 0 in the ResultSet for scale with a null when describing
an unscaled Decimal or Numeric column. getInt will still convert the null to a 0,
but the caller can then use wasNull() to find out if the underlying value was 0
or null.

This addresses #1712.  It is a breaking change, but if the correct getter
(getInt) is used for the column, there is no difference. Other getters may behave
differently.

Signed-off-by: crwr45 <charlie.wheelerrobinson@gmail.com>

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Does mvn checkstyle:check pass ?
3. [x] Have you added your new test classes to an existing test suite in alphabetical order?

### Changes to Existing Features:

* [x] Does this break existing behaviour? If so please explain.
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
