### PR TITLE
fix: resultsets should be updateable if there is a unique constraint on the table fixes issue #2196

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
@@ -1646,7 +1646,7 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
     @Nullable String[] s = quotelessTableName(castNonNull(tableName));
     String quotelessTableName = castNonNull(s[0]);
     @Nullable String quotelessSchemaName = s[1];
-    java.sql.ResultSet rs = connection.getMetaData().getPrimaryKeys("",
+    java.sql.ResultSet rs = ((PgDatabaseMetaData)connection.getMetaData()).getPrimaryUniqueKeys("",
         quotelessSchemaName, quotelessTableName);
 
     while (rs.next()) {

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/UpdateableResultTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/UpdateableResultTest.java
@@ -56,6 +56,8 @@ public class UpdateableResultTest extends BaseTest4 {
     // put some dummy data into second
     st2.execute("insert into second values (1,'anyvalue' )");
     st2.close();
+    TestUtil.createTable(con, "uniqueconstraint", "u1 int unique, name1 text");
+    TestUtil.execute("insert into uniqueconstraint values (1, 'dave')", con);
 
   }
 
@@ -68,6 +70,7 @@ public class UpdateableResultTest extends BaseTest4 {
     TestUtil.dropTable(con, "stream");
     TestUtil.dropTable(con, "nopkmulticol");
     TestUtil.dropTable(con, "booltable");
+    TestUtil.dropTable(con, "uniqueconstraint");
     super.tearDown();
   }
 
@@ -700,6 +703,18 @@ public class UpdateableResultTest extends BaseTest4 {
     assertTrue(rs.next());
     assertTrue(rs.first());
     rs.updateString("relname", "pg_class");
+    rs.close();
+    st.close();
+  }
+
+  @Test
+  public void testUniqueUpdatable() throws Exception {
+    Statement st = con.createStatement(ResultSet.TYPE_SCROLL_INSENSITIVE,
+        ResultSet.CONCUR_UPDATABLE);
+    ResultSet rs = st.executeQuery("SELECT * from uniqueconstraint");
+    assertTrue(rs.next());
+    assertTrue(rs.first());
+    rs.updateString("name1", "bob");
     rs.close();
     st.close();
   }


### PR DESCRIPTION
Created a protected method inside PgDatabaseMetaData to extend the search for primary keys to include unique keys as well
Added tests