### PR TITLE
Change TestUtil.terminateBackend(...) to wait for terminated process to exit

### DIFF
--- a/pgjdbc/src/test/java/org/postgresql/replication/ReplicationConnectionTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/replication/ReplicationConnectionTest.java
@@ -68,7 +68,7 @@ public class ReplicationConnectionTest {
     boolean result = replConnection.isValid(3);
 
     assertThat("When postgresql terminate session with replication connection, "
-            + "isValid methos should return false, because next query on this connection will fail",
+            + "isValid() should return false, because next query on this connection will fail",
         result, equalTo(false)
     );
   }

--- a/pgjdbc/src/test/java/org/postgresql/replication/ReplicationConnectionTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/replication/ReplicationConnectionTest.java
@@ -56,9 +56,7 @@ public class ReplicationConnectionTest {
 
   @Test
   public void testConnectionNotValidWhenSessionTerminated() throws Exception {
-    int backendId = ((PGConnection) replConnection).getBackendPID();
-
-    TestUtil.terminateBackend(backendId);
+    TestUtil.terminateBackend(replConnection);
 
     boolean result = replConnection.isValid(3);
 

--- a/pgjdbc/src/test/java/org/postgresql/replication/ReplicationConnectionTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/replication/ReplicationConnectionTest.java
@@ -58,12 +58,7 @@ public class ReplicationConnectionTest {
   public void testConnectionNotValidWhenSessionTerminated() throws Exception {
     int backendId = ((PGConnection) replConnection).getBackendPID();
 
-    Connection sqlConnection = TestUtil.openDB();
-
-    Statement terminateStatement = sqlConnection.createStatement();
-    terminateStatement.execute("SELECT pg_terminate_backend(" + backendId + ")");
-    terminateStatement.close();
-    sqlConnection.close();
+    TestUtil.terminateBackend(backendId);
 
     boolean result = replConnection.isValid(3);
 

--- a/pgjdbc/src/test/java/org/postgresql/test/TestUtil.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/TestUtil.java
@@ -5,6 +5,7 @@
 
 package org.postgresql.test;
 
+import org.postgresql.PGConnection;
 import org.postgresql.PGProperty;
 import org.postgresql.core.BaseConnection;
 import org.postgresql.core.ServerVersion;
@@ -971,13 +972,8 @@ public class TestUtil {
    * Retrieve the backend process id for a given connection.
    */
   public static int getBackendPid(Connection conn) throws SQLException {
-    Statement stmt = conn.createStatement();
-    ResultSet rs = stmt.executeQuery("SELECT pg_backend_pid()");
-    rs.next();
-    int pid = rs.getInt(1);
-    rs.close();
-    stmt.close();
-    return pid;
+    PGConnection pgConn = conn.unwrap(PGConnection.class);
+    return pgConn.getBackendPID();
   }
 
   /**

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/CopyTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/CopyTest.java
@@ -425,14 +425,10 @@ public class CopyTest {
     // on the Connection object fails to deadlock.
     con.setAutoCommit(false);
 
-    // We get the process id before the COPY as we cannot run other commands
-    // on the connection during the COPY operation.
-    int pid = TestUtil.getBackendPid(con);
-
     CopyManager manager = con.unwrap(PGConnection.class).getCopyAPI();
     CopyIn copyIn = manager.copyIn("COPY copytest FROM STDIN with " + copyParams);
+    TestUtil.terminateBackend(con);
     try {
-      TestUtil.terminateBackend(pid);
       byte[] bunchOfNulls = ",,\n".getBytes();
       while (true) {
         copyIn.writeToCopy(bunchOfNulls, 0, bunchOfNulls.length);


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [X] Does your submission pass tests?
2. [X] Does `./gradlew autostyleCheck checkstyleAll` pass ?

-------

Adds helpers to wait for a terminated process to exit by repeatedly checking `pg_stat_activity` in a loop for up to five seconds. This needs to be done everywhere that we call `pg_terminate_backend(...)` as it only sends the termination signal without waiting. That makes a race condition for anything that is subsequently testing against the terminated process. Ex: https://github.com/pgjdbc/pgjdbc/pull/1087#issuecomment-798700040

Rather than have to remember to add the `waitForBackendTermination(...)` everywhere that we issue a terminate, I've made it the default and renamed the original method to `terminateBackendNoWait(...)`.

Hopefully this gets rid of some CI gremlins...