### PR TITLE
Add plugin manager to allow dynamically supplying passwords

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ In addition to the standard connection parameters the driver supports a number o
 | adaptiveFetchMaximum          | Integer | -1      | Specifies maximum number of rows, which can be calculated by adaptiveFetch. Number of rows used by adaptiveFetch cannot go above this value. Any negative number set as adaptiveFetchMaximum is used by adaptiveFetch as infinity number of rows.
 | localSocketAddress            | String  | null    | Hostname or IP address given to explicitly configure the interface that the driver will bind the client side of the TCP/IP connection to when connecting.
 | quoteReturningIdentifiers     | Boolean | true    | By default we double quote returning identifiers. Some ORM's already quote them. Switch allows them to turn this off
+| authenticationPluginClassName | String  | null    | Fully qualified class name of the class implementing the AuthenticationPlugin interface. If this is null, the password value in the connection properties will be used.
 
 ## Contributing
 For information on how to contribute to the project see the [Contributing Guidelines](CONTRIBUTING.md)

--- a/docs/documentation/head/connect.md
+++ b/docs/documentation/head/connect.md
@@ -586,6 +586,11 @@ Connection conn = DriverManager.getConnection(url);
   If we quote them, then we end up sending ""colname"" to the backend instead of "colname"
   which will not be found.
 
+* **authenticationPluginClassName** == String
+
+  Fully qualified class name of the class implementing the AuthenticationPlugin interface.
+  If this is null, the password value in the connection properties will be used.
+
 <a name="unix sockets"></a>
 ## Unix sockets
 

--- a/pgjdbc/src/main/java/org/postgresql/Driver.java
+++ b/pgjdbc/src/main/java/org/postgresql/Driver.java
@@ -465,7 +465,7 @@ public class Driver implements java.sql.Driver {
    * @throws SQLException if the connection could not be made
    */
   private static Connection makeConnection(String url, Properties props) throws SQLException {
-    return new PgConnection(hostSpecs(props), user(props), database(props), props, url);
+    return new PgConnection(hostSpecs(props), props, url);
   }
 
   /**
@@ -730,20 +730,6 @@ public class Driver implements java.sql.Driver {
       hostSpecs[i] = new HostSpec(hosts[i], Integer.parseInt(ports[i]), localSocketAddress);
     }
     return hostSpecs;
-  }
-
-  /**
-   * @return the username of the URL
-   */
-  private static String user(Properties props) {
-    return props.getProperty("user", "");
-  }
-
-  /**
-   * @return the database name of the URL
-   */
-  private static String database(Properties props) {
-    return props.getProperty("PGDBNAME", "");
   }
 
   /**

--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -83,6 +83,16 @@ public enum PGProperty {
       "Assume the server is at least that version"),
 
   /**
+   * AuthenticationPluginClass
+   */
+
+  AUTHENTICATION_PLUGIN_CLASS_NAME(
+      "authenticationPluginClassName",
+      null,
+      "Name of class which implements AuthenticationPlugin"
+  ),
+
+  /**
    * Specifies what the driver should do if a query fails. In {@code autosave=always} mode, JDBC driver sets a savepoint before each query,
    * and rolls back to that savepoint in case of failure. In {@code autosave=never} mode (default), no savepoint dance is made ever.
    * In {@code autosave=conservative} mode, savepoint is set for each query, however the rollback is done only for rare cases

--- a/pgjdbc/src/main/java/org/postgresql/core/AuthenticationPluginManager.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/AuthenticationPluginManager.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2021, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.core;
+
+import org.postgresql.PGProperty;
+import org.postgresql.plugin.AuthenticationPlugin;
+import org.postgresql.plugin.AuthenticationRequestType;
+import org.postgresql.util.GT;
+import org.postgresql.util.ObjectFactory;
+import org.postgresql.util.PSQLException;
+import org.postgresql.util.PSQLState;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Properties;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class AuthenticationPluginManager {
+  private static final Logger LOGGER = Logger.getLogger(AuthenticationPluginManager.class.getName());
+
+  private AuthenticationPluginManager() {
+  }
+
+  /**
+   * If a password is requested by the server during connection initiation, this
+   * method will be invoked to supply the password. This method will only be
+   * invoked if the server actually requests a password, e.g. trust authentication
+   * will skip it entirely.
+   *
+   * @param type The authentication type that is being requested
+   * @param info The connection properties for the connection
+   * @return The password to use for authentication or null if none is available
+   * @throws PSQLException Throws a PSQLException if the plugin class cannot be instantiated
+   */
+  public static @Nullable String getPassword(AuthenticationRequestType type, Properties info) throws PSQLException {
+    String authPluginClassName = PGProperty.AUTHENTICATION_PLUGIN_CLASS_NAME.get(info);
+
+    if (authPluginClassName == null || authPluginClassName.equals("")) {
+      // Default auth plugin simply pulls password directly from connection properties
+      return PGProperty.PASSWORD.get(info);
+    }
+
+    AuthenticationPlugin authPlugin;
+    try {
+      authPlugin = (AuthenticationPlugin) ObjectFactory.instantiate(authPluginClassName, info,
+          false, null);
+    } catch (Exception ex) {
+      LOGGER.log(Level.FINE, "Unable to load Authentication Plugin " + ex.toString());
+      throw new PSQLException(ex.getMessage(), PSQLState.UNEXPECTED_ERROR);
+    }
+    return authPlugin.getPassword(type);
+  }
+
+  /**
+   * Helper that wraps getPassword(...), checks that it is not-null, and encodes
+   * it as a byte array. Used by internal code paths that require an encoded password that may be an
+   * empty string, but not null.
+   *
+   * @param type The authentication type that is being requested
+   * @param info The connection properties for the connection
+   * @return The password to use for authentication encoded as a byte array
+   * @throws PSQLException Throws a PSQLException if the plugin class cannot be instantiated or if the retrieved password is null.
+   */
+  public static byte[] getEncodedPassword(AuthenticationRequestType type, Properties info) throws PSQLException {
+    String password = getPassword(type, info);
+
+    if (password == null) {
+      throw new PSQLException(
+          GT.tr("The server requested password-based authentication, but no password was provided."),
+          PSQLState.CONNECTION_REJECTED);
+    }
+
+    return password.getBytes(StandardCharsets.UTF_8);
+  }
+}

--- a/pgjdbc/src/main/java/org/postgresql/core/ConnectionFactory.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/ConnectionFactory.java
@@ -35,21 +35,19 @@ public abstract class ConnectionFactory {
    *
    * @param hostSpecs at least one host and port to connect to; multiple elements for round-robin
    *        failover
-   * @param user the username to authenticate with; may not be null.
-   * @param database the database on the server to connect to; may not be null.
    * @param info extra properties controlling the connection; notably, "password" if present
    *        supplies the password to authenticate with.
    * @return the new, initialized, connection
    * @throws SQLException if the connection could not be established.
    */
-  public static QueryExecutor openConnection(HostSpec[] hostSpecs, String user,
-      String database, Properties info) throws SQLException {
+  public static QueryExecutor openConnection(HostSpec[] hostSpecs,
+      Properties info) throws SQLException {
     String protoName = PGProperty.PROTOCOL_VERSION.get(info);
 
     if (protoName == null || protoName.isEmpty() || "3".equals(protoName)) {
       ConnectionFactory connectionFactory = new ConnectionFactoryImpl();
       QueryExecutor queryExecutor = connectionFactory.openConnectionImpl(
-          hostSpecs, user, database, info);
+          hostSpecs, info);
       if (queryExecutor != null) {
         return queryExecutor;
       }
@@ -66,8 +64,6 @@ public abstract class ConnectionFactory {
    *
    * @param hostSpecs at least one host and port to connect to; multiple elements for round-robin
    *        failover
-   * @param user the username to authenticate with; may not be null.
-   * @param database the database on the server to connect to; may not be null.
    * @param info extra properties controlling the connection; notably, "password" if present
    *        supplies the password to authenticate with.
    * @return the new, initialized, connection, or <code>null</code> if this protocol version is not
@@ -75,8 +71,7 @@ public abstract class ConnectionFactory {
    * @throws SQLException if the connection could not be established for a reason other than
    *         protocol version incompatibility.
    */
-  public abstract QueryExecutor openConnectionImpl(HostSpec[] hostSpecs, String user,
-      String database, Properties info) throws SQLException;
+  public abstract QueryExecutor openConnectionImpl(HostSpec[] hostSpecs, Properties info) throws SQLException;
 
   /**
    * Safely close the given stream.

--- a/pgjdbc/src/main/java/org/postgresql/core/QueryExecutorBase.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/QueryExecutorBase.java
@@ -67,11 +67,10 @@ public abstract class QueryExecutorBase implements QueryExecutor {
       = new TreeMap<String,String>(String.CASE_INSENSITIVE_ORDER);
 
   @SuppressWarnings({"assignment.type.incompatible", "argument.type.incompatible"})
-  protected QueryExecutorBase(PGStream pgStream, String user,
-      String database, int cancelSignalTimeout, Properties info) throws SQLException {
+  protected QueryExecutorBase(PGStream pgStream, int cancelSignalTimeout, Properties info) throws SQLException {
     this.pgStream = pgStream;
-    this.user = user;
-    this.database = database;
+    this.user = PGProperty.USER.get(info);
+    this.database = PGProperty.PG_DBNAME.get(info);
     this.cancelSignalTimeout = cancelSignalTimeout;
     this.reWriteBatchedInserts = PGProperty.REWRITE_BATCHED_INSERTS.getBoolean(info);
     this.columnSanitiserDisabled = PGProperty.DISABLE_COLUMN_SANITISER.getBoolean(info);

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java
@@ -239,10 +239,8 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
                   tryConnect(user, database, info, socketFactory, hostSpec, SslMode.DISABLE,gssEncMode);
               LOGGER.log(Level.FINE, "Downgraded to non-encrypted connection for host {0}",
                   hostSpec);
-            } catch (SQLException ee) {
+            } catch (SQLException | IOException ee) {
               ex = ee;
-            } catch (IOException ee) {
-              ex = ee; // Can't use multi-catch in Java 6 :(
             }
             if (ex != null) {
               log(Level.FINE, "sslMode==PREFER, however non-SSL connection failed as well", ex);

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -159,9 +159,9 @@ public class QueryExecutorImpl extends QueryExecutorBase {
 
   @SuppressWarnings({"assignment.type.incompatible", "argument.type.incompatible",
       "method.invocation.invalid"})
-  public QueryExecutorImpl(PGStream pgStream, String user, String database,
+  public QueryExecutorImpl(PGStream pgStream,
       int cancelSignalTimeout, Properties info) throws SQLException, IOException {
-    super(pgStream, user, database, cancelSignalTimeout, info);
+    super(pgStream, cancelSignalTimeout, info);
 
     long maxResultBuffer = pgStream.getMaxResultBuffer();
     this.adaptiveFetchCache = new AdaptiveFetchCache(maxResultBuffer, info);

--- a/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
+++ b/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
@@ -1321,6 +1321,26 @@ public abstract class BaseDataSource implements CommonDataSource, Referenceable 
     setUrl(url);
   }
 
+  /**
+   *
+   * @return the class name to use for the Authentication Plugin.
+   *         This can be null in which case the default password authentication plugin will be used
+   */
+  public @Nullable String getAuthenticationPluginClassName() {
+    return PGProperty.AUTHENTICATION_PLUGIN_CLASS_NAME.get(properties);
+  }
+
+  /**
+   *
+   * @param className name of a class which implements {@link org.postgresql.plugin.AuthenticationPlugin}
+   *                  This class will be used to get the encoded bytes to be sent to the server as the
+   *                  password to authenticate the user.
+   *
+   */
+  public void setAuthenticationPluginClassName(String className) {
+    PGProperty.AUTHENTICATION_PLUGIN_CLASS_NAME.set(properties, className);
+  }
+
   public @Nullable String getProperty(String name) throws SQLException {
     PGProperty pgProperty = PGProperty.forName(name);
     if (pgProperty != null) {

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
@@ -203,8 +203,6 @@ public class PgConnection implements BaseConnection {
   //
   @SuppressWarnings({"method.invocation.invalid", "argument.type.incompatible"})
   public PgConnection(HostSpec[] hostSpecs,
-                      String user,
-                      String database,
                       Properties info,
                       String url) throws SQLException {
     // Print out the driver version number
@@ -222,7 +220,7 @@ public class PgConnection implements BaseConnection {
     }
 
     // Now make the initial connection and set up local state
-    this.queryExecutor = ConnectionFactory.openConnection(hostSpecs, user, database, info);
+    this.queryExecutor = ConnectionFactory.openConnection(hostSpecs, info);
 
     // WARNING for unsupported servers (8.1 and lower are not supported)
     if (LOGGER.isLoggable(Level.WARNING) && !haveMinimumServerVersion(ServerVersion.v8_2)) {

--- a/pgjdbc/src/main/java/org/postgresql/plugin/AuthenticationPlugin.java
+++ b/pgjdbc/src/main/java/org/postgresql/plugin/AuthenticationPlugin.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2021, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.plugin;
+
+import org.postgresql.util.PSQLException;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+public interface AuthenticationPlugin {
+  @Nullable
+  String getPassword(AuthenticationRequestType type) throws PSQLException;
+
+}

--- a/pgjdbc/src/main/java/org/postgresql/plugin/AuthenticationRequestType.java
+++ b/pgjdbc/src/main/java/org/postgresql/plugin/AuthenticationRequestType.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2021, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.plugin;
+
+public enum AuthenticationRequestType {
+    CLEARTEXT_PASSWORD,
+    GSS,
+    MD5_PASSWORD,
+    SASL,
+}

--- a/pgjdbc/src/test/java/org/postgresql/test/TestUtil.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/TestUtil.java
@@ -788,6 +788,13 @@ public class TestUtil {
     return false;
   }
 
+  public static void assumeHaveMinimumServerVersion(Version version)
+      throws SQLException {
+    try (Connection conn = openPrivilegedDB()) {
+      Assume.assumeTrue(TestUtil.haveMinimumServerVersion(conn, version));
+    }
+  }
+
   public static boolean haveMinimumJVMVersion(String version) {
     String jvm = java.lang.System.getProperty("java.version");
     return (jvm.compareTo(version) >= 0);

--- a/pgjdbc/src/test/java/org/postgresql/test/plugin/AuthenticationPluginTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/plugin/AuthenticationPluginTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2021, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.test.plugin;
+
+import org.postgresql.PGProperty;
+import org.postgresql.core.ServerVersion;
+import org.postgresql.plugin.AuthenticationPlugin;
+import org.postgresql.plugin.AuthenticationRequestType;
+import org.postgresql.test.TestUtil;
+import org.postgresql.util.PSQLException;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Properties;
+import java.util.function.Consumer;
+
+public class AuthenticationPluginTest {
+  @BeforeClass
+  public static void setUp() throws SQLException {
+    TestUtil.assumeHaveMinimumServerVersion(ServerVersion.v10);
+  }
+
+  public static class DummyAuthenticationPlugin implements AuthenticationPlugin {
+    private static Consumer<AuthenticationRequestType> onGetPassword;
+
+    @Override
+    public @Nullable String getPassword(AuthenticationRequestType type) throws PSQLException {
+      onGetPassword.accept(type);
+
+      // Ex: "MD5" => "DUMMY-MD5"
+      return "DUMMY-" + type.toString();
+    }
+  }
+
+  private void testAuthPlugin(String username, String passwordEncryption, AuthenticationRequestType expectedType) throws SQLException {
+    createRole(username, passwordEncryption, "DUMMY-" + expectedType.toString());
+    try {
+      Properties props = new Properties();
+      props.setProperty(PGProperty.AUTHENTICATION_PLUGIN_CLASS_NAME.getName(), DummyAuthenticationPlugin.class.getName());
+      props.setProperty("username", username);
+
+      boolean[] wasCalled = { false };
+      DummyAuthenticationPlugin.onGetPassword = type -> {
+        wasCalled[0] = true;
+        Assert.assertEquals("The authentication type should match", expectedType, type);
+      };
+      try (Connection conn = TestUtil.openDB(props)) {
+        Assert.assertTrue("The custom authentication plugin should be invoked", wasCalled[0]);
+      }
+    } finally {
+      dropRole(username);
+    }
+  }
+
+  @Test
+  public void testAuthPluginMD5() throws Exception {
+    testAuthPlugin("auth_plugin_test_md5", "md5", AuthenticationRequestType.MD5_PASSWORD);
+  }
+
+  @Test
+  public void testAuthPluginSASL() throws Exception {
+    testAuthPlugin("auth_plugin_test_sasl", "scram-sha-256", AuthenticationRequestType.SASL);
+  }
+
+  private static void createRole(String username, String passwordEncryption, String password) throws SQLException {
+    try (Connection conn = TestUtil.openPrivilegedDB()) {
+      TestUtil.execute("SET password_encryption='" + passwordEncryption + "'", conn);
+      TestUtil.execute("DROP ROLE IF EXISTS " + username, conn);
+      TestUtil.execute("CREATE USER " + username + " WITH PASSWORD '" + password + "'", conn);
+    }
+  }
+
+  private static void dropRole(String username) throws SQLException {
+    try (Connection conn = TestUtil.openPrivilegedDB()) {
+      TestUtil.execute("DROP ROLE IF EXISTS " + username, conn);
+    }
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/test/plugin/PluginTestSuite.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/plugin/PluginTestSuite.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2021, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.test.plugin;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+@RunWith(Suite.class)
+@SuiteClasses({
+    AuthenticationPluginTest.class,
+})
+public class PluginTestSuite {
+
+}


### PR DESCRIPTION
This is a revised version of #2321. I'll close that one out in favor of this.

The first two commits do some refactoring to consolidate where username and passwords are pulled from the properties map and removing those args from the various internal creation methods. This simplifies the changeset for actual feature which adds a plugin hook for dynamically providing the password. The plugin callback also provides the authentication type so the caller has a bit more information to make a decision (e.g. the caller can ensure they are using SCRAM and not sending the password over plaintext).

Because of the message flow of the driver, if the server is configured with trust authentication then no callback will be invoked.

@davecramer While reviewing, in particular take a peek at the public interfaces to make sure it makes sense as we'll be stuck with them.

### All Submissions:

* [X] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [X] Does your submission pass tests?
2. [X] Does `./gradlew autostyleCheck checkstyleAll` pass ?

