### PR TITLE
test: Fix DatabaseMetadataTest to perform mview tests only on 9.3+

### DIFF
--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseMetaDataTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseMetaDataTest.java
@@ -18,6 +18,7 @@ import org.postgresql.test.jdbc2.BaseTest4.BinaryMode;
 
 import org.junit.After;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -82,7 +83,6 @@ public class DatabaseMetaDataTest {
     TestUtil.createTable(con, "arraytable", "a numeric(5,2)[], b varchar(100)[]");
     TestUtil.createTable(con, "intarraytable", "a int4[], b int4[][]");
     TestUtil.createView(con, "viewtest", "SELECT id, quest FROM metadatatest");
-    TestUtil.createMaterializedView(con, "matviewtest", "SELECT id, quest FROM metadatatest");
     TestUtil.dropType(con, "custom");
     TestUtil.dropType(con, "_custom");
     TestUtil.createCompositeType(con, "custom", "i int", false);
@@ -145,7 +145,6 @@ public class DatabaseMetaDataTest {
     TestUtil.dropTable(con, "duplicate");
 
     TestUtil.dropView(con, "viewtest");
-    TestUtil.dropMaterializedView(con, "matviewtest");
     TestUtil.dropTable(con, "metadatatest");
     TestUtil.dropTable(con, "sercoltest");
     TestUtil.dropSequence(con, "sercoltest_b_seq");
@@ -670,7 +669,13 @@ public class DatabaseMetaDataTest {
 
   @Test
   public void testMaterializedViewPrivileges() throws SQLException {
-    relationPrivilegesHelper("matviewtest");
+    Assume.assumeTrue(TestUtil.haveMinimumServerVersion(con, ServerVersion.v9_3));
+    TestUtil.createMaterializedView(con, "matviewtest", "SELECT id, quest FROM metadatatest");
+    try {
+      relationPrivilegesHelper("matviewtest");
+    } finally {
+      TestUtil.dropMaterializedView(con, "matviewtest");
+    }
   }
 
   @Test


### PR DESCRIPTION
The new mview metadata tests in #2209 broke the omni build on the older platforms that do not support mviews: https://github.com/pgjdbc/pgjdbc/runs/4202223480?check_suite_focus=true#step:11:491

This PR fixes those tests to only be enabled on 9.3+ where mviews are supported.

Tested in the omni action in my repo, at https://github.com/sehrope/pgjdbc/actions/runs/1458865278, so once this passes style etc in CI I'll merge it.