### PR TITLE
Fix PGCopyInputStream readFromCopy() returning last row twice and add tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - Fix "Required class information missing" when old org.jboss:jandex parses pgjdbc classes [issue 2008][https://github.com/pgjdbc/pgjdbc/issues/2008]
+- Fix PGCopyInputStream returning the last row twice when reading with CopyOut API [issue 2016][https://github.com/pgjdbc/pgjdbc/issues/2016]
 
 ## [42.2.18]
 ### Fixed

--- a/pgjdbc/src/main/java/org/postgresql/copy/PGCopyInputStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/copy/PGCopyInputStream.java
@@ -104,7 +104,7 @@ public class PGCopyInputStream extends InputStream implements CopyOut {
   }
 
   public byte @Nullable [] readFromCopy() throws SQLException {
-    byte[] result = buf;
+    byte[] result = null;
     try {
       byte[] buf = fillBuffer();
       if (buf != null) {

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc4/PGCopyInputStreamTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc4/PGCopyInputStreamTest.java
@@ -5,111 +5,124 @@
 
 package org.postgresql.test.jdbc4;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 import org.postgresql.PGConnection;
 import org.postgresql.copy.PGCopyInputStream;
-import org.postgresql.core.ServerVersion;
 import org.postgresql.test.TestUtil;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
-import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
 
 public class PGCopyInputStreamTest {
+  private static final int NUM_TEST_ROWS = 4;
+  /**
+   * COPY .. TO STDOUT terminates each row of data with a LF regardless of platform so the size of
+   * each output row will always be two, one byte for the character and one for the LF.
+   */
+  private static final int COPY_ROW_SIZE = 2; // One character plus newline
+  private static final int COPY_DATA_SIZE = NUM_TEST_ROWS * COPY_ROW_SIZE;
+  private static final String COPY_SQL = String.format("COPY (SELECT i FROM generate_series(0, %d - 1) i) TO STDOUT", NUM_TEST_ROWS);
+
   private Connection conn;
-  private PGCopyInputStream sut;
-  private String copyParams;
 
   @Before
   public void setUp() throws Exception {
     conn = TestUtil.openDB();
-    TestUtil.createTable(conn, "cpinstreamtest", "i int");
-    if (TestUtil.haveMinimumServerVersion(conn, ServerVersion.v9_0)) {
-      copyParams = "(FORMAT CSV, HEADER false)";
-    } else {
-      copyParams = "CSV";
-    }
   }
 
   @After
   public void tearDown() throws SQLException {
-    silentlyCloseStream(sut);
-    TestUtil.dropTable(conn, "cpinstreamtest");
     TestUtil.closeDB(conn);
   }
 
   @Test
   public void testReadBytesCorrectlyHandlesEof() throws SQLException, IOException {
-    insertSomeData();
-
-    sut = new PGCopyInputStream((PGConnection) conn,
-        "COPY cpinstreamtest (i) TO STDOUT WITH " + copyParams);
-
-    byte[] buf = new byte[100]; // large enough to read everything on the next step
-    assertTrue(sut.read(buf) > 0);
-
-    assertEquals(-1, sut.read(buf));
+    PGConnection pgConn = conn.unwrap(PGConnection.class);
+    try (PGCopyInputStream in = new PGCopyInputStream(pgConn, COPY_SQL)) {
+      // large enough to read everything on the next step
+      byte[] buf = new byte[COPY_DATA_SIZE + 100];
+      assertEquals("First read should get the entire table into the byte array",
+          COPY_DATA_SIZE, in.read(buf));
+      assertEquals("Subsequent read should return -1 to indicate stream is finished",
+          -1, in.read(buf));
+    }
   }
 
   @Test
   public void testReadBytesCorrectlyReadsDataInChunks() throws SQLException, IOException {
-    insertSomeData();
-
-    sut = new PGCopyInputStream((PGConnection) conn,
-        "COPY (select i from cpinstreamtest order by i asc) TO STDOUT WITH " + copyParams);
-
-    byte[] buf = new byte[2]; // small enough to read in multiple chunks
-    StringBuilder result = new StringBuilder(100);
-    int chunks = 0;
-    while (sut.read(buf) > 0) {
-      result.append(new String(buf));
-      ++chunks;
+    PGConnection pgConn = conn.unwrap(PGConnection.class);
+    try (PGCopyInputStream in = new PGCopyInputStream(pgConn, COPY_SQL)) {
+      // Read in row sized chunks
+      List<byte[]> chunks = readFully(in, COPY_ROW_SIZE);
+      assertEquals("Should read one chunk per row", NUM_TEST_ROWS, chunks.size());
+      assertEquals("Entire table should have be read", "0\n1\n2\n3\n", chunksToString(chunks));
     }
-
-    assertEquals(4, chunks);
-    assertEquals("0\n1\n2\n3\n", result.toString());
   }
 
   @Test
-  public void testStreamCanBeClosedAfterReadUp() throws SQLException, IOException {
-    insertSomeData();
-
-    sut = new PGCopyInputStream((PGConnection) conn,
-        "COPY (select i from cpinstreamtest order by i asc) TO STDOUT WITH " + copyParams);
-
-    byte[] buff = new byte[100];
-    while (sut.read(buff) > 0) {
-      // do nothing
+  public void testCopyAPI() throws SQLException, IOException {
+    PGConnection pgConn = conn.unwrap(PGConnection.class);
+    try (PGCopyInputStream in = new PGCopyInputStream(pgConn, COPY_SQL)) {
+      List<byte[]> chunks = readFromCopyFully(in);
+      assertEquals("Should read one chunk per row", NUM_TEST_ROWS, chunks.size());
+      assertEquals("Entire table should have be read", "0\n1\n2\n3\n", chunksToString(chunks));
     }
-
-    sut.close();
   }
 
-  private void silentlyCloseStream(PGCopyInputStream sut) {
-    if (sut != null) {
-      try {
-        if (sut.isActive()) {
-          sut.close();
-        }
-      } catch (IOException e) {
-        // intentionally ignore
+  @Test
+  public void testMixedAPI() throws SQLException, IOException {
+    PGConnection pgConn = conn.unwrap(PGConnection.class);
+    try (PGCopyInputStream in = new PGCopyInputStream(pgConn, COPY_SQL)) {
+      // First read using java.io.InputStream API
+      byte[] firstChar = new byte[1];
+      in.read(firstChar);
+      assertArrayEquals("IO API should read first character", "0".getBytes(), firstChar);
+
+      // Read remainder of first row using CopyOut API
+      assertArrayEquals("readFromCopy() should return remainder of first row", "\n".getBytes(), in.readFromCopy());
+
+      // Then read the rest using CopyOut API
+      List<byte[]> chunks = readFromCopyFully(in);
+      assertEquals("Should read one chunk per row", NUM_TEST_ROWS - 1, chunks.size());
+      assertEquals("Rest of table should have be read", "1\n2\n3\n", chunksToString(chunks));
+    }
+  }
+
+  private static List<byte[]> readFully(PGCopyInputStream in, int size) throws SQLException, IOException {
+    List<byte[]> chunks = new ArrayList<>();
+    do {
+      byte[] buf = new byte[size];
+      if (in.read(buf) <= 0) {
+        break;
       }
-    }
+      chunks.add(buf);
+    } while (true);
+    return chunks;
   }
 
-  private void insertSomeData() throws SQLException {
-    PreparedStatement pstmt = conn.prepareStatement("insert into cpinstreamtest (i) values (?)");
-    for (int i = 0; i < 4; ++i) {
-      pstmt.setInt(1, i);
-      pstmt.addBatch();
+  private static List<byte[]> readFromCopyFully(PGCopyInputStream in) throws SQLException, IOException {
+    List<byte[]> chunks = new ArrayList<>();
+    byte[] buf;
+    while ((buf = in.readFromCopy()) != null) {
+      chunks.add(buf);
     }
-    pstmt.executeBatch();
+    return chunks;
+  }
+
+  private static String chunksToString(List<byte[]> chunks) {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    chunks.forEach(chunk -> out.write(chunk, 0, chunk.length));
+    return new String(out.toByteArray(), StandardCharsets.UTF_8);
   }
 }


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [X] Does your submission pass tests?
2. [X] Does `./gradlew autostyleCheck checkstyleAll` pass ?

### Changes to Existing Features:

* [X] Have you written new tests for your core changes, as applicable?
* [X] Have you successfully run tests with your changes locally?

###

Fixes #2016.

Actual fix is one line, the rest is cleaning up the tests and adding some new ones to catch this behavior.

Having read through that PGCopyInputStream class a bit more, I really don't like the internals. Half the methods have variables that shadow the private members and it's pretty confusing to understand what it's trying to do. To keep this PR simple I haven't touched any of it here, but I'm planning on submitting a separate PR that eventually cleans that up. Maybe we should deprecate the CopyOut interface half of those classes first though.