### PR TITLE
fix: throw SQLException for #getBoolean BIT(>1)

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgCallableStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgCallableStatement.java
@@ -248,8 +248,7 @@ class PgCallableStatement extends PgPreparedStatement implements CallableStateme
     if (result == null) {
       return false;
     }
-
-    return (Boolean) result;
+    return BooleanTypeUtil.castToBoolean(result);
   }
 
   public byte getByte(@Positive int parameterIndex) throws SQLException {


### PR DESCRIPTION
Throw SQLException instead of ClassCastException when calling
CallableStatement#getBoolean(int) on BIT(>1).

Currently when users call `CallableStatement#getBoolean(int)` on an out parameter of type `BIT(>1)` they get `ClassCastException` because the driver casts the result to a `Boolean` without checking the type first. This works for `BIT(1)` bit fails for `BIT(>1)` because then the type currently is `PGobject`. I know there are many related issues and PRs resolving around how we should treat bistring types

- #1910
- #892 
- #908
- #698
- #813

This PR doesn't preclude any approach on these issues, it just changes the exception type for the current behavior.

### All Submissions:

* [X] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
  There are many related ones but I didn't find any for this specific issue.

### Changes to Existing Features:

* [X] Does this break existing behaviour? If so please explain.
  Users get `SQLException` instead of `ClassCastException`. Users already need to catch `SQLException` so hopefully the impact isn't too big. Additionally the combination of `CallableStatement` and `BIT(>1)` may be quite low, otherwise we may have gotten bug reports.
* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you written new tests for your core changes, as applicable?
* [X] Have you successfully run tests with your changes locally?
