### PR TITLE
remove check for negative pid in cancel request. Apparently pgbouncer can send one fixes Issue #2318

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/QueryExecutorBase.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/QueryExecutorBase.java
@@ -169,9 +169,6 @@ public abstract class QueryExecutorBase implements QueryExecutor {
 
   @Override
   public void sendQueryCancel() throws SQLException {
-    if (cancelPid <= 0) {
-      return;
-    }
 
     PGStream cancelStream = null;
 


### PR DESCRIPTION
The protocol does not forbid it.