### PR TITLE
fix: PgTokenizer was ignoring last empty token

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/util/PGtokenizer.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/PGtokenizer.java
@@ -59,9 +59,9 @@ public class PGtokenizer {
     int s;
     boolean skipChar = false;
     boolean nestedDoubleQuote = false;
-
+    char c=(char)0;
     for (p = 0, s = 0; p < string.length(); p++) {
-      char c = string.charAt(p);
+      c = string.charAt(p);
 
       // increase nesting if an open character is found
       if (c == '(' || c == '[' || c == '<' || (!nestedDoubleQuote && !skipChar && c == '"')) {
@@ -93,7 +93,9 @@ public class PGtokenizer {
     if (s < string.length()) {
       tokens.add(string.substring(s));
     }
-
+    if ( s == string.length() && c==delim) {
+      tokens.add("");
+    }
     return tokens.size();
   }
 

--- a/pgjdbc/src/test/java/org/postgresql/util/PGtokenizerTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/util/PGtokenizerTest.java
@@ -1,0 +1,36 @@
+package org.postgresql.util;
+
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+
+import java.util.StringTokenizer;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PGtokenizerTest {
+
+  @Test
+  void tokenize() {
+    PGtokenizer pGtokenizer = new PGtokenizer("1,2EC1830300027,1,,",',');
+    assertEquals(5,pGtokenizer.getSize());
+
+  }
+
+  @Test
+  void removePara() {
+    String string = PGtokenizer.removePara("(1,2EC1830300027,1,,)");
+    Assert.assertEquals("1,2EC1830300027,1,,", string);
+  }
+
+  @Test
+  void removeBox() {
+  }
+
+  @Test
+  void removeAngle() {
+  }
+
+  @Test
+  void removeCurlyBrace() {
+  }
+}


### PR DESCRIPTION
Fixes #1881 
Added tests and now check for last empty token