### PR TITLE
fix: PgDatabaseMetaData should return UPPERCASE column names as per s…

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/Field.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/Field.java
@@ -10,8 +10,6 @@ import org.postgresql.jdbc.FieldMetadata;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.dataflow.qual.Pure;
 
-/*
- */
 public class Field {
   // The V3 protocol defines two constants for the format of data
   public static final int TEXT_FORMAT = 0;
@@ -20,7 +18,7 @@ public class Field {
   private final int length; // Internal Length of this field
   private final int oid; // OID of the type
   private final int mod; // type modifier of this field
-  private final String columnLabel; // Column label
+  private String columnLabel; // Column label
 
   private int format = TEXT_FORMAT; // In the V3 protocol each field has a format
   // 0 = text, 1 = binary
@@ -171,5 +169,9 @@ public class Field {
 
   public boolean isTypeInitialized() {
     return pgType != NOT_YET_LOADED;
+  }
+
+  public void upperCaseLabel() {
+    columnLabel = columnLabel.toUpperCase();
   }
 }

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
@@ -1345,7 +1345,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
     }
     String sql = select + orderby;
 
-    return createMetaDataStatement().executeQuery(sql);
+    return ((PgResultSet)createMetaDataStatement().executeQuery(sql)).upperCaseFieldLabels();
   }
 
   private static final Map<String, Map<String, String>> tableTypeClauses;

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
@@ -4001,6 +4001,7 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
    * to change the fields after the fact rather than try to coerce all the columns
    * to upper case in the queries as this would require surrounding all columns with " and
    * escaping them making them even harder to read than they are now.
+   * @return PgResultSet
    */
   protected PgResultSet upperCaseFieldLabels() {
     for (Field field: fields ) {

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
@@ -3993,4 +3993,19 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
     }
     return sharedCalendar;
   }
+
+  /**
+   * This is here to be used by metadata functions
+   * to make all column labels upper case.
+   * Because postgres folds columns to lower case in queries it will be easier
+   * to change the fields after the fact rather than try to coerce all the columns
+   * to upper case in the queries as this would require surrounding all columns with " and
+   * escaping them making them even harder to read than they are now.
+   */
+  protected PgResultSet upperCaseFieldLabels() {
+    for (Field field: fields ) {
+      field.upperCaseLabel();
+    }
+    return this;
+  }
 }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseMetaDataTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseMetaDataTest.java
@@ -1583,4 +1583,16 @@ public class DatabaseMetaDataTest {
     stmt.close();
   }
 
+  @Test
+  public void testUpperCaseMetaDataLabels() throws SQLException {
+    ResultSet rs = con.getMetaData().getTables(null, null, null, null);
+    ResultSetMetaData rsmd = rs.getMetaData();
+
+    assertEquals("TABLE_CAT", rsmd.getColumnName(1));
+    assertEquals("TABLE_SCHEM", rsmd.getColumnName(2));
+    assertEquals("TABLE_NAME", rsmd.getColumnName(3));
+    assertEquals("TABLE_TYPE", rsmd.getColumnName(4));
+    assertEquals("REMARKS", rsmd.getColumnName(5));
+
+  }
 }


### PR DESCRIPTION
The only questionable thing is exposing this method publicly and removing final on Field.columnName