### PR TITLE
fix: Update checkstyle command in PR template to reference gradle

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,7 @@
 ### New Feature Submissions:
 
 1. [ ] Does your submission pass tests?
-2. [ ] Does mvn checkstyle:check pass ?
+2. [ ] Does `./gradlew autostyleCheck checkstyleAll` pass ?
 3. [ ] Have you added your new test classes to an existing test suite in alphabetical order?
 
 ### Changes to Existing Features:


### PR DESCRIPTION
GitHub PR template has the old maven checkstyle commands. This fixes it to reference gradle.