### PR TITLE
chore: javadoc changes in PgResultSet.java to pass upcoming checkstyle version

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
@@ -2159,11 +2159,11 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
    *
    * @param columnIndex the first column is 1, the second is 2, ...
    * @return the column value; if the value is SQL <code>NULL</code>, the value returned is
-   * <code>false</code>
+   *         <code>false</code>
    * @exception SQLException if the columnIndex is not valid; if a database access error occurs; if
-   *     this method is called on a closed result set or is an invalid cast to boolean type.
+   *            this method is called on a closed result set or is an invalid cast to boolean type.
    * @see <a href="https://www.postgresql.org/docs/current/static/datatype-boolean.html">PostgreSQL
-   * Boolean Type</a>
+   *      Boolean Type</a>
    */
   @Pure
   @Override


### PR DESCRIPTION
Due to issue https://github.com/checkstyle/checkstyle/issues/5711 some violations in the Javadoc were not reported.
This PR is to pass validation with the new Checkstyle version.

No changes in the code or docs, only some new whitespases.