### PR TITLE
refactor:(loom) change synchronized this block to ReentrantLock for PgStatement…(rebased) 

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgCallableStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgCallableStatement.java
@@ -152,8 +152,11 @@ class PgCallableStatement extends PgPreparedStatement implements CallableStateme
 
     }
     rs.close();
-    synchronized (this) {
+    lock.lock();
+    try {
       result = null;
+    } finally {
+      lock.unlock();
     }
     return false;
   }

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
@@ -161,9 +161,12 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
 
       execute(preparedQuery, preparedParameters, flags);
 
-      synchronized (this) {
+      lock.lock();
+      try {
         checkClosed();
         return (result != null && result.getResultSet() != null);
+      } finally {
+        lock.unlock();
       }
     } finally {
       defaultTimeZone = null;

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc4/BlobTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc4/BlobTest.java
@@ -90,7 +90,7 @@ public class BlobTest {
     byte[] fullData = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse placerat tristique tellus, id tempus lectus."
             .getBytes("UTF-8");
     byte[] data =
-       "Lorem ipsum dolor sit amet, consectetur adipiscing elit.".getBytes("UTF-8");
+        "Lorem ipsum dolor sit amet, consectetur adipiscing elit.".getBytes("UTF-8");
     PreparedStatement insertPS = conn.prepareStatement(TestUtil.insertSQL("testblob", "lo", "?"));
     try {
       insertPS.setBlob(1, new ByteArrayInputStream(fullData), data.length);


### PR DESCRIPTION
Referencing #1951 for outline / motivation which is to improve compatibility with loom.

Change PgStatement, PgPreparedStatement and PgCallableStatement replacing synchronized (this) blocks with use of ReentrantLock to be compatible with loom.

In doing this change for PgStatement this PR must include:

All synchronized (this) blocks in PgStatement
All synchronized (this) blocks in it's sub types (PgPreparedStatement and PgCallableStatement)
I confirm that this PR includes all synchronized (this) blocks across PgStatement and all it's sub types.

Note that this PR does not add any new tests or change any existing tests. I do not believe either is required.



### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Does `./gradlew autostyleCheck checkstyleAll` pass ?
3. [ ] Have you added your new test classes to an existing test suite in alphabetical order?

### Changes to Existing Features:

* [ ] Does this break existing behaviour? If so please explain.
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
