### PR TITLE
fix: send type void parameters as null value

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/v3/SimpleParameterList.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/SimpleParameterList.java
@@ -283,7 +283,7 @@ class SimpleParameterList implements V3ParameterList {
     for (int i = 0; i < paramTypes.length; ++i) {
       if (direction(i) == OUT) {
         paramTypes[i] = Oid.VOID;
-        paramValues[i] = "null";
+        paramValues[i] = NULL_OBJECT;
       }
     }
   }


### PR DESCRIPTION
I'm working on adding support for procedure OUT parameters to the JDBC driver. More on that later. In the meantime, while I was playing around with various ideas, I noticed that the parameters of type `void` are sent to the server with a payload value of `"null"` as a string. This seems a bit strange and wasteful. I suggest to change this to a real null value.

I looked up the original commit where this came in (ccc8f4c37), but didn't see any explanation there either. Perhaps it wasn't ever questioned.

### All Submissions:

* [X] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes to Existing Features:

* [X] Have you successfully run tests with your changes locally?
