### PR TITLE
test: Add paths-ignore to GitHub actions to skip on doc only changes

### DIFF
--- a/.github/workflows/buildcache.yml
+++ b/.github/workflows/buildcache.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - '*'
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - 'appveyor.xml'
 
 jobs:
   ubuntu-code-style:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,9 +4,17 @@ on:
   push:
     branches:
       - '*'
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - 'appveyor.xml'
   pull_request:
     branches:
       - '*'
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - 'appveyor.xml'
 
 # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/software-installed-on-github-hosted-runners
 # GitHub Actions does not support Docker, PostgreSQL server on Windows, macOS :(

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,6 +22,12 @@ matrix:
     - platform: x86
       pg: master
 
+skip_commits:
+  files:
+    - 'docs/**'
+    - '**/*.md'
+    - '.github/**'
+
 init:
 - set pf=%ProgramFiles%&& set x64=-x64
 - set exe=postgresql-%pg%-windows%x64%.exe


### PR DESCRIPTION
Cleans up the GitHub Actions a bit to skip CI if the only changes are docs or markdown changes. Per the GitHub docs, `paths-ignore` will skip the action if all the changed files in the diff match those glob patterns.