### PR TITLE
fix Issue #2300. The spec says that calling close() on a closed connection is a noop.

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
@@ -733,7 +733,7 @@ public class PgConnection implements BaseConnection {
   /**
    * <B>Note:</B> even though {@code Statement} is automatically closed when it is garbage
    * collected, it is better to close it explicitly to lower resource consumption.
-   * The spec says that calling close on a closed connection is a noop
+   * The spec says that calling close on a closed connection is a no-op.
    *
    * {@inheritDoc}
    */

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
@@ -744,15 +744,12 @@ public class PgConnection implements BaseConnection {
       // When that happens the connection is still registered in the finalizer queue, so it gets finalized
       return;
     }
-    // this should not be necessary, but adding it to be cautious
-    synchronized ( queryExecutor ) {
       if (queryExecutor.isClosed()) {
         return;
       }
       releaseTimer();
       queryExecutor.close();
       openStackTrace = null;
-    }
   }
 
   @Override

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
@@ -744,12 +744,12 @@ public class PgConnection implements BaseConnection {
       // When that happens the connection is still registered in the finalizer queue, so it gets finalized
       return;
     }
-      if (queryExecutor.isClosed()) {
-        return;
-      }
-      releaseTimer();
-      queryExecutor.close();
-      openStackTrace = null;
+    if (queryExecutor.isClosed()) {
+      return;
+    }
+    releaseTimer();
+    queryExecutor.close();
+    openStackTrace = null;
   }
 
   @Override


### PR DESCRIPTION
Previously we did not honour this requirement.

Honestly not sure if the synchronization is necessary. Thoughts ?

Fixes Issue #2300 
