### PR TITLE
improv: Lru estimate size for jdk9+

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/BaseQueryKey.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/BaseQueryKey.java
@@ -9,6 +9,8 @@ import org.postgresql.util.CanEstimateSize;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 
+import java.util.Objects;
+
 /**
  * This class is used as a cache key for simple statements that have no "returning columns".
  * Prepared statements that have no returning columns use just {@code String sql} as a key.
@@ -37,10 +39,7 @@ class BaseQueryKey implements CanEstimateSize {
 
   @Override
   public long getSize() {
-    if (sql == null) { // just in case
-      return 16;
-    }
-    return 16 + sql.length() * 2L; // 2 bytes per char, revise with Java 9's compact strings
+    return 16 + JavaVersion.getRuntimeVersion().size(sql);
   }
 
   @Override
@@ -54,14 +53,9 @@ class BaseQueryKey implements CanEstimateSize {
 
     BaseQueryKey that = (BaseQueryKey) o;
 
-    if (isParameterized != that.isParameterized) {
-      return false;
-    }
-    if (escapeProcessing != that.escapeProcessing) {
-      return false;
-    }
-    return sql != null ? sql.equals(that.sql) : that.sql == null;
-
+    return isParameterized == that.isParameterized
+        && escapeProcessing == that.escapeProcessing
+        && Objects.equals(sql, that.sql);
   }
 
   @Override

--- a/pgjdbc/src/main/java/org/postgresql/core/CachedQuery.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/CachedQuery.java
@@ -56,7 +56,7 @@ public class CachedQuery implements CanEstimateSize {
   public long getSize() {
     long queryLength;
     if (key instanceof String) {
-      queryLength = ((String) key).length() * 2L; // 2 bytes per char, revise with Java 9's compact strings
+      queryLength = JavaVersion.getRuntimeVersion().size((String) key);
     } else {
       queryLength = ((CanEstimateSize) key).getSize();
     }

--- a/pgjdbc/src/main/java/org/postgresql/core/JavaVersion.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/JavaVersion.java
@@ -5,6 +5,8 @@
 
 package org.postgresql.core;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 public enum JavaVersion {
   // Note: order is important,
   v1_8(2),
@@ -37,7 +39,7 @@ public enum JavaVersion {
 
   private final int sizeMultiple;
 
-  private JavaVersion(int sizeMultiple) {
+  JavaVersion(int sizeMultiple) {
     this.sizeMultiple = sizeMultiple;
   }
 
@@ -47,7 +49,7 @@ public enum JavaVersion {
    * @param string The {@code String} instance to estimate memory consumption for.
    * @return Approximate memory used by <i>string</i>.
    */
-  public final int size(String string) {
+  public final int size(@Nullable String string) {
     return string != null ? string.length() * sizeMultiple : 0;
   }
 }

--- a/pgjdbc/src/main/java/org/postgresql/core/JavaVersion.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/JavaVersion.java
@@ -7,8 +7,8 @@ package org.postgresql.core;
 
 public enum JavaVersion {
   // Note: order is important,
-  v1_8,
-  other;
+  v1_8(2),
+  other(1);
 
   private static final JavaVersion RUNTIME_VERSION = from(System.getProperty("java.version"));
 
@@ -33,5 +33,21 @@ public enum JavaVersion {
       return v1_8;
     }
     return other;
+  }
+
+  private final int sizeMultiple;
+
+  private JavaVersion(int sizeMultiple) {
+    this.sizeMultiple = sizeMultiple;
+  }
+
+  /**
+   * Provides a version specific estimate of memory consumed by <i>string</i>.
+   *
+   * @param string The {@code String} instance to estimate memory consumption for.
+   * @return Approximate memory used by <i>string</i>.
+   */
+  public final int size(String string) {
+    return string != null ? string.length() * sizeMultiple : 0;
   }
 }

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/FieldMetadata.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/FieldMetadata.java
@@ -5,6 +5,7 @@
 
 package org.postgresql.jdbc;
 
+import org.postgresql.core.JavaVersion;
 import org.postgresql.util.CanEstimateSize;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -14,7 +15,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * This class is not meant to be used outside of pgjdbc.
  */
 public class FieldMetadata implements CanEstimateSize {
-  public static class Key {
+  public static final class Key {
     final int tableOid;
     final int positionInTable;
 
@@ -28,16 +29,13 @@ public class FieldMetadata implements CanEstimateSize {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof Key)) {
         return false;
       }
 
-      Key key = (Key) o;
+      final Key key = (Key) o;
 
-      if (tableOid != key.tableOid) {
-        return false;
-      }
-      return positionInTable == key.positionInTable;
+      return tableOid == key.tableOid && positionInTable == key.positionInTable;
     }
 
     @Override
@@ -75,10 +73,12 @@ public class FieldMetadata implements CanEstimateSize {
     this.autoIncrement = autoIncrement;
   }
 
+  @Override
   public long getSize() {
-    return columnName.length() * 2
-        + tableName.length() * 2
-        + schemaName.length() * 2
+    final JavaVersion runtimeVersion = JavaVersion.getRuntimeVersion();
+    return runtimeVersion.size(columnName)
+        + runtimeVersion.size(tableName)
+        + runtimeVersion.size(schemaName)
         + 4L
         + 1L;
   }


### PR DESCRIPTION
jdk 9 and compact strings changes how memory size for strings should be estimated.
this PR also cleans up/optimizes a few small things in the affected classes where size estimates occur

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Does `./gradlew autostyleCheck checkstyleAll` pass ?
3. [x] Have you added your new test classes to an existing test suite in alphabetical order?

### Changes to Existing Features:

* [x] Does this break existing behaviour? If so please explain.
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
