### PR TITLE
Group startup statements

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java
@@ -835,6 +835,10 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
     final int dbVersion = queryExecutor.getServerVersionNum();
 
     if (dbVersion >= ServerVersion.v9_0.getVersionNum()) {
+      SetupQueryRunner.run(queryExecutor, "BEGIN", false);
+    }
+
+    if (dbVersion >= ServerVersion.v9_0.getVersionNum()) {
       SetupQueryRunner.run(queryExecutor, "SET extra_float_digits = 3", false);
     }
 
@@ -847,6 +851,9 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
       SetupQueryRunner.run(queryExecutor, sql.toString(), false);
     }
 
+    if (dbVersion >= ServerVersion.v9_0.getVersionNum()) {
+      SetupQueryRunner.run(queryExecutor, "COMMIT", false);
+    }
   }
 
   private boolean isPrimary(QueryExecutor queryExecutor) throws SQLException, IOException {


### PR DESCRIPTION
This pull request wraps the statements executed during startup inside a transaction.

This is important in pool-by-transaction scenarios in order to make sure that all the statements reaches the same connection that is being initialized. Since these are `SET` statements their changes persists outside the transaction scope, but we do receive the `Z????T` messages from the server.

This should only be considered for 42.3.