### PR TITLE
fix: we will ask the server if it supports GSS Encryption if gssEncryption is prefer or require

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java
@@ -441,10 +441,13 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
       return pgStream;
     }
 
-    if ( gssEncMode != GSSEncMode.REQUIRE ) {
-      return pgStream;
-    }
-
+    /*
+     at this point gssEncMode is either PREFER or REQUIRE
+     libpq looks to see if there is a ticket in the cache before asking
+     the server if it supports encrypted GSS connections or not.
+     since the user has specifically asked or either prefer or require we can
+     assume they want it.
+     */
     /*
     let's see if the server will allow a GSS encrypted connection
      */

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java
@@ -31,7 +31,6 @@ import org.postgresql.plugin.AuthenticationRequestType;
 import org.postgresql.sspi.ISSPIClient;
 import org.postgresql.util.GT;
 import org.postgresql.util.HostSpec;
-import org.postgresql.util.KerberosTicket;
 import org.postgresql.util.MD5Digest;
 import org.postgresql.util.PSQLException;
 import org.postgresql.util.PSQLState;
@@ -442,15 +441,13 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
       return pgStream;
     }
 
-    // If there is not credential cache there is little point in attempting this
-    if (!KerberosTicket.credentialCacheExists(info)) {
-      if ( gssEncMode == GSSEncMode.REQUIRE ) {
-        throw new PSQLException("GSSAPI encryption required but was impossible (possibly no credential cache)", PSQLState.CONNECTION_REJECTED);
-      } else {
-        return pgStream;
-      }
+    if ( gssEncMode != GSSEncMode.REQUIRE ) {
+      return pgStream;
     }
 
+    /*
+    let's see if the server will allow a GSS encrypted connection
+     */
     String user = PGProperty.USER.get(info);
     if (user == null) {
       throw new PSQLException("GSSAPI encryption required but was impossible user is null", PSQLState.CONNECTION_REJECTED);


### PR DESCRIPTION
* [ x] Does this break existing behaviour? If so please explain.