### PR TITLE
fix: make enum, json, and jsonb array result classes to be the same as 42.2.14 and earlier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,22 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Added
 
 ### Fixed
-- Handle nulls when the following clasess are used: PGbox, PGcircle, PGline, PGlseg, PGpath, PGpoint, PGpolygon, and PGmoney.
+- Avoid NullPointerException when receiving PGbox, PGcircle, PGline, PGlseg, PGpath, PGpoint, PGpolygon, and PGmoney.
+- The driver returns enum and jsonb arrays elements as String objects (like in 42.2.14 and earlier versions) [PR 1879](https://github.com/pgjdbc/pgjdbc/pull/1879). 
 
 ## [42.2.16] (2020-08-20)
+### Known issues
+- The driver returns enum and jsonb arrays elements are returned as PGobject instances (fixed in 42.2.17)
 
 ### Fixed
-- - Arrays sent in binary format are now sent as 1 based. This was a regression for multi-dimensional arrays as well as text/varchar, oid and bytea arrays. 
+- Arrays sent in binary format are now sent as 1 based. This was a regression for multi-dimensional arrays as well as text/varchar, oid and bytea arrays. 
   Since 42.2.0 single dimensional arrays were stored 0 based. They are now sent 1 based which is the SQL standard, and the default 
   for Postgres when sent as strings such as '{1,2,3}'. Fixes [issue 1860](https://github.com/pgjdbc/pgjdbc/issues/1860) in [PR 1863](https://github.com/pgjdbc/pgjdbc/pull/1863).
 
 ## [42.2.15] (2020-08-14)
+### Known issues
+- The driver returns enum and jsonb arrays elements are returned as PGobject instances (fixed in 42.2.17)
+
 ### Changed
 - Rename source distribution archive to `postgresql-$version-jdbc-src.tar.gz`, and add top-level archive folder [ba017507](https://github.com/pgjdbc/pgjdbc/commit/ba0175072ee9c751c1496d2fe170f4af7256f1a5)
 - Add the ability to connect with a GSSAPI encrypted connection. As of PostgreSQL version 12 GSSAPI encrypted connections

--- a/docs/_posts/2020-01-30-42.2.10-release.md
+++ b/docs/_posts/2020-01-30-42.2.10-release.md
@@ -7,8 +7,6 @@ version: 42.2.10
 ---
 **Notable changes**
 
-
-## [42.2.10] (2020-01-30)
 ### Changed
  - (!) Regression: remove receiving EOF from backend after cancel [PR 1641](https://github.com/pgjdbc/pgjdbc/pull/1252). The regression is that the subsequent query might receive the cancel signal.
 

--- a/docs/_posts/2020-03-31-42.2.12-release.md
+++ b/docs/_posts/2020-03-31-42.2.12-release.md
@@ -12,11 +12,6 @@ version: 42.2.12
  This change introduced a breaking change which will be moved to 42.3.0
  - reverted [PR 1719](https://github.com/pgjdbc/pgjdbc/pull/1719)  add support for full names of data types (#1719)
 
-### Added
-
-### Fixed
-
-
 <!--more-->
 
 **Commits by author**

--- a/docs/_posts/2020-06-04-42.2.13-release.md
+++ b/docs/_posts/2020-06-04-42.2.13-release.md
@@ -7,22 +7,11 @@ version: 42.2.13
 ---
 **Notable changes**
 
-### Changed
-
-### Added
-
-### Fixed
-
-## [42.2.13] (2020-06-04)
-
-**Notable Changes**
 The primary reason to release this version and to continue the 42.2.x branch is for CVE-2020-13692.
 Reported by David Dworken this is an XXE and more information can be found [here](https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html)
 Sehrope Sarkuni reworked the XML parsing to provide a solution in commit 14b62aca4 
 The build system has been changed to Gradle thanks to Vladimir [PR 1627](https://github.com/pgjdbc/pgjdbc/pull/1627)
 Regression: com.github.waffle:waffle-jna, org.osgi:org.osgi.core, org.osgi:org.osgi.enterprise dependencies are listed as non-optional [issue 1975](https://github.com/pgjdbc/pgjdbc/issues/1795).
-
-### Changed
 
 ### Added
 - jre-6 was added back to allow us to release fixes for all artifacts in the 42.2.x branch [PR 1787](https://github.com/pgjdbc/pgjdbc/pull/1787)

--- a/docs/_posts/2020-08-14-42.2.15-release.md
+++ b/docs/_posts/2020-08-14-42.2.15-release.md
@@ -7,6 +7,9 @@ version: 42.2.15
 ---
 **Notable changes**
 
+### Known issues
+- The driver returns enum and jsonb arrays elements are returned as PGobject instances (fixed in 42.2.17)
+
 ### Changed
 - Rename source distribution archive to `postgresql-$version-jdbc-src.tar.gz`, and add top-level archive folder [ba017507](https://github.com/pgjdbc/pgjdbc/commit/ba0175072ee9c751c1496d2fe170f4af7256f1a5)
 - Add the ability to connect with a GSSAPI encrypted connection. As of PostgreSQL version 12 GSSAPI encrypted connections

--- a/docs/_posts/2020-08-20-42.2.16-release.md
+++ b/docs/_posts/2020-08-20-42.2.16-release.md
@@ -7,7 +7,8 @@ version: 42.2.16
 ---
 **Notable changes**
 
-## [42.2.16] (2020-08-20)
+### Known issues
+- The driver returns enum and jsonb arrays elements are returned as PGobject instances (fixed in 42.2.17)
 
 ### Fixed
 - Arrays sent in binary format are now sent as 1 based. This was a regression for multi-dimensional arrays as well as text/varchar, oid and bytea arrays. 

--- a/pgjdbc/src/main/java/org/postgresql/core/Oid.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/Oid.java
@@ -72,6 +72,7 @@ public class Oid {
   public static final int POINT = 600;
   public static final int POINT_ARRAY = 1017;
   public static final int BOX = 603;
+  public static final int JSONB = 3802;
   public static final int JSONB_ARRAY = 3807;
   public static final int JSON = 114;
   public static final int JSON_ARRAY = 199;

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/ArrayDecoding.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/ArrayDecoding.java
@@ -27,6 +27,7 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
+import java.sql.Types;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -374,13 +375,16 @@ final class ArrayDecoding {
     OID_TO_DECODER.put(Oid.FLOAT4, FLOAT_OBJ_ARRAY);
     OID_TO_DECODER.put(Oid.TEXT, STRING_ARRAY);
     OID_TO_DECODER.put(Oid.VARCHAR, STRING_ARRAY);
+    // 42.2.x decodes jsonb array as String rather than PGobject
+    OID_TO_DECODER.put(Oid.JSONB, STRING_ONLY_DECODER);
     OID_TO_DECODER.put(Oid.BIT, BOOLEAN_OBJ_ARRAY);
     OID_TO_DECODER.put(Oid.BOOL, BOOLEAN_OBJ_ARRAY);
     OID_TO_DECODER.put(Oid.BYTEA, BYTE_ARRAY_ARRAY);
     OID_TO_DECODER.put(Oid.NUMERIC, BIG_DECIMAL_STRING_DECODER);
     OID_TO_DECODER.put(Oid.BPCHAR, STRING_ONLY_DECODER);
     OID_TO_DECODER.put(Oid.CHAR, STRING_ONLY_DECODER);
-    OID_TO_DECODER.put(Oid.JSON, STRING_ONLY_DECODER);
+    // 42.2.x decodes json array as PGobject rather than String
+    // OID_TO_DECODER.put(Oid.JSON, STRING_ONLY_DECODER);
     OID_TO_DECODER.put(Oid.DATE, DATE_DECODER);
     OID_TO_DECODER.put(Oid.TIME, TIME_DECODER);
     OID_TO_DECODER.put(Oid.TIMETZ, TIME_DECODER);
@@ -469,6 +473,12 @@ final class ArrayDecoding {
     final String typeName = connection.getTypeInfo().getPGType(oid);
     if (typeName == null) {
       throw org.postgresql.Driver.notImplemented(PgArray.class, "readArray(data,oid)");
+    }
+
+    // 42.2.x should return enums as strings
+    int type = connection.getTypeInfo().getSQLType(typeName);
+    if (type == Types.CHAR || type == Types.VARCHAR) {
+      return (ArrayDecoder<A>) STRING_ONLY_DECODER;
     }
 
     return (ArrayDecoder<A>) new MappedTypeObjectArrayDecoder(typeName);

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/EnumTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/EnumTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2020, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.test.jdbc2;
+
+import org.postgresql.test.TestUtil;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.sql.Array;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+
+@RunWith(Parameterized.class)
+public class EnumTest extends BaseTest4 {
+  public EnumTest(BinaryMode binaryMode) {
+    setBinaryMode(binaryMode);
+  }
+
+  @Parameterized.Parameters(name = "binary = {0}")
+  public static Iterable<Object[]> data() {
+    Collection<Object[]> ids = new ArrayList<Object[]>();
+    for (BinaryMode binaryMode : BinaryMode.values()) {
+      ids.add(new Object[]{binaryMode});
+    }
+    return ids;
+  }
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    TestUtil.createEnumType(con, "flag", "'duplicate','spike','new'");
+  }
+
+  @Override
+  public void tearDown() throws SQLException {
+    TestUtil.dropType(con, "flag");
+    super.tearDown();
+  }
+
+  @Test
+  public void enumArray() throws SQLException {
+    PreparedStatement pstmt = con.prepareStatement("SELECT '{duplicate,new}'::flag[]");
+    ResultSet rs = pstmt.executeQuery();
+    rs.next();
+    Array array = rs.getArray(1);
+    Assert.assertNotNull("{duplicate,new} should come up as a non-null array", array);
+    Object[] objectArray = (Object[]) array.getArray();
+    Assert.assertEquals(
+        "{duplicate,new} should come up as Java array with two entries",
+        "[duplicate, new]",
+        Arrays.deepToString(objectArray)
+    );
+
+    Assert.assertEquals(
+        "Enum array entries should come up as strings",
+        "java.lang.String, java.lang.String",
+        objectArray[0].getClass().getName() + ", " + objectArray[1].getClass().getName()
+    );
+    rs.close();
+    pstmt.close();
+  }
+
+  @Test
+  public void enumArrayArray() throws SQLException {
+    String value = "{{duplicate,new},{spike,spike}}";
+    PreparedStatement pstmt = con.prepareStatement("SELECT '" + value + "'::flag[][]");
+    ResultSet rs = pstmt.executeQuery();
+    rs.next();
+    Array array = rs.getArray(1);
+    Assert.assertNotNull(value + " should come up as a non-null array", array);
+    Object[] objectArray = (Object[]) array.getArray();
+    Assert.assertEquals(
+        value + " should come up as Java array with two entries",
+        "[[duplicate, new], [spike, spike]]",
+        Arrays.deepToString(objectArray)
+    );
+
+    Assert.assertEquals(
+        "Enum array entries should come up as strings",
+        "[Ljava.lang.String;, [Ljava.lang.String;",
+        objectArray[0].getClass().getName() + ", " + objectArray[1].getClass().getName()
+    );
+    rs.close();
+    pstmt.close();
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc4/JsonbTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc4/JsonbTest.java
@@ -11,16 +11,37 @@ import static org.junit.Assert.assertTrue;
 import org.postgresql.core.ServerVersion;
 import org.postgresql.test.TestUtil;
 import org.postgresql.test.jdbc2.BaseTest4;
+import org.postgresql.util.PGobject;
 
+import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+import java.sql.Array;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 
+@RunWith(Parameterized.class)
 public class JsonbTest extends BaseTest4 {
+  public JsonbTest(BinaryMode binaryMode) {
+    setBinaryMode(binaryMode);
+  }
+
+  @Parameterized.Parameters(name = "binary = {0}")
+  public static Iterable<Object[]> data() {
+    Collection<Object[]> ids = new ArrayList<Object[]>();
+    for (BinaryMode binaryMode : BinaryMode.values()) {
+      ids.add(new Object[]{binaryMode});
+    }
+    return ids;
+  }
 
   @Override
   public void setUp() throws Exception {
@@ -57,6 +78,37 @@ public class JsonbTest extends BaseTest4 {
     ResultSet rs = stmt.executeQuery();
     assertTrue(rs.next());
     assertEquals(2, rs.getInt(1));
+    rs.close();
+    stmt.close();
+  }
+
+  @Test
+  public void jsonbArray() throws SQLException {
+    jsonArrayGet("jsonb", String.class);
+  }
+
+  @Test
+  public void jsonArray() throws SQLException {
+    jsonArrayGet("json", PGobject.class);
+  }
+
+  private void jsonArrayGet(String type, Class<?> arrayElement) throws SQLException {
+    PreparedStatement stmt = con.prepareStatement("SELECT '{[2],[3]}'::" + type + "[]");
+    ResultSet rs = stmt.executeQuery();
+    assertTrue(rs.next());
+    Array array = rs.getArray(1);
+    Object[] objectArray = (Object[]) array.getArray();
+    Assert.assertEquals(
+        "'{[2],[3]}'::" + type + "[] should come up as Java array with two entries",
+        "[[2], [3]]",
+        Arrays.deepToString(objectArray)
+    );
+
+    Assert.assertEquals(
+        type + " array entries should come up as strings",
+        arrayElement.getName() + ", " + arrayElement.getName(),
+        objectArray[0].getClass().getName() + ", " + objectArray[1].getClass().getName()
+    );
     rs.close();
     stmt.close();
   }


### PR DESCRIPTION
```
enum[] => String[]
jsonb[] => String[]
json[] => PGobject[]
```

fixes #1876