### PR TITLE
fix: getProcedures returns only procedures (not functions) for psql11+

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
@@ -1037,6 +1037,10 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
           + " LEFT JOIN pg_catalog.pg_class c ON (d.classoid=c.oid AND c.relname='pg_proc') "
           + " LEFT JOIN pg_catalog.pg_namespace pn ON (c.relnamespace=pn.oid AND pn.nspname='pg_catalog') "
           + " WHERE p.pronamespace=n.oid ";
+
+    if (connection.haveMinimumServerVersion(ServerVersion.v11)) {
+      sql += " AND p.prokind='p'";
+    }
     if (schemaPattern != null && !schemaPattern.isEmpty()) {
       sql += " AND n.nspname LIKE " + escapeQuotes(schemaPattern);
     } else {

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc4/DatabaseMetaDataHideUnprivilegedObjectsTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc4/DatabaseMetaDataHideUnprivilegedObjectsTest.java
@@ -459,42 +459,45 @@ public class DatabaseMetaDataHideUnprivilegedObjectsTest {
 
   @Test
   public void testGetProcedures() throws SQLException {
+    String executeGranted = TestUtil.haveMinimumServerVersion(hidingCon, ServerVersion.v11) ? "execute_granted_insert_procedure" : "execute_granted_add_function";
+    String noGrants = TestUtil.haveMinimumServerVersion(hidingCon, ServerVersion.v11) ? "no_grants_insert_procedure" : "no_grants_add_function";
+
     List<String> proceduresWithHiding =
         getProcedureNames(hidingDatabaseMetaData, "high_privileges_schema");
     assertThat(proceduresWithHiding,
-        hasItem("execute_granted_add_function"));
+        hasItem(executeGranted));
     assertThat(proceduresWithHiding,
-        not(hasItem("no_grants_add_function")));
+        not(hasItem(noGrants)));
 
     List<String> proceduresWithNoHiding =
         getProcedureNames(nonhidingDatabaseMetaData, "high_privileges_schema");
     assertThat(proceduresWithNoHiding,
-        hasItems("execute_granted_add_function", "no_grants_add_function"));
+        hasItems(executeGranted, noGrants));
 
     proceduresWithHiding =
         getProcedureNames(hidingDatabaseMetaData, "low_privileges_schema");
     assertThat(proceduresWithHiding,
-        hasItem("execute_granted_add_function"));
+        hasItem(executeGranted));
     assertThat(proceduresWithHiding,
-        not(hasItem("no_grants_add_function")));
+        not(hasItem(noGrants)));
 
     proceduresWithNoHiding =
         getProcedureNames(nonhidingDatabaseMetaData, "low_privileges_schema");
     assertThat(proceduresWithNoHiding,
-        hasItems("execute_granted_add_function", "no_grants_add_function"));
+        hasItems(executeGranted, noGrants));
 
     // Or should the the function names not be returned because the schema is not visible?
     proceduresWithHiding =
         getProcedureNames(hidingDatabaseMetaData, "no_privileges_schema");
     assertThat(proceduresWithHiding,
-        hasItem("execute_granted_add_function"));
+        hasItem(executeGranted));
     assertThat(proceduresWithHiding,
-        not(hasItem("no_grants_add_function")));
+        not(hasItem(noGrants)));
 
     proceduresWithNoHiding =
         getProcedureNames(nonhidingDatabaseMetaData, "no_privileges_schema");
     assertThat(proceduresWithNoHiding,
-        hasItems("execute_granted_add_function", "no_grants_add_function"));
+        hasItems(executeGranted, noGrants));
 
   }
 

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc4/DatabaseMetaDataTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc4/DatabaseMetaDataTest.java
@@ -171,28 +171,27 @@ public class DatabaseMetaDataTest {
 
   @Test
   public void testGetProceduresInSchemaForProcedures() throws SQLException {
-    DatabaseMetaData dbmd = conn.getMetaData();
-    Statement statement = conn.createStatement();
+    // Only run this test for PostgreSQL version 11+; assertions for versions prior would be vacuously true as we don't create a procedure in the setup for older versions
+    if (TestUtil.haveMinimumServerVersion(conn, ServerVersion.v11)) {
+      DatabaseMetaData dbmd = conn.getMetaData();
+      Statement statement = conn.createStatement();
 
-    // Search for procedures in schema "hasprocedures" (which should expect a record regardless of PostgreSQL version)
-    ResultSet rs = dbmd.getProcedures("", "hasprocedures",null);
-    assertTrue(rs.next());
+      ResultSet rs = dbmd.getProcedures("", "hasprocedures", null);
+      assertTrue(rs.next());
 
-    // Search for procedures in schema "noprocedures" (which should never expect records for any PostgreSQL version)
-    rs = dbmd.getProcedures("", "nofunctions",null);
-    assertFalse(rs.next());
+      rs = dbmd.getProcedures("", "nofunctions", null);
+      assertFalse(rs.next());
 
-    // Search for procedures by procedure name "addprocedure" within schema "hasprocedures" (which should expect a record regardless of PostgreSQL version)
-    statement.execute("set search_path=hasprocedures");
-    rs = dbmd.getProcedures("", "","addprocedure");
-    assertTrue(rs.next());
+      statement.execute("set search_path=hasprocedures");
+      rs = dbmd.getProcedures("", "", "addprocedure");
+      assertTrue(rs.next());
 
-    // Search for procedures by procedure name "addprocedure" within schema "noprocedures" (which should never expect records for any PostgreSQL version)
-    statement.execute("set search_path=noprocedures");
-    rs = dbmd.getProcedures("", "","addprocedure");
-    assertFalse(rs.next());
+      statement.execute("set search_path=noprocedures");
+      rs = dbmd.getProcedures("", "", "addprocedure");
+      assertFalse(rs.next());
 
-    statement.close();
+      statement.close();
+    }
   }
 
   @Test

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc4/DatabaseMetaDataTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc4/DatabaseMetaDataTest.java
@@ -44,8 +44,10 @@ public class DatabaseMetaDataTest {
     TestUtil.createSchema(conn, "noprocedures");
     TestUtil.execute("create function hasfunctions.addfunction (integer, integer) "
         + "RETURNS integer AS 'select $1 + $2;' LANGUAGE SQL IMMUTABLE", conn);
-    TestUtil.execute("create procedure hasprocedures.addprocedure() "
-        + "LANGUAGE plpgsql AS $$ BEGIN SELECT 1; END; $$", conn);
+    if (TestUtil.haveMinimumServerVersion(conn, ServerVersion.v11)) {
+      TestUtil.execute("create procedure hasprocedures.addprocedure() "
+          + "LANGUAGE plpgsql AS $$ BEGIN SELECT 1; END; $$", conn);
+    }
   }
 
   @After


### PR DESCRIPTION
Currently the `PGDatabaseMetaData.getProcedures()` method returns both
procedures and functions. This made sense prior to PostgreSQL11, but now
actual procedures can be created instead of just functions, and pgjdbc
has an added `getFunctions()` method to distinguish between the two. For
only PostgreSQL version 11 and onward, this will make `getFunctions()`
return only functions and `getProcedures()` return only procedures.

I believe this closes #1340 and closes #1629, which both seem to essentially be
the same thing?

### All Submissions:

* [✓] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [✓] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes to Existing Features:

* [?] Does this break existing behaviour? If so please explain.

I am unsure if this should be considered breaking. Since PostgreSQL 11 has been out since 2018, I assume there is _some_ code out there relying on the assumption that `getProcedures()` returns both functions _and_ procedures rather than _just_ procedures. ¯\\_(ツ)_/¯

* [✓] Have you added an explanation of what your changes do and why you'd like us to include them?
* [✓] Have you written new tests for your core changes, as applicable?
* [✓] Have you successfully run tests with your changes locally?
