### PR TITLE
fix: properly set cancel socket timeout

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/QueryExecutorBase.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/QueryExecutorBase.java
@@ -182,7 +182,7 @@ public abstract class QueryExecutorBase implements QueryExecutor {
       cancelStream =
           new PGStream(pgStream.getSocketFactory(), pgStream.getHostSpec(), cancelSignalTimeout);
       if (cancelSignalTimeout > 0) {
-        cancelStream.getSocket().setSoTimeout(cancelSignalTimeout);
+        cancelStream.setNetworkTimeout(cancelSignalTimeout);
       }
       cancelStream.sendInteger4(16);
       cancelStream.sendInteger2(1234);

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/StatementTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/StatementTest.java
@@ -12,9 +12,11 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import org.postgresql.PGProperty;
 import org.postgresql.core.ServerVersion;
 import org.postgresql.jdbc.PgStatement;
 import org.postgresql.test.TestUtil;
+import org.postgresql.test.util.StrangeProxyServer;
 import org.postgresql.util.PSQLState;
 
 import org.junit.After;
@@ -23,6 +25,7 @@ import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -31,6 +34,7 @@ import java.sql.SQLWarning;
 import java.sql.Statement;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Random;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
@@ -842,6 +846,30 @@ public class StatementTest {
       TestUtil.closeQuietly(connB);
     }
     assertEquals(0, sharedTimer.getRefCount());
+  }
+
+  @Test(timeout = 30000)
+  public void testCancelQueryWithBrokenNetwork() throws SQLException, IOException, InterruptedException {
+    // check that stmt.cancel() doesn't hang forever if the network is broken
+
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+
+    try (StrangeProxyServer proxyServer = new StrangeProxyServer(TestUtil.getServer(), TestUtil.getPort())) {
+      Properties props = new Properties();
+      props.setProperty(TestUtil.SERVER_HOST_PORT_PROP, String.format("%s:%s", "localhost", proxyServer.getServerPort()));
+      PGProperty.CANCEL_SIGNAL_TIMEOUT.set(props, 1);
+
+      try (Connection conn = TestUtil.openDB(props); Statement stmt = conn.createStatement()) {
+        executor.submit(() -> stmt.execute("select pg_sleep(60)"));
+
+        Thread.sleep(1000);
+        proxyServer.stopForwardingAllClients();
+
+        stmt.cancel();
+      }
+    }
+
+    executor.shutdownNow();
   }
 
   @Test(timeout = 10000)

--- a/pgjdbc/src/test/java/org/postgresql/test/util/StrangeProxyServer.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/util/StrangeProxyServer.java
@@ -60,6 +60,10 @@ public class StrangeProxyServer implements Closeable {
     this.minAcceptedAt = System.currentTimeMillis();
   }
 
+  public void stopForwardingAllClients() {
+    this.minAcceptedAt = Long.MAX_VALUE;
+  }
+
   private void doAsync(Runnable task) {
     Thread thread = new Thread(task);
     thread.setDaemon(true);


### PR DESCRIPTION
If we set a socket timeout on `PGStream`'s socket, but don't set `PGStream.pgInput.timeoutRequested` to `true`, then `PGStream.pgInput` will ignore SocketTimeoutExceptions ([VisibleBufferedInputStream.java#L169](https://github.com/pgjdbc/pgjdbc/blob/0dbc6078b98215f11413a8b0f3a15a7c08180a29/pgjdbc/src/main/java/org/postgresql/core/VisibleBufferedInputStream.java#L169)) and the timeout effectively doesn't work.

`PGStream.setNetworkTimeout()` sets both the timeout and the `timeoutRequested` field.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes to Existing Features:

* [ ] Does this break existing behaviour? If so please explain.
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
