### PR TITLE
perf: read in_hot_standby GUC on connection

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java
@@ -878,7 +878,7 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
    * during initial connection:</p>
    *
    * <ul>
-   * <li>{@code in_hot_standby} was reported and the value was "on" them the server is replica
+   * <li>{@code in_hot_standby} was reported and the value was "on" then the server is a replica
    * and database is read-only by definition, false is returned.</li>
    * <li>{@code in_hot_standby} was reported and the value was "off"
    * then the server is indeed primary but database may be in

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java
@@ -76,6 +76,8 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
   private static final int AUTH_REQ_SASL_CONTINUE = 11;
   private static final int AUTH_REQ_SASL_FINAL = 12;
 
+  private static final String IN_HOT_STANDBY = "in_hot_standby";
+
   private ISSPIClient createSSPI(PGStream pgStream,
       @Nullable String spnServiceClass,
       boolean enableNegotiate) {
@@ -864,7 +866,7 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
   }
 
   private boolean isPrimary(QueryExecutor queryExecutor) throws SQLException, IOException {
-    String inHotStandby = queryExecutor.getParameterStatus("in_hot_standby");
+    String inHotStandby = queryExecutor.getParameterStatus(IN_HOT_STANDBY);
     if (inHotStandby != null && inHotStandby.equalsIgnoreCase("on")) {
       return false;
     }

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -99,6 +99,7 @@ public class QueryExecutorImpl extends QueryExecutorBase {
     Encoding.canonicalize("TimeZone");
     Encoding.canonicalize("UTF8");
     Encoding.canonicalize("UTF-8");
+    Encoding.canonicalize("in_hot_standby");
   }
 
   /**


### PR DESCRIPTION
<details>
  <summary>PR checklist</summary>

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Does `./gradlew autostyleCheck checkstyleAll` pass ?

### Changes to Existing Features:

* [ ] Does this break existing behaviour? If so please explain.
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

  
</details>

Since PG 14 reports `in_hot_standby` GUC on connection there is an opportunity to skip `show transaction_read_only` query during new connection opening phase.