### PR TITLE
Options to use bytea/text fields as backing for Blob/Clob types

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ In addition to the standard connection parameters the driver supports a number o
 | adaptiveFetchMinimum          | Integer | 0       | Specifies minimum number of rows, which can be calculated by adaptiveFetch. Number of rows used by adaptiveFetch cannot go below this value. 
 | adaptiveFetchMaximum          | Integer | -1      | Specifies maximum number of rows, which can be calculated by adaptiveFetch. Number of rows used by adaptiveFetch cannot go above this value. Any negative number set as adaptiveFetchMaximum is used by adaptiveFetch as infinity number of rows.
 | localSocketAddress            | String  | null    | Hostname or IP address given to explicitly configure the interface that the driver will bind the client side of the TCP/IP connection to when connecting.
+| blobAsBytea                   | Boolean | false   | Treat Blobs as bytea fields instead of as LargeObjects |
+| clobAsText                    | Boolean | false  | Treat Clobs as text fields instead of as LargeObjects |
 
 ## Contributing
 For information on how to contribute to the project see the [Contributing Guidelines](CONTRIBUTING.md)

--- a/docs/documentation/head/connect.md
+++ b/docs/documentation/head/connect.md
@@ -541,6 +541,18 @@ Connection conn = DriverManager.getConnection(url);
     A limit during setting of property is 90% of max heap memory. All given values, which gonna be higher than limit, gonna lowered to the limit.
     
 	By default, maxResultBuffer is not set (is null), what means that reading of results gonna be performed without limits.
+
+* **blobAsBytea** = boolean
+
+    When true, Blobs are treated as bytea fields, instead of as Large Objects,
+
+    By default blobAsBytea is false.
+
+* **clobAsText** = boolean
+
+    When true, Clobs are treated as text fields, instead of as Large Objects,
+
+    By default clobAsText is false.
 	
 * **adaptiveFetch** = boolean	
 

--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -124,6 +124,16 @@ public enum PGProperty {
       "Comma separated list of types to enable binary transfer. Either OID numbers or names"),
 
   /**
+   * Use the Blob API for bytea fields (if true) or for Postgres
+   * Large Objects (if false). Default is false.
+   */
+  BLOB_AS_BYTEA(
+              "blobAsBytea",
+              null,
+              "Treat BLOB as bytea rather than as PostgreSQL Large Objects",
+              false),
+
+  /**
    * Cancel command is sent out of band over its own connection, so cancel message can itself get
    * stuck.
    * This property controls "connect timeout" and "socket timeout" used for cancel commands.
@@ -143,6 +153,16 @@ public enum PGProperty {
       "Determine whether SAVEPOINTS used in AUTOSAVE will be released per query or not",
       false,
       new String[] {"true", "false"}),
+
+  /**
+   * Use the Clob API for text fields (if true) or for Postgres
+   * Large Objects (if false). Default is false.
+   */
+  CLOB_AS_TEXT(
+              "clobAsText",
+              null,
+              "Treat CLOB as text rather than as PostgreSQL Large Objects",
+              false),
 
   /**
    * <p>The timeout value used for socket connect operations. If connecting to the server takes longer

--- a/pgjdbc/src/main/java/org/postgresql/core/BaseConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/BaseConnection.java
@@ -228,4 +228,14 @@ public interface BaseConnection extends PGConnection, Connection {
    * @throws SQLException if the class cannot be found or instantiated.
    */
   PGXmlFactoryFactory getXmlFactoryFactory() throws SQLException;
+
+  /**
+   * Returns the clobAsText connection setting.
+   */
+  boolean getClobAsText();
+
+  /**
+   * Returns the blobAsBytea connection setting.
+   */
+  boolean getBlobAsBytea();
 }

--- a/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
+++ b/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
@@ -864,6 +864,38 @@ public abstract class BaseDataSource implements CommonDataSource, Referenceable 
   }
 
   /**
+   * @return true iff using bytea for Blob API instead of LOs
+   * @see PGProperty#BLOB_AS_BYTEA
+   */
+  public boolean getBlobAsBytea() {
+    return PGProperty.BLOB_AS_BYTEA.getBoolean(properties);
+  }
+
+  /**
+   * @param useBytea use bytea type for Blob API instead of LOs
+   * @see PGProperty#BLOB_AS_BYTEA
+   */
+  public void setBlobAsBytea(boolean useBytea) {
+    PGProperty.BLOB_AS_BYTEA.set(properties, useBytea);
+  }
+
+  /**
+   * @return true iff using text for Clob API instead of LOs
+   * @see PGProperty#CLOB_AS_TEXT
+   */
+  public boolean getClobAsText() {
+    return PGProperty.CLOB_AS_TEXT.getBoolean(properties);
+  }
+
+  /**
+   * @param useText use text type for Clob API instead of LOs
+   * @see PGProperty#CLOB_AS_TEXT
+   */
+  public void setClobAsText(boolean useText) {
+    PGProperty.CLOB_AS_TEXT.set(properties, useText);
+  }
+
+  /**
    * @return true if column sanitizer is disabled
    * @see PGProperty#DISABLE_COLUMN_SANITISER
    */

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgBlobBytea.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgBlobBytea.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright (c) 2021, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+/*
+ * Implementation of Blob interface backed by Postgres bytea fields.
+ *
+ * See PgBlob.java for implementation using Postgres Large Objects.
+ */
+
+package org.postgresql.jdbc;
+
+import org.postgresql.util.GT;
+import org.postgresql.util.PSQLException;
+import org.postgresql.util.PSQLState;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.sql.Blob;
+import java.sql.SQLException;
+import java.util.Arrays;
+
+public class PgBlobBytea implements java.sql.Blob {
+
+  private byte[] data;
+
+  protected static final int MAX_BYTES = 1073741824; // 1GiB max size of a bytea
+
+  public PgBlobBytea() {
+    this.data = null;
+  }
+
+  public PgBlobBytea(byte[] in) throws SQLException {
+    if (in.length > MAX_BYTES) {
+      throw new PSQLException(GT.tr("Input data too long for bytea type Blob {0}", in.length),
+                              PSQLState.INVALID_PARAMETER_VALUE);
+    }
+    this.data = in;
+  }
+
+  @Override
+  public void	free() 	 {
+    this.data = null;
+  }
+
+  @Override
+  public InputStream getBinaryStream() {
+    if (this.data != null) {
+      return new ByteArrayInputStream(this.data);
+    }
+    return null;
+  }
+
+  @Override
+  public InputStream getBinaryStream​(long pos, long length) throws SQLException {
+    if (this.data == null) {
+      return null;
+    }
+    if (pos < 1) {
+      throw new PSQLException(GT.tr("Invalid pos parameter {0}", pos),
+                              PSQLState.INVALID_PARAMETER_VALUE);
+    }
+    if (length < 0 || pos + length - 1 > data.length) {
+      throw new PSQLException(GT.tr("Invalid length parameter {0}", length),
+                              PSQLState.INVALID_PARAMETER_VALUE);
+    }
+    byte [] part = new byte[(int)length];
+    System.arraycopy(this.data, (int) pos - 1, part, 0, (int) length);
+    return new ByteArrayInputStream(part);
+  }
+
+  @Override
+  public byte[]	getBytes​(long pos, int length) throws SQLException {
+    if (this.data == null) {
+      return null;
+    }
+    if (pos < 1) {
+      throw new PSQLException(GT.tr("Invalid pos parameter {0}", pos),
+                              PSQLState.INVALID_PARAMETER_VALUE);
+    }
+    if (length < 0) {
+      throw new PSQLException(GT.tr("Invalid length parameter {0}", length),
+                              PSQLState.INVALID_PARAMETER_VALUE);
+    }
+    pos--; // adjust for 1 offset
+    // don't run off the end of the array
+    if ((int)pos + length > this.data.length) {
+      length = this.data.length - (int) pos;
+    }
+    byte [] part = new byte[length];
+    System.arraycopy(this.data, (int) pos, part, 0, length);
+    return part;
+  }
+
+  @Override
+  public long length() {
+    return this.data == null ? 0 : this.data.length;
+  }
+
+  @Override
+  public long	position​(byte[] pattern, long start) throws SQLException {
+    if (this.data == null) {
+      return -1;
+    }
+    if (start < 1 || start > data.length) {
+      throw new PSQLException(GT.tr("Invalid start parameter {0}", start),
+                              PSQLState.INVALID_PARAMETER_VALUE);
+    }
+    int res = indexOf(this.data, pattern, (int) start - 1);
+    if (res >= 0) {
+      res = res + 1;
+    }
+    return res;
+  }
+
+  @Override
+  public long position​(Blob pattern, long start) throws SQLException {
+    return position(pattern.getBytes(1, (int) pattern.length()), start);
+  }
+
+  @Override
+  public OutputStream setBinaryStream​(long pos) throws SQLException {
+    return new ByteaBlobOutputStream(pos);
+  }
+
+  @Override
+  public int setBytes​(long pos, byte[] bytes) throws SQLException {
+    return setBytes(pos, bytes, 0, bytes.length);
+  }
+
+  @Override
+  public int setBytes​(long pos, byte[] bytes, int offset, int len) throws SQLException {
+    if (this.data == null) {
+      if (pos == 1) {
+        this.data = new byte[0];
+      } else {
+        throw new PSQLException(GT.tr("Called setBytes on null Blob"),
+                              PSQLState.INVALID_PARAMETER_VALUE);
+      }
+    }
+
+    if (pos < 1 || pos > data.length + 1) {
+      throw new PSQLException(GT.tr("Invalid pos parameter {0} for length {1}", pos, data.length),
+                              PSQLState.INVALID_PARAMETER_VALUE);
+    }
+    if (offset < 0) {
+      throw new PSQLException(GT.tr("Invalid offset parameter {0}", offset),
+                              PSQLState.INVALID_PARAMETER_VALUE);
+    }
+    if (offset + len > bytes.length) {
+      throw new PSQLException(GT.tr("Invalid offset/len parameters {0}/{1} for length {2}", offset, len, bytes.length),
+                              PSQLState.INVALID_PARAMETER_VALUE);
+    }
+    pos--;
+    // extend the array if necessary
+    if (pos + len > data.length) {
+      this.data = Arrays.copyOf(this.data, (int) pos + len);
+    }
+    System.arraycopy(bytes, offset, this.data, (int) pos, len);
+    return len;
+  }
+
+  @Override
+  public void	truncate​(long len) throws SQLException {
+    if (this.data == null) {
+      throw new PSQLException(GT.tr("Called truncate on null Blob}"),
+                              PSQLState.INVALID_PARAMETER_VALUE);
+    }
+    if (len <= data.length) {
+      this.data = Arrays.copyOf(this.data, (int) len);
+    } else {
+      throw new PSQLException(GT.tr("Called truncate with length too long for string of length {0}", data.length),
+                              PSQLState.INVALID_PARAMETER_VALUE);
+    }
+  }
+
+  // shamelessly stolen from
+  // http://www.java2s.com/Code/CSharp/File-Stream/Searchabytearrayforasubbytearray.htm
+  // nice single loop solution
+  private static int indexOf(byte[] array, byte[] pattern, int offset) {
+    int success = 0;
+    for (int i = offset; i < array.length; i++) {
+      if (array[i] == pattern[success]) {
+        success++;
+      } else {
+        success = 0;
+      }
+      if (pattern.length == success) {
+        return i - pattern.length + 1;
+      }
+    }
+    return -1;
+  }
+
+  /*
+   * This class just provides an OutputStream interface over writing to the
+   * data buffer. Since we can't throw SQLExceptions here, we catch them
+   * and rethrow as IOExceptions.
+   */
+
+  private class ByteaBlobOutputStream extends OutputStream {
+
+    // keep track of where the stream is writing to in the buffer
+    private int writePos;
+
+    ByteaBlobOutputStream(long pos) {
+      writePos = (int) pos;
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+      byte[] nb = new byte[1];
+      nb[0] = (byte) b;
+      write(nb);
+    }
+
+    @Override
+    public void write(byte[] b) throws IOException {
+      try {
+        writePos += PgBlobBytea.this.setBytes(writePos, b, 0 , b.length);
+      } catch (SQLException e) {
+        throw new IOException(e.getMessage());
+      }
+    }
+
+    @Override
+    public void write​(byte[] b, int off, int len) throws IOException {
+      try {
+        writePos += PgBlobBytea.this.setBytes(writePos, b, off, len);
+      } catch (SQLException e) {
+        throw new IOException(e.getMessage());
+      }
+    }
+  }
+}

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgClobText.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgClobText.java
@@ -1,0 +1,266 @@
+/*
+ * Copyright (c) 2021, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+/*
+ * Implementation of Clob interface backed by Postgres varchar/text fields.
+ *
+ * See PgClob.java for implementation using Postgres Large Objects.
+ */
+
+package org.postgresql.jdbc;
+
+import org.postgresql.util.GT;
+import org.postgresql.util.PSQLException;
+import org.postgresql.util.PSQLState;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Reader;
+import java.io.StringReader;
+import java.io.Writer;
+import java.sql.Clob;
+import java.sql.SQLException;
+
+public class PgClobText implements java.sql.Clob {
+
+  private String data;
+
+  public PgClobText() {
+    this.data = null;
+  }
+
+  public PgClobText(String s) {
+    this.data = s;
+  }
+
+  @Override
+  public void free() {
+    this.data = null;
+  }
+
+  @Override
+  public InputStream	getAsciiStream() {
+    if (this.data != null) {
+      return new ByteArrayInputStream(this.data.getBytes());
+    }
+    return null;
+  }
+
+  @Override
+  public Reader getCharacterStream() {
+    if (this.data != null) {
+      return new StringReader(this.data);
+    }
+    return null;
+  }
+
+  @Override
+  public Reader getCharacterStream(long pos, long length) {
+    pos--;
+    if (this.data != null) {
+      return new StringReader(this.data.substring((int)pos, (int)(pos + length)));
+    }
+    return null;
+  }
+
+  @Override
+  public String getSubString(long pos, int length)  throws SQLException {
+    if (this.data != null) {
+      if (pos < 1) {
+        throw new PSQLException(GT.tr("Invalid pos parameter {0}", pos),
+                                PSQLState.INVALID_PARAMETER_VALUE);
+      }
+      if (length < 0) {
+        throw new PSQLException(GT.tr("Invalid length parameter {0}", length),
+                                PSQLState.INVALID_PARAMETER_VALUE);
+      }
+      long dlen = this.data.length();
+      pos--; // CLOBS start at 1, Strings start at 0 - go figure
+      if (pos + (long) length > dlen) {
+        // don't  run off the end of the string, we return UP TO length chars
+        // according to the spec
+        length = (int) (dlen - pos);
+      }
+      return this.data.substring((int)pos, (int) (pos + length));
+    }
+    return null;
+  }
+
+  @Override
+  public long length() {
+    if (this.data != null) {
+      return this.data.length();
+    }
+    return 0;
+  }
+
+  @Override
+  public long position(Clob searchstr, long start) throws SQLException {
+    return position(searchstr.getSubString(1L, (int) searchstr.length()), start);
+  }
+
+  @Override
+  public long position(String searchstr, long start) throws SQLException {
+    if (this.data != null) {
+      int pos = this.data.indexOf(searchstr,(int) (start - 1));
+      return (pos == -1) ? -1 : (pos + 1);
+    }
+    return -1;
+  }
+
+  @Override
+  public OutputStream setAsciiStream(long pos) throws SQLException {
+    return new TextClobOutputStream(pos);
+  }
+
+  @Override
+  public Writer setCharacterStream(long pos) throws SQLException {
+    return new TextClobOutputStreamWriter(new TextClobOutputStream(pos));
+  }
+
+  @Override
+  public int setString(long pos, String str) throws SQLException {
+    if (pos < 1) {
+      throw new PSQLException(GT.tr("Invalid pos parameter {0}", pos),
+                              PSQLState.INVALID_PARAMETER_VALUE);
+    }
+    if (this.data == null) {
+      if (pos == 1) {
+        this.data = "";
+      } else {
+        throw new PSQLException(GT.tr("Called setString on null Clob"),
+                              PSQLState.INVALID_PARAMETER_VALUE);
+      }
+    }
+    StringBuilder buf = new StringBuilder(this.data);
+    int len = str.length();
+    try {
+      buf.replace((int)pos - 1, (int) (pos + len - 1), str);
+      this.data = buf.toString();
+    } catch (StringIndexOutOfBoundsException e) {
+      throw new PSQLException(GT.tr("Invalid pos parameter {0}", pos),
+                              PSQLState.INVALID_PARAMETER_VALUE);
+    }
+    return len;
+  }
+
+  @Override
+  public int setString(long pos, String str, int offset, int len) throws SQLException {
+    if (pos < 1) {
+      throw new PSQLException(GT.tr("Invalid pos parameter {0}", pos),
+                              PSQLState.INVALID_PARAMETER_VALUE);
+    }
+    if (this.data == null) {
+      if (pos == 1) {
+        this.data = "";
+      } else {
+        throw new PSQLException(GT.tr("Called setString on null Clob"),
+                              PSQLState.INVALID_PARAMETER_VALUE);
+      }
+    }
+    StringBuilder buf = new StringBuilder(this.data);
+    try {
+      String repl = str.substring(offset, offset + len);
+      buf.replace((int)pos - 1, (int) (pos + repl.length() - 1), repl);
+      this.data = buf.toString();
+    } catch (StringIndexOutOfBoundsException e) {
+      throw new PSQLException(GT.tr("Invalid pos parameter {0}", pos),
+                              PSQLState.INVALID_PARAMETER_VALUE);
+    }
+    return len;
+  }
+
+  @Override
+  public void truncate(long len) throws SQLException {
+    if (this.data == null) {
+      throw new PSQLException(GT.tr("Called truncate on null Clob}"),
+                              PSQLState.INVALID_PARAMETER_VALUE);
+    }
+    if (len <= data.length()) {
+      this.data = this.data.substring(0, (int) len);
+    } else {
+      throw new PSQLException(GT.tr("Called truncate with length too long for string of length {0}", data.length()),
+                              PSQLState.INVALID_PARAMETER_VALUE);
+    }
+  }
+
+  public String toString() {
+    return this.data;
+  }
+
+  /*
+   * This class just provides an OutputStream interface over writing to the
+   * data buffer. Since we can't throw SQLExceptions here, we catch them
+   * and rethrow as IOExceptions.
+   */
+
+  private class TextClobOutputStream extends OutputStream {
+
+    // keep track of where the stream is writing to in the buffer
+    private int writePos;
+
+    TextClobOutputStream(long pos) {
+      writePos = (int) pos;
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+      char c = (char) b;
+      byte[] nb = String.valueOf(c).getBytes();
+      write(nb);
+    }
+
+    @Override
+    public void write(byte[] b) throws IOException {
+      String sb = new String(b);
+      try {
+        writePos += PgClobText.this.setString(writePos, sb, 0 , sb.length());
+      } catch (SQLException e) {
+        throw new IOException(e.getMessage());
+      }
+    }
+
+    @Override
+    public void write​(byte[] b, int off, int len) throws IOException {
+      String sb = new String(b);
+      try {
+        writePos += PgClobText.this.setString(writePos, sb, off, len);
+      } catch (SQLException e) {
+        throw new IOException(e.getMessage());
+      }
+    }
+  }
+
+  /*
+   * subclass of OutputStreamWriter that calls flush after every write
+   */
+  private class TextClobOutputStreamWriter extends OutputStreamWriter {
+
+    TextClobOutputStreamWriter(OutputStream os) {
+      super(os);
+    }
+
+    @Override
+    public void write​(char[] cbuf, int off, int len) throws IOException {
+      super.write(cbuf, off, len);
+      this.flush();
+    }
+
+    @Override
+    public void write​(int c) throws IOException {
+      super.write(c);
+      flush();
+    }
+
+    @Override
+    public void write​(String str, int off, int len) throws IOException {
+      super.write(str, off, len);
+      flush();
+    }
+  }
+}

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
@@ -37,6 +37,8 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.common.value.qual.IntRange;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -245,9 +247,11 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
       case Types.LONGVARBINARY:
         oid = Oid.BYTEA;
         break;
-      case Types.BLOB:
       case Types.CLOB:
-        oid = Oid.OID;
+        oid = connection.getClobAsText() ? (connection.getStringVarcharFlag() ? Oid.VARCHAR : Oid.UNSPECIFIED) : Oid.OID;
+        break;
+      case Types.BLOB:
+        oid = connection.getBlobAsBytea() ? Oid.BYTEA : Oid.OID;
         break;
       case Types.REF_CURSOR:
         oid = Oid.REF_CURSOR;
@@ -653,9 +657,15 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
       case Types.BLOB:
         if (in instanceof Blob) {
           setBlob(parameterIndex, (Blob) in);
+        } else if (in instanceof byte[]) {
+          setBlob(parameterIndex, new ByteArrayInputStream((byte[]) in));
         } else if (in instanceof InputStream) {
-          long oid = createBlob(parameterIndex, (InputStream) in, -1);
-          setLong(parameterIndex, oid);
+          if (connection.getBlobAsBytea()) {
+            setBlobBytea(parameterIndex, (InputStream) in);
+          } else {
+            long oid = createBlob(parameterIndex, (InputStream) in, -1);
+            setLong(parameterIndex, oid);
+          }
         } else {
           throw new PSQLException(
               GT.tr("Cannot cast an instance of {0} to type {1}",
@@ -664,7 +674,13 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
         }
         break;
       case Types.CLOB:
-        if (in instanceof Clob) {
+        if (connection.getClobAsText()) {
+          if (in instanceof PgClobText) {
+            setString(parameterIndex, in.toString());
+          } else {
+            setString(parameterIndex, castToString(in), getStringType());
+          }
+        } else if (in instanceof Clob) {
           setClob(parameterIndex, (Clob) in);
         } else {
           throw new PSQLException(
@@ -1176,8 +1192,22 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
     return oid;
   }
 
+  private void setBlobBytea(@Positive int i, @Nullable Blob x) throws SQLException {
+    if (x == null) {
+      setNull(i,Types.VARBINARY);
+      return;
+    }
+    byte[] b = x.getBytes(1,(int) x.length());
+    preparedParameters.setBytea(i, b, 0, b.length);
+  }
+
   public void setBlob(@Positive int i, @Nullable Blob x) throws SQLException {
     checkClosed();
+
+    if (connection.getBlobAsBytea()) {
+      setBlobBytea(i, x);
+      return;
+    }
 
     if (x == null) {
       setNull(i, Types.BLOB);
@@ -1544,10 +1574,57 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
     throw Driver.notImplemented(this.getClass(), "setClob(int, Reader)");
   }
 
+  private void setBlobBytea(@Positive int parameterIndex,
+      @Nullable InputStream inputStream, @NonNegative long length)
+      throws SQLException {
+
+    if (inputStream == null) {
+      setNull(parameterIndex, Types.VARBINARY);
+      return;
+    }
+
+    byte [] b;
+
+    try {
+      // for JDK 9+ we could use b = inputStream.readNBytes(length). However ...
+      ByteArrayOutputStream os = new ByteArrayOutputStream();
+      byte[] buffer = new byte[4096];
+      long remaining = length;
+      int toRead = remaining > buffer.length ? buffer.length : (int) remaining;
+      int len = inputStream.read(buffer, 0, toRead);
+      while (remaining > 0 && len > -1) {
+        remaining -= len;
+        os.write(buffer, 0, len);
+        toRead = remaining > buffer.length ? buffer.length : (int) remaining;
+        len = inputStream.read(buffer, 0, toRead);
+      }
+      if (remaining > 0) {
+        // not enough bytes
+      }
+      b = os.toByteArray();
+    } catch (IOException ioe) {
+      throw new PSQLException(GT.tr("Provided InputStream failed."), PSQLState.UNEXPECTED_ERROR,
+          ioe);
+    }
+
+    if (b.length > PgBlobBytea.MAX_BYTES) {
+      throw new PSQLException(GT.tr("Input data too long for bytea type Blob {0}", b.length),
+                              PSQLState.INVALID_PARAMETER_VALUE);
+    }
+
+    preparedParameters.setBytea(parameterIndex, b, 0, b.length);
+
+  }
+
   public void setBlob(@Positive int parameterIndex,
       @Nullable InputStream inputStream, @NonNegative long length)
       throws SQLException {
     checkClosed();
+
+    if (connection.getBlobAsBytea()) {
+      setBlobBytea(parameterIndex, inputStream, length);
+      return;
+    }
 
     if (inputStream == null) {
       setNull(parameterIndex, Types.BLOB);
@@ -1564,9 +1641,47 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
     setLong(parameterIndex, oid);
   }
 
+  private void setBlobBytea(@Positive int parameterIndex,
+      @Nullable InputStream inputStream)
+      throws SQLException {
+
+    if (inputStream == null) {
+      setNull(parameterIndex, Types.VARBINARY);
+      return;
+    }
+
+    byte [] b;
+
+    try {
+      // for JDK 9+ we could use b = is.readAllBytes(). However ...
+      ByteArrayOutputStream os = new ByteArrayOutputStream();
+      byte[] buffer = new byte[4096];
+      for (int len = inputStream.read(buffer); len != -1; len = inputStream.read(buffer)) {
+        os.write(buffer, 0, len);
+      }
+      b = os.toByteArray();
+    } catch (IOException ioe) {
+      throw new PSQLException(GT.tr("Provided InputStream failed."), PSQLState.UNEXPECTED_ERROR,
+          ioe);
+    }
+
+    if (b.length > PgBlobBytea.MAX_BYTES) {
+      throw new PSQLException(GT.tr("Input data too long for bytea type Blob {0}", b.length),
+                              PSQLState.INVALID_PARAMETER_VALUE);
+    }
+
+    preparedParameters.setBytea(parameterIndex, b, 0, b.length);
+
+  }
+
   public void setBlob(@Positive int parameterIndex,
       @Nullable InputStream inputStream) throws SQLException {
     checkClosed();
+
+    if (connection.getBlobAsBytea()) {
+      setBlobBytea(parameterIndex, inputStream);
+      return;
+    }
 
     if (inputStream == null) {
       setNull(parameterIndex, Types.BLOB);

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/AbstractArraysTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/AbstractArraysTest.java
@@ -959,5 +959,20 @@ public abstract class AbstractArraysTest<A> {
       throw new UnsupportedOperationException();
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean getClobAsText() {
+      return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean getBlobAsBytea() {
+      return false;
+    }
   }
 }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc4/Jdbc4TestSuite.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc4/Jdbc4TestSuite.java
@@ -24,6 +24,7 @@ import org.junit.runners.Suite;
     DatabaseMetaDataTest.class,
     IsValidTest.class,
     JsonbTest.class,
+    LobVarlenaTest.class,
     LogTest.class,
     PGCopyInputStreamTest.class,
     UUIDTest.class,

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc4/LobVarlenaTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc4/LobVarlenaTest.java
@@ -1,0 +1,323 @@
+/*
+ * Copyright (c) 2021, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.test.jdbc4;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.postgresql.PGProperty;
+import org.postgresql.jdbc.PgBlobBytea;
+import org.postgresql.jdbc.PgClobText;
+import org.postgresql.jdbc.PgConnection;
+import org.postgresql.test.TestUtil;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.Reader;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.sql.Blob;
+import java.sql.Clob;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Types;
+import java.util.Arrays;
+import java.util.Properties;
+
+public class LobVarlenaTest {
+
+  private Connection conn;
+
+  @Before
+  public void setUp() throws Exception {
+    Properties props = new Properties();
+    props.setProperty(PGProperty.BLOB_AS_BYTEA.getName(),"true");
+    props.setProperty(PGProperty.CLOB_AS_TEXT.getName(),"true");
+    conn = TestUtil.openDB(props);
+    TestUtil.createTable(conn, "testlobvarlena",
+                         "textcol text, byteacol bytea");
+    TestUtil.execute("insert into testlobvarlena values("
+                     + "repeat($$ksjkdjkdshtrb\\000ujy2t8mnnksdf$$,500),"
+                     + "decode(repeat($$ksjkds\\000trbut8mnnksdf$$,600),"
+                     + "'escape'))",
+                     conn);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    TestUtil.dropTable(conn, "testlobvarlena");
+    TestUtil.closeDB(conn);
+  }
+
+  @Test
+  public void testConnClob() throws SQLException {
+    // test we can get a clob from the connection and do basic set, get,
+    // and search operations on it
+    assertTrue("Connection has clobAsText enabled", ((PgConnection)conn).getClobAsText());
+    Clob clob = conn.createClob();
+    assertTrue("Successfully create a Clob", clob instanceof PgClobText);
+    assertEquals("Length of Clob is 0", clob.length(), 0);
+    clob.setString(1,"foobarbaz");
+    assertEquals("Clob length is 9", clob.length(), 9);
+    assertTrue("Clob text is 'foobarbaz'", clob.toString().equals("foobarbaz"));
+    String s = clob.getSubString(4,3);
+    assertTrue("Fetched substring is 'bar'", s.equals("bar"));
+    String s2 = clob.getSubString(7,99);
+    assertTrue("Fetched substring is 'baz'", s2.equals("baz"));
+    long pos = clob.position("bar",1);
+    assertEquals("Found 'bar' at position 4 starting at 1", pos, 4);
+    pos = clob.position("bar",4);
+    assertEquals("Found 'bar' at position 4 starting at 4", pos, 4);
+    pos = clob.position("bar",7);
+    assertEquals("'bar' not found starting at 7", pos, -1);
+    pos = clob.position("blurfl",4);
+    assertEquals("'blurfl' not found starting at 4", pos, -1);
+    Clob srch = new PgClobText("bar");
+    pos = clob.position(srch,1);
+    assertEquals("Found clob 'bar' at position 4 starting at 1", pos, 4);
+    pos = clob.position(srch,4);
+    assertEquals("Found clob 'bar' at position 4 starting at 4", pos, 4);
+    pos = clob.position(srch,7);
+    assertEquals("clob 'bar' not found starting at 7", pos, -1);
+    srch.setString(1,"blurfl");
+    pos = clob.position(srch,4);
+    assertEquals("clob 'blurfl' not found starting at 4", pos, -1);
+    clob.truncate(3);
+    assertEquals("Truncated clob length is 3", clob.length(), 3);
+    String s3 = clob.toString();
+    assertTrue("Truncated clob value is 'foo'", s3.equals("foo"));
+  }
+
+  @Test
+  public void testResultSetClob() throws SQLException {
+    // test we can get a clob from a text field in a resultset
+    Statement stmt = conn.createStatement();
+    ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("testlobvarlena", "textcol"));
+    try {
+      assertTrue("Connection has getClobAsText", ((PgConnection)conn).getClobAsText());
+      assertTrue("Result set has a row", rs.next());
+      Clob clob = rs.getClob(1);
+      assertTrue("rs.getClob(1) returns a PgClobText", clob instanceof PgClobText);
+    } finally {
+      rs.close();
+    }
+  }
+
+  @Test
+  public void testClobStatementParams() throws SQLException {
+    // test we can set a string or a Clob as a parameter
+    conn.setAutoCommit(false);
+    PreparedStatement pstmt = conn.prepareStatement("INSERT INTO testlobvarlena (textcol) VALUES (?)");
+    pstmt.setObject(1, "foo", Types.CLOB);
+    pstmt.executeUpdate();
+    Clob clob = conn.createClob();
+    clob.setString(1,"foobar");
+    pstmt.setObject(1, clob, Types.CLOB);
+    pstmt.executeUpdate();
+    conn.rollback();
+  }
+
+  @Test
+  public void testClobReaderStreams() throws SQLException, IOException {
+    // test streams operations of a Clob
+    Statement stmt = conn.createStatement();
+    ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("testlobvarlena", "textcol"));
+    try {
+      rs.next();
+      Clob clob = rs.getClob(1);
+      Reader r = clob.getCharacterStream();
+      StringWriter w = new StringWriter((int)clob.length());
+      int i;
+      while ((i = r.read()) != -1) {
+        w.write(i);
+      }
+      w.close();
+      String cs = clob.toString();
+      assertTrue("Clob contents = character stream", cs.equals(w.toString()));
+      r = clob.getCharacterStream(100,20);
+      w = new StringWriter(300);
+      while ((i = r.read()) != -1) {
+        w.write(i);
+      }
+      w.close();
+      String cs2 = clob.getSubString(100,20);
+      String ws = w.toString();
+      assertTrue("Clob substring = character stream substring", cs2.equals(ws));
+      char[] buffer  = new char[(int)clob.length()];
+      InputStream is = clob.getAsciiStream();
+      int index = 0;
+      int c = is.read();
+      while (c > 0) {
+        buffer[index++] = (char) c;
+        c = is.read();
+      }
+      String as = new String(buffer);
+      assertTrue("Ascii stream equals clob contents", as.equals(cs));
+    } finally {
+      rs.close();
+    }
+  }
+
+  @Test
+  public void testClobWriterStreams() throws SQLException, IOException {
+    // test streams operations of a Clob
+    Statement stmt = conn.createStatement();
+    ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("testlobvarlena", "textcol"));
+    try {
+      rs.next();
+      Clob clob = rs.getClob(1);
+      int origLen = (int) clob.length();
+      OutputStream os = clob.setAsciiStream(origLen - 4);
+      byte[] blurfl = "blurfl".getBytes();
+      os.write(blurfl, 0, 5);
+      assertEquals("Length stays the same", clob.length(), origLen);
+      os.write("bazBarfoo".getBytes());
+      assertEquals("Length grown by 9", clob.length(), origLen + 9);
+      String end = clob.getSubString(origLen - 4, 999);
+      assertTrue("Stream has written bytes correctly", end.equals("blurfbazBarfoo"));
+      clob.truncate(origLen);
+      Writer w = clob.setCharacterStream(origLen - 4);
+      w.write("Blurfl", 0, 5);
+      assertEquals("Length stays the same", clob.length(), origLen);
+      w.write("BazBarfoo", 0, 9);
+      assertEquals("Length grown by 9", clob.length(), origLen + 9);
+      end = clob.getSubString(origLen - 4, 999);
+      assertTrue("Stream has written bytes correctly", end.equals("BlurfBazBarfoo"));
+    } finally {
+      rs.close();
+    }
+  }
+
+  @Test
+  public void testConnBlob() throws SQLException {
+    // test we can get a blob from the connection and do basic set, get,
+    // and search operations on it
+    byte[] foobarbaz = "foobarbaz".getBytes();
+    byte[] foo = "foo".getBytes();
+    byte[] bar = "bar".getBytes();
+    byte[] baz = "baz".getBytes();
+    byte[] blurfl = "blurfl".getBytes();
+    assertTrue("Connection has blobAsBytea", ((PgConnection)conn).getBlobAsBytea());
+    Blob blob = conn.createBlob();
+    assertEquals("PgBlobBytea created", blob instanceof PgBlobBytea, true);
+    assertEquals("Initial blob has length 0", blob.length(),  0);
+    blob.setBytes(1,foobarbaz);
+    assertEquals("Blob has length 9", blob.length(), 9);
+    assertTrue("Blob has contents 'foobarbaz'", Arrays.equals(blob.getBytes(1,999),foobarbaz));
+    byte[] s = blob.getBytes(4,3);
+    assertTrue("blob subcontents = 'bar'", Arrays.equals(s,bar));
+    byte[] s2 = blob.getBytes(7,99);
+    assertEquals("blob remaining contents have length 3", s2.length, 3);
+    assertTrue("blob remaining contents = 'baz'", Arrays.equals(s2,baz));
+    long pos = blob.position(bar,1);
+    assertEquals("blob position of 'bar' starting at 1 is 4", pos, 4);
+    pos = blob.position(bar,4);
+    assertEquals("blob position of 'bar' starting at 4 is 4", pos, 4);
+    pos = blob.position(bar,7);
+    assertEquals("'bar' not found in blob starting at 7", pos, -1);
+    pos = blob.position(blurfl,4);
+    assertEquals("'blurfl' not found in blob", pos, -1);
+    Blob srch = new PgBlobBytea(bar);
+    pos = blob.position(srch,1);
+    assertEquals("blob position of blob 'bar' starting at 1 is 4", pos, 4);
+    pos = blob.position(srch,4);
+    assertEquals("blob position of blob 'bar' starting at 4 is 4", pos, 4);
+    pos = blob.position(srch,7);
+    assertEquals("blob 'bar' not found in blob starting at 7", pos, -1);
+    srch.setBytes(1,blurfl);
+    pos = blob.position(srch,4);
+    assertEquals("blob 'blurfl' not found in blob", pos, -1);
+    blob.truncate(3);
+    assertEquals("truncated blob length = 3", blob.length(), 3);
+    assertTrue("truncated blob contents = 'foo'", Arrays.equals(blob.getBytes(1,999),foo));
+  }
+
+  @Test
+  public void testResultSetBlob() throws SQLException {
+    // test we can get a blob from a bytea field in a resultset
+    Statement stmt = conn.createStatement();
+    ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("testlobvarlena", "byteacol"));
+    try {
+      assertTrue("Connection has blobAsText", ((PgConnection)conn).getBlobAsBytea());
+      assertTrue("Result set has a row", rs.next());
+      Blob blob = rs.getBlob(1);
+      assertTrue("returned result is a PgBlobBytea", blob instanceof PgBlobBytea);
+    } finally {
+      rs.close();
+    }
+  }
+
+  @Test
+  public void testBlobStatementParams() throws SQLException {
+    // test we can set a Blob as a parameter
+    conn.setAutoCommit(false);
+    PreparedStatement pstmt = conn.prepareStatement("INSERT INTO testlobvarlena (byteacol) VALUES (?)");
+    byte[] foo = "foo".getBytes();
+    byte[] foobar = "foobar".getBytes();
+    pstmt.setObject(1, foo, Types.BLOB);
+    pstmt.executeUpdate();
+    Blob blob = conn.createBlob();
+    blob.setBytes(1,foobar);
+    pstmt.setObject(1, blob, Types.BLOB);
+    pstmt.executeUpdate();
+    conn.rollback();
+  }
+
+  @Test
+  public void testBlobReaderStreams() throws SQLException, IOException {
+    // test streams operations of a Blob
+    Statement stmt = conn.createStatement();
+    ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("testlobvarlena", "byteacol"));
+    try {
+      rs.next();
+      Blob blob = rs.getBlob(1);
+      byte[] b =  blob.getBytes(1,99999);
+      InputStream is = blob.getBinaryStream();
+      byte[] buffer = new byte[b.length];
+      int index = 0;
+      int c = is.read();
+      while (c >= 0) {
+        buffer[index++] = (byte) c;
+        c = is.read();
+      }
+      assertEquals("Input stream from blob has corrrect length", index, b.length);
+      assertTrue("Input stream from blob has correct contents", Arrays.equals(b,buffer));
+    } finally {
+      rs.close();
+    }
+  }
+
+  @Test
+  public void testBlobWriterStreams() throws SQLException, IOException {
+    // test streams operations of a Blob
+    Statement stmt = conn.createStatement();
+    ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("testlobvarlena", "byteacol"));
+    try {
+      rs.next();
+      Blob blob = rs.getBlob(1);
+      int origLen = (int) blob.length();
+      OutputStream os = blob.setBinaryStream(origLen - 4);
+      byte[] blurfl = "blurfl".getBytes();
+      os.write(blurfl, 0, 5);
+      assertEquals("Length stays the same", blob.length(), origLen);
+      os.write("bazBarfoo".getBytes());
+      assertEquals("Length grown by 9", blob.length(), origLen + 9);
+      byte[] end = blob.getBytes(origLen - 4, 999);
+      assertTrue("Stream has written bytes correctly", Arrays.equals(end,"blurfbazBarfoo".getBytes()));
+    } finally {
+      rs.close();
+    }
+  }
+
+}


### PR DESCRIPTION
The new connection options are blobAsBytea and clobAsText. They both
default to false meaning the current behaviour, where both types
are backed by Postgres Large Objects, remains the default.

All of the methods in the Blob and Clob interfaces are implemented.

This feature will help people porting code from other RDBMS systems
where these types are backed by conventional database types.

### All Submissions:

* [ Yes] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [ Yes] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### New Feature Submissions:

1. [ Yes] Does your submission pass tests?
2. [ Yes] Does `./gradlew autostyleCheck checkstyleAll` pass ?
3. [ Yes] Have you added your new test classes to an existing test suite in alphabetical order?

### Changes to Existing Features:

* [ No] Does this break existing behaviour? If so please explain.

