### PR TITLE
style: fix typos in pgobject javadoc

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/geometric/PGbox.java
+++ b/pgjdbc/src/main/java/org/postgresql/geometric/PGbox.java
@@ -65,7 +65,7 @@ public class PGbox extends PGobject implements PGBinaryObject, Serializable, Clo
   }
 
   /**
-   * This method sets the value of this object. It should be overidden, but still called by
+   * This method sets the value of this object. It should be overridden, but still called by
    * subclasses.
    *
    * @param value a string representation of the value of the object

--- a/pgjdbc/src/main/java/org/postgresql/util/PGBinaryObject.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/PGBinaryObject.java
@@ -8,8 +8,8 @@ package org.postgresql.util;
 import java.sql.SQLException;
 
 /**
- * PGBinaryObject is a inteface that classes extending {@link PGobject} can use to take advantage of
- * more optimal binary encoding of the data type.
+ * PGBinaryObject is a interface that classes extending {@link PGobject} can use to take advantage
+ * of more optimal binary encoding of the data type.
  */
 public interface PGBinaryObject {
   /**

--- a/pgjdbc/src/main/java/org/postgresql/util/PGobject.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/PGobject.java
@@ -57,7 +57,7 @@ public class PGobject implements Serializable, Cloneable {
   }
 
   /**
-   * This must be overidden, to return the value of the object, in the form required by
+   * This must be overridden, to return the value of the object, in the form required by
    * org.postgresql.
    *
    * @return the value of this object
@@ -77,7 +77,7 @@ public class PGobject implements Serializable, Cloneable {
   }
 
   /**
-   * This must be overidden to allow comparisons of objects.
+   * This must be overridden to allow comparisons of objects.
    *
    * @param obj Object to compare with
    * @return true if the two boxes are identical
@@ -95,7 +95,7 @@ public class PGobject implements Serializable, Cloneable {
   }
 
   /**
-   * This must be overidden to allow the object to be cloned.
+   * This must be overridden to allow the object to be cloned.
    */
   public Object clone() throws CloneNotSupportedException {
     return super.clone();


### PR DESCRIPTION
Fix typos in the javadocs of PGobject, PGBinaryObject and PGbox.

- replace 'overidden' with 'overridden'
- replace 'inteface' with 'interface'

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

