### PR TITLE
fix: handle nulls when the following clasess are used: PGbox, PGcircl…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ is executed a second time it will fail.
 - The driver returns enum and jsonb arrays elements as String objects (like in 42.2.14 and earlier versions) [PR 1879](https://github.com/pgjdbc/pgjdbc/pull/1879).
 - PgTokenizer was ignoring last empty token [PR #1882](https://github.com/pgjdbc/pgjdbc/pull/1882)
 - Remove osgi from karaf fixes Issue #1891 [PR #1902](https://github.com/pgjdbc/pgjdbc/pull/1902)
+- Handle nulls when the following clasess are used: PGbox, PGcircle, PGline, PGlseg, PGpath, PGpoint, PGpolygon, and PGmoney.
 
 ## [42.2.16] (2020-08-20)
 ### Known issues

--- a/pgjdbc/src/main/java/org/postgresql/geometric/PGcircle.java
+++ b/pgjdbc/src/main/java/org/postgresql/geometric/PGcircle.java
@@ -71,7 +71,11 @@ public class PGcircle extends PGobject implements Serializable, Cloneable {
    * @throws SQLException on conversion failure
    */
   @Override
-  public void setValue(String s) throws SQLException {
+  public void setValue(@Nullable String s) throws SQLException {
+    if (s == null) {
+      center = null;
+      return;
+    }
     PGtokenizer t = new PGtokenizer(PGtokenizer.removeAngle(s), ',');
     if (t.getSize() != 2) {
       throw new PSQLException(GT.tr("Conversion to type {0} failed: {1}.", type, s),
@@ -94,17 +98,26 @@ public class PGcircle extends PGobject implements Serializable, Cloneable {
   public boolean equals(@Nullable Object obj) {
     if (obj instanceof PGcircle) {
       PGcircle p = (PGcircle) obj;
-      return p.radius == radius && equals(p.center, center);
+      PGpoint center = this.center;
+      PGpoint pCenter = p.center;
+      if (center == null) {
+        return pCenter == null;
+      } else if (pCenter == null) {
+        return false;
+      }
+
+      return p.radius == radius && equals(pCenter, center);
     }
     return false;
   }
 
   public int hashCode() {
-    long bits = Double.doubleToLongBits(radius);
-    int v = (int)(bits ^ (bits >>> 32));
-    if (center != null) {
-      v = v * 31 + center.hashCode();
+    if (center == null) {
+      return 0;
     }
+    long bits = Double.doubleToLongBits(radius);
+    int v = (int) (bits ^ (bits >>> 32));
+    v = v * 31 + center.hashCode();
     return v;
   }
 
@@ -119,7 +132,7 @@ public class PGcircle extends PGobject implements Serializable, Cloneable {
   /**
    * @return the PGcircle in the syntax expected by org.postgresql
    */
-  public String getValue() {
-    return "<" + center + "," + radius + ">";
+  public @Nullable String getValue() {
+    return center == null ? null : "<" + center + "," + radius + ">";
   }
 }

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
@@ -651,14 +651,14 @@ public class PgConnection implements BaseConnection {
           PGBinaryObject binObj = (PGBinaryObject) obj;
           binObj.setByteValue(byteValue, 0);
         } else {
-          obj.setValue(castNonNull(value));
+          obj.setValue(value);
         }
       } else {
         // If className is null, then the type is unknown.
         // so return a PGobject with the type set, and the value set
         obj = new PGobject();
         obj.setType(type);
-        obj.setValue(castNonNull(value));
+        obj.setValue(value);
       }
 
       return obj;

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
@@ -489,7 +489,12 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
 
     if ((x instanceof PGBinaryObject) && connection.binaryTransferSend(oid)) {
       PGBinaryObject binObj = (PGBinaryObject) x;
-      byte[] data = new byte[binObj.lengthInBytes()];
+      int length = binObj.lengthInBytes();
+      if (length == 0) {
+        preparedParameters.setNull(parameterIndex, oid);
+        return;
+      }
+      byte[] data = new byte[length];
       binObj.toBytes(data, 0);
       bindBytes(parameterIndex, data, oid);
     } else {

--- a/pgjdbc/src/main/java/org/postgresql/util/PGmoney.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/PGmoney.java
@@ -20,6 +20,11 @@ public class PGmoney extends PGobject implements Serializable, Cloneable {
   public double val;
 
   /**
+   * If the object represents {@code null::money}
+   */
+  public boolean isNull;
+
+  /**
    * @param value of field
    */
   public PGmoney(double value) {
@@ -40,7 +45,11 @@ public class PGmoney extends PGobject implements Serializable, Cloneable {
     type = "money";
   }
 
-  public void setValue(String s) throws SQLException {
+  public void setValue(@Nullable String s) throws SQLException {
+    isNull = s == null;
+    if (s == null) {
+      return;
+    }
     try {
       String s1;
       boolean negative;
@@ -68,6 +77,9 @@ public class PGmoney extends PGobject implements Serializable, Cloneable {
 
   @Override
   public int hashCode() {
+    if (isNull) {
+      return 0;
+    }
     final int prime = 31;
     int result = super.hashCode();
     long temp;
@@ -79,12 +91,20 @@ public class PGmoney extends PGobject implements Serializable, Cloneable {
   public boolean equals(@Nullable Object obj) {
     if (obj instanceof PGmoney) {
       PGmoney p = (PGmoney) obj;
+      if (isNull) {
+        return p.isNull;
+      } else if (p.isNull) {
+        return false;
+      }
       return val == p.val;
     }
     return false;
   }
 
-  public String getValue() {
+  public @Nullable String getValue() {
+    if (isNull) {
+      return null;
+    }
     if (val < 0) {
       return "-$" + (-val);
     } else {

--- a/pgjdbc/src/main/java/org/postgresql/util/PGobject.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/PGobject.java
@@ -43,7 +43,7 @@ public class PGobject implements Serializable, Cloneable {
    * @param value a string representation of the value of the object
    * @throws SQLException thrown if value is invalid for this type
    */
-  public void setValue(String value) throws SQLException {
+  public void setValue(@Nullable String value) throws SQLException {
     this.value = value;
   }
 
@@ -53,7 +53,7 @@ public class PGobject implements Serializable, Cloneable {
    * @return the type name of this object
    */
   public final String getType() {
-    return castNonNull(type);
+    return castNonNull(type, "PGobject#type is uninitialized. Please call setType(String)");
   }
 
   /**
@@ -64,6 +64,16 @@ public class PGobject implements Serializable, Cloneable {
    */
   public @Nullable String getValue() {
     return value;
+  }
+
+  /**
+   * Returns true if the current object wraps `null` value.
+   * This might be helpful
+   *
+   * @return true if the current object wraps `null` value.
+   */
+  public boolean isNull() {
+    return getValue() != null;
   }
 
   /**

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PGObjectGetTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PGObjectGetTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2020, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.test.jdbc2;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.postgresql.geometric.PGbox;
+import org.postgresql.geometric.PGcircle;
+import org.postgresql.geometric.PGline;
+import org.postgresql.geometric.PGlseg;
+import org.postgresql.geometric.PGpath;
+import org.postgresql.geometric.PGpoint;
+import org.postgresql.geometric.PGpolygon;
+import org.postgresql.util.PGInterval;
+import org.postgresql.util.PGmoney;
+import org.postgresql.util.PGobject;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collection;
+
+@RunWith(Parameterized.class)
+public class PGObjectGetTest extends BaseTest4 {
+  private final String sqlExpression;
+  private final Class<? extends PGobject> type;
+  private final String expected;
+  private final String stringValue;
+
+  public PGObjectGetTest(BinaryMode binaryMode, String sqlExpression,
+      Class<? extends PGobject> type, String expected, String stringValue) {
+    setBinaryMode(binaryMode);
+    this.sqlExpression = sqlExpression;
+    this.type = type;
+    this.expected = expected;
+    this.stringValue = stringValue;
+  }
+
+  @Parameterized.Parameters(name = "binary = {0}, sql = {1}, type = {2}")
+  public static Iterable<Object[]> data() {
+    Collection<Object[]> ids = new ArrayList<Object[]>();
+    for (BinaryMode binaryMode : BinaryMode.values()) {
+      ids.add(new Object[]{binaryMode, "null::inet", PGobject.class,
+          "PGobject(type=inet, value=null)", null});
+      ids.add(new Object[]{binaryMode, "null::box", PGbox.class,
+          "PGbox(type=box, value=null)", null});
+      ids.add(new Object[]{binaryMode, "null::circle", PGcircle.class,
+          "PGcircle(type=circle, value=null)", null});
+      ids.add(new Object[]{binaryMode, "null::line", PGline.class,
+          "PGline(type=line, value=null)", null});
+      ids.add(new Object[]{binaryMode, "null::lseg", PGlseg.class,
+          "PGlseg(type=lseg, value=null)", null});
+      ids.add(new Object[]{binaryMode, "null::path", PGpath.class,
+          "PGpath(type=path, value=null)", null});
+      ids.add(new Object[]{binaryMode, "null::point", PGpoint.class,
+          "PGpoint(type=point, value=null)", null});
+      ids.add(new Object[]{binaryMode, "null::polygon", PGpolygon.class,
+          "PGpolygon(type=polygon, value=null)", null});
+      ids.add(new Object[]{binaryMode, "null::money", PGmoney.class,
+          "PGmoney(type=money, value=null)", null});
+      ids.add(new Object[]{binaryMode, "null::interval", PGInterval.class,
+          "PGInterval(type=interval, value=null)", null});
+    }
+    return ids;
+  }
+
+  @Test
+  public void getAsPGobject() throws SQLException {
+    testGet(sqlExpression, expected, PGobject.class);
+  }
+
+  @Test
+  public void getAsPGobjectSubtype() throws SQLException {
+    testGet(sqlExpression, expected, type);
+  }
+
+  @Test
+  public void getAsString() throws SQLException {
+    PreparedStatement ps = con.prepareStatement("select " + sqlExpression);
+    ResultSet rs = ps.executeQuery();
+    rs.next();
+    assertEquals(
+        "'" + sqlExpression + "'.getString(1)",
+        stringValue,
+        rs.getString(1)
+    );
+  }
+
+  private void testGet(final String s, String expected, Class<? extends PGobject> type) throws SQLException {
+    PreparedStatement ps = con.prepareStatement("select " + s);
+    ResultSet rs = ps.executeQuery();
+    rs.next();
+    assertEquals(
+        "'" + s + "'.getObject(1, " + type.getSimpleName() + ".class)",
+        expected,
+        printObject(rs.getObject(1, type))
+    );
+    if (expected.contains("value=null)")) {
+      // For some reason we return objects as nulls
+      assertNull(
+          "'select " + s + "'.getObject(1)",
+          rs.getObject(1)
+      );
+    } else {
+      assertEquals(
+          "'select " + s + "'.getObject(1)",
+          expected,
+          printObject(rs.getObject(1))
+      );
+    }
+  }
+
+  String printObject(@Nullable Object object) {
+    if (!(object instanceof PGobject)) {
+      return String.valueOf(object);
+    }
+    PGobject pg = (PGobject) object;
+    return pg.getClass().getSimpleName() + "(type=" + pg.getType() + ", value=" + pg.getValue() + ")";
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PGObjectSetTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PGObjectSetTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2020, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.test.jdbc2;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.postgresql.geometric.PGbox;
+import org.postgresql.geometric.PGcircle;
+import org.postgresql.geometric.PGline;
+import org.postgresql.geometric.PGlseg;
+import org.postgresql.geometric.PGpath;
+import org.postgresql.geometric.PGpoint;
+import org.postgresql.geometric.PGpolygon;
+import org.postgresql.util.PGInterval;
+import org.postgresql.util.PGmoney;
+import org.postgresql.util.PGobject;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.lang.reflect.InvocationTargetException;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collection;
+
+@RunWith(Parameterized.class)
+public class PGObjectSetTest extends BaseTest4 {
+  private final String typeName;
+  private final String expected;
+  private final Class<? extends PGobject> type;
+
+  public PGObjectSetTest(BinaryMode binaryMode, Class<? extends PGobject> type,
+      String typeName, String expected) {
+    setBinaryMode(binaryMode);
+    this.expected = expected;
+    this.type = type;
+    this.typeName = typeName;
+  }
+
+  @Parameterized.Parameters(name = "binary = {0}, sql = {2}, type = {1}")
+  public static Iterable<Object[]> data() {
+    Collection<Object[]> ids = new ArrayList<Object[]>();
+    for (BinaryMode binaryMode : BinaryMode.values()) {
+      ids.add(new Object[]{binaryMode, PGobject.class, "inet",
+          "PGobject(type=inet, value=null)"});
+      ids.add(new Object[]{binaryMode, PGbox.class, "box",
+          "PGbox(type=box, value=null)"});
+      ids.add(new Object[]{binaryMode, PGcircle.class, "circle",
+          "PGcircle(type=circle, value=null)"});
+      ids.add(new Object[]{binaryMode, PGline.class, "line",
+          "PGline(type=line, value=null)"});
+      ids.add(new Object[]{binaryMode, PGlseg.class, "lseg",
+          "PGlseg(type=lseg, value=null)"});
+      ids.add(new Object[]{binaryMode, PGpath.class, "path",
+          "PGpath(type=path, value=null)"});
+      ids.add(new Object[]{binaryMode, PGpoint.class, "point",
+          "PGpoint(type=point, value=null)"});
+      ids.add(new Object[]{binaryMode, PGpolygon.class, "polygon",
+          "PGpolygon(type=polygon, value=null)"});
+      ids.add(new Object[]{binaryMode, PGmoney.class, "money",
+          "PGmoney(type=money, value=null)"});
+      ids.add(new Object[]{binaryMode, PGInterval.class, "interval",
+          "PGInterval(type=interval, value=null)"});
+    }
+    return ids;
+  }
+
+  @Test
+  public void setNullAsPGobject() throws SQLException {
+    PGobject object = new PGobject();
+    object.setType(typeName);
+    object.setValue(null);
+    testSet(object, expected, PGobject.class);
+  }
+
+  @Test
+  public void setNullAsPGobjectSubtype() throws SQLException, NoSuchMethodException,
+      IllegalAccessException, InvocationTargetException, InstantiationException {
+    if (type == PGobject.class) {
+      // We can't use PGobject without setType
+      return;
+    }
+    PGobject object = type.getConstructor().newInstance();
+    object.setValue(null);
+    testSet(object, expected, type);
+  }
+
+  private void testSet(PGobject value, String expected, Class<? extends PGobject> type) throws SQLException {
+    PreparedStatement ps = con.prepareStatement("select ?::" + value.getType());
+    ps.setObject(1, value);
+    ResultSet rs = ps.executeQuery();
+    rs.next();
+    assertEquals(
+        "'select ?::" + value.getType() + "'.withParam(" + printObject(value) + ").getObject(1, " + type.getSimpleName() + ".class)",
+        expected,
+        printObject(rs.getObject(1, type))
+    );
+    if (expected.contains("value=null)")) {
+      assertNull(
+          "'select ?::" + value.getType() + "'.withParam(" + printObject(value) + ").getObject(1)",
+          rs.getObject(1)
+      );
+    } else {
+      assertEquals(
+          "'select ?::" + value.getType() + "'.withParam(" + printObject(value) + ").getObject(1)",
+          expected,
+          printObject(rs.getObject(1))
+      );
+    }
+  }
+
+  String printObject(@Nullable Object object) {
+    if (!(object instanceof PGobject)) {
+      return String.valueOf(object);
+    }
+    PGobject pg = (PGobject) object;
+    return pg.getClass().getSimpleName() + "(type=" + pg.getType() + ", value=" + pg.getValue() + ")";
+  }
+}


### PR DESCRIPTION
…e, PGline, PGlseg, PGpath, PGpoint, PGpolygon, and PGmoney

1) PGobject.setValue(null) can be used to set the wrapped value to null
Note: previously the sub-classes of PGobject threw NPE for setValue(null)
2) Return null from `getValue` in case the typed null is received from the database
3) Assume PGBinaryObject#lengthInBytes == 0 means the value should be set as null when sending data to the database

see #1870

### All Submissions:

* [ ] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Does `./gradlew autostyleCheck checkstyleAll` pass ?
3. [ ] Have you added your new test classes to an existing test suite in alphabetical order?

### Changes to Existing Features:

* [ ] Does this break existing behaviour? If so please explain.
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
