### PR TITLE
Make SingleCertValidatingFactory initialization with ENV treat spaces like newlines

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/ssl/SingleCertValidatingFactory.java
+++ b/pgjdbc/src/main/java/org/postgresql/ssl/SingleCertValidatingFactory.java
@@ -58,7 +58,7 @@ import javax.net.ssl.X509TrustManager;
  * <tr>
  *     <td><code>env:</code></td>
  *     <td><code>env:mydb_cert</code></td>
- *     <td>Loaded from string value of the <code>mydb_cert</code> environment variable.</td>
+ *     <td>Loaded from string value of the <code>mydb_cert</code> environment variable. Spaces are converted to line separators</td>
  * </tr>
  * <tr>
  *     <td><code>sys:</code></td>

--- a/pgjdbc/src/main/java/org/postgresql/ssl/SingleCertValidatingFactory.java
+++ b/pgjdbc/src/main/java/org/postgresql/ssl/SingleCertValidatingFactory.java
@@ -125,6 +125,7 @@ public class SingleCertValidatingFactory extends WrappedFactory {
           throw new GeneralSecurityException(GT.tr(
               "The environment variable containing the server's SSL certificate must not be empty."));
         }
+        cert = cert.replaceAll(" ", System.lineSeparator());
         in = new ByteArrayInputStream(cert.getBytes(StandardCharsets.UTF_8));
       } else if (sslFactoryArg.startsWith(SYS_PROP_PREFIX)) {
         String name = sslFactoryArg.substring(SYS_PROP_PREFIX.length());


### PR DESCRIPTION
Described in https://github.com/pgjdbc/pgjdbc/issues/2342
- made SingleCertValidatingFactory initialization with ENV treat spaces like newlines
- Updated doc to reflect this change
### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes to Existing Features:

* [x] Does this break existing behaviour? If so please explain.
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
