### PR TITLE
Fix PGCopyOutputStream out of order writes

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/copy/PGCopyOutputStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/copy/PGCopyOutputStream.java
@@ -144,6 +144,11 @@ public class PGCopyOutputStream extends OutputStream implements CopyIn {
   }
 
   public void writeToCopy(ByteStreamWriter from) throws SQLException {
+    if (at > 0) {
+      // flush existing buffer so order is preserved
+      getOp().writeToCopy(copyBuffer, 0, at);
+      at = 0;
+    }
     getOp().writeToCopy(from);
   }
 

--- a/pgjdbc/src/test/java/org/postgresql/test/TestUtil.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/TestUtil.java
@@ -952,6 +952,21 @@ public class TestUtil {
   }
 
   /**
+   * Execute a SQL query with a given connection, fetch the first row, and return its
+   * string value.
+   */
+  public static String queryForString(Connection conn, String sql) throws SQLException {
+    Statement stmt = conn.createStatement();
+    ResultSet rs = stmt.executeQuery(sql);
+    Assert.assertTrue("Query should have returned exactly one row but none was found: " + sql, rs.next());
+    String value = rs.getString(1);
+    Assert.assertFalse("Query should have returned exactly one row but more than one found: " + sql, rs.next());
+    rs.close();
+    stmt.close();
+    return value;
+  }
+
+  /**
    * Retrieve the backend process id for a given connection.
    */
   public static int getBackendPid(Connection conn) throws SQLException {


### PR DESCRIPTION
This PR fixes #1777 

It's just a fix for the out of order writes and an additional test for the corrected functionality. It does not deprecate the existing copy classes or add new replacements. We can follow up with that in a subsequent release.
