### PR TITLE
Allow Clobs to be based on text and Blobs on bytea

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ In addition to the standard connection parameters the driver supports a number o
 | escapeSyntaxCallMode          | String  | select  | Specifies how JDBC escape call syntax is transformed into underlying SQL (CALL/SELECT), for invoking procedures or functions (requires server version >= 11), possible values: select, callIfNoReturn, call |
 | maxResultBuffer               | String  | null    | Specifies size of result buffer in bytes, which can't be exceeded during reading result set. Can be specified as particular size (i.e. "100", "200M" "2G") or as percent of max heap memory (i.e. "10p", "20pct", "50percent") |
 | gssEncMode                    | String  | prefer  | Controls the preference for using GSSAPI encryption for the connection,  values are disable, allow, prefer, and require |
+| lobVarlena                    | Boolean | false   | Treat Clobs as text and Blobs as bytea, instead of treating both as LargeObjects |
 
 ## Contributing
 For information on how to contribute to the project see the [Contributing Guidelines](CONTRIBUTING.md)

--- a/docs/documentation/head/connect.md
+++ b/docs/documentation/head/connect.md
@@ -532,6 +532,12 @@ Connection conn = DriverManager.getConnection(url);
     A limit during setting of property is 90% of max heap memory. All given values, which gonna be higher than limit, gonna lowered to the limit.
     
 	By default, maxResultBuffer is not set (is null), what means that reading of results gonna be performed without limits.
+
+* **lobVarlena** = boolean
+
+    When true, Clobs are treated as text/varchar fields, and Blobs as bytea fields, instead of treating both as Large Objects,
+
+    By default lobVarlena is false.
 	
 <a name="unix sockets"></a>
 ## Unix sockets

--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -252,6 +252,16 @@ public enum PGProperty {
     "If disabled hosts are connected in the given order. If enabled hosts are chosen randomly from the set of suitable candidates"),
 
   /**
+   * Use the Clob/Blob API for text/bytea fields (if true) or for Postgres
+   * Large Objects (if false). Default is false.
+   */
+  LOB_VARLENA(
+              "lobVarlena",
+              null,
+              "Treat CLOB/BLOB as text/bytea rather than as PostgreSQL Large Objects",
+              false),
+
+  /**
    * <p>File name output of the Logger, if set, the Logger will use a
    * {@link java.util.logging.FileHandler} to write to a specified file. If the parameter is not set
    * or the file can't be created the {@link java.util.logging.ConsoleHandler} will be used instead.</p>

--- a/pgjdbc/src/main/java/org/postgresql/core/BaseConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/BaseConnection.java
@@ -228,4 +228,9 @@ public interface BaseConnection extends PGConnection, Connection {
    * @throws SQLException if the class cannot be found or instantiated.
    */
   PGXmlFactoryFactory getXmlFactoryFactory() throws SQLException;
+
+  /**
+   * Returns the lobVarlena connection setting.
+   */
+  boolean getLobVarlena();
 }

--- a/pgjdbc/src/main/java/org/postgresql/core/BaseConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/BaseConnection.java
@@ -231,6 +231,9 @@ public interface BaseConnection extends PGConnection, Connection {
 
   /**
    * Returns the lobVarlena connection setting.
+   *
+   * @return Indication that the connection is using varlena-backed Clob/Blob
+   * @see PGProperty#LOB_VARLENA
    */
   boolean getLobVarlena();
 }

--- a/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
+++ b/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
@@ -864,6 +864,22 @@ public abstract class BaseDataSource implements CommonDataSource, Referenceable 
   }
 
   /**
+   * @return true iff using varlena types for Clob/Blob API instead of LOs
+   * @see PGProperty#LOB_VARLENA
+   */
+  public boolean getLobVarlena() {
+    return PGProperty.LOB_VARLENA.getBoolean(properties);
+  }
+
+  /**
+   * @param useVarlena use varlena types for Clob/Blob API instead of LOs
+   * @see PGProperty#LOB_VARLENA
+   */
+  public void setLobVarlena(boolean useVarlena) {
+    PGProperty.LOB_VARLENA.set(properties, useVarlena);
+  }
+
+  /**
    * @return true if column sanitizer is disabled
    * @see PGProperty#DISABLE_COLUMN_SANITISER
    */

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgBlobBytea.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgBlobBytea.java
@@ -43,7 +43,7 @@ public class PgBlobBytea implements java.sql.Blob {
   // This method frees the Blob object and releases the resources that it holds.
   @Override
   public void	free() 	 {
-    this.data = null;
+    this.data = new byte[0];
   }
 
   // Retrieves the BLOB value designated by this Blob instance as a stream.
@@ -52,7 +52,7 @@ public class PgBlobBytea implements java.sql.Blob {
     if (this.data != null) {
       return new ByteArrayInputStream(this.data);
     }
-    return null;
+    return new ByteArrayInputStream(new byte[0]);
   }
 
   // Returns an InputStream object that contains a partial Blob value,
@@ -60,7 +60,7 @@ public class PgBlobBytea implements java.sql.Blob {
   @Override
   public InputStream getBinaryStream​(long pos, long length) throws SQLException {
     if (this.data == null) {
-      return null;
+      return new ByteArrayInputStream(new byte[0]);
     }
     if (pos < 1) {
       throw new PSQLException(GT.tr("invalid pos parameter {0}", pos),
@@ -80,7 +80,8 @@ public class PgBlobBytea implements java.sql.Blob {
   @Override
   public byte[]	getBytes​(long pos, int length) throws SQLException {
     if (this.data == null) {
-      return null;
+      throw new PSQLException(GT.tr("called getBytes on null Blob"),
+                              PSQLState.INVALID_PARAMETER_VALUE);
     }
     if (pos < 1) {
       throw new PSQLException(GT.tr("invalid pos parameter {0}", pos),

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgBlobBytea.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgBlobBytea.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2004, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+/*
+ * Implementation of Blob interface backed by Postgres bytea fields.
+ *
+ * See PgBlob.java for implementation using Postgres Large Objects.
+ */
+
+package org.postgresql.jdbc;
+
+import org.postgresql.util.GT;
+import org.postgresql.util.PSQLException;
+import org.postgresql.util.PSQLState;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.sql.Blob;
+import java.sql.SQLException;
+import java.util.Arrays;
+
+public class PgBlobBytea implements java.sql.Blob {
+
+  private byte[] data;
+
+  public static final int MAX_BYTES = 1073741824; // 1GiB max size of a bytea
+
+  public PgBlobBytea() {
+    this.data = new byte[0];
+  }
+
+  public PgBlobBytea(byte[] in) throws SQLException {
+    if (in.length > MAX_BYTES) {
+      throw new PSQLException(GT.tr("input data too long for bytea type Blob {0}", in.length),
+                              PSQLState.INVALID_PARAMETER_VALUE);
+    }
+    this.data = in;
+  }
+
+  // This method frees the Blob object and releases the resources that it holds.
+  @Override
+  public void	free() 	 {
+    this.data = null;
+  }
+
+  // Retrieves the BLOB value designated by this Blob instance as a stream.
+  @Override
+  public InputStream getBinaryStream() {
+    if (this.data != null) {
+      return new ByteArrayInputStream(this.data);
+    }
+    return null;
+  }
+
+  // Returns an InputStream object that contains a partial Blob value,
+  // starting with the byte specified by pos, which is length bytes in length.
+  @Override
+  public InputStream getBinaryStream​(long pos, long length) throws SQLException {
+    if (this.data == null) {
+      return null;
+    }
+    if (pos < 1) {
+      throw new PSQLException(GT.tr("invalid pos parameter {0}", pos),
+                              PSQLState.INVALID_PARAMETER_VALUE);
+    }
+    if (length < 0 || pos + length - 1 > data.length) {
+      throw new PSQLException(GT.tr("invalid length parameter {0}", length),
+                              PSQLState.INVALID_PARAMETER_VALUE);
+    }
+    byte [] part = new byte[(int)length];
+    System.arraycopy(this.data, (int) pos - 1, part, 0, (int) length);
+    return new ByteArrayInputStream(part);
+  }
+
+  // Retrieves all or part of the BLOB value that this Blob object represents,
+  // as an array of bytes.
+  @Override
+  public byte[]	getBytes​(long pos, int length) throws SQLException {
+    if (this.data == null) {
+      return null;
+    }
+    if (pos < 1) {
+      throw new PSQLException(GT.tr("invalid pos parameter {0}", pos),
+                              PSQLState.INVALID_PARAMETER_VALUE);
+    }
+    if (length < 0) {
+      throw new PSQLException(GT.tr("invalid length parameter {0}", length),
+                              PSQLState.INVALID_PARAMETER_VALUE);
+    }
+    pos--; // adjust for 1 offset
+    // don't run off the end of the array
+    if ((int)pos + length > this.data.length) {
+      length = this.data.length - (int) pos;
+    }
+    byte [] part = new byte[length];
+    System.arraycopy(this.data, (int) pos, part, 0, length);
+    return part;
+  }
+
+  // Returns the number of bytes in the BLOB value designated by this
+  // Blob object.
+  @Override
+  public long length() {
+    return this.data == null ? 0 : this.data.length;
+  }
+
+  // Retrieves the byte position at which the specified byte array pattern
+  // begins within the BLOB value that this Blob object represents.
+  @Override
+  public long	position​(byte[] pattern, long start) throws SQLException {
+    if (start < 1 || start > data.length) {
+      throw new PSQLException(GT.tr("invalid start parameter {0}", start),
+                              PSQLState.INVALID_PARAMETER_VALUE);
+    }
+    int res = indexOf(this.data, pattern, (int) start - 1);
+    if (res >= 0) {
+      res = res + 1;
+    }
+    return res;
+  }
+
+  // Retrieves the byte position in the BLOB value designated by this Blob
+  // object at which pattern begins.
+  @Override
+  public long position​(Blob pattern, long start) throws SQLException {
+    return position(pattern.getBytes(1, (int) pattern.length()), start);
+  }
+
+  // Retrieves a stream that can be used to write to the BLOB value that this
+  // Blob object represents.
+  @Override
+  public OutputStream setBinaryStream​(long pos) throws SQLException {
+    throw org.postgresql.Driver.notImplemented(this.getClass(), "setBinaryStream(long)");
+  }
+
+  // Writes the given array of bytes to the BLOB value that this Blob object
+  // represents, starting at position pos, and returns the number of bytes
+  // written.
+  @Override
+  public int setBytes​(long pos, byte[] bytes) throws SQLException {
+    return setBytes(pos, bytes, 0, bytes.length);
+  }
+
+  // Writes all or part of the given byte array to the BLOB value that this
+  // Blob object represents and returns the number of bytes written.
+  @Override
+  public int setBytes​(long pos, byte[] bytes, int offset, int len) throws SQLException {
+    if (pos < 1 || pos > data.length + 1) {
+      throw new PSQLException(GT.tr("invalid pos parameter {0} for length {1}", pos, data.length),
+                              PSQLState.INVALID_PARAMETER_VALUE);
+    }
+    if (offset < 0) {
+      throw new PSQLException(GT.tr("invalid offset parameter {0}", offset),
+                              PSQLState.INVALID_PARAMETER_VALUE);
+    }
+    if (offset + len > bytes.length) {
+      throw new PSQLException(GT.tr("invalid offset/len parameters {0}/{1} for length {2}", offset, len, bytes.length),
+                              PSQLState.INVALID_PARAMETER_VALUE);
+    }
+    pos--;
+    // extend the array if necessary
+    if (pos + len > data.length) {
+      this.data = Arrays.copyOf(this.data, (int) pos + len);
+    }
+    System.arraycopy(bytes, offset, this.data, (int) pos, len);
+    return len;
+  }
+
+  // Truncates the BLOB value that this Blob object represents to be len
+  // bytes in length.
+  @Override
+  public void	truncate​(long len) throws SQLException {
+    if (len <= data.length) {
+      this.data = Arrays.copyOf(this.data, (int) len);
+    } else {
+      throw new PSQLException(GT.tr("truncate length too long for string of length {0}", data.length),
+                              PSQLState.INVALID_PARAMETER_VALUE);
+    }
+  }
+
+  // shamelessly stolen from http://www.java2s.com/Code/CSharp/File-Stream/Searchabytearrayforasubbytearray.htm
+  // nice single loop solution
+  private static int indexOf(byte[] array, byte[] pattern, int offset) {
+    int success = 0;
+    for (int i = offset; i < array.length; i++) {
+      if (array[i] == pattern[success]) {
+        success++;
+      } else {
+        success = 0;
+      }
+      if (pattern.length == success) {
+        return i - pattern.length + 1;
+      }
+    }
+    return -1;
+  }
+}

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgClobText.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgClobText.java
@@ -106,7 +106,7 @@ public class PgClobText implements java.sql.Clob {
   @Override
   public long length() {
     if (this.data != null) {
-        return this.data.length();
+      return this.data.length();
     }
     return 0;
   }

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgClobText.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgClobText.java
@@ -15,6 +15,8 @@ import org.postgresql.util.GT;
 import org.postgresql.util.PSQLException;
 import org.postgresql.util.PSQLState;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -26,13 +28,13 @@ import java.sql.SQLException;
 
 public class PgClobText implements java.sql.Clob {
 
-  private String data;
+  private @Nullable String data;
 
   public PgClobText() {
     this.data = "";
   }
 
-  public PgClobText(String s) {
+  public PgClobText(@Nullable String s) {
     this.data = s;
   }
 
@@ -40,7 +42,7 @@ public class PgClobText implements java.sql.Clob {
   // resources that it holds.
   @Override
   public void free() {
-    this.data = null;
+    this.data = "";
   }
 
   // Retrieves the CLOB value designated by this Clob object as an ascii stream.
@@ -49,7 +51,7 @@ public class PgClobText implements java.sql.Clob {
     if (this.data != null) {
       return new ByteArrayInputStream(this.data.getBytes());
     }
-    return null;
+    return new ByteArrayInputStream(new byte[0]);
   }
 
   // Retrieves the CLOB value designated by this Clob object as a
@@ -59,7 +61,7 @@ public class PgClobText implements java.sql.Clob {
     if (this.data != null) {
       return new StringReader(this.data);
     }
-    return null;
+    return new StringReader("");
   }
 
   //Returns a Reader object that contains a partial Clob value, starting
@@ -70,7 +72,7 @@ public class PgClobText implements java.sql.Clob {
     if (this.data != null) {
       return new StringReader(this.data.substring((int)pos, (int)(pos + length)));
     }
-    return null;
+    return new StringReader("");
   }
 
   // Retrieves a copy of the specified substring in the CLOB value designated
@@ -95,14 +97,18 @@ public class PgClobText implements java.sql.Clob {
       }
       return this.data.substring((int)pos, (int) (pos + length));
     }
-    return null;
+    throw new PSQLException(GT.tr("getSubString called on null Clob"),
+                              PSQLState.INVALID_PARAMETER_VALUE);
   }
 
   // Retrieves the number of characters in the CLOB value designated by this
   // Clob object.
   @Override
   public long length() {
-    return this.data.length();
+    if (this.data != null) {
+        return this.data.length();
+    }
+    return 0;
   }
 
   // Retrieves the character position at which the specified Clob object
@@ -203,7 +209,10 @@ public class PgClobText implements java.sql.Clob {
   }
 
   public String toString() {
-    return this.data;
+    if (this.data != null) {
+      return this.data;
+    }
+    return "";
   }
 
 }

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgClobText.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgClobText.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) 2004, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+/*
+ * Implementation of Clob interface backed by Postgres varchar/text fields.
+ *
+ * See PgClob.java for implementation using Postgres Large Objects.
+ */
+
+package org.postgresql.jdbc;
+
+import org.postgresql.util.GT;
+import org.postgresql.util.PSQLException;
+import org.postgresql.util.PSQLState;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.Reader;
+import java.io.StringReader;
+import java.io.Writer;
+import java.sql.Clob;
+import java.sql.SQLException;
+
+public class PgClobText implements java.sql.Clob {
+
+  private String data;
+
+  public PgClobText() {
+    this.data = "";
+  }
+
+  public PgClobText(String s) {
+    this.data = s;
+  }
+
+  // This method frees the Clob object and releases the resources the
+  // resources that it holds.
+  @Override
+  public void free() {
+    this.data = null;
+  }
+
+  // Retrieves the CLOB value designated by this Clob object as an ascii stream.
+  @Override
+  public InputStream	getAsciiStream() {
+    if (this.data != null) {
+      return new ByteArrayInputStream(this.data.getBytes());
+    }
+    return null;
+  }
+
+  // Retrieves the CLOB value designated by this Clob object as a
+  // java.io.Reader object (or as a stream of characters).
+  @Override
+  public Reader getCharacterStream() {
+    if (this.data != null) {
+      return new StringReader(this.data);
+    }
+    return null;
+  }
+
+  //Returns a Reader object that contains a partial Clob value, starting
+  // with the character specified by pos, which is length characters in length.
+  @Override
+  public Reader getCharacterStream(long pos, long length) {
+    pos--;
+    if (this.data != null) {
+      return new StringReader(this.data.substring((int)pos, (int)(pos + length)));
+    }
+    return null;
+  }
+
+  // Retrieves a copy of the specified substring in the CLOB value designated
+  // by this Clob object.
+  @Override
+  public String getSubString(long pos, int length)  throws SQLException {
+    if (this.data != null) {
+      if (pos < 1) {
+        throw new PSQLException(GT.tr("invalid pos parameter {0}", pos),
+                                PSQLState.INVALID_PARAMETER_VALUE);
+      }
+      if (length < 0) {
+        throw new PSQLException(GT.tr("invalid length parameter {0}", length),
+                                PSQLState.INVALID_PARAMETER_VALUE);
+      }
+      long dlen = this.data.length();
+      pos--; // CLOBS start at 1, Strings start at 0 - go figure
+      if (pos + (long) length > dlen) {
+        // don't  run off the end of the string, we return UP TO length chars
+        // according to the spec
+        length = (int) (dlen - pos);
+      }
+      return this.data.substring((int)pos, (int) (pos + length));
+    }
+    return null;
+  }
+
+  // Retrieves the number of characters in the CLOB value designated by this
+  // Clob object.
+  @Override
+  public long length() {
+    return this.data.length();
+  }
+
+  // Retrieves the character position at which the specified Clob object
+  // searchstr appears in this Clob object.
+  // implement by calling the string variant
+  @Override
+  public long position(Clob searchstr, long start) throws SQLException {
+    return position(searchstr.getSubString(1L, (int) searchstr.length()), start);
+  }
+
+  // Retrieves the character position at which the specified substring
+  // searchstr appears in the SQL CLOB value represented by this Clob object.
+  @Override
+  public long position(String searchstr, long start) throws SQLException {
+    if (this.data != null) {
+      int pos = this.data.indexOf(searchstr,(int) (start - 1));
+      return (pos == -1) ? -1 : (pos + 1);
+    }
+    return -1;
+  }
+
+  // Retrieves a stream to be used to write Ascii characters to the CLOB
+  // value that this Clob object represents, starting at position pos.
+  @Override
+  public OutputStream setAsciiStream(long pos) throws SQLException {
+    throw org.postgresql.Driver.notImplemented(this.getClass(), "setAsciiStream(long)");
+  }
+
+  // Retrieves a stream to be used to write a stream of Unicode characters to
+  // the CLOB value that this Clob object represents, at position pos.
+  @Override
+  public Writer setCharacterStream(long pos) throws SQLException {
+    throw org.postgresql.Driver.notImplemented(this.getClass(), "setCharacterStream(long)");
+  }
+
+  // Writes the given Java String to the CLOB value that this Clob object
+  // designates at the position pos.
+  @Override
+  public int setString(long pos, String str) throws SQLException {
+    if (pos < 1) {
+      throw new PSQLException(GT.tr("invalid pos parameter {0}", pos),
+                              PSQLState.INVALID_PARAMETER_VALUE);
+    }
+    if (this.data == null) {
+      throw new PSQLException(GT.tr("setString called on null Clob"),
+                              PSQLState.INVALID_PARAMETER_VALUE);
+    }
+    StringBuilder buf = new StringBuilder(this.data);
+    int len = str.length();
+    try {
+      buf.replace((int)pos - 1, (int) (pos + len - 1), str);
+      this.data = buf.toString();
+    } catch (StringIndexOutOfBoundsException e) {
+      throw new PSQLException(GT.tr("invalid pos parameter {0}", pos),
+                              PSQLState.INVALID_PARAMETER_VALUE);
+    }
+    return len;
+  }
+
+  // Writes len characters of str, starting at character offset, to the CLOB
+  // value that this Clob represents.
+  @Override
+  public int setString(long pos, String str, int offset, int len) throws SQLException {
+    if (pos < 1) {
+      throw new PSQLException(GT.tr("invalid pos parameter {0}", pos),
+                              PSQLState.INVALID_PARAMETER_VALUE);
+    }
+    if (this.data == null) {
+      throw new PSQLException(GT.tr("setString called on null Clob"),
+                              PSQLState.INVALID_PARAMETER_VALUE);
+    }
+    StringBuilder buf = new StringBuilder(this.data);
+    try {
+      String repl = str.substring(offset, offset + len);
+      buf.replace((int)pos - 1, (int) (pos + repl.length() - 1), repl);
+      this.data = buf.toString();
+    } catch (StringIndexOutOfBoundsException e) {
+      throw new PSQLException(GT.tr("invalid pos parameter {0}", pos),
+                              PSQLState.INVALID_PARAMETER_VALUE);
+    }
+    return len;
+  }
+
+  // Truncates the CLOB value that this Clob designates to have a length of
+  // len characters.
+  @Override
+  public void truncate(long len) throws SQLException {
+    if (this.data == null) {
+      throw new PSQLException(GT.tr("truncate on null Clob}"),
+                              PSQLState.INVALID_PARAMETER_VALUE);
+    }
+    if (len <= data.length()) {
+      this.data = this.data.substring(0, (int) len);
+    } else {
+      throw new PSQLException(GT.tr("truncate length too long for string of length {0}", data.length()),
+                              PSQLState.INVALID_PARAMETER_VALUE);
+    }
+  }
+
+  public String toString() {
+    return this.data;
+  }
+
+}

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/AbstractArraysTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/AbstractArraysTest.java
@@ -942,5 +942,9 @@ public abstract class AbstractArraysTest<A> {
     public boolean hintReadOnly() {
       return false;
     }
+
+    public boolean getLobVarlena() {
+      return false;
+    }
   }
 }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc4/Jdbc4TestSuite.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc4/Jdbc4TestSuite.java
@@ -23,6 +23,7 @@ import org.junit.runners.Suite;
     DatabaseMetaDataTest.class,
     IsValidTest.class,
     JsonbTest.class,
+    LobVarlenaTest.class,
     LogTest.class,
     PGCopyInputStreamTest.class,
     UUIDTest.class,

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc4/LobVarlenaTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc4/LobVarlenaTest.java
@@ -1,0 +1,269 @@
+/*
+ * Copyright (c) 2005, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.test.jdbc4;
+
+// import static org.junit.Assert.assertEquals;
+// import static org.junit.Assert.assertFalse;
+// import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.postgresql.PGProperty;
+import org.postgresql.jdbc.PgBlobBytea;
+import org.postgresql.jdbc.PgClobText;
+import org.postgresql.jdbc.PgConnection;
+import org.postgresql.test.TestUtil;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.io.StringWriter;
+import java.sql.Blob;
+import java.sql.Clob;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Types;
+import java.util.Arrays;
+import java.util.Properties;
+
+public class LobVarlenaTest {
+
+  private Connection conn;
+
+  @Before
+  public void setUp() throws Exception {
+    Properties props = new Properties();
+    props.setProperty(PGProperty.LOB_VARLENA.getName(),"true");
+    conn = TestUtil.openDB(props);
+    TestUtil.createTable(conn, "testlobvarlena",
+                         "textcol text, byteacol bytea");
+    TestUtil.execute("insert into testlobvarlena values("
+                     + "repeat('ksjkdjkdshtrb\\000ujy2t8mnnksdf',500),"
+                     + "decode(repeat('ksjkds\\000trbut8mnnksdf',600),"
+                     + "'escape'))",
+                     conn);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    TestUtil.dropTable(conn, "testlobvarlena");
+    TestUtil.closeDB(conn);
+  }
+
+  @Test
+  public void testConnClob() throws SQLException {
+    // test we can get a clob from the connection and do basic set, get,
+    // and search operations on it
+    assertTrue(((PgConnection)conn).getLobVarlena());
+    Clob clob = conn.createClob();
+    assertTrue(clob instanceof PgClobText);
+    assertTrue(clob.length() == 0);
+    clob.setString(1,"foobarbaz");
+    assertTrue(clob.length() == 9);
+    assertTrue(clob.toString().equals("foobarbaz"));
+    String s = clob.getSubString(4,3);
+    assertTrue(s.equals("bar"));
+    String s2 = clob.getSubString(7,99);
+    assertTrue(s2.equals("baz"));
+    long pos = clob.position("bar",1);
+    assertTrue(pos == 4);
+    pos = clob.position("bar",4);
+    assertTrue(pos == 4);
+    pos = clob.position("bar",7);
+    assertTrue(pos == -1);
+    pos = clob.position("blurfl",4);
+    assertTrue(pos == -1);
+    Clob srch = new PgClobText("bar");
+    pos = clob.position(srch,1);
+    assertTrue(pos == 4);
+    pos = clob.position(srch,4);
+    assertTrue(pos == 4);
+    pos = clob.position(srch,7);
+    assertTrue(pos == -1);
+    srch.setString(1,"blurfl");
+    pos = clob.position(srch,4);
+    assertTrue(pos == -1);
+    clob.truncate(3);
+    assertTrue(clob.length() == 3);
+    String s3 = clob.toString();
+    assertTrue(s3.equals("foo"));
+  }
+
+  @Test
+  public void testResultSetClob() throws SQLException {
+    // test we can get a clob from a text field in a resultset
+    Statement stmt = conn.createStatement();
+    ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("testlobvarlena", "textcol"));
+    try {
+      assertTrue(((PgConnection)conn).getLobVarlena());
+      assertTrue(rs.next());
+      Clob clob = rs.getClob(1);
+      assertTrue(clob instanceof PgClobText);
+    } finally {
+      rs.close();
+    }
+  }
+
+  @Test
+  public void testClobStatementParams() throws SQLException {
+    // test we can set a string or a Clob as a parameter
+    conn.setAutoCommit(false);
+    PreparedStatement pstmt = conn.prepareStatement("INSERT INTO testlobvarlena (textcol) VALUES (?)");
+    pstmt.setObject(1, "foo", Types.CLOB);
+    pstmt.executeUpdate();
+    Clob clob = conn.createClob();
+    clob.setString(1,"foobar");
+    pstmt.setObject(1, clob, Types.CLOB);
+    pstmt.executeUpdate();
+    conn.rollback();
+  }
+
+  @Test
+  public void testClobStreams() throws SQLException, IOException {
+    // test streams operations of a Clob
+    Statement stmt = conn.createStatement();
+    ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("testlobvarlena", "textcol"));
+    try {
+      rs.next();
+      Clob clob = rs.getClob(1);
+      Reader r = clob.getCharacterStream();
+      StringWriter w = new StringWriter((int)clob.length());
+      int i;
+      while ((i = r.read()) != -1) {
+        w.write(i);
+      }
+      w.close();
+      String cs = clob.toString();
+      assertTrue(cs.equals(w.toString()));
+      r = clob.getCharacterStream(100,20);
+      w = new StringWriter(300);
+      while ((i = r.read()) != -1) {
+        w.write(i);
+      }
+      w.close();
+      String cs2 = clob.getSubString(100,20);
+      String ws = w.toString();
+      assertTrue(cs2.equals(ws));
+      char[] buffer  = new char[(int)clob.length()];
+      InputStream is = clob.getAsciiStream();
+      int index = 0;
+      int c = is.read();
+      while (c > 0) {
+        buffer[index++] = (char) c;
+        c = is.read();
+      }
+      String as = new String(buffer);
+      assertTrue(as.equals(cs));
+    } finally {
+      rs.close();
+    }
+  }
+
+  @Test
+  public void testConnBlob() throws SQLException {
+    // test we can get a blob from the connection and do basic set, get,
+    // and search operations on it
+    byte[] foobarbaz = "foobarbaz".getBytes();
+    byte[] foo = "foo".getBytes();
+    byte[] bar = "bar".getBytes();
+    byte[] baz = "baz".getBytes();
+    byte[] blurfl = "blurfl".getBytes();
+    assertTrue(((PgConnection)conn).getLobVarlena());
+    Blob blob = conn.createBlob();
+    assertTrue(blob instanceof PgBlobBytea);
+    assertTrue(blob.length() == 0);
+    blob.setBytes(1,foobarbaz);
+    assertTrue(blob.length() == 9);
+    assertTrue(Arrays.equals(blob.getBytes(1,999),foobarbaz));
+    byte[] s = blob.getBytes(4,3);
+    assertTrue(Arrays.equals(s,bar));
+    byte[] s2 = blob.getBytes(7,99);
+    assertTrue(s2.length == 3);
+    assertTrue(Arrays.equals(s2,baz));
+    long pos = blob.position(bar,1);
+    assertTrue(pos == 4);
+    pos = blob.position(bar,4);
+    assertTrue(pos == 4);
+    pos = blob.position(bar,7);
+    assertTrue(pos == -1);
+    pos = blob.position(blurfl,4);
+    assertTrue(pos == -1);
+    Blob srch = new PgBlobBytea(bar);
+    pos = blob.position(srch,1);
+    assertTrue(pos == 4);
+    pos = blob.position(srch,4);
+    assertTrue(pos == 4);
+    pos = blob.position(srch,7);
+    assertTrue(pos == -1);
+    srch.setBytes(1,blurfl);
+    pos = blob.position(srch,4);
+    assertTrue(pos == -1);
+    blob.truncate(3);
+    assertTrue(blob.length() == 3);
+    assertTrue(Arrays.equals(blob.getBytes(1,999),foo));
+  }
+
+  @Test
+  public void testResultSetBlob() throws SQLException {
+    // test we can get a blob from a bytea field in a resultset
+    Statement stmt = conn.createStatement();
+    ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("testlobvarlena", "byteacol"));
+    try {
+      assertTrue(((PgConnection)conn).getLobVarlena());
+      assertTrue(rs.next());
+      Blob blob = rs.getBlob(1);
+      assertTrue(blob instanceof PgBlobBytea);
+    } finally {
+      rs.close();
+    }
+  }
+
+  @Test
+  public void testBlobStatementParams() throws SQLException {
+    // test we can set a Blob as a parameter
+    conn.setAutoCommit(false);
+    PreparedStatement pstmt = conn.prepareStatement("INSERT INTO testlobvarlena (byteacol) VALUES (?)");
+    byte[] foo = "foo".getBytes();
+    byte[] foobar = "foobar".getBytes();
+    pstmt.setObject(1, foo, Types.BLOB);
+    pstmt.executeUpdate();
+    Blob blob = conn.createBlob();
+    blob.setBytes(1,foobar);
+    pstmt.setObject(1, blob, Types.BLOB);
+    pstmt.executeUpdate();
+    conn.rollback();
+  }
+
+  @Test
+  public void testBlobStreams() throws SQLException, IOException {
+    // test streams operations of a Blob
+    Statement stmt = conn.createStatement();
+    ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("testlobvarlena", "byteacol"));
+    try {
+      rs.next();
+      Blob blob = rs.getBlob(1);
+      byte[] b =  blob.getBytes(1,99999);
+      InputStream is = blob.getBinaryStream();
+      byte[] buffer = new byte[b.length];
+      int index = 0;
+      int c = is.read();
+      while (c >= 0) {
+        buffer[index++] = (byte) c;
+        c = is.read();
+      }
+      assertTrue(index == b.length);
+      assertTrue(Arrays.equals(b,buffer));
+    } finally {
+      rs.close();
+    }
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc4/LobVarlenaTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc4/LobVarlenaTest.java
@@ -47,8 +47,8 @@ public class LobVarlenaTest {
     TestUtil.createTable(conn, "testlobvarlena",
                          "textcol text, byteacol bytea");
     TestUtil.execute("insert into testlobvarlena values("
-                     + "repeat('ksjkdjkdshtrb\\000ujy2t8mnnksdf',500),"
-                     + "decode(repeat('ksjkds\\000trbut8mnnksdf',600),"
+                     + "repeat($$ksjkdjkdshtrb\\000ujy2t8mnnksdf$$,500),"
+                     + "decode(repeat($$ksjkds\\000trbut8mnnksdf$$,600),"
                      + "'escape'))",
                      conn);
   }


### PR DESCRIPTION
Provide a connection setting lobVarlena, which is false by default.
If true, Clobs are treated as text fields and Blobs as bytea fields,
similarly to how they are treated in MySQL and elsewhere. This makes
it easier to use the same code when dealing with multiple databases.
Comparatively few users use large objects, and this will come more
naturally to many users.


