### PR TITLE
Verify code via forbidden-apis (jdk-internal and jdk-non-portable signatures)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 ### Added 
+- Verify code via forbidden-apis (jdk-internal and jdk-non-portable signatures) [PR #2012](https://github.com/pgjdbc/pgjdbc/pull/2012)
 
 ### Fixed
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,6 +12,7 @@ import com.github.vlsi.gradle.properties.dsl.props
 import com.github.vlsi.gradle.properties.dsl.stringProperty
 import com.github.vlsi.gradle.publishing.dsl.simplifyXml
 import com.github.vlsi.gradle.publishing.dsl.versionFromResolution
+import de.thetaphi.forbiddenapis.gradle.CheckForbiddenApisExtension
 import org.postgresql.buildtools.JavaCommentPreprocessorTask
 
 plugins {
@@ -24,6 +25,7 @@ plugins {
     id("org.owasp.dependencycheck")
     id("org.checkerframework") apply false
     id("com.github.johnrengelman.shadow") apply false
+    id("de.thetaphi.forbiddenapis") apply false
     id("org.nosphere.gradle.github.actions")
     // IDE configuration
     id("org.jetbrains.gradle.plugin.idea-ext")
@@ -45,6 +47,7 @@ val enableCheckerframework by props()
 val skipCheckstyle by props()
 val skipAutostyle by props()
 val skipJavadoc by props()
+val skipForbiddenApis by props()
 val enableMavenLocal by props()
 val enableGradleMetadata by props()
 // For instance -PincludeTestTags=!org.postgresql.test.SlowTests
@@ -371,6 +374,22 @@ allprojects {
         if (!enableGradleMetadata) {
             tasks.withType<GenerateModuleMetadata> {
                 enabled = false
+            }
+        }
+
+        if (!skipForbiddenApis && !props.bool("skipCheckstyle")) {
+            apply(plugin = "de.thetaphi.forbiddenapis")
+            configure<CheckForbiddenApisExtension> {
+                failOnUnsupportedJava = false
+                bundledSignatures.addAll(
+                    listOf(
+                        // "jdk-deprecated",
+                        "jdk-internal",
+                        "jdk-non-portable"
+                        // "jdk-system-out"
+                        // "jdk-unsafe"
+                    )
+                )
             }
         }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -33,6 +33,7 @@ com.github.johnrengelman.shadow.version=5.1.0
 com.github.lburgazzoli.karaf.version=0.5.1
 com.github.spotbugs.version=2.0.0
 com.github.vlsi.vlsi-release-plugins.version=1.70
+de.thetaphi.forbiddenapis.version=3.1
 kotlin.version=1.3.70
 me.champeau.gradle.jmh.version=0.5.0
 org.checkerframework.version=0.5.5

--- a/pgjdbc-jre6/gradle.properties
+++ b/pgjdbc-jre6/gradle.properties
@@ -1,3 +1,4 @@
 # There's no point in verifying preprocessed sources
 skipCheckstyle=true
 jdbc.specification.version=4.0
+skipForbiddenApis=true

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -20,6 +20,7 @@ pluginManagement {
         idv("com.github.vlsi.ide", "com.github.vlsi.vlsi-release-plugins")
         idv("com.github.vlsi.license-gather", "com.github.vlsi.vlsi-release-plugins")
         idv("com.github.vlsi.stage-vote-release", "com.github.vlsi.vlsi-release-plugins")
+        idv("de.thetaphi.forbiddenapis")
         idv("me.champeau.gradle.jmh")
         idv("org.checkerframework")
         idv("org.jetbrains.gradle.plugin.idea-ext")


### PR DESCRIPTION
This prevents unwanted method calls, and it ensures the produced bytecode is parseable.