### PR TITLE
test: Add explicit stop and remove of docker-compose containers in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -146,7 +146,10 @@ jobs:
         fetch-depth: 50
     - name: Start PostgreSQL
       working-directory: docker
-      run: docker-compose up -d && docker-compose logs
+      run: |
+        docker-compose down -v --rmi local || true
+        docker-compose up -d
+        docker-compose logs
     - name: 'Get test node ARCH'
       run: echo "::set-output name=arch_name::$(uname -i)"
       id: get_arch_name
@@ -177,6 +180,12 @@ jobs:
         properties: |
           skipReplicationTests=
           port=${{ job.services.postgres.ports['5432'] }}
+    - name: Cleanup Docker
+      if: ${{ always() }}
+      working-directory: docker
+      run: |
+        docker-compose ps
+        docker-compose down -v --rmi local
 
   gss-encryption:
     name: 'GSS Test - JDK ${{ matrix.jdk }} on ${{ matrix.os }}'


### PR DESCRIPTION
Adds removing existing docker containers before starting them and always at the end of the test job. This has not been necessary for the hosted runners but the self-hosted one preserves state between runs so we need to clean up it up.

If this runs through CI cleanly then we'll have a clean slate on the self-hosted runner and be able to switch around both the ports and parent directory (docker-compose uses that for network and volume naming).

See #2154 for more details.