### PR TITLE
added post for 42.2.25 [SKIP CI]

### DIFF
--- a/docs/_posts/2021-02-01-42.2.25-release.md
+++ b/docs/_posts/2021-02-01-42.2.25-release.md
@@ -1,0 +1,18 @@
+---
+title: PostgreSQL JDBC Driver 42.2.25 Released
+date: 2022-02-01 07:35:28 -0500
+categories:
+  - new_release
+version: 42.2.25
+---
+
+### Security
+- CVE-2022-21724 pgjdbc instantiates plugin instances based on class names provided via authenticationPluginClassName,
+  sslhostnameverifier, socketFactory, sslfactory, sslpasswordcallback connection properties.
+  However, the driver did not verify if the class implements the expected interface before instantiating the class. This
+  would allow a malicious class to be instantiated that could execute arbitrary code from the JVM. Fixed in [commit](https://github.com/pgjdbc/pgjdbc/commit/f4d0ed69c0b3aae8531d83d6af4c57f22312c813)
+
+<!--more-->
+
+**Commits by author**
+


### PR DESCRIPTION
This just adds an entry for 42.2.25 into the downloads to clarify that it is the official latest 42.2.x version