### PR TITLE
fix "savepoint does not exist" error when cleanupSavepoints=true

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -367,6 +367,10 @@ public class QueryExecutorImpl extends QueryExecutorBase {
         && query != restoreToAutoSave
         && !query.getNativeSql().equalsIgnoreCase("COMMIT")
         && getAutoSave() != AutoSave.NEVER
+        // Avoid savepoint does not exist error
+        && !query.getNativeSql().startsWith("SAVEPOINT")
+        && !query.getNativeSql().startsWith("ROLLBACK")
+        && !query.getNativeSql().startsWith("RELEASE")
         // If query has no resulting fields, it cannot fail with 'cached plan must not change result type'
         // thus no need to set a savepoint before such query
         && (getAutoSave() == AutoSave.ALWAYS

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/CleanupSavepointsTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/CleanupSavepointsTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2020, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.test.jdbc2;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.postgresql.PGProperty;
+import org.postgresql.test.TestUtil;
+
+import org.junit.Test;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Savepoint;
+import java.sql.Statement;
+import java.util.Properties;
+
+public class CleanupSavepointsTest extends BaseTest4 {
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    TestUtil.createTable(con, "rollbacktest", "a int, str text");
+    con.setAutoCommit(false);
+  }
+
+  @Override
+  public void tearDown() throws SQLException {
+    try {
+      con.setAutoCommit(true);
+      TestUtil.dropTable(con, "rollbacktest");
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+    super.tearDown();
+  }
+
+  @Override
+  protected void updateProperties(Properties props) {
+    super.updateProperties(props);
+    PGProperty.AUTOSAVE.set(props, "always");
+    PGProperty.CLEANUP_SAVEPOINTS.set(props, "true");
+  }
+
+  @Test
+  public void testCommit() throws Exception {
+    Statement stmt = con.createStatement();
+    stmt.execute("INSERT INTO rollbacktest(a, str) VALUES (0, 'test')");
+
+    con.commit();
+
+    ResultSet rs = stmt.executeQuery("SELECT * FROM rollbacktest");
+
+    assertTrue(rs.next());
+    assertEquals(0, rs.getInt(1));
+    assertEquals("test", rs.getString(2));
+
+    stmt.close();
+  }
+
+  @Test
+  public void testRollback() throws Exception {
+    Statement stmt = con.createStatement();
+    stmt.executeUpdate("INSERT INTO rollbacktest(a, str) VALUES (0, 'test')");
+
+    con.rollback();
+
+    ResultSet rs = stmt.executeQuery("SELECT * FROM rollbacktest");
+
+    assertTrue(!rs.next());
+
+    stmt.close();
+  }
+
+  @Test
+  public void testRollbackToSavepoint() throws Exception {
+    Statement stmt = con.createStatement();
+    stmt.executeUpdate("INSERT INTO rollbacktest(a, str) VALUES (0, 'testbefore')");
+
+    Savepoint savepoint = con.setSavepoint();
+
+    stmt.executeUpdate("INSERT INTO rollbacktest(a, str) VALUES (1, 'testafter')");
+
+    con.rollback(savepoint);
+
+    ResultSet rs = stmt.executeQuery("SELECT * FROM rollbacktest");
+
+    assertTrue(rs.next());
+    assertEquals(0, rs.getInt(1));
+    assertEquals("testbefore", rs.getString(2));
+
+    stmt.close();
+  }
+
+  @Test
+  public void testReleaseSavepoint() throws Exception {
+    Statement stmt = con.createStatement();
+    stmt.executeUpdate("INSERT INTO rollbacktest(a, str) VALUES (0, 'testbefore')");
+
+    Savepoint savepoint = con.setSavepoint();
+
+    stmt.executeUpdate("INSERT INTO rollbacktest(a, str) VALUES (1, 'testafter')");
+
+    con.releaseSavepoint(savepoint);
+
+    ResultSet rs = stmt.executeQuery("SELECT * FROM rollbacktest ORDER BY a");
+
+    assertTrue(rs.next());
+    assertEquals(0, rs.getInt(1));
+    assertEquals("testbefore", rs.getString(2));
+
+    assertTrue(rs.next());
+    assertEquals(1, rs.getInt(1));
+    assertEquals("testafter", rs.getString(2));
+
+    stmt.close();
+  }
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes to Existing Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
A possible fix for #1834
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
