### PR TITLE
Fixed issue #892

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
@@ -89,11 +89,7 @@ public class TypeInfoCache implements TypeInfo {
       {"name", Oid.NAME, Types.VARCHAR, "java.lang.String", Oid.NAME_ARRAY},
       {"bytea", Oid.BYTEA, Types.BINARY, "[B", Oid.BYTEA_ARRAY},
       {"bool", Oid.BOOL, Types.BIT, "java.lang.Boolean", Oid.BOOL_ARRAY},
-      // Commented out this line to fix issue #892, an error that occurs when calling ResultSet getObject on a bit field.
-      // According to the PostgreSql the bit values are strings of 1's and 0's. Values of this type do not
-      // map to true or false values (unless the length specified for the field is 1). Also varbit is not in this
-      // list, so removing the bit type is consistent with the way the varbit field is handled.
-      // {"bit", Oid.BIT, Types.BIT, "java.lang.Boolean", Oid.BIT_ARRAY},
+      {"bit", Oid.BIT, Types.BIT, "java.lang.Boolean", Oid.BIT_ARRAY},
       {"date", Oid.DATE, Types.DATE, "java.sql.Date", Oid.DATE_ARRAY},
       {"time", Oid.TIME, Types.TIME, "java.sql.Time", Oid.TIME_ARRAY},
       {"timetz", Oid.TIMETZ, Types.TIME, "java.sql.Time", Oid.TIMETZ_ARRAY},

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
@@ -89,7 +89,11 @@ public class TypeInfoCache implements TypeInfo {
       {"name", Oid.NAME, Types.VARCHAR, "java.lang.String", Oid.NAME_ARRAY},
       {"bytea", Oid.BYTEA, Types.BINARY, "[B", Oid.BYTEA_ARRAY},
       {"bool", Oid.BOOL, Types.BIT, "java.lang.Boolean", Oid.BOOL_ARRAY},
-      {"bit", Oid.BIT, Types.BIT, "java.lang.Boolean", Oid.BIT_ARRAY},
+      // Commented out this line to fix issue #892, an error that occurs when calling ResultSet getObject on a bit field.
+      // According to the PostgreSql the bit values are strings of 1's and 0's. Values of this type do not
+      // map to true or false values (unless the length specified for the field is 1). Also varbit is not in this
+      // list, so removing the bit type is consistent with the way the varbit field is handled.
+      // {"bit", Oid.BIT, Types.BIT, "java.lang.Boolean", Oid.BIT_ARRAY},
       {"date", Oid.DATE, Types.DATE, "java.sql.Date", Oid.DATE_ARRAY},
       {"time", Oid.TIME, Types.TIME, "java.sql.Time", Oid.TIME_ARRAY},
       {"timetz", Oid.TIMETZ, Types.TIME, "java.sql.Time", Oid.TIMETZ_ARRAY},

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/BitFieldTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/BitFieldTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2005, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.jdbc;
+
+import org.postgresql.test.TestUtil;
+import org.postgresql.test.jdbc2.BaseTest4;
+import org.postgresql.util.PGobject;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+public class BitFieldTest extends BaseTest4 {
+
+  private static final String bitValue = "1011";
+
+  @Override
+  @Before
+  public void setUp() throws Exception {
+    super.setUp();
+    con = TestUtil.openDB();
+    TestUtil.createTempTable(con, "test_bit_field", String.format("field_bit bit(%d)",
+        bitValue.length()));
+    Statement stmt = con.createStatement();
+    stmt.execute(String.format("INSERT INTO test_bit_field values(b'%s')", bitValue));
+
+    stmt.close();
+  }
+
+  @After
+  public void tearDown() throws SQLException {
+    Statement stmt = con.createStatement();
+    stmt.execute("DROP TABLE test_bit_field");
+    stmt.close();
+    TestUtil.closeDB(con);
+  }
+
+  @Test
+  public void TestGetObjectForBitField() throws SQLException {
+    PreparedStatement pstmt = con.prepareStatement("SELECT field_bit  FROM test_bit_field limit 1");
+    checkBitFieldValue(pstmt);
+  }
+
+  @Test
+  public void TestSetBitParameter() throws SQLException {
+    PreparedStatement pstmt = con.prepareStatement("SELECT field_bit  FROM test_bit_field where field_bit = ?");
+    PGobject param = new PGobject();
+    param.setValue(bitValue);
+    param.setType("bit");
+    pstmt.setObject(1, param);
+    checkBitFieldValue(pstmt);
+  }
+
+  private void checkBitFieldValue(PreparedStatement pstmt) throws SQLException {
+    ResultSet rs = pstmt.executeQuery();
+    Assert.assertTrue(rs.next());
+    Object o = rs.getObject(1);
+    Assert.assertTrue(o instanceof PGobject);
+    PGobject pGobject = (PGobject) o;
+    Assert.assertEquals(bitValue, pGobject.getValue());
+    String s = rs.getString(1);
+    Assert.assertEquals(bitValue, s);
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/BitFieldTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/BitFieldTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, PostgreSQL Global Development Group
+ * Copyright (c) 2020, PostgreSQL Global Development Group
  * See the LICENSE file in the project root for more information.
  */
 

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/BitFieldTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/BitFieldTest.java
@@ -21,52 +21,103 @@ import java.sql.Statement;
 
 public class BitFieldTest extends BaseTest4 {
 
-  private static final String bitValue = "1011";
+  private static class TestData {
+    private final String bitValue;
+    private final String tableName;
+    private final String tableFields;
+
+    TestData(String bitValue, String tableName, String tableFields) {
+      this.bitValue = bitValue;
+      this.tableName = tableName;
+      this.tableFields = tableFields;
+    }
+
+    public String getBitValue() {
+      return bitValue;
+    }
+
+    public String getTableName() {
+      return tableName;
+    }
+
+    public String getTableFields() {
+      return tableFields;
+    }
+  }
+
+  private static final String fieldName = "field_bit";
+  public static final String testBitValue = "0101010100101010101010100101";
+  private static final TestData[] testBitValues = new TestData[]{
+      new TestData("0", "test_bit_field_0a", fieldName + " bit"),
+      new TestData("0", "test_bit_field_0b", fieldName + " bit(1)"),
+      new TestData("1", "test_bit_field_1a", fieldName + " bit"),
+      new TestData("1", "test_bit_field_1b", fieldName + " bit(1)"),
+      new TestData(testBitValue, "test_bit_field_gt1_1", String.format("%s bit(%d)", fieldName,
+          testBitValue.length()))
+  };
 
   @Override
   @Before
   public void setUp() throws Exception {
     super.setUp();
     con = TestUtil.openDB();
-    TestUtil.createTempTable(con, "test_bit_field", String.format("field_bit bit(%d)",
-        bitValue.length()));
     Statement stmt = con.createStatement();
-    stmt.execute(String.format("INSERT INTO test_bit_field values(b'%s')", bitValue));
-
-    stmt.close();
+    for (TestData testData : testBitValues) {
+      TestUtil.createTempTable(con, testData.getTableName(), testData.getTableFields());
+      stmt.execute(String.format("INSERT INTO %s values(b'%s')", testData.getTableName(),
+          testData.getBitValue()));
+    }
   }
 
   @After
   public void tearDown() throws SQLException {
     Statement stmt = con.createStatement();
-    stmt.execute("DROP TABLE test_bit_field");
+    for (TestData testData : testBitValues) {
+      stmt.execute(String.format("DROP TABLE %s", testData.getTableName()));
+    }
     stmt.close();
     TestUtil.closeDB(con);
   }
 
   @Test
-  public void TestGetObjectForBitField() throws SQLException {
-    PreparedStatement pstmt = con.prepareStatement("SELECT field_bit  FROM test_bit_field limit 1");
-    checkBitFieldValue(pstmt);
+  public void TestGetObjectForBitFields() throws SQLException {
+    // Start from 1 to skip the first testBit value
+    for (TestData testData : testBitValues) {
+      PreparedStatement pstmt = con.prepareStatement(String.format("SELECT field_bit FROM %s "
+          + "limit 1", testData.getTableName()));
+      checkBitFieldValue(pstmt, testData.getBitValue());
+      pstmt.close();
+    }
   }
 
   @Test
   public void TestSetBitParameter() throws SQLException {
-    PreparedStatement pstmt = con.prepareStatement("SELECT field_bit  FROM test_bit_field where field_bit = ?");
-    PGobject param = new PGobject();
-    param.setValue(bitValue);
-    param.setType("bit");
-    pstmt.setObject(1, param);
-    checkBitFieldValue(pstmt);
+    for (TestData testData : testBitValues) {
+      PreparedStatement pstmt = con.prepareStatement(
+          String.format("SELECT field_bit FROM %s where ", testData.getTableName())
+              + "field_bit = ?");
+      PGobject param = new PGobject();
+      param.setValue(testData.getBitValue());
+      param.setType("bit");
+      pstmt.setObject(1, param);
+      checkBitFieldValue(pstmt, testData.getBitValue());
+      pstmt.close();
+    }
   }
 
-  private void checkBitFieldValue(PreparedStatement pstmt) throws SQLException {
+  private void checkBitFieldValue(PreparedStatement pstmt, String bitValue) throws SQLException {
     ResultSet rs = pstmt.executeQuery();
     Assert.assertTrue(rs.next());
     Object o = rs.getObject(1);
-    Assert.assertTrue(o instanceof PGobject);
-    PGobject pGobject = (PGobject) o;
-    Assert.assertEquals(bitValue, pGobject.getValue());
+    if (bitValue.length() == 1) {
+      Assert.assertTrue("Failed for " + bitValue, o instanceof java.lang.Boolean);
+      Boolean b = (Boolean) o;
+      Assert.assertEquals("Failed for " + bitValue, bitValue.charAt(0) == '1', b);
+    } else {
+      Assert.assertTrue("Failed for " + bitValue, o instanceof PGobject);
+      PGobject pGobject = (PGobject) o;
+      Assert.assertEquals("Failed for " + bitValue, bitValue, pGobject.getValue());
+    }
     String s = rs.getString(1);
     Assert.assertEquals(bitValue, s);
   }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/Jdbc2TestSuite.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/Jdbc2TestSuite.java
@@ -15,6 +15,7 @@ import org.postgresql.core.UTF8EncodingTest;
 import org.postgresql.core.v3.V3ParameterListTests;
 import org.postgresql.jdbc.ArraysTest;
 import org.postgresql.jdbc.ArraysTestSuite;
+import org.postgresql.jdbc.BitFieldTest;
 import org.postgresql.jdbc.DeepBatchedInsertStatementTest;
 import org.postgresql.jdbc.NoColumnMetadataIssue1613Test;
 import org.postgresql.jdbc.PgSQLXMLTest;
@@ -48,6 +49,7 @@ import org.junit.runners.Suite;
     BatchedInsertReWriteEnabledTest.class,
     BatchExecuteTest.class,
     BatchFailureTest.class,
+    BitFieldTest.class,
     BlobTest.class,
     BlobTransactionTest.class,
     CallableStmtTest.class,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Does `./gradlew autostyleCheck checkstyleAll` pass ?
3. [x] Have you added your new test classes to an existing test suite in alphabetical order?

### Changes to Existing Features:

* [ ] Does this break existing behaviour? If so please explain.
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

This PR is to fix issue #892. I spent some time reading the code, and to fix the issue I decided to comment out the line of code that adds the bit data type to the types array in TypeCacheInfo. I had two reasons for it: 1. The bit field is not really in a boolean field, according to the docs it is a string of 1s or 0s. 2. The driver should be consistent in the way it handles bit and varbit fields. There is also another issue #908 related to bit fields but I think this is another discussion. For now I attempted to fix the exception that occurs when ResultSet getObject on a bit field. I created a test class that tests getObject and also getString to make sure the field value can be retrieved a string. 