### PR TITLE
docs: Add note to update CHANGELOG to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,7 @@
 
 * [ ] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
 * [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
+* [ ] Have you added an entry to the CHANGELOG to reflect your changes?
 
 <!-- You can erase any parts of this template not applicable to your Pull Request. -->
 


### PR DESCRIPTION
I myself have forgotten more than once to do this until after PRs are merged so how about adding it to the PR template?

Not needed for typos or doc updates, but anything that actually fixes something or adds a feature should have a CHANGELOG entry.