### PR TITLE
Fix typo in TimestampUtils.java

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/TimestampUtils.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/TimestampUtils.java
@@ -1461,7 +1461,7 @@ public class TimestampUtils {
     // java epoc to postgres epoc
     secs -= 946684800L;
 
-    // Julian/Greagorian calendar cutoff point
+    // Julian/Gregorian calendar cutoff point
     if (secs < -13165977600L) { // October 15, 1582 -> October 4, 1582
       secs -= 86400 * 10;
       if (secs < -15773356800L) { // 1500-03-01 -> 1500-02-28


### PR DESCRIPTION
Change `Greagorian` to `Gregorian`.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

