### PR TITLE
test: reduce stdout verbosity of CopyLargeFileTest

### DIFF
--- a/pgjdbc/src/test/java/org/postgresql/test/util/StrangeInputStream.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/util/StrangeInputStream.java
@@ -16,15 +16,10 @@ import java.util.Random;
  * array. This allows to stress test {@link org.postgresql.copy.CopyManager} or other consumers.
  */
 public class StrangeInputStream extends FilterInputStream {
-  private Random rand; // generator of fun events
+  private final Random rand = new Random(); // generator of fun events
 
-  public StrangeInputStream(InputStream is) throws FileNotFoundException {
+  public StrangeInputStream(InputStream is, long seed) throws FileNotFoundException {
     super(is);
-    rand = new Random();
-    long seed = Long.getLong("StrangeInputStream.seed", System.currentTimeMillis());
-    System.out
-        .println("Using seed = " + seed + " for StrangeInputStream. Set -DStrangeInputStream.seed="
-            + seed + " to reproduce the test");
     rand.setSeed(seed);
   }
 


### PR DESCRIPTION
The messages should be printed only in case of failure:

```
   Using seed = 1595149058158 for StrangeInputStream. Set -DStrangeInputStream.seed=1595149058158 to reproduce the test
    Using seed = 1595149058580 for StrangeInputStream. Set -DStrangeInputStream.seed=1595149058580 to reproduce the test
    Using seed = 1595149059017 for StrangeInputStream. Set -DStrangeInputStream.seed=1595149059017 to reproduce the test
    Using seed = 1595149059459 for StrangeInputStream. Set -DStrangeInputStream.seed=1595149059459 to reproduce the test
    Using seed = 159514
```
