### PR TITLE
chore: javadoc changes in Driver.java to pass upcoming checkstyle version

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/Driver.java
+++ b/pgjdbc/src/main/java/org/postgresql/Driver.java
@@ -205,7 +205,7 @@ public class Driver implements java.sql.Driver {
    * @param info a list of arbitrary tag/value pairs as connection arguments
    * @return a connection to the URL or null if it isnt us
    * @exception SQLException if a database access error occurs or the url is
-   * {@code null}
+   *            {@code null}
    * @see java.sql.Driver#connect
    */
   @Override


### PR DESCRIPTION
Due to issue https://github.com/checkstyle/checkstyle/issues/5711 some violations in the Javadoc were not reported.
This PR is to pass validation with the new Checkstyle version.

No changes in the code or docs, only some new whitespases.