### PR TITLE
improv: utf8 ascii detection

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/ByteOptimizedUTF8Encoder.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/ByteOptimizedUTF8Encoder.java
@@ -105,7 +105,7 @@ final class ByteOptimizedUTF8Encoder extends OptimizedUTF8Encoder {
    * @param offset The offset into <i>bytes</i> to start checking.
    * @param length The number of bytes to check.
    * @return {@code -1} if no values in range are negative. A non-negative value indicates that some value
-   * at or after the returned index is negative.
+   *     at or after the returned index is negative.
    */
   private static int negativeIndex(byte[] bytes, int offset, int length) {
     try {
@@ -143,7 +143,8 @@ final class ByteOptimizedUTF8Encoder extends OptimizedUTF8Encoder {
     final int toIdx = offset + length;
     int i = offset;
     for (int j = toIdx - 7; i < j; i += 8) {
-      //the only way to get here is if this value is not null
+      //this method is only called from negativeIndex if VAR_HANDLE_GET_LONG was successfully
+      //populated in the static block
       @SuppressWarnings("nullness")
       final long l = (long) VAR_HANDLE_GET_LONG.invokeExact(bytes, i);
       if ((l & POSITIVE_MASK) != l) {
@@ -154,7 +155,7 @@ final class ByteOptimizedUTF8Encoder extends OptimizedUTF8Encoder {
       }
     }
     //take care of any remaining (up to 7)
-    for ( ; i<toIdx; ++i) {
+    for ( ; i < toIdx; ++i) {
       if (bytes[i] < 0) {
         return i;
       }

--- a/pgjdbc/src/main/java/org/postgresql/core/ByteOptimizedUTF8Encoder.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/ByteOptimizedUTF8Encoder.java
@@ -140,8 +140,18 @@ final class ByteOptimizedUTF8Encoder extends OptimizedUTF8Encoder {
    */
   @SuppressWarnings("unused") //called via MethodHandle
   private static int varHandleNegativeIndex(byte[] bytes, int offset, int length) throws Throwable {
+    assert length > 8;
     final int toIdx = offset + length;
     int i = offset;
+    //first get aligned for reads (for architectures other than x86)
+    //we know length is longer than 8, so no need to check length each
+    //time through loop
+    while ((i & 7) != 0) {
+      if (bytes[i] < 0) {
+        return i;
+      }
+      i++;
+    }
     for (int j = toIdx - 7; i < j; i += 8) {
       //this method is only called from negativeIndex if VAR_HANDLE_GET_LONG was successfully
       //populated in the static block

--- a/pgjdbc/src/main/java/org/postgresql/core/ByteOptimizedUTF8Encoder.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/ByteOptimizedUTF8Encoder.java
@@ -5,6 +5,8 @@
 
 package org.postgresql.core;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 import java.io.IOException;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -22,139 +24,141 @@ import java.util.logging.Logger;
  */
 final class ByteOptimizedUTF8Encoder extends OptimizedUTF8Encoder {
 
-    /**
-     * {@code MethodHandle} for a jdk 9+ {@code byteArrayViewVarHandle} for {@code long[]} using the {@link ByteOrder#nativeOrder()}.
-     * The method signature is {@code long get(byte[], int)}.
-     */
-    private static final MethodHandle VAR_HANDLE_GET_LONG;
+  /**
+   * {@code MethodHandle} for a jdk 9+ {@code byteArrayViewVarHandle} for {@code long[]} using the {@link ByteOrder#nativeOrder()}.
+   * The method signature is {@code long get(byte[], int)}.
+   */
+  private static final @Nullable MethodHandle VAR_HANDLE_GET_LONG;
 
-    /**
-     * {@code MethodHandle} for the actual implementation to use at runtime.
-     */
-    private static final MethodHandle NEGATIVE_INDEX;
+  /**
+   * {@code MethodHandle} for the actual implementation to use at runtime.
+   */
+  private static final MethodHandle NEGATIVE_INDEX;
 
-    /**
-     * Mask to identify if the sign bit for any byte is set.
-     */
-    private static final long POSITIVE_MASK = 0x7F7F7F7F7F7F7F7FL;
+  /**
+   * Mask to identify if the sign bit for any byte is set.
+   */
+  private static final long POSITIVE_MASK = 0x7F7F7F7F7F7F7F7FL;
 
-    static {
-      MethodHandle varHandleGetLong = null;
-      MethodHandle negativeIdx = null;
-      final MethodHandles.Lookup lookup = MethodHandles.lookup();
-      final MethodType negIdxType = MethodType.methodType(int.class, byte[].class, int.class, int.class);
+  static {
+    MethodHandle varHandleGetLong = null;
+    MethodHandle negativeIdx = null;
+    final MethodHandles.Lookup lookup = MethodHandles.lookup();
+    final MethodType negIdxType = MethodType.methodType(int.class, byte[].class, int.class, int.class);
+    try {
+      final Class<?> varHandleClazz = Class.forName("java.lang.invoke.VarHandle", true, null);
+      final Method byteArrayViewHandle = MethodHandles.class.getDeclaredMethod("byteArrayViewVarHandle", new Class[] {Class.class, ByteOrder.class});
+      final Object varHandle = byteArrayViewHandle.invoke(null, long[].class, ByteOrder.nativeOrder());
+      final Class<?> accessModeEnum = Class.forName("java.lang.invoke.VarHandle$AccessMode", true, null);
+      @SuppressWarnings({ "unchecked", "rawtypes" })
+      final Object getAccessModeEnum = Enum.valueOf((Class)accessModeEnum, "GET");
+      final Method toMethodHandle = varHandleClazz.getDeclaredMethod("toMethodHandle", accessModeEnum);
+      varHandleGetLong = (MethodHandle) toMethodHandle.invoke(varHandle, getAccessModeEnum);
+      negativeIdx = lookup.findStatic(ByteOptimizedUTF8Encoder.class, "varHandleNegativeIndex", negIdxType);
+    } catch (Throwable t) {
+      Logger.getLogger(ByteOptimizedUTF8Encoder.class.getName())
+            .log(Level.INFO, "Failure trying to load byteArrayViewVarHandle.", t);
+      varHandleGetLong = null;
       try {
-        final Class<?> varHandleClazz = Class.forName("java.lang.invoke.VarHandle", true, null);
-        final Method byteArrayViewHandle = MethodHandles.class.getDeclaredMethod("byteArrayViewVarHandle", new Class[] {Class.class, ByteOrder.class});
-        final Object varHandle = byteArrayViewHandle.invoke(null, long[].class, ByteOrder.nativeOrder());
-        final Class<?> accessModeEnum = Class.forName("java.lang.invoke.VarHandle$AccessMode", true, null);
-        @SuppressWarnings({ "unchecked", "rawtypes" })
-        final Object getAccessModeEnum = Enum.valueOf((Class)accessModeEnum, "GET");
-        final Method toMethodHandle = varHandleClazz.getDeclaredMethod("toMethodHandle", accessModeEnum);
-        varHandleGetLong = (MethodHandle) toMethodHandle.invoke(varHandle, getAccessModeEnum);
-        negativeIdx = lookup.findStatic(ByteOptimizedUTF8Encoder.class, "varHandleNegativeIndex", negIdxType);
-      } catch (Throwable t) {
-        Logger.getLogger(ByteOptimizedUTF8Encoder.class.getName())
-              .log(Level.INFO, "Failure trying to load byteArrayViewVarHandle.", t);
-        varHandleGetLong = null;
-        try {
-          negativeIdx = lookup.findStatic(ByteOptimizedUTF8Encoder.class, "legacyNegativeIndex", negIdxType);
-        } catch (Exception e) {
-          throw new IllegalStateException(e);
-        }
+        negativeIdx = lookup.findStatic(ByteOptimizedUTF8Encoder.class, "legacyNegativeIndex", negIdxType);
+      } catch (Exception e) {
+        throw new IllegalStateException(e);
       }
-      VAR_HANDLE_GET_LONG = varHandleGetLong;
-      NEGATIVE_INDEX = negativeIdx;
     }
+    VAR_HANDLE_GET_LONG = varHandleGetLong;
+    NEGATIVE_INDEX = negativeIdx;
+  }
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public String decode(byte[] encodedString, int offset, int length) throws IOException {
-      //for very short strings going straight to chars is up to 30% faster
-      if (length < 24) {
-        return charDecode(encodedString, offset, length);
-      }
-      //check to see if there are any negative byte values
-      final int indexOfNegativeByte = negativeIndex(encodedString, offset, length);
-      // if indexOfNegativeByte is -1, that means ascii, use String constructor
-      return indexOfNegativeByte == -1 ? new String(encodedString, offset, length, StandardCharsets.US_ASCII)
-                                       : slowDecode(encodedString, offset, length, indexOfNegativeByte);
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public String decode(byte[] encodedString, int offset, int length) throws IOException {
+    //for very short strings going straight to chars is up to 30% faster
+    if (length < 24) {
+      return charDecode(encodedString, offset, length);
     }
+    //check to see if there are any negative byte values
+    final int indexOfNegativeByte = negativeIndex(encodedString, offset, length);
+    // if indexOfNegativeByte is -1, that means ascii, use String constructor
+    return indexOfNegativeByte == -1 ? new String(encodedString, offset, length, StandardCharsets.US_ASCII)
+                                     : slowDecode(encodedString, offset, length, indexOfNegativeByte);
+  }
 
-    /**
-     * Decodes to {@code char[]} in presence of non-ascii values after first copying all known ascii chars directly
-     * from {@code byte[]} to {@code char[]}.
-     */
-    private synchronized String slowDecode(byte[] encodedString, int offset, int length, int curIdx) throws IOException {
-      final char[] chars = getCharArray(length);
-      int out = 0;
-      for (int i = offset; i < curIdx; ++i) {
-        chars[out++] = (char) encodedString[i];
-      }
-      return decodeToChars(encodedString, curIdx, length - (curIdx - offset), chars, out);
+  /**
+   * Decodes to {@code char[]} in presence of non-ascii values after first copying all known ascii chars directly
+   * from {@code byte[]} to {@code char[]}.
+   */
+  private synchronized String slowDecode(byte[] encodedString, int offset, int length, int curIdx) throws IOException {
+    final char[] chars = getCharArray(length);
+    int out = 0;
+    for (int i = offset; i < curIdx; ++i) {
+      chars[out++] = (char) encodedString[i];
     }
+    return decodeToChars(encodedString, curIdx, length - (curIdx - offset), chars, out);
+  }
 
-    /**
-     * Returns index into <i>bytes</i> which is at or shortly before a negative value. Will return {@code -1}
-     * if all values are non-negative.
-     * @param bytes The bytes to check.
-     * @param offset The offset into <i>bytes</i> to start checking.
-     * @param length The number of bytes to check.
-     * @return {@code -1} if no values in range are negative. A non-negative value indicates that some value
-     * at or after the returned index is negative.
-     */
-    private static int negativeIndex(byte[] bytes, int offset, int length) {
-      try {
-        return (int) NEGATIVE_INDEX.invokeExact(bytes, offset, length);
-      } catch (RuntimeException e) {
-        throw e;
-      } catch (Error e) {
-        throw e;
-      } catch (Throwable t) {
-        throw new RuntimeException(t);
-      }
+  /**
+   * Returns index into <i>bytes</i> which is at or shortly before a negative value. Will return {@code -1}
+   * if all values are non-negative.
+   * @param bytes The bytes to check.
+   * @param offset The offset into <i>bytes</i> to start checking.
+   * @param length The number of bytes to check.
+   * @return {@code -1} if no values in range are negative. A non-negative value indicates that some value
+   * at or after the returned index is negative.
+   */
+  private static int negativeIndex(byte[] bytes, int offset, int length) {
+    try {
+      return (int) NEGATIVE_INDEX.invokeExact(bytes, offset, length);
+    } catch (RuntimeException e) {
+      throw e;
+    } catch (Error e) {
+      throw e;
+    } catch (Throwable t) {
+      throw new RuntimeException(t);
     }
+  }
 
-    /**
-     * This method is only called if {@link #VAR_HANDLE_GET_LONG} cannot be loaded at runtime. It does
-     * a traditional loop over <i>bytes</i> to see if any are negative.
-     */
-    @SuppressWarnings("unused") //called via MethodHandle
-    private static int legacyNegativeIndex(byte[] bytes, int offset, int length) {
-      for (int i = offset, j = offset + length; i < j; ++i) {
-        // bytes are signed values. all ascii values are positive
-        if (bytes[i] < 0) {
-          return i;
-        }
+  /**
+   * This method is only called if {@link #VAR_HANDLE_GET_LONG} cannot be loaded at runtime. It does
+   * a traditional loop over <i>bytes</i> to see if any are negative.
+   */
+  @SuppressWarnings("unused") //called via MethodHandle
+  private static int legacyNegativeIndex(byte[] bytes, int offset, int length) {
+    for (int i = offset, j = offset + length; i < j; ++i) {
+      // bytes are signed values. all ascii values are positive
+      if (bytes[i] < 0) {
+        return i;
       }
-      return -1;
     }
+    return -1;
+  }
 
-    /**
-     * Uses {@link #VAR_HANDLE_GET_LONG} to read 8 bytes at a time as a {@code long} from <i>bytes</i> to check
-     * if any are negative using {@link #POSITIVE_MASK}.
-     */
-    @SuppressWarnings("unused") //called via MethodHandle
-    private static int varHandleNegativeIndex(byte[] bytes, int offset, int length) throws Throwable {
-      final int toIdx = offset + length;
-      int i = offset;
-      for (int j = toIdx - 7; i < j; i += 8) {
-        final long l = (long) VAR_HANDLE_GET_LONG.invokeExact(bytes, i);
-        if ((l & POSITIVE_MASK) != l) {
-          //we could do work to find a more specific value for i
-          //but it does not really matter, as the bytes just have to be
-          //looped over again anyway in either slowDecode or decodeToChars
-          return i;
-        }
+  /**
+   * Uses {@link #VAR_HANDLE_GET_LONG} to read 8 bytes at a time as a {@code long} from <i>bytes</i> to check
+   * if any are negative using {@link #POSITIVE_MASK}.
+   */
+  @SuppressWarnings("unused") //called via MethodHandle
+  private static int varHandleNegativeIndex(byte[] bytes, int offset, int length) throws Throwable {
+    final int toIdx = offset + length;
+    int i = offset;
+    for (int j = toIdx - 7; i < j; i += 8) {
+      //the only way to get here is if this value is not null
+      @SuppressWarnings("nullness")
+      final long l = (long) VAR_HANDLE_GET_LONG.invokeExact(bytes, i);
+      if ((l & POSITIVE_MASK) != l) {
+        //we could do work to find a more specific value for i
+        //but it does not really matter, as the bytes just have to be
+        //looped over again anyway in either slowDecode or decodeToChars
+        return i;
       }
-      //take care of any remaining (up to 7)
-      for ( ; i<toIdx; ++i) {
-        if (bytes[i] < 0) {
-          return i;
-        }
-      }
-      return -1;
     }
+    //take care of any remaining (up to 7)
+    for ( ; i<toIdx; ++i) {
+      if (bytes[i] < 0) {
+        return i;
+      }
+    }
+    return -1;
+  }
 }

--- a/pgjdbc/src/main/java/org/postgresql/core/ByteOptimizedUTF8Encoder.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/ByteOptimizedUTF8Encoder.java
@@ -6,7 +6,14 @@
 package org.postgresql.core;
 
 import java.io.IOException;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.reflect.Method;
+import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * UTF-8 encoder which validates input and is optimized for jdk 9+ where {@code String} objects are backed by
@@ -15,35 +22,139 @@ import java.nio.charset.StandardCharsets;
  */
 final class ByteOptimizedUTF8Encoder extends OptimizedUTF8Encoder {
 
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  public String decode(byte[] encodedString, int offset, int length) throws IOException {
-    //for very short strings going straight to chars is up to 30% faster
-    if (length <= 32) {
-      return charDecode(encodedString, offset, length);
+    /**
+     * {@code MethodHandle} for a jdk 9+ {@code byteArrayViewVarHandle} for {@code long[]} using the {@link ByteOrder#nativeOrder()}.
+     * The method signature is {@code long get(byte[], int)}.
+     */
+    private static final MethodHandle VAR_HANDLE_GET_LONG;
+
+    /**
+     * {@code MethodHandle} for the actual implementation to use at runtime.
+     */
+    private static final MethodHandle NEGATIVE_INDEX;
+
+    /**
+     * Mask to identify if the sign bit for any byte is set.
+     */
+    private static final long POSITIVE_MASK = 0x7F7F7F7F7F7F7F7FL;
+
+    static {
+      MethodHandle varHandleGetLong = null;
+      MethodHandle negativeIdx = null;
+      final MethodHandles.Lookup lookup = MethodHandles.lookup();
+      final MethodType negIdxType = MethodType.methodType(int.class, byte[].class, int.class, int.class);
+      try {
+        final Class<?> varHandleClazz = Class.forName("java.lang.invoke.VarHandle", true, null);
+        final Method byteArrayViewHandle = MethodHandles.class.getDeclaredMethod("byteArrayViewVarHandle", new Class[] {Class.class, ByteOrder.class});
+        final Object varHandle = byteArrayViewHandle.invoke(null, long[].class, ByteOrder.nativeOrder());
+        final Class<?> accessModeEnum = Class.forName("java.lang.invoke.VarHandle$AccessMode", true, null);
+        @SuppressWarnings({ "unchecked", "rawtypes" })
+        final Object getAccessModeEnum = Enum.valueOf((Class)accessModeEnum, "GET");
+        final Method toMethodHandle = varHandleClazz.getDeclaredMethod("toMethodHandle", accessModeEnum);
+        varHandleGetLong = (MethodHandle) toMethodHandle.invoke(varHandle, getAccessModeEnum);
+        negativeIdx = lookup.findStatic(ByteOptimizedUTF8Encoder.class, "varHandleNegativeIndex", negIdxType);
+      } catch (Throwable t) {
+        Logger.getLogger(ByteOptimizedUTF8Encoder.class.getName())
+              .log(Level.INFO, "Failure trying to load byteArrayViewVarHandle.", t);
+        varHandleGetLong = null;
+        try {
+          negativeIdx = lookup.findStatic(ByteOptimizedUTF8Encoder.class, "legacyNegativeIndex", negIdxType);
+        } catch (Exception e) {
+          throw new IllegalStateException(e);
+        }
+      }
+      VAR_HANDLE_GET_LONG = varHandleGetLong;
+      NEGATIVE_INDEX = negativeIdx;
     }
-    for (int i = offset, j = offset + length; i < j; ++i) {
-      // bytes are signed values. all ascii values are positive
-      if (encodedString[i] < 0) {
-        return slowDecode(encodedString, offset, length, i);
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String decode(byte[] encodedString, int offset, int length) throws IOException {
+      //for very short strings going straight to chars is up to 30% faster
+      if (length < 24) {
+        return charDecode(encodedString, offset, length);
+      }
+      //check to see if there are any negative byte values
+      final int indexOfNegativeByte = negativeIndex(encodedString, offset, length);
+      // if indexOfNegativeByte is -1, that means ascii, use String constructor
+      return indexOfNegativeByte == -1 ? new String(encodedString, offset, length, StandardCharsets.US_ASCII)
+                                       : slowDecode(encodedString, offset, length, indexOfNegativeByte);
+    }
+
+    /**
+     * Decodes to {@code char[]} in presence of non-ascii values after first copying all known ascii chars directly
+     * from {@code byte[]} to {@code char[]}.
+     */
+    private synchronized String slowDecode(byte[] encodedString, int offset, int length, int curIdx) throws IOException {
+      final char[] chars = getCharArray(length);
+      int out = 0;
+      for (int i = offset; i < curIdx; ++i) {
+        chars[out++] = (char) encodedString[i];
+      }
+      return decodeToChars(encodedString, curIdx, length - (curIdx - offset), chars, out);
+    }
+
+    /**
+     * Returns index into <i>bytes</i> which is at or shortly before a negative value. Will return {@code -1}
+     * if all values are non-negative.
+     * @param bytes The bytes to check.
+     * @param offset The offset into <i>bytes</i> to start checking.
+     * @param length The number of bytes to check.
+     * @return {@code -1} if no values in range are negative. A non-negative value indicates that some value
+     * at or after the returned index is negative.
+     */
+    private static int negativeIndex(byte[] bytes, int offset, int length) {
+      try {
+        return (int) NEGATIVE_INDEX.invokeExact(bytes, offset, length);
+      } catch (RuntimeException e) {
+        throw e;
+      } catch (Error e) {
+        throw e;
+      } catch (Throwable t) {
+        throw new RuntimeException(t);
       }
     }
-    // we have confirmed all chars are ascii, give java that hint
-    return new String(encodedString, offset, length, StandardCharsets.US_ASCII);
-  }
 
-  /**
-   * Decodes to {@code char[]} in presence of non-ascii values after first copying all known ascii chars directly
-   * from {@code byte[]} to {@code char[]}.
-   */
-  private synchronized String slowDecode(byte[] encodedString, int offset, int length, int curIdx) throws IOException {
-    final char[] chars = getCharArray(length);
-    int out = 0;
-    for (int i = offset; i < curIdx; ++i) {
-      chars[out++] = (char) encodedString[i];
+    /**
+     * This method is only called if {@link #VAR_HANDLE_GET_LONG} cannot be loaded at runtime. It does
+     * a traditional loop over <i>bytes</i> to see if any are negative.
+     */
+    @SuppressWarnings("unused") //called via MethodHandle
+    private static int legacyNegativeIndex(byte[] bytes, int offset, int length) {
+      for (int i = offset, j = offset + length; i < j; ++i) {
+        // bytes are signed values. all ascii values are positive
+        if (bytes[i] < 0) {
+          return i;
+        }
+      }
+      return -1;
     }
-    return decodeToChars(encodedString, curIdx, length - (curIdx - offset), chars, out);
-  }
+
+    /**
+     * Uses {@link #VAR_HANDLE_GET_LONG} to read 8 bytes at a time as a {@code long} from <i>bytes</i> to check
+     * if any are negative using {@link #POSITIVE_MASK}.
+     */
+    @SuppressWarnings("unused") //called via MethodHandle
+    private static int varHandleNegativeIndex(byte[] bytes, int offset, int length) throws Throwable {
+      final int toIdx = offset + length;
+      int i = offset;
+      for (int j = toIdx - 7; i < j; i += 8) {
+        final long l = (long) VAR_HANDLE_GET_LONG.invokeExact(bytes, i);
+        if ((l & POSITIVE_MASK) != l) {
+          //we could do work to find a more specific value for i
+          //but it does not really matter, as the bytes just have to be
+          //looped over again anyway in either slowDecode or decodeToChars
+          return i;
+        }
+      }
+      //take care of any remaining (up to 7)
+      for ( ; i<toIdx; ++i) {
+        if (bytes[i] < 0) {
+          return i;
+        }
+      }
+      return -1;
+    }
 }

--- a/pgjdbc/src/test/java/org/postgresql/core/UTF8EncodingTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/core/UTF8EncodingTest.java
@@ -89,4 +89,12 @@ public class UTF8EncodingTest {
     final byte[] encoded = encoding.encode(string);
     assertEquals(string, encoding.decode(encoded));
   }
+
+  @Test
+  public void testOffset() throws Exception {
+    final byte[] encoded = encoding.encode(string);
+    final byte[] copied = new byte[encoded.length  + 1];
+    System.arraycopy(encoded, 0, copied, 1, encoded.length);
+    assertEquals(string, encoding.decode(copied, 1, encoded.length));
+  }
 }


### PR DESCRIPTION
The [ByteOptimizedUTF8Encoder](https://github.com/pgjdbc/pgjdbc/blob/master/pgjdbc/src/main/java/org/postgresql/core/ByteOptimizedUTF8Encoder.java) is used for jdk 9+. It identifies if the `byte[]` being decoded is ascii (all values non-negative) and in that case uses the String constructor with `byte[]` and `StandardCharsets.US_ASCII`.

Also in jdk 9, [VarHandle](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/invoke/VarHandle.html) was introduced as part of the ongoing effort to remove public use of `sun.misc.Unsafe`. The [byteArrayViewVarHandle](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/invoke/MethodHandles.html#byteArrayViewVarHandle(java.lang.Class,java.nio.ByteOrder)) method was added to `MethodHandles`. This provides a standard way to read other primitive types out of a `byte[]`.
Using this mechanism to read 8 bytes at a time as a `long`, and then doing a bitwise comparison to see if any byte has the sign bit set, allows us to more quickly determine if all values are positive. The gains are pretty minimal with shorter strings (say 30 or fewer characters), but the grow to be pretty meaningful with longer strings. By 200 characters, it takes half the time to decode an all ascii string.
For non-ascii strings, the gains are not as significant. If the first non-ascii character is early in the string, there is effectively no difference. If it is late in the string there are some gains with longer strings.

```
Benchmark                   (nonascii)  (size)  Mode  Cnt     Score     Error  Units
UTF8DecodeTest.byteDecode         none      10  avgt    4    24.491 ±  24.141  ns/op
UTF8DecodeTest.byteDecode         none      21  avgt    4    29.674 ±   0.485  ns/op
UTF8DecodeTest.byteDecode         none      33  avgt    4    34.521 ±   8.716  ns/op
UTF8DecodeTest.byteDecode         none      42  avgt    4    37.226 ±   1.181  ns/op
UTF8DecodeTest.byteDecode         none      67  avgt    4    45.219 ±   2.339  ns/op
UTF8DecodeTest.byteDecode         none      85  avgt    4    49.992 ±   0.847  ns/op
UTF8DecodeTest.byteDecode         none     201  avgt    4    81.148 ±   3.941  ns/op
UTF8DecodeTest.byteDecode         none     511  avgt    4   175.482 ±   3.841  ns/op
UTF8DecodeTest.byteDecode         none    1027  avgt    4   352.741 ±   1.639  ns/op
UTF8DecodeTest.byteDecode         none    4093  avgt    4  1340.075 ±  28.911  ns/op
UTF8DecodeTest.byteDecode        first      10  avgt    4    38.568 ±   0.752  ns/op
UTF8DecodeTest.byteDecode        first      21  avgt    4    52.658 ±   2.071  ns/op
UTF8DecodeTest.byteDecode        first      33  avgt    4    71.833 ±   1.282  ns/op
UTF8DecodeTest.byteDecode        first      42  avgt    4    93.155 ±  48.654  ns/op
UTF8DecodeTest.byteDecode        first      67  avgt    4   131.299 ±   0.944  ns/op
UTF8DecodeTest.byteDecode        first      85  avgt    4   153.810 ±   9.156  ns/op
UTF8DecodeTest.byteDecode        first     201  avgt    4   334.417 ±   9.889  ns/op
UTF8DecodeTest.byteDecode        first     511  avgt    4   827.276 ±   7.832  ns/op
UTF8DecodeTest.byteDecode        first    1027  avgt    4  1439.246 ±  35.413  ns/op
UTF8DecodeTest.byteDecode        first    4093  avgt    4  5681.369 ± 212.638  ns/op
UTF8DecodeTest.byteDecode         last      10  avgt    4    30.598 ±   0.883  ns/op
UTF8DecodeTest.byteDecode         last      21  avgt    4    34.551 ±   1.200  ns/op
UTF8DecodeTest.byteDecode         last      33  avgt    4    45.318 ±   1.471  ns/op
UTF8DecodeTest.byteDecode         last      42  avgt    4    52.921 ±   4.158  ns/op
UTF8DecodeTest.byteDecode         last      67  avgt    4    78.328 ±   0.769  ns/op
UTF8DecodeTest.byteDecode         last      85  avgt    4    92.434 ±   3.636  ns/op
UTF8DecodeTest.byteDecode         last     201  avgt    4   167.634 ±   1.705  ns/op
UTF8DecodeTest.byteDecode         last     511  avgt    4   399.995 ±   8.223  ns/op
UTF8DecodeTest.byteDecode         last    1027  avgt    4   793.311 ±  13.804  ns/op
UTF8DecodeTest.byteDecode         last    4093  avgt    4  2987.328 ±  35.215  ns/op
UTF8DecodeTest.byteDecode2        none      10  avgt    4    22.397 ±   0.710  ns/op
UTF8DecodeTest.byteDecode2        none      21  avgt    4    29.516 ±   0.713  ns/op
UTF8DecodeTest.byteDecode2        none      33  avgt    4    29.639 ±   1.533  ns/op
UTF8DecodeTest.byteDecode2        none      42  avgt    4    31.040 ±   1.289  ns/op
UTF8DecodeTest.byteDecode2        none      67  avgt    4    34.030 ±   1.284  ns/op
UTF8DecodeTest.byteDecode2        none      85  avgt    4    36.440 ±   2.101  ns/op
UTF8DecodeTest.byteDecode2        none     201  avgt    4    41.693 ±   1.507  ns/op
UTF8DecodeTest.byteDecode2        none     511  avgt    4    78.010 ±   2.026  ns/op
UTF8DecodeTest.byteDecode2        none    1027  avgt    4   140.924 ±   6.026  ns/op
UTF8DecodeTest.byteDecode2        none    4093  avgt    4   605.689 ±  14.186  ns/op
UTF8DecodeTest.byteDecode2       first      10  avgt    4    37.214 ±   1.442  ns/op
UTF8DecodeTest.byteDecode2       first      21  avgt    4    52.524 ±   1.538  ns/op
UTF8DecodeTest.byteDecode2       first      33  avgt    4    71.759 ±   2.639  ns/op
UTF8DecodeTest.byteDecode2       first      42  avgt    4    82.086 ±   3.214  ns/op
UTF8DecodeTest.byteDecode2       first      67  avgt    4   131.296 ±   9.519  ns/op
UTF8DecodeTest.byteDecode2       first      85  avgt    4   152.813 ±   5.674  ns/op
UTF8DecodeTest.byteDecode2       first     201  avgt    4   334.176 ±   4.781  ns/op
UTF8DecodeTest.byteDecode2       first     511  avgt    4   824.706 ±  11.475  ns/op
UTF8DecodeTest.byteDecode2       first    1027  avgt    4  1438.562 ±  48.083  ns/op
UTF8DecodeTest.byteDecode2       first    4093  avgt    4  6748.101 ± 181.989  ns/op
UTF8DecodeTest.byteDecode2        last      10  avgt    4    30.833 ±   0.516  ns/op
UTF8DecodeTest.byteDecode2        last      21  avgt    4    34.351 ±   1.364  ns/op
UTF8DecodeTest.byteDecode2        last      33  avgt    4    46.318 ±   1.363  ns/op
UTF8DecodeTest.byteDecode2        last      42  avgt    4    50.218 ±   1.339  ns/op
UTF8DecodeTest.byteDecode2        last      67  avgt    4    67.239 ±   1.051  ns/op
UTF8DecodeTest.byteDecode2        last      85  avgt    4    75.952 ±   1.198  ns/op
UTF8DecodeTest.byteDecode2        last     201  avgt    4   124.608 ±   2.113  ns/op
UTF8DecodeTest.byteDecode2        last     511  avgt    4   281.554 ±   3.169  ns/op
UTF8DecodeTest.byteDecode2        last    1027  avgt    4   589.749 ±  14.238  ns/op
UTF8DecodeTest.byteDecode2        last    4093  avgt    4  2246.736 ±  20.406  ns/op
```

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Does `./gradlew autostyleCheck checkstyleAll` pass ?
3. [x] Have you added your new test classes to an existing test suite in alphabetical order?

### Changes to Existing Features:

* [x] Does this break existing behaviour? If so please explain.
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
