### PR TITLE
fix: return metadata privileges for views and foreign tables

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
@@ -1798,11 +1798,12 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
     f[6] = new Field("IS_GRANTABLE", Oid.VARCHAR);
 
     String sql;
+    // r = ordinary table, p = partitioned table, v = view, m = materialized view, f = foreign table
     sql = "SELECT n.nspname,c.relname,r.rolname,c.relacl "
           + " FROM pg_catalog.pg_namespace n, pg_catalog.pg_class c, pg_catalog.pg_roles r "
           + " WHERE c.relnamespace = n.oid "
           + " AND c.relowner = r.oid "
-          + " AND c.relkind IN ('r','p') ";
+          + " AND c.relkind IN ('r','p','v','m','f') ";
 
     if (schemaPattern != null && !schemaPattern.isEmpty()) {
       sql += " AND n.nspname LIKE " + escapeQuotes(schemaPattern);

--- a/pgjdbc/src/test/java/org/postgresql/test/TestUtil.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/TestUtil.java
@@ -465,6 +465,23 @@ public class TestUtil {
     }
   }
 
+  /*
+   * Helper - creates a view
+   */
+  public static void createView(Connection con, String view, String columns, String table)
+      throws SQLException {
+    Statement st = con.createStatement();
+    try {
+      dropView(con, view);
+
+      String sql = "CREATE VIEW " + view + " AS SELECT " + columns + " FROM " + table;
+
+      st.executeUpdate(sql);
+    } finally {
+      closeQuietly(st);
+    }
+  }
+
   /**
    * Helper creates an enum type.
    *
@@ -559,6 +576,13 @@ public class TestUtil {
    */
   public static void dropTable(Connection con, String table) throws SQLException {
     dropObject(con, "TABLE", table);
+  }
+
+  /*
+   * Helper - drops a view
+   */
+  public static void dropView(Connection con, String view) throws SQLException {
+    dropObject(con, "VIEW", view);
   }
 
   /*

--- a/pgjdbc/src/test/java/org/postgresql/test/TestUtil.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/TestUtil.java
@@ -403,18 +403,7 @@ public class TestUtil {
    * Helper - drops a schema
    */
   public static void dropSchema(Connection con, String schema) throws SQLException {
-    Statement stmt = con.createStatement();
-    try {
-      if (con.getAutoCommit()) {
-        // Not in a transaction so ignore error for missing object
-        stmt.executeUpdate("DROP SCHEMA IF EXISTS " + schema + " CASCADE");
-      } else {
-        // In a transaction so do not ignore errors for missing object
-        stmt.executeUpdate("DROP SCHEMA " + schema + " CASCADE");
-      }
-    } finally {
-      closeQuietly(stmt);
-    }
+    dropObject(con, "SCHEMA", schema);
   }
 
   /*
@@ -442,7 +431,6 @@ public class TestUtil {
    * @param table String
    * @param columns String
    */
-
   public static void createTempTable(Connection con, String table, String columns)
       throws SQLException {
     Statement st = con.createStatement();
@@ -484,7 +472,6 @@ public class TestUtil {
    * @param name String
    * @param values String
    */
-
   public static void createEnumType(Connection con, String name, String values)
       throws SQLException {
     Statement st = con.createStatement();
@@ -534,22 +521,11 @@ public class TestUtil {
    * Drops a domain.
    *
    * @param con Connection
-   * @param name String
+   * @param domain String
    */
-  public static void dropDomain(Connection con, String name)
+  public static void dropDomain(Connection con, String domain)
       throws SQLException {
-    Statement stmt = con.createStatement();
-    try {
-      if (con.getAutoCommit()) {
-        // Not in a transaction so ignore error for missing object
-        stmt.executeUpdate("DROP DOMAIN IF EXISTS " + name + " CASCADE");
-      } else {
-        // In a transaction so do not ignore errors for missing object
-        stmt.executeUpdate("DROP DOMAIN " + name + " CASCADE");
-      }
-    } finally {
-      closeQuietly(stmt);
-    }
+    dropObject(con, "DOMAIN", domain);
   }
 
   /**
@@ -575,50 +551,32 @@ public class TestUtil {
    * drop a sequence because older versions don't have dependency information for serials
    */
   public static void dropSequence(Connection con, String sequence) throws SQLException {
-    Statement stmt = con.createStatement();
-    try {
-      if (con.getAutoCommit()) {
-        // Not in a transaction so ignore error for missing object
-        stmt.executeUpdate("DROP SEQUENCE IF EXISTS " + sequence + " CASCADE");
-      } else {
-        // In a transaction so do not ignore errors for missing object
-        stmt.executeUpdate("DROP SEQUENCE " + sequence + " CASCADE");
-      }
-    } finally {
-      closeQuietly(stmt);
-    }
+    dropObject(con, "SEQUENCE", sequence);
   }
 
   /*
    * Helper - drops a table
    */
   public static void dropTable(Connection con, String table) throws SQLException {
-    Statement stmt = con.createStatement();
-    try {
-      if (con.getAutoCommit()) {
-        // Not in a transaction so ignore error for missing object
-        stmt.executeUpdate("DROP TABLE IF EXISTS " + table + " CASCADE ");
-      } else {
-        // In a transaction so do not ignore errors for missing object
-        stmt.executeUpdate("DROP TABLE " + table + " CASCADE ");
-      }
-    } finally {
-      closeQuietly(stmt);
-    }
+    dropObject(con, "TABLE", table);
   }
 
   /*
    * Helper - drops a type
    */
   public static void dropType(Connection con, String type) throws SQLException {
+    dropObject(con, "TYPE", type);
+  }
+
+  private static void dropObject(Connection con, String type, String name) throws SQLException {
     Statement stmt = con.createStatement();
     try {
       if (con.getAutoCommit()) {
         // Not in a transaction so ignore error for missing object
-        stmt.executeUpdate("DROP TYPE IF EXISTS " + type + " CASCADE");
+        stmt.executeUpdate("DROP " + type + " IF EXISTS " + name + " CASCADE");
       } else {
         // In a transaction so do not ignore errors for missing object
-        stmt.executeUpdate("DROP TYPE " + type + " CASCADE");
+        stmt.executeUpdate("DROP " + type + " " + name + " CASCADE");
       }
     } finally {
       closeQuietly(stmt);

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseMetaDataTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseMetaDataTest.java
@@ -80,6 +80,7 @@ public class DatabaseMetaDataTest {
     TestUtil.createTable(con, "\"a'\"", "a int4");
     TestUtil.createTable(con, "arraytable", "a numeric(5,2)[], b varchar(100)[]");
     TestUtil.createTable(con, "intarraytable", "a int4[], b int4[][]");
+    TestUtil.createView(con, "viewtest", "id, quest", "metadatatest");
     TestUtil.dropType(con, "custom");
     TestUtil.dropType(con, "_custom");
     TestUtil.createCompositeType(con, "custom", "i int", false);
@@ -124,6 +125,7 @@ public class DatabaseMetaDataTest {
     Statement stmt = con.createStatement();
     stmt.execute("DROP FUNCTION f4(int)");
 
+    TestUtil.dropView(con, "viewtest");
     TestUtil.dropTable(con, "metadatatest");
     TestUtil.dropTable(con, "sercoltest");
     TestUtil.dropSequence(con, "sercoltest_b_seq");
@@ -624,6 +626,24 @@ public class DatabaseMetaDataTest {
     DatabaseMetaData dbmd = con.getMetaData();
     ResultSet rs = dbmd.getTablePrivileges(null, null, "metadatatest");
     assertTrue(!rs.next());
+  }
+
+  @Test
+  public void testViewPrivileges() throws SQLException {
+    DatabaseMetaData dbmd = con.getMetaData();
+    assertNotNull(dbmd);
+    ResultSet rs = dbmd.getTablePrivileges(null, null, "viewtest");
+    boolean foundSelect = false;
+    while (rs.next()) {
+      if (rs.getString("GRANTEE").equals(TestUtil.getUser())
+          && rs.getString("PRIVILEGE").equals("SELECT")) {
+        foundSelect = true;
+      }
+    }
+    rs.close();
+    // Test that the view owner has select priv
+    assertTrue("Couldn't find SELECT priv on table metadatatest for " + TestUtil.getUser(),
+        foundSelect);
   }
 
   @Test


### PR DESCRIPTION
As discussed in the issue, include the overlooked types as part of the metadata impl.
Securable objects which are returned by `getTables()` should also work in `getTablePrivileges()`.

Fixes #2048
