### PR TITLE
fix: Add missing closing fi to travis_release.sh

### DIFF
--- a/.travis/travis_release.sh
+++ b/.travis/travis_release.sh
@@ -54,7 +54,7 @@ if [[ "x$JRE" == "x" ]]; then
   git push --dry-run git@github.com:$TRAVIS_REPO_SLUG.git "HEAD:$ORIGINAL_BRANCH"
 
   git checkout -b "$TMP_BRANCH"
-
+fi
 
 # Remove release tag if exists just in case
 git push git@github.com:$TRAVIS_REPO_SLUG$JRE.git :$RELEASE_TAG || true


### PR DESCRIPTION
Fixes missing closing "fi" that was removed in:

https://github.com/pgjdbc/pgjdbc/commit/866c6a9e4cc42d9c279d68b8c756f562eaf0f249#diff-9122fe87e52418ef839c9ce46f241ea1e2ed7d6390d8ac2f64dee6734b00cbeeL70-L91

We haven't noticed this yet as it's only run for a release. Can't really test this without performing a release either so would be nice to have a second pair of eyes confirm prior to merging.