### PR TITLE
fix: handle ParameterStatus messages in QueryExecutorImpl.receiveFastpathResult

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -880,6 +880,19 @@ public class QueryExecutorImpl extends QueryExecutorBase {
 
           break;
 
+        case 'S': // Parameter Status
+          try {
+            receiveParameterStatus();
+          } catch (SQLException e) {
+            if (error == null) {
+              error = e;
+            } else {
+              error.setNextException(e);
+            }
+            endQuery = true;
+          }
+          break;
+
         default:
           throw new PSQLException(GT.tr("Unknown Response Type {0}.", (char) c),
               PSQLState.CONNECTION_FAILURE);

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/LargeObjectManagerTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/LargeObjectManagerTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2021, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.jdbc;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.postgresql.largeobject.LargeObjectManager;
+import org.postgresql.test.TestUtil;
+import org.postgresql.util.PSQLException;
+import org.postgresql.util.PSQLState;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Statement;
+
+class LargeObjectManagerTest {
+  private PgConnection con;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    con = (PgConnection) TestUtil.openDB();
+    con.setAutoCommit(false);
+  }
+
+  /*
+   * It is possible for PostgreSQL to send a ParameterStatus message after an ErrorResponse
+   * Receiving such a message should not lead to an invalid connection state
+   * See https://github.com/pgjdbc/pgjdbc/issues/2237
+   */
+  @Test
+  public void testOpenWithErrorAndSubsequentParameterStatusMessageShouldLeaveConnectionInUsableStateAndUpdateParameterStatus() throws Exception {
+    String originalApplicationName = con.getParameterStatus("application_name");
+    try (Statement statement = con.createStatement()) {
+      statement.execute("begin;");
+      // Set transaction application_name to trigger ParameterStatus message after error
+      // https://www.postgresql.org/docs/14/protocol-flow.html#PROTOCOL-ASYNC
+      String updatedApplicationName = "LargeObjectManagerTest-application-name";
+      statement.execute("set application_name to '" + updatedApplicationName + "'");
+
+      LargeObjectManager loManager = con.getLargeObjectAPI();
+      try {
+        loManager.open(0, false);
+        fail("Succeeded in opening a non-existent large object");
+      } catch (PSQLException e) {
+        assertEquals(PSQLState.UNDEFINED_OBJECT.getState(), e.getSQLState());
+      }
+
+      // Should be reset to original application name
+      assertEquals(originalApplicationName, con.getParameterStatus("application_name"));
+    }
+  }
+}


### PR DESCRIPTION
QueryExecutorImpl.receiveFastpathResult did not properly handle ParameterStatus messages.
This in turn caused failures for some LargeObjectManager operations.
Fixed by adding the missing code path, based on the existing handling in processResults.

Closes #2237

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes to Existing Features:

* [n] Does this break existing behaviour? If so please explain.
* [y] Have you added an explanation of what your changes do and why you'd like us to include them?
* [y] Have you written new tests for your core changes, as applicable?
* [y] Have you successfully run tests with your changes locally?
