### PR TITLE
RETURNING clause mistakenly added to CREATE and ALTER table statements

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/Parser.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/Parser.java
@@ -211,7 +211,11 @@ public class Parser {
       if (keywordStart >= 0 && (i == aChars.length - 1 || !isKeyWordChar)) {
         int wordLength = (isKeyWordChar ? i + 1 : keywordEnd) - keywordStart;
         if (currentCommandType == SqlCommandType.BLANK) {
-          if (wordLength == 6 && parseUpdateKeyword(aChars, keywordStart)) {
+          if (wordLength == 6 && parseCreateKeyword(aChars, keywordStart)) {
+            currentCommandType = SqlCommandType.CREATE;
+          } else if (wordLength == 5 && parseAlterKeyword(aChars, keywordStart)) {
+            currentCommandType = SqlCommandType.ALTER;
+          } else if (wordLength == 6 && parseUpdateKeyword(aChars, keywordStart)) {
             currentCommandType = SqlCommandType.UPDATE;
           } else if (wordLength == 6 && parseDeleteKeyword(aChars, keywordStart)) {
             currentCommandType = SqlCommandType.DELETE;
@@ -654,6 +658,45 @@ public class Parser {
         && (query[offset + 3] | 32) == 'e'
         && (query[offset + 4] | 32) == 'c'
         && (query[offset + 5] | 32) == 't';
+  }
+
+  /**
+   * Parse string to check presence of CREATE keyword regardless of case.
+   *
+   * @param query char[] of the query statement
+   * @param offset position of query to start checking
+   * @return boolean indicates presence of word
+   */
+  public static boolean parseAlterKeyword(final char[] query, int offset) {
+    if (query.length < (offset + 5)) {
+      return false;
+    }
+
+    return (query[offset] | 32) == 'a'
+        && (query[offset + 1] | 32) == 'l'
+        && (query[offset + 2] | 32) == 't'
+        && (query[offset + 3] | 32) == 'e'
+        && (query[offset + 4] | 32) == 'r';
+  }
+
+  /**
+   * Parse string to check presence of CREATE keyword regardless of case.
+   *
+   * @param query char[] of the query statement
+   * @param offset position of query to start checking
+   * @return boolean indicates presence of word
+   */
+  public static boolean parseCreateKeyword(final char[] query, int offset) {
+    if (query.length < (offset + 6)) {
+      return false;
+    }
+
+    return (query[offset] | 32) == 'c'
+        && (query[offset + 1] | 32) == 'r'
+        && (query[offset + 2] | 32) == 'e'
+        && (query[offset + 3] | 32) == 'a'
+        && (query[offset + 4] | 32) == 't'
+        && (query[offset + 5] | 32) == 'e';
   }
 
   /**

--- a/pgjdbc/src/main/java/org/postgresql/core/SqlCommandType.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/SqlCommandType.java
@@ -23,5 +23,7 @@ public enum SqlCommandType {
   DELETE,
   MOVE,
   SELECT,
-  WITH;
+  WITH,
+  CREATE,
+  ALTER;
 }

--- a/pgjdbc/src/test/java/org/postgresql/core/ParserTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/core/ParserTest.java
@@ -252,7 +252,7 @@ public class ParserTest {
     List<NativeQuery> qry = Parser.parseJdbcSql(query, true, true, true, true, returningColumns);
     SqlCommand command = qry.get(0).getCommand();
     Assert.assertFalse("No returning keyword should be present", command.isReturningKeywordPresent());
-    Assert.assertEquals(SqlCommandType.BLANK, command.getType());
+    Assert.assertEquals(SqlCommandType.CREATE, command.getType());
   }
 
   @Test
@@ -262,6 +262,26 @@ public class ParserTest {
     List<NativeQuery> qry = Parser.parseJdbcSql(query, true, true, true, true, returningColumns);
     SqlCommand command = qry.get(0).getCommand();
     Assert.assertFalse("No returning keyword should be present", command.isReturningKeywordPresent());
-    Assert.assertEquals(SqlCommandType.BLANK, command.getType());
+    Assert.assertEquals(SqlCommandType.CREATE, command.getType());
+  }
+
+  @Test
+  public void alterTableParseWithOnDeleteClause() throws SQLException {
+    String[] returningColumns = {"*"};
+    String query = "alter table \"testTable\" ADD \"foreignId\" INT REFERENCES \"otherTable\" (\"id\") ON DELETE NO ACTION";
+    List<NativeQuery> qry = Parser.parseJdbcSql(query, true, true, true, true, returningColumns);
+    SqlCommand command = qry.get(0).getCommand();
+    Assert.assertFalse("No returning keyword should be present", command.isReturningKeywordPresent());
+    Assert.assertEquals(SqlCommandType.ALTER, command.getType());
+  }
+
+  @Test
+  public void alterTableParseWithOnUpdateClause() throws SQLException {
+    String[] returningColumns = {"*"};
+    String query = "alter table \"testTable\" ADD \"foreignId\" INT REFERENCES \"otherTable\" (\"id\") ON UPDATE RESTRICT";
+    List<NativeQuery> qry = Parser.parseJdbcSql(query, true, true, true, true, returningColumns);
+    SqlCommand command = qry.get(0).getCommand();
+    Assert.assertFalse("No returning keyword should be present", command.isReturningKeywordPresent());
+    Assert.assertEquals(SqlCommandType.ALTER, command.getType());
   }
 }

--- a/pgjdbc/src/test/java/org/postgresql/core/ParserTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/core/ParserTest.java
@@ -244,4 +244,24 @@ public class ParserTest {
     Assert.assertEquals(43,command.getBatchRewriteValuesBraceOpenPosition());
     Assert.assertEquals(49,command.getBatchRewriteValuesBraceClosePosition());
   }
+
+  @Test
+  public void createTableParseWithOnDeleteClause() throws SQLException {
+    String[] returningColumns = {"*"};
+    String query = "create table \"testTable\" (\"id\" INT SERIAL NOT NULL PRIMARY KEY, \"foreignId\" INT REFERENCES \"otherTable\" (\"id\") ON DELETE NO ACTION)";
+    List<NativeQuery> qry = Parser.parseJdbcSql(query, true, true, true, true, returningColumns);
+    SqlCommand command = qry.get(0).getCommand();
+    Assert.assertFalse("No returning keyword should be present", command.isReturningKeywordPresent());
+    Assert.assertEquals(SqlCommandType.BLANK, command.getType());
+  }
+
+  @Test
+  public void createTableParseWithOnUpdateClause() throws SQLException {
+    String[] returningColumns = {"*"};
+    String query = "create table \"testTable\" (\"id\" INT SERIAL NOT NULL PRIMARY KEY, \"foreignId\" INT REFERENCES \"otherTable\" (\"id\")) ON UPDATE NO ACTION";
+    List<NativeQuery> qry = Parser.parseJdbcSql(query, true, true, true, true, returningColumns);
+    SqlCommand command = qry.get(0).getCommand();
+    Assert.assertFalse("No returning keyword should be present", command.isReturningKeywordPresent());
+    Assert.assertEquals(SqlCommandType.BLANK, command.getType());
+  }
 }


### PR DESCRIPTION
When trying to create or alter a table that includes a foreign key constraint and an `ON DELETE` or `ON UPDATE` clause, the parser incorrectly marks the `CommandType` as `DELETE` or `UPDATE`, respectively.  Combined with a `returningColumns` of `{"*"}` (which is the default when just passing in the `autoGeneratedKeys` flag to `execute` in `PgStatement`) this causes a `RETURNING` clause to be added where it is invalid.

This PR adds four test cases showing the issue.

This PR also adds two new `CommandType` values for `CREATE` and `ALTER` to detect this scenario and prevent the `RETURNING` clause from being added. This is my first PR to this project and while the tests are passing, there may be a better implementation.  I defer to the more seasoned contributors.

I want to add that while using `executeUpdate` would solve this issue handily, it is unfortunately not exposed by the application framework.  They simply use `public boolean execute(String sql, int autoGeneratedKeys)` and trust this JDBC driver to handle it.  I am also working on that project to be more correct in their implementation as well.  I think this feature will be a benefit to all regardless of any change in downstream frameworks.

Thank you for your time!

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Does `./gradlew autostyleCheck checkstyleAll` pass ?
3. [x] Have you added your new test classes to an existing test suite in alphabetical order? N/A

### Changes to Existing Features:

* [ ] Does this break existing behaviour? If so please explain. N/A
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
