### PR TITLE
test: Fix GitHub actions os matrix to use inline arrays

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,9 +17,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        include:
-          - os: ubuntu-latest
-          - os: self-hosted
+        os:
+          - ubuntu-latest
+          - self-hosted
     env:
       ACTIONS_STEP_DEBUG: true
       ACTIONS_RUNNER_DEBUG: true
@@ -65,9 +65,9 @@ jobs:
       fail-fast: false
       matrix:
         jdk: [8, 11]
-        include:
-          - os: ubuntu-latest
-          - os: self-hosted
+        os:
+          - ubuntu-latest
+          - self-hosted
     env:
       ACTIONS_STEP_DEBUG: true
       ACTIONS_RUNNER_DEBUG: true
@@ -206,10 +206,9 @@ jobs:
       fail-fast: false
       matrix:
         jdk: [8, 11]
-        include:
-          - os: ubuntu-latest
-          - os: self-hosted
-
+        os:
+          - ubuntu-latest
+          - self-hosted
     env:
       ACTIONS_STEP_DEBUG: true
       ACTIONS_RUNNER_DEBUG: true
@@ -232,7 +231,11 @@ jobs:
         impl: hotspot # or openj9
         version: '8'
         architecture: aarch64
-
+    - name: 'Install software'
+      if: ${{ steps.get_arch_name.outputs.arch_name != 'aarch64' }}
+      run: |
+        sudo apt -y update
+        sudo apt -y install krb5-kdc krb5-admin-server libkrb5-dev postgresql-12
     - name: 'Update hosts'
       run: |
         sudo -- sh -c "echo 127.0.0.1 localhost auth-test-localhost.postgresql.example.com > /etc/hosts"


### PR DESCRIPTION
Looks like #2096 / d6ef27ab6d91b305f028079f0c0d26ef420e7c0e broke CI to run only on the self-hosted runners. I think it's because the YAML config works by overriding the `os` tag rather than merging the values as list. Not sure if that should be an error or if it's a "feature" of YAML.

Comparing the CI matrix for the PR I submitted to fix the login time https://github.com/pgjdbc/pgjdbc/runs/2410396955 and the CI matrix this one https://github.com/sehrope/pgjdbc/actions/runs/774372965 and you'll see the latter has twice as many jobs.

This PR hopefully fixes things. For now I just replaced the lists inline but may be worth a second look later to run some parts (e.g. checkstyle or the checker framework) only on ubuntu-latest as they're source based and I don't expect anybody cares about running things like that on ARM.