### PR TITLE
fix: convert silent rollbacks into exception if application sends commit command

### DIFF
--- a/docs/documentation/head/connect.md
+++ b/docs/documentation/head/connect.md
@@ -220,6 +220,15 @@ Connection conn = DriverManager.getConnection(url);
      
     The default is 'false'
 
+* **raiseExceptionOnSilentRollback** = boolean
+
+    since 42.2.11
+
+    Certain database versions perform a silent rollback instead of commit in case the transaction was in a failed state.
+    See https://www.postgresql.org/message-id/b9fb50dc-0f6e-15fb-6555-8ddb86f4aa71%40postgresfriends.org
+
+    The default is 'true'
+
 * **binaryTransfer** = boolean
 
 	Use binary format for sending and receiving data if possible.

--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -662,6 +662,14 @@ public enum PGProperty {
     "false",
     "Use SPNEGO in SSPI authentication requests"),
 
+  /**
+   * Certain database versions perform a silent rollback instead of commit in case the transaction was in a failed state.
+   */
+  RAISE_EXCEPTION_ON_SILENT_ROLLBACK(
+    "raiseExceptionOnSilentRollback",
+    "true",
+    "Certain database versions perform a silent rollback instead of commit in case the transaction was in a failed state"),
+
   ;
 
   private final String name;

--- a/pgjdbc/src/main/java/org/postgresql/core/QueryExecutor.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/QueryExecutor.java
@@ -444,6 +444,10 @@ public interface QueryExecutor extends TypeTransferModeRegistry {
 
   boolean willHealOnRetry(SQLException e);
 
+  boolean isRaiseExceptionOnSilentRollback();
+
+  void setRaiseExceptionOnSilentRollback(boolean raiseExceptionOnSilentRollback);
+
   /**
    * By default, the connection resets statement cache in case deallocate all/discard all
    * message is observed.

--- a/pgjdbc/src/main/java/org/postgresql/core/QueryExecutorBase.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/QueryExecutorBase.java
@@ -48,6 +48,7 @@ public abstract class QueryExecutorBase implements QueryExecutor {
   private AutoSave autoSave;
   private boolean flushCacheOnDeallocate = true;
   protected final boolean logServerErrorDetail;
+  private boolean raiseExceptionOnSilentRollback;
 
   // default value for server versions that don't report standard_conforming_strings
   private boolean standardConformingStrings = false;
@@ -406,6 +407,16 @@ public abstract class QueryExecutorBase implements QueryExecutor {
 
   public void setFlushCacheOnDeallocate(boolean flushCacheOnDeallocate) {
     this.flushCacheOnDeallocate = flushCacheOnDeallocate;
+  }
+
+  @Override
+  public boolean isRaiseExceptionOnSilentRollback() {
+    return raiseExceptionOnSilentRollback;
+  }
+
+  @Override
+  public void setRaiseExceptionOnSilentRollback(boolean raiseExceptionOnSilentRollback) {
+    this.raiseExceptionOnSilentRollback = raiseExceptionOnSilentRollback;
   }
 
   protected boolean hasNotifications() {

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -67,6 +67,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.regex.Pattern;
 
 /**
  * QueryExecutor implementation for the V3 protocol.
@@ -75,6 +76,23 @@ public class QueryExecutorImpl extends QueryExecutorBase {
 
   private static final Logger LOGGER = Logger.getLogger(QueryExecutorImpl.class.getName());
   private static final String COPY_ERROR_MESSAGE = "COPY commands are only supported using the CopyManager API.";
+  private static final Pattern ROLLBACK_PATTERN = Pattern.compile("\\brollback\\b", Pattern.CASE_INSENSITIVE);
+  private static final Pattern COMMIT_PATTERN = Pattern.compile("\\bcommit\\b", Pattern.CASE_INSENSITIVE);
+  private static final Pattern PREPARE_PATTERN = Pattern.compile("\\bprepare ++transaction\\b", Pattern.CASE_INSENSITIVE);
+
+  private static boolean looksLikeCommit(String sql) {
+    if ("COMMIT".equalsIgnoreCase(sql)) {
+      return true;
+    }
+    if ("ROLLBACK".equalsIgnoreCase(sql)) {
+      return false;
+    }
+    return COMMIT_PATTERN.matcher(sql).find() && !ROLLBACK_PATTERN.matcher(sql).find();
+  }
+
+  private static boolean looksLikePrepare(String sql) {
+    return sql.startsWith("PREPARE TRANSACTION") || PREPARE_PATTERN.matcher(sql).find();
+  }
 
   /**
    * TimeZone of the current connection (TimeZone backend parameter).
@@ -355,7 +373,6 @@ public class QueryExecutorImpl extends QueryExecutorBase {
     if (((flags & QueryExecutor.QUERY_SUPPRESS_BEGIN) == 0
         || getTransactionState() == TransactionState.OPEN)
         && query != restoreToAutoSave
-        && !query.getNativeSql().equalsIgnoreCase("COMMIT")
         && getAutoSave() != AutoSave.NEVER
         // If query has no resulting fields, it cannot fail with 'cached plan must not change result type'
         // thus no need to set a savepoint before such query
@@ -2166,8 +2183,36 @@ public class QueryExecutorImpl extends QueryExecutorBase {
           SimpleQuery currentQuery = executeData.query;
           Portal currentPortal = executeData.portal;
 
+          String nativeSql = currentQuery.getNativeQuery().nativeSql;
+          // Certain backend versions (e.g. 12.2, 11.7, 10.12, 9.6.17, 9.5.21, etc)
+          // silently rollback the transaction in the response to COMMIT statement
+          // in case the transaction has failed.
+          // See discussion in pgsql-hackers: https://www.postgresql.org/message-id/b9fb50dc-0f6e-15fb-6555-8ddb86f4aa71%40postgresfriends.org
+          if (isRaiseExceptionOnSilentRollback()
+              && handler.getException() == null
+              && status.startsWith("ROLLBACK")) {
+            String message = null;
+            if (looksLikeCommit(nativeSql)) {
+              if (transactionFailCause == null) {
+                message = GT.tr("The database returned ROLLBACK, so the transaction cannot be committed. Transaction failure is not known (check server logs?)");
+              } else {
+                message = GT.tr("The database returned ROLLBACK, so the transaction cannot be committed. Transaction failure cause is <<{0}>>", transactionFailCause.getMessage());
+              }
+            } else if (looksLikePrepare(nativeSql)) {
+              if (transactionFailCause == null) {
+                message = GT.tr("The database returned ROLLBACK, so the transaction cannot be prepared. Transaction failure is not known (check server logs?)");
+              } else {
+                message = GT.tr("The database returned ROLLBACK, so the transaction cannot be prepared. Transaction failure cause is <<{0}>>", transactionFailCause.getMessage());
+              }
+            }
+            if (message != null) {
+              handler.handleError(
+                  new PSQLException(
+                      message, PSQLState.IN_FAILED_SQL_TRANSACTION, transactionFailCause));
+            }
+          }
+
           if (status.startsWith("SET")) {
-            String nativeSql = currentQuery.getNativeQuery().nativeSql;
             // Scan only the first 1024 characters to
             // avoid big overhead for long queries.
             if (nativeSql.lastIndexOf("search_path", 1024) != -1

--- a/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
+++ b/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
@@ -1462,6 +1462,22 @@ public abstract class BaseDataSource implements CommonDataSource, Referenceable 
   }
 
   /**
+   * @return connection configuration regarding throwing exception from commit if database rolls back the transaction
+   * @see PGProperty#RAISE_EXCEPTION_ON_SILENT_ROLLBACK
+   */
+  public boolean isRaiseExceptionOnSilentRollback() {
+    return PGProperty.RAISE_EXCEPTION_ON_SILENT_ROLLBACK.getBoolean(properties);
+  }
+
+  /**
+   * @param raiseExceptionOnSilentRollback if the database should throw exception if commit silently rolls back
+   * @see PGProperty#RAISE_EXCEPTION_ON_SILENT_ROLLBACK
+   */
+  public void setRaiseExceptionOnSilentRollback(boolean raiseExceptionOnSilentRollback) {
+    PGProperty.RAISE_EXCEPTION_ON_SILENT_ROLLBACK.set(properties, raiseExceptionOnSilentRollback);
+  }
+
+  /**
    * see PGProperty#CLEANUP_SAVEPOINTS
    *
    * @return boolean indicating property set

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
@@ -247,6 +247,10 @@ public class PgConnection implements BaseConnection {
       LOGGER.log(Level.FINEST, "    integer date/time = {0}", queryExecutor.getIntegerDateTimes());
     }
 
+    queryExecutor.setRaiseExceptionOnSilentRollback(
+        PGProperty.RAISE_EXCEPTION_ON_SILENT_ROLLBACK.getBoolean(info)
+    );
+
     //
     // String -> text or unknown?
     //

--- a/pgjdbc/src/main/java/org/postgresql/xa/PGXAConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/xa/PGXAConnection.java
@@ -647,6 +647,9 @@ public class PGXAConnection extends PGPooledConnection implements XAConnection, 
     if (isPostgreSQLIntegrityConstraintViolation(sqlException)) {
       return XAException.XA_RBINTEGRITY;
     }
+    if (PSQLState.IN_FAILED_SQL_TRANSACTION.getState().equals(sqlException.getSQLState())) {
+      return XAException.XA_RBOTHER;
+    }
 
     return XAException.XAER_RMFAIL;
   }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/AutoRollbackTestSuite.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/AutoRollbackTestSuite.java
@@ -162,6 +162,9 @@ public class AutoRollbackTestSuite extends BaseTest4 {
   public void tearDown() throws SQLException {
     try {
       con.setAutoCommit(true);
+    } catch (Exception ignored) {
+    }
+    try {
       TestUtil.dropTable(con, "rollbacktest");
     } catch (Exception e) {
       e.printStackTrace();
@@ -292,15 +295,46 @@ public class AutoRollbackTestSuite extends BaseTest4 {
     switch (continueMode) {
       case COMMIT:
         try {
+          TransactionState transactionState = pgConnection.getTransactionState();
           doCommit();
-          // No assert here: commit should always succeed with exception of well known failure cases in catch
+          Assert.assertNotEquals(
+              ".commit() should throw exception since the transaction was in failed state",
+                TransactionState.FAILED, transactionState);
+          Assert.assertEquals("Transaction should be IDLE after .commit()",
+              TransactionState.IDLE, pgConnection.getTransactionState());
+          // Commit might fail in case the transaction is in aborted state
         } catch (SQLException e) {
+          if (!PSQLState.INVALID_SQL_STATEMENT_NAME.getState().equals(e.getSQLState())) {
+            // In preferQueryMode=extendedCacheEverything mode it might be that "commit"
+            // statement is using server-prepared mode, and it might result in
+            // ERROR: prepared statement "S_4" does not exist
+            try {
+              Assert.assertEquals("Transaction should be IDLE after .commit()",
+                  TransactionState.IDLE, pgConnection.getTransactionState());
+            } catch (AssertionError ae) {
+              ae.initCause(e);
+              throw ae;
+            }
+          }
+          if (PSQLState.IN_FAILED_SQL_TRANSACTION.getState().equals(e.getSQLState())
+              && (!flushCacheOnDeallocate && DEALLOCATES.contains(failMode)
+              || autoCommit == AutoCommit.NO)) {
+            // We have two cases here:
+            // 1) autocommit=false, so transaction was in progress, so it is expected that commit
+            //    fails with IN_FAILED_SQL_TRANSACTION
+            // 2) commit might fail due to <<ERROR: prepared statement "S_4" does not exist>>
+            //    However, if flushCacheOnDeallocate is false, then autosave can't really work, so
+            //    it is expected that commit fails
+            // Commit terminates the transaction, so "autosave" can't really "rollback"
+            return;
+          }
           if (!flushCacheOnDeallocate && DEALLOCATES.contains(failMode)
               && autoSave == AutoSave.NEVER) {
             Assert.assertEquals(
                 "flushCacheOnDeallocate is disabled, thus " + failMode + " should cause 'prepared statement \"...\" does not exist'"
                     + " error message is " + e.getMessage(),
                 PSQLState.INVALID_SQL_STATEMENT_NAME.getState(), e.getSQLState());
+            // Commit terminates the transaction, so "autosave" can't really "rollback"
             return;
           }
           throw e;

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BatchExecuteTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BatchExecuteTest.java
@@ -8,6 +8,7 @@ package org.postgresql.test.jdbc2;
 import org.postgresql.PGProperty;
 import org.postgresql.PGStatement;
 import org.postgresql.test.TestUtil;
+import org.postgresql.util.PSQLState;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -238,13 +239,13 @@ public class BatchExecuteTest extends BaseTest4 {
   }
 
   @Test
-  public void testSelectInBatchThrowsAutoCommit() throws Exception {
+  public void testSelectInBatchThrowsAutoCommit() throws Throwable {
     con.setAutoCommit(true);
     testSelectInBatchThrows();
   }
 
   @Test
-  public void testSelectInBatchThrows() throws Exception {
+  public void testSelectInBatchThrows() throws Throwable {
     Statement stmt = con.createStatement();
 
     int oldValue = getCol1Value();
@@ -261,7 +262,13 @@ public class BatchExecuteTest extends BaseTest4 {
     }
 
     if (!con.getAutoCommit()) {
-      con.commit();
+      try {
+        con.commit();
+      } catch (SQLException e) {
+        if (!PSQLState.IN_FAILED_SQL_TRANSACTION.getState().equals(e.getSQLState())) {
+          throw e;
+        }
+      }
     }
 
     int newValue = getCol1Value();

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BatchFailureTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BatchFailureTest.java
@@ -7,6 +7,7 @@ package org.postgresql.test.jdbc2;
 
 import org.postgresql.PGProperty;
 import org.postgresql.test.TestUtil;
+import org.postgresql.util.PSQLState;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -242,7 +243,14 @@ public class BatchFailureTest extends BaseTest4 {
     }
 
     if (!con.getAutoCommit()) {
-      con.commit();
+      try {
+        // Commit might fail if the transaction is in aborted state
+        con.commit();
+      } catch (SQLException e) {
+        if (!PSQLState.IN_FAILED_SQL_TRANSACTION.getState().equals(e.getSQLState())) {
+          throw e;
+        }
+      }
     }
 
     int finalCount = getBatchUpdCount();

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/Jdbc2TestSuite.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/Jdbc2TestSuite.java
@@ -118,6 +118,7 @@ import org.junit.runners.Suite;
     TimeTest.class,
     TimezoneCachingTest.class,
     TimezoneTest.class,
+    TransactionTest.class,
     TypeCacheDLLStressTest.class,
     UpdateableResultTest.class,
     UpsertTest.class,

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/MiscTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/MiscTest.java
@@ -9,7 +9,9 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
 import org.postgresql.test.TestUtil;
+import org.postgresql.util.PSQLState;
 
+import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -88,7 +90,15 @@ public class MiscTest {
       oos.close();
     }
 
-    con.commit();
+    try {
+      con.commit();
+    } catch (SQLException e) {
+      Assert.assertEquals(
+          "Transaction is in failed state, so .commit() should throw",
+          PSQLState.IN_FAILED_SQL_TRANSACTION.getState(),
+          e.getSQLState()
+      );
+    }
     con.close();
   }
 

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/TransactionTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/TransactionTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2020, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.test.jdbc2;
+
+import org.postgresql.test.TestUtil;
+import org.postgresql.util.PSQLState;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.concurrent.Callable;
+
+public class TransactionTest extends BaseTest4 {
+  @Before
+  public void setUp() throws Exception {
+    super.setUp();
+    TestUtil.createTempTable(con, "transaction_test_table", "i int");
+    con.setAutoCommit(false);
+  }
+
+  @After
+  public void tearDown() throws SQLException {
+    con.setAutoCommit(true);
+    TestUtil.dropTable(con, "transaction_test_table");
+    super.tearDown();
+  }
+
+  private void setupTransaction() throws SQLException {
+    Statement st = con.createStatement();
+    st.execute("insert into transaction_test_table(i) values(42)");
+    try {
+      st.execute("invalid sql to abort transaction");
+    } catch (SQLException ignored) {
+    }
+    TestUtil.closeQuietly(st);
+  }
+
+  private void assertFails(Callable<Void> action) throws Exception {
+    String msg = "commit should fail since the transaction is in invalid state";
+    try {
+      action.call();
+      Assert.fail(msg);
+    } catch (SQLException e) {
+      try {
+        Assert.assertEquals(
+            msg,
+            PSQLState.IN_FAILED_SQL_TRANSACTION.getState(),
+            e.getSQLState()
+        );
+      } catch (Throwable t) {
+        t.initCause(e);
+        throw t;
+      }
+    }
+  }
+
+  @Test
+  public void commitShouldFailIfTransactionWasInvalidState() throws Exception {
+    setupTransaction();
+    assertFails(new Callable<Void>() {
+      @Override
+      public Void call() throws Exception {
+        con.commit();
+        return null;
+      }
+    });
+  }
+
+  @Test
+  public void execute_commit_statement_ShouldFailIfTransactionWasInvalidState() throws Exception {
+    setupTransaction();
+    assertFails(new Callable<Void>() {
+      @Override
+      public Void call() throws Exception {
+        con.createStatement().execute("commit");
+        return null;
+      }
+    });
+  }
+
+  @Test
+  public void execute_CoMMiT_statement_ShouldFailIfTransactionWasInvalidState() throws Exception {
+    setupTransaction();
+    assertFails(new Callable<Void>() {
+      @Override
+      public Void call() throws Exception {
+        con.createStatement().execute("CoMMiT");
+        return null;
+      }
+    });
+  }
+
+  @Test
+  public void execute_CoMMiT_with_comments_statement_ShouldFailIfTransactionWasInvalidState() throws Exception {
+    setupTransaction();
+    assertFails(new Callable<Void>() {
+      @Override
+      public Void call() throws Exception {
+        con.createStatement().execute("/* Dear database, please save the data if possible, thanks */CoMMiT");
+        return null;
+      }
+    });
+  }
+
+  @Test
+  public void execute_rollback_with_comments_statement_should_not_fail() throws Exception {
+    setupTransaction();
+    // Note: there's rollback, so exception should not be there
+    con.createStatement().execute("/*adsf,commit*/rollBack/*CoMMiT,commit*/");
+  }
+
+  @Test
+  public void execute_rollback_statement_shouldsucceed() throws Exception {
+    setupTransaction();
+    con.createStatement().execute("rollback");
+  }
+
+  @Test
+  public void rolback_shouldsucceed() throws Exception {
+    setupTransaction();
+    con.rollback();
+  }
+
+  @Test
+  public void switch_to_autocommit_should_fail_because_it_does_implicit_commit() throws Exception {
+    setupTransaction();
+    assertFails(new Callable<Void>() {
+      @Override
+      public Void call() throws Exception {
+        con.setAutoCommit(true);
+        return null;
+      }
+    });
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc3/Jdbc3SavepointTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc3/Jdbc3SavepointTest.java
@@ -9,8 +9,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 import org.postgresql.test.TestUtil;
+import org.postgresql.util.PSQLState;
 
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -34,7 +36,15 @@ public class Jdbc3SavepointTest {
 
   @After
   public void tearDown() throws SQLException {
-    conn.setAutoCommit(true);
+    try {
+      conn.setAutoCommit(true);
+    } catch (SQLException e) {
+      Assert.assertEquals(
+          "Unexpected exception from setAutoCommit(true)",
+          PSQLState.IN_FAILED_SQL_TRANSACTION.getState(),
+          e.getSQLState()
+      );
+    }
     TestUtil.dropTable(conn, "savepointtable");
     TestUtil.closeDB(conn);
   }

--- a/pgjdbc/src/test/java/org/postgresql/test/xa/XAPrepareFailureTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/xa/XAPrepareFailureTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2020, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.test.xa;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
+
+import org.postgresql.test.TestUtil;
+import org.postgresql.test.jdbc2.BaseTest4;
+import org.postgresql.test.jdbc2.optional.BaseDataSourceTest;
+import org.postgresql.xa.PGXADataSource;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.concurrent.Callable;
+
+import javax.sql.XAConnection;
+import javax.sql.XADataSource;
+import javax.transaction.xa.XAException;
+import javax.transaction.xa.XAResource;
+
+public class XAPrepareFailureTest extends BaseTest4 {
+  private XADataSource xaDs;
+
+  private XAConnection xaconn;
+  private XAResource xaRes;
+  private Connection conn;
+  XADataSourceTest.CustomXid xid = new XADataSourceTest.CustomXid(7);
+
+  public XAPrepareFailureTest() {
+    xaDs = new PGXADataSource();
+    BaseDataSourceTest.setupDataSource((PGXADataSource) xaDs);
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    super.setUp();
+    assumeTrue(isPreparedTransactionEnabled(con));
+
+    TestUtil.createTable(con, "xatransaction_test_table", "i int");
+
+    clearAllPrepared();
+    xaconn = xaDs.getXAConnection();
+    xaRes = xaconn.getXAResource();
+    conn = xaconn.getConnection();
+  }
+
+  @After
+  public void tearDown() throws SQLException {
+    TestUtil.dropTable(con, "xatransaction_test_table");
+    clearAllPrepared();
+    super.tearDown();
+  }
+
+  private static boolean isPreparedTransactionEnabled(Connection connection) throws SQLException {
+    Statement stmt = connection.createStatement();
+    ResultSet rs = stmt.executeQuery("SHOW max_prepared_transactions");
+    rs.next();
+    int mpt = rs.getInt(1);
+    rs.close();
+    stmt.close();
+    return mpt > 0;
+  }
+
+  private void clearAllPrepared() throws SQLException {
+    Statement st = con.createStatement();
+    try {
+      ResultSet rs = st.executeQuery(
+          "SELECT x.gid, x.owner = current_user "
+          + "FROM pg_prepared_xacts x "
+          + "WHERE x.database = current_database()");
+
+      Statement st2 = con.createStatement();
+      while (rs.next()) {
+        // TODO: This should really use org.junit.Assume once we move to JUnit 4
+        assertTrue("Only prepared xacts owned by current user may be present in db",
+            rs.getBoolean(2));
+        st2.executeUpdate("ROLLBACK PREPARED '" + rs.getString(1) + "'");
+      }
+      TestUtil.closeQuietly(st2);
+    } finally {
+      TestUtil.closeQuietly(st);
+    }
+  }
+
+  private XADataSourceTest.CustomXid setupTransaction() throws SQLException, XAException {
+    xaRes.start(xid, XAResource.TMNOFLAGS);
+    Statement st = conn.createStatement();
+    st.execute("insert into xatransaction_test_table(i) values(42)");
+    try {
+      st.execute("invalid sql to abort transaction");
+    } catch (SQLException ignored) {
+    }
+    TestUtil.closeQuietly(st);
+    return xid;
+  }
+
+  private void assertFails(Callable<Void> action) throws Exception {
+    String msg = "prepare transaction should fail since the transaction is in invalid state";
+    try {
+      action.call();
+      Assert.fail(msg);
+    } catch (XAException e) {
+      try {
+        Assert.assertEquals(msg, XAException.XA_RBOTHER, e.errorCode);
+      } catch (Throwable t) {
+        t.initCause(e);
+        throw t;
+      }
+    }
+  }
+
+  @Test
+  public void prepareShouldFailIfTransactionWasInvalidState() throws Exception {
+    setupTransaction();
+    assertFails(new Callable<Void>() {
+      @Override
+      public Void call() throws Exception {
+        xaRes.end(xid, XAResource.TMSUCCESS);
+        xaRes.prepare(xid);
+        return null;
+      }
+    });
+  }
+
+  @Test
+  public void execute_rollback_statement_shouldsucceed() throws Exception {
+    setupTransaction();
+    xaRes.end(xid, XAResource.TMSUCCESS);
+    xaRes.rollback(xid);
+  }
+}


### PR DESCRIPTION
Hopefully, the server would fix the error in the future.

See discussion in pgsql-hackers: https://www.postgresql.org/message-id/b9fb50dc-0f6e-15fb-6555-8ddb86f4aa71%40postgresfriends.org

fixes #1697

For documentation purposes: the feature will be enabled by default.
It can be disabled by setting `raiseExceptionOnSilentRollback=false` connection property.

Sample failure:

```
org.postgresql.util.PSQLException: The database returned ROLLBACK, so the transaction cannot be committed. Transaction failure cause is <<ERROR: savepoint "jdbc_savepoint_1" does not exist>>
	at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2191)
	at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:316)
	at org.postgresql.jdbc.PgConnection.executeTransactionCommand(PgConnection.java:829)
	at org.postgresql.jdbc.PgConnection.commit(PgConnection.java:851)
	at org.postgresql.jdbc.PgConnection.setAutoCommit(PgConnection.java:793)
	at org.postgresql.test.jdbc3.Jdbc3SavepointTest.tearDown(Jdbc3SavepointTest.java:40)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.RunAfters.invokeMethod(RunAfters.java:46)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:33)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:115)
	at org.junit.vintage.engine.execution.RunnerExecutor.execute(RunnerExecutor.java:43)
	at java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:183)
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
	at java.util.Iterator.forEachRemaining(Iterator.java:116)
	at java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1801)
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482)
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472)
	at java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150)
	at java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173)
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:485)
	at org.junit.vintage.engine.VintageTestEngine.executeAllChildren(VintageTestEngine.java:82)
	at org.junit.vintage.engine.VintageTestEngine.execute(VintageTestEngine.java:73)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:220)
	at org.junit.platform.launcher.core.DefaultLauncher.lambda$execute$6(DefaultLauncher.java:188)
	at org.junit.platform.launcher.core.DefaultLauncher.withInterceptedStreams(DefaultLauncher.java:202)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:181)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:128)
	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor$CollectAllTestClassesExecutor.processAllTestClasses(JUnitPlatformTestClassProcessor.java:99)
	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor$CollectAllTestClassesExecutor.access$000(JUnitPlatformTestClassProcessor.java:79)
	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor.stop(JUnitPlatformTestClassProcessor.java:75)
	at org.gradle.api.internal.tasks.testing.SuiteTestClassProcessor.stop(SuiteTestClassProcessor.java:61)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:36)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
	at org.gradle.internal.dispatch.ContextClassLoaderDispatch.dispatch(ContextClassLoaderDispatch.java:33)
	at org.gradle.internal.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:94)
	at com.sun.proxy.$Proxy2.stop(Unknown Source)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.stop(TestWorker.java:132)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:36)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
	at org.gradle.internal.remote.internal.hub.MessageHubBackedObjectConnection$DispatchWrapper.dispatch(MessageHubBackedObjectConnection.java:182)
	at org.gradle.internal.remote.internal.hub.MessageHubBackedObjectConnection$DispatchWrapper.dispatch(MessageHubBackedObjectConnection.java:164)
	at org.gradle.internal.remote.internal.hub.MessageHub$Handler.run(MessageHub.java:412)
	at org.gradle.internal.concurrent.ExecutorPolicy$CatchAndRecordFailures.onExecute(ExecutorPolicy.java:64)
	at org.gradle.internal.concurrent.ManagedExecutorImpl$1.run(ManagedExecutorImpl.java:48)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at org.gradle.internal.concurrent.ThreadFactoryImpl$ManagedThreadRunnable.run(ThreadFactoryImpl.java:56)
	at java.lang.Thread.run(Thread.java:748)
Caused by: org.postgresql.util.PSQLException: ERROR: savepoint "jdbc_savepoint_1" does not exist
	at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2562)
	at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2297)
	at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:316)
	at org.postgresql.jdbc.PgStatement.executeInternal(PgStatement.java:448)
	at org.postgresql.jdbc.PgStatement.execute(PgStatement.java:369)
	at org.postgresql.jdbc.PgStatement.executeWithFlags(PgStatement.java:310)
	at org.postgresql.jdbc.PgStatement.executeCachedSql(PgStatement.java:296)
	at org.postgresql.jdbc.PgStatement.executeWithFlags(PgStatement.java:273)
	at org.postgresql.jdbc.PgConnection.execSQLUpdate(PgConnection.java:479)
	at org.postgresql.jdbc.PgConnection.rollback(PgConnection.java:1741)
	at org.postgresql.test.jdbc3.Jdbc3SavepointTest.testRollingBackToInvalidSavepointFails(Jdbc3SavepointTest.java:216)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	... 61 more
```