### PR TITLE
Remove CopyIn and internal buffering from PGCopyOutputStream

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/copy/PGCopyOutputStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/copy/PGCopyOutputStream.java
@@ -16,11 +16,9 @@ import java.sql.SQLException;
 /**
  * OutputStream for buffered input into a PostgreSQL COPY FROM STDIN operation.
  */
-public class PGCopyOutputStream extends OutputStream implements CopyIn {
+public class PGCopyOutputStream extends OutputStream {
   private CopyIn op;
-  private final byte[] copyBuffer;
   private final byte[] singleByteBuffer = new byte[1];
-  private int at = 0;
 
   /**
    * Uses given connection for specified COPY FROM STDIN operation.
@@ -30,20 +28,7 @@ public class PGCopyOutputStream extends OutputStream implements CopyIn {
    * @throws SQLException if initializing the operation fails
    */
   public PGCopyOutputStream(PGConnection connection, String sql) throws SQLException {
-    this(connection, sql, CopyManager.DEFAULT_BUFFER_SIZE);
-  }
-
-  /**
-   * Uses given connection for specified COPY FROM STDIN operation.
-   *
-   * @param connection database connection to use for copying (protocol version 3 required)
-   * @param sql        COPY FROM STDIN statement
-   * @param bufferSize try to send this many bytes at a time
-   * @throws SQLException if initializing the operation fails
-   */
-  public PGCopyOutputStream(PGConnection connection, String sql, int bufferSize)
-      throws SQLException {
-    this(connection.getCopyAPI().copyIn(sql), bufferSize);
+    this(connection.getCopyAPI().copyIn(sql));
   }
 
   /**
@@ -52,18 +37,7 @@ public class PGCopyOutputStream extends OutputStream implements CopyIn {
    * @param op COPY FROM STDIN operation
    */
   public PGCopyOutputStream(CopyIn op) {
-    this(op, CopyManager.DEFAULT_BUFFER_SIZE);
-  }
-
-  /**
-   * Use given CopyIn operation for writing.
-   *
-   * @param op         COPY FROM STDIN operation
-   * @param bufferSize try to send this many bytes at a time
-   */
-  public PGCopyOutputStream(CopyIn op, int bufferSize) {
     this.op = op;
-    copyBuffer = new byte[bufferSize];
   }
 
   public void write(int b) throws IOException {
@@ -82,7 +56,7 @@ public class PGCopyOutputStream extends OutputStream implements CopyIn {
   public void write(byte[] buf, int off, int siz) throws IOException {
     checkClosed();
     try {
-      writeToCopy(buf, off, siz);
+      op.writeToCopy(buf, off, siz);
     } catch (SQLException se) {
       IOException ioe = new IOException("Write to copy failed.");
       ioe.initCause(se);
@@ -104,7 +78,7 @@ public class PGCopyOutputStream extends OutputStream implements CopyIn {
 
     if (op.isActive()) {
       try {
-        endCopy();
+        op.endCopy();
       } catch (SQLException se) {
         IOException ioe = new IOException("Ending write to copy failed.");
         ioe.initCause(se);
@@ -117,8 +91,6 @@ public class PGCopyOutputStream extends OutputStream implements CopyIn {
   public void flush() throws IOException {
     checkClosed();
     try {
-      op.writeToCopy(copyBuffer, 0, at);
-      at = 0;
       op.flushCopy();
     } catch (SQLException e) {
       IOException ioe = new IOException("Unable to flush stream");
@@ -127,58 +99,7 @@ public class PGCopyOutputStream extends OutputStream implements CopyIn {
     }
   }
 
-  public void writeToCopy(byte[] buf, int off, int siz) throws SQLException {
-    if (at > 0
-        && siz > copyBuffer.length - at) { // would not fit into rest of our buf, so flush buf
-      op.writeToCopy(copyBuffer, 0, at);
-      at = 0;
-    }
-    if (siz > copyBuffer.length) { // would still not fit into buf, so just pass it through
-      op.writeToCopy(buf, off, siz);
-    } else { // fits into our buf, so save it there
-      System.arraycopy(buf, off, copyBuffer, at, siz);
-      at += siz;
-    }
-  }
-
   public void writeToCopy(ByteStreamWriter from) throws SQLException {
     op.writeToCopy(from);
   }
-
-  public int getFormat() {
-    return op.getFormat();
-  }
-
-  public int getFieldFormat(int field) {
-    return op.getFieldFormat(field);
-  }
-
-  public void cancelCopy() throws SQLException {
-    op.cancelCopy();
-  }
-
-  public int getFieldCount() {
-    return op.getFieldCount();
-  }
-
-  public boolean isActive() {
-    return op != null && op.isActive();
-  }
-
-  public void flushCopy() throws SQLException {
-    op.flushCopy();
-  }
-
-  public long endCopy() throws SQLException {
-    if (at > 0) {
-      op.writeToCopy(copyBuffer, 0, at);
-    }
-    op.endCopy();
-    return getHandledRowCount();
-  }
-
-  public long getHandledRowCount() {
-    return op.getHandledRowCount();
-  }
-
 }

--- a/pgjdbc/src/test/java/org/postgresql/test/TestUtil.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/TestUtil.java
@@ -937,6 +937,21 @@ public class TestUtil {
   }
 
   /**
+   * Execute a SQL query with a given connection, fetch the first row, and return its
+   * string value.
+   */
+  public static String queryForString(Connection conn, String sql) throws SQLException {
+    Statement stmt = conn.createStatement();
+    ResultSet rs = stmt.executeQuery(sql);
+    Assert.assertTrue("Query should have returned exactly one row but none was found: " + sql, rs.next());
+    String value = rs.getString(1);
+    Assert.assertFalse("Query should have returned exactly one row but more than one found: " + sql, rs.next());
+    rs.close();
+    stmt.close();
+    return value;
+  }
+
+  /**
    * Retrieve the backend process id for a given connection.
    */
   public static int getBackendPid(Connection conn) throws SQLException {

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/CopyTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/CopyTest.java
@@ -6,7 +6,6 @@
 package org.postgresql.test.jdbc2;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -127,7 +126,7 @@ public class CopyTest {
   @Test
   public void testCopyInAsOutputStream() throws SQLException, IOException {
     String sql = "COPY copytest FROM STDIN";
-    OutputStream os = new PGCopyOutputStream((PGConnection) con, sql, 1000);
+    OutputStream os = new PGCopyOutputStream((PGConnection) con, sql);
     for (String anOrigData : origData) {
       byte[] buf = anOrigData.getBytes();
       os.write(buf);
@@ -140,17 +139,15 @@ public class CopyTest {
   @Test
   public void testCopyInAsOutputStreamClosesAfterEndCopy() throws SQLException, IOException {
     String sql = "COPY copytest FROM STDIN";
-    PGCopyOutputStream os = new PGCopyOutputStream((PGConnection) con, sql, 1000);
+    PGCopyOutputStream os = new PGCopyOutputStream((PGConnection) con, sql);
     try {
       for (String anOrigData : origData) {
         byte[] buf = anOrigData.getBytes();
         os.write(buf);
       }
-      os.endCopy();
     } finally {
       os.close();
     }
-    assertFalse(os.isActive());
     int rowCount = getCount();
     assertEquals(dataRows, rowCount);
   }
@@ -158,13 +155,12 @@ public class CopyTest {
   @Test
   public void testCopyInAsOutputStreamFailsOnFlushAfterEndCopy() throws SQLException, IOException {
     String sql = "COPY copytest FROM STDIN";
-    PGCopyOutputStream os = new PGCopyOutputStream((PGConnection) con, sql, 1000);
+    PGCopyOutputStream os = new PGCopyOutputStream((PGConnection) con, sql);
     try {
       for (String anOrigData : origData) {
         byte[] buf = anOrigData.getBytes();
         os.write(buf);
       }
-      os.endCopy();
     } finally {
       os.close();
     }


### PR DESCRIPTION
# Breaking Change! :bomb:

This is a breaking change that removes both the internal buffering and the CopyIn interface implementation from PGCopyOutputStream. Fixing the buffering would be a breaking change so might as well fix both at once (at least that's my vote...).

Commit message has some more details on the break, rationale, and migration for existing code.. There's also some older issues on this subject including prior discussion of eventually making this breaking change:

https://github.com/pgjdbc/pgjdbc/issues/1574
https://github.com/pgjdbc/pgjdbc/pull/1575
https://github.com/pgjdbc/pgjdbc/pull/1387 (me submitting essentially the same PR but without the breaking test)

PR passes all tests including new one to showcase the previous issue with buffering.

Fixes #1777.
