### PR TITLE
fix: use local TimestampUtil in PgStatement and PgResultset for thread safety

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgCallableStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgCallableStatement.java
@@ -452,7 +452,7 @@ class PgCallableStatement extends PgPreparedStatement implements CallableStateme
     }
 
     String value = result.toString();
-    return connection.getTimestampUtils().toDate(cal, value);
+    return getTimestampUtils().toDate(cal, value);
   }
 
   public @Nullable Time getTime(int i, java.util.@Nullable Calendar cal) throws SQLException {
@@ -463,7 +463,7 @@ class PgCallableStatement extends PgPreparedStatement implements CallableStateme
     }
 
     String value = result.toString();
-    return connection.getTimestampUtils().toTime(cal, value);
+    return getTimestampUtils().toTime(cal, value);
   }
 
   public @Nullable Timestamp getTimestamp(int i, java.util.@Nullable Calendar cal) throws SQLException {
@@ -474,7 +474,7 @@ class PgCallableStatement extends PgPreparedStatement implements CallableStateme
     }
 
     String value = result.toString();
-    return connection.getTimestampUtils().toTimestamp(cal, value);
+    return getTimestampUtils().toTimestamp(cal, value);
   }
 
   public void registerOutParameter(@Positive int parameterIndex, int sqlType, String typeName)

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
@@ -595,7 +595,7 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
             setDate(parameterIndex, (java.time.LocalDate) in);
             break;
           } else {
-            tmpd = connection.getTimestampUtils().toDate(getDefaultCalendar(), in.toString());
+            tmpd = getTimestampUtils().toDate(getDefaultCalendar(), in.toString());
           }
           setDate(parameterIndex, tmpd);
         }
@@ -611,7 +611,7 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
             setTime(parameterIndex, (java.time.LocalTime) in);
             break;
           } else {
-            tmpt = connection.getTimestampUtils().toTime(getDefaultCalendar(), in.toString());
+            tmpt = getTimestampUtils().toTime(getDefaultCalendar(), in.toString());
           }
           setTime(parameterIndex, tmpt);
         }
@@ -629,7 +629,7 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
             setTimestamp(parameterIndex, (java.time.LocalDateTime) in);
             break;
           } else {
-            tmpts = connection.getTimestampUtils().toTimestamp(getDefaultCalendar(), in.toString());
+            tmpts = getTimestampUtils().toTimestamp(getDefaultCalendar(), in.toString());
           }
           setTimestamp(parameterIndex, tmpts);
         }
@@ -1310,7 +1310,7 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
     if (connection.binaryTransferSend(Oid.DATE)) {
       byte[] val = new byte[4];
       TimeZone tz = cal != null ? cal.getTimeZone() : null;
-      connection.getTimestampUtils().toBinDate(tz, val, d);
+      getTimestampUtils().toBinDate(tz, val, d);
       preparedParameters.setBinaryParameter(i, val, Oid.DATE);
       return;
     }
@@ -1337,7 +1337,7 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
     if (cal == null) {
       cal = getDefaultCalendar();
     }
-    bindString(i, connection.getTimestampUtils().toString(cal, d), Oid.UNSPECIFIED);
+    bindString(i, getTimestampUtils().toString(cal, d), Oid.UNSPECIFIED);
   }
 
   public void setTime(@Positive int i, @Nullable Time t,
@@ -1365,7 +1365,7 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
     if (cal == null) {
       cal = getDefaultCalendar();
     }
-    bindString(i, connection.getTimestampUtils().toString(cal, t), oid);
+    bindString(i, getTimestampUtils().toString(cal, t), oid);
   }
 
   public void setTimestamp(@Positive int i, @Nullable Timestamp t,
@@ -1422,29 +1422,29 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
     if (cal == null) {
       cal = getDefaultCalendar();
     }
-    bindString(i, connection.getTimestampUtils().toString(cal, t), oid);
+    bindString(i, getTimestampUtils().toString(cal, t), oid);
   }
 
   private void setDate(@Positive int i, java.time.LocalDate localDate) throws SQLException {
     int oid = Oid.DATE;
-    bindString(i, connection.getTimestampUtils().toString(localDate), oid);
+    bindString(i, getTimestampUtils().toString(localDate), oid);
   }
 
   private void setTime(@Positive int i, java.time.LocalTime localTime) throws SQLException {
     int oid = Oid.TIME;
-    bindString(i, connection.getTimestampUtils().toString(localTime), oid);
+    bindString(i, getTimestampUtils().toString(localTime), oid);
   }
 
   private void setTimestamp(@Positive int i, java.time.LocalDateTime localDateTime)
       throws SQLException {
     int oid = Oid.TIMESTAMP;
-    bindString(i, connection.getTimestampUtils().toString(localDateTime), oid);
+    bindString(i, getTimestampUtils().toString(localDateTime), oid);
   }
 
   private void setTimestamp(@Positive int i, java.time.OffsetDateTime offsetDateTime)
       throws SQLException {
     int oid = Oid.TIMESTAMPTZ;
-    bindString(i, connection.getTimestampUtils().toString(offsetDateTime), oid);
+    bindString(i, getTimestampUtils().toString(offsetDateTime), oid);
   }
 
   public ParameterMetaData createParameterMetaData(BaseConnection conn, int[] oids)
@@ -1638,11 +1638,10 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
   }
 
   private Calendar getDefaultCalendar() {
-    TimestampUtils timestampUtils = connection.getTimestampUtils();
-    if (timestampUtils.hasFastDefaultTimeZone()) {
-      return timestampUtils.getSharedCalendar(null);
+    if (getTimestampUtils().hasFastDefaultTimeZone()) {
+      return getTimestampUtils().getSharedCalendar(null);
     }
-    Calendar sharedCalendar = timestampUtils.getSharedCalendar(defaultTimeZone);
+    Calendar sharedCalendar = getTimestampUtils().getSharedCalendar(defaultTimeZone);
     if (defaultTimeZone == null) {
       defaultTimeZone = sharedCalendar.getTimeZone();
     }

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
@@ -14,6 +14,7 @@ import org.postgresql.core.BaseStatement;
 import org.postgresql.core.Encoding;
 import org.postgresql.core.Field;
 import org.postgresql.core.Oid;
+import org.postgresql.core.Provider;
 import org.postgresql.core.Query;
 import org.postgresql.core.ResultCursor;
 import org.postgresql.core.ResultHandlerBase;
@@ -4023,7 +4024,7 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
 
   private TimestampUtils getTimestampUtils() {
     if (timestampUtils == null) {
-      timestampUtils = new TimestampUtils(! connection.getQueryExecutor().getIntegerDateTimes(), new QueryExecutorTimeZoneProvider(connection.getQueryExecutor()));
+        timestampUtils = new TimestampUtils(! connection.getQueryExecutor().getIntegerDateTimes(), (Provider< TimeZone>)new QueryExecutorTimeZoneProvider(connection.getQueryExecutor()));
     }
     return timestampUtils;
   }

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
@@ -4024,7 +4024,7 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
 
   private TimestampUtils getTimestampUtils() {
     if (timestampUtils == null) {
-        timestampUtils = new TimestampUtils(! connection.getQueryExecutor().getIntegerDateTimes(), (Provider< TimeZone>)new QueryExecutorTimeZoneProvider(connection.getQueryExecutor()));
+      timestampUtils = new TimestampUtils(! connection.getQueryExecutor().getIntegerDateTimes(), (Provider<TimeZone>)new QueryExecutorTimeZoneProvider(connection.getQueryExecutor()));
     }
     return timestampUtils;
   }

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgStatement.java
@@ -13,6 +13,7 @@ import org.postgresql.core.BaseStatement;
 import org.postgresql.core.CachedQuery;
 import org.postgresql.core.Field;
 import org.postgresql.core.ParameterList;
+import org.postgresql.core.Provider;
 import org.postgresql.core.Query;
 import org.postgresql.core.QueryExecutor;
 import org.postgresql.core.ResultCursor;
@@ -35,6 +36,7 @@ import java.sql.SQLWarning;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.TimeZone;
 import java.util.TimerTask;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
@@ -1296,7 +1298,7 @@ public class PgStatement implements Statement, BaseStatement {
 
   protected TimestampUtils getTimestampUtils() {
     if (timestampUtils == null) {
-      timestampUtils = new TimestampUtils(! connection.getQueryExecutor().getIntegerDateTimes(), new QueryExecutorTimeZoneProvider(connection.getQueryExecutor()));
+        timestampUtils = new TimestampUtils(! connection.getQueryExecutor().getIntegerDateTimes(), (Provider<TimeZone>) new QueryExecutorTimeZoneProvider(connection.getQueryExecutor()));
     }
     return timestampUtils;
   }

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgStatement.java
@@ -147,6 +147,8 @@ public class PgStatement implements Statement, BaseStatement {
 
   protected boolean adaptiveFetch = false;
 
+  private @Nullable TimestampUtils timestampUtils; // our own Object because it's not thread safe
+
   @SuppressWarnings("method.invocation.invalid")
   PgStatement(PgConnection c, int rsType, int rsConcurrency, int rsHoldability)
       throws SQLException {
@@ -1292,4 +1294,10 @@ public class PgStatement implements Statement, BaseStatement {
     return adaptiveFetch;
   }
 
+  protected TimestampUtils getTimestampUtils() {
+    if (timestampUtils == null) {
+      timestampUtils = new TimestampUtils(! connection.getQueryExecutor().getIntegerDateTimes(), new QueryExecutorTimeZoneProvider(connection.getQueryExecutor()));
+    }
+    return timestampUtils;
+  }
 }

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgStatement.java
@@ -1298,7 +1298,7 @@ public class PgStatement implements Statement, BaseStatement {
 
   protected TimestampUtils getTimestampUtils() {
     if (timestampUtils == null) {
-        timestampUtils = new TimestampUtils(! connection.getQueryExecutor().getIntegerDateTimes(), (Provider<TimeZone>) new QueryExecutorTimeZoneProvider(connection.getQueryExecutor()));
+      timestampUtils = new TimestampUtils(! connection.getQueryExecutor().getIntegerDateTimes(), (Provider<TimeZone>) new QueryExecutorTimeZoneProvider(connection.getQueryExecutor()));
     }
     return timestampUtils;
   }


### PR DESCRIPTION
TimestampUtil is not thread safe. It raises exeptions when multiple
Threads use ResultSets of one
connection. If PgStatement and PgResultSet use their own TimestampUtil
no synchronize is needed.

Issue: fix: synchronize modification of shared calendar (#921)

