### PR TITLE
refactor:(loom) change synchronized methods of Clob Blob to ReentrantLock

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgClob.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgClob.java
@@ -20,60 +20,110 @@ public class PgClob extends AbstractBlobClob implements java.sql.Clob {
     super(conn, oid);
   }
 
-  public synchronized Reader getCharacterStream(long pos, long length) throws SQLException {
-    checkFreed();
-    throw org.postgresql.Driver.notImplemented(this.getClass(), "getCharacterStream(long, long)");
+  public Reader getCharacterStream(long pos, long length) throws SQLException {
+    lock.lock();
+    try {
+      checkFreed();
+      throw org.postgresql.Driver.notImplemented(this.getClass(), "getCharacterStream(long, long)");
+    } finally {
+      lock.unlock();
+    }
   }
 
-  public synchronized int setString(long pos, String str) throws SQLException {
-    checkFreed();
-    throw org.postgresql.Driver.notImplemented(this.getClass(), "setString(long,str)");
+  public int setString(long pos, String str) throws SQLException {
+    lock.lock();
+    try {
+      checkFreed();
+      throw org.postgresql.Driver.notImplemented(this.getClass(), "setString(long,str)");
+    } finally {
+      lock.unlock();
+    }
   }
 
-  public synchronized int setString(long pos, String str, int offset, int len) throws SQLException {
-    checkFreed();
-    throw org.postgresql.Driver.notImplemented(this.getClass(), "setString(long,String,int,int)");
+  public int setString(long pos, String str, int offset, int len) throws SQLException {
+    lock.lock();
+    try {
+      checkFreed();
+      throw org.postgresql.Driver.notImplemented(this.getClass(), "setString(long,String,int,int)");
+    } finally {
+      lock.unlock();
+    }
   }
 
-  public synchronized java.io.OutputStream setAsciiStream(long pos) throws SQLException {
-    checkFreed();
-    throw org.postgresql.Driver.notImplemented(this.getClass(), "setAsciiStream(long)");
+  public java.io.OutputStream setAsciiStream(long pos) throws SQLException {
+    lock.lock();
+    try {
+      checkFreed();
+      throw org.postgresql.Driver.notImplemented(this.getClass(), "setAsciiStream(long)");
+    } finally {
+      lock.unlock();
+    }
   }
 
-  public synchronized java.io.Writer setCharacterStream(long pos) throws SQLException {
-    checkFreed();
-    throw org.postgresql.Driver.notImplemented(this.getClass(), "setCharacteStream(long)");
+  public java.io.Writer setCharacterStream(long pos) throws SQLException {
+    lock.lock();
+    try {
+      checkFreed();
+      throw org.postgresql.Driver.notImplemented(this.getClass(), "setCharacteStream(long)");
+    } finally {
+      lock.unlock();
+    }
   }
 
-  public synchronized InputStream getAsciiStream() throws SQLException {
-    return getBinaryStream();
+  public InputStream getAsciiStream() throws SQLException {
+    lock.lock();
+    try {
+      return getBinaryStream();
+    } finally {
+      lock.unlock();
+    }
   }
 
-  public synchronized Reader getCharacterStream() throws SQLException {
-    Charset connectionCharset = Charset.forName(conn.getEncoding().name());
-    return new InputStreamReader(getBinaryStream(), connectionCharset);
+  public Reader getCharacterStream() throws SQLException {
+    lock.lock();
+    try {
+      Charset connectionCharset = Charset.forName(conn.getEncoding().name());
+      return new InputStreamReader(getBinaryStream(), connectionCharset);
+    } finally {
+      lock.unlock();
+    }
   }
 
-  public synchronized String getSubString(long i, int j) throws SQLException {
-    assertPosition(i, j);
-    LargeObject lo = getLo(false);
-    lo.seek((int) i - 1);
-    return new String(lo.read(j));
+  public String getSubString(long i, int j) throws SQLException {
+    lock.lock();
+    try {
+      assertPosition(i, j);
+      LargeObject lo = getLo(false);
+      lo.seek((int) i - 1);
+      return new String(lo.read(j));
+    } finally {
+      lock.unlock();
+    }
   }
 
   /**
    * For now, this is not implemented.
    */
-  public synchronized long position(String pattern, long start) throws SQLException {
-    checkFreed();
-    throw org.postgresql.Driver.notImplemented(this.getClass(), "position(String,long)");
+  public long position(String pattern, long start) throws SQLException {
+    lock.lock();
+    try {
+      checkFreed();
+      throw org.postgresql.Driver.notImplemented(this.getClass(), "position(String,long)");
+    } finally {
+      lock.unlock();
+    }
   }
 
   /**
    * This should be simply passing the byte value of the pattern Blob.
    */
-  public synchronized long position(Clob pattern, long start) throws SQLException {
-    checkFreed();
-    throw org.postgresql.Driver.notImplemented(this.getClass(), "position(Clob,start)");
+  public long position(Clob pattern, long start) throws SQLException {
+    lock.lock();
+    try {
+      checkFreed();
+      throw org.postgresql.Driver.notImplemented(this.getClass(), "position(Clob,start)");
+    } finally {
+      lock.unlock();
+    }
   }
 }


### PR DESCRIPTION
Referencing #1951 for outline / motivation which is to improve compatibility with loom.

Change PgClob, PgBlob, AbstractClobBlob replacing synchronized methods with use of ReentrantLock to be compatible with loom.

This diff is best viewed ignoring whitespace changes (as lots of code is indented with the additional try finally block)

### Changes to Existing Features:

* [x] Does this break existing behaviour? If so please explain. **No.**
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
