### PR TITLE
Fix issue #2215 - handle OIDs >= 2**31

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/TypeInfo.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/TypeInfo.java
@@ -116,4 +116,30 @@ public interface TypeInfo {
    * @throws SQLException if something goes wrong
    */
   boolean requiresQuotingSqlType(int sqlType) throws SQLException;
+
+  /**
+   * <p>Java Integers are signed 32-bit integers, but oids are unsigned 32-bit integers.
+   * We therefore read them as positive long values and then force them into signed integers
+   * (wrapping around into negative values when required) or we'd be unable to correctly
+   * handle the upper half of the oid space.</p>
+   *
+   * <p>This function handles the mapping of uint32-values in the long to java integers, and
+   * throws for values that are out of range.</p>
+   *
+   * @param oid the oid as a long.
+   * @return the (internal) signed integer representation of the (unsigned) oid.
+   * @throws SQLException if the long has a value outside of the range representable by uint32
+   */
+  int longOidToInt(long oid) throws SQLException;
+
+  /**
+   * Java Integers are signed 32-bit integers, but oids are unsigned 32-bit integers.
+   * We must therefore first map the (internal) integer representation to a positive long
+   * value before sending it to postgresql, or we would be unable to correctly handle the
+   * upper half of the oid space because these negative values are disallowed as OID values.
+   *
+   * @param oid the (signed) integer oid to convert into a long.
+   * @return the non-negative value of this oid, stored as a java long.
+   */
+  long intOidToLong(int oid);
 }

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
@@ -279,7 +279,7 @@ public class TypeInfoCache implements TypeInfo {
         pgNameToSQLType.put(typeName, type);
       }
 
-      Integer typeOid = castNonNull(rs.getInt("oid"));
+      Integer typeOid = longOidToInt(castNonNull(rs.getLong("oid")));
       if (!oidToSQLType.containsKey(typeOid)) {
         oidToSQLType.put(typeOid, type);
       }
@@ -310,11 +310,11 @@ public class TypeInfoCache implements TypeInfo {
       return i;
     }
 
-    LOGGER.log(Level.FINEST, "querying SQL typecode for pg type oid '{0}'", typeOid);
+    LOGGER.log(Level.FINEST, "querying SQL typecode for pg type oid '{0}'", intOidToLong(typeOid));
 
     PreparedStatement getTypeInfoStatement = prepareGetTypeInfoStatement();
 
-    getTypeInfoStatement.setInt(1, typeOid);
+    getTypeInfoStatement.setLong(1, intOidToLong(typeOid));
 
     // Go through BaseStatement to avoid transaction start.
     if (!((BaseStatement) getTypeInfoStatement)
@@ -972,5 +972,19 @@ public class TypeInfoCache implements TypeInfo {
         return false;
     }
     return true;
+  }
+
+  @Override
+  public int longOidToInt(long oid) throws SQLException {
+    if ((oid & 0xFFFF_FFFF_0000_0000L) != 0) {
+      throw new PSQLException(GT.tr("Value is not an OID: {0}", oid), PSQLState.NUMERIC_VALUE_OUT_OF_RANGE);
+    }
+
+    return (int) oid;
+  }
+
+  @Override
+  public long intOidToLong(int oid) {
+    return ((long) oid) & 0xFFFFFFFFL;
   }
 }


### PR DESCRIPTION
Correctly handle the non-signedness of OIDs in relation to signed java integers in this new OID-based type storage.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes to Existing Features:

* [x] Does this break existing behaviour? If so please explain.
  Previously, OIDs >= 2**31 could not be handled by the driver. This was exposed in 42.2.23, when OIDs became the primary source of truth about type information (before that version this was the type string). 
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
  This patch fixes the bugged behaviour of 42.2.23, and other misbehaviours with int-typed OIDs by first casting the oids to positive Long values, such that the full OID space is represented in integer values, and can be handled correctly.

* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
