### PR TITLE
test: ensure PGProperty entries are declared in ascending order

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -42,6 +42,14 @@ public enum PGProperty {
     "Name of the Application (backend >= 9.0)"),
 
   /**
+   * Assume the server is at least that version.
+   */
+  ASSUME_MIN_SERVER_VERSION(
+    "assumeMinServerVersion",
+    null,
+    "Assume the server is at least that version"),
+
+  /**
    * Specifies what the driver should do if a query fails. In {@code autosave=always} mode, JDBC driver sets a savepoint before each query,
    * and rolls back to that savepoint in case of failure. In {@code autosave=never} mode (default), no savepoint dance is made ever.
    * In {@code autosave=conservative} mode, savepoint is set for each query, however the rollback is done only for rare cases
@@ -56,15 +64,6 @@ public enum PGProperty {
         + " like 'cached statement cannot change return type' or 'statement XXX is not valid' so JDBC driver rollsback and retries",
     false,
     new String[] {"always", "never", "conservative"}),
-
-  /**
-   * Assume the server is at least that version.
-   */
-  ASSUME_MIN_SERVER_VERSION(
-    "assumeMinServerVersion",
-    null,
-    "Assume the server is at least that version"),
-
 
   /**
    * Use binary format for sending and receiving data if possible.

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PGPropertyTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PGPropertyTest.java
@@ -77,6 +77,18 @@ public class PGPropertyTest {
     }
   }
 
+  @Test
+  public void testSortOrder() {
+    String prevName = null;
+    for (PGProperty property : PGProperty.values()) {
+      String name = property.name();
+      if (prevName != null) {
+        assertTrue("PGProperty names should be sorted in ascending order: " + name + " < " + prevName, name.compareTo(prevName) > 0);
+      }
+      prevName = name;
+    }
+  }
+
   /**
    * Test that the enum constant is common with the underlying property name.
    */


### PR DESCRIPTION
Adds a test to check that any new enum values for PGProperty are in sorted order and if not gives a helpful message:

```
Failed tests: 
  PGPropertyTest.testSortOrder:86 PGProperty names should be sorted in ascending order: ASSUME_MIN_SERVER_VERSION < AUTOSAVE
```

Also fixes one value that apparently was not in the right order. 

Should be useful to keep things tidy going forward.