### PR TITLE
chore: remove broken files from .gradle cache folder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,10 +64,10 @@ script:
   #- mv $HOME/.m2/repository/org/postgresql /tmp/cache-trick/
 
 before_cache:
-  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
-  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
-  - find $HOME/.ivy2 -name "ivydata-*.properties" -delete
-  - find $HOME/.sbt -name "*.lock" -delete
+  - F=CleanupGradleCache sh -x -c 'curl -O https://raw.githubusercontent.com/vlsi/cleanup-gradle-cache/v1.x/$F.java && javac -J-Xmx128m $F.java && java -Xmx128m $F'
+  - find $HOME/.ivy2 -name "ivydata-*.properties" -print0 | xargs -0 rm -v
+  - rm -rf $HOME/.ivy2/cache/org.postgresql/
+  - find $HOME/.sbt -name "*.lock" -print0 | xargs -0 rm -v
   # No sense in caching current build artifacts
   - rm -rf $HOME/.m2/repository/org/postgresql
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -33,6 +33,14 @@ tasks.withType<KotlinCompile> {
     }
 }
 
+tasks.withType<AbstractArchiveTask>().configureEach {
+    // Ensure builds are reproducible
+    isPreserveFileTimestamps = false
+    isReproducibleFileOrder = true
+    dirMode = "775".toInt(8)
+    fileMode = "664".toInt(8)
+}
+
 autostyle {
     kotlin {
         ktlint {


### PR DESCRIPTION
Let's see what's inside /home/travis/.gradle/caches/modules-2/files-2.1/org.apache.bcel/bcel/6.0/7d08bcac4832f81467d3e2ca5bd58ad627288656/bcel-6.0.jar