### PR TITLE
fix: isValid() should not wait longer than network timeout

### DIFF
--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc4/ConnectionValidTimeoutTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc4/ConnectionValidTimeoutTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2021, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.test.jdbc4;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.postgresql.PGProperty;
+import org.postgresql.jdbc.SslMode;
+import org.postgresql.test.TestUtil;
+import org.postgresql.test.util.ConnectionBreaker;
+import org.postgresql.test.util.rules.annotation.HaveMinimalServerVersion;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+@RunWith(Parameterized.class)
+@HaveMinimalServerVersion("9.4")
+public class ConnectionValidTimeoutTest {
+
+  @Rule
+  public Timeout timeout = new Timeout(30, TimeUnit.SECONDS);
+
+  private Connection connection;
+
+  private ConnectionBreaker connectionBreaker;
+
+  @Parameterized.Parameter(0)
+  public int networkTimeoutMillis;
+  @Parameterized.Parameter(1)
+  public int validationTimeoutSeconds;
+  @Parameterized.Parameter(2)
+  public int expectedMaxValidationTimeMillis;
+
+  @Parameterized.Parameters(name = "networkTimeoutMillis={0}, validationTimeoutSeconds={1}, expectedMaxValidationTimeMillis={2}")
+  public static Iterable<Object[]> data() {
+    return Arrays.asList(new Object[][]{
+      {500, 1, 600},
+      {1500, 1, 1100},
+      {0, 1, 1100},
+      {500, 0, 600},
+    });
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    connectionBreaker = new ConnectionBreaker(TestUtil.getServer(), TestUtil.getPort());
+    connectionBreaker.acceptAsyncConnection();
+
+    final Properties shadowProperties = new Properties();
+    shadowProperties.setProperty(TestUtil.SERVER_HOST_PORT_PROP,
+        String.format("%s:%s", "localhost", connectionBreaker.getServerPort()));
+
+    // closing an ssl socket can require one more read attempt, which effectively doubles the waiting time
+    // so we disable ssl for this test to get more predictable results
+    PGProperty.SSL_MODE.set(shadowProperties, SslMode.DISABLE.value);
+
+    connection = TestUtil.openDB(shadowProperties);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    connectionBreaker.close();
+    connection.close();
+  }
+
+  @Test
+  public void testIsValidRespectsSmallerTimeout() throws SQLException {
+    connection.setNetworkTimeout(null, networkTimeoutMillis);
+    connectionBreaker.breakConnection();
+
+    long start = System.nanoTime();
+    boolean result = connection.isValid(validationTimeoutSeconds);
+    long elapsedMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
+
+    assertFalse("Broken connection should not be valid", result);
+
+    assertTrue(String.format(
+            "Connection validation should not take longer than %d ms"
+                + " when network timeout is %d ms and validation timeout is %d s"
+                + " (actual result: %d ms)",
+            expectedMaxValidationTimeMillis,
+            networkTimeoutMillis,
+            validationTimeoutSeconds,
+            elapsedMillis
+        ),
+        elapsedMillis <= expectedMaxValidationTimeMillis
+    );
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc4/Jdbc4TestSuite.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc4/Jdbc4TestSuite.java
@@ -19,6 +19,7 @@ import org.junit.runners.Suite;
     BlobTest.class,
     CharacterStreamTest.class,
     ClientInfoTest.class,
+    ConnectionValidTimeoutTest.class,
     DatabaseMetaDataHideUnprivilegedObjectsTest.class,
     DatabaseMetaDataTest.class,
     IsValidTest.class,

--- a/pgjdbc/src/test/java/org/postgresql/test/util/ConnectionBreaker.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/util/ConnectionBreaker.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2021, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.test.util;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+public class ConnectionBreaker {
+
+  private final ExecutorService workers;
+
+  private final ServerSocket internalServer;
+
+  private final Socket pgSocket;
+
+  private final int serverPort;
+
+  private volatile boolean breakConnection;
+
+  /**
+   * Constructor of the forwarder for the PostgreSQL server.
+   *
+   * @param pgServer   The PostgreSQL server address.
+   * @param pgPort     The PostgreSQL server port.
+   * @throws Exception if anything goes wrong binding the server.
+   */
+  public ConnectionBreaker(final String pgServer, final int pgPort) throws Exception {
+    workers = Executors.newCachedThreadPool();
+    internalServer = new ServerSocket(0);
+    serverPort = internalServer.getLocalPort();
+    pgSocket = new Socket(pgServer, pgPort);
+    breakConnection = false;
+  }
+
+  /**
+   * Starts to accept a asynchronous connection.
+   *
+   * @throws Exception if something goes wrong with the sockets.
+   */
+  public void acceptAsyncConnection() throws Exception {
+    final InputStream pgServerInputStream = pgSocket.getInputStream();
+    final OutputStream pgServerOutputStream = pgSocket.getOutputStream();
+
+    // Future socket;
+    final Future<Socket> futureConnection = workers.submit(internalServer::accept);
+
+    // Forward reads;
+    workers.submit(() -> {
+      while (!breakConnection) {
+        final Socket conn = futureConnection.get();
+        int read = pgServerInputStream.read();
+        conn.getOutputStream().write(read);
+      }
+      return null;
+    });
+
+    // Forwards writes;
+    workers.submit(() -> {
+      while (!breakConnection) {
+        final Socket conn = futureConnection.get();
+        int read = conn.getInputStream().read();
+        pgServerOutputStream.write(read);
+      }
+      return null;
+    });
+  }
+
+  public int getServerPort() {
+    return serverPort;
+  }
+
+  /**
+   * Breaks the forwarding.
+   */
+  public void breakConnection() {
+    this.breakConnection = true;
+  }
+
+  /**
+   * Closes the sockets.
+   */
+  public void close() throws Exception {
+    this.workers.shutdownNow();
+    this.internalServer.close();
+    this.pgSocket.close();
+  }
+}


### PR DESCRIPTION
Some time ago PR https://github.com/pgjdbc/pgjdbc/pull/1557 was merged into master and it introduced a kind of regression:
* before the change: if we called `setNetworkTimeout()` with some small value (say, 500 ms) and then called `isValid()` with a larger timeout (say, 2 seconds) on an unresponsive connection, `isValid()` would respect the smaller timeout and would wait for only 500 ms;
* after the change: in the same scenario as above `isValid()` would override the network timeout and wait for 2 seconds.

This is a problem for me, because at the company where I work we often use timeouts smaller than 1 second. We use HikariCP and it allows validation timeouts as small as 250 ms, which is implemented by smth. like `conn.setNetworkTimeout(250); return conn.isValid(1);` (see https://github.com/brettwooldridge/HikariCP/blob/HikariCP-3.4.5/src/main/java/com/zaxxer/hikari/pool/PoolBase.java#L156-L162).
And if we update to the latest PgJDBC version we'll be limited to validation timeouts that are multiples of 1 second.

As a solution I suggest to change `isValid` method so that it overrides the network timeout only in those cases where the new timeout is smaller than the one already set. So, for example, if you call `setNetworkTimeout(500)` and then call `isValid(2)`, it would wait for at most 500 ms. And if you call `setNetworkTimeout(3000)` and then call `isValid(1)`, it would wait for at most 1 second.
I wrote some code to show the proposed solution. I haven't added any tests, but I think I could try to (if this PR is otherwise considered good).


### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes to Existing Features:

* [x] Does this break existing behaviour? If so please explain.
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
