### PR TITLE
refactor:(loom) change from synchronized to lock for SharedTimer and PKCS12KeyManager

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/util/SharedTimer.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/SharedTimer.java
@@ -37,15 +37,15 @@ public class SharedTimer {
       if (timer == null) {
         int index = timerCount.incrementAndGet();
 
-      /*
-       Temporarily switch contextClassLoader to the one that loaded this driver to avoid TimerThread preventing current
-       contextClassLoader - which may be the ClassLoader of a web application - from being GC:ed.
-       */
+        /*
+         Temporarily switch contextClassLoader to the one that loaded this driver to avoid TimerThread preventing current
+         contextClassLoader - which may be the ClassLoader of a web application - from being GC:ed.
+         */
         final ClassLoader prevContextCL = Thread.currentThread().getContextClassLoader();
         try {
-        /*
-         Scheduled tasks whould not need to use .getContextClassLoader, so we just reset it to null
-         */
+          /*
+           Scheduled tasks whould not need to use .getContextClassLoader, so we just reset it to null
+           */
           Thread.currentThread().setContextClassLoader(null);
 
           this.timer = timer = new Timer("PostgreSQL-JDBC-SharedTimer-" + index, true);


### PR DESCRIPTION
Referencing #1951 for outline / motivation which is to improve compatibility with loom.

Change SharedTimer and PKCS12KeyManager replacing the synchronized methods with use of ReentrantLock.

The diff for this PR is best viewed ignoring whitespace due to indentation change

### Changes to Existing Features:

* [x] Does this break existing behaviour? If so please explain.
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
