### PR TITLE
fix: close database connection in LargeObjectManagerTest

### DIFF
--- a/pgjdbc/src/test/java/org/postgresql/jdbc/LargeObjectManagerTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/LargeObjectManagerTest.java
@@ -13,19 +13,11 @@ import org.postgresql.test.TestUtil;
 import org.postgresql.util.PSQLException;
 import org.postgresql.util.PSQLState;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.sql.Statement;
 
 class LargeObjectManagerTest {
-  private PgConnection con;
-
-  @BeforeEach
-  public void setUp() throws Exception {
-    con = (PgConnection) TestUtil.openDB();
-    con.setAutoCommit(false);
-  }
 
   /*
    * It is possible for PostgreSQL to send a ParameterStatus message after an ErrorResponse
@@ -34,24 +26,27 @@ class LargeObjectManagerTest {
    */
   @Test
   public void testOpenWithErrorAndSubsequentParameterStatusMessageShouldLeaveConnectionInUsableStateAndUpdateParameterStatus() throws Exception {
-    String originalApplicationName = con.getParameterStatus("application_name");
-    try (Statement statement = con.createStatement()) {
-      statement.execute("begin;");
-      // Set transaction application_name to trigger ParameterStatus message after error
-      // https://www.postgresql.org/docs/14/protocol-flow.html#PROTOCOL-ASYNC
-      String updatedApplicationName = "LargeObjectManagerTest-application-name";
-      statement.execute("set application_name to '" + updatedApplicationName + "'");
+    try (PgConnection con = (PgConnection) TestUtil.openDB()) {
+      con.setAutoCommit(false);
+      String originalApplicationName = con.getParameterStatus("application_name");
+      try (Statement statement = con.createStatement()) {
+        statement.execute("begin;");
+        // Set transaction application_name to trigger ParameterStatus message after error
+        // https://www.postgresql.org/docs/14/protocol-flow.html#PROTOCOL-ASYNC
+        String updatedApplicationName = "LargeObjectManagerTest-application-name";
+        statement.execute("set application_name to '" + updatedApplicationName + "'");
 
-      LargeObjectManager loManager = con.getLargeObjectAPI();
-      try {
-        loManager.open(0, false);
-        fail("Succeeded in opening a non-existent large object");
-      } catch (PSQLException e) {
-        assertEquals(PSQLState.UNDEFINED_OBJECT.getState(), e.getSQLState());
+        LargeObjectManager loManager = con.getLargeObjectAPI();
+        try {
+          loManager.open(0, false);
+          fail("Succeeded in opening a non-existent large object");
+        } catch (PSQLException e) {
+          assertEquals(PSQLState.UNDEFINED_OBJECT.getState(), e.getSQLState());
+        }
+
+        // Should be reset to original application name
+        assertEquals(originalApplicationName, con.getParameterStatus("application_name"));
       }
-
-      // Should be reset to original application name
-      assertEquals(originalApplicationName, con.getParameterStatus("application_name"));
     }
   }
 }


### PR DESCRIPTION
Fixes the database connection leak in LargeObjectManagerTest introduced in #2247.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?