### PR TITLE
docs: remove Supported Versions from downloads page

### DIFF
--- a/docs/download.md
+++ b/docs/download.md
@@ -9,7 +9,6 @@ nav:
 ***
 * [About](#about)
 * [Current Version](#current)
-* [Supported Versions](#supported)
 * [Other Versions](#others)
 * [Archived Versions](#archived)
 


### PR DESCRIPTION
docs: Remove a reference to a missing tag

The "Supported versions" leads to a missing section. Cleanup proposed.
