### PR TITLE
test: Fix typo in seed build cache action output name

### DIFF
--- a/.github/workflows/buildcache.yml
+++ b/.github/workflows/buildcache.yml
@@ -22,9 +22,9 @@ jobs:
       - id: set-matrix
         run: |
           if [[ -n "${S3_BUILD_CACHE_ACCESS_KEY_ID:-}" ]] && [[ -n "${S3_BUILD_CACHE_SECRET_KEY:-}" ]]; then
-            echo "::set-output name=secret_available::true"
+            echo "::set-output name=secrets_available::true"
           else
-            echo "::set-output name=secret_available::false"
+            echo "::set-output name=secrets_available::false"
           fi
 
   seed-build-cache:


### PR DESCRIPTION
Fixes typo in seed build cache action to actually run when the secrets are available.

Tested by debug logging the values in a separate dummy commit: https://github.com/sehrope/pgjdbc/runs/2640150751?check_suite_focus=true
