### PR TITLE
Fix the RPM CI - typo in branch names

### DIFF
--- a/.github/workflows/fedora-copr-build.yml
+++ b/.github/workflows/fedora-copr-build.yml
@@ -2,9 +2,9 @@
 name: RPM build in Fedora Copr
 on:
   push:
-    branches: [main]
+    branches: [master]
   pull_request:
-    branches: [main]
+    branches: [master]
 
 jobs:
   build:


### PR DESCRIPTION
Sorry for the rush.  Going through PR to actually test the PR workflow.