### PR TITLE
fix: Correct path to docker entrypoint in postgres-server container

### DIFF
--- a/docker/postgres-server/scripts/entrypoint.sh
+++ b/docker/postgres-server/scripts/entrypoint.sh
@@ -68,7 +68,16 @@ main () {
 
     echo "Starting postgres version $PG_MAJOR with options: ${pg_opts} $@"
 
-    exec /docker-entrypoint.sh "$@" ${pg_opts}
+    local entrypoint_script
+    if [[ -x /docker-entrypoint.sh ]]; then
+        entrypoint_script='/docker-entrypoint.sh'
+    elif [[ -x /usr/local/bin/docker-entrypoint.sh ]]; then
+        # On 13+ the script is not longer symlinked to the root
+        entrypoint_script='/usr/local/bin/docker-entrypoint.sh'
+    else
+        err "Could not find postgres container entry point script"
+    fi
+    exec "${entrypoint_script}" "$@" ${pg_opts}
 }
 
 main "$@"


### PR DESCRIPTION
The latest versions of the postgres docker container no longer symlink the entrypoint script to the root. This PR fixes our customized entry point to handle both the old and newer container versions.