### PR TITLE
fix: Added openj9 classname separator support. Fixes Issue 2133.

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/osgi/PGBundleActivator.java
+++ b/pgjdbc/src/main/java/org/postgresql/osgi/PGBundleActivator.java
@@ -31,9 +31,8 @@ public class PGBundleActivator implements BundleActivator {
       registration = context.registerService(DataSourceFactory.class.getName(),
           new PGDataSourceFactory(), properties);
     } catch (NoClassDefFoundError e) {
-      String msg = e.getMessage();
-      if (msg != null && (msg.contains("org/osgi/service/jdbc/DataSourceFactory")
-                       || msg.contains("org.osgi.service.jdbc.DataSourceFactory"))) {
+      String msg = e.getCause().getMessage();
+      if (msg != null && msg.contains("org.osgi.service.jdbc.DataSourceFactory")) {
         if (!Boolean.getBoolean("pgjdbc.osgi.debug")) {
           return;
         }

--- a/pgjdbc/src/main/java/org/postgresql/osgi/PGBundleActivator.java
+++ b/pgjdbc/src/main/java/org/postgresql/osgi/PGBundleActivator.java
@@ -31,7 +31,7 @@ public class PGBundleActivator implements BundleActivator {
       registration = context.registerService(DataSourceFactory.class.getName(),
           new PGDataSourceFactory(), properties);
     } catch (NoClassDefFoundError e) {
-      String msg = e.getCause().getMessage();
+      String msg = e.getCause() != null ? e.getCause().getMessage() : null;
       if (msg != null && msg.contains("org.osgi.service.jdbc.DataSourceFactory")) {
         if (!Boolean.getBoolean("pgjdbc.osgi.debug")) {
           return;

--- a/pgjdbc/src/main/java/org/postgresql/osgi/PGBundleActivator.java
+++ b/pgjdbc/src/main/java/org/postgresql/osgi/PGBundleActivator.java
@@ -32,7 +32,8 @@ public class PGBundleActivator implements BundleActivator {
           new PGDataSourceFactory(), properties);
     } catch (NoClassDefFoundError e) {
       String msg = e.getMessage();
-      if (msg != null && msg.contains("org/osgi/service/jdbc/DataSourceFactory")) {
+      if (msg != null && (msg.contains("org/osgi/service/jdbc/DataSourceFactory")
+                       || msg.contains("org.osgi.service.jdbc.DataSourceFactory"))) {
         if (!Boolean.getBoolean("pgjdbc.osgi.debug")) {
           return;
         }


### PR DESCRIPTION
This PR fixes the issue raised in Issue 2133:

In openj9 the separator used in the NoClassDefFoundError is a '.' and not a '/' that the code code checks for.
This PR updates the code to also check for the '.' separator.