### PR TITLE
fix: close refcursors when underlying cursor==null instead of relying on defaultRowFetchSize

### DIFF
--- a/docs/_posts/2022-02-01-42.3.2-release.md
+++ b/docs/_posts/2022-02-01-42.3.2-release.md
@@ -7,6 +7,9 @@ version: 42.3.2
 ---
 
 **Notable changes**
+### Known issues
+- Regression since 42.3.2: "cursor <unnamed portal 1> does not exist" when using ResultSet.setFetchSize from CallableStatement, fixed in 42.3.5 (see [PG #2377](https://github.com/pgjdbc/pgjdbc/pull/2377))
+
 ### Security
 - CVE-2022-21724 pgjdbc instantiates plugin instances based on class names provided via authenticationPluginClassName,
   sslhostnameverifier, socketFactory, sslfactory, sslpasswordcallback connection properties.

--- a/docs/_posts/2022-02-15-42.3.3-release.md
+++ b/docs/_posts/2022-02-15-42.3.3-release.md
@@ -7,6 +7,9 @@ version: 42.3.3
 ---
 **Notable changes**
 
+### Known issues
+- Regression since 42.3.2: "cursor <unnamed portal 1> does not exist" when using ResultSet.setFetchSize from CallableStatement, fixed in 42.3.5 (see [PG #2377](https://github.com/pgjdbc/pgjdbc/pull/2377))
+
 ### Changed
 - fix: Removed loggerFile and loggerLevel configuration. While the properties still exist. 
   They can no longer be used to configure the driver logging. Instead use java.util.logging

--- a/docs/_posts/2022-04-15-42.3.4-release.md
+++ b/docs/_posts/2022-04-15-42.3.4-release.md
@@ -7,6 +7,8 @@ version: 42.3.4
 ---
 
 **Notable changes**
+### Known issues
+- Regression since 42.3.2: "cursor <unnamed portal 1> does not exist" when using ResultSet.setFetchSize from CallableStatement, fixed in 42.3.5 (see [PG #2377](https://github.com/pgjdbc/pgjdbc/pull/2377))
 
 ### Changed
 - fix: change name of build cache [PR 2471](https://github.com/pgjdbc/pgjdbc/pull/2471)

--- a/docs/_posts/2022-05-04-42.3.5-release.md
+++ b/docs/_posts/2022-05-04-42.3.5-release.md
@@ -6,6 +6,8 @@ categories:
 version: 42.3.5
 ---
 **Notable changes**
+### Known issues
+- Regression since 42.3.2: "cursor <unnamed portal 1> does not exist" when using ResultSet.setFetchSize from CallableStatement, fixed in 42.3.5 (see [PG #2377](https://github.com/pgjdbc/pgjdbc/pull/2377))
 
 ### Changed
 - test: polish TimestampUtilsTest

--- a/pgjdbc/src/test/java/org/postgresql/test/TestUtil.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/TestUtil.java
@@ -654,6 +654,13 @@ public class TestUtil {
     dropObject(con, "TYPE", type);
   }
 
+  /*
+   * Drops a function with a given signature.
+   */
+  public static void dropFunction(Connection con, String name, String arguments) throws SQLException {
+    dropObject(con, "FUNCTION", name + "(" + arguments + ")");
+  }
+
   private static void dropObject(Connection con, String type, String name) throws SQLException {
     Statement stmt = con.createStatement();
     try {
@@ -1163,7 +1170,19 @@ public class TestUtil {
     }
   }
 
+  /**
+   * Executes given SQL via {@link Statement#execute(String)} on a given connection.
+   * @deprecated prefer {@link #execute(Connection, String)} since it yields easier for read code
+   */
+  @Deprecated
   public static void execute(String sql, Connection connection) throws SQLException {
+    execute(connection, sql);
+  }
+
+  /**
+   * Executes given SQL via {@link Statement#execute(String)} on a given connection.
+   */
+  public static void execute(Connection connection, String sql) throws SQLException {
     try (Statement stmt = connection.createStatement()) {
       stmt.execute(sql);
     }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/RefCursorFetchTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/RefCursorFetchTest.java
@@ -7,115 +7,151 @@ package org.postgresql.test.jdbc2;
 
 import static org.junit.Assert.assertEquals;
 
-import org.postgresql.PGConnection;
+import org.postgresql.PGProperty;
 import org.postgresql.core.ServerVersion;
 import org.postgresql.test.TestUtil;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import java.sql.CallableStatement;
+import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Properties;
 
+@RunWith(Parameterized.class)
 public class RefCursorFetchTest extends BaseTest4 {
+  private final int numRows;
+  private final @Nullable Integer defaultFetchSize;
+  private final @Nullable Integer resultSetFetchSize;
+  private final AutoCommit autoCommit;
+  private final boolean commitAfterExecute;
+
+  public RefCursorFetchTest(BinaryMode binaryMode, int numRows,
+      @Nullable Integer defaultFetchSize,
+      @Nullable Integer resultSetFetchSize,
+      AutoCommit autoCommit, boolean commitAfterExecute) {
+    this.numRows = numRows;
+    this.defaultFetchSize = defaultFetchSize;
+    this.resultSetFetchSize = resultSetFetchSize;
+    this.autoCommit = autoCommit;
+    this.commitAfterExecute = commitAfterExecute;
+    setBinaryMode(binaryMode);
+  }
+
+  @Parameterized.Parameters(name = "binary = {0}, numRows = {1}, defaultFetchSize = {2}, resultSetFetchSize = {3}, autoCommit = {4}, commitAfterExecute = {5}")
+  public static Iterable<Object[]> data() {
+    Collection<Object[]> ids = new ArrayList<>();
+    for (BinaryMode binaryMode : BinaryMode.values()) {
+      for (int numRows : new int[]{0, 10, 101}) {
+        for (Integer defaultFetchSize : new Integer[]{null, 0, 9, 50}) {
+          for (AutoCommit autoCommit : AutoCommit.values()) {
+            for (boolean commitAfterExecute : new boolean[]{true, false}) {
+              for (Integer resultSetFetchSize : new Integer[]{null, 0, 9, 50}) {
+                ids.add(new Object[]{binaryMode, numRows, defaultFetchSize, resultSetFetchSize, autoCommit, commitAfterExecute});
+              }
+            }
+          }
+        }
+      }
+    }
+    return ids;
+  }
+
+  @Override
+  protected void updateProperties(Properties props) {
+    super.updateProperties(props);
+    if (defaultFetchSize != null) {
+      PGProperty.DEFAULT_ROW_FETCH_SIZE.set(props, defaultFetchSize);
+    }
+  }
+
   @BeforeClass
-  public static void checkVersion() throws SQLException {
+  public static void beforeClass() throws Exception {
     TestUtil.assumeHaveMinimumServerVersion(ServerVersion.v9_0);
+    try (Connection con = TestUtil.openDB();) {
+      TestUtil.createTable(con, "test_blob", "content bytea");
+      TestUtil.execute(con, "");
+      TestUtil.execute(con, "--create function to read data\n"
+          + "CREATE OR REPLACE FUNCTION test_blob(p_cur OUT REFCURSOR, p_limit int4) AS $body$\n"
+          + "BEGIN\n"
+          + "OPEN p_cur FOR SELECT content FROM test_blob LIMIT p_limit;\n"
+          + "END;\n"
+          + "$body$ LANGUAGE plpgsql STABLE");
+
+      TestUtil.execute(con,"--generate 101 rows with 4096 bytes:\n"
+          + "insert into test_blob\n"
+          + "select(select decode(string_agg(lpad(to_hex(width_bucket(random(), 0, 1, 256) - 1), 2, '0'), ''), 'hex')"
+          + " FROM generate_series(1, 4096))\n"
+          + "from generate_series (1, 200)");
+    }
+  }
+
+  @AfterClass
+  public static void afterClass() throws Exception {
+    try (Connection con = TestUtil.openDB();) {
+      TestUtil.dropTable(con, "test_blob");
+      TestUtil.dropFunction(con,"test_blob", "REFCURSOR, int4");
+    }
   }
 
   @Override
   public void setUp() throws Exception {
     super.setUp();
     assumeCallableStatementsSupported();
-
-    TestUtil.dropTable(con, "test_blob");
-    TestUtil.createTable(con, "test_blob", "content bytea");
-
-    // Create a function to read the blob data
-    TestUtil.execute("CREATE OR REPLACE FUNCTION test_blob (p_cur OUT REFCURSOR) AS\n"
-        + "$body$\n"
-        + "  BEGIN\n"
-        + "    OPEN p_cur FOR SELECT content FROM test_blob;\n"
-        + "  END;\n"
-        + "$body$ LANGUAGE plpgsql STABLE", con);
-
-    // Generate 101 rows with 4096 bytes
-    TestUtil.execute("INSERT INTO test_blob (content)\n"
-        + "SELECT (SELECT decode(string_agg(lpad(to_hex(width_bucket(random(), 0, 1, 256) - 1), 2, '0'), ''), 'hex')\n"
-        + "        FROM generate_series(1, 4096)) AS content\n"
-        + "FROM generate_series (1, 101)", con);
-  }
-
-  @Override
-  public void tearDown() throws SQLException {
-    TestUtil.execute("DROP FUNCTION IF EXISTS test_blob (OUT REFCURSOR)", con);
-    TestUtil.dropTable(con, "test_blob");
-    super.tearDown();
+    con.setAutoCommit(autoCommit == AutoCommit.YES);
   }
 
   @Test
-  public void testRefCursorWithFetchSize() throws SQLException {
-    ((PGConnection)con).setDefaultFetchSize(50);
+  public void fetchAllRows() throws SQLException {
     int cnt = 0;
-    try (CallableStatement call = con.prepareCall("{? = call test_blob()}")) {
+    try (CallableStatement call = con.prepareCall("{? = call test_blob(?)}")) {
       con.setAutoCommit(false); // ref cursors only work if auto commit is off
       call.registerOutParameter(1, Types.REF_CURSOR);
+      call.setInt(2, numRows);
       call.execute();
+      if (commitAfterExecute) {
+        if (autoCommit == AutoCommit.NO) {
+          con.commit();
+        } else {
+          con.setAutoCommit(false);
+          con.setAutoCommit(true);
+        }
+      }
       try (ResultSet rs = (ResultSet) call.getObject(1)) {
+        if (resultSetFetchSize != null) {
+          rs.setFetchSize(resultSetFetchSize);
+        }
         while (rs.next()) {
           cnt++;
         }
-      }
-      assertEquals(101, cnt);
-    }
-  }
-
-  @Test
-  public void testRefCursorWithOutFetchSize() throws SQLException {
-    assumeCallableStatementsSupported();
-    int cnt = 0;
-    try (CallableStatement call = con.prepareCall("{? = call test_blob()}")) {
-      con.setAutoCommit(false); // ref cursors only work if auto commit is off
-      call.registerOutParameter(1, Types.REF_CURSOR);
-      call.execute();
-      try (ResultSet rs = (ResultSet) call.getObject(1)) {
-        while (rs.next()) {
-          cnt++;
+        assertEquals("number of rows from test_blob(...) call", numRows, cnt);
+      } catch (SQLException e) {
+        if (commitAfterExecute && "34000".equals(e.getSQLState())) {
+          // Transaction commit closes refcursor, so the fetch call is expected to fail
+          // File: postgres.c, Routine: exec_execute_message, Line: 2070
+          //   Server SQLState: 34000
+          int expectedRows =
+              defaultFetchSize != null && defaultFetchSize != 0 ? Math.min(defaultFetchSize, numRows) : numRows;
+          assertEquals(
+              "The transaction was committed before processing the results,"
+                  + " so expecting ResultSet to buffer fetchSize=" + defaultFetchSize + " rows out of "
+                  + numRows,
+              expectedRows,
+              cnt
+          );
+          return;
         }
-      }
-      assertEquals(101, cnt);
-    }
-  }
-
-  /*
-  test to make sure that close in the result set does not attempt to get rid of the non-existent
-  portal
-   */
-  @Test
-  public void testRefCursorWithFetchSizeNoTransaction() throws SQLException {
-    assumeCallableStatementsSupported();
-    ((PGConnection)con).setDefaultFetchSize(50);
-    int cnt = 0;
-    try (CallableStatement call = con.prepareCall("{? = call test_blob()}")) {
-      con.setAutoCommit(false); // ref cursors only work if auto commit is off
-      call.registerOutParameter(1, Types.REF_CURSOR);
-      call.execute();
-      // end the transaction here, which will get rid of the refcursor
-      con.setAutoCommit(true);
-      // we should be able to read the first 50 as they were read before the tx was ended
-      try (ResultSet rs = (ResultSet) call.getObject(1)) {
-        while (rs.next()) {
-          cnt++;
-        }
-      } catch (SQLException ex) {
-        // should get an exception here as we try to read more but the portal is gone
-        assertEquals("34000", ex.getSQLState());
-      } finally {
-        assertEquals(50, cnt);
+        throw e;
       }
     }
   }
-
 }


### PR DESCRIPTION
`PgResultSet` might hold `ResultCursor cursor` for fetching the next rows.
So we should use `ResultCursor cursor==null` condition to check if we want to close `<unnamed portal 1>` from refcursors.

See https://github.com/pgjdbc/pgjdbc/issues/2227
See https://github.com/pgjdbc/pgjdbc/pull/2371

/cc @davecramer