### PR TITLE
Fix issue PgDatabaseMetaData.getFunctions()

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
@@ -2751,7 +2751,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
         + "WHERE true  ";
 
     if (connection.haveMinimumServerVersion(ServerVersion.v11)) {
-        sql += " AND p.prokind='f'";
+      sql += " AND p.prokind='f'";
     }
     /*
     if the user provides a schema then search inside the schema for it

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
@@ -2749,6 +2749,10 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
         + "INNER JOIN pg_catalog.pg_namespace n ON p.pronamespace=n.oid "
         + "LEFT JOIN pg_catalog.pg_description d ON p.oid=d.objoid "
         + "WHERE true  ";
+
+    if (connection.haveMinimumServerVersion(ServerVersion.v11)) {
+        sql += " AND p.prokind='f'";
+    }
     /*
     if the user provides a schema then search inside the schema for it
      */


### PR DESCRIPTION
Fix issue (#1771) to return only functions in PgDatabaseMetaData.getFunctions()

- This is a breaking change
- Locally tested with Version 10.12 and 12.2
