### PR TITLE
Fix some changelog formatting and add link to XXE fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ We recommend that version 42.2.11 not be used.
 
 ## [42.2.11] (2020-03-07)
 
-** Notable **
+**Notable changes**
 As mentioned above this version is broken and should not be used.
 ### Changed
  - Reverted [PR 1641](https://github.com/pgjdbc/pgjdbc/pull/1252). The driver will now wait for EOF when sending cancel signals. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## [42.2.13] (2020-06-04)
 
 **Notable Changes**
-The primary reason to release this version and to continue the 42.2.x branch is for CVE-2020-13692.
-Reported by David Dworken this is an XXE and more information can be found [here](https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html)
-Sehrope Sarkuni reworked the XML parsing to provide a solution in commit 14b62aca4 
-The build system has been changed to Gradle thanks to Vladimir [PR 1627](https://github.com/pgjdbc/pgjdbc/pull/1627)
+
+- Security: The primary reason to release this version and to continue the 42.2.x branch is for CVE-2020-13692.
+Reported by David Dworken, this is an XXE and more information can be found [here](https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html).
+Sehrope Sarkuni reworked the XML parsing to provide a solution in commit [14b62aca4](https://github.com/pgjdbc/pgjdbc/commit/14b62aca4764d496813f55a43d050b017e01eb65).
+- The build system has been changed to Gradle thanks to Vladimir [PR 1627](https://github.com/pgjdbc/pgjdbc/pull/1627).
 
 ### Changed
 


### PR DESCRIPTION
This updates the latest changelog entry to clean up some formatting and add links to the fix commit in the latest changelog entry. The other commit also fixes a missing bold heading on an older entry.

Related, would have been nice if the merge commit for the fix had a better title. Seeing "*Merge pull request from GHSA-37xm-4h3m-5w3v*" isn't particularly descriptive when you're scanning commit headings.

Not worth rewriting history for it, but going forward would be good to either rebase and add the actual commits for PRs (if they're individually relevant) or manually update merge titles so they reflect something meaningful at merge time (if they're a bunch of commits that only make sense in tandem).