### PR TITLE
fix: default file name is ".pg_service.conf" on Windows (not "pg_service.conf")

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/util/PGPropertyServiceParser.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/PGPropertyServiceParser.java
@@ -116,9 +116,8 @@ public class PGPropertyServiceParser {
       String resourceName = OSUtil.getUserConfigRootDirectory();
       if (OSUtil.isWindows()) {
         resourceName += "postgresql" + File.separator;
-      } else {
-        resourceName += ".";
       }
+      resourceName += ".";
       resourceName += pgServceConfFileDefaultName;
       if (new File(resourceName).canRead()) {
         LOGGER.log(Level.FINE, "Value [{0}] selected because file exist in user home directory", new Object[]{resourceName});


### PR DESCRIPTION
Fix for default location of file pg_service.conf on Windows:
Current (wrong) location/name:
  **`"%APPDATA%\postgresql\pg_service.conf"`**
Fixed (correct) location/name:
  **`"%APPDATA%\postgresql\.pg_service.conf"`**

### All Submissions:

* [yes] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [yes] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### Changes to Existing Features:

* [no ] Does this break existing behaviour? If so please explain.
* [yes] Have you successfully run tests with your changes locally?
