### PR TITLE
test: Change LoginTimeoutTest to listen on localhost to workaround GitHub Actions issue

### DIFF
--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/LoginTimeoutTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/LoginTimeoutTest.java
@@ -17,7 +17,6 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
-import java.net.UnknownHostException;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
@@ -87,13 +86,7 @@ public class LoginTimeoutTest {
 
   private static class TimeoutHelper implements Runnable {
     TimeoutHelper() throws IOException {
-      InetAddress localAddr;
-      try {
-        localAddr = InetAddress.getLocalHost();
-      } catch (UnknownHostException ex) {
-        System.err.println("WARNING: Could not resolve local host name, trying 'localhost'. " + ex);
-        localAddr = InetAddress.getByName("localhost");
-      }
+      InetAddress localAddr = InetAddress.getByName("localhost");
       this.listenSocket = new ServerSocket(0, 1, localAddr);
     }
 


### PR DESCRIPTION
Let's see if this fixes the CI issue for now. The GitHubActions issue thread for this says they're publishing a general fix to add the docker hostname to the hosts file for everybody, but it could be another week until it's published to everybody.

Having this test run on localhost (v.s. the test machine's hostname) does not meaningfully change anything and it's supposed to be the fallback anyway.