### PR TITLE
fix: LruCache evict on usage rather than insertion

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/QueryExecutorBase.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/QueryExecutorBase.java
@@ -84,8 +84,7 @@ public abstract class QueryExecutorBase implements QueryExecutor {
     this.cachedQueryCreateAction = new CachedQueryCreateAction(this);
     statementCache = new LruCache<Object, CachedQuery>(
         Math.max(0, PGProperty.PREPARED_STATEMENT_CACHE_QUERIES.getInt(info)),
-        Math.max(0, PGProperty.PREPARED_STATEMENT_CACHE_SIZE_MIB.getInt(info) * 1024 * 1024),
-        false,
+        Math.max(0, PGProperty.PREPARED_STATEMENT_CACHE_SIZE_MIB.getInt(info) * 1024L * 1024L),
         cachedQueryCreateAction,
         new LruCache.EvictAction<CachedQuery>() {
           @Override

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
@@ -322,8 +322,7 @@ public class PgConnection implements BaseConnection {
 
     fieldMetadataCache = new LruCache<FieldMetadata.Key, FieldMetadata>(
             Math.max(0, PGProperty.DATABASE_METADATA_CACHE_FIELDS.getInt(info)),
-            Math.max(0, PGProperty.DATABASE_METADATA_CACHE_FIELDS_MIB.getInt(info) * 1024 * 1024),
-        false);
+            Math.max(0, PGProperty.DATABASE_METADATA_CACHE_FIELDS_MIB.getInt(info) * 1024L * 1024L));
 
     replicationConnection = PGProperty.REPLICATION.get(info) != null;
 

--- a/pgjdbc/src/test/java/org/postgresql/test/util/LruCacheTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/util/LruCacheTest.java
@@ -6,6 +6,7 @@
 package org.postgresql.test.util;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.fail;
 
 import org.postgresql.util.CanEstimateSize;
@@ -49,7 +50,7 @@ public class LruCacheTest {
 
   @Before
   public void setUp() throws Exception {
-    cache = new LruCache<Integer, Entry>(4, 1000, false, new LruCache.CreateAction<Integer, Entry>() {
+    cache = new LruCache<Integer, Entry>(4, 1000, new LruCache.CreateAction<Integer, Entry>() {
       @Override
       public Entry create(Integer key) throws SQLException {
         assertEquals("Unexpected create", expectCreate[0], key);
@@ -104,7 +105,9 @@ public class LruCacheTest {
     a = use(1);
     b = use(2);
     c = use(3);
-    a = use(1); // reuse a
+    //calling use actually inserts value into map, which tests eviction based
+    //on insertion order rather than USED order.
+    assertSame(a, cache.get(1));
     use(5);
     d = use(4, b); // expect b to be evicted
   }


### PR DESCRIPTION
Also change to StampedLock rather than synchronized keyword.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Does `./gradlew autostyleCheck checkstyleAll` pass ?
3. [x] Have you added your new test classes to an existing test suite in alphabetical order?

### Changes to Existing Features:

* [x] Does this break existing behaviour? If so please explain.
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
