### PR TITLE
fix: assume PKCS-8 SSL key format by default (#1819)

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/ssl/LibPQFactory.java
+++ b/pgjdbc/src/main/java/org/postgresql/ssl/LibPQFactory.java
@@ -121,12 +121,11 @@ public class LibPQFactory extends WrappedFactory {
         defaultfile = true;
         sslkeyfile = defaultdir + "postgresql.pk8";
       }
-      if (sslkeyfile.endsWith("pk8")) {
-        initPk8(sslkeyfile, defaultdir, info);
-      }
 
-      if (sslkeyfile.endsWith("p12")) {
+      if (sslkeyfile.endsWith(".p12") || sslkeyfile.endsWith(".pfx")) {
         initP12(sslkeyfile, info);
+      } else {
+        initPk8(sslkeyfile, defaultdir, info);
       }
 
       TrustManager[] tm;


### PR DESCRIPTION
check for the most common PKCS-12 extensions (.p12, .pfx) and assume
PKCS-8 if these do not match

closes #1819

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
