### PR TITLE
Nanosecond part of binary-received float8-timestamp needs to be rounded.

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/TimestampUtils.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/TimestampUtils.java
@@ -1148,7 +1148,7 @@ public class TimestampUtils {
       }
 
       secs = (long) time;
-      nanos = (int) Math.round(((time - secs) * 1000000));
+      nanos = (int) ((time - secs) * 1000000 + 0.5);
     } else {
       long time = ByteConverter.int8(bytes, 0);
 

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/TimestampUtils.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/TimestampUtils.java
@@ -1148,7 +1148,7 @@ public class TimestampUtils {
       }
 
       secs = (long) time;
-      nanos = (int) ((time - secs) * 1000000);
+      nanos = (int) Math.round(((time - secs) * 1000000));
     } else {
       long time = ByteConverter.int8(bytes, 0);
 

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BinaryTransferTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BinaryTransferTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2020, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.test.jdbc2;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
+
+import org.postgresql.test.TestUtil;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Properties;
+
+/**
+ * Tests binaryTransfer.
+ */
+public class BinaryTransferTest {
+  /**
+   * The name of the test table.
+   */
+  private static final String TEST_TABLE = "testbintrans";
+
+  private Connection con;
+
+  @Before
+  public void setUp() throws Exception {
+    Properties props = new Properties();
+    props.setProperty("binaryTransfer", Boolean.TRUE.toString());
+    con = TestUtil.openDB(props);
+    TestUtil.createTable(con, TEST_TABLE, "ts timestamp");
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    TestUtil.dropTable(con, TEST_TABLE);
+    TestUtil.closeDB(con);
+  }
+
+  /**
+   * Verifies that timestamps are correctly transferred in binary
+   * transfer mode.  Mainly intended for float-timestamps.
+   *
+   * @throws SQLException if a JDBC or database problem occurs.
+   */
+  @Test
+  public void verifyFloatTimestampTransfer() throws SQLException {
+    Statement stmt = con.createStatement();
+    ResultSet rs = stmt.executeQuery("SELECT setting FROM pg_settings WHERE name = 'integer_datetimes'");
+    assertTrue(rs.next());
+
+    boolean is_float_datetime = !rs.getBoolean(1);
+    rs.close();
+	assumeTrue(is_float_datetime);
+
+    String targettime = "2020-01-01 00:00:00.464";
+    String inssql = "INSERT INTO " + TEST_TABLE
+        + " VALUES ('" + targettime + "'::timestamp)";
+    String selsql = "SELECT ts FROM " + TEST_TABLE;
+
+    // Insert the timestamp as casted strings.
+    assertEquals(stmt.executeUpdate(inssql), 1);
+
+    // Insert the timestamps as PGTimestamp objects.
+    PreparedStatement pstmt = con.prepareStatement(selsql);
+
+	// Make sure to run server-side prepare
+	int repeats = TestUtil.getPrepareThreshold() + 1;
+    for (int i = 0 ; i < repeats ; i++) {
+      rs = pstmt.executeQuery();
+      assertTrue(rs.next());
+      assertEquals(rs.getTimestamp(1).toString(), targettime);
+    }
+
+    // Clean up.
+    assertEquals(1, stmt.executeUpdate("DELETE FROM " + TEST_TABLE));
+    stmt.close();
+    pstmt.close();
+  }
+}


### PR DESCRIPTION
If a float8-timestamp is received on a binaryTransfer connection, its
nanosecond part is just truncated in toParsedTimestampBinPlain. If the
result of the subtraction just before gets slightly smaller, the
result gets smaller by 1 microsecond. Nanosecond part is rounded off
on server side so it should be handled the same way.

This problem can be seen by the following steps, with pgjdbc versions from 9_2 where binaryTransfer was introduced.

Create a table on a PostgreSQL server built with --disable-integer-datetimes:
CREATE TABLE t AS (SELECT '2020-6-5 0:0:0.464'::timestamp as a);

Access by a program like the follows:
    public static void main (String args[]) {

     String url = "jdbc:postgresql:postgres?binaryTransfer=true"; // URL

     try {
       Class.forName("org.postgresql.Driver");
       Connection con = DriverManager.getConnection(url);
       PreparedStatement pst = con.prepareStatement("SELECT a from t;");
       for (int i = 0 ; i < 6 ; i++) {
         ResultSet rs = pst.executeQuery();
         while (rs.next())
           System.out.format("%d: %s\n", i, rs.getTimestamp(1).toString());
         rs.close();
       }

You should see the following result. The last one is the issue here.

    0: 2020-06-05 00:00:00.464
    1: 2020-06-05 00:00:00.464
    2: 2020-06-05 00:00:00.464
    3: 2020-06-05 00:00:00.464
    4: 2020-06-05 00:00:00.464
    5: 2020-06-05 00:00:00.463999
reagrds.

