### PR TITLE
Build cache

### DIFF
--- a/.github/workflows/buildcache.yml
+++ b/.github/workflows/buildcache.yml
@@ -1,0 +1,35 @@
+name: Seed build cache
+
+on:
+  push:
+    branches:
+      - '*'
+
+jobs:
+  ubuntu-code-style:
+    strategy:
+      matrix:
+        os: [ubuntu, macos, windows]
+        jdk: [8, 11]
+
+    name: '${{ matrix.os }}, ${{ matrix.jdk }} seed build cache'
+    runs-on: ${{ matrix.os }}-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 50
+      - name: 'Set up JDK ${{ matrix.jdk }}'
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.jdk }}
+      - uses: actions/cache@v2
+        name: Cache ./gradle/caches/
+        with:
+          path: |
+            ~/.gradle/caches/
+          key: gradle-${{ runner.os }}-caches-${{ hashFiles('build.properties', '**/*.gradle.kts', 'gradle/wrapper/gradle-wrapper.properties') }}
+      - name: Build pgjdbc
+        env:
+          S3_BUILD_CACHE_ACCESS_KEY_ID: ${{ secrets.S3_BUILD_CACHE_ACCESS_KEY_ID }}
+          S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.S3_BUILD_CACHE_SECRET_KEY }}
+        run: ./gradlew build -x test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,16 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 8
+    - uses: actions/cache@v2
+      name: Cache ./gradle/caches/
+      with:
+        path: |
+          ~/.gradle/caches/
+        key: gradle-${{ runner.os }}-caches-${{ hashFiles('build.properties', '**/*.gradle.kts', 'gradle/wrapper/gradle-wrapper.properties') }}
     - name: 'Verify code style'
+      env:
+        S3_BUILD_CACHE_ACCESS_KEY_ID: ${{ secrets.S3_BUILD_CACHE_ACCESS_KEY_ID }}
+        S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.S3_BUILD_CACHE_SECRET_KEY }}
       run: ./gradlew autostyleCheck checkstyleAll
 
   ubuntu-latest:
@@ -61,7 +70,16 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 8
+    - uses: actions/cache@v2
+      name: Cache ./gradle/caches/
+      with:
+        path: |
+          ~/.gradle/caches/
+        key: gradle-${{ runner.os }}-caches-${{ hashFiles('build.properties', '**/*.gradle.kts', 'gradle/wrapper/gradle-wrapper.properties') }}
     - name: 'Test'
+      env:
+        S3_BUILD_CACHE_ACCESS_KEY_ID: ${{ secrets.S3_BUILD_CACHE_ACCESS_KEY_ID }}
+        S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.S3_BUILD_CACHE_SECRET_KEY }}
       run: |
         echo enable_ssl_tests=true > ssltest.local.properties
         # '-PincludeTestTags=!org.postgresql.test.SlowTests'
@@ -79,7 +97,16 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 11
+      - uses: actions/cache@v2
+        name: Cache ./gradle/caches/
+        with:
+          path: |
+            ~/.gradle/caches/
+          key: gradle-${{ runner.os }}-caches-${{ hashFiles('build.properties', '**/*.gradle.kts', 'gradle/wrapper/gradle-wrapper.properties') }}
       - name: 'Run CheckerFramework'
+        env:
+          S3_BUILD_CACHE_ACCESS_KEY_ID: ${{ secrets.S3_BUILD_CACHE_ACCESS_KEY_ID }}
+          S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.S3_BUILD_CACHE_SECRET_KEY }}
         run: |
           ./gradlew --no-parallel --no-daemon -PenableCheckerframework classes
 
@@ -97,6 +124,12 @@ jobs:
       run: sudo apt -y install krb5-kdc krb5-admin-server libkrb5-dev postgresql-12
     - name: 'Update hosts'
       run: sudo -- sh -c "echo 127.0.0.1 auth-test-localhost.postgresql.example.com >> /etc/hosts"
+    - uses: actions/cache@v2
+      name: Cache ./gradle/caches/
+      with:
+        path: |
+          ~/.gradle/caches/
+        key: gradle-${{ runner.os }}-caches-${{ hashFiles('build.properties', '**/*.gradle.kts', 'gradle/wrapper/gradle-wrapper.properties') }}
     - name: 'Build pgjdbc'
       run:  ./gradlew publishToMavenLocal -Ppgjdbc.version=1.0.0-dev-master -PskipJavadoc
     - name: 'Run tests'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,7 +83,7 @@ jobs:
       run: |
         echo enable_ssl_tests=true > ssltest.local.properties
         # '-PincludeTestTags=!org.postgresql.test.SlowTests'
-        ./gradlew --no-parallel --no-daemon -PskipReplicationTests -Pport=${{ job.services.postgres.ports['5432'] }} test
+        ./gradlew --scan --no-parallel --no-daemon -PskipReplicationTests -Pport=${{ job.services.postgres.ports['5432'] }} test
         # test javadoc -Pport=${{ job.services.postgres.ports['5432'] }}
 
   linux-checkerframework:

--- a/.travis.yml
+++ b/.travis.yml
@@ -102,6 +102,7 @@ matrix:
         - PG_VERSION=10
         - JDK=12
         - TZ=America/New_York # flips between −05:00 and −04:00
+        - BUILD_SCAN=Y
     - jdk: openjdk-ea
       sudo: required
       addons:
@@ -134,6 +135,7 @@ matrix:
         - NO_HSTORE=Y
         - PLPGSQL_EXTENSION=Y
         - JDK=8
+        - BUILD_SCAN=Y
     - jdk: oraclejdk11
       sudo: required
       addons:

--- a/.travis/travis_build.sh
+++ b/.travis/travis_build.sh
@@ -50,6 +50,11 @@ then
     GRADLE_ARGS="$GRADLE_ARGS -Dcurrent.jdk=1.9 -Djavac.target=1.9"
 fi
 
+if [[ $BUILD_SCAN == "Y" ]];
+then
+    GRADLE_ARGS="$GRADLE_ARGS --scan"
+fi
+
 if [[ $JDOC == "Y" ]];
 then
     # Build javadocs for Java 8 only

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -211,9 +211,6 @@ allprojects {
             // TOOD: move to /config
             configDirectory.set(File(rootDir, "pgjdbc/src/main/checkstyle"))
             configFile = configDirectory.get().file("checks.xml").asFile
-            configProperties = mapOf(
-                "base_dir" to rootDir.toString()
-            )
         }
         tasks.register("checkstyleAll") {
             dependsOn(tasks.withType<Checkstyle>())

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,7 @@ plugins {
     id("org.owasp.dependencycheck")
     id("org.checkerframework") apply false
     id("com.github.johnrengelman.shadow") apply false
+    id("org.nosphere.gradle.github.actions")
     // IDE configuration
     id("org.jetbrains.gradle.plugin.idea-ext")
     id("com.github.vlsi.ide")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,8 @@
 org.gradle.parallel=true
+# Build cache can be disabled with --no-build-cache option
+org.gradle.caching=true
+#org.gradle.caching.debug=true
+s3.build.cache=true
 
 # See https://github.com/gradle/gradle/pull/11358
 # repository.apache.org does not yet support .sha256 and .sha512 checksums
@@ -24,6 +28,7 @@ pgjdbc.version=42.2.15
 # Plugins
 biz.aQute.bnd.builder.version=4.3.1
 com.github.autostyle.version=3.1
+com.github.burrunan.s3-build-cache.version=1.1
 com.github.johnrengelman.shadow.version=5.1.0
 com.github.lburgazzoli.karaf.version=0.5.1
 com.github.spotbugs.version=2.0.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -37,6 +37,7 @@ kotlin.version=1.3.70
 me.champeau.gradle.jmh.version=0.5.0
 org.checkerframework.version=0.5.5
 org.jetbrains.gradle.plugin.idea-ext.version=0.7
+org.nosphere.gradle.github.actions.version=1.2.0
 org.owasp.dependencycheck.version=5.3.0
 
 # Tools

--- a/pgjdbc/build.gradle.kts
+++ b/pgjdbc/build.gradle.kts
@@ -74,6 +74,12 @@ if (skipReplicationTests) {
     }
 }
 
+tasks.configureEach<Test> {
+    outputs.cacheIf("test results on the database configuration, so we can't cache it") {
+        false
+    }
+}
+
 val preprocessVersion by tasks.registering(org.postgresql.buildtools.JavaCommentPreprocessorTask::class) {
     baseDir.set(projectDir)
     sourceFolders.add("src/main/version")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -23,12 +23,14 @@ pluginManagement {
         idv("me.champeau.gradle.jmh")
         idv("org.checkerframework")
         idv("org.jetbrains.gradle.plugin.idea-ext")
+        idv("org.nosphere.gradle.github.actions")
         idv("org.owasp.dependencycheck")
         kotlin("jvm") version "kotlin".v()
     }
 }
 
 plugins {
+    `gradle-enterprise`
     id("com.github.burrunan.s3-build-cache")
 }
 
@@ -57,6 +59,16 @@ fun property(name: String) =
     }
 
 val isCiServer = System.getenv().containsKey("CI")
+
+if (isCiServer) {
+    gradleEnterprise {
+        buildScan {
+            termsOfServiceUrl = "https://gradle.com/terms-of-service"
+            termsOfServiceAgree = "yes"
+            tag("CI")
+        }
+    }
+}
 
 // Cache build artifacts, so expensive operations do not need to be re-computed
 buildCache {


### PR DESCRIPTION
This PR adds caching to CI jobs, and it collects `Gradle Build Scan` for some of the jobs.

1) [Gradle Build Cache](https://docs.gradle.org/current/userguide/build_cache.html#sec:build_cache_configure) caches task outputs (e.g. compilation results, Javadoc, Checkstyle, etc. That means it could download task output from the remote build cache (see `FROM-CACHE` task status).

    Remote cache is populated by GitHub Actions / Travis CI jobs. Otherwise, it is used in a read-only mode.

2) [Gradle Build Scan](https://guides.gradle.org/creating-build-scans/) is a detailed report on the build execution. I've added its collection for certain jobs. For instance, `Ubuntu, PG latest (JDK 8)` Actions CI job.

    See the following at the end of `Test` step:

       BUILD SUCCESSFUL in 6m 27s
       14 actionable tasks: 11 executed, 3 from cache

       Publishing build scan...
       https://gradle.com/s/gvviwmsjbtdle

    https://gradle.com/s/gvviwmsjbtdle