### PR TITLE
fix: Provide useful error message for empty or missing passwords for SCRAM auth

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java
@@ -765,6 +765,18 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
               case AUTH_REQ_SASL:
                 LOGGER.log(Level.FINEST, " <=BE AuthenticationSASL");
 
+                if (password == null) {
+                  throw new PSQLException(
+                      GT.tr(
+                          "The server requested SCRAM-based authentication, but no password was provided."),
+                      PSQLState.CONNECTION_REJECTED);
+                }
+                if (password.equals("")) {
+                  throw new PSQLException(
+                      GT.tr(
+                          "The server requested SCRAM-based authentication, but the password is an empty string."),
+                      PSQLState.CONNECTION_REJECTED);
+                }
                 scramAuthenticator = new org.postgresql.jre7.sasl.ScramAuthenticator(user, castNonNull(password), pgStream);
                 scramAuthenticator.processServerMechanismsAndInit();
                 scramAuthenticator.sendScramClientFirstMessage();


### PR DESCRIPTION
Fixes #2288 to provide better error messages if the password is missing or empty during SCRAM auth.

### All Submissions:

* [X] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [X] Does your submission pass tests?
2. [X] Does `./gradlew autostyleCheck checkstyleAll` pass ?

### Changes to Existing Features:

* [ ] Does this break existing behaviour? If so please explain.
* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you written new tests for your core changes, as applicable?
* [X] Have you successfully run tests with your changes locally?
