### PR TITLE
fix: autosave=conservative does not cover XX000 cache lookup failed for function

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/QueryExecutorBase.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/QueryExecutorBase.java
@@ -374,6 +374,13 @@ public abstract class QueryExecutorBase implements QueryExecutor {
       return false;
     }
 
+    // "cache lookup failed for function"
+    if (PSQLState.INTERNAL_ERROR.getState().equals(e.getSQLState())
+        && e.getMessage() != null
+        && e.getMessage().startsWith("cache lookup failed for function")) {
+      return true;
+    }
+
     if (!(e instanceof PSQLException)) {
       return false;
     }

--- a/pgjdbc/src/main/java/org/postgresql/util/PSQLState.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/PSQLState.java
@@ -103,7 +103,9 @@ public enum PSQLState {
   SYSTEM_ERROR("60000"),
   IO_ERROR("58030"),
 
-  UNEXPECTED_ERROR("99999");
+  UNEXPECTED_ERROR("99999"),
+
+  INTERNAL_ERROR("XX000");
 
   private final String state;
 


### PR DESCRIPTION
In come rare cases PostgreSQL backend could return error XX000 cache lookup failed for function <oid>.
This error not reproduced after rolling back to savepoint just before query, so autosave=conservative could fix it.

Closes #1786

### All Submissions:

* [+] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [+] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes to Existing Features:

* [-] Does this break existing behaviour? If so please explain.
* [+] Have you added an explanation of what your changes do and why you'd like us to include them?
* [-] Have you written new tests for your core changes, as applicable?
* [*] Have you successfully run tests with your changes locally?
`2471 tests completed, 61 failed, 77 skipped`, the same result before and after changes.
AutoRollbackTestSuite is not present in testing logs and I didn't managed to run it.