### PR TITLE
refactor: adding new getters for classes

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/PGStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/PGStream.java
@@ -672,4 +672,8 @@ public class PGStream implements Closeable, Flushable {
   public boolean isClosed() {
     return connection.isClosed();
   }
+
+  public VisibleBufferedInputStream getPgInput() {
+    return pgInput;
+  }
 }

--- a/pgjdbc/src/main/java/org/postgresql/core/QueryExecutorBase.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/QueryExecutorBase.java
@@ -448,4 +448,8 @@ public abstract class QueryExecutorBase implements QueryExecutor {
 
     parameterStatuses.put(parameterName, parameterStatus);
   }
+
+  public PGStream getPgStream() {
+    return pgStream;
+  }
 }

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgParameterMetaData.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgParameterMetaData.java
@@ -101,4 +101,8 @@ public class PgParameterMetaData implements ParameterMetaData {
     }
     throw new SQLException("Cannot unwrap to " + iface.getName());
   }
+
+  public int[] getOids() {
+    return oids;
+  }
 }

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
@@ -68,7 +68,7 @@ import java.util.Map;
 import java.util.TimeZone;
 import java.util.UUID;
 
-class PgPreparedStatement extends PgStatement implements PreparedStatement {
+public class PgPreparedStatement extends PgStatement implements PreparedStatement {
   protected final CachedQuery preparedQuery; // Query fragments for prepared statement.
   protected final ParameterList preparedParameters; // Parameter values for prepared statement.
 
@@ -1644,5 +1644,9 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
     }
     batchStatements = newBatchStatements;
     batchParameters = newBatchParameters;
+  }
+
+  public ParameterList getPreparedParameters() {
+    return preparedParameters;
   }
 }

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSetMetaData.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSetMetaData.java
@@ -440,4 +440,8 @@ public class PgResultSetMetaData implements ResultSetMetaData, PGResultSetMetaDa
     }
     throw new SQLException("Cannot unwrap to " + iface.getName());
   }
+
+  public Field[] getFields() {
+    return fields;
+  }
 }

--- a/pgjdbc/src/test/java/org/postgresql/core/PGStreamTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/core/PGStreamTest.java
@@ -33,11 +33,15 @@ public class PGStreamTest {
   }
 
   /**
-   * Test to check work of getPgInput() method.
+   * Test for case of retrieving pgInput from PGStream object. Checks if returned
+   * VisibleBufferedInputStream is the same as VisibleBufferedInputStream object inside pgStream.
    */
   @Test
   public void testGetPgInput() throws NoSuchFieldException, IllegalAccessException {
-    Assert.assertEquals(getPgInput(), pgStream.getPgInput());
+    VisibleBufferedInputStream expectedPgInput = getPgInput();
+    VisibleBufferedInputStream actualPgInput = pgStream.getPgInput();
+
+    Assert.assertEquals(expectedPgInput, actualPgInput);
   }
 
   /**

--- a/pgjdbc/src/test/java/org/postgresql/core/PGStreamTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/core/PGStreamTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2020, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.core;
+
+import org.postgresql.test.TestUtil;
+import org.postgresql.util.HostSpec;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+
+import javax.net.SocketFactory;
+
+public class PGStreamTest {
+
+  private PGStream pgStream;
+
+  private static String pgInputVariableName = "pgInput";
+
+  /**
+   * Setup to create PGStream object.
+   */
+  @Before
+  public void setUp() throws IOException {
+    pgStream = new PGStream(SocketFactory.getDefault(),
+      new HostSpec(TestUtil.getServer(), TestUtil.getPort()), 0);
+  }
+
+  /**
+   * Test to check work of getPgInput() method.
+   */
+  @Test
+  public void testGetPgInput() throws NoSuchFieldException, IllegalAccessException {
+    Assert.assertEquals(getPgInput(), pgStream.getPgInput());
+  }
+
+  /**
+   * Get pgInput from pgStream via reflection.
+   *
+   * @return pgInput variable from pgStream
+   */
+  private VisibleBufferedInputStream getPgInput()
+      throws NoSuchFieldException, IllegalAccessException {
+    Field field = pgStream.getClass().getDeclaredField(pgInputVariableName);
+    field.setAccessible(true);
+    return (VisibleBufferedInputStream) field.get(pgStream);
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/core/QueryExecutorBaseTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/core/QueryExecutorBaseTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2020, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.core;
+
+import org.postgresql.copy.CopyOperation;
+import org.postgresql.jdbc.BatchResultHandler;
+import org.postgresql.test.TestUtil;
+import org.postgresql.util.HostSpec;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+import java.util.TimeZone;
+
+import javax.net.SocketFactory;
+
+public class QueryExecutorBaseTest {
+
+  private PGStream pgStream;
+  private QueryExecutorBase queryExecutor;
+
+  /**
+   * Setup to create object of QueryExecutorBase class.
+   */
+  @Before
+  public void setUp() throws IOException, SQLException {
+    pgStream = new PGStream(SocketFactory.getDefault(),
+      new HostSpec(TestUtil.getServer(), TestUtil.getPort()), 0);
+    queryExecutor = new QueryExecutorBaseMock(pgStream, TestUtil.getUser(), TestUtil.getDatabase(),
+      0, new Properties());
+  }
+
+  /**
+   * Test to check work of getPgStream() method.
+   */
+  @Test
+  public void testGetPgStream() {
+    Assert.assertEquals(pgStream, queryExecutor.getPgStream());
+  }
+
+  /**
+   * Mockup extending QueryExecutorBase for testing.
+   */
+  private class QueryExecutorBaseMock extends QueryExecutorBase {
+
+    protected QueryExecutorBaseMock(PGStream pgStream, String user, String database,
+        int cancelSignalTimeout, Properties info) throws SQLException {
+      super(pgStream, user, database, cancelSignalTimeout, info);
+    }
+
+    @Override
+    protected void sendCloseMessage() throws IOException {
+
+    }
+
+    @Override
+    public void execute(Query query, ParameterList parameters,
+        ResultHandler handler, int maxRows, int fetchSize, int flags) throws SQLException {
+
+    }
+
+    @Override
+    public void execute(Query[] queries, ParameterList[] parameterLists,
+        BatchResultHandler handler, int maxRows, int fetchSize, int flags) throws SQLException {
+
+    }
+
+    @Override
+    public void fetch(ResultCursor cursor,
+        ResultHandler handler, int fetchSize) throws SQLException {
+
+    }
+
+    @Override
+    public Query createSimpleQuery(String sql) throws SQLException {
+      return null;
+    }
+
+    @Override
+    public Query wrap(List<NativeQuery> queries) {
+      return null;
+    }
+
+    @Override
+    public void processNotifies() throws SQLException {
+
+    }
+
+    @Override
+    public void processNotifies(int timeoutMillis) throws SQLException {
+
+    }
+
+    @Override
+    public ParameterList createFastpathParameters(int count) {
+      return null;
+    }
+
+    @Override
+    public byte[] fastpathCall(int fnid, ParameterList params, boolean suppressBegin)
+        throws SQLException {
+      return new byte[0];
+    }
+
+    @Override
+    public CopyOperation startCopy(String sql, boolean suppressBegin) throws SQLException {
+      return null;
+    }
+
+    @Override
+    public int getProtocolVersion() {
+      return 0;
+    }
+
+    @Override
+    public void setBinaryReceiveOids(Set<Integer> useBinaryForOids) {
+
+    }
+
+    @Override
+    public void setBinarySendOids(Set<Integer> useBinaryForOids) {
+
+    }
+
+    @Override
+    public boolean getIntegerDateTimes() {
+      return false;
+    }
+
+    @Override
+    public TimeZone getTimeZone() {
+      return null;
+    }
+
+    @Override
+    public String getApplicationName() {
+      return null;
+    }
+
+    @Override
+    public ReplicationProtocol getReplicationProtocol() {
+      return null;
+    }
+
+    @Override
+    public boolean useBinaryForSend(int oid) {
+      return false;
+    }
+
+    @Override
+    public boolean useBinaryForReceive(int oid) {
+      return false;
+    }
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/core/QueryExecutorBaseTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/core/QueryExecutorBaseTest.java
@@ -40,11 +40,14 @@ public class QueryExecutorBaseTest {
   }
 
   /**
-   * Test to check work of getPgStream() method.
+   * Test for case of retrieving pgStream from QueryExecutorBase class. Checks if returned PGStream
+   * is the same as PGStream object inside queryExecutor.
    */
   @Test
   public void testGetPgStream() {
-    Assert.assertEquals(pgStream, queryExecutor.getPgStream());
+    PGStream actualPgStream = queryExecutor.getPgStream();
+
+    Assert.assertEquals(pgStream, actualPgStream);
   }
 
   /**

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/PgParameterMetaDataTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/PgParameterMetaDataTest.java
@@ -26,10 +26,13 @@ public class PgParameterMetaDataTest {
   }
 
   /**
-   * Test to check work of getOids() method.
+   * Test for case of retrieving oids array from PgParameterMetaData object. Checks if returned
+   * array is the same as array set inside pgParameterMetaData object.
    */
   @Test
   public void testGetOids() {
-    Assert.assertArrayEquals(oids, pgParameterMetaData.getOids());
+    int[] actualOids = pgParameterMetaData.getOids();
+
+    Assert.assertArrayEquals(oids, actualOids);
   }
 }

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/PgParameterMetaDataTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/PgParameterMetaDataTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2020, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.jdbc;
+
+import org.postgresql.core.Oid;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class PgParameterMetaDataTest {
+
+  private PgParameterMetaData pgParameterMetaData;
+  private int[] oids;
+
+  /**
+   * Simple setup to create with PgParameterMetaData object with no connection.
+   */
+  @Before
+  public void setUp() {
+    oids = new int[]{Oid.VOID, Oid.UNSPECIFIED, Oid.BIT, Oid.VARBIT_ARRAY};
+    pgParameterMetaData = new PgParameterMetaData(null, oids);
+  }
+
+  /**
+   * Test to check work of getOids() method.
+   */
+  @Test
+  public void testGetOids() {
+    Assert.assertArrayEquals(oids, pgParameterMetaData.getOids());
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/PgPreparedStatementTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/PgPreparedStatementTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2020, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.jdbc;
+
+import org.postgresql.core.ParameterList;
+import org.postgresql.test.jdbc2.BaseTest4;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.sql.SQLException;
+
+public class PgPreparedStatementTest extends BaseTest4 {
+
+  private static PgPreparedStatement preparedStatement;
+
+  private static String preparedParametersVariableName = "preparedParameters";
+
+  /**
+   * Test to check work of getPreparedParameters() method.
+   */
+  @Test
+  public void testGetPreparedParameters()
+      throws SQLException, NoSuchFieldException, IllegalAccessException {
+    preparedStatement = (PgPreparedStatement) con
+      .prepareStatement("SELECT * from function(?,?,?,?)");
+
+    Assert.assertEquals(getPreparedParameters(), preparedStatement.getPreparedParameters());
+  }
+
+  /**
+   * Get preparedParameters from preparedStatement via reflection.
+   *
+   * @return preparedParameters variable from preparedStatement
+   */
+  public ParameterList getPreparedParameters() throws NoSuchFieldException, IllegalAccessException {
+    Field field = preparedStatement.getClass().getDeclaredField(preparedParametersVariableName);
+    field.setAccessible(true);
+    return (ParameterList) field.get(preparedStatement);
+  }
+
+}

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/PgPreparedStatementTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/PgPreparedStatementTest.java
@@ -21,7 +21,8 @@ public class PgPreparedStatementTest extends BaseTest4 {
   private static String preparedParametersVariableName = "preparedParameters";
 
   /**
-   * Test to check work of getPreparedParameters() method.
+   * Test for case of retrieving preparedParameters from PgPreparedStatement object. Checks if
+   * returned ParameterList is the same as ParameterList object inside preparedStatement.
    */
   @Test
   public void testGetPreparedParameters()
@@ -29,7 +30,10 @@ public class PgPreparedStatementTest extends BaseTest4 {
     preparedStatement = (PgPreparedStatement) con
       .prepareStatement("SELECT * from function(?,?,?,?)");
 
-    Assert.assertEquals(getPreparedParameters(), preparedStatement.getPreparedParameters());
+    ParameterList expectedParameterList = getPreparedParameters();
+    ParameterList actualParameterList = preparedStatement.getPreparedParameters();
+
+    Assert.assertEquals(expectedParameterList, actualParameterList);
   }
 
   /**

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/PgResultSetMetaDataTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/PgResultSetMetaDataTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2020, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.jdbc;
+
+import org.postgresql.core.Field;
+import org.postgresql.core.Oid;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class PgResultSetMetaDataTest {
+
+  private PgResultSetMetaData pgResultSetMetaData;
+  private Field[] fields;
+
+  /**
+   * Simple setup to create PgResultSetMetaData object with no connection.
+   */
+  @Before
+  public void setUp() {
+    fields = new Field[]{
+      new Field("a", Oid.VOID),
+      new Field("b", Oid.VARCHAR),
+      new Field("c", Oid.INT2)
+    };
+    pgResultSetMetaData = new PgResultSetMetaData(null, fields);
+  }
+
+  /**
+   * Test to check work of getFields() method.
+   */
+  @Test
+  public void testGetFields() {
+    Assert.assertArrayEquals(fields, pgResultSetMetaData.getFields());
+  }
+
+}

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/PgResultSetMetaDataTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/PgResultSetMetaDataTest.java
@@ -31,11 +31,14 @@ public class PgResultSetMetaDataTest {
   }
 
   /**
-   * Test to check work of getFields() method.
+   * Test for case of retrieving fields array from PgResultSetMetaData object. Checks if returned
+   * fields array is the same as array set in pgResultSetMetaData.
    */
   @Test
   public void testGetFields() {
-    Assert.assertArrayEquals(fields, pgResultSetMetaData.getFields());
+    Field[] actualFields = pgResultSetMetaData.getFields();
+
+    Assert.assertArrayEquals(fields, actualFields);
   }
 
 }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/Jdbc2TestSuite.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/Jdbc2TestSuite.java
@@ -9,12 +9,17 @@ import org.postgresql.core.CommandCompleteParserNegativeTest;
 import org.postgresql.core.CommandCompleteParserTest;
 import org.postgresql.core.OidToStringTest;
 import org.postgresql.core.OidValueOfTest;
+import org.postgresql.core.PGStreamTest;
 import org.postgresql.core.ParserTest;
+import org.postgresql.core.QueryExecutorBaseTest;
 import org.postgresql.core.ReturningParserTest;
 import org.postgresql.core.UTF8EncodingTest;
 import org.postgresql.core.v3.V3ParameterListTests;
 import org.postgresql.jdbc.DeepBatchedInsertStatementTest;
 import org.postgresql.jdbc.NoColumnMetadataIssue1613Test;
+import org.postgresql.jdbc.PgParameterMetaDataTest;
+import org.postgresql.jdbc.PgPreparedStatementTest;
+import org.postgresql.jdbc.PgResultSetMetaDataTest;
 import org.postgresql.jdbc.PgSQLXMLTest;
 import org.postgresql.jdbc.PrimitiveArraySupportTest;
 import org.postgresql.test.core.FixedLengthOutputStreamTest;
@@ -95,9 +100,14 @@ import org.junit.runners.Suite;
     PGPropertyTest.class,
     PGTimestampTest.class,
     PGTimeTest.class,
+    PGStreamTest.class,
+    PgParameterMetaDataTest.class,
+    PgPreparedStatementTest.class,
+    PgResultSetMetaDataTest.class,
     PgSQLXMLTest.class,
     PreparedStatementTest.class,
     PrimitiveArraySupportTest.class,
+    QueryExecutorBaseTest.class,
     QuotationTest.class,
     ReaderInputStreamTest.class,
     RefCursorTest.class,


### PR DESCRIPTION
Change to add getters for:
- pgInput variable from PGStream class;
- pgStream variable from QueryExecutorBase class;
- oids variable from PgParameterMetaData class;
- preparedParameters variable from PgPreparedStatement class;
- fields variable from PgResultSetMetaData class;
Additionally, change to make PgPreparedStatement class public, to get access to getter.

Commit made for Heimdall Data's request to get access to some classes variables.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? (Because I don't think there is a pull request for this change.)

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Simple change, mostly required to let API give more information about variables inside classes. The only big change is setting PgPreparedStatement as public class, but I found it as the only way to get access for implemented getter. 

I would be glad for any comments about possibilities to improve my code (maybe a different place in the code to implement getters?) or different methods to access variables (which I may didn't find).