### PR TITLE
fix: Fixing the order of javadoc tags

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/ssl/jdbc4/LibPQFactory.java
+++ b/pgjdbc/src/main/java/org/postgresql/ssl/jdbc4/LibPQFactory.java
@@ -38,10 +38,10 @@ public class LibPQFactory extends org.postgresql.ssl.LibPQFactory implements Hos
   /**
    * Verifies if given hostname matches pattern.
    *
-   * @deprecated use {@link PGjdbcHostnameVerifier}
    * @param hostname input hostname
    * @param pattern domain name pattern
    * @return true when domain matches pattern
+   * @deprecated use {@link PGjdbcHostnameVerifier}
    */
   @Deprecated
   public static boolean verifyHostName(String hostname, String pattern) {
@@ -68,11 +68,11 @@ public class LibPQFactory extends org.postgresql.ssl.LibPQFactory implements Hos
    * the certificate will not match subdomains. If the connection is made using an IP address
    * instead of a hostname, the IP address will be matched (without doing any DNS lookups).
    *
-   * @deprecated use PgjdbcHostnameVerifier
    * @param hostname Hostname or IP address of the server.
    * @param session The SSL session.
    * @return true if the certificate belongs to the server, false otherwise.
    * @see PGjdbcHostnameVerifier
+   * @deprecated use PgjdbcHostnameVerifier
    */
   @Deprecated
   public boolean verify(String hostname, SSLSession session) {


### PR DESCRIPTION
### All Submissions:

* [Yes] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [Yes] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes to Existing Features:

* [No] Does this break existing behaviour? If so please explain.

These changes are with respect to [Issue](https://github.com/checkstyle/checkstyle/issues/9941), [PR](https://github.com/checkstyle/checkstyle/pull/9942) of the checkstlye project. Only minor changes have been done as wrecker was failing on pgjdbc project.
