### PR TITLE
fix: Throw an exception if the driver cannot parse the URL instead of returning NULL 

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/Driver.java
+++ b/pgjdbc/src/main/java/org/postgresql/Driver.java
@@ -246,7 +246,9 @@ public class Driver implements java.sql.Driver {
     }
     // parse URL and add more properties
     if ((props = parseURL(url, props)) == null) {
-      return null;
+      throw new PSQLException(
+          GT.tr("Unable to parse URL "),
+          PSQLState.UNEXPECTED_ERROR);
     }
     try {
       // Setup java.util.logging.Logger using connection properties.


### PR DESCRIPTION
Fixes Issue #2421 