### PR TITLE
style: fix annotaion array initiliazation indent according to checkstyle new check changes

### DIFF
--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/optional/OptionalTestSuite.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/optional/OptionalTestSuite.java
@@ -16,13 +16,13 @@ import org.junit.runners.Suite;
  */
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
-        BaseDataSourceFailoverUrlsTest.class,
-        CaseOptimiserDataSourceTest.class,
-        ConnectionPoolTest.class,
-        PoolingDataSourceTest.class,
-        SimpleDataSourceTest.class,
-        SimpleDataSourceWithSetURLTest.class,
-        SimpleDataSourceWithUrlTest.class,
+  BaseDataSourceFailoverUrlsTest.class,
+  CaseOptimiserDataSourceTest.class,
+  ConnectionPoolTest.class,
+  PoolingDataSourceTest.class,
+  SimpleDataSourceTest.class,
+  SimpleDataSourceWithSetURLTest.class,
+  SimpleDataSourceWithUrlTest.class,
 })
 public class OptionalTestSuite {
 


### PR DESCRIPTION
Its a checkstyle indentation changes for annotation array initialization that is coming with merging PR checkstyle/checkstyle#8083
please see the diff report run on latest changes with checkstyle/checkstyle#8083 : https://abhishek-kumar09.github.io/github-actions-report-fetch/

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes to Existing Features: No

