### PR TITLE
Rework sql type gathering to use OID instead of typname.

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/TypeInfo.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/TypeInfo.java
@@ -85,6 +85,8 @@ public interface TypeInfo {
 
   Iterator<String> getPGTypeNamesWithSQLTypes();
 
+  Iterator<Integer> getPGTypeOidsWithSQLTypes();
+
   @Nullable Class<? extends PGobject> getPGobject(String type);
 
   String getJavaClass(int oid) throws SQLException;

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
@@ -2608,10 +2608,10 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
         + "as remarks, CASE WHEN t.typtype = 'd' then  (select CASE";
 
     StringBuilder sqlwhen = new StringBuilder();
-    for (Iterator<String> i = connection.getTypeInfo().getPGTypeNamesWithSQLTypes(); i.hasNext(); ) {
-      String pgType = i.next();
-      int sqlType = connection.getTypeInfo().getSQLType(pgType);
-      sqlwhen.append(" when typname = ").append(escapeQuotes(pgType)).append(" then ").append(sqlType);
+    for (Iterator<Integer> i = connection.getTypeInfo().getPGTypeOidsWithSQLTypes(); i.hasNext(); ) {
+      Integer typOid = i.next();
+      int sqlType = connection.getTypeInfo().getSQLType(typOid);
+      sqlwhen.append(" when t.oid = ").append(typOid).append(" then ").append(sqlType);
     }
     sql += sqlwhen.toString();
 

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc42/DatabaseMetaDataTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc42/DatabaseMetaDataTest.java
@@ -18,6 +18,7 @@ import org.junit.Test;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
+import java.sql.Types;
 
 public class DatabaseMetaDataTest {
 
@@ -26,12 +27,22 @@ public class DatabaseMetaDataTest {
   @Before
   public void setUp() throws Exception {
     conn = TestUtil.openDB();
+    TestUtil.createSchema(conn, "test_schema");
+    TestUtil.createEnumType(conn, "test_schema.test_enum", "'val'");
+    TestUtil.createTable(conn, "test_schema.off_path_table", "var test_schema.test_enum[]");
+    TestUtil.createEnumType(conn, "_test_enum", "'evil'");
+    TestUtil.createEnumType(conn, "test_enum", "'other'");
+    TestUtil.createTable(conn, "on_path_table", "a test_schema.test_enum[], b _test_enum, c test_enum[]");
     TestUtil.createTable(conn, "decimaltest", "a decimal, b decimal(10, 5)");
   }
 
   @After
   public void tearDown() throws Exception {
     TestUtil.dropTable(conn, "decimaltest");
+    TestUtil.dropTable(conn, "on_path_table");
+    TestUtil.dropType(conn, "test_enum");
+    TestUtil.dropType(conn, "_test_enum");
+    TestUtil.dropSchema(conn, "test_schema");
     TestUtil.closeDB(conn);
   }
 
@@ -51,5 +62,44 @@ public class DatabaseMetaDataTest {
     assertFalse(rs.wasNull());
 
     assertTrue(!rs.next());
+  }
+
+  @Test
+  public void testGetCorrectSQLTypeForOffPathTypes() throws Exception {
+    DatabaseMetaData dbmd = conn.getMetaData();
+
+    ResultSet rs = dbmd.getColumns("%", "%", "off_path_table", "%");
+    assertTrue(rs.next());
+    assertEquals("var", rs.getString("COLUMN_NAME"));
+    assertEquals("Detects correct off-path type name", "\"test_schema\".\"_test_enum\"", rs.getString("TYPE_NAME"));
+    assertEquals("Detects correct SQL type for off-path types", Types.ARRAY, rs.getInt("DATA_TYPE"));
+
+    assertFalse(rs.next());
+  }
+
+  @Test
+  public void testGetCorrectSQLTypeForShadowedTypes() throws Exception {
+    DatabaseMetaData dbmd = conn.getMetaData();
+
+    ResultSet rs = dbmd.getColumns("%", "%", "on_path_table", "%");
+
+    assertTrue(rs.next());
+    assertEquals("a", rs.getString("COLUMN_NAME"));
+    assertEquals("Correctly maps types from other schemas","\"test_schema\".\"_test_enum\"", rs.getString("TYPE_NAME"));
+    assertEquals(Types.ARRAY, rs.getInt("DATA_TYPE"));
+
+    assertTrue(rs.next());
+    assertEquals("b", rs.getString("COLUMN_NAME"));
+    // = TYPE _test_enum AS ENUM ('evil')
+    assertEquals( "_test_enum", rs.getString("TYPE_NAME"));
+    assertEquals(Types.VARCHAR, rs.getInt("DATA_TYPE"));
+
+    assertTrue(rs.next());
+    assertEquals("c", rs.getString("COLUMN_NAME"));
+    // = array of TYPE test_enum AS ENUM ('value')
+    assertEquals("Correctly detects shadowed array type name","___test_enum", rs.getString("TYPE_NAME"));
+    assertEquals("Correctly detects type of shadowed name", Types.ARRAY, rs.getInt("DATA_TYPE"));
+
+    assertFalse(rs.next());
   }
 }


### PR DESCRIPTION
This is more stable, and has the added benefit of fixing #1948.

I'd like to remove the pgNameToSQLType map too, but that's used for the public api of getPGTypeNamesWithSQLTypes() - I'm not certain I can just remove that and be done with it...

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
 - I believe so
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
  - possibly has overlap with #914 

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes to Existing Features:

* [x] Does this break existing behaviour? If so please explain.
  - It alters the API of TypeInfoCache to prefer OID type lookups over named lookups, to correctly determine the type of data of which the OID is known, and only a qualified path is known (e.g. off-path types) 
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
 - yes
