### PR TITLE
More test speeds ups with temp tables and disabling autovaccum

### DIFF
--- a/.github/workflows/omni.yml
+++ b/.github/workflows/omni.yml
@@ -32,6 +32,10 @@ on:
         description: SCRAM (true | false)
         required: false
         default: "*"
+      matrix_slow_tests:
+        description: Slow Tests (default | always | never)
+        required: false
+        default: default
   schedule:
     - cron: "0 6 * * *"
 
@@ -48,10 +52,20 @@ jobs:
       MATRIX_QUERY_MODE: '${{ github.event.inputs.matrix_query_mode }}'
       MATRIX_SCRAM: '${{ github.event.inputs.matrix_scram }}'
       MATRIX_SSL: '${{ github.event.inputs.matrix_ssl }}'
+      MATRIX_SLOW_TESTS: '${{ github.event.inputs.matrix_slow_tests }}'
     steps:
     - id: set-matrix
       run: |
         node -e "
+          const DEFAULT_SLOW_TESTS = (() => {
+            if (process.env.MATRIX_SLOW_TESTS === 'always') {
+              return true;
+            } else if (process.env.MATRIX_SLOW_TESTS === 'never') {
+              return false;
+            }
+            return undefined;
+          })();
+
           const JDK_OPTIONS = [
               { version: '8', lts: true, distribution: 'zulu' },
               { version: '11', lts: true, distribution: 'zulu' },
@@ -110,7 +124,7 @@ jobs:
               const os = 'ubuntu-latest';
               const pg_version = opts.pg_version ?? LATEST_PG_VERSION;
               const jdk = opts.jdk ?? LATEST_JDK;
-              const slow_tests = opts.slow_tests ?? false;
+              const slow_tests = DEFAULT_SLOW_TESTS ?? opts.slow_tests ?? false;
               const replication_tests = opts.replication_tests ?? false;
 
               const isAtLeast = (minVersion) => Number(pg_version) >= Number(minVersion);
@@ -223,7 +237,14 @@ jobs:
             throw new Error('Matrix list is empty. Check you matrix filters to ensure they match a valid combination.');
           }
 
-          console.log('::set-output name=matrix::' + JSON.stringify({ include: list }));
+          const toKey = (item) => JSON.stringify(Object.entries(item).sort())
+          const include = list.filter((item, i) => {
+            const key = toKey(item);
+            // Deduplicate by picking only the first entry matching this key
+            return i === list.findIndex((other) => key === toKey(other));
+          });
+
+          console.log('::set-output name=matrix::' + JSON.stringify({ include }));
         "
 
   test:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -18,8 +18,8 @@ services:
       - SCRAM=${SCRAM:-yes}
       - TZ=${TZ:-Etc/UTC}
       - FSYNC=${FSYNC:-no}
-      - SYNC_COMMIT="${SYNC_COMMIT:-no}"
-      - FULL_PAGE_WRITES="${FULL_PAGE_WRITES:-no}"
+      - SYNC_COMMIT=${SYNC_COMMIT:-no}
+      - FULL_PAGE_WRITES=${FULL_PAGE_WRITES:-no}
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=
       - POSTGRES_DB=postgres

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -20,6 +20,8 @@ services:
       - FSYNC=${FSYNC:-no}
       - SYNC_COMMIT=${SYNC_COMMIT:-no}
       - FULL_PAGE_WRITES=${FULL_PAGE_WRITES:-no}
+      - AUTO_VACCUUM=${AUTO_VACCUUM:-no}
+      - TRACK_COUNTS=${TRACK_COUNTS:-no}
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=
       - POSTGRES_DB=postgres

--- a/docker/scripts/entrypoint.sh
+++ b/docker/scripts/entrypoint.sh
@@ -26,6 +26,14 @@ main () {
         add_pg_opt "-c full_page_writes=off"
     fi
 
+    if is_option_disabled "${AUTO_VACCUUM}"; then
+        add_pg_opt "-c autovacuum=off"
+    fi
+
+    if is_option_disabled "${TRACK_COUNTS}"; then
+        add_pg_opt "-c track_counts=off"
+    fi
+
     # Customize pg_hba.conf
     local pg_hba="/home/certdir/pg_hba.conf"
     sed -i 's/127.0.0.1\/32/0.0.0.0\/0/g' "${pg_hba}"

--- a/pgjdbc/src/test/java/org/postgresql/test/TestUtil.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/TestUtil.java
@@ -313,6 +313,7 @@ public class TestUtil {
     PGProperty.GSS_ENC_MODE.set(properties,getGSSEncMode().value);
     properties.setProperty("user", getPrivilegedUser());
     properties.setProperty("password", getPrivilegedPassword());
+    properties.setProperty("options", "-c synchronous_commit=on");
     return DriverManager.getConnection(getURL(), properties);
 
   }
@@ -326,6 +327,7 @@ public class TestUtil {
     PGProperty.PREFER_QUERY_MODE.set(properties, "simple");
     properties.setProperty("username", TestUtil.getPrivilegedUser());
     properties.setProperty("password", TestUtil.getPrivilegedPassword());
+    properties.setProperty("options", "-c synchronous_commit=on");
     return TestUtil.openDB(properties);
   }
 

--- a/pgjdbc/src/test/java/org/postgresql/test/TestUtil.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/TestUtil.java
@@ -1097,14 +1097,8 @@ public class TestUtil {
   }
 
   public static void execute(String sql, Connection connection) throws SQLException {
-    Statement stmt = connection.createStatement();
-    try {
+    try (Statement stmt = connection.createStatement()) {
       stmt.execute(sql);
-    } finally {
-      try {
-        stmt.close();
-      } catch (SQLException e) {
-      }
     }
   }
 }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseEncodingTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseEncodingTest.java
@@ -13,6 +13,7 @@ import org.postgresql.core.Encoding;
 import org.postgresql.test.TestUtil;
 
 import org.junit.After;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -69,21 +70,8 @@ public class DatabaseEncodingTest {
 
   @Test
   public void testEncoding() throws Exception {
-    // Check that we have a UTF8 server encoding, or we must skip this test.
-    Statement stmt = con.createStatement();
-    ResultSet rs = stmt.executeQuery("SELECT getdatabaseencoding()");
-    assertTrue(rs.next());
-
-    String dbEncoding = rs.getString(1);
-    if (!dbEncoding.equals("UTF8")) {
-      System.err.println(
-          "DatabaseEncodingTest: Skipping UTF8 database tests as test database encoding is "
-              + dbEncoding);
-      rs.close();
-      return; // not a UTF8 database.
-    }
-
-    rs.close();
+    String databaseEncoding = TestUtil.queryForString(con, "SELECT getdatabaseencoding()");
+    Assume.assumeTrue("Database encoding must be UTF8", databaseEncoding.equals("UTF8"));
 
     boolean testHighUnicode = true;
 
@@ -142,8 +130,9 @@ public class DatabaseEncodingTest {
     con.commit();
 
     // Check data.
+    Statement stmt = con.createStatement();
     stmt.setFetchSize(1);
-    rs = stmt.executeQuery(
+    ResultSet rs = stmt.executeQuery(
         "SELECT unicode_ordinal, unicode_string FROM testdbencoding ORDER BY unicode_ordinal");
     for (int i = 1; i < 0xd800; i += STEP) {
       assertTrue(rs.next());

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseEncodingTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseEncodingTest.java
@@ -40,7 +40,7 @@ public class DatabaseEncodingTest {
   @Before
   public void setUp() throws Exception {
     con = TestUtil.openDB();
-    TestUtil.createTable(con, "testdbencoding",
+    TestUtil.createTempTable(con, "testdbencoding",
         "unicode_ordinal integer primary key not null, unicode_string varchar(" + STEP + ")");
     // disabling auto commit makes the test run faster
     // by not committing each insert individually.
@@ -51,7 +51,6 @@ public class DatabaseEncodingTest {
   @After
   public void tearDown() throws Exception {
     con.setAutoCommit(true);
-    TestUtil.dropTable(con, "testdbencoding");
     TestUtil.closeDB(con);
   }
 

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseEncodingTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseEncodingTest.java
@@ -10,12 +10,14 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import org.postgresql.core.Encoding;
+import org.postgresql.test.SlowTests;
 import org.postgresql.test.TestUtil;
 
 import org.junit.After;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import java.io.IOException;
 import java.sql.Connection;
@@ -68,6 +70,7 @@ public class DatabaseEncodingTest {
   }
 
   @Test
+  @Category(SlowTests.class)
   public void testEncoding() throws Exception {
     String databaseEncoding = TestUtil.queryForString(con, "SELECT getdatabaseencoding()");
     Assume.assumeTrue("Database encoding must be UTF8", databaseEncoding.equals("UTF8"));

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc4/CharacterStreamTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc4/CharacterStreamTest.java
@@ -17,7 +17,6 @@ import java.io.Reader;
 import java.io.StringReader;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
-import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 
 public class CharacterStreamTest extends BaseTest4 {
@@ -25,12 +24,10 @@ public class CharacterStreamTest extends BaseTest4 {
   private static final String TEST_TABLE_NAME = "charstream";
   private static final String TEST_COLUMN_NAME = "cs";
 
-  private static final String _delete;
   private static final String _insert;
   private static final String _select;
 
   static {
-    _delete = String.format("DELETE FROM %s", TEST_TABLE_NAME);
     _insert = String.format("INSERT INTO %s (%s) VALUES (?)", TEST_TABLE_NAME, TEST_COLUMN_NAME);
     _select = String.format("SELECT %s FROM %s", TEST_COLUMN_NAME, TEST_TABLE_NAME);
   }
@@ -38,13 +35,7 @@ public class CharacterStreamTest extends BaseTest4 {
   @Override
   public void setUp() throws Exception {
     super.setUp();
-    TestUtil.createTable(con, TEST_TABLE_NAME, "cs text");
-  }
-
-  @Override
-  public void tearDown() throws SQLException {
-    TestUtil.dropTable(con, TEST_TABLE_NAME);
-    super.tearDown();
+    TestUtil.createTempTable(con, TEST_TABLE_NAME, "cs text");
   }
 
   private void insertStreamKnownIntLength(String data) throws Exception {

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc4/CharacterStreamTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc4/CharacterStreamTest.java
@@ -16,7 +16,6 @@ import org.junit.experimental.categories.Category;
 import java.io.Reader;
 import java.io.StringReader;
 import java.sql.PreparedStatement;
-import java.sql.ResultSet;
 import java.sql.SQLFeatureNotSupportedException;
 
 public class CharacterStreamTest extends BaseTest4 {
@@ -74,22 +73,8 @@ public class CharacterStreamTest extends BaseTest4 {
   }
 
   private void validateContent(String data) throws Exception {
-    PreparedStatement selectPS = con.prepareStatement(_select);
-    try {
-      ResultSet rs = selectPS.executeQuery();
-      try {
-        if (rs.next()) {
-          String actualData = rs.getString(1);
-          Assert.assertEquals("Sent and received data are not the same", data, actualData);
-        } else {
-          Assert.fail("query returned zero rows");
-        }
-      } finally {
-        TestUtil.closeQuietly(rs);
-      }
-    } finally {
-      TestUtil.closeQuietly(selectPS);
-    }
+    String actualData = TestUtil.queryForString(con, _select);
+    Assert.assertEquals("Sent and received data are not the same", data, actualData);
   }
 
   private String getTestData(int size) {

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc4/CharacterStreamTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc4/CharacterStreamTest.java
@@ -228,6 +228,7 @@ public class CharacterStreamTest extends BaseTest4 {
   }
 
   @Test(expected = SQLFeatureNotSupportedException.class)
+  @Category(SlowTests.class)
   public void testKnownLongLength200Kb() throws Exception {
     String data = getTestData(200 * 1024);
     insertStreamKnownLongLength(data);
@@ -235,6 +236,7 @@ public class CharacterStreamTest extends BaseTest4 {
   }
 
   @Test
+  @Category(SlowTests.class)
   public void testUnknownLength200Kb() throws Exception {
     String data = getTestData(200 * 1024);
     insertStreamUnknownLength(data);


### PR DESCRIPTION
First commit fixes the quoting in some default docker-compose environment values so that they're actually disabled. Second disables some more server settings by default that we don't need in the test environment: autovaccum and track_counts

The rest of the commits clean up some more tests to use temp tables. I took at a peek at these tests in particular because I noticed they were randomly hanging during CI runs. 

For example the DatabaseEncodingTest was randomly taking *30+ minutes* to run: https://github.com/pgjdbc/pgjdbc/runs/2589252666?check_suite_focus=true#step:10:303

```
1852.4sec, org.postgresql.test.jdbc2.DatabaseEncodingTest > testEncoding
```

It does a crazy amount of inserts so seemed like low hanging fruit to switch it to an unlogged temp table. Ditto for CharacterStreamTest so I made the same change there as well.