### PR TITLE
fix: Close existing open result set if a statement is executed again fixes ISSUE #1852

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgStatement.java
@@ -59,7 +59,7 @@ public class PgStatement implements Statement, BaseStatement {
   private boolean closeOnCompletion = false;
   // fetch direction hint (currently ignored)
   protected int fetchdirection = ResultSet.FETCH_FORWARD;
-  private ResultSet currentResultSet = null;
+  private @Nullable ResultSet currentResultSet = null;
 
   /**
    * Protects current statement from cancelTask starting, waiting for a bit, and waking up exactly

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/StatementTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/StatementTest.java
@@ -137,6 +137,19 @@ public class StatementTest {
   }
 
   @Test
+  public void testSecondQueryClosesFirstResultSet() throws SQLException {
+    try (Statement stmt = con.createStatement()) {
+      ResultSet rs = stmt.executeQuery("select 1 as one");
+      assertNotNull(rs);
+      assertTrue(rs.next());
+      try (ResultSet rs2 = stmt.executeQuery("select 2 as two")) {
+        assertNotNull(rs2);
+        assertTrue(rs.isClosed());
+      }
+    }
+  }
+
+  @Test
   public void testUpdateCount() throws SQLException {
     Statement stmt = con.createStatement();
     int count;


### PR DESCRIPTION
Spec says that if we execute a statement more than once the existing result set must be closed