### PR TITLE
Attempt to load from the TCCL first

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
@@ -789,7 +789,13 @@ public class PgConnection implements BaseConnection {
   @Override
   public void addDataType(String type, String name) {
     try {
-      addDataType(type, Class.forName(name).asSubclass(PGobject.class));
+      Class<?> klass;
+      try {
+        klass = Class.forName(name, false, Thread.currentThread().getContextClassLoader());
+      } catch (ClassNotFoundException exception) {
+        klass = Class.forName(name);
+      }
+      addDataType(type, klass.asSubclass(PGobject.class));
     } catch (Exception e) {
       throw new RuntimeException("Cannot register new type " + type, e);
     }
@@ -836,12 +842,16 @@ public class PgConnection implements BaseConnection {
         Class<?> klass;
 
         try {
-          klass = Class.forName(className);
-        } catch (ClassNotFoundException cnfe) {
-          throw new PSQLException(
-              GT.tr("Unable to load the class {0} responsible for the datatype {1}",
-                  className, typeName),
-              PSQLState.SYSTEM_ERROR, cnfe);
+          klass = Class.forName(className, false, Thread.currentThread().getContextClassLoader());
+        } catch (ClassNotFoundException exception) {
+          try {
+            klass = Class.forName(className);
+          } catch (ClassNotFoundException cnfe) {
+            throw new PSQLException(
+                GT.tr("Unable to load the class {0} responsible for the datatype {1}",
+                    className, typeName),
+                PSQLState.SYSTEM_ERROR, cnfe);
+          }
         }
 
         addDataType(typeName, klass.asSubclass(PGobject.class));

--- a/pgjdbc/src/main/java/org/postgresql/util/ObjectFactory.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/ObjectFactory.java
@@ -46,8 +46,14 @@ public class ObjectFactory {
           IllegalArgumentException, InstantiationException, IllegalAccessException,
           InvocationTargetException {
     @Nullable Object[] args = {info};
-    Constructor<? extends T> ctor = null;
-    Class<? extends T> cls = Class.forName(classname).asSubclass(expectedClass);
+    Constructor<?> ctor = null;
+    Class<? extends T> cls;
+    try {
+      //first use the TCCL, but fall back to the CL that loaded this class if the TCCL fails
+      cls = Class.forName(classname, false, Thread.currentThread().getContextClassLoader()).asSubclass(expectedClass);
+    } catch (ClassNotFoundException e) {
+      cls = Class.forName(classname).asSubclass(expectedClass);
+    }
     try {
       ctor = cls.getConstructor(Properties.class);
     } catch (NoSuchMethodException ignored) {

--- a/pgjdbc/src/test/java/org/postgresql/test/socketfactory/ClassLoaderCustomSocketFactory.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/socketfactory/ClassLoaderCustomSocketFactory.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2021, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.test.socketfactory;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.net.UnknownHostException;
+
+import javax.net.SocketFactory;
+
+public class ClassLoaderCustomSocketFactory extends SocketFactory {
+
+  private final String argument;
+  private int socketCreated;
+  private static ClassLoaderCustomSocketFactory instance;
+
+  public ClassLoaderCustomSocketFactory(String argument) {
+    if (Holder.customSocketFactory != null) {
+      throw new IllegalStateException("Test failed, multiple custom socket factory instanciation");
+    }
+    Holder.customSocketFactory = this;
+    instance = this;
+    this.argument = argument;
+  }
+
+  @Override
+  public Socket createSocket(String arg0, int arg1) throws IOException, UnknownHostException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Socket createSocket(InetAddress arg0, int arg1) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Socket createSocket(String arg0, int arg1, InetAddress arg2, int arg3)
+      throws IOException, UnknownHostException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Socket createSocket(InetAddress arg0, int arg1, InetAddress arg2, int arg3)
+      throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Socket createSocket() throws IOException {
+    socketCreated++;
+    return new Socket();
+  }
+
+  public String getArgument() {
+    return argument;
+  }
+
+  public int getSocketCreated() {
+    return socketCreated;
+  }
+
+  public static ClassLoaderCustomSocketFactory getInstance() {
+    return instance;
+  }
+
+}

--- a/pgjdbc/src/test/java/org/postgresql/test/socketfactory/Holder.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/socketfactory/Holder.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2021, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.test.socketfactory;
+
+import javax.net.SocketFactory;
+
+public class Holder {
+
+  public static SocketFactory customSocketFactory;
+
+}

--- a/pgjdbc/src/test/java/org/postgresql/test/socketfactory/SocketFactoryCustomClassLoaderTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/socketfactory/SocketFactoryCustomClassLoaderTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2021, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.test.socketfactory;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import org.postgresql.PGProperty;
+import org.postgresql.test.TestUtil;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.sql.Connection;
+import java.util.Properties;
+
+/**
+ * Tests that the socket factory is loaded from the TCCL, and not from the same CL as the driver.
+ */
+public class SocketFactoryCustomClassLoaderTest {
+
+  private static final String STRING_ARGUMENT = "name of a socket";
+
+  private Connection conn;
+
+  private ClassLoader oldTccl;
+
+  @Before
+  public void setUp() throws Exception {
+    oldTccl = Thread.currentThread().getContextClassLoader();
+    //this is an isolatedCL, that will define a new ClassLoaderCustomSocketFactory
+    //everything else is loaded parent first
+    Thread.currentThread().setContextClassLoader(new ClassLoader(oldTccl) {
+      @Override
+      public Class<?> loadClass(String name) throws ClassNotFoundException {
+        return loadClass(name, false);
+      }
+
+      @Override
+      protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+        if (name.equals(ClassLoaderCustomSocketFactory.class.getName())) {
+          ByteArrayOutputStream out = new ByteArrayOutputStream();
+          try (InputStream in = getClass().getClassLoader().getResourceAsStream(name.replace(".",
+              "/") + ".class")) {
+            int r;
+            byte[] buf = new byte[1024];
+            while ((r = in.read(buf)) > 0) {
+              out.write(buf, 0, r);
+            }
+            return defineClass(name, out.toByteArray(), 0, out.size());
+          } catch (IOException e) {
+            throw new RuntimeException(e);
+          }
+        } else {
+          return super.loadClass(name, resolve);
+        }
+      }
+    });
+    Properties properties = new Properties();
+    properties.put(PGProperty.SOCKET_FACTORY.getName(),
+        ClassLoaderCustomSocketFactory.class.getName());
+    properties.put(PGProperty.SOCKET_FACTORY_ARG.getName(), STRING_ARGUMENT);
+    conn = TestUtil.openDB(properties);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    Thread.currentThread().setContextClassLoader(oldTccl);
+    TestUtil.closeDB(conn);
+  }
+
+  @Test
+  public void testFactoryLoadedFromNewClassLoader() throws Exception {
+    assertNotNull("Custom socket factory not null", Holder.customSocketFactory);
+    //verify that we loaded the factory from a different CL
+    assertNotEquals("Loaded from wrong CL", getClass().getClassLoader(), Holder.customSocketFactory.getClass().getClassLoader());
+    assertFalse(Holder.customSocketFactory instanceof ClassLoaderCustomSocketFactory);
+    assertNull("Instance of ClassLoaderCustomSocketFactory created in wrong ClassLoader",
+        ClassLoaderCustomSocketFactory.getInstance());
+  }
+
+}


### PR DESCRIPTION
This allows user specified classes to be loaded from
the current Thread context ClassLoader, rather than
from the ClassLoader of the driver itself.

Fixes #2112

### All Submissions:

* [ ] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes to Existing Features:

* [ ] Does this break existing behaviour? If so please explain.

If you had a situation where the TCCL was different to the Driver CL, and both ClassLoaders contained a copy of the same class that is being loaded then a different class could be loaded. This seems like a very unlikely situation, and IMHO is a bug in the caller to not have the correct TCCL set.

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
