### PR TITLE
Gradle and CI improvements

### DIFF
--- a/.github/workflows/buildcache.yml
+++ b/.github/workflows/buildcache.yml
@@ -10,7 +10,26 @@ on:
       - 'appveyor.xml'
 
 jobs:
-  ubuntu-code-style:
+  check_secrets:
+    name: Check if required secrets are available
+    runs-on: ubuntu-latest
+    env:
+      S3_BUILD_CACHE_ACCESS_KEY_ID: ${{ secrets.S3_BUILD_CACHE_ACCESS_KEY_ID }}
+      S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.S3_BUILD_CACHE_SECRET_KEY }}
+    outputs:
+      secrets_available: ${{ steps.set-matrix.outputs.secrets_available }}
+    steps:
+      - id: set-matrix
+        run: |
+          if [[ -n "${S3_BUILD_CACHE_ACCESS_KEY_ID:-}" ]] && [[ -n "${S3_BUILD_CACHE_SECRET_KEY:-}" ]]; then
+            echo "::set-output name=secret_available::true"
+          else
+            echo "::set-output name=secret_available::false"
+          fi
+
+  seed-build-cache:
+    needs: check_secrets
+    if: ${{ needs.check_secrets.outputs.secrets_available == 'true' }}
     strategy:
       matrix:
         os: [ubuntu, macos, windows]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
           })"
 
   code-style:
-    name: 'Code style - Ubuntu / JDK 8'
+    name: 'Code style'
     runs-on: ubuntu-latest
     env:
       ACTIONS_STEP_DEBUG: true
@@ -82,7 +82,7 @@ jobs:
         arguments: autostyleCheck checkstyleAll jandex
 
   build-test:
-    name: 'Build and Test - Ubuntu, PG latest (JDK ${{ matrix.jdk }}) running on ${{ matrix.os }}'
+    name: 'Test - JDK ${{ matrix.jdk }} on ${{ matrix.os }}'
     runs-on: ${{ matrix.os }}
     needs: matrix_prep
     strategy:
@@ -155,7 +155,7 @@ jobs:
           port=${{ job.services.postgres.ports['5432'] }}
 
   linux-checkerframework:
-    name: 'CheckerFramework (JDK 11)'
+    name: 'CheckerFramework'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -219,7 +219,7 @@ jobs:
           mvn --batch-mode --fail-at-end --show-version verify
 
   gss-encryption:
-    name: 'GSS Build and Test - Ubuntu (JDK ${{matrix.jdk}}) running on ${{matrix.os}}'
+    name: 'GSS Test - JDK ${{ matrix.jdk }} on ${{ matrix.os }}'
     runs-on: ${{ matrix.os }}
     needs: matrix_prep
     strategy:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -91,24 +91,15 @@ jobs:
         working-directory: docker
         run: docker-compose up -d && docker-compose logs
       - name: 'Set up JDK 11'
-        if: ${{ steps.get_arch_name.outputs.arch_name != 'aarch64' }}
         uses: actions/setup-java@v1
         with:
           java-version: 11
-      - name: 'Setup JDK 11 on ARM64'
-        if: ${{ steps.get_arch_name.outputs.arch_name == 'aarch64' }}
-        uses: AdoptOpenJDK/install-jdk@v1
-        with:
-          impl: hotspot # or openj9
-          version: '11'
-          architecture: aarch64
       - uses: burrunan/gradle-cache-action@v1
         name: Prepare source distribution
         env:
           S3_BUILD_CACHE_ACCESS_KEY_ID: ${{ secrets.S3_BUILD_CACHE_ACCESS_KEY_ID }}
           S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.S3_BUILD_CACHE_SECRET_KEY }}
         with:
-          read-only: ${{ matrix.os == 'self-hosted' }}
           job-id: source-release-jdk11
           arguments: --scan --no-parallel --no-daemon sourceDistribution -Ppgjdbc.version=1.0 -Prelease
       - name: Verify source distribution

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,6 @@ jobs:
     env:
       ACTIONS_STEP_DEBUG: true
       ACTIONS_RUNNER_DEBUG: true
-      ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     steps:
     - uses: actions/checkout@v2
       with:
@@ -92,7 +91,6 @@ jobs:
     env:
       ACTIONS_STEP_DEBUG: true
       ACTIONS_RUNNER_DEBUG: true
-      ACTIONS_ALLOW_UNSECURE_COMMANDS: true
 # Service must be started after checkout, because we want to use git-stored files for initialization
 # of the Docker container. So we start it with and explicit docker ... command
 #    services:
@@ -230,7 +228,6 @@ jobs:
     env:
       ACTIONS_STEP_DEBUG: true
       ACTIONS_RUNNER_DEBUG: true
-      ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     steps:
     - uses: actions/checkout@v2
     - name: 'Get test node ARCH'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,27 +20,6 @@ on:
 # GitHub Actions does not support Docker, PostgreSQL server on Windows, macOS :(
 
 jobs:
-  matrix_prep:
-    name: Matrix Preparation
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
-    steps:
-    - id: set-matrix
-      run: |
-        node -p "
-          '::set-output name=matrix::' + JSON.stringify({
-            jdk: [
-              8,
-              11,
-            ],
-            os: [
-              'ubuntu-latest',
-              // Disable self-hosted on forks:
-              ...(process.env.GITHUB_REPOSITORY === 'pgjdbc/pgjdbc' ? ['self-hosted'] : [])
-            ],
-          })"
-
   code-style:
     name: 'Code style'
     runs-on: ubuntu-latest
@@ -51,17 +30,14 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 50
-
     - name: 'Get test node ARCH'
       run: echo "::set-output name=arch_name::$(uname -i)"
       id: get_arch_name
-
     - name: 'Set up JDK 8'
       if: ${{ steps.get_arch_name.outputs.arch_name != 'aarch64' }}
       uses: actions/setup-java@v1
       with:
         java-version: 8
-
     - name: 'Setup JDK 8 on ARM64'
       if: ${{ steps.get_arch_name.outputs.arch_name == 'aarch64' }}
       uses: AdoptOpenJDK/install-jdk@v1
@@ -69,7 +45,6 @@ jobs:
         impl: hotspot # or openj9
         version: '8'
         architecture: aarch64
-
     - uses: burrunan/gradle-cache-action@v1
       name: Verify code style
       env:
@@ -80,79 +55,6 @@ jobs:
         read-only: ${{ matrix.os == 'self-hosted' }}
         job-id: jdk8
         arguments: autostyleCheck checkstyleAll jandex
-
-  build-test:
-    name: 'Test - JDK ${{ matrix.jdk }} on ${{ matrix.os }}'
-    runs-on: ${{ matrix.os }}
-    needs: matrix_prep
-    strategy:
-      fail-fast: false
-      matrix: ${{fromJson(needs.matrix_prep.outputs.matrix)}}
-    env:
-      ACTIONS_STEP_DEBUG: true
-      ACTIONS_RUNNER_DEBUG: true
-# Service must be started after checkout, because we want to use git-stored files for initialization
-# of the Docker container. So we start it with and explicit docker ... command
-#    services:
-#      postgres:
-#        image: postgres:latest
-#        env:
-#          POSTGRES_USER: postgres
-#          # Empty password
-#          # POSTGRES_PASSWORD: postgres
-#          POSTGRES_DB: postgres
-#        ports:
-#          - 5432:5432
-#        volumes:
-#          - /home/runner/work/pgjdbc/pgjdbc/.travis:/scripts/.travis
-#        # needed because the postgres container does not provide a healthcheck
-#        options: >-
-#          --name db
-#          --health-cmd pg_isready
-#          --health-interval 10s
-#          --health-timeout 5s
-#          --health-retries 5
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 50
-    - name: Start PostgreSQL
-      working-directory: docker
-      run: docker-compose up -d && docker-compose logs
-
-    - name: 'Get test node ARCH'
-      run: echo "::set-output name=arch_name::$(uname -i)"
-      id: get_arch_name
-
-    - name: 'Set up JDK ${{ matrix.jdk }}'
-      if: ${{ steps.get_arch_name.outputs.arch_name != 'aarch64' }}
-      uses: actions/setup-java@v1
-      with:
-        java-version: ${{ matrix.jdk }}
-        architecture: x64
-
-    - name: 'Setup JDK ${{ matrix.jdk }} on ARM64'
-      if: ${{ steps.get_arch_name.outputs.arch_name == 'aarch64' }}
-      uses: AdoptOpenJDK/install-jdk@v1
-      with:
-        impl: hotspot # or openj9
-        version: ${{ matrix.jdk }}
-        architecture: aarch64
-
-    - name: Prepare ssltest.local.properties
-      run: echo enable_ssl_tests=true > ssltest.local.properties
-    - uses: burrunan/gradle-cache-action@v1
-      name: Test
-      env:
-        S3_BUILD_CACHE_ACCESS_KEY_ID: ${{ secrets.S3_BUILD_CACHE_ACCESS_KEY_ID }}
-        S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.S3_BUILD_CACHE_SECRET_KEY }}
-      with:
-        read-only: ${{ matrix.os == 'self-hosted' }}
-        job-id: jdk${{ matrix.jdk }}
-        arguments: --scan --no-parallel --no-daemon jandex test
-        properties: |
-          skipReplicationTests=
-          port=${{ job.services.postgres.ports['5432'] }}
 
   linux-checkerframework:
     name: 'CheckerFramework'
@@ -193,7 +95,6 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 11
-
       - name: 'Setup JDK 11 on ARM64'
         if: ${{ steps.get_arch_name.outputs.arch_name == 'aarch64' }}
         uses: AdoptOpenJDK/install-jdk@v1
@@ -201,7 +102,6 @@ jobs:
           impl: hotspot # or openj9
           version: '11'
           architecture: aarch64
-
       - uses: burrunan/gradle-cache-action@v1
         name: Prepare source distribution
         env:
@@ -218,6 +118,75 @@ jobs:
           cd postgresql-1.0-jdbc-src
           mvn --batch-mode --fail-at-end --show-version verify
 
+  matrix_prep:
+    name: Matrix Preparation
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+    - id: set-matrix
+      run: |
+        node -p "
+          '::set-output name=matrix::' + JSON.stringify({
+            jdk: [
+              8,
+              11,
+            ],
+            os: [
+              'ubuntu-latest',
+              // Disable self-hosted on forks:
+              ...(process.env.GITHUB_REPOSITORY === 'pgjdbc/pgjdbc' ? ['self-hosted'] : [])
+            ],
+          })"
+
+  build-test:
+    name: 'Test - JDK ${{ matrix.jdk }} on ${{ matrix.os }}'
+    runs-on: ${{ matrix.os }}
+    needs: matrix_prep
+    strategy:
+      fail-fast: false
+      matrix: ${{fromJson(needs.matrix_prep.outputs.matrix)}}
+    env:
+      ACTIONS_STEP_DEBUG: true
+      ACTIONS_RUNNER_DEBUG: true
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 50
+    - name: Start PostgreSQL
+      working-directory: docker
+      run: docker-compose up -d && docker-compose logs
+    - name: 'Get test node ARCH'
+      run: echo "::set-output name=arch_name::$(uname -i)"
+      id: get_arch_name
+    - name: 'Set up JDK ${{ matrix.jdk }}'
+      if: ${{ steps.get_arch_name.outputs.arch_name != 'aarch64' }}
+      uses: actions/setup-java@v1
+      with:
+        java-version: ${{ matrix.jdk }}
+        architecture: x64
+    - name: 'Setup JDK ${{ matrix.jdk }} on ARM64'
+      if: ${{ steps.get_arch_name.outputs.arch_name == 'aarch64' }}
+      uses: AdoptOpenJDK/install-jdk@v1
+      with:
+        impl: hotspot # or openj9
+        version: ${{ matrix.jdk }}
+        architecture: aarch64
+    - name: Prepare ssltest.local.properties
+      run: echo enable_ssl_tests=true > ssltest.local.properties
+    - uses: burrunan/gradle-cache-action@v1
+      name: Test
+      env:
+        S3_BUILD_CACHE_ACCESS_KEY_ID: ${{ secrets.S3_BUILD_CACHE_ACCESS_KEY_ID }}
+        S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.S3_BUILD_CACHE_SECRET_KEY }}
+      with:
+        read-only: ${{ matrix.os == 'self-hosted' }}
+        job-id: jdk${{ matrix.jdk }}
+        arguments: --scan --no-parallel --no-daemon jandex test
+        properties: |
+          skipReplicationTests=
+          port=${{ job.services.postgres.ports['5432'] }}
+
   gss-encryption:
     name: 'GSS Test - JDK ${{ matrix.jdk }} on ${{ matrix.os }}'
     runs-on: ${{ matrix.os }}
@@ -233,7 +202,6 @@ jobs:
     - name: 'Get test node ARCH'
       run: echo "::set-output name=arch_name::$(uname -i)"
       id: get_arch_name
-
     - name: 'Set up JDK 8'
       if: ${{ steps.get_arch_name.outputs.arch_name != 'aarch64' }}
       uses: actions/setup-java@v1
@@ -255,7 +223,6 @@ jobs:
       run: |
         sudo -- sh -c "echo 127.0.0.1 localhost auth-test-localhost.postgresql.example.com > /etc/hosts"
         cat /etc/hosts
-
     - uses: burrunan/gradle-cache-action@v1
       name: Build pgjdbc
       with:

--- a/.github/workflows/omni.yml
+++ b/.github/workflows/omni.yml
@@ -272,7 +272,6 @@ jobs:
     env:
       ACTIONS_STEP_DEBUG: true
       ACTIONS_RUNNER_DEBUG: true
-      ACTIONS_ALLOW_UNSECURE_COMMANDS: true
       SSL: ${{ matrix.ssl }}
       SCRAM: ${{ matrix.scram }}
       TZ: ${{ matrix.server_tz }}

--- a/.github/workflows/omni.yml
+++ b/.github/workflows/omni.yml
@@ -54,9 +54,9 @@ jobs:
         const DEFAULT_TEST_GROUP = process.env.MATRIX_DEFAULT_TEST_GROUP || 'fast';
 
         const JDK_OPTIONS = [
-            { version: '8', lts: true, distribution: 'zulu' },
-            { version: '11', lts: true, distribution: 'zulu' },
-            { version: '15', lts: false, distribution: 'zulu' },
+            { group: 'Zulu', version: '8', lts: true, distribution: 'zulu' },
+            { group: 'Zulu', version: '11', lts: true, distribution: 'zulu' },
+            { group: 'Zulu', version: '15', lts: false, distribution: 'zulu' },
         ];
 
         const OTHER_JDK_OPTIONS = [
@@ -157,6 +157,7 @@ jobs:
                   `${jdk.group} ${jdk.version} x PG ${pg_version}`
                   ].filter(x => x).join(' - '),
                 os,
+                jdk_group: jdk.group,
                 jdk_version: jdk.version,
                 jdk_distribution: jdk.distribution,
                 jdk_url: jdk.url,
@@ -344,7 +345,8 @@ jobs:
         S3_BUILD_CACHE_ACCESS_KEY_ID: ${{ secrets.S3_BUILD_CACHE_ACCESS_KEY_ID }}
         S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.S3_BUILD_CACHE_SECRET_KEY }}
       with:
-        job-id: jdk${{ matrix.jdk_version }}_pg${{ matrix.pg_version}}
+        # Separate cache for each JDK distribution and version
+        job-id: jdk${{ matrix.jdk_version}}_${{ matrix.jdk_group }}
         arguments: --no-parallel --no-daemon --scan jandex test jacocoReport
         properties: |
           includeTestTags=${{ matrix.junit_include_tags }}

--- a/.github/workflows/omni.yml
+++ b/.github/workflows/omni.yml
@@ -3,10 +3,6 @@ name: Omni CI
 on:
   workflow_dispatch:
     inputs:
-      gradle_args:
-        description: Gradle arguments
-        required: false
-        default: "jandex test jacocoReport"
       # Filters to limit generated matrix. Empty or "*" values are ignored.
       matrix_jdk_distribution:
         description: JDK Distribution (adopt, zulu, ...)
@@ -32,10 +28,10 @@ on:
         description: SCRAM (true | false)
         required: false
         default: "*"
-      matrix_slow_tests:
-        description: Slow Tests (default | always | never)
+      matrix_default_test_group:
+        description: Default test group (fast | slow | all)
         required: false
-        default: default
+        default: fast
   schedule:
     - cron: "0 6 * * *"
 
@@ -52,203 +48,220 @@ jobs:
       MATRIX_QUERY_MODE: '${{ github.event.inputs.matrix_query_mode }}'
       MATRIX_SCRAM: '${{ github.event.inputs.matrix_scram }}'
       MATRIX_SSL: '${{ github.event.inputs.matrix_ssl }}'
-      MATRIX_SLOW_TESTS: '${{ github.event.inputs.matrix_slow_tests }}'
+      MATRIX_DEFAULT_TEST_GROUP: '${{ github.event.inputs.matrix_default_test_group }}'
+      # Script as an environment variable so we don't have to worry shell substitions
+      MATRIX_GENERATION_NODE_JS_SCRIPT: |
+        const DEFAULT_TEST_GROUP = process.env.MATRIX_DEFAULT_TEST_GROUP || 'fast';
+
+        const JDK_OPTIONS = [
+            { version: '8', lts: true, distribution: 'zulu' },
+            { version: '11', lts: true, distribution: 'zulu' },
+            { version: '15', lts: false, distribution: 'zulu' },
+        ];
+
+        const OTHER_JDK_OPTIONS = [
+          // Adopt
+          { group: 'Adopt Hotspot', version: '8', lts: true, distribution: 'adopt-hotspot' },
+          { group: 'Adopt Hotspot', version: '11', lts: true, distribution: 'adopt-hotspot' },
+
+          // Adopt OpenJ9
+          // TODO: Replace these hard coded versions with something that dynamically picks the most recent
+          { group: 'Adopt OpenJ9', version: '8', lts: true, distribution: 'adopt-openj9'},
+          { group: 'Adopt OpenJ9', version: '11', lts: true, distribution: 'adopt-openj9'},
+
+          // Amazon Corretto
+          { group: 'Corretto', version: '8', lts: true, distribution: 'jdkfile', url: 'https://corretto.aws/downloads/latest/amazon-corretto-8-x64-linux-jdk.tar.gz'},
+          { group: 'Corretto', version: '11', lts: true, distribution: 'jdkfile', url: 'https://corretto.aws/downloads/latest/amazon-corretto-11-x64-linux-jdk.tar.gz'},
+        ];
+
+        const PG_VERSIONS = [
+            '8.4',
+            '9.0',
+            '9.1',
+            '9.2',
+            '9.3',
+            '9.4',
+            '9.5',
+            '9.6',
+            '10',
+            '11',
+            '12',
+            '13',
+            // TODO: Determine the latest and greatest server version automatically so we don't need to periodically update this
+        ];
+
+
+        const LTS_JDK_OPTIONS = JDK_OPTIONS.filter(jdk => jdk.lts);
+        const UNSTABLE_JDK_OPTIONS = JDK_OPTIONS.filter(jdk => !jdk.lts);
+        const LATEST_JDK = LTS_JDK_OPTIONS.slice(-1)[0];
+        const LATEST_PG_VERSION = PG_VERSIONS.slice(-1)[0];
+
+        const list = [];
+
+        const matchesMatrixFilter = (name, value) => {
+            const env_value = process.env['MATRIX_' + name];
+            if (!env_value || env_value === '*') {
+              return true;
+            }
+            // TODO: Consider expanding this to do globbing
+            return env_value === ('' + value);
+        };
+
+        const addItem = (opts) => {
+            const name = opts.name ?? '';
+            const os = 'ubuntu-latest';
+            const pg_version = opts.pg_version ?? LATEST_PG_VERSION;
+            const jdk = opts.jdk ?? LATEST_JDK;
+            const experimental = opts.experimental ?? false;
+            const test_group = opts.test_group ?? DEFAULT_TEST_GROUP;
+
+            const isAtLeast = (minVersion) => Number(pg_version) >= Number(minVersion);
+            const scramSupported = isAtLeast('10');
+            const sslSupported = isAtLeast('9.3');
+
+            const query_mode = opts.query_mode;
+            const ssl = opts.ssl ?? sslSupported;
+            const scram = opts.scram ?? scramSupported;
+
+            if (!matchesMatrixFilter('JDK_DISTRIBUTION', jdk.distribution) ||
+                !matchesMatrixFilter('JDK_VERSION', jdk.version) ||
+                !matchesMatrixFilter('PG_VERSION', pg_version) ||
+                !matchesMatrixFilter('QUERY_MODE', query_mode ?? '') ||
+                !matchesMatrixFilter('SCRAM', scram) ||
+                !matchesMatrixFilter('SSL', ssl)) {
+              return;
+            }
+
+            const junit_include_tags = (() => {
+              switch (test_group) {
+                case 'replication':
+                  // Only replication tests
+                  return 'org.postgresql.test.Replication';
+                case 'fast':
+                  // Fast group does not run slow or replication tests
+                  return '!org.postgresql.test.SlowTests & !org.postgresql.test.Replication';
+                case 'slow':
+                  // Everything but replication tests (which includes all the really slow ones)
+                  return '!org.postgresql.test.Replication';
+                case 'all':
+                  // Everything
+                  return ''
+              }
+              throw new Error('Invalid test group: ' + test_group);
+            })();
+
+            list.push({
+                name: [
+                  experimental ? 'Experimental' : '',
+                  name,
+                  `${jdk.group} ${jdk.version} x PG ${pg_version}`
+                  ].filter(x => x).join(' - '),
+                os,
+                jdk_version: jdk.version,
+                jdk_distribution: jdk.distribution,
+                jdk_url: jdk.url,
+                pg_version,
+                ssl,
+                scram,
+                server_tz: opts.server_tz ?? 'Etc/UTC',
+                experimental,
+                junit_include_tags,
+                query_mode,
+            });
+        };
+
+        // Latest JDK x each stable PG version
+        for (const pg_version of PG_VERSIONS) {
+            addItem({
+                pg_version,
+            });
+        }
+
+        // Latest PG version x each remaining JDK
+        for (const jdk of JDK_OPTIONS) {
+            if (jdk == LATEST_JDK) {
+                continue; // Skip duplicate
+            }
+            addItem({
+                jdk,
+                pg_version: LATEST_PG_VERSION,
+                experimental: !jdk.lts,
+            });
+        }
+
+        // No SSL / No SCRAM (only on latest PG / JDK)
+        addItem({
+            name: `No SSL / No SCRAM`,
+            ssl: false,
+            scram: false,
+        });
+
+        // Custom server timezones (only on latest PG / JDK)
+        addItem({
+            name: `Server TZ - America/New_York`,
+            server_tz: 'America/New_York'
+        });
+        addItem({
+            name: `Server TZ - Pacific/Chatham`,
+            server_tz: 'Pacific/Chatham'
+        });
+
+        // Custom query modes (only on latest PG / JDK)
+        addItem({
+            name: `Query Mode - simple`,
+            query_mode: 'simple',
+        });
+        addItem({
+            name: `Query Mode - extendedForPrepared`,
+            query_mode: 'extendedForPrepared',
+        });
+        addItem({
+            name: `Query Mode - extendedCacheEverything`,
+            query_mode: 'extendedCacheEverything',
+        });
+
+        // Slow tests (only on latest PG / JDK)
+        addItem({
+            name: `Slow Tests`,
+            test_group: 'slow',
+        });
+        // Replication tests (only on latest PG / JDK)
+        addItem({
+            name: `Replication Tests`,
+            test_group: 'replication',
+        });
+
+        // TODO: Add latest PG built from source marked as experimental
+
+        for(const jdk of OTHER_JDK_OPTIONS) {
+            addItem({
+                jdk,
+                pg_version: LATEST_PG_VERSION,
+                experimental: !jdk.lts,
+            });
+        }
+
+        if (list.length === 0) {
+          throw new Error('Matrix list is empty. Check you matrix filters to ensure they match a valid combination.');
+        }
+
+        const toKey = (item) => JSON.stringify(Object.entries(item).filter(([field]) => field != 'name').sort())
+        const include = list.filter((item, i) => {
+          const key = toKey(item);
+          // Deduplicate by picking only the first entry matching this key
+          return i === list.findIndex((other) => key === toKey(other));
+        });
+        // Sort so that all the experimental jobs appear at the end of the list
+        include.sort((a, b) => (a.experimental ? 1 : 0) - (b.experimental ? 1 : 0))
+
+        console.log('::set-output name=matrix::' + JSON.stringify({ include }));
     steps:
     - id: set-matrix
       run: |
-        node -e "
-          const DEFAULT_SLOW_TESTS = (() => {
-            if (process.env.MATRIX_SLOW_TESTS === 'always') {
-              return true;
-            } else if (process.env.MATRIX_SLOW_TESTS === 'never') {
-              return false;
-            }
-            return undefined;
-          })();
-
-          const JDK_OPTIONS = [
-              { version: '8', lts: true, distribution: 'zulu' },
-              { version: '11', lts: true, distribution: 'zulu' },
-              { version: '15', lts: false, distribution: 'zulu' },
-          ];
-
-          const OTHER_JDK_OPTIONS = [
-            // Adopt
-            { version: '8', lts: true, distribution: 'adopt' },
-            { version: '11', lts: true, distribution: 'adopt' },
-
-            // Adopt OpenJ9
-            // TODO: Replace these hard coded versions with something that dynamically picks the most recent
-            { version: '8', lts: true, distribution: 'jdkfile', url: 'https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u292-b10_openj9-0.26.0/OpenJDK8U-jdk_x64_linux_openj9_8u292b10_openj9-0.26.0.tar.gz'},
-            { version: '11', lts: true, distribution: 'jdkfile', url: 'https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.11%2B9_openj9-0.26.0/OpenJDK11U-jdk_x64_linux_openj9_11.0.11_9_openj9-0.26.0.tar.gz'},
-
-            // Amazon Corretto
-            { version: '8', lts: true, distribution: 'jdkfile', url: 'https://corretto.aws/downloads/latest/amazon-corretto-8-x64-linux-jdk.tar.gz'},
-            { version: '11', lts: true, distribution: 'jdkfile', url: 'https://corretto.aws/downloads/latest/amazon-corretto-11-x64-linux-jdk.tar.gz'},
-          ];
-
-          const PG_VERSIONS = [
-              '8.4',
-              '9.0',
-              '9.1',
-              '9.2',
-              '9.3',
-              '9.4',
-              '9.5',
-              '9.6',
-              '10',
-              '11',
-              '12',
-              '13',
-              // TODO: Determine the latest and greatest server version automatically so we don't need to periodically update this
-          ];
-
-
-          const LTS_JDK_OPTIONS = JDK_OPTIONS.filter(jdk => jdk.lts);
-          const UNSTABLE_JDK_OPTIONS = JDK_OPTIONS.filter(jdk => !jdk.lts);
-          const LATEST_JDK = LTS_JDK_OPTIONS.slice(-1)[0];
-          const LATEST_PG_VERSION = PG_VERSIONS.slice(-1)[0];
-
-          const list = [];
-
-          const matchesMatrixFilter = (name, value) => {
-              const env_value = process.env['MATRIX_' + name];
-              if (!env_value || env_value === '*') {
-                return true;
-              }
-              // TODO: Consider expanding this to do globbing
-              return env_value === ('' + value);
-          };
-
-          const addItem = (opts) => {
-              const os = 'ubuntu-latest';
-              const pg_version = opts.pg_version ?? LATEST_PG_VERSION;
-              const jdk = opts.jdk ?? LATEST_JDK;
-              const slow_tests = DEFAULT_SLOW_TESTS ?? opts.slow_tests ?? false;
-              const replication_tests = opts.replication_tests ?? false;
-
-              const isAtLeast = (minVersion) => Number(pg_version) >= Number(minVersion);
-              const scramSupported = isAtLeast('10');
-              const sslSupported = isAtLeast('9.3');
-
-              const query_mode = opts.query_mode;
-              const ssl = opts.ssl ?? sslSupported;
-              const scram = opts.scram ?? scramSupported;
-
-              if (!matchesMatrixFilter('JDK_DISTRIBUTION', jdk.distribution) ||
-                  !matchesMatrixFilter('JDK_VERSION', jdk.version) ||
-                  !matchesMatrixFilter('PG_VERSION', pg_version) ||
-                  !matchesMatrixFilter('QUERY_MODE', query_mode ?? '') ||
-                  !matchesMatrixFilter('SCRAM', scram) ||
-                  !matchesMatrixFilter('SSL', ssl)) {
-                return;
-              }
-
-              const tags = [];
-              if (!slow_tests) {
-                  tags.push('!org.postgresql.test.SlowTests');
-              }
-              if (!replication_tests) {
-                  tags.push('!org.postgresql.test.Replication');
-              }
-              const junit_include_tags = tags.join(' & ');
-
-              list.push({
-                  os,
-                  jdk_version: jdk.version,
-                  jdk_distribution: jdk.distribution,
-                  jdk_url: jdk.url,
-                  pg_version,
-                  ssl,
-                  scram,
-                  server_tz: opts.server_tz ?? 'Etc/UTC',
-                  slow_tests,
-                  replication_tests,
-                  junit_include_tags,
-                  experimental: opts.experimental ?? false,
-                  query_mode,
-                  gradle_args: opts.gradle_args ?? '',
-              });
-          };
-
-          // Latest JDK x each stable PG version
-          for (const pg_version of PG_VERSIONS) {
-              addItem({
-                  pg_version,
-              });
-          }
-
-          // Latest PG version x each remaining JDK
-          for (const jdk of JDK_OPTIONS) {
-              if (jdk == LATEST_JDK) {
-                  continue; // Skip duplicate
-              }
-              addItem({
-                  jdk,
-                  pg_version: LATEST_PG_VERSION,
-                  experimental: !jdk.lts,
-              });
-          }
-
-          // No SSL / No SCRAM (only on latest PG / JDK)
-          addItem({
-              ssl: false,
-              scram: false,
-          });
-
-          // Custom server timezones (only on latest PG / JDK)
-          addItem({
-              server_tz: 'America/New_York'
-          });
-          addItem({
-              server_tz: 'Pacific/Chatham'
-          });
-
-          // Custom query modes (only on latest PG / JDK)
-          addItem({
-              query_mode: 'simple',
-          });
-          addItem({
-              query_mode: 'extendedForPrepared',
-          });
-          addItem({
-              query_mode: 'extendedCacheEverything',
-          });
-
-          // Slow and replication tests (only on latest PG / JDK)
-          // NOTE: Marked experimental for now due to server issues
-          addItem({
-              slow_tests: true,
-              replication_tests: true,
-              experimental: true,
-              gradle_args: '--scan',
-          });
-
-          // TODO: Add latest PG built from source marked as experimental
-          for(const jdk of OTHER_JDK_OPTIONS) {
-              addItem({
-                  jdk,
-                  pg_version: LATEST_PG_VERSION,
-                  experimental: !jdk.lts,
-              });
-          }
-
-          if (list.length === 0) {
-            throw new Error('Matrix list is empty. Check you matrix filters to ensure they match a valid combination.');
-          }
-
-          const toKey = (item) => JSON.stringify(Object.entries(item).sort())
-          const include = list.filter((item, i) => {
-            const key = toKey(item);
-            // Deduplicate by picking only the first entry matching this key
-            return i === list.findIndex((other) => key === toKey(other));
-          });
-
-          console.log('::set-output name=matrix::' + JSON.stringify({ include }));
-        "
+        node -e "${MATRIX_GENERATION_NODE_JS_SCRIPT}"
 
   test:
-    name: '${{ toJson(matrix) }}'
+    name: '${{ matrix.name }}'
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.experimental }}
     needs: matrix_prep
@@ -263,6 +276,10 @@ jobs:
       SCRAM: ${{ matrix.scram }}
       TZ: ${{ matrix.server_tz }}
     steps:
+    - name: 'Show Matrix'
+      env:
+          MATRIX_JSON: ${{ toJSON(matrix) }}
+      run: echo "${MATRIX_JSON}"
     - uses: actions/checkout@v2
       with:
         fetch-depth: 50
@@ -321,7 +338,6 @@ jobs:
         cat <<EOF >build.local.properties
         preferQueryMode=${{ matrix.query_mode}}
         EOF
-
     - name: Test
       uses: burrunan/gradle-cache-action@v1
       env:
@@ -329,12 +345,10 @@ jobs:
         S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.S3_BUILD_CACHE_SECRET_KEY }}
       with:
         job-id: jdk${{ matrix.jdk_version }}_pg${{ matrix.pg_version}}
-        arguments: ${{ matrix.gradle_args }} --no-parallel --no-daemon ${{ github.event.inputs.gradle_args }}
+        arguments: --no-parallel --no-daemon --scan jandex test jacocoReport
         properties: |
           includeTestTags=${{ matrix.junit_include_tags }}
-
     - name: 'Upload code coverage'
       uses: codecov/codecov-action@a1ed4b322b4b38cb846afb5a0ebfa17086917d27
-      if: ${{ contains(github.event.inputs.gradle_args, 'jacoco') }}
       with:
         file: ./build/reports/jacoco/jacocoReport/jacocoReport.xml

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -527,6 +527,14 @@ allprojects {
                         includeTags.add(includeTestTags)
                     }
                 }
+                inputs.file("../build.properties")
+                if (file("../build.local.properties").exists()) {
+                    inputs.file("../build.local.properties")
+                }
+                inputs.file("../ssltest.properties")
+                if (file("../ssltest.local.properties").exists()) {
+                    inputs.file("../ssltest.local.properties")
+                }
                 testLogging {
                     showStandardStreams = true
                 }

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       - SCRAM=${SCRAM:-yes}
       - TZ=${TZ:-Etc/UTC}
       - FSYNC=${FSYNC:-no}
-      - SYNC_COMMIT=${SYNC_COMMIT:-no}
+      - SYNC_COMMIT=${SYNC_COMMIT:-yes}
       - FULL_PAGE_WRITES=${FULL_PAGE_WRITES:-no}
       - AUTO_VACCUUM=${AUTO_VACCUUM:-no}
       - TRACK_COUNTS=${TRACK_COUNTS:-no}

--- a/pgjdbc/src/test/java/org/postgresql/test/util/ByteStreamWriterTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/util/ByteStreamWriterTest.java
@@ -10,12 +10,14 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import org.postgresql.test.SlowTests;
 import org.postgresql.test.TestUtil;
 import org.postgresql.test.jdbc2.BaseTest4;
 import org.postgresql.util.ByteBufferByteStreamWriter;
 import org.postgresql.util.ByteStreamWriter;
 
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -103,6 +105,7 @@ public class ByteStreamWriterTest extends BaseTest4 {
   }
 
   @Test
+  @Category(SlowTests.class)
   public void testLength100Kb() throws Exception {
     ByteBuffer testData = testData(100 * 1024);
     insertStream(testData);
@@ -110,6 +113,7 @@ public class ByteStreamWriterTest extends BaseTest4 {
   }
 
   @Test
+  @Category(SlowTests.class)
   public void testLength200Kb() throws Exception {
     ByteBuffer testData = testData(200 * 1024);
     insertStream(testData);


### PR DESCRIPTION
First commit marks two more "big" methods as slow tests.

Second teaches gradle to include `build.properties`, `build.local.properties` (if it exists), and `ssltest.properties` as runtime dependencies for tests. Otherwise changes to those files don't actually trigger re-running tests because gradle thinks all the inputs match its cached values.

Third commit teaches gradle to include the files `gradle.ci.test-runtime-only` and `gradle.ci.test-implementation` as dependencies and has the CI actions populate the test-runtime file with the matrix, OS, and PostgreSQL server version information. The actual contents of the file don't matter, it just needs to include something to uniquely identify that environment.

I noticed that similar to `build.properties`, changing the PostgreSQL server version didn't trigger a new test run as it's the same cache key. I thought about having it actually connect to the test DB to determine the version at runtime but figured there's going to be other external details that we may want to include so I went with this approach. Additional information can be appended to the same file.

Prior to this change, if there's no code change in the repo then the daily omni action would not actually run the tests if the PG server changed, i.e. if core releases a new patch version. Now it should reflect those and any other changes to the matrix while still preserve caching across similar runs.