### PR TITLE
Added setQueryTimeoutMs() to the org.postgresql.jdbc.PgStatement interface.

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/PGStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGStatement.java
@@ -94,4 +94,21 @@ public interface PGStatement {
    * @return state of adaptive fetch (turned on or off)
    */
   boolean getAdaptiveFetch();
+
+  /**
+   * The queryTimeout limit is the number of milliseconds the driver will wait for a Statement to
+   * execute. If the limit is exceeded, a SQLException is thrown.
+   *
+   * @return the current query timeout limit in milliseconds; 0 = unlimited
+   * @throws SQLException if a database access error occurs
+   */
+  long getQueryTimeoutMs() throws SQLException;
+
+  /**
+   * Sets the queryTimeout limit.
+   *
+   * @param millis - the new query timeout limit in milliseconds
+   * @throws SQLException if a database access error occurs
+   */
+  void setQueryTimeoutMs(long millis) throws SQLException;
 }

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgStatement.java
@@ -566,24 +566,13 @@ public class PgStatement implements Statement, BaseStatement {
     setQueryTimeoutMs(seconds * 1000L);
   }
 
-  /**
-   * The queryTimeout limit is the number of milliseconds the driver will wait for a Statement to
-   * execute. If the limit is exceeded, a SQLException is thrown.
-   *
-   * @return the current query timeout limit in milliseconds; 0 = unlimited
-   * @throws SQLException if a database access error occurs
-   */
+  @Override
   public long getQueryTimeoutMs() throws SQLException {
     checkClosed();
     return timeout;
   }
 
-  /**
-   * Sets the queryTimeout limit.
-   *
-   * @param millis - the new query timeout limit in milliseconds
-   * @throws SQLException if a database access error occurs
-   */
+  @Override
   public void setQueryTimeoutMs(long millis) throws SQLException {
     checkClosed();
 


### PR DESCRIPTION
This is a public documented API. It would make sense to have this in the `PgStatement` interface so that timeouts smaller than 1 seconds can be set just by using unwrap() to get that interface and call that method without further casts.