### PR TITLE
fix: added GROUP_STARTUP_PARAMETERS boolean property to determine whether or not to group startup parameters in a transaction or not fixes Issue 2423 pgbouncer cannot deal with transactions in statement pooling mode

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -76,6 +76,15 @@ build_script:
 test_script:
   - echo redirect escape ^> foo.bar
   - echo privilegedPassword=Password12!>c:\projects\pgjdbc\build.local.properties
+  - set PGDATABASE=
+  - set PGHOST=
+  - set PGPASSFILE=
+  - set PGPASSWORD=
+  - set PGPORT=
+  - set PGSERVICE=
+  - set PGSERVICEFILE=
+  - set PGSYSCONFDIR=
+  - set PGUSER=
   - gradlew test
 
 cache:

--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -223,6 +223,20 @@ public enum PGProperty {
       false,
       new String[] {"select", "callIfNoReturn", "call"}),
 
+  /**
+   * Group startup parameters in a transaction
+   * This is important in pool-by-transaction scenarios in order to make sure that all the statements
+   * reaches the same connection that is being initialized. All of the startup parameters will be wrapped
+   * in a transaction
+   * Note this is off by default as pgbouncer in statement mode
+   */
+  GROUP_STARTUP_PARAMETERS(
+      "groupStartupParameters",
+      "false",
+      "This is important in pool-by-transaction scenarios in order to make sure that all "
+          + "the statements reaches the same connection that is being initialized."
+  ),
+
   GSS_ENC_MODE(
       "gssEncMode",
       "allow",

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java
@@ -852,7 +852,7 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
 
     final int dbVersion = queryExecutor.getServerVersionNum();
 
-    if (dbVersion >= ServerVersion.v9_0.getVersionNum()) {
+    if (PGProperty.GROUP_STARTUP_PARAMETERS.getBoolean(info) && dbVersion >= ServerVersion.v9_0.getVersionNum()) {
       SetupQueryRunner.run(queryExecutor, "BEGIN", false);
     }
 
@@ -869,7 +869,7 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
       SetupQueryRunner.run(queryExecutor, sql.toString(), false);
     }
 
-    if (dbVersion >= ServerVersion.v9_0.getVersionNum()) {
+    if (PGProperty.GROUP_STARTUP_PARAMETERS.getBoolean(info) && dbVersion >= ServerVersion.v9_0.getVersionNum()) {
       SetupQueryRunner.run(queryExecutor, "COMMIT", false);
     }
   }

--- a/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
+++ b/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
@@ -1016,6 +1016,26 @@ public abstract class BaseDataSource implements CommonDataSource, Referenceable 
   }
 
   /**
+   * This is important in pool-by-transaction scenarios in order to make sure that all the statements
+   * reaches the same connection that is being initialized. If set then we will group the startup
+   * parameters in a transaction
+   * @return whether to group starup parameters or not
+   * @see PGProperty#GROUP_STARTUP_PARAMETERS
+   */
+  public boolean getGroupStartupParameters() {
+    return PGProperty.GROUP_STARTUP_PARAMETERS.getBoolean(properties);
+  }
+
+  /**
+   *
+   * @param groupStartupParameters whether to group startup Parameters in a transaction or not
+   * @see PGProperty#GROUP_STARTUP_PARAMETERS
+   */
+  public void setGroupStartupParameters(boolean groupStartupParameters) {
+    PGProperty.GROUP_STARTUP_PARAMETERS.set(properties, groupStartupParameters);
+  }
+
+  /**
    * @return JAAS application name
    * @see PGProperty#JAAS_APPLICATION_NAME
    */


### PR DESCRIPTION
fixes [Issue #2423](https://github.com/pgjdbc/pgjdbc/issues/2423)