### PR TITLE
Revert "perf: add read(b,o,l) to BlobInputStream"

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/largeobject/BlobInputStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/largeobject/BlobInputStream.java
@@ -23,7 +23,7 @@ public class BlobInputStream extends InputStream {
   /**
    * The absolute position.
    */
-  private long absolutePosition;
+  private long apos;
 
   /**
    * Buffer used to improve performance.
@@ -33,17 +33,17 @@ public class BlobInputStream extends InputStream {
   /**
    * Position within buffer.
    */
-  private int bufferPosition;
+  private int bpos;
 
   /**
    * The buffer size.
    */
-  private final int bufferSize;
+  private int bsize;
 
   /**
    * The mark position.
    */
-  private long markPosition = 0;
+  private long mpos = 0;
 
   /**
    * The limit.
@@ -74,9 +74,9 @@ public class BlobInputStream extends InputStream {
   public BlobInputStream(LargeObject lo, int bsize, long limit) {
     this.lo = lo;
     buffer = null;
-    bufferPosition = 0;
-    absolutePosition = 0;
-    this.bufferSize = bsize;
+    bpos = 0;
+    apos = 0;
+    this.bsize = bsize;
     this.limit = limit;
   }
 
@@ -86,86 +86,31 @@ public class BlobInputStream extends InputStream {
   public int read() throws java.io.IOException {
     LargeObject lo = getLo();
     try {
-      if (limit > 0 && absolutePosition >= limit) {
+      if (limit > 0 && apos >= limit) {
         return -1;
       }
-      // read more in if necessary
-      if (buffer == null || bufferPosition >= buffer.length) {
-        buffer = lo.read(bufferSize);
-        bufferPosition = 0;
+      if (buffer == null || bpos >= buffer.length) {
+        buffer = lo.read(bsize);
+        bpos = 0;
       }
 
       // Handle EOF
-      if ( buffer == null || bufferPosition >= buffer.length) {
+      if (buffer == null || bpos >= buffer.length) {
         return -1;
       }
 
-      int ret = (buffer[bufferPosition] & 0xFF);
+      int ret = (buffer[bpos] & 0x7F);
+      if ((buffer[bpos] & 0x80) == 0x80) {
+        ret |= 0x80;
+      }
 
-      bufferPosition++;
-      absolutePosition++;
+      bpos++;
+      apos++;
 
       return ret;
     } catch (SQLException se) {
       throw new IOException(se.toString());
     }
-  }
-
-  @Override
-  public int read(byte[] b, int off, int len) throws IOException {
-    int bytesCopied = 0;
-    LargeObject lo = getLo();
-
-    /* check to make sure we aren't at the limit
-    *  funny to test for 0, but I guess someone could create a blob
-    * with a limit of zero
-    */
-    if ( limit >= 0 && absolutePosition >= limit ) {
-      return -1;
-    }
-
-    /* check to make sure we are not going to read past the limit */
-    if ( limit >= 0 && len > limit - absolutePosition ) {
-      len = (int)(limit - absolutePosition);
-    }
-
-    try {
-      // have we read anything into the buffer
-      if ( buffer != null ) {
-        // now figure out how much data is in the buffer
-        int bytesInBuffer = buffer.length - bufferPosition;
-        // figure out how many bytes the user wants
-        int bytesToCopy = len > bytesInBuffer ? bytesInBuffer : len;
-        // copy them in
-        System.arraycopy(buffer, bufferPosition, b, off, bytesToCopy);
-        // move the buffer position
-        bufferPosition += bytesToCopy;
-        // position in the blob
-        absolutePosition += bytesToCopy;
-        // increment offset
-        off += bytesToCopy;
-        // decrement the length
-        len -= bytesToCopy;
-        bytesCopied = bytesToCopy;
-      }
-
-      if (len > 0 ) {
-        bytesCopied += lo.read(b, off, len);
-        buffer = null;
-        bufferPosition = 0;
-        absolutePosition += bytesCopied;
-        /*
-        if there is a limit on the size of the blob then we could have read to the limit
-        so bytesCopied will be non-zero but we will have read nothing
-         */
-        if ( bytesCopied == 0 && (buffer == null) ) {
-          return -1;
-        }
-      }
-    } catch (SQLException ex ) {
-      throw new IOException(ex.getCause());
-    }
-    return bytesCopied;
   }
 
   /**
@@ -208,7 +153,7 @@ public class BlobInputStream extends InputStream {
    * @see java.io.InputStream#reset()
    */
   public synchronized void mark(int readlimit) {
-    markPosition = absolutePosition;
+    mpos = apos;
   }
 
   /**
@@ -221,13 +166,13 @@ public class BlobInputStream extends InputStream {
   public synchronized void reset() throws IOException {
     LargeObject lo = getLo();
     try {
-      if (markPosition <= Integer.MAX_VALUE) {
-        lo.seek((int)markPosition);
+      if (mpos <= Integer.MAX_VALUE) {
+        lo.seek((int)mpos);
       } else {
-        lo.seek64(markPosition, LargeObject.SEEK_SET);
+        lo.seek64(mpos, LargeObject.SEEK_SET);
       }
       buffer = null;
-      absolutePosition = markPosition;
+      apos = mpos;
     } catch (SQLException se) {
       throw new IOException(se.toString());
     }

--- a/pgjdbc/src/main/java/org/postgresql/largeobject/LargeObject.java
+++ b/pgjdbc/src/main/java/org/postgresql/largeobject/LargeObject.java
@@ -399,20 +399,6 @@ public class LargeObject
   }
 
   /**
-   * Returns an {@link InputStream} from this object, that will limit the amount of data that is
-   * visible.
-   * Added mostly for testing
-   *
-   * @param maxSize internal buffer size
-   * @param limit maximum number of bytes the resulting stream will serve
-   * @return {@link InputStream} from this object
-   * @throws SQLException if a database-access error occurs.
-   */
-  public InputStream getInputStream(int maxSize, long limit) throws SQLException {
-    return new BlobInputStream(this, maxSize, limit);
-  }
-
-  /**
    * <p>Returns an {@link OutputStream} to this object.</p>
    *
    * <p>This OutputStream can then be used in any method that requires an OutputStream.</p>

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BlobTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BlobTest.java
@@ -16,9 +16,7 @@ import org.postgresql.largeobject.LargeObjectManager;
 import org.postgresql.test.TestUtil;
 
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.InputStream;
@@ -37,136 +35,98 @@ import java.sql.Types;
  * problems from re-occurring ;-)
  */
 public class BlobTest {
-  private static final String TEST_FILE =  "/test-file.xml";
-
   private static final int LOOP = 0; // LargeObject API using loop
   private static final int NATIVE_STREAM = 1; // LargeObject API using OutputStream
 
   private Connection con;
 
-  /*
-    Only do this once
-  */
-  @BeforeClass
-  public static void createLargeBlob() throws Exception {
-    try ( Connection con = TestUtil.openDB() ) {
-      TestUtil.createTable(con, "testblob", "id name,lo oid");
-      con.setAutoCommit(false);
-      LargeObjectManager lom = ((org.postgresql.PGConnection) con).getLargeObjectAPI();
-      long oid = lom.createLO(LargeObjectManager.READWRITE);
-      LargeObject blob = lom.open(oid);
-
-      byte[] buf = new byte[256];
-      for (int i = 0; i < buf.length; i++) {
-        buf[i] = (byte) i;
-      }
-      // I want to create a large object
-      int i = 1024 / buf.length;
-      for (int j = i; j > 0; j--) {
-        blob.write(buf, 0, buf.length);
-      }
-      assertEquals(1024, blob.size());
-      blob.close();
-      try (PreparedStatement pstmt = con.prepareStatement("INSERT INTO testblob(id, lo) VALUES(?,?)")) {
-        pstmt.setString(1, "l1");
-        pstmt.setLong(2, oid);
-        pstmt.executeUpdate();
-      }
-      con.commit();
-    }
-  }
-
-  @AfterClass
-  public static void cleanup() throws Exception {
-    try ( Connection con = TestUtil.openDB() ) {
-      try (Statement stmt = con.createStatement()) {
-        stmt.execute("SELECT lo_unlink(lo) FROM testblob where id = 'l1'");
-      } finally {
-        TestUtil.dropTable(con, "testblob");
-      }
-    }
-  }
-
   @Before
   public void setUp() throws Exception {
     con = TestUtil.openDB();
+    TestUtil.createTable(con, "testblob", "id name,lo oid");
     con.setAutoCommit(false);
   }
 
   @After
   public void tearDown() throws Exception {
     con.setAutoCommit(true);
-    try ( Statement stmt = con.createStatement() ) {
-      stmt.execute("SELECT lo_unlink(lo) FROM testblob where id != 'l1'");
-      stmt.execute("delete from testblob where id != 'l1'");
+    try {
+      Statement stmt = con.createStatement();
+      try {
+        stmt.execute("SELECT lo_unlink(lo) FROM testblob");
+      } finally {
+        try {
+          stmt.close();
+        } catch (Exception e) {
+        }
+      }
     } finally {
+      TestUtil.dropTable(con, "testblob");
       TestUtil.closeDB(con);
     }
   }
 
   @Test
   public void testSetNull() throws Exception {
-    try (PreparedStatement pstmt = con.prepareStatement("INSERT INTO testblob(lo) VALUES (?)")) {
+    PreparedStatement pstmt = con.prepareStatement("INSERT INTO testblob(lo) VALUES (?)");
 
-      pstmt.setBlob(1, (Blob) null);
-      pstmt.executeUpdate();
+    pstmt.setBlob(1, (Blob) null);
+    pstmt.executeUpdate();
 
-      pstmt.setNull(1, Types.BLOB);
-      pstmt.executeUpdate();
+    pstmt.setNull(1, Types.BLOB);
+    pstmt.executeUpdate();
 
-      pstmt.setObject(1, null, Types.BLOB);
-      pstmt.executeUpdate();
+    pstmt.setObject(1, null, Types.BLOB);
+    pstmt.executeUpdate();
 
-      pstmt.setClob(1, (Clob) null);
-      pstmt.executeUpdate();
+    pstmt.setClob(1, (Clob) null);
+    pstmt.executeUpdate();
 
-      pstmt.setNull(1, Types.CLOB);
-      pstmt.executeUpdate();
+    pstmt.setNull(1, Types.CLOB);
+    pstmt.executeUpdate();
 
-      pstmt.setObject(1, null, Types.CLOB);
-      pstmt.executeUpdate();
-    }
+    pstmt.setObject(1, null, Types.CLOB);
+    pstmt.executeUpdate();
   }
 
   @Test
   public void testSet() throws SQLException {
-    try ( Statement stmt = con.createStatement() ) {
-      stmt.execute("INSERT INTO testblob(id,lo) VALUES ('1', lo_creat(-1))");
-      ResultSet rs = stmt.executeQuery("SELECT lo FROM testblob where id = '1'");
-      assertTrue(rs.next());
+    Statement stmt = con.createStatement();
+    stmt.execute("INSERT INTO testblob(id,lo) VALUES ('1', lo_creat(-1))");
+    ResultSet rs = stmt.executeQuery("SELECT lo FROM testblob");
+    assertTrue(rs.next());
 
-      PreparedStatement pstmt = con.prepareStatement("INSERT INTO testblob(id, lo) VALUES(?,?)");
+    PreparedStatement pstmt = con.prepareStatement("INSERT INTO testblob(id, lo) VALUES(?,?)");
 
-      Blob blob = rs.getBlob(1);
-      pstmt.setString(1, "setObjectTypeBlob");
-      pstmt.setObject(2, blob, Types.BLOB);
-      assertEquals(1, pstmt.executeUpdate());
+    Blob blob = rs.getBlob(1);
+    pstmt.setString(1, "setObjectTypeBlob");
+    pstmt.setObject(2, blob, Types.BLOB);
+    assertEquals(1, pstmt.executeUpdate());
 
-      blob = rs.getBlob(1);
-      pstmt.setString(1, "setObjectBlob");
-      pstmt.setObject(2, blob);
-      assertEquals(1, pstmt.executeUpdate());
+    blob = rs.getBlob(1);
+    pstmt.setString(1, "setObjectBlob");
+    pstmt.setObject(2, blob);
+    assertEquals(1, pstmt.executeUpdate());
 
-      blob = rs.getBlob(1);
-      pstmt.setString(1, "setBlob");
-      pstmt.setBlob(2, blob);
-      assertEquals(1, pstmt.executeUpdate());
+    blob = rs.getBlob(1);
+    pstmt.setString(1, "setBlob");
+    pstmt.setBlob(2, blob);
+    assertEquals(1, pstmt.executeUpdate());
 
-      Clob clob = rs.getClob(1);
-      pstmt.setString(1, "setObjectTypeClob");
-      pstmt.setObject(2, clob, Types.CLOB);
-      assertEquals(1, pstmt.executeUpdate());
+    Clob clob = rs.getClob(1);
+    pstmt.setString(1, "setObjectTypeClob");
+    pstmt.setObject(2, clob, Types.CLOB);
+    assertEquals(1, pstmt.executeUpdate());
 
-      clob = rs.getClob(1);
-      pstmt.setString(1, "setObjectClob");
-      pstmt.setObject(2, clob);
-      assertEquals(1, pstmt.executeUpdate());
+    clob = rs.getClob(1);
+    pstmt.setString(1, "setObjectClob");
+    pstmt.setObject(2, clob);
+    assertEquals(1, pstmt.executeUpdate());
 
-      clob = rs.getClob(1);
-      pstmt.setString(1, "setClob");
-      pstmt.setClob(2, clob);
-      assertEquals(1, pstmt.executeUpdate());
-    }
+    clob = rs.getClob(1);
+    pstmt.setString(1, "setClob");
+    pstmt.setClob(2, clob);
+    assertEquals(1, pstmt.executeUpdate());
   }
 
   /*
@@ -174,13 +134,13 @@ public class BlobTest {
    */
   @Test
   public void testUploadBlob_LOOP() throws Exception {
-    assertTrue(uploadFile(TEST_FILE, LOOP) > 0);
+    assertTrue(uploadFile("/test-file.xml", LOOP) > 0);
 
     // Now compare the blob & the file. Note this actually tests the
     // InputStream implementation!
-    assertTrue(compareBlobsLOAPI(TEST_FILE));
-    assertTrue(compareBlobs(TEST_FILE));
-    assertTrue(compareClobs(TEST_FILE));
+    assertTrue(compareBlobsLOAPI());
+    assertTrue(compareBlobs());
+    assertTrue(compareClobs());
   }
 
   /*
@@ -188,110 +148,101 @@ public class BlobTest {
    */
   @Test
   public void testUploadBlob_NATIVE() throws Exception {
-    assertTrue(uploadFile(TEST_FILE, NATIVE_STREAM) > 0);
+    assertTrue(uploadFile("/test-file.xml", NATIVE_STREAM) > 0);
 
     // Now compare the blob & the file. Note this actually tests the
     // InputStream implementation!
-    assertTrue(compareBlobs(TEST_FILE));
+    assertTrue(compareBlobs());
   }
 
   @Test
   public void testMarkResetStream() throws Exception {
-    assertTrue(uploadFile(TEST_FILE, NATIVE_STREAM) > 0);
+    assertTrue(uploadFile("/test-file.xml", NATIVE_STREAM) > 0);
 
-    try ( Statement stmt = con.createStatement() ) {
-      try ( ResultSet rs = stmt.executeQuery("SELECT lo FROM testblob where id = '/test-file.xml'") ) {
-        assertTrue(rs.next());
+    Statement stmt = con.createStatement();
+    ResultSet rs = stmt.executeQuery("SELECT lo FROM testblob");
+    assertTrue(rs.next());
 
-        LargeObjectManager lom = ((org.postgresql.PGConnection) con).getLargeObjectAPI();
+    LargeObjectManager lom = ((org.postgresql.PGConnection) con).getLargeObjectAPI();
 
-        long oid = rs.getLong(1);
-        LargeObject blob = lom.open(oid);
-        InputStream bis = blob.getInputStream();
+    long oid = rs.getLong(1);
+    LargeObject blob = lom.open(oid);
+    InputStream bis = blob.getInputStream();
 
-        assertEquals('<', bis.read());
-        bis.mark(4);
-        assertEquals('?', bis.read());
-        assertEquals('x', bis.read());
-        assertEquals('m', bis.read());
-        assertEquals('l', bis.read());
-        bis.reset();
-        assertEquals('?', bis.read());
-      }
-    }
+    assertEquals('<', bis.read());
+    bis.mark(4);
+    assertEquals('?', bis.read());
+    assertEquals('x', bis.read());
+    assertEquals('m', bis.read());
+    assertEquals('l', bis.read());
+    bis.reset();
+    assertEquals('?', bis.read());
   }
 
   @Test
   public void testGetBytesOffset() throws Exception {
-    assertTrue(uploadFile(TEST_FILE, NATIVE_STREAM) > 0);
+    assertTrue(uploadFile("/test-file.xml", NATIVE_STREAM) > 0);
 
-    try ( Statement stmt = con.createStatement() ) {
-      try (ResultSet rs = stmt.executeQuery("SELECT lo FROM testblob where id = '/test-file.xml'")) {
+    Statement stmt = con.createStatement();
+    ResultSet rs = stmt.executeQuery("SELECT lo FROM testblob");
+    assertTrue(rs.next());
 
-        assertTrue(rs.next());
-
-        Blob lob = rs.getBlob(1);
-        byte[] data = lob.getBytes(2, 4);
-        assertEquals(data.length, 4);
-        assertEquals(data[0], '?');
-        assertEquals(data[1], 'x');
-        assertEquals(data[2], 'm');
-        assertEquals(data[3], 'l');
-      }
-    }
+    Blob lob = rs.getBlob(1);
+    byte[] data = lob.getBytes(2, 4);
+    assertEquals(data.length, 4);
+    assertEquals(data[0], '?');
+    assertEquals(data[1], 'x');
+    assertEquals(data[2], 'm');
+    assertEquals(data[3], 'l');
   }
 
   @Test
   public void testMultipleStreams() throws Exception {
-    assertTrue(uploadFile(TEST_FILE, NATIVE_STREAM) > 0);
+    assertTrue(uploadFile("/test-file.xml", NATIVE_STREAM) > 0);
 
-    try ( Statement stmt = con.createStatement() ) {
-      try (ResultSet rs = stmt.executeQuery("SELECT lo FROM testblob where id = '/test-file.xml'")) {
-        assertTrue(rs.next());
+    Statement stmt = con.createStatement();
+    ResultSet rs = stmt.executeQuery("SELECT lo FROM testblob");
+    assertTrue(rs.next());
 
-        Blob lob = rs.getBlob(1);
-        byte[] data = new byte[2];
+    Blob lob = rs.getBlob(1);
+    byte[] data = new byte[2];
 
-        InputStream is = lob.getBinaryStream();
-        assertEquals(data.length, is.read(data));
-        assertEquals(data[0], '<');
-        assertEquals(data[1], '?');
-        is.close();
+    InputStream is = lob.getBinaryStream();
+    assertEquals(data.length, is.read(data));
+    assertEquals(data[0], '<');
+    assertEquals(data[1], '?');
+    is.close();
 
-        is = lob.getBinaryStream();
-        assertEquals(data.length, is.read(data));
-        assertEquals(data[0], '<');
-        assertEquals(data[1], '?');
-        is.close();
-      }
-    }
+    is = lob.getBinaryStream();
+    assertEquals(data.length, is.read(data));
+    assertEquals(data[0], '<');
+    assertEquals(data[1], '?');
+    is.close();
   }
 
   @Test
   public void testParallelStreams() throws Exception {
-    assertTrue(uploadFile(TEST_FILE, NATIVE_STREAM) > 0);
+    assertTrue(uploadFile("/test-file.xml", NATIVE_STREAM) > 0);
 
-    try ( Statement stmt = con.createStatement() ) {
-      try (ResultSet rs = stmt.executeQuery("SELECT lo FROM testblob where id = '/test-file.xml'")) {
-        assertTrue(rs.next());
+    Statement stmt = con.createStatement();
+    ResultSet rs = stmt.executeQuery("SELECT lo FROM testblob");
+    assertTrue(rs.next());
 
-        Blob lob = rs.getBlob(1);
-        InputStream is1 = lob.getBinaryStream();
-        InputStream is2 = lob.getBinaryStream();
+    Blob lob = rs.getBlob(1);
+    InputStream is1 = lob.getBinaryStream();
+    InputStream is2 = lob.getBinaryStream();
 
-        while (true) {
-          int i1 = is1.read();
-          int i2 = is2.read();
-          assertEquals(i1, i2);
-          if (i1 == -1) {
-            break;
-          }
-        }
-
-        is1.close();
-        is2.close();
+    while (true) {
+      int i1 = is1.read();
+      int i2 = is2.read();
+      assertEquals(i1, i2);
+      if (i1 == -1) {
+        break;
       }
     }
+
+    is1.close();
+    is2.close();
   }
 
   @Test
@@ -300,63 +251,15 @@ public class BlobTest {
       return;
     }
 
-    try ( Statement stmt = con.createStatement() ) {
-      stmt.execute("INSERT INTO testblob(id,lo) VALUES ('1', lo_creat(-1))");
-      try ( ResultSet rs = stmt.executeQuery("SELECT lo FROM testblob where id ='1'") ) {
-        assertTrue(rs.next());
+    Statement stmt = con.createStatement();
+    stmt.execute("INSERT INTO testblob(id,lo) VALUES ('1', lo_creat(-1))");
+    ResultSet rs = stmt.executeQuery("SELECT lo FROM testblob");
+    assertTrue(rs.next());
 
-        Blob lob = rs.getBlob(1);
-        long length = ((long) Integer.MAX_VALUE) + 1024;
-        lob.truncate(length);
-        assertEquals(length, lob.length());
-      }
-    }
-  }
-
-  @Test
-  public void testLargeObjectRead() throws Exception {
-    con.setAutoCommit(false);
-    LargeObjectManager lom = ((org.postgresql.PGConnection) con).getLargeObjectAPI();
-    try ( Statement stmt = con.createStatement() ) {
-      try ( ResultSet rs = stmt.executeQuery("SELECT lo FROM testblob where id='l1'") ) {
-        assertTrue(rs.next());
-
-        long oid = rs.getLong(1);
-        InputStream lois = lom.open(oid).getInputStream();
-        // read half of the data with read
-        for ( int j = 0; j < 512; j++ ) {
-          lois.read();
-        }
-        byte []buf2 = new byte[512];
-        lois.read(buf2, 0, 512);
-        lois.close();
-
-      }
-    }
-    con.commit();
-  }
-
-  @Test
-  public void testLargeObjectRead1() throws Exception {
-    con.setAutoCommit(false);
-    LargeObjectManager lom = ((org.postgresql.PGConnection) con).getLargeObjectAPI();
-    try ( Statement stmt = con.createStatement() ) {
-      try ( ResultSet rs = stmt.executeQuery("SELECT lo FROM testblob where id='l1'") ) {
-        assertTrue(rs.next());
-
-        long oid = rs.getLong(1);
-        InputStream lois = lom.open(oid).getInputStream(512, 1024);
-        // read one byte
-        assertEquals(0, lois.read());
-        byte []buf2 = new byte[1024];
-        int bytesRead = lois.read(buf2, 0, buf2.length);
-        assertEquals( 1023, bytesRead);
-        assertEquals(1, buf2[0]);
-        lois.close();
-
-      }
-    }
-    con.commit();
+    Blob lob = rs.getBlob(1);
+    long length = ((long) Integer.MAX_VALUE) + 1024;
+    lob.truncate(length);
+    assertEquals(length, lob.length());
   }
 
   /*
@@ -416,123 +319,125 @@ public class BlobTest {
    * Helper - compares the blobs in a table with a local file. Note this uses the postgresql
    * specific Large Object API
    */
-  private boolean compareBlobsLOAPI(String id) throws Exception {
+  private boolean compareBlobsLOAPI() throws Exception {
     boolean result = true;
 
     LargeObjectManager lom = ((org.postgresql.PGConnection) con).getLargeObjectAPI();
 
-    try ( Statement st = con.createStatement() ) {
-      try ( ResultSet rs = st.executeQuery(TestUtil.selectSQL("testblob", "id,lo", "id = '" + id + "'")) ) {
-        assertNotNull(rs);
+    Statement st = con.createStatement();
+    ResultSet rs = st.executeQuery(TestUtil.selectSQL("testblob", "id,lo"));
+    assertNotNull(rs);
 
-        while (rs.next()) {
-          String file = rs.getString(1);
-          long oid = rs.getLong(2);
+    while (rs.next()) {
+      String file = rs.getString(1);
+      long oid = rs.getLong(2);
 
-          InputStream fis = getClass().getResourceAsStream(file);
-          LargeObject blob = lom.open(oid);
-          InputStream bis = blob.getInputStream();
+      InputStream fis = getClass().getResourceAsStream(file);
+      LargeObject blob = lom.open(oid);
+      InputStream bis = blob.getInputStream();
 
-          int f = fis.read();
-          int b = bis.read();
-          int c = 0;
-          while (f >= 0 && b >= 0 & result) {
-            result = (f == b);
-            f = fis.read();
-            b = bis.read();
-            c++;
-          }
-          result = result && f == -1 && b == -1;
-
-          if (!result) {
-            fail("Large Object API Blob compare failed at " + c + " of " + blob.size());
-          }
-
-          blob.close();
-          fis.close();
-        }
+      int f = fis.read();
+      int b = bis.read();
+      int c = 0;
+      while (f >= 0 && b >= 0 & result) {
+        result = (f == b);
+        f = fis.read();
+        b = bis.read();
+        c++;
       }
+      result = result && f == -1 && b == -1;
+
+      if (!result) {
+        fail("Large Object API Blob compare failed at " + c + " of " + blob.size());
+      }
+
+      blob.close();
+      fis.close();
     }
+    rs.close();
+    st.close();
+
     return result;
   }
 
   /*
    * Helper - compares the blobs in a table with a local file. This uses the jdbc java.sql.Blob api
    */
-  private boolean compareBlobs(String id) throws Exception {
+  private boolean compareBlobs() throws Exception {
     boolean result = true;
 
-    try ( Statement st = con.createStatement() ) {
-      try (ResultSet rs = st.executeQuery(TestUtil.selectSQL("testblob", "id,lo", "id = '" + id + "'"))) {
-        assertNotNull(rs);
+    Statement st = con.createStatement();
+    ResultSet rs = st.executeQuery(TestUtil.selectSQL("testblob", "id,lo"));
+    assertNotNull(rs);
 
-        while (rs.next()) {
-          String file = rs.getString(1);
-          Blob blob = rs.getBlob(2);
+    while (rs.next()) {
+      String file = rs.getString(1);
+      Blob blob = rs.getBlob(2);
 
-          InputStream fis = getClass().getResourceAsStream(file);
-          InputStream bis = blob.getBinaryStream();
+      InputStream fis = getClass().getResourceAsStream(file);
+      InputStream bis = blob.getBinaryStream();
 
-          int f = fis.read();
-          int b = bis.read();
-          int c = 0;
-          while (f >= 0 && b >= 0 & result) {
-            result = (f == b);
-            f = fis.read();
-            b = bis.read();
-            c++;
-          }
-          result = result && f == -1 && b == -1;
-
-          if (!result) {
-            fail("JDBC API Blob compare failed at " + c + " of " + blob.length());
-          }
-
-          bis.close();
-          fis.close();
-        }
+      int f = fis.read();
+      int b = bis.read();
+      int c = 0;
+      while (f >= 0 && b >= 0 & result) {
+        result = (f == b);
+        f = fis.read();
+        b = bis.read();
+        c++;
       }
+      result = result && f == -1 && b == -1;
+
+      if (!result) {
+        fail("JDBC API Blob compare failed at " + c + " of " + blob.length());
+      }
+
+      bis.close();
+      fis.close();
     }
+    rs.close();
+    st.close();
+
     return result;
   }
 
   /*
    * Helper - compares the clobs in a table with a local file.
    */
-  private boolean compareClobs(String id) throws Exception {
+  private boolean compareClobs() throws Exception {
     boolean result = true;
 
-    try ( Statement st = con.createStatement() ) {
-      try (ResultSet rs = st.executeQuery(TestUtil.selectSQL("testblob", "id,lo", "id = '" + id + "'"))) {
-        assertNotNull(rs);
+    Statement st = con.createStatement();
+    ResultSet rs = st.executeQuery(TestUtil.selectSQL("testblob", "id,lo"));
+    assertNotNull(rs);
 
-        while (rs.next()) {
-          String file = rs.getString(1);
-          Clob clob = rs.getClob(2);
+    while (rs.next()) {
+      String file = rs.getString(1);
+      Clob clob = rs.getClob(2);
 
-          InputStream fis = getClass().getResourceAsStream(file);
-          InputStream bis = clob.getAsciiStream();
+      InputStream fis = getClass().getResourceAsStream(file);
+      InputStream bis = clob.getAsciiStream();
 
-          int f = fis.read();
-          int b = bis.read();
-          int c = 0;
-          while (f >= 0 && b >= 0 & result) {
-            result = (f == b);
-            f = fis.read();
-            b = bis.read();
-            c++;
-          }
-          result = result && f == -1 && b == -1;
-
-          if (!result) {
-            fail("Clob compare failed at " + c + " of " + clob.length());
-          }
-
-          bis.close();
-          fis.close();
-        }
+      int f = fis.read();
+      int b = bis.read();
+      int c = 0;
+      while (f >= 0 && b >= 0 & result) {
+        result = (f == b);
+        f = fis.read();
+        b = bis.read();
+        c++;
       }
+      result = result && f == -1 && b == -1;
+
+      if (!result) {
+        fail("Clob compare failed at " + c + " of " + clob.length());
+      }
+
+      bis.close();
+      fis.close();
     }
+    rs.close();
+    st.close();
 
     return result;
   }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc4/BlobTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc4/BlobTest.java
@@ -63,20 +63,25 @@ public class BlobTest {
   public void testSetBlobWithStream() throws Exception {
     byte[] data = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque bibendum dapibus varius."
         .getBytes("UTF-8");
-    try ( PreparedStatement insertPS = conn.prepareStatement(TestUtil.insertSQL("testblob", "lo", "?")) ) {
+    PreparedStatement insertPS = conn.prepareStatement(TestUtil.insertSQL("testblob", "lo", "?"));
+    try {
       insertPS.setBlob(1, new ByteArrayInputStream(data));
       insertPS.executeUpdate();
+    } finally {
+      insertPS.close();
     }
 
-    try (Statement selectStmt = conn.createStatement() ) {
-      try (ResultSet rs = selectStmt.executeQuery(TestUtil.selectSQL("testblob", "lo"))) {
-        assertTrue(rs.next());
+    Statement selectStmt = conn.createStatement();
+    try {
+      ResultSet rs = selectStmt.executeQuery(TestUtil.selectSQL("testblob", "lo"));
+      assertTrue(rs.next());
 
-        Blob actualBlob = rs.getBlob(1);
-        byte[] actualBytes = actualBlob.getBytes(1, (int) actualBlob.length());
+      Blob actualBlob = rs.getBlob(1);
+      byte[] actualBytes = actualBlob.getBytes(1, (int) actualBlob.length());
 
-        assertArrayEquals(data, actualBytes);
-      }
+      assertArrayEquals(data, actualBytes);
+    } finally {
+      selectStmt.close();
     }
   }
 
@@ -86,21 +91,25 @@ public class BlobTest {
             .getBytes("UTF-8");
     byte[] data =
         "Lorem ipsum dolor sit amet, consectetur adipiscing elit.".getBytes("UTF-8");
-
-    try ( PreparedStatement insertPS = conn.prepareStatement(TestUtil.insertSQL("testblob", "lo", "?")) ) {
+    PreparedStatement insertPS = conn.prepareStatement(TestUtil.insertSQL("testblob", "lo", "?"));
+    try {
       insertPS.setBlob(1, new ByteArrayInputStream(fullData), data.length);
       insertPS.executeUpdate();
+    } finally {
+      insertPS.close();
     }
 
-    try ( Statement selectStmt = conn.createStatement() ) {
-      try (ResultSet rs = selectStmt.executeQuery(TestUtil.selectSQL("testblob", "lo"))) {
-        assertTrue(rs.next());
+    Statement selectStmt = conn.createStatement();
+    try {
+      ResultSet rs = selectStmt.executeQuery(TestUtil.selectSQL("testblob", "lo"));
+      assertTrue(rs.next());
 
-        Blob actualBlob = rs.getBlob(1);
-        byte[] actualBytes = actualBlob.getBytes(1, (int) actualBlob.length());
+      Blob actualBlob = rs.getBlob(1);
+      byte[] actualBytes = actualBlob.getBytes(1, (int) actualBlob.length());
 
-        assertArrayEquals(data, actualBytes);
-      }
+      assertArrayEquals(data, actualBytes);
+    } finally {
+      selectStmt.close();
     }
   }
 
@@ -108,75 +117,48 @@ public class BlobTest {
   public void testGetBinaryStreamWithBoundaries() throws Exception {
     byte[] data =
         "Cras vestibulum tellus eu sapien imperdiet ornare.".getBytes("UTF-8");
-    try ( PreparedStatement insertPS = conn.prepareStatement(TestUtil.insertSQL("testblob", "lo", "?")) ) {
+    PreparedStatement insertPS = conn.prepareStatement(TestUtil.insertSQL("testblob", "lo", "?"));
+    try {
       insertPS.setBlob(1, new ByteArrayInputStream(data), data.length);
       insertPS.executeUpdate();
+    } finally {
+      insertPS.close();
     }
-    try ( Statement selectStmt = conn.createStatement() ) {
-      try (ResultSet rs = selectStmt.executeQuery(TestUtil.selectSQL("testblob", "lo"))) {
-        assertTrue(rs.next());
 
-        byte[] actualData = new byte[10];
-        Blob actualBlob = rs.getBlob(1);
-        InputStream stream = actualBlob.getBinaryStream(6, 10);
-        try {
-          stream.read(actualData);
-          assertEquals("Stream should be at end", -1, stream.read(new byte[1]));
-        } finally {
-          stream.close();
-        }
-        assertEquals("vestibulum", new String(actualData, "UTF-8"));
+    Statement selectStmt = conn.createStatement();
+    try {
+      ResultSet rs = selectStmt.executeQuery(TestUtil.selectSQL("testblob", "lo"));
+      assertTrue(rs.next());
+
+      byte[] actualData = new byte[10];
+      Blob actualBlob = rs.getBlob(1);
+      InputStream stream = actualBlob.getBinaryStream(6, 10);
+      try {
+        stream.read(actualData);
+        assertEquals("Stream should be at end", -1, stream.read(new byte[1]));
+      } finally {
+        stream.close();
       }
-    }
-  }
-
-  @Test
-  public void testGetBinaryStreamWithBoundaries2() throws Exception {
-    byte[] data =
-        "Cras vestibulum tellus eu sapien imperdiet ornare.".getBytes("UTF-8");
-
-    try ( PreparedStatement insertPS = conn.prepareStatement(TestUtil.insertSQL("testblob", "lo", "?")) ) {
-      insertPS.setBlob(1, new ByteArrayInputStream(data), data.length);
-      insertPS.executeUpdate();
-    }
-
-    try ( Statement selectStmt = conn.createStatement() ) {
-      try (ResultSet rs = selectStmt.executeQuery(TestUtil.selectSQL("testblob", "lo"))) {
-        assertTrue(rs.next());
-
-        byte[] actualData = new byte[9];
-        Blob actualBlob = rs.getBlob(1);
-        try ( InputStream stream = actualBlob.getBinaryStream(6, 10) ) {
-          // read 9 bytes 1 at a time
-          for (int i = 0; i < 9; i++) {
-            actualData[i] = (byte) stream.read();
-          }
-          /* try to read past the end and make sure we get 1 byte */
-          assertEquals("There should be 1 byte left", 1, stream.read(new byte[2]));
-          /* now read one more and we should get an EOF */
-          assertEquals("Stream should be at end", -1, stream.read(new byte[1]));
-        }
-        assertEquals("vestibulu", new String(actualData, "UTF-8"));
-      }
+      assertEquals("vestibulum", new String(actualData, "UTF-8"));
+    } finally {
+      selectStmt.close();
     }
   }
 
   @Test
   public void testFree() throws SQLException {
-    try ( Statement stmt = conn.createStatement() ) {
-      stmt.execute("INSERT INTO testblob(lo) VALUES(lo_creat(-1))");
-      try (ResultSet rs = stmt.executeQuery("SELECT lo FROM testblob")) {
-        assertTrue(rs.next());
+    Statement stmt = conn.createStatement();
+    stmt.execute("INSERT INTO testblob(lo) VALUES(lo_creat(-1))");
+    ResultSet rs = stmt.executeQuery("SELECT lo FROM testblob");
+    assertTrue(rs.next());
 
-        Blob blob = rs.getBlob(1);
-        blob.free();
-        try {
-          blob.length();
-          fail("Should have thrown an Exception because it was freed.");
-        } catch (SQLException sqle) {
-          // expected
-        }
-      }
+    Blob blob = rs.getBlob(1);
+    blob.free();
+    try {
+      blob.length();
+      fail("Should have thrown an Exception because it was freed.");
+    } catch (SQLException sqle) {
+      // expected
     }
   }
 }


### PR DESCRIPTION
Reverts pgjdbc/pgjdbc#2376

As @vlsi mentioned a better solution would be to buffer at the LargeObject layer.
As I'm not entirely sure this doesn't introduce more issues I am reverting in favour of a different implementation