### PR TITLE
feat: intern/canonicalize common strings

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/AsciiStringInterner.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/AsciiStringInterner.java
@@ -1,0 +1,314 @@
+/*
+ * Copyright (c) 2020, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.core;
+
+import static org.postgresql.util.internal.Nullness.castNonNull;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.io.IOException;
+import java.lang.ref.Reference;
+import java.lang.ref.ReferenceQueue;
+import java.lang.ref.SoftReference;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Provides the canonicalization/interning of {@code String} instances which contain only ascii characters,
+ * keyed by the {@code byte[]} representation (in ascii).
+ *
+ * <p>
+ * The values are stored in {@link SoftReference}s, allowing them to be garbage collected if not in use and there is
+ * memory pressure.
+ * </p>
+ *
+ * <p>
+ * <b>NOTE:</b> Instances are safe for concurrent use.
+ * </p>
+ *
+ * @author Brett Okken
+ */
+final class AsciiStringInterner {
+
+  private abstract static class BaseKey {
+    private final int hash;
+
+    BaseKey(int hash) {
+      this.hash = hash;
+    }
+
+    @Override
+    public final int hashCode() {
+      return hash;
+    }
+
+    @Override
+    public final boolean equals(@Nullable Object obj) {
+      if (obj == this) {
+        return true;
+      }
+      if (!(obj instanceof BaseKey)) {
+        return false;
+      }
+      final BaseKey other = (BaseKey) obj;
+      return equalsBytes(other);
+    }
+
+    abstract boolean equalsBytes(BaseKey other);
+
+    abstract boolean equals(byte[] other, int offset, int length);
+
+    abstract void appendString(StringBuilder sb);
+  }
+
+  /**
+   * Only used for lookups, never to actually store entries.
+   */
+  private static class TempKey extends BaseKey {
+    final byte[] bytes;
+    final int offset;
+    final int length;
+
+    TempKey(int hash, byte[] bytes, int offset, int length) {
+      super(hash);
+      this.bytes = bytes;
+      this.offset = offset;
+      this.length = length;
+    }
+
+    @Override
+    boolean equalsBytes(BaseKey other) {
+      return other.equals(bytes, offset, length);
+    }
+
+    @Override
+    public boolean equals(byte[] other, int offset, int length) {
+      return arrayEquals(this.bytes, this.offset, this.length, other, offset, length);
+    }
+
+    @Override
+    void appendString(StringBuilder sb) {
+      for (int i = offset, j = offset + length; i < j; ++i) {
+        sb.append((char) bytes[i]);
+      }
+    }
+  }
+
+  /**
+   * Instance used for inserting values into the cache. The {@code byte[]} must be a copy
+   * that will never be mutated.
+   */
+  private static final class Key extends BaseKey {
+    final byte[] key;
+
+    Key(byte[] key, int hash) {
+      super(hash);
+      this.key = key;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    boolean equalsBytes(BaseKey other) {
+      return other.equals(key, 0, key.length);
+    }
+
+    @Override
+    public boolean equals(byte[] other, int offset, int length) {
+      return arrayEquals(this.key, 0, this.key.length, other, offset, length);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    void appendString(StringBuilder sb) {
+      for (int i = 0; i < key.length; ++i) {
+        sb.append((char) key[i]);
+      }
+    }
+  }
+
+  /**
+   * Custom {@link SoftReference} implementation which maintains a reference to the key in the cache,
+   * which allows aggressive cleaning when garbage collector collects the {@code String} instance.
+   */
+  private final class StringReference extends SoftReference<String> {
+
+    private final BaseKey key;
+
+    StringReference(BaseKey key, String referent) {
+      super(referent, refQueue);
+      this.key = key;
+    }
+
+    void dispose() {
+      cache.remove(key, this);
+    }
+  }
+
+  /**
+   * Contains the canonicalized values, keyed by the ascii {@code byte[]}.
+   */
+  final ConcurrentMap<BaseKey, SoftReference<String>> cache = new ConcurrentHashMap<>(128);
+
+  /**
+   * Used for {@link Reference} as values in {@code cache}.
+   */
+  final ReferenceQueue<String> refQueue = new ReferenceQueue<>();
+
+  /**
+   * Preemptively populates a value into the cache. This is intended to be used with {@code String} constants
+   * which are frequently used. While this can work with other {@code String} values, if <i>val</i> is ever
+   * garbage collected, it will not be actively removed from this instance.
+   *
+   * @param val The value to intern. Must not be {@code null}.
+   * @return Indication if <i>val</i> is an ascii String and placed into cache.
+   */
+  public boolean putString(String val) {
+    //ask for utf-8 so that we can detect if any of the characters are not ascii
+    final byte[] copy = val.getBytes(StandardCharsets.UTF_8);
+    final int hash = hashKey(copy, 0, copy.length);
+    if (hash == 0) {
+      return false;
+    }
+    final Key key = new Key(copy, hash);
+    //we are assuming this is a java interned string from , so this is unlikely to ever be
+    //reclaimed. so there is no value in using the custom StringReference or hand off to
+    //the refQueue.
+    //on the outside chance it actually does get reclaimed, it will just hang around as an
+    //empty reference in the map unless/until attempted to be retrieved
+    cache.put(key, new SoftReference<String>(val));
+    return true;
+  }
+
+  /**
+   * Produces a {@link String} instance for the given <i>bytes</i>. If all are valid ascii (i.e. {@code >= 0})
+   * either an existing value will be returned, or the newly created {@code String} will be stored before being
+   * returned.
+   *
+   * <p>
+   * If non-ascii bytes are discovered, the <i>encoding</i> will be used to
+   * {@link Encoding#decode(byte[], int, int) decode} and that value will be returned (but not stored).
+   * </p>
+   *
+   * @param bytes The bytes of the String. Must not be {@code null}.
+   * @param offset Offset into <i>bytes</i> to start.
+   * @param length The number of bytes in <i>bytes</i> which are relevant.
+   * @param encoding To use if non-ascii bytes seen.
+   * @return Decoded {@code String} from <i>bytes</i>.
+   * @throws IOException If error decoding from <i>Encoding</i>.
+   */
+  public String getString(byte[] bytes, int offset, int length, Encoding encoding) throws IOException {
+    if (length == 0) {
+      return "";
+    }
+
+    final int hash = hashKey(bytes, offset, length);
+    // 0 indicates the presence of a non-ascii character - defer to encoding to create the string
+    if (hash == 0) {
+      return encoding.decode(bytes, offset, length);
+    }
+    cleanQueue();
+    // create a TempKey with the byte[] given
+    final TempKey tempKey = new TempKey(hash, bytes, offset, length);
+    SoftReference<String> ref = cache.get(tempKey);
+    if (ref != null) {
+      final String val = ref.get();
+      if (val != null) {
+        return val;
+      }
+    }
+    // in order to insert we need to create a "real" key with copy of bytes that will not be changed
+    final byte[] copy = Arrays.copyOfRange(bytes, offset, offset + length);
+    final Key key = new Key(copy, hash);
+    final String value = new String(copy, StandardCharsets.US_ASCII);
+
+    // handle case where a concurrent thread has populated the map or existing value has cleared reference
+    ref = cache.compute(key, (k,v) -> {
+      if (v == null) {
+        return new StringReference(key, value);
+      }
+      final String val = v.get();
+      return val != null ? v : new StringReference(key, value);
+    });
+
+    return castNonNull(ref.get());
+  }
+
+  /**
+   * Process any entries in {@link #refQueue} to purge from the {@link #cache}.
+   * @see StringReference#dispose()
+   */
+  private void cleanQueue() {
+    Reference<?> ref;
+    while ((ref = refQueue.poll()) != null) {
+      ((StringReference)ref).dispose();
+    }
+  }
+
+  /**
+   * Generates a hash value for the relevant entries in <i>bytes</i> as long as all values are ascii ({@code >= 0}).
+   * @return hash code for relevant bytes, or {@code 0} if non-ascii bytes present.
+   */
+  private static int hashKey(byte[] bytes, int offset, int length) {
+    int result = 1;
+    for (int i = offset, j = offset + length; i < j; ++i) {
+      final byte b = bytes[i];
+      // bytes are signed values. all ascii values are positive
+      if (b < 0) {
+        return 0;
+      }
+      result = 31 * result + b;
+    }
+    return result;
+  }
+
+  /**
+   * Performs equality check between <i>a</i> and <i>b</i> (with corresponding offset/length values).
+   * <p>
+   * The {@code static boolean equals(byte[].class, int, int, byte[], int, int} method in {@link java.util.Arrays}
+   * is optimized for longer {@code byte[]} instances than is expected to be seen here.
+   * </p>
+   */
+  static boolean arrayEquals(byte[] a, int aOffset, int aLength, byte[] b, int bOffset, int bLength) {
+    if (aLength != bLength) {
+      return false;
+    }
+    //TODO: in jdk9, could use VarHandle to read 4 bytes at a time as an int for comparison
+    // or 8 bytes as a long - though we likely expect short values here
+    for (int i = 0; i < aLength; ++i) {
+      if (a[aOffset + i] != b[bOffset + i]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public String toString() {
+    final StringBuilder sb = new StringBuilder(32 + (8 * cache.size()));
+    sb.append("AsciiStringInterner [");
+    cache.forEach((k,v) -> {
+      sb.append('\'');
+      k.appendString(sb);
+      sb.append("', ");
+    });
+    //replace trailing ', ' with ']';
+    final int length = sb.length();
+    if (length > 21) {
+      sb.setLength(sb.length() - 2);
+    }
+    sb.append(']');
+    return sb.toString();
+  }
+}

--- a/pgjdbc/src/main/java/org/postgresql/core/PGStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/PGStream.java
@@ -545,6 +545,22 @@ public class PGStream implements Closeable, Flushable {
   }
 
   /**
+   * Receives a null-terminated string from the backend and attempts to decode to a
+   * {@link Encoding#decodeCanonicalized(byte[], int, int) canonical} {@code String}.
+   * If we don't see a null, then we assume something has gone wrong.
+   *
+   * @return string from back end
+   * @throws IOException if an I/O error occurs, or end of file
+   * @see Encoding#decodeCanonicalized(byte[], int, int)
+   */
+  public String receiveCanonicalString() throws IOException {
+    int len = pgInput.scanCStringLength();
+    String res = encoding.decodeCanonicalized(pgInput.getBuffer(), pgInput.getIndex(), len - 1);
+    pgInput.skip(len);
+    return res;
+  }
+
+  /**
    * Read a tuple from the back end. A tuple is a two dimensional array of bytes. This variant reads
    * the V3 protocol's tuple representation.
    *

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -84,6 +84,22 @@ public class QueryExecutorImpl extends QueryExecutorBase {
 
   private static final Field[] NO_FIELDS = new Field[0];
 
+  static {
+    //canonicalize commonly seen strings to reduce memory and speed comparisons
+    Encoding.canonicalize("application_name");
+    Encoding.canonicalize("client_encoding");
+    Encoding.canonicalize("DateStyle");
+    Encoding.canonicalize("integer_datetimes");
+    Encoding.canonicalize("off");
+    Encoding.canonicalize("on");
+    Encoding.canonicalize("server_version");
+    Encoding.canonicalize("server_version_num");
+    Encoding.canonicalize("standard_conforming_strings");
+    Encoding.canonicalize("TimeZone");
+    Encoding.canonicalize("UTF8");
+    Encoding.canonicalize("UTF-8");
+  }
+
   /**
    * TimeZone of the current connection (TimeZone backend parameter).
    */
@@ -2616,7 +2632,7 @@ public class QueryExecutorImpl extends QueryExecutorBase {
     }
 
     for (int i = 0; i < fields.length; i++) {
-      String columnLabel = pgStream.receiveString();
+      String columnLabel = pgStream.receiveCanonicalString();
       int tableOid = pgStream.receiveInteger4();
       short positionInTable = (short) pgStream.receiveInteger2();
       int typeOid = pgStream.receiveInteger4();
@@ -2638,7 +2654,7 @@ public class QueryExecutorImpl extends QueryExecutorBase {
     assert len > 4 : "Length for AsyncNotify must be at least 4";
 
     int pid = pgStream.receiveInteger4();
-    String msg = pgStream.receiveString();
+    String msg = pgStream.receiveCanonicalString();
     String param = pgStream.receiveString();
     addNotification(new org.postgresql.core.Notification(msg, pid, param));
 
@@ -2803,17 +2819,20 @@ public class QueryExecutorImpl extends QueryExecutorBase {
   public void receiveParameterStatus() throws IOException, SQLException {
     // ParameterStatus
     pgStream.receiveInteger4(); // MESSAGE SIZE
-    String name = pgStream.receiveString();
-    String value = pgStream.receiveString();
+    final String name = pgStream.receiveCanonicalString();
+    final String value = pgStream.receiveCanonicalString();
 
     if (LOGGER.isLoggable(Level.FINEST)) {
       LOGGER.log(Level.FINEST, " <=BE ParameterStatus({0} = {1})", new Object[]{name, value});
     }
 
-    /* Update client-visible parameter status map for getParameterStatuses() */
-    if (name != null && !name.equals("")) {
-      onParameterStatus(name, value);
+    // if the name is empty, there is nothing to do
+    if (name.isEmpty()) {
+      return;
     }
+
+    // Update client-visible parameter status map for getParameterStatuses()
+    onParameterStatus(name, value);
 
     if (name.equals("client_encoding")) {
       if (allowEncodingChanges) {

--- a/pgjdbc/src/test/java/org/postgresql/core/AsciiStringInternerTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/core/AsciiStringInternerTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2020, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.core;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import org.postgresql.test.SlowTests;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.LongAdder;
+
+/**
+ *
+ * @author Brett Okken
+ */
+public class AsciiStringInternerTest {
+
+  @Test
+  public void testCanonicalValue() throws Exception {
+    AsciiStringInterner interner = new AsciiStringInterner();
+    String s1 = "testCanonicalValue";
+    byte[] bytes = s1.getBytes(StandardCharsets.US_ASCII);
+    String interned = interner.getString(bytes, 0, bytes.length, null);
+
+    //interned value should be equal
+    assertEquals(s1, interned);
+    //but should be different instance
+    assertNotSame(s1, interned);
+    //asking for it again, however should return same instance
+    assertSame(interned, interner.getString(bytes, 0, bytes.length, null));
+
+    //now show that we can get the value back from a different byte[]
+    byte[] bytes2 = new byte[128];
+    System.arraycopy(bytes, 0, bytes2, 73, bytes.length);
+    assertSame(interned, interner.getString(bytes2, 73, bytes.length, null));
+
+    //now we will mutate the original byte[] to show that does not affect the map
+    Arrays.fill(bytes, (byte) 13);
+    assertSame(interned, interner.getString(bytes2, 73, bytes.length, null));
+  }
+
+  @Test
+  public void testStagedValue() throws Exception {
+    AsciiStringInterner interner = new AsciiStringInterner();
+    String s1 = "testStagedValue";
+    interner.putString(s1);
+    byte[] bytes = s1.getBytes(StandardCharsets.US_ASCII);
+    String interned = interner.getString(bytes, 0, bytes.length, null);
+    // should be same instance
+    assertSame(s1, interned);
+    //asking for it again should also return same instance
+    assertSame(s1, interner.getString(bytes, 0, bytes.length, null));
+
+    //now show that we can get the value back from a different byte[]
+    byte[] bytes2 = new byte[128];
+    System.arraycopy(bytes, 0, bytes2, 73, bytes.length);
+    assertSame(s1, interner.getString(bytes2, 73, bytes.length, null));
+  }
+
+  @Test
+  public void testNonAsciiValue() throws Exception {
+    final Encoding encoding = Encoding.getJVMEncoding("UTF-8");
+    AsciiStringInterner interner = new AsciiStringInterner();
+    String s1 = "testNonAsciiValue" + '\u03C0'; // add multi-byte to string to make invalid for intern
+    byte[] bytes = s1.getBytes(StandardCharsets.UTF_8);
+    String interned = interner.getString(bytes, 0, bytes.length, encoding);
+
+    //interned value should be equal
+    assertEquals(s1, interned);
+    //but should be different instance
+    assertNotSame(s1, interned);
+    //asking for it again should again return a different instance
+    final String interned2 = interner.getString(bytes, 0, bytes.length, encoding);
+    assertEquals(s1, interned2);
+    assertNotSame(s1, interned2);
+    assertNotSame(interned, interned2);
+  }
+
+  @Test
+  public void testToString() throws Exception {
+    AsciiStringInterner interner = new AsciiStringInterner();
+    assertEquals("empty", "AsciiStringInterner []", interner.toString());
+    interner.putString("s1");
+    assertEquals("empty", "AsciiStringInterner ['s1']", interner.toString());
+    interner.getString("s2".getBytes(StandardCharsets.US_ASCII), 0, 2, null);
+    assertEquals("empty", "AsciiStringInterner ['s1', 's2']", interner.toString());
+  }
+
+  @Test
+  @Category(SlowTests.class)
+  public void testGarbageCleaning() throws Exception {
+    final byte[] bytes = new byte[100000];
+    for (int i = 0; i < 100000; ++i) {
+      bytes[i] = (byte) ThreadLocalRandom.current().nextInt(128);
+    }
+    final AsciiStringInterner interner = new AsciiStringInterner();
+    final LongAdder length = new LongAdder();
+    final Callable<Void> c = () -> {
+      for (int i = 0; i < 25000; ++i) {
+        String str;
+        try {
+          str = interner.getString(bytes, 0, ThreadLocalRandom.current().nextInt(1000, bytes.length), null);
+        } catch (IOException e) {
+          throw new IllegalStateException(e);
+        }
+        length.add(str.length());
+      }
+      return null;
+    };
+    final ExecutorService exec = Executors.newCachedThreadPool();
+    try {
+      exec.invokeAll(Arrays.asList(c, c, c, c));
+    } finally {
+      exec.shutdown();
+    }
+    //this is really just done to make sure java cannot tell that nothing is really being done
+    assertTrue(length.sum() > 0);
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/Jdbc2TestSuite.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/Jdbc2TestSuite.java
@@ -5,6 +5,7 @@
 
 package org.postgresql.test.jdbc2;
 
+import org.postgresql.core.AsciiStringInternerTest;
 import org.postgresql.core.CommandCompleteParserNegativeTest;
 import org.postgresql.core.CommandCompleteParserTest;
 import org.postgresql.core.OidToStringTest;
@@ -49,6 +50,7 @@ import org.junit.runners.Suite;
     ArrayTest.class,
     ArraysTest.class,
     ArraysTestSuite.class,
+    AsciiStringInternerTest.class,
     BatchedInsertReWriteEnabledTest.class,
     BatchExecuteTest.class,
     BatchFailureTest.class,


### PR DESCRIPTION
Provide canonical String mappings for ascii Strings keyed by the binary representation intended for use with field names, startup parameters, and async message types.
By only supporting ascii characters, a singleton instance supports the most commonly used character encodings.
Performance getting an ascii string from AsciiStringInternerTest based on byte[] takes similar time as creating a new String instance.
The canonicalized String values are wrapped in SoftReference which allows them to be GC'd when not referenced anywhere and there is memory pressure.

Replacement for
https://github.com/pgjdbc/pgjdbc/pull/1988

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Does `./gradlew autostyleCheck checkstyleAll` pass ?
3. [x] Have you added your new test classes to an existing test suite in alphabetical order?

### Changes to Existing Features:

* [x] Does this break existing behaviour? If so please explain. N/A
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
