### PR TITLE
feat(parser): add flag to disable escaping returning columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ In addition to the standard connection parameters the driver supports a number o
 | cleanupSavepoints             | Boolean | false   | In Autosave mode the driver sets a SAVEPOINT for every query. It is possible to exhaust the server shared buffers. Setting this to true will release each SAVEPOINT at the cost of an additional round trip. |
 | preferQueryMode               | String  | extended | Specifies which mode is used to execute queries to database, possible values: extended, extendedForPrepared, extendedCacheEverything, simple |
 | reWriteBatchedInserts         | Boolean | false   | Enable optimization to rewrite and collapse compatible INSERT statements that are batched. |
+| escapeReturningColumns        | Boolean | true    | Enable escaping column identifiers when appending them to the `RETURNING` clause |
 | escapeSyntaxCallMode          | String  | select  | Specifies how JDBC escape call syntax is transformed into underlying SQL (CALL/SELECT), for invoking procedures or functions (requires server version >= 11), possible values: select, callIfNoReturn, call |
 | maxResultBuffer               | String  | null    | Specifies size of result buffer in bytes, which can't be exceeded during reading result set. Can be specified as particular size (i.e. "100", "200M" "2G") or as percent of max heap memory (i.e. "10p", "20pct", "50percent") |
 | gssEncMode                    | String  | prefer  | Controls the preference for using GSSAPI encryption for the connection,  values are disable, allow, prefer, and require |

--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -167,6 +167,18 @@ public enum PGProperty {
     "Enable optimization that disables column name sanitiser"),
 
   /**
+   * Instructs the {@link org.postgresql.core.Parser} to escape (with double quotes) the column
+   * identifiers appended to the returning clause. A value of {@code true} (default) will make the
+   * parser escape the column identifiers in the returning clause. A value of {@code false} will
+   * disable this behavior and leave the column identifiers unchanged.
+   */
+  ESCAPE_RETURNING_COLUMNS(
+      "escapeReturningColumns",
+      "true",
+      "Escaping column identifiers when appending them to the `RETURNING` clause"
+  ),
+
+  /**
    * Specifies how the driver transforms JDBC escape call syntax into underlying SQL, for invoking procedures or functions. (backend &gt;= 11)
    * In {@code escapeSyntaxCallMode=select} mode (the default), the driver always uses a SELECT statement (allowing function invocation only).
    * In {@code escapeSyntaxCallMode=callIfNoReturn} mode, the driver uses a CALL statement (allowing procedure invocation) if there is no return parameter specified, otherwise the driver uses a SELECT statement.

--- a/pgjdbc/src/main/java/org/postgresql/core/CachedQueryCreateAction.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/CachedQueryCreateAction.java
@@ -64,7 +64,8 @@ class CachedQueryCreateAction implements LruCache.CreateAction<Object, CachedQue
 
     List<NativeQuery> queries = Parser.parseJdbcSql(parsedSql,
         queryExecutor.getStandardConformingStrings(), isParameterized, splitStatements,
-        queryExecutor.isReWriteBatchedInsertsEnabled(), returningColumns);
+        queryExecutor.isReWriteBatchedInsertsEnabled(), queryExecutor.isEscapeReturningColumns(),
+        returningColumns);
 
     Query query = queryExecutor.wrap(queries);
     return new CachedQuery(key, query, isFunction);

--- a/pgjdbc/src/main/java/org/postgresql/core/Parser.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/Parser.java
@@ -46,7 +46,7 @@ public class Parser {
    */
   public static List<NativeQuery> parseJdbcSql(String query, boolean standardConformingStrings,
       boolean withParameters, boolean splitStatements,
-      boolean isBatchedReWriteConfigured,
+      boolean isBatchedReWriteConfigured, boolean escapeReturningColumns,
       String... returningColumnNames) throws SQLException {
     if (!withParameters && !splitStatements
         && returningColumnNames != null && returningColumnNames.length == 0) {
@@ -145,7 +145,7 @@ public class Parser {
             }
             fragmentStart = i + 1;
             if (nativeSql.length() > 0) {
-              if (addReturning(nativeSql, currentCommandType, returningColumnNames, isReturningPresent)) {
+              if (addReturning(nativeSql, currentCommandType, returningColumnNames, isReturningPresent, escapeReturningColumns)) {
                 isReturningPresent = true;
               }
 
@@ -280,7 +280,7 @@ public class Parser {
       return nativeQueries != null ? nativeQueries : Collections.<NativeQuery>emptyList();
     }
 
-    if (addReturning(nativeSql, currentCommandType, returningColumnNames, isReturningPresent)) {
+    if (addReturning(nativeSql, currentCommandType, returningColumnNames, isReturningPresent, escapeReturningColumns)) {
       isReturningPresent = true;
     }
 
@@ -342,7 +342,7 @@ public class Parser {
   }
 
   private static boolean addReturning(StringBuilder nativeSql, SqlCommandType currentCommandType,
-      String[] returningColumnNames, boolean isReturningPresent) throws SQLException {
+      String[] returningColumnNames, boolean isReturningPresent, boolean escapeReturningColumns) throws SQLException {
     if (isReturningPresent || returningColumnNames.length == 0) {
       return false;
     }
@@ -363,7 +363,11 @@ public class Parser {
       if (col > 0) {
         nativeSql.append(", ");
       }
-      Utils.escapeIdentifier(nativeSql, columnName);
+      if (escapeReturningColumns) {
+        Utils.escapeIdentifier(nativeSql, columnName);
+      } else {
+        nativeSql.append(columnName);
+      }
     }
     return true;
   }

--- a/pgjdbc/src/main/java/org/postgresql/core/QueryExecutor.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/QueryExecutor.java
@@ -192,6 +192,8 @@ public interface QueryExecutor extends TypeTransferModeRegistry {
 
   boolean isReWriteBatchedInsertsEnabled();
 
+  boolean isEscapeReturningColumns();
+
   CachedQuery createQuery(String sql, boolean escapeProcessing, boolean isParameterized,
       String @Nullable ... columnNames)
       throws SQLException;

--- a/pgjdbc/src/main/java/org/postgresql/core/QueryExecutorBase.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/QueryExecutorBase.java
@@ -45,6 +45,7 @@ public abstract class QueryExecutorBase implements QueryExecutor {
   private int serverVersionNum = 0;
   private TransactionState transactionState = TransactionState.IDLE;
   private final boolean reWriteBatchedInserts;
+  private final boolean escapeReturningColumns;
   private final boolean columnSanitiserDisabled;
   private final EscapeSyntaxCallMode escapeSyntaxCallMode;
   private final PreferQueryMode preferQueryMode;
@@ -73,6 +74,7 @@ public abstract class QueryExecutorBase implements QueryExecutor {
     this.database = database;
     this.cancelSignalTimeout = cancelSignalTimeout;
     this.reWriteBatchedInserts = PGProperty.REWRITE_BATCHED_INSERTS.getBoolean(info);
+    this.escapeReturningColumns = PGProperty.ESCAPE_RETURNING_COLUMNS.getBoolean(info);
     this.columnSanitiserDisabled = PGProperty.DISABLE_COLUMN_SANITISER.getBoolean(info);
     String callMode = PGProperty.ESCAPE_SYNTAX_CALL_MODE.get(info);
     this.escapeSyntaxCallMode = EscapeSyntaxCallMode.of(callMode);
@@ -286,6 +288,11 @@ public abstract class QueryExecutorBase implements QueryExecutor {
   @Override
   public boolean isReWriteBatchedInsertsEnabled() {
     return this.reWriteBatchedInserts;
+  }
+
+  @Override
+  public boolean isEscapeReturningColumns() {
+    return this.escapeReturningColumns;
   }
 
   @Override

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -229,7 +229,7 @@ public class QueryExecutorImpl extends QueryExecutorBase {
   public Query createSimpleQuery(String sql) throws SQLException {
     List<NativeQuery> queries = Parser.parseJdbcSql(sql,
         getStandardConformingStrings(), false, true,
-        isReWriteBatchedInsertsEnabled());
+        isReWriteBatchedInsertsEnabled(), true);
     return wrap(queries);
   }
 

--- a/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
+++ b/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
@@ -1152,6 +1152,22 @@ public abstract class BaseDataSource implements CommonDataSource, Referenceable 
   }
 
   /**
+   * @return boolean indicating property is enabled or not.
+   * @see PGProperty#ESCAPE_RETURNING_COLUMNS
+   */
+  public boolean isEscapeReturningColumns() {
+    return PGProperty.ESCAPE_RETURNING_COLUMNS.getBoolean(properties);
+  }
+
+  /**
+   * @return boolean indicating property is enabled or not.
+   * @see PGProperty#ESCAPE_RETURNING_COLUMNS
+   */
+  public void setEscapeReturningColumns(boolean escapeReturningColumns) {
+    PGProperty.ESCAPE_RETURNING_COLUMNS.set(properties, escapeReturningColumns);
+  }
+
+  /**
    * @return 'select', "callIfNoReturn', or 'call'
    * @see PGProperty#ESCAPE_SYNTAX_CALL_MODE
    */

--- a/pgjdbc/src/test/java/org/postgresql/core/ParserTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/core/ParserTest.java
@@ -168,9 +168,44 @@ public class ParserTest {
         "insert test(id, name) select 1, 'value' as RETURNING from test2";
     List<NativeQuery> qry =
         Parser.parseJdbcSql(
-            query, true, true, true, true);
+            query, true, true, true, true, true);
     boolean returningKeywordPresent = qry.get(0).command.isReturningKeywordPresent();
     Assert.assertFalse("Query does not have returning clause " + query, returningKeywordPresent);
+  }
+
+
+  /**
+   * Non regression test for default behavior when PGProperty.ESCAPE_RETURNING_COLUMNS = true
+   */
+  @Test
+  public void updateReturningEscapingOn() throws SQLException {
+    String query =
+        "update test t set a = 1";
+    List<NativeQuery> qry =
+        Parser.parseJdbcSql(
+            query, true, true, true, true, true, "t.a", "t.b");
+    NativeQuery nativeQuery = qry.get(0);
+    boolean returningKeywordPresent = nativeQuery.command.isReturningKeywordPresent();
+    Assert.assertTrue("Query has a returning clause : " + nativeQuery.nativeSql, returningKeywordPresent);
+    boolean hasEscapedReturningColumns = nativeQuery.nativeSql.endsWith("RETURNING \"t.a\", \"t.b\"");
+    Assert.assertTrue("Query has escaped `RETURNING` columns : " + nativeQuery.nativeSql, hasEscapedReturningColumns);
+  }
+
+  /**
+   * Test for optional behavior when PGProperty.ESCAPE_RETURNING_COLUMNS = false
+   */
+  @Test
+  public void updateReturningEscapingOff() throws SQLException {
+    String query =
+        "update test t set a = 1";
+    List<NativeQuery> qry =
+        Parser.parseJdbcSql(
+            query, true, true, true,true, false, "t.a", "t.b");
+    NativeQuery nativeQuery = qry.get(0);
+    boolean returningKeywordPresent = nativeQuery.command.isReturningKeywordPresent();
+    Assert.assertTrue("Query has a returning clause : " + nativeQuery.nativeSql, returningKeywordPresent);
+    boolean hasEscapedReturningColumns = nativeQuery.nativeSql.endsWith("RETURNING t.a, t.b");
+    Assert.assertTrue("Query has non-escaped `RETURNING` columns : " + nativeQuery.nativeSql, hasEscapedReturningColumns);
   }
 
   @Test
@@ -179,7 +214,7 @@ public class ParserTest {
         "insert test(id, name) select 1, 'value' from test2 RETURNING id";
     List<NativeQuery> qry =
         Parser.parseJdbcSql(
-            query, true, true, true, true);
+            query, true, true, true, true, true);
     boolean returningKeywordPresent = qry.get(0).command.isReturningKeywordPresent();
     Assert.assertTrue("Query has a returning clause " + query, returningKeywordPresent);
   }
@@ -190,7 +225,7 @@ public class ParserTest {
         "with x as (insert into mytab(x) values(1) returning x) insert test(id, name) select 1, 'value' from test2";
     List<NativeQuery> qry =
         Parser.parseJdbcSql(
-            query, true, true, true, true);
+            query, true, true, true, true, true);
     boolean returningKeywordPresent = qry.get(0).command.isReturningKeywordPresent();
     Assert.assertFalse("There's no top-level <<returning>> clause " + query, returningKeywordPresent);
   }
@@ -198,7 +233,7 @@ public class ParserTest {
   @Test
   public void insertBatchedReWriteOnConflict() throws SQLException {
     String query = "insert into test(id, name) values (:id,:name) ON CONFLICT (id) DO NOTHING";
-    List<NativeQuery> qry = Parser.parseJdbcSql(query, true, true, true, true);
+    List<NativeQuery> qry = Parser.parseJdbcSql(query, true, true, true, true, true);
     SqlCommand command = qry.get(0).getCommand();
     Assert.assertEquals(34, command.getBatchRewriteValuesBraceOpenPosition());
     Assert.assertEquals(44, command.getBatchRewriteValuesBraceClosePosition());
@@ -207,7 +242,7 @@ public class ParserTest {
   @Test
   public void insertBatchedReWriteOnConflictUpdateBind() throws SQLException {
     String query = "insert into test(id, name) values (?,?) ON CONFLICT (id) UPDATE SET name=?";
-    List<NativeQuery> qry = Parser.parseJdbcSql(query, true, true, true, true);
+    List<NativeQuery> qry = Parser.parseJdbcSql(query, true, true, true, true, true);
     SqlCommand command = qry.get(0).getCommand();
     Assert.assertFalse("update set name=? is NOT compatible with insert rewrite", command.isBatchedReWriteCompatible());
   }
@@ -215,7 +250,7 @@ public class ParserTest {
   @Test
   public void insertBatchedReWriteOnConflictUpdateConstant() throws SQLException {
     String query = "insert into test(id, name) values (?,?) ON CONFLICT (id) UPDATE SET name='default'";
-    List<NativeQuery> qry = Parser.parseJdbcSql(query, true, true, true, true);
+    List<NativeQuery> qry = Parser.parseJdbcSql(query, true, true, true, true, true);
     SqlCommand command = qry.get(0).getCommand();
     Assert.assertTrue("update set name='default' is compatible with insert rewrite", command.isBatchedReWriteCompatible());
   }
@@ -224,7 +259,7 @@ public class ParserTest {
   public void insertMultiInsert() throws SQLException {
     String query =
         "insert into test(id, name) values (:id,:name),(:id,:name) ON CONFLICT (id) DO NOTHING";
-    List<NativeQuery> qry = Parser.parseJdbcSql(query, true, true, true, true);
+    List<NativeQuery> qry = Parser.parseJdbcSql(query, true, true, true, true, true);
     SqlCommand command = qry.get(0).getCommand();
     Assert.assertEquals(34, command.getBatchRewriteValuesBraceOpenPosition());
     Assert.assertEquals(56, command.getBatchRewriteValuesBraceClosePosition());
@@ -233,13 +268,13 @@ public class ParserTest {
   @Test
   public void valuesTableParse() throws SQLException {
     String query = "insert into values_table (id, name) values (?,?)";
-    List<NativeQuery> qry = Parser.parseJdbcSql(query, true, true, true, true);
+    List<NativeQuery> qry = Parser.parseJdbcSql(query, true, true, true, true, true);
     SqlCommand command = qry.get(0).getCommand();
     Assert.assertEquals(43,command.getBatchRewriteValuesBraceOpenPosition());
     Assert.assertEquals(49,command.getBatchRewriteValuesBraceClosePosition());
 
     query = "insert into table_values (id, name) values (?,?)";
-    qry = Parser.parseJdbcSql(query, true, true, true, true);
+    qry = Parser.parseJdbcSql(query, true, true, true, true, true);
     command = qry.get(0).getCommand();
     Assert.assertEquals(43,command.getBatchRewriteValuesBraceOpenPosition());
     Assert.assertEquals(49,command.getBatchRewriteValuesBraceClosePosition());

--- a/pgjdbc/src/test/java/org/postgresql/core/ReturningParserTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/core/ReturningParserTest.java
@@ -52,7 +52,7 @@ public class ReturningParserTest {
     String query =
         "insert into\"prep\"(a, " + prefix + columnName + suffix + ")values(1,2)" + prefix
             + returning + suffix;
-    List<NativeQuery> qry = Parser.parseJdbcSql(query, true, true, true, true);
+    List<NativeQuery> qry = Parser.parseJdbcSql(query, true, true, true, true, true);
     boolean returningKeywordPresent = qry.get(0).command.isReturningKeywordPresent();
 
     boolean expectedReturning = this.returning.equalsIgnoreCase("returning")

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/EscapeReturningColumnsOffTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/EscapeReturningColumnsOffTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2020, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.jdbc;
+
+import org.postgresql.PGProperty;
+import org.postgresql.test.TestUtil;
+import org.postgresql.test.jdbc2.BaseTest4;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Properties;
+
+/**
+ * This object tests than RETURNING clause is handled properly when escapeReturningColumns is false
+ */
+public class EscapeReturningColumnsOffTest extends BaseTest4 {
+
+  /*
+   * Set up the fixture for this testcase: a connection to a database with a
+   * table for this test.
+   */
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    Statement stmt = con.createStatement();
+
+    /*
+     * Drop the test table if it already exists for some reason. It is not an
+     * error if it doesn't exist.
+     */
+    TestUtil.createTable(con, "testreturning", "pk INTEGER, col1 INTEGER, col2 INTEGER");
+
+    stmt.executeUpdate("INSERT INTO testreturning VALUES (1, 0, 0)");
+    stmt.close();
+
+    /*
+     * Generally recommended with batch updates. By default we run all tests in
+     * this test case with autoCommit disabled.
+     */
+    con.setAutoCommit(false);
+  }
+
+  // Tear down the fixture for this test case.
+  @Override
+  public void tearDown() throws SQLException {
+    TestUtil.dropTable(con, "testreturning");
+    super.tearDown();
+  }
+
+  @Override
+  protected void updateProperties(Properties props) {
+    PGProperty.ESCAPE_RETURNING_COLUMNS.set(props, false);
+  }
+
+  /**
+   * Test for optional behavior when PGProperty.ESCAPE_RETURNING_COLUMNS = false
+   */
+  @Test
+  public void updateReturningEscapingOff() throws SQLException {
+    PgPreparedStatement pstmt = null;
+    try {
+      pstmt = (PgPreparedStatement)con.prepareStatement("update testreturning t set col1 = ?, col2 = ?",
+          new String[] {"t.col1 as alias1", "t.col2 as alias2"});
+      pstmt.setInt(1, 1);
+      pstmt.setInt(2, 2);
+      pstmt.execute();
+      ResultSet rs = pstmt.getGeneratedKeys();
+      Assert.assertTrue("Returning result set is non null", rs != null);
+      int returnedRows = 0;
+      while (rs.next()) {
+        returnedRows++;
+        Assert.assertTrue("alias1 value is 1", rs.getInt("alias1") == 1);
+        Assert.assertTrue("alias2 value is 2", rs.getInt("alias2") == 2);
+      }
+      Assert.assertTrue("Returning result set returned a row", returnedRows == 1);
+    } finally {
+      TestUtil.closeQuietly(pstmt);
+    }
+  }
+
+}

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/EscapeReturningColumnsOnTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/EscapeReturningColumnsOnTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2020, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.jdbc;
+
+import org.postgresql.PGProperty;
+import org.postgresql.test.TestUtil;
+import org.postgresql.test.jdbc2.BaseTest4;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Properties;
+
+/**
+ * This object tests than RETURNING clause is handled properly when escapeReturningColumns is true
+ */
+public class EscapeReturningColumnsOnTest extends BaseTest4 {
+
+  /*
+   * Set up the fixture for this testcase: a connection to a database with a
+   * table for this test.
+   */
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    Statement stmt = con.createStatement();
+
+    /*
+     * Drop the test table if it already exists for some reason. It is not an
+     * error if it doesn't exist.
+     */
+    TestUtil.createTable(con, "testreturning", "pk INTEGER, col1 INTEGER, col2 INTEGER");
+
+    stmt.executeUpdate("INSERT INTO testreturning VALUES (1, 0, 0)");
+    stmt.close();
+
+    /*
+     * Generally recommended with batch updates. By default we run all tests in
+     * this test case with autoCommit disabled.
+     */
+    con.setAutoCommit(false);
+  }
+
+  // Tear down the fixture for this test case.
+  @Override
+  public void tearDown() throws SQLException {
+    TestUtil.dropTable(con, "testreturning");
+    super.tearDown();
+  }
+
+  @Override
+  protected void updateProperties(Properties props) {
+    PGProperty.ESCAPE_RETURNING_COLUMNS.set(props, true);
+  }
+
+  /**
+   * Non regression test for default behavior when PGProperty.ESCAPE_RETURNING_COLUMNS = true
+   */
+  @Test
+  public void updateReturningEscapingOn() throws SQLException {
+    PgPreparedStatement pstmt = null;
+    try {
+      pstmt = (PgPreparedStatement)con.prepareStatement("update testreturning t set col1 = ?, col2 = ?",
+          new String[] {"col1", "col2"});
+      pstmt.setInt(1, 1);
+      pstmt.setInt(2, 2);
+      pstmt.execute();
+      ResultSet rs = pstmt.getGeneratedKeys();
+      Assert.assertTrue("Returning result set is non null", rs != null);
+      int returnedRows = 0;
+      while (rs.next()) {
+        returnedRows++;
+        Assert.assertTrue("col1 value is 1", rs.getInt("col1") == 1);
+        Assert.assertTrue("col2 value is 2", rs.getInt("col2") == 2);
+      }
+      Assert.assertTrue("Returning result set returned a row", returnedRows == 1);
+    } finally {
+      TestUtil.closeQuietly(pstmt);
+    }
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/Jdbc2TestSuite.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/Jdbc2TestSuite.java
@@ -16,6 +16,8 @@ import org.postgresql.core.v3.V3ParameterListTests;
 import org.postgresql.jdbc.ArraysTest;
 import org.postgresql.jdbc.ArraysTestSuite;
 import org.postgresql.jdbc.DeepBatchedInsertStatementTest;
+import org.postgresql.jdbc.EscapeReturningColumnsOffTest;
+import org.postgresql.jdbc.EscapeReturningColumnsOnTest;
 import org.postgresql.jdbc.NoColumnMetadataIssue1613Test;
 import org.postgresql.jdbc.PgSQLXMLTest;
 import org.postgresql.test.core.FixedLengthOutputStreamTest;
@@ -71,6 +73,8 @@ import org.junit.runners.Suite;
     DeepBatchedInsertStatementTest.class,
     DriverTest.class,
     EncodingTest.class,
+    EscapeReturningColumnsOffTest.class,
+    EscapeReturningColumnsOnTest.class,
     ExpressionPropertiesTest.class,
     GeometricTest.class,
     GetXXXTest.class,

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc3/CompositeQueryParseTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc3/CompositeQueryParseTest.java
@@ -95,16 +95,16 @@ public class CompositeQueryParseTest {
   @Test
   public void testHasReturning() throws SQLException {
     List<NativeQuery> queries = Parser.parseJdbcSql("insert into foo (a,b,c) values (?,?,?) RetuRning a", true, true, false,
-        true);
+        true, true);
     NativeQuery query = queries.get(0);
     assertTrue("The parser should find the word returning", query.command.isReturningKeywordPresent());
 
-    queries = Parser.parseJdbcSql("insert into foo (a,b,c) values (?,?,?)", true, true, false, true);
+    queries = Parser.parseJdbcSql("insert into foo (a,b,c) values (?,?,?)", true, true, false, true, true);
     query = queries.get(0);
     assertFalse("The parser should not find the word returning", query.command.isReturningKeywordPresent());
 
     queries = Parser.parseJdbcSql("insert into foo (a,b,c) values ('returning',?,?)", true, true, false,
-        true);
+        true, true);
     query = queries.get(0);
     assertFalse("The parser should not find the word returning as it is in quotes ", query.command.isReturningKeywordPresent());
   }
@@ -112,7 +112,7 @@ public class CompositeQueryParseTest {
   @Test
   public void testSelect() throws SQLException {
     List<NativeQuery> queries;
-    queries = Parser.parseJdbcSql("select 1 as returning from (update table)", true, true, false, true);
+    queries = Parser.parseJdbcSql("select 1 as returning from (update table)", true, true, false, true, true);
     NativeQuery query = queries.get(0);
     assertEquals("This is a select ", SqlCommandType.SELECT, query.command.getType());
     assertTrue("Returning is OK here as it is not an insert command ", query.command.isReturningKeywordPresent());
@@ -121,7 +121,7 @@ public class CompositeQueryParseTest {
   @Test
   public void testDelete() throws SQLException {
     List<NativeQuery> queries = Parser.parseJdbcSql("DeLeTe from foo where a=1", true, true, false,
-        true);
+        true, true);
     NativeQuery query = queries.get(0);
     assertEquals("This is a delete command", SqlCommandType.DELETE, query.command.getType());
   }
@@ -130,7 +130,7 @@ public class CompositeQueryParseTest {
   public void testMultiQueryWithBind() throws SQLException {
     // braces around (42) are required to puzzle the parser
     String sql = "INSERT INTO inttable(a) VALUES (?);SELECT (42)";
-    List<NativeQuery> queries = Parser.parseJdbcSql(sql, true, true, true,true);
+    List<NativeQuery> queries = Parser.parseJdbcSql(sql, true, true, true,true, true);
     NativeQuery query = queries.get(0);
     assertEquals("query(0) of " + sql,
         "INSERT: INSERT INTO inttable(a) VALUES ($1)",
@@ -143,7 +143,7 @@ public class CompositeQueryParseTest {
 
   @Test
   public void testMove() throws SQLException {
-    List<NativeQuery> queries = Parser.parseJdbcSql("MoVe NEXT FROM FOO", true, true, false, true);
+    List<NativeQuery> queries = Parser.parseJdbcSql("MoVe NEXT FROM FOO", true, true, false, true, true);
     NativeQuery query = queries.get(0);
     assertEquals("This is a move command", SqlCommandType.MOVE, query.command.getType());
   }
@@ -152,7 +152,7 @@ public class CompositeQueryParseTest {
   public void testUpdate() throws SQLException {
     List<NativeQuery> queries;
     NativeQuery query;
-    queries = Parser.parseJdbcSql("update foo set (a=?,b=?,c=?)", true, true, false, true);
+    queries = Parser.parseJdbcSql("update foo set (a=?,b=?,c=?)", true, true, false, true, true);
     query = queries.get(0);
     assertEquals("This is an UPDATE command", SqlCommandType.UPDATE, query.command.getType());
   }
@@ -160,11 +160,11 @@ public class CompositeQueryParseTest {
   @Test
   public void testInsert() throws SQLException {
     List<NativeQuery> queries = Parser.parseJdbcSql("InSeRt into foo (a,b,c) values (?,?,?) returning a", true, true, false,
-        true);
+        true, true);
     NativeQuery query = queries.get(0);
     assertEquals("This is an INSERT command", SqlCommandType.INSERT, query.command.getType());
 
-    queries = Parser.parseJdbcSql("select 1 as insert", true, true, false, true);
+    queries = Parser.parseJdbcSql("select 1 as insert", true, true, false, true, true);
     query = queries.get(0);
     assertEquals("This is a SELECT command", SqlCommandType.SELECT, query.command.getType());
   }
@@ -172,7 +172,7 @@ public class CompositeQueryParseTest {
   @Test
   public void testWithSelect() throws SQLException {
     List<NativeQuery> queries;
-    queries = Parser.parseJdbcSql("with update as (update foo set (a=?,b=?,c=?)) select * from update", true, true, false, true);
+    queries = Parser.parseJdbcSql("with update as (update foo set (a=?,b=?,c=?)) select * from update", true, true, false, true, true);
     NativeQuery query = queries.get(0);
     assertEquals("with ... () select", SqlCommandType.SELECT, query.command.getType());
   }
@@ -180,7 +180,7 @@ public class CompositeQueryParseTest {
   @Test
   public void testWithInsert() throws SQLException {
     List<NativeQuery> queries;
-    queries = Parser.parseJdbcSql("with update as (update foo set (a=?,b=?,c=?)) insert into table(select) values(1)", true, true, false, true);
+    queries = Parser.parseJdbcSql("with update as (update foo set (a=?,b=?,c=?)) insert into table(select) values(1)", true, true, false, true, true);
     NativeQuery query = queries.get(0);
     assertEquals("with ... () insert", SqlCommandType.INSERT, query.command.getType());
   }
@@ -201,7 +201,7 @@ public class CompositeQueryParseTest {
       boolean splitStatements) {
     try {
       return toString(
-          Parser.parseJdbcSql(query, standardConformingStrings, withParameters, splitStatements, false));
+          Parser.parseJdbcSql(query, standardConformingStrings, withParameters, splitStatements, false, true));
     } catch (SQLException e) {
       throw new IllegalStateException("Parser.parseJdbcSql: " + e.getMessage(), e);
     }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc3/SqlCommandParseTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc3/SqlCommandParseTest.java
@@ -47,7 +47,7 @@ public class SqlCommandParseTest {
   @Test
   public void run() throws SQLException {
     List<NativeQuery> queries;
-    queries = Parser.parseJdbcSql(sql, true, true, false, true);
+    queries = Parser.parseJdbcSql(sql, true, true, false, true, true);
     NativeQuery query = queries.get(0);
     assertEquals(sql, type, query.command.getType());
   }


### PR DESCRIPTION
Add a new optional PGProperty escapeReturningColumns that allow disabling a parser feature which escapes the columnNames[] passed in PgConnection::PreparedStatement prepareStatement(String sql, String columnNames[]). The default escaping just add double quotes around the whole string so it prevents using aliases to disambiguate identical column name because it provocks an sql error. See issues in https://github.com/pgjdbc/pgjdbc/issues/1895 and https://github.com/pgjdbc/pgjdbc/issues/1168

The PR adds a new PGProperty boolean parameter called `escapeReturningColumns` which defaults to `true` (existing behavior). When optionally set to false, it will prevent this escaping, see modified code in the Parser class : 

```
      if (escapeReturningColumns) {
        Utils.escapeIdentifier(nativeSql, columnName);
      } else {
        nativeSql.append(columnName);
      }
```

Closes #1168
Closes #1895

### All Submissions:

* [X] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [X] Does your submission pass tests?
2. [X] Does `./gradlew autostyleCheck checkstyleAll` pass ?
3. [X] Have you added your new test classes to an existing test suite in alphabetical order?

### Changes to Existing Features:

* [ ] Does this break existing behaviour? If so please explain. : **no breaking changes**
* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you written new tests for your core changes, as applicable?
* [X] Have you successfully run tests with your changes locally?
