### PR TITLE
Clean up open connections to fix test failures on omni and appveyor

### DIFF
--- a/pgjdbc/src/test/java/org/postgresql/jdbc/LargeObjectManagerTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/LargeObjectManagerTest.java
@@ -8,11 +8,13 @@ package org.postgresql.jdbc;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import org.postgresql.core.ServerVersion;
 import org.postgresql.largeobject.LargeObjectManager;
 import org.postgresql.test.TestUtil;
 import org.postgresql.util.PSQLException;
 import org.postgresql.util.PSQLState;
 
+import org.junit.Assume;
 import org.junit.jupiter.api.Test;
 
 import java.sql.Statement;
@@ -27,6 +29,7 @@ class LargeObjectManagerTest {
   @Test
   public void testOpenWithErrorAndSubsequentParameterStatusMessageShouldLeaveConnectionInUsableStateAndUpdateParameterStatus() throws Exception {
     try (PgConnection con = (PgConnection) TestUtil.openDB()) {
+      Assume.assumeTrue(TestUtil.haveMinimumServerVersion(con, ServerVersion.v9_0));
       con.setAutoCommit(false);
       String originalApplicationName = con.getParameterStatus("application_name");
       try (Statement statement = con.createStatement()) {

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseMetaDataTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseMetaDataTest.java
@@ -92,7 +92,7 @@ public class DatabaseMetaDataTest {
     TestUtil.createTable(con, "duplicate", "x text");
     TestUtil.execute("comment on table duplicate is 'duplicate table'", con);
     TestUtil.execute("create or replace function bar() returns integer language sql as $$ select 1 $$", con);
-    TestUtil.execute("comment on function bar is 'bar function'", con);
+    TestUtil.execute("comment on function bar() is 'bar function'", con);
     TestUtil.execute("update pg_description set objoid = 'duplicate'::regclass where objoid = 'bar'::regproc",conPriv);
 
     // 8.2 does not support arrays of composite types

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseMetaDataTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseMetaDataTest.java
@@ -64,7 +64,6 @@ public class DatabaseMetaDataTest {
 
   @Before
   public void setUp() throws Exception {
-    Connection conPriv = TestUtil.openPrivilegedDB();
     if (binaryMode == BinaryMode.FORCE) {
       final Properties props = new Properties();
       PGProperty.PREPARE_THRESHOLD.set(props, -1);
@@ -93,7 +92,9 @@ public class DatabaseMetaDataTest {
     TestUtil.execute("comment on table duplicate is 'duplicate table'", con);
     TestUtil.execute("create or replace function bar() returns integer language sql as $$ select 1 $$", con);
     TestUtil.execute("comment on function bar() is 'bar function'", con);
-    TestUtil.execute("update pg_description set objoid = 'duplicate'::regclass where objoid = 'bar'::regproc",conPriv);
+    try (Connection conPriv = TestUtil.openPrivilegedDB()) {
+      TestUtil.execute("update pg_description set objoid = 'duplicate'::regclass where objoid = 'bar'::regproc", conPriv);
+    }
 
     // 8.2 does not support arrays of composite types
     TestUtil.createTable(con, "customtable", "c1 custom, c2 _custom"


### PR DESCRIPTION
The omni CI and appveyor are failing on some of the older server versions. Couple unrelated causes.

First is #2245 added some DDL for adding a `COMMENT ON FUNCTION ... f ...` (rather than `f()`) that only works on server v10+.

Second is that some tests were creating connections but not closing them. Again on some older versions and on appveyor this was leading to connection exhaustion. Same PR had one offender and I found another in Statement Test.

Finally, the new test added in #2247 was failing on v8.4 as updating `application_name` is not supported.

This PR should fix all of that. The StatementTest change is just a wrapping that block in try-with-resources so viewing the diff with whitespaced ignored is a easier:

```diff
diff --git a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/StatementTest.java b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/StatementTest.java
index d6ef9e8b..0901e5f2 100644
--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/StatementTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/StatementTest.java
@@ -476,7 +476,7 @@ public class StatementTest {
   @Test
   public void testWarningsAreAvailableAsap()
       throws Exception {
-    final Connection outerLockCon = TestUtil.openDB();
+    try (final Connection outerLockCon = TestUtil.openDB()) {
       outerLockCon.setAutoCommit(false);
       //Acquire an exclusive lock so we can block the notice generating statement
       outerLockCon.createStatement().execute("LOCK TABLE test_lock IN ACCESS EXCLUSIVE MODE;");
@@ -529,6 +529,7 @@ public class StatementTest {
         executorService.shutdownNow();
       }
     }
+  }
 
   /**
    * <p>Demonstrates a safe approach to concurrently reading the latest
```

I've got it running the omni action on my branch: https://github.com/sehrope/pgjdbc/actions/runs/1224062070. Once it passes I'll merge this in.