### PR TITLE
Add printing of client and server information so it shows up in CI logs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ before_script:
   - test "x$PG_VERSION" = 'xHEAD' || psql -U postgres -c "create user test with password 'test';"
   - test "x$REPLICATION" == 'x' || psql -U postgres -c "alter user test with replication;"
   - psql -c 'create database test owner test;' -U postgres
+  - psql -c 'select version()' -U postgres
   - test "x$SSLTEST" == 'x' || ./.travis/travis_ssl_users.sh
   - test "x$REPLICATION" == 'x' || ./.travis/travis_create_slaves.sh
   - if [[ $TRAVIS_BRANCH == release/* ]]; then echo "MAVEN_OPTS='-Xmx1g'" > ~/.mavenrc; else echo "MAVEN_OPTS='-Xmx1g -Dgpg.skip=true'" > ~/.mavenrc; fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -63,6 +63,7 @@ before_build:
 - psql -U postgres -c "alter user test with replication" postgres
 - createuser -U postgres testsspi
 - createdb -U postgres -O test test
+- psql -U postgres -t -c "select version()" postgres
 
 build_script:
   - gradlew assemble

--- a/pgjdbc/src/test/java/org/postgresql/core/PrintDebugInfoTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/core/PrintDebugInfoTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2021, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.core;
+
+import org.postgresql.test.TestUtil;
+import org.postgresql.util.DriverInfo;
+
+import org.junit.Test;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.OffsetDateTime;
+
+/**
+ * Test cases to print debug information of both client and server.
+ */
+public class PrintDebugInfoTest {
+  @Test
+  public void testShowDriverInfo() {
+    System.err.println("========================================================================");
+    System.err.println("                      PostgreSQL JDBC Driver Info                       ");
+    System.err.println("                      ---------------------------                       ");
+    System.err.println("                                                                        ");
+    System.err.println("JAVA_VERSION = " + System.getProperty("java.version"));
+    System.err.println("JAVA_VERSION = " + System.getProperty("os.name"));
+    System.err.println("CLIENT_NOW = " + OffsetDateTime.now().toString());
+    System.err.println("DRIVER_NAME = " + DriverInfo.DRIVER_NAME);
+    System.err.println("DRIVER_SHORT_NAME = " + DriverInfo.DRIVER_SHORT_NAME);
+    System.err.println("DRIVER_VERSION = " + DriverInfo.DRIVER_VERSION);
+    System.err.println("DRIVER_MAJOR_VERSION = " + DriverInfo.MAJOR_VERSION);
+    System.err.println("MINOR_VERSION = " + DriverInfo.MINOR_VERSION);
+    System.err.println("PATCH_VERSION = " + DriverInfo.PATCH_VERSION);
+    System.err.println("JDBC_VERSION = " + DriverInfo.JDBC_VERSION);
+    System.err.println("========================================================================");
+  }
+
+  @Test
+  public void testShowServerInfo() throws SQLException {
+    System.err.println("========================================================================");
+    System.err.println("                      PostgreSQL Test Server Info                       ");
+    System.err.println("                      ---------------------------                       ");
+    System.err.println("                                                                        ");
+    try (Connection conn = TestUtil.openDB()) {
+      System.err.println("SELECT version()");
+      System.err.println("----------------");
+      System.err.println(TestUtil.queryForString(conn, "SELECT version()"));
+      System.err.println("");
+
+      System.err.println("SELECT now()");
+      System.err.println("------------");
+      System.err.println(TestUtil.queryForString(conn, "SELECT now()"));
+      System.err.println("");
+
+      System.err.println("SELECT USER");
+      System.err.println("----------------");
+      System.err.println(TestUtil.queryForString(conn, "SELECT USER"));
+      System.err.println("");
+
+      System.err.println("SELECT current_database()");
+      System.err.println("-------------------------");
+      System.err.println(TestUtil.queryForString(conn, "SELECT current_database()"));
+      System.err.println("");
+
+      System.err.println("SHOW ALL");
+      System.err.println("--------");
+      Statement stmt = conn.createStatement();
+      ResultSet rs = stmt.executeQuery("SHOW ALL");
+      while (rs.next()) {
+        String name = rs.getString(1);
+        String value = rs.getString(2);
+        System.err.println(name + " = " + value);
+      }
+      rs.close();
+      stmt.close();
+    }
+    System.err.println("========================================================================");
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/Jdbc2TestSuite.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/Jdbc2TestSuite.java
@@ -10,6 +10,7 @@ import org.postgresql.core.CommandCompleteParserTest;
 import org.postgresql.core.OidToStringTest;
 import org.postgresql.core.OidValueOfTest;
 import org.postgresql.core.ParserTest;
+import org.postgresql.core.PrintDebugInfoTest;
 import org.postgresql.core.ReturningParserTest;
 import org.postgresql.core.UTF8EncodingTest;
 import org.postgresql.core.v3.V3ParameterListTests;
@@ -107,6 +108,7 @@ import org.junit.runners.Suite;
     PGTimeTest.class,
     PgSQLXMLTest.class,
     PreparedStatementTest.class,
+    PrintDebugInfoTest.class,
     QuotationTest.class,
     ReaderInputStreamTest.class,
     RefCursorTest.class,


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [X] Does your submission pass tests?
2. [X] Does `./gradlew autostyleCheck checkstyleAll` pass ?
3. [X] Have you added your new test classes to an existing test suite in alphabetical order?

----

Reworded @adunstan's on #2097 that adds a psql command to print the server version, added a similar one for travis, and finally added a new test case that prints client and server version information using the actual connection being tested. This should give us the exact JVM and server info to hopefully make it easier to reproduce CI issues. I also included a couple other things like the current time, timezone, and the output of `SHOW ALL`  in case a changed setting is the cause (ex:  `max_prepared_transactions`).

Here's a sample of the output:

```text
2021-03-13T16:11:31.8030003Z PrintDebugInfoTest > testShowServerInfo STANDARD_ERROR
2021-03-13T16:11:31.8031119Z     ========================================================================
2021-03-13T16:11:31.8032091Z                           PostgreSQL Test Server Info                       
2021-03-13T16:11:31.8033671Z                           ---------------------------                       
2021-03-13T16:11:31.8034559Z                                                                         
2021-03-13T16:11:31.8035369Z     SELECT version()
2021-03-13T16:11:31.8036315Z     ----------------
2021-03-13T16:11:31.8037720Z     PostgreSQL 13.2 (Debian 13.2-1.pgdg100+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 8.3.0-6) 8.3.0, 64-bit
2021-03-13T16:11:31.8038634Z 
2021-03-13T16:11:31.8039349Z     SELECT now()
2021-03-13T16:11:31.8040257Z     ------------
2021-03-13T16:11:31.8041200Z     2021-03-13 16:11:31.768115+00
2021-03-13T16:11:31.8041750Z 
2021-03-13T16:11:31.8042473Z     SELECT USER
2021-03-13T16:11:31.8043374Z     ----------------
2021-03-13T16:11:31.8044160Z     test
2021-03-13T16:11:31.8044681Z 
2021-03-13T16:11:31.8045457Z     SELECT current_database()
2021-03-13T16:11:31.8046776Z     -------------------------
2021-03-13T16:11:31.8050987Z     test
2021-03-13T16:11:31.8056026Z 
2021-03-13T16:11:31.8057077Z     SHOW ALL
2021-03-13T16:11:31.8057946Z     --------
2021-03-13T16:11:31.8058560Z     allow_system_table_mods = off
2021-03-13T16:11:31.8059299Z     application_name = Driver Tests
2021-03-13T16:11:31.8060024Z     archive_cleanup_command = 
2021-03-13T16:11:31.8060741Z     archive_command = (disabled)
2021-03-13T16:11:31.8063160Z     archive_mode = off
2021-03-13T16:11:31.8063782Z     archive_timeout = 0
2021-03-13T16:11:31.8064392Z     array_nulls = on
2021-03-13T16:11:31.8065074Z     authentication_timeout = 1min
2021-03-13T16:11:31.8065752Z     autovacuum = on
2021-03-13T16:11:31.8066448Z     autovacuum_analyze_scale_factor = 0.1
2021-03-13T16:11:31.8067405Z     autovacuum_analyze_threshold = 50
2021-03-13T16:11:31.8068146Z     autovacuum_freeze_max_age = 200000000
2021-03-13T16:11:31.8068977Z     autovacuum_max_workers = 3
2021-03-13T16:11:31.8069749Z     autovacuum_multixact_freeze_max_age = 400000000
2021-03-13T16:11:31.8070707Z     autovacuum_naptime = 1min
2021-03-13T16:11:31.8071439Z     autovacuum_vacuum_cost_delay = 2ms
2021-03-13T16:11:31.8072494Z     autovacuum_vacuum_cost_limit = -1
2021-03-13T16:11:31.8073267Z     autovacuum_vacuum_insert_scale_factor = 0.2
2021-03-13T16:11:31.8074092Z     autovacuum_vacuum_insert_threshold = 1000
2021-03-13T16:11:31.8076105Z     autovacuum_vacuum_scale_factor = 0.2
2021-03-13T16:11:31.8076888Z     autovacuum_vacuum_threshold = 50
2021-03-13T16:11:31.8077844Z     autovacuum_work_mem = -1
2021-03-13T16:11:31.8078517Z     backend_flush_after = 0
2021-03-13T16:11:31.8079212Z     backslash_quote = safe_encoding
2021-03-13T16:11:31.8079934Z     backtrace_functions = 
2021-03-13T16:11:31.8080606Z     bgwriter_delay = 200ms
2021-03-13T16:11:31.8081259Z     bgwriter_flush_after = 512kB
2021-03-13T16:11:31.8081954Z     bgwriter_lru_maxpages = 100
2021-03-13T16:11:31.8082664Z     bgwriter_lru_multiplier = 2
2021-03-13T16:11:31.8084614Z     block_size = 8192
2021-03-13T16:11:31.8085215Z     bonjour = off
2021-03-13T16:11:31.8085793Z     bonjour_name = 
2021-03-13T16:11:31.8086402Z     bytea_output = hex
2021-03-13T16:11:31.8087051Z     check_function_bodies = on
2021-03-13T16:11:31.8087780Z     checkpoint_completion_target = 0.5
2021-03-13T16:11:31.8088530Z     checkpoint_flush_after = 256kB
2021-03-13T16:11:31.8089239Z     checkpoint_timeout = 5min
2021-03-13T16:11:31.8089928Z     checkpoint_warning = 30s
2021-03-13T16:11:31.8090608Z     client_encoding = UTF8
2021-03-13T16:11:31.8091295Z     client_min_messages = notice
2021-03-13T16:11:31.8091936Z     cluster_name = 
2021-03-13T16:11:31.8092533Z     commit_delay = 0
2021-03-13T16:11:31.8093146Z     commit_siblings = 5
2021-03-13T16:11:31.8093849Z     constraint_exclusion = partition
2021-03-13T16:11:31.8094579Z     cpu_index_tuple_cost = 0.005
2021-03-13T16:11:31.8095231Z     cpu_operator_cost = 0.0025
2021-03-13T16:11:31.8095851Z     cpu_tuple_cost = 0.01
2021-03-13T16:11:31.8096497Z     cursor_tuple_fraction = 0.1
2021-03-13T16:11:31.8097172Z     data_checksums = off
2021-03-13T16:11:31.8097818Z     data_directory_mode = 0700
2021-03-13T16:11:31.8098459Z     data_sync_retry = off
2021-03-13T16:11:31.8099088Z     DateStyle = ISO, MDY
2021-03-13T16:11:31.8105577Z     db_user_namespace = off
2021-03-13T16:11:31.8106355Z     deadlock_timeout = 1s
2021-03-13T16:11:31.8107011Z     debug_assertions = off
2021-03-13T16:11:31.8107688Z     debug_pretty_print = on
2021-03-13T16:11:31.8108349Z     debug_print_parse = off
2021-03-13T16:11:31.8109184Z     debug_print_plan = off
2021-03-13T16:11:31.8109865Z     debug_print_rewritten = off
2021-03-13T16:11:31.8164128Z     default_statistics_target = 100
2021-03-13T16:11:31.8164901Z     default_table_access_method = heap
2021-03-13T16:11:31.8165639Z     default_tablespace = 
2021-03-13T16:11:31.8166456Z     default_text_search_config = pg_catalog.english
2021-03-13T16:11:31.8167325Z     default_transaction_deferrable = off
2021-03-13T16:11:31.8168247Z     default_transaction_isolation = read committed
2021-03-13T16:11:31.8169329Z     default_transaction_read_only = off
2021-03-13T16:11:31.8170087Z     dynamic_shared_memory_type = posix
2021-03-13T16:11:31.8170825Z     effective_cache_size = 4GB
2021-03-13T16:11:31.8171556Z     effective_io_concurrency = 1
2021-03-13T16:11:31.8172266Z     enable_bitmapscan = on
2021-03-13T16:11:31.8172965Z     enable_gathermerge = on
2021-03-13T16:11:31.8173637Z     enable_hashagg = on
2021-03-13T16:11:31.8175361Z     enable_hashjoin = on
2021-03-13T16:11:31.8176097Z     enable_incremental_sort = on
2021-03-13T16:11:31.8176823Z     enable_indexonlyscan = on
2021-03-13T16:11:31.8177528Z     enable_indexscan = on
2021-03-13T16:11:31.8178188Z     enable_material = on
2021-03-13T16:11:31.8178834Z     enable_mergejoin = on
2021-03-13T16:11:31.8179501Z     enable_nestloop = on
2021-03-13T16:11:31.8180192Z     enable_parallel_append = on
2021-03-13T16:11:31.9030618Z     enable_parallel_hash = on
2021-03-13T16:11:31.9031802Z     enable_partition_pruning = on
2021-03-13T16:11:31.9033138Z     enable_partitionwise_aggregate = off
2021-03-13T16:11:31.9034182Z     enable_partitionwise_join = off
2021-03-13T16:11:31.9035072Z     enable_seqscan = on
2021-03-13T16:11:31.9035892Z     enable_sort = on
2021-03-13T16:11:31.9036701Z     enable_tidscan = on
2021-03-13T16:11:31.9055528Z     escape_string_warning = on
2021-03-13T16:11:31.9094000Z     event_source = PostgreSQL
2021-03-13T16:11:31.9094795Z     exit_on_error = off
2021-03-13T16:11:31.9095419Z     extra_float_digits = 3
2021-03-13T16:11:31.9096088Z     force_parallel_mode = off
2021-03-13T16:11:31.9096767Z     from_collapse_limit = 8
2021-03-13T16:11:31.9097364Z     fsync = on
2021-03-13T16:11:31.9098032Z     full_page_writes = on
2021-03-13T16:11:31.9098620Z     geqo = on
2021-03-13T16:11:31.9099172Z     geqo_effort = 5
2021-03-13T16:11:31.9099806Z     geqo_generations = 0
2021-03-13T16:11:31.9100445Z     geqo_pool_size = 0
2021-03-13T16:11:31.9101018Z     geqo_seed = 0
2021-03-13T16:11:31.9101671Z     geqo_selection_bias = 2
2021-03-13T16:11:31.9109379Z     geqo_threshold = 12
2021-03-13T16:11:31.9110220Z     gin_fuzzy_search_limit = 0
2021-03-13T16:11:31.9110908Z     gin_pending_list_limit = 4MB
2021-03-13T16:11:31.9111607Z     hash_mem_multiplier = 1
2021-03-13T16:11:31.9112238Z     hot_standby = on
2021-03-13T16:11:31.9112894Z     hot_standby_feedback = off
2021-03-13T16:11:31.9113566Z     huge_pages = try
2021-03-13T16:11:31.9114290Z     idle_in_transaction_session_timeout = 0
2021-03-13T16:11:31.9115071Z     ignore_checksum_failure = off
2021-03-13T16:11:31.9115768Z     ignore_invalid_pages = off
2021-03-13T16:11:31.9116464Z     ignore_system_indexes = off
2021-03-13T16:11:31.9117161Z     integer_datetimes = on
2021-03-13T16:11:31.9117879Z     IntervalStyle = postgres
2021-03-13T16:11:31.9162545Z     jit = on
2021-03-13T16:11:31.9163171Z     jit_above_cost = 100000
2021-03-13T16:11:31.9163825Z     jit_debugging_support = off
2021-03-13T16:11:31.9164469Z     jit_dump_bitcode = off
2021-03-13T16:11:31.9165124Z     jit_expressions = on
2021-03-13T16:11:31.9165779Z     jit_inline_above_cost = 500000
2021-03-13T16:11:31.9166419Z     jit_optimize_above_cost = 500000
2021-03-13T16:11:31.9167101Z     jit_profiling_support = off
2021-03-13T16:11:31.9167773Z     jit_tuple_deforming = on
2021-03-13T16:11:31.9168403Z     join_collapse_limit = 8
2021-03-13T16:11:31.9169032Z     krb_caseins_users = off
2021-03-13T16:11:31.9169667Z     lc_collate = en_US.utf8
2021-03-13T16:11:31.9170275Z     lc_ctype = en_US.utf8
2021-03-13T16:11:31.9170901Z     lc_messages = en_US.utf8
2021-03-13T16:11:31.9171541Z     lc_monetary = en_US.utf8
2021-03-13T16:11:31.9172191Z     lc_numeric = en_US.utf8
2021-03-13T16:11:31.9172797Z     lc_time = en_US.utf8
2021-03-13T16:11:31.9173407Z     listen_addresses = *
2021-03-13T16:11:31.9174053Z     lo_compat_privileges = off
2021-03-13T16:11:31.9174733Z     local_preload_libraries = 
2021-03-13T16:11:31.9175361Z     lock_timeout = 0
2021-03-13T16:11:31.9176642Z     log_autovacuum_min_duration = -1
2021-03-13T16:11:31.9177572Z     log_checkpoints = off
2021-03-13T16:11:31.9178218Z     log_connections = off
2021-03-13T16:11:31.9178863Z     log_destination = stderr
2021-03-13T16:11:31.9179547Z     log_disconnections = off
2021-03-13T16:11:31.9180176Z     log_duration = off
2021-03-13T16:11:31.9180823Z     log_error_verbosity = default
2021-03-13T16:11:31.9181490Z     log_executor_stats = off
2021-03-13T16:11:31.9182081Z     log_file_mode = 0600
2021-03-13T16:11:31.9182665Z     log_hostname = off
2021-03-13T16:11:31.9183269Z     log_line_prefix = %m [%p] 
2021-03-13T16:11:31.9183852Z     log_lock_waits = off
2021-03-13T16:11:31.9184651Z     log_min_duration_sample = -1
2021-03-13T16:11:31.9185479Z     log_min_duration_statement = -1
2021-03-13T16:11:31.9186169Z     log_min_error_statement = error
2021-03-13T16:11:31.9186851Z     log_min_messages = warning
2021-03-13T16:11:31.9187668Z     log_parameter_max_length = -1
2021-03-13T16:11:31.9188368Z     log_parameter_max_length_on_error = 0
2021-03-13T16:11:31.9207463Z     log_parser_stats = off
2021-03-13T16:11:31.9208418Z     log_planner_stats = off
2021-03-13T16:11:31.9209090Z     log_replication_commands = off
2021-03-13T16:11:31.9209757Z     log_rotation_age = 1d
2021-03-13T16:11:31.9210369Z     log_rotation_size = 10MB
2021-03-13T16:11:31.9210980Z     log_statement = none
2021-03-13T16:11:31.9211638Z     log_statement_sample_rate = 1
2021-03-13T16:11:31.9212309Z     log_statement_stats = off
2021-03-13T16:11:31.9213374Z     log_temp_files = -1
2021-03-13T16:11:31.9213988Z     log_timezone = Etc/UTC
2021-03-13T16:11:31.9214664Z     log_transaction_sample_rate = 0
2021-03-13T16:11:31.9215350Z     log_truncate_on_rotation = off
2021-03-13T16:11:31.9216020Z     logging_collector = off
2021-03-13T16:11:31.9216681Z     logical_decoding_work_mem = 64MB
2021-03-13T16:11:31.9217406Z     maintenance_io_concurrency = 10
2021-03-13T16:11:31.9218116Z     maintenance_work_mem = 64MB
2021-03-13T16:11:31.9218748Z     max_connections = 100
2021-03-13T16:11:31.9219404Z     max_files_per_process = 1000
2021-03-13T16:11:31.9220036Z     max_function_args = 100
2021-03-13T16:11:31.9220666Z     max_identifier_length = 63
2021-03-13T16:11:31.9221295Z     max_index_keys = 32
2021-03-13T16:11:31.9221923Z     max_locks_per_transaction = 64
2021-03-13T16:11:31.9222634Z     max_logical_replication_workers = 4
2021-03-13T16:11:31.9223410Z     max_parallel_maintenance_workers = 2
2021-03-13T16:11:31.9224127Z     max_parallel_workers = 8
2021-03-13T16:11:31.9224811Z     max_parallel_workers_per_gather = 2
2021-03-13T16:11:31.9225500Z     max_pred_locks_per_page = 2
2021-03-13T16:11:31.9226332Z     max_pred_locks_per_relation = -2
2021-03-13T16:11:31.9227036Z     max_pred_locks_per_transaction = 64
2021-03-13T16:11:31.9227767Z     max_prepared_transactions = 64
2021-03-13T16:11:31.9228471Z     max_replication_slots = 10
2021-03-13T16:11:31.9229452Z     max_slot_wal_keep_size = -1
2021-03-13T16:11:31.9230073Z     max_stack_depth = 2MB
2021-03-13T16:11:31.9230717Z     max_standby_archive_delay = 30s
2021-03-13T16:11:31.9231411Z     max_standby_streaming_delay = 30s
2021-03-13T16:11:31.9232150Z     max_sync_workers_per_subscription = 2
2021-03-13T16:11:31.9232826Z     max_wal_senders = 10
2021-03-13T16:11:31.9233392Z     max_wal_size = 1GB
2021-03-13T16:11:31.9234000Z     max_worker_processes = 8
2021-03-13T16:11:31.9234675Z     min_parallel_index_scan_size = 512kB
2021-03-13T16:11:31.9235386Z     min_parallel_table_scan_size = 8MB
2021-03-13T16:11:31.9236023Z     min_wal_size = 80MB
2021-03-13T16:11:31.9236787Z     old_snapshot_threshold = -1
2021-03-13T16:11:31.9237522Z     operator_precedence_warning = off
2021-03-13T16:11:31.9238311Z     parallel_leader_participation = on
2021-03-13T16:11:31.9239028Z     parallel_setup_cost = 1000
2021-03-13T16:11:31.9239674Z     parallel_tuple_cost = 0.1
2021-03-13T16:11:31.9240342Z     password_encryption = md5
2021-03-13T16:11:31.9240984Z     plan_cache_mode = auto
2021-03-13T16:11:31.9241551Z     port = 5432
2021-03-13T16:11:31.9242099Z     post_auth_delay = 0
2021-03-13T16:11:31.9242854Z     pre_auth_delay = 0
2021-03-13T16:11:31.9243451Z     primary_slot_name = 
2021-03-13T16:11:31.9244095Z     promote_trigger_file = 
2021-03-13T16:11:31.9244758Z     quote_all_identifiers = off
2021-03-13T16:11:31.9245399Z     random_page_cost = 4
2021-03-13T16:11:31.9246026Z     recovery_end_command = 
2021-03-13T16:11:31.9246680Z     recovery_min_apply_delay = 0
2021-03-13T16:11:31.9247328Z     recovery_target = 
2021-03-13T16:11:31.9247993Z     recovery_target_action = pause
2021-03-13T16:11:31.9249745Z     recovery_target_inclusive = on
2021-03-13T16:11:31.9250449Z     recovery_target_lsn = 
2021-03-13T16:11:31.9251084Z     recovery_target_name = 
2021-03-13T16:11:31.9251736Z     recovery_target_time = 
2021-03-13T16:11:31.9252438Z     recovery_target_timeline = latest
2021-03-13T16:11:31.9253124Z     recovery_target_xid = 
2021-03-13T16:11:31.9253774Z     restart_after_crash = on
2021-03-13T16:11:31.9254404Z     restore_command = 
2021-03-13T16:11:31.9254996Z     row_security = on
2021-03-13T16:11:31.9255728Z     search_path = "$user", public
2021-03-13T16:11:31.9256362Z     segment_size = 1GB
2021-03-13T16:11:31.9256923Z     seq_page_cost = 1
2021-03-13T16:11:31.9257534Z     server_encoding = UTF8
2021-03-13T16:11:31.9258764Z     server_version = 13.2 (Debian 13.2-1.pgdg100+1)
2021-03-13T16:11:31.9259459Z     server_version_num = 130002
2021-03-13T16:11:31.9260155Z     session_replication_role = origin
2021-03-13T16:11:31.9260843Z     shared_buffers = 128MB
2021-03-13T16:11:31.9261458Z     shared_memory_type = mmap
2021-03-13T16:11:31.9262180Z     ssl = on
2021-03-13T16:11:31.9262790Z     ssl_ca_file = /home/certdir/root.crt
2021-03-13T16:11:31.9263526Z     ssl_cert_file = /home/certdir/server.crt
2021-03-13T16:11:31.9264195Z     ssl_crl_file = 
2021-03-13T16:11:31.9264856Z     ssl_key_file = /home/certdir/server.key
2021-03-13T16:11:31.9265545Z     ssl_library = OpenSSL
2021-03-13T16:11:31.9266285Z     ssl_passphrase_command_supports_reload = off
2021-03-13T16:11:31.9267066Z     ssl_prefer_server_ciphers = on
2021-03-13T16:11:31.9267776Z     standard_conforming_strings = on
2021-03-13T16:11:31.9268465Z     statement_timeout = 0
2021-03-13T16:11:31.9269375Z     superuser_reserved_connections = 3
2021-03-13T16:11:31.9270124Z     synchronize_seqscans = on
2021-03-13T16:11:31.9270802Z     synchronous_commit = on
2021-03-13T16:11:31.9271475Z     synchronous_standby_names = 
2021-03-13T16:11:31.9272158Z     syslog_facility = local0
2021-03-13T16:11:31.9272809Z     syslog_ident = postgres
2021-03-13T16:11:31.9273470Z     syslog_sequence_numbers = on
2021-03-13T16:11:31.9274152Z     syslog_split_messages = on
2021-03-13T16:11:31.9274819Z     tcp_keepalives_count = 9
2021-03-13T16:11:31.9275471Z     tcp_keepalives_idle = 7200
2021-03-13T16:11:31.9276159Z     tcp_keepalives_interval = 75
2021-03-13T16:11:31.9276811Z     tcp_user_timeout = 0
2021-03-13T16:11:31.9277392Z     temp_buffers = 8MB
2021-03-13T16:11:31.9278201Z     temp_file_limit = -1
2021-03-13T16:11:31.9278825Z     temp_tablespaces = 
2021-03-13T16:11:31.9279448Z     TimeZone = Etc/UTC
2021-03-13T16:11:31.9280140Z     timezone_abbreviations = Default
2021-03-13T16:11:31.9280830Z     trace_notify = off
2021-03-13T16:11:31.9281461Z     trace_recovery_messages = log
2021-03-13T16:11:31.9282097Z     trace_sort = off
2021-03-13T16:11:31.9282682Z     track_activities = on
2021-03-13T16:11:31.9283340Z     track_activity_query_size = 1kB
2021-03-13T16:11:31.9284030Z     track_commit_timestamp = off
2021-03-13T16:11:31.9284653Z     track_counts = on
2021-03-13T16:11:31.9285257Z     track_functions = none
2021-03-13T16:11:31.9285877Z     track_io_timing = off
2021-03-13T16:11:31.9286529Z     transaction_deferrable = off
2021-03-13T16:11:31.9287309Z     transaction_isolation = read committed
2021-03-13T16:11:31.9288061Z     transaction_read_only = off
2021-03-13T16:11:31.9288725Z     transform_null_equals = off
2021-03-13T16:11:31.9289370Z     unix_socket_group = 
2021-03-13T16:11:31.9290028Z     unix_socket_permissions = 0777
2021-03-13T16:11:31.9290863Z     update_process_title = on
2021-03-13T16:11:31.9291575Z     vacuum_cleanup_index_scale_factor = 0.1
2021-03-13T16:11:31.9292250Z     vacuum_cost_delay = 0
2021-03-13T16:11:31.9292840Z     vacuum_cost_limit = 200
2021-03-13T16:11:31.9293462Z     vacuum_cost_page_dirty = 20
2021-03-13T16:11:31.9294093Z     vacuum_cost_page_hit = 1
2021-03-13T16:11:31.9294711Z     vacuum_cost_page_miss = 10
2021-03-13T16:11:31.9295362Z     vacuum_defer_cleanup_age = 0
2021-03-13T16:11:31.9296026Z     vacuum_freeze_min_age = 50000000
2021-03-13T16:11:31.9296672Z     vacuum_freeze_table_age = 150000000
2021-03-13T16:11:31.9297386Z     vacuum_multixact_freeze_min_age = 5000000
2021-03-13T16:11:31.9298144Z     vacuum_multixact_freeze_table_age = 150000000
2021-03-13T16:11:31.9298803Z     wal_block_size = 8192
2021-03-13T16:11:31.9299377Z     wal_buffers = 4MB
2021-03-13T16:11:31.9299977Z     wal_compression = off
2021-03-13T16:11:31.9300651Z     wal_consistency_checking = 
2021-03-13T16:11:31.9301294Z     wal_init_zero = on
2021-03-13T16:11:31.9301959Z     wal_keep_size = 0
2021-03-13T16:11:31.9302562Z     wal_level = replica
2021-03-13T16:11:31.9303156Z     wal_log_hints = off
2021-03-13T16:11:31.9303795Z     wal_receiver_create_temp_slot = off
2021-03-13T16:11:31.9304532Z     wal_receiver_status_interval = 10s
2021-03-13T16:11:31.9305233Z     wal_receiver_timeout = 1min
2021-03-13T16:11:31.9305848Z     wal_recycle = on
2021-03-13T16:11:31.9306501Z     wal_retrieve_retry_interval = 5s
2021-03-13T16:11:31.9307168Z     wal_segment_size = 16MB
2021-03-13T16:11:31.9307785Z     wal_sender_timeout = 1min
2021-03-13T16:11:31.9308429Z     wal_skip_threshold = 2MB
2021-03-13T16:11:31.9309476Z     wal_sync_method = fdatasync
2021-03-13T16:11:31.9310106Z     wal_writer_delay = 200ms
2021-03-13T16:11:31.9310745Z     wal_writer_flush_after = 1MB
2021-03-13T16:11:31.9311342Z     work_mem = 4MB
2021-03-13T16:11:31.9311908Z     xmlbinary = base64
2021-03-13T16:11:31.9312530Z     xmloption = content
2021-03-13T16:11:31.9313205Z     zero_damaged_pages = off
2021-03-13T16:11:31.9313825Z     ========================================================================
2021-03-13T16:11:31.9314216Z 
2021-03-13T16:11:31.9315033Z PrintDebugInfoTest > testShowDriverInfo STANDARD_ERROR
2021-03-13T16:11:31.9315921Z     ========================================================================
2021-03-13T16:11:31.9316621Z                           PostgreSQL JDBC Driver Info                       
2021-03-13T16:11:31.9317678Z                           ---------------------------                       
2021-03-13T16:11:31.9318332Z                                                                         
2021-03-13T16:11:31.9318912Z     JAVA_VERSION = 11.0.10
2021-03-13T16:11:31.9319507Z     JAVA_VERSION = Linux
2021-03-13T16:11:31.9320312Z     CLIENT_NOW = 2021-03-13T16:11:31.826057Z
2021-03-13T16:11:31.9321020Z     DRIVER_NAME = PostgreSQL JDBC Driver
2021-03-13T16:11:31.9321723Z     DRIVER_SHORT_NAME = PgJDBC
2021-03-13T16:11:31.9322551Z     DRIVER_VERSION = 42.3.0-SNAPSHOT
2021-03-13T16:11:31.9323232Z     DRIVER_MAJOR_VERSION = 42
2021-03-13T16:11:31.9323828Z     MINOR_VERSION = 3
2021-03-13T16:11:31.9324408Z     PATCH_VERSION = 0
2021-03-13T16:11:31.9324988Z     JDBC_VERSION = 4.2
2021-03-13T16:11:31.9325556Z     ========================================================================
```
