### PR TITLE
test: Fix git hash emptiness check in postgres-head Dockerfile

### DIFF
--- a/docker/postgres-head/Dockerfile
+++ b/docker/postgres-head/Dockerfile
@@ -31,7 +31,7 @@ ARG GIT_SHA
 RUN mkdir -p /build/postgres \
     && git clone -b "${GIT_TAG}" --single-branch "${GIT_URL}" --depth 10 /build/postgres \
     && cd /build/postgres \
-    && [[ -z "${GIT_SHA:-}" ]] || git reset --hard "${GIT_SHA:-}"
+    && [ -z "${GIT_SHA:-}" ] || git reset --hard "${GIT_SHA:-}"
 
 # Default configure options that can be overridden with build arg
 ARG CONFIGURE_OPTS=" \


### PR DESCRIPTION
Fixes emptiness check in postgres-head building Dockerfile. Had a bash-ism so it was always failing the emptiness check but didn't notice locally as as the `docker/bin/postgres-head` script always supplies a value. Updated check works in my fork: https://github.com/sehrope/pgjdbc/runs/2676337730?check_suite_focus=true#step:6:18
