### PR TITLE
fix: When calling Driver.connect multiple times, System.err is closed unexpectedly.

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/Driver.java
+++ b/pgjdbc/src/main/java/org/postgresql/Driver.java
@@ -36,6 +36,7 @@ import java.util.Enumeration;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.ConsoleHandler;
 import java.util.logging.Formatter;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -343,7 +344,7 @@ public class Driver implements java.sql.Driver {
       } else if ( DriverManager.getLogStream() != null) {
         handler = new StreamHandler(DriverManager.getLogStream(), formatter);
       } else {
-        handler = new StreamHandler(System.err, formatter);
+        handler = new ConsoleHandler();
       }
     } else {
       handler.setFormatter(formatter);

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DriverTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DriverTest.java
@@ -290,17 +290,17 @@ public class DriverTest {
     PrintStream buffer = new PrintStream(new ByteArrayOutputStream());
     System.setErr(buffer);
     try {
-      Connection con = DriverManager.getConnection(TestUtil.getURL());
+      Connection con = DriverManager.getConnection(TestUtil.getURL(), TestUtil.getUser(), TestUtil.getPassword());
       try {
         assertNotNull(con);
       } finally {
         con.close();
       }
-      con = DriverManager.getConnection(TestUtil.getURL());
+      con = DriverManager.getConnection(TestUtil.getURL(), TestUtil.getUser(), TestUtil.getPassword());
       try {
         assertNotNull(con);
-        System.err.println("");
-        assertFalse(System.err.checkError());
+        System.err.println();
+        assertFalse("The System.err should not be closed.", System.err.checkError());
       } finally {
         con.close();
       }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DriverTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DriverTest.java
@@ -21,6 +21,8 @@ import org.postgresql.util.URLCoder;
 
 import org.junit.Test;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.lang.reflect.Method;
 import java.sql.Connection;
@@ -272,6 +274,40 @@ public class DriverTest {
       DriverManager.setLogStream(null);
       setProperty("loggerLevel", loggerLevel);
       setProperty("loggerFile", loggerFile);
+    }
+  }
+
+  @Test
+  public void testSystemErrIsNotClosedWhenCreatedMultipleConnections() throws Exception {
+    TestUtil.initDriver();
+    PrintStream err = System.err;
+    String loggerLevel = System.getProperty("loggerLevel");
+    String loggerFile = System.getProperty("loggerFile");
+
+    System.clearProperty("loggerLevel");
+    System.clearProperty("loggerFile");
+    System.setProperty("loggerLevel", "INFO");
+    PrintStream buffer = new PrintStream(new ByteArrayOutputStream());
+    System.setErr(buffer);
+    try {
+      Connection con = DriverManager.getConnection(TestUtil.getURL());
+      try {
+        assertNotNull(con);
+      } finally {
+        con.close();
+      }
+      con = DriverManager.getConnection(TestUtil.getURL());
+      try {
+        assertNotNull(con);
+        System.err.println("");
+        assertFalse(System.err.checkError());
+      } finally {
+        con.close();
+      }
+    } finally {
+      System.setProperty("loggerLevel", loggerLevel);
+      System.setProperty("loggerFile", loggerFile);
+      System.setErr(err);
     }
   }
 


### PR DESCRIPTION
Fix https://github.com/pgjdbc/pgjdbc/issues/2130.

When closing `java.util.logging.Handler`, it also closes the internal `OutputStream`.
In some cases, the internal `OutputStream` is `System.out` or `System.err`, and in these cases, we should not close it, so stop closing the Handler.

This fix is a bit rough, but I don't see any other way to fix it.

I don't think it's possible to change the behavior of re-setting `PARENT_LOGGER` based on the props argument every time `getConnection`, because it's a breaking change.
I thought about giving special treatment to `System.err` and `System.out`, but that's not a fundamental solution because the same problem can occur in the stream returned by `DriverManager.getLogWriter()` (re-used when calling `getConnection` multiple times).

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
