### PR TITLE
test: Remove PG 14 procedure error special handling

### DIFF
--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc3/EscapeSyntaxCallModeCallIfNoReturnTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc3/EscapeSyntaxCallModeCallIfNoReturnTest.java
@@ -12,7 +12,6 @@ import static org.junit.Assert.fail;
 import org.postgresql.PGProperty;
 import org.postgresql.core.ServerVersion;
 import org.postgresql.jdbc.EscapeSyntaxCallMode;
-import org.postgresql.test.TestUtil;
 import org.postgresql.util.PSQLState;
 
 import org.junit.Test;
@@ -38,11 +37,6 @@ public class EscapeSyntaxCallModeCallIfNoReturnTest extends EscapeSyntaxCallMode
     PSQLState expected = PSQLState.WRONG_OBJECT_TYPE;
     assumeCallableStatementsSupported();
     assumeMinimumServerVersion(ServerVersion.v11);
-
-    // version 14 changes this to undefined function
-    if (TestUtil.haveMinimumServerVersion(con, ServerVersion.v14)) {
-      expected = PSQLState.UNDEFINED_FUNCTION;
-    }
 
     CallableStatement cs = con.prepareCall("{ call myiofunc(?,?) }");
     cs.registerOutParameter(1, Types.INTEGER);

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc3/EscapeSyntaxCallModeCallTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc3/EscapeSyntaxCallModeCallTest.java
@@ -38,11 +38,6 @@ public class EscapeSyntaxCallModeCallTest extends EscapeSyntaxCallModeBaseTest {
     assumeCallableStatementsSupported();
     assumeMinimumServerVersion(ServerVersion.v11);
 
-    // version 14 changes this to undefined function
-    if (TestUtil.haveMinimumServerVersion(con, ServerVersion.v14)) {
-      expected = PSQLState.UNDEFINED_FUNCTION;
-    }
-
     CallableStatement cs = con.prepareCall("{ call myiofunc(?,?) }");
     cs.registerOutParameter(1, Types.INTEGER);
     cs.registerOutParameter(2, Types.INTEGER);


### PR DESCRIPTION
Removes special handling for PG 14 procedure errors. The behavior in the latest source builds of the server now matches previous versions.

Fixes #2190

I tried this out in the omin action in my fork and it looks good there: https://github.com/sehrope/pgjdbc/runs/2943561822?check_suite_focus=true