### PR TITLE
chore: skip caching .gradle/wrapper at Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,7 +80,8 @@ install: true
 cache:
   directories:
     - $HOME/.gradle/caches/
-    - $HOME/.gradle/wrapper/
+    # Gradle can be downloaded via wrapper, so no need to download it from the cache and upload as cache changes
+    # - $HOME/.gradle/wrapper/
     - $HOME/.m2/repository
     - $HOME/.ivy2/cache
     - $HOME/.sbt/boot/


### PR DESCRIPTION
Let's see if it improves Travis performance