### PR TITLE
chore: remove dependency on java-comment-preprocesor from postgresql-jdbc.spec.tpl

### DIFF
--- a/packaging/rpm/postgresql-jdbc.spec.tpl
+++ b/packaging/rpm/postgresql-jdbc.spec.tpl
@@ -51,7 +51,6 @@ Provides:	pgjdbc = %version-%release
 BuildArch:	noarch
 BuildRequires:	java-devel >= 1.8
 BuildRequires:	maven-local
-BuildRequires:	java-comment-preprocessor
 BuildRequires:	maven-plugin-bundle
 BuildRequires:	classloader-leak-test-framework
 


### PR DESCRIPTION
This dependency is no longer needed for package build

### All Submissions:

* [ ] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Does `./gradlew autostyleCheck checkstyleAll` pass ?
3. [ ] Have you added your new test classes to an existing test suite in alphabetical order?

### Changes to Existing Features:

* [ ] Does this break existing behaviour? If so please explain.
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
