### PR TITLE
fix startup regressions caused by PR #1949. Instead of checking all types by OID, we can return types for well known types

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
@@ -291,17 +291,21 @@ public class TypeInfoCache implements TypeInfo {
      */
     if (pgTypeName.endsWith("[]")) {
       return Types.ARRAY;
-    } else {
-      Integer i = (Integer) this.pgNameToSQLType.get(pgTypeName);
-      if (i != null) {
-        return i;
-      } else {
-        /*
-        All else fails then we will query the database.
-         */
-        return getSQLType(castNonNull(getPGType(pgTypeName)));
-      }
     }
+    Integer i = this.pgNameToSQLType.get(pgTypeName);
+    if (i != null) {
+      return i;
+    }
+
+    /*
+      All else fails then we will query the database.
+      save for future calls
+    */
+    i = getSQLType(castNonNull(getPGType(pgTypeName)));
+
+    pgNameToSQLType.put(pgTypeName, i);
+    return i;
+
   }
 
   public synchronized int getSQLType(int typeOid) throws SQLException {

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
@@ -291,7 +291,7 @@ public class TypeInfoCache implements TypeInfo {
      */
     if (pgTypeName.endsWith("[]")) {
       return Types.ARRAY;
-    }else {
+    } else {
       Integer i = (Integer) this.pgNameToSQLType.get(pgTypeName);
       if (i != null) {
         return i;

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
@@ -286,7 +286,22 @@ public class TypeInfoCache implements TypeInfo {
   }
 
   public synchronized int getSQLType(String pgTypeName) throws SQLException {
-    return getSQLType(castNonNull(getPGType(pgTypeName)));
+    /*
+    Get a few things out of the way such as arrays and known types
+     */
+    if (pgTypeName.endsWith("[]")) {
+      return Types.ARRAY;
+    }else {
+      Integer i = (Integer) this.pgNameToSQLType.get(pgTypeName);
+      if (i != null) {
+        return i;
+      } else {
+        /*
+        All else fails then we will query the database.
+         */
+        return getSQLType(castNonNull(getPGType(pgTypeName)));
+      }
+    }
   }
 
   public synchronized int getSQLType(int typeOid) throws SQLException {


### PR DESCRIPTION
Fixes Issue #2236 