### PR TITLE
style: fix Unicode junk

### DIFF
--- a/docs/documentation/head/resultset.md
+++ b/docs/documentation/head/resultset.md
@@ -22,6 +22,6 @@ The following must be considered when using the `ResultSet` interface:
 	connection property, see [Server Prepared Statements](server-prepare.md)). 
 	This may cause unexpected behavior when some methods are called. For example, 
 	results on method calls such as `getString()` on non-string data types, 	
-	while logically　equivalent, may be formatted differently after execution exceeds 
+	while logically equivalent, may be formatted differently after execution exceeds 
 	the set `prepareThreshold` when conversion to object method switches to one 
 	matching the return mode. 


### PR DESCRIPTION
Replace U+3000 character ("ideographic space") with a regular space in Markdown documentation file.

(This can lead to build failures for example when creating a PDF of the documentation.)

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
