### PR TITLE
Change org.checkerframework:checker-qual to be a compileOnly dependency

### DIFF
--- a/bom/build.gradle.kts
+++ b/bom/build.gradle.kts
@@ -41,7 +41,7 @@ dependencies {
         apiv("javax:javaee-api")
         apiv("junit:junit", "junit4")
         apiv("org.apache.felix:org.apache.felix.framework")
-        apiv("org.checkerframework:checker-qual", "checkerframework")
+        apiv("org.checkerframework:checker-qual-android", "checkerframework")
         apiv("org.hamcrest:hamcrest")
         apiv("org.hamcrest:hamcrest-core", "hamcrest")
         apiv("org.hamcrest:hamcrest-library", "hamcrest")

--- a/pgjdbc/build.gradle.kts
+++ b/pgjdbc/build.gradle.kts
@@ -54,7 +54,8 @@ dependencies {
     shaded(platform(project(":bom")))
     shaded("com.ongres.scram:client")
 
-    implementation("org.checkerframework:checker-qual")
+    compileOnly("org.checkerframework:checker-qual-android")
+    testCompileOnly("org.checkerframework:checker-qual-android")
     testImplementation("se.jiderhamn:classloader-leak-test-framework")
 }
 


### PR DESCRIPTION
Currently `checker-qual` is a Gradle implementation scope dependency and the checker-qual annotations are RUNTIME retention.

This changes to use `checker-qual-android` which has the exact same annotations as `checker-qual` but with CLASS retention. This allows us to change it to a compileOnly dependency.

Note that with checker-qual-android as a compileOnly dependency we then need to additionally explicitly add it as a testCompileOnly dependency.
