### PR TITLE
docs: Fix CHANGELOG.md misformatted markdown headings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-##[42.3.3] (2022-02-15 11:32:24 -0500)
+## [42.3.3] (2022-02-15 11:32:24 -0500)
 ### Changed
 - fix: Removed loggerFile and loggerLevel configuration. While the properties still exist. 
   They can no longer be used to configure the driver logging. Instead use java.util.logging
@@ -20,7 +20,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-##[42.3.2] (2022-02-01 07:35:41 -0500)
+## [42.3.2] (2022-02-01 07:35:41 -0500)
 ### Security
 - CVE-2022-21724 pgjdbc instantiates plugin instances based on class names provided via authenticationPluginClassName, 
 sslhostnameverifier, socketFactory, sslfactory, sslpasswordcallback connection properties.


### PR DESCRIPTION
Minor cosmetic fix.

Example of rendered documents on GitHub:

Before:
![image](https://user-images.githubusercontent.com/978424/154537859-e1b963a8-8d7b-417f-9452-6484e92612fb.png)

After:
![image](https://user-images.githubusercontent.com/978424/154538042-4b2becec-5fb8-4d4b-b2de-2bd86582add4.png)

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
