### PR TITLE
feat(parser): disable add quotes around column name in returning clause if the quotes are already there

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/Parser.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/Parser.java
@@ -363,7 +363,19 @@ public class Parser {
       if (col > 0) {
         nativeSql.append(", ");
       }
-      Utils.escapeIdentifier(nativeSql, columnName);
+      if (columnName.trim().endsWith("\"")) {
+        // In that case, consider that the columnName has already been quoted by the user
+        // e.g. supports leaving columnName unchanged for :
+        // "col1"
+        // "t"."col1"
+        // t."col1" as "alias1"
+        // t.col1 as "alias1"
+        // date_trunc('day', value) as "day"
+        // ...
+        nativeSql.append(columnName);
+      } else {
+        Utils.escapeIdentifier(nativeSql, columnName);
+      }
     }
     return true;
   }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc42/Jdbc42TestSuite.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc42/Jdbc42TestSuite.java
@@ -19,6 +19,7 @@ import org.junit.runners.Suite.SuiteClasses;
     PreparedStatementTest.class,
     SetObject310Test.class,
     SimpleJdbc42Test.class,
+    ReturningColumnsTest.class,
 })
 public class Jdbc42TestSuite {
 

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc42/ReturningColumnsTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc42/ReturningColumnsTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2020, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.test.jdbc42;
+
+import org.postgresql.test.TestUtil;
+import org.postgresql.test.jdbc2.BaseTest4;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+/**
+ * This object tests than RETURNING clause is handled properly
+ */
+public class ReturningColumnsTest extends BaseTest4 {
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    TestUtil.createTable(con, "testreturning", "pk INTEGER, col1 INTEGER, col2 text");
+
+    Statement st = con.createStatement();
+    st.executeUpdate("INSERT INTO testreturning VALUES (1, 0, 'a')");
+    st.close();
+  }
+
+  @Override
+  public void tearDown() throws SQLException {
+    TestUtil.dropTable(con, "testreturning");
+    super.tearDown();
+  }
+
+  /**
+   * Test for optional behavior when PGProperty.ESCAPE_RETURNING_COLUMNS = false
+   */
+  @Test
+  public void updateReturningEscapingOff() throws SQLException {
+    PreparedStatement pstmt = null;
+    try {
+      pstmt = con.prepareStatement("update testreturning t set col1 = ?, col2 = ?",
+          new String[] {"t.col1 as \"alias1\"", "length(t.col2) as \"alias2\""});
+      pstmt.setInt(1, 1);
+      pstmt.setString(2, "aaaaa");
+      pstmt.execute();
+      ResultSet rs = pstmt.getGeneratedKeys();
+      Assert.assertTrue("Returning result set is non null", rs != null);
+      int returnedRows = 0;
+      while (rs.next()) {
+        returnedRows++;
+        Assert.assertTrue("alias1 value is 1", rs.getInt("alias1") == 1);
+        Assert.assertTrue("alias2 value is 5", rs.getInt("alias2") == 5);
+      }
+      Assert.assertTrue("Returning result set returned a row", returnedRows == 1);
+    } finally {
+      TestUtil.closeQuietly(pstmt);
+    }
+  }
+
+  /**
+   * Non regression test for default behavior when PGProperty.ESCAPE_RETURNING_COLUMNS = true
+   */
+  @Test
+  public void updateReturningEscapingOn() throws SQLException {
+    PreparedStatement pstmt = null;
+    try {
+      pstmt = con.prepareStatement("update testreturning t set col1 = ?, col2 = ?",
+          new String[] {"col1", "col2"});
+      pstmt.setInt(1, 1);
+      pstmt.setString(2, "aaaaa");
+      pstmt.execute();
+      ResultSet rs = pstmt.getGeneratedKeys();
+      Assert.assertTrue("Returning result set is non null", rs != null);
+      int returnedRows = 0;
+      while (rs.next()) {
+        returnedRows++;
+        Assert.assertTrue("col1 value is 1", rs.getInt("col1") == 1);
+        Assert.assertTrue("col2 value is aaaaa", rs.getString("col2").equals("aaaaa"));
+      }
+      Assert.assertTrue("Returning result set returned a row", returnedRows == 1);
+    } finally {
+      TestUtil.closeQuietly(pstmt);
+    }
+  }
+
+}


### PR DESCRIPTION
Allow to automaically disable a parser feature which escapes the columnNames[] passed in PgConnection::PreparedStatement prepareStatement(String sql, String columnNames[]). The default escaping just add double quotes around the whole string so it prevent using aliases to disambiguate identical column name. See issues in https://github.com/pgjdbc/pgjdbc/issues/1895 and https://github.com/pgjdbc/pgjdbc/issues/1168. With this changes, the parser no longer add quotes around the columnName if the string ends with such a double quote (after trimming)

**Replaces PR** https://github.com/pgjdbc/pgjdbc/pull/1896

Closes #1168
Closes #1895

### All Submissions:

* [X] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [X] Does your submission pass tests?
2. [X] Does `./gradlew autostyleCheck checkstyleAll` pass ?
3. [X] Have you added your new test classes to an existing test suite in alphabetical order?

### Changes to Existing Features:

* [ ] Does this break existing behaviour? If so please explain.
* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you written new tests for your core changes, as applicable?
* [X] Have you successfully run tests with your changes locally?
