### PR TITLE
fix: change PGInterval parseISO8601Format to support fractional second

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/util/PGInterval.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/PGInterval.java
@@ -98,13 +98,13 @@ public class PGInterval extends PGobject implements Serializable, Cloneable {
       for (int i = 0; i < timeValue.length(); i++) {
         int lookAhead = lookAhead(timeValue, i, "HMS");
         if (lookAhead > 0) {
-          number = Integer.parseInt(timeValue.substring(i, lookAhead));
+          final String substring = timeValue.substring(i, lookAhead);
           if (timeValue.charAt(lookAhead) == 'H') {
-            setHours(number);
+            setHours(Integer.parseInt(substring));
           } else if (timeValue.charAt(lookAhead) == 'M') {
-            setMinutes(number);
+            setMinutes(Integer.parseInt(substring));
           } else if (timeValue.charAt(lookAhead) == 'S') {
-            setSeconds(number);
+            setSeconds(Double.parseDouble(substring));
           }
           i = lookAhead;
         }

--- a/pgjdbc/src/main/java/org/postgresql/util/PGInterval.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/PGInterval.java
@@ -98,13 +98,12 @@ public class PGInterval extends PGobject implements Serializable, Cloneable {
       for (int i = 0; i < timeValue.length(); i++) {
         int lookAhead = lookAhead(timeValue, i, "HMS");
         if (lookAhead > 0) {
-          final String substring = timeValue.substring(i, lookAhead);
           if (timeValue.charAt(lookAhead) == 'H') {
-            setHours(Integer.parseInt(substring));
+            setHours(Integer.parseInt(timeValue.substring(i, lookAhead)));
           } else if (timeValue.charAt(lookAhead) == 'M') {
-            setMinutes(Integer.parseInt(substring));
+            setMinutes(Integer.parseInt(timeValue.substring(i, lookAhead)));
           } else if (timeValue.charAt(lookAhead) == 'S') {
-            setSeconds(Double.parseDouble(substring));
+            setSeconds(Double.parseDouble(timeValue.substring(i, lookAhead)));
           }
           i = lookAhead;
         }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/IntervalTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/IntervalTest.java
@@ -304,6 +304,16 @@ public class IntervalTest {
     assertEquals(-1, pgi.getYears());
     assertEquals(-2, pgi.getMonths());
     assertEquals(-4, pgi.getHours());
+
+    pgi = new PGInterval("PT6.123456S");
+    assertEquals(6.123456, pgi.getSeconds(), .0);
+    assertEquals(6, pgi.getWholeSeconds());
+    assertEquals(123456, pgi.getMicroSeconds());
+
+    pgi = new PGInterval("PT-6.123456S");
+    assertEquals(-6.123456, pgi.getSeconds(), .0);
+    assertEquals(-6, pgi.getWholeSeconds());
+    assertEquals(-123456, pgi.getMicroSeconds());
   }
 
   @Test


### PR DESCRIPTION
change parse seconds segment from Integer to Double

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes to Existing Features:

* [ ] Does this break existing behaviour? If so please explain.
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
