### PR TITLE
fix: make sure socketTimeout is enforced

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java
@@ -100,7 +100,7 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
     // Set the socket timeout if the "socketTimeout" property has been set.
     int socketTimeout = PGProperty.SOCKET_TIMEOUT.getInt(info);
     if (socketTimeout > 0) {
-      newStream.getSocket().setSoTimeout(socketTimeout * 1000);
+      newStream.setNetworkTimeout(socketTimeout * 1000);
     }
 
     String maxResultBuffer = PGProperty.MAX_RESULT_BUFFER.get(info);
@@ -148,6 +148,12 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
       // Construct and send an ssl startup packet if requested.
       newStream = enableSSL(newStream, sslMode, info, connectTimeout);
     }
+
+    // Make sure to set network timeout again, in case the stream changed due to GSS or SSL
+    if (socketTimeout > 0) {
+      newStream.setNetworkTimeout(socketTimeout * 1000);
+    }
+
     List<String[]> paramList = getParametersForStartup(user, database, info);
     sendStartupPacket(newStream, paramList);
 

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/SocketTimeoutTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/SocketTimeoutTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2020, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.test.jdbc2;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.postgresql.PGProperty;
+import org.postgresql.test.TestUtil;
+
+import org.junit.Test;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Properties;
+
+public class SocketTimeoutTest {
+
+  @Test
+  public void testSocketTimeoutEnforcement() throws Exception {
+    Properties properties = new Properties();
+    PGProperty.SOCKET_TIMEOUT.set(properties, 1);
+
+    Connection conn = TestUtil.openDB(properties);
+    Statement stmt = null;
+    try {
+      stmt = conn.createStatement();
+      stmt.execute("SELECT pg_sleep(2)");
+      fail("Connection with socketTimeout did not throw expected exception");
+    } catch (SQLException e) {
+      assertTrue(conn.isClosed());
+    } finally {
+      TestUtil.closeQuietly(stmt);
+      TestUtil.closeDB(conn);
+    }
+  }
+}


### PR DESCRIPTION
fixes #1816 

I have added a failing test for the `socketTimeout` and then made the required changed to `ConnectionFactoryImpl` to make sure the `socketTimeout` is actually set using the `setNetworkTimeout()` method.

One thing I am not sure about, is the fact that the `pgInput` may be recreated when switching to SSL. This requires `ConnectionFactoryImpl` to re-set the `socketTimeout`, but it may be better if `PGStream` makes sure it keeps the `pgInput.timeoutRequested` state when it recreates `pgInput`. But that would require changes in two places (`PGStream.changeSocket()` and `PGStream.setSecContext()`) which does not seem to great either.

I ran the tests and I had no new test failures. I was unable to run the replication tests as it seems the suggested docker-compose file does not have the correct permissions and settings for replication to work.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Does `./gradlew autostyleCheck checkstyleAll` pass ?
3. [x] Have you added your new test classes to an existing test suite in alphabetical order?

### Changes to Existing Features:

* [x] Does this break existing behaviour? If so please explain.
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
