### PR TITLE
WiP: feat: allow getScale() to use a custom value for null scale

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -646,6 +646,14 @@ public enum PGProperty {
     "Specifies the length to return for types of unknown length"),
 
   /**
+   * Specifies the scale to return for numerics of unknown scale.
+   */
+  UNKNOWN_SCALE(
+    "unknownScale",
+    Integer.toString(0),
+    "Specifies the scale to return for numerics of unknown scale"),
+
+  /**
    * Username to connect to the database as.
    */
   USER(

--- a/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
+++ b/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
@@ -516,6 +516,22 @@ public abstract class BaseDataSource implements CommonDataSource, Referenceable 
   }
 
   /**
+   * @param unknownScale unknown scale
+   * @see PGProperty#UNKNOWN_SCALE
+   */
+  public void setUnknownScale(int unknownScale) {
+    PGProperty.UNKNOWN_SCALE.set(properties, unknownScale);
+  }
+
+  /**
+   * @return unknown scale
+   * @see PGProperty#UNKNOWN_SCALE
+   */
+  public int getUnknownScale() {
+    return PGProperty.UNKNOWN_SCALE.getIntNoCheck(properties);
+  }
+
+  /**
    * @param seconds socket timeout
    * @see PGProperty#SOCKET_TIMEOUT
    */

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
@@ -281,9 +281,10 @@ public class PgConnection implements BaseConnection {
     rollbackQuery = createQuery("ROLLBACK", false, true).query;
 
     int unknownLength = PGProperty.UNKNOWN_LENGTH.getInt(info);
+    int unknownScale = PGProperty.UNKNOWN_SCALE.getInt(info);
 
     // Initialize object handling
-    typeCache = createTypeInfo(this, unknownLength);
+    typeCache = createTypeInfo(this, unknownLength, unknownScale);
     initObjectTypes(info);
 
     if (PGProperty.LOG_UNCLOSED_CONNECTIONS.getBoolean(info)) {
@@ -648,8 +649,8 @@ public class PgConnection implements BaseConnection {
     }
   }
 
-  protected TypeInfo createTypeInfo(BaseConnection conn, int unknownLength) {
-    return new TypeInfoCache(conn, unknownLength);
+  protected TypeInfo createTypeInfo(BaseConnection conn, int unknownLength, int unknownScale) {
+    return new TypeInfoCache(conn, unknownLength, unknownScale);
   }
 
   public TypeInfo getTypeInfo() {

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
@@ -54,6 +54,7 @@ public class TypeInfoCache implements TypeInfo {
 
   private BaseConnection conn;
   private final int unknownLength;
+  private final int unknownScale;
   private PreparedStatement getOidStatementSimple;
   private PreparedStatement getOidStatementComplexNonArray;
   private PreparedStatement getOidStatementComplexArray;
@@ -121,9 +122,10 @@ public class TypeInfoCache implements TypeInfo {
     typeAliases.put("decimal", "numeric");
   }
 
-  public TypeInfoCache(BaseConnection conn, int unknownLength) {
+  public TypeInfoCache(BaseConnection conn, int unknownLength, int unknownScale) {
     this.conn = conn;
     this.unknownLength = unknownLength;
+    this.unknownScale = unknownScale;
     oidToPgName = new HashMap<Integer, String>((int) Math.round(types.length * 1.5));
     pgNameToOid = new HashMap<String, Integer>((int) Math.round(types.length * 1.5));
     pgNameToJavaClass = new HashMap<String, String>((int) Math.round(types.length * 1.5));
@@ -701,7 +703,7 @@ public class TypeInfoCache implements TypeInfo {
         return 17;
       case Oid.NUMERIC:
         if (typmod == -1) {
-          return 0;
+          return unknownScale;
         }
         return (typmod - 4) & 0xFFFF;
       case Oid.TIME:


### PR DESCRIPTION
a scale of null is reported as 0. This change adds a config parameter
that allows the user to specify a new value in the connection string.

The interntion is thata value like -127 can be used, as it (probably)
is in the oracle jdbc driver, to represent a null scale on a column
when describing a ResultSet.

Signed-off-by: crwr45 <charlie.wheelerrobinson@gmail.com>
