### PR TITLE
feat: add support for ResultSet#getObject(OffsetTime.class) and PreparedStatement#setObject(OffsetTime.class)

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
@@ -69,6 +69,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
+import java.time.OffsetTime;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Map;
@@ -614,6 +615,9 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
           } else if (in instanceof LocalTime) {
             setTime(parameterIndex, (LocalTime) in);
             break;
+          } else if (in instanceof OffsetTime) {
+            setTime(parameterIndex, (OffsetTime) in);
+            break;
           } else {
             tmpt = getTimestampUtils().toTime(getDefaultCalendar(), in.toString());
           }
@@ -988,6 +992,8 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
       setDate(parameterIndex, (LocalDate) x);
     } else if (x instanceof LocalTime) {
       setTime(parameterIndex, (LocalTime) x);
+    } else if (x instanceof OffsetTime) {
+      setTime(parameterIndex, (OffsetTime) x);
     } else if (x instanceof LocalDateTime) {
       setTimestamp(parameterIndex, (LocalDateTime) x);
     } else if (x instanceof OffsetDateTime) {
@@ -1437,6 +1443,11 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
   private void setTime(@Positive int i, LocalTime localTime) throws SQLException {
     int oid = Oid.TIME;
     bindString(i, getTimestampUtils().toString(localTime), oid);
+  }
+
+  private void setTime(@Positive int i, OffsetTime offsetTime) throws SQLException {
+    int oid = Oid.TIMETZ;
+    bindString(i, getTimestampUtils().toString(offsetTime), oid);
   }
 
   private void setTimestamp(@Positive int i, LocalDateTime localDateTime)

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
@@ -3762,7 +3762,7 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
                 PSQLState.INVALID_PARAMETER_VALUE);
       }
     } else if (type == OffsetDateTime.class) {
-      if (sqlType == Types.TIMESTAMP_WITH_TIMEZONE || sqlType == Types.TIMESTAMP || sqlType == Types.TIME) {
+      if (sqlType == Types.TIMESTAMP_WITH_TIMEZONE || sqlType == Types.TIMESTAMP || sqlType == Types.TIME || sqlType == Types.TIME_WITH_TIMEZONE) {
         OffsetDateTime offsetDateTime = getOffsetDateTime(columnIndex);
         return type.cast(offsetDateTime);
       } else {
@@ -3770,7 +3770,8 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
                 PSQLState.INVALID_PARAMETER_VALUE);
       }
     } else if (type == OffsetTime.class) {
-      if (sqlType == Types.TIME) {
+      // Postgres currently always returns Types#TIME, also for TIMETZ:
+      if (sqlType == Types.TIME || sqlType == Types.TIME_WITH_TIMEZONE) {
         return type.cast(getOffsetTime(columnIndex));
       } else {
         throw new PSQLException(GT.tr("conversion to {0} from {1} not supported", type, getPGType(columnIndex)),

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
@@ -3741,42 +3741,15 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
       }
       // JSR-310 support
     } else if (type == LocalDate.class) {
-      if (sqlType == Types.DATE || sqlType == Types.TIMESTAMP) {
-        return type.cast(getLocalDate(columnIndex));
-      } else {
-        throw new PSQLException(GT.tr("conversion to {0} from {1} not supported", type, getPGType(columnIndex)),
-                PSQLState.INVALID_PARAMETER_VALUE);
-      }
+      return type.cast(getLocalDate(columnIndex));
     } else if (type == LocalTime.class) {
-      if (sqlType == Types.TIME) {
-        return type.cast(getLocalTime(columnIndex));
-      } else {
-        throw new PSQLException(GT.tr("conversion to {0} from {1} not supported", type, getPGType(columnIndex)),
-                PSQLState.INVALID_PARAMETER_VALUE);
-      }
+      return type.cast(getLocalTime(columnIndex));
     } else if (type == LocalDateTime.class) {
-      if (sqlType == Types.TIMESTAMP) {
-        return type.cast(getLocalDateTime(columnIndex));
-      } else {
-        throw new PSQLException(GT.tr("conversion to {0} from {1} not supported", type, getPGType(columnIndex)),
-                PSQLState.INVALID_PARAMETER_VALUE);
-      }
+      return type.cast(getLocalDateTime(columnIndex));
     } else if (type == OffsetDateTime.class) {
-      if (sqlType == Types.TIMESTAMP_WITH_TIMEZONE || sqlType == Types.TIMESTAMP || sqlType == Types.TIME || sqlType == Types.TIME_WITH_TIMEZONE) {
-        OffsetDateTime offsetDateTime = getOffsetDateTime(columnIndex);
-        return type.cast(offsetDateTime);
-      } else {
-        throw new PSQLException(GT.tr("conversion to {0} from {1} not supported", type, getPGType(columnIndex)),
-                PSQLState.INVALID_PARAMETER_VALUE);
-      }
+      return type.cast(getOffsetDateTime(columnIndex));
     } else if (type == OffsetTime.class) {
-      // Postgres currently always returns Types#TIME, also for TIMETZ:
-      if (sqlType == Types.TIME || sqlType == Types.TIME_WITH_TIMEZONE) {
-        return type.cast(getOffsetTime(columnIndex));
-      } else {
-        throw new PSQLException(GT.tr("conversion to {0} from {1} not supported", type, getPGType(columnIndex)),
-                PSQLState.INVALID_PARAMETER_VALUE);
-      }
+      return type.cast(getOffsetTime(columnIndex));
     } else if (PGobject.class.isAssignableFrom(type)) {
       Object object;
       if (isBinary(columnIndex)) {

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
@@ -586,29 +586,6 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
     return getTimestampUtils().toTime(cal, string);
   }
 
-  private @Nullable LocalTime getLocalTime(int i) throws SQLException {
-    byte[] value = getRawValue(i);
-    if (value == null) {
-      return null;
-    }
-
-    if (isBinary(i)) {
-      int col = i - 1;
-      int oid = fields[col].getOID();
-      if (oid == Oid.TIME) {
-        return getTimestampUtils().toLocalTimeBin(value);
-      } else {
-        throw new PSQLException(
-            GT.tr("Cannot convert the column of type {0} to requested type {1}.",
-                Oid.toString(oid), "time"),
-            PSQLState.DATA_TYPE_MISMATCH);
-      }
-    }
-
-    String string = getString(i);
-    return getTimestampUtils().toLocalTime(string);
-  }
-
   @Pure
   @Override
   public @Nullable Timestamp getTimestamp(
@@ -776,6 +753,29 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
     throw new PSQLException(
         GT.tr("Cannot convert the column of type {0} to requested type {1}.",
             Oid.toString(oid), "java.time.LocalDate"),
+        PSQLState.DATA_TYPE_MISMATCH);
+  }
+
+  private @Nullable LocalTime getLocalTime(int i) throws SQLException {
+    byte[] value = getRawValue(i);
+    if (value == null) {
+      return null;
+    }
+
+    int col = i - 1;
+    int oid = fields[col].getOID();
+
+    if (oid == Oid.TIME) {
+      if (isBinary(i)) {
+        return getTimestampUtils().toLocalTimeBin(value);
+      } else {
+        return getTimestampUtils().toLocalTime(getString(i));
+      }
+    }
+
+    throw new PSQLException(
+        GT.tr("Cannot convert the column of type {0} to requested type {1}.",
+            Oid.toString(oid), "java.time.LocalTime"),
         PSQLState.DATA_TYPE_MISMATCH);
   }
 

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
@@ -672,6 +672,7 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
 
   }
 
+  // TODO: In Java 8 this constant is missing, later versions (at least 11) have LocalDate#EPOCH:
   private static final LocalDate LOCAL_DATE_EPOCH = LocalDate.of(1970, 1, 1);
 
   private @Nullable OffsetDateTime getOffsetDateTime(int i) throws SQLException {

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
@@ -709,7 +709,7 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
     int oid = fields[col].getOID();
 
     if (isBinary(i)) {
-     if (oid == Oid.TIMETZ || oid == Oid.TIME) {
+      if (oid == Oid.TIMETZ || oid == Oid.TIME) {
         return getTimestampUtils().toOffsetTimeBin(value);
       } else {
         throw new PSQLException(

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/TimestampUtils.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/TimestampUtils.java
@@ -435,13 +435,11 @@ public class TimestampUtils {
    * @throws PSQLException If binary format could not be parsed.
    */
   public OffsetTime toOffsetTimeBin(byte[] bytes) throws PSQLException {
-    if ((bytes.length != 8 && bytes.length != 12)) {
+    if (bytes.length != 12) {
       throw new PSQLException(GT.tr("Unsupported binary encoding of {0}.", "time"),
           PSQLState.BAD_DATETIME_FORMAT);
     }
 
-    // question: use default timezone with offset of current day here?
-    ZoneOffset timeOffset = ZoneOffset.UTC;
     final long micros;
 
     if (usesDouble) {
@@ -451,10 +449,8 @@ public class TimestampUtils {
       micros = ByteConverter.int8(bytes, 0);
     }
 
-    if (bytes.length == 12) {
-      // postgres offset is negative, so we have to flip sign:
-      timeOffset = ZoneOffset.ofTotalSeconds(-ByteConverter.int4(bytes, 8));
-    }
+    // postgres offset is negative, so we have to flip sign:
+    final ZoneOffset timeOffset = ZoneOffset.ofTotalSeconds(-ByteConverter.int4(bytes, 8));
 
     return OffsetTime.of(LocalTime.ofNanoOfDay(Math.multiplyExact(micros, 1000L)), timeOffset);
   }
@@ -515,12 +511,12 @@ public class TimestampUtils {
   }
 
   /**
-   * Parse a string and return a LocalDateTime representing its value.
+   * Parse a string and return a OffsetDateTime representing its value.
    *
    * @param s The ISO formated date string to parse.
    * @param adaptToUTC if true the timezone is adapted to be UTC;
    *     this must be done for timestamp and timestamptz as they have no zone on server side
-   * @return null if s is null or a LocalDateTime of the parsed string s.
+   * @return null if s is null or a OffsetDateTime of the parsed string s.
    * @throws SQLException if there is a problem parsing s.
    */
   public @PolyNull OffsetDateTime toOffsetDateTime(

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/TimestampUtils.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/TimestampUtils.java
@@ -569,7 +569,7 @@ public class TimestampUtils {
     }
     ParsedTimestamp ts = parseBackendTimestamp(s);
     Calendar useCal = ts.hasOffset ? setupCalendar(ts.offset) : setupCalendar(cal);
-    if (ts.offset == null) {
+    if (!ts.hasOffset) {
       // When no time zone provided (e.g. time or timestamp)
       // We get the year-month-day from the string, then truncate the day to 1970-01-01
       // This is used for timestamp -> time conversion
@@ -596,7 +596,7 @@ public class TimestampUtils {
     useCal.set(Calendar.MILLISECOND, 0);
 
     long timeMillis = useCal.getTimeInMillis() + ts.nanos / 1000000;
-    if (ts.offset != null || (ts.year == 1970 && ts.era == GregorianCalendar.AD)) {
+    if (ts.hasOffset || (ts.year == 1970 && ts.era == GregorianCalendar.AD)) {
       // time with time zone has proper time zone, so the value can be returned as is
       return new Time(timeMillis);
     }

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/TimestampUtils.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/TimestampUtils.java
@@ -286,7 +286,7 @@ public class TimestampUtils {
       sep = charAt(s, start);
       if (sep == '-' || sep == '+') {
         result.hasOffset = true;
-        
+
         int tzsign = (sep == '-') ? -1 : 1;
         int tzhr;
         int tzmin;
@@ -461,9 +461,9 @@ public class TimestampUtils {
     if (s.startsWith("24:00:00")) {
       return OffsetTime.MAX;
     }
-    
+
     final ParsedTimestamp ts = parseBackendTimestamp(s);
-    return OffsetTime.of(ts.hour, ts.minute, ts.second, ts.nanos, ts.offset); 
+    return OffsetTime.of(ts.hour, ts.minute, ts.second, ts.nanos, ts.offset);
   }
 
   /**
@@ -506,7 +506,7 @@ public class TimestampUtils {
    *
    * @param s The ISO formated date string to parse.
    * @param adaptToUTC if true the timezone is adapted to be UTC;
-   *   this must be done for timestamp and timestamptz as they have no zone on server side
+   *     this must be done for timestamp and timestamptz as they have no zone on server side
    * @return null if s is null or a LocalDateTime of the parsed string s.
    * @throws SQLException if there is a problem parsing s.
    */

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/TimestampUtils.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/TimestampUtils.java
@@ -893,6 +893,29 @@ public class TimestampUtils {
     return sbuf.toString();
   }
 
+  public synchronized String toString(OffsetTime offsetTime) {
+
+    sbuf.setLength(0);
+
+    final LocalTime localTime = offsetTime.toLocalTime();
+    if (localTime.isAfter(MAX_TIME)) {
+      sbuf.append("24:00:00");
+      appendTimeZone(sbuf, offsetTime.getOffset());
+      return sbuf.toString();
+    }
+
+    int nano = offsetTime.getNano();
+    if (nanosExceed499(nano)) {
+      // Technically speaking this is not a proper rounding, however
+      // it relies on the fact that appendTime just truncates 000..999 nanosecond part
+      offsetTime = offsetTime.plus(ONE_MICROSECOND);
+    }
+    appendTime(sbuf, localTime);
+    appendTimeZone(sbuf, offsetTime.getOffset());
+
+    return sbuf.toString();
+  }
+
   public synchronized String toString(OffsetDateTime offsetDateTime) {
     if (offsetDateTime.isAfter(MAX_OFFSET_DATETIME)) {
       return "infinity";

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/TimestampUtils.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/TimestampUtils.java
@@ -39,6 +39,7 @@ import java.time.temporal.ChronoField;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.HashMap;
+import java.util.Objects;
 import java.util.TimeZone;
 
 /**
@@ -130,7 +131,7 @@ public class TimestampUtils {
   private final TimeZone utcTz = TimeZone.getTimeZone(ZoneOffset.UTC);
 
   private @Nullable Calendar calCache;
-  private ZoneOffset calCacheZone;
+  private @Nullable ZoneOffset calCacheZone;
 
   /**
    * True if the backend uses doubles for time values. False if long is used.
@@ -144,7 +145,7 @@ public class TimestampUtils {
   }
 
   private Calendar getCalendar(ZoneOffset offset) {
-    if (calCache != null && calCacheZone == offset) {
+    if (calCache != null && Objects.equals(offset, calCacheZone)) {
       return calCache;
     }
 

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/TimestampUtils.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/TimestampUtils.java
@@ -111,7 +111,6 @@ public class TimestampUtils {
         tzField = TimeZone.class.getDeclaredField("defaultTimeZone");
         tzField.setAccessible(true);
         TimeZone defaultTz = TimeZone.getDefault();
-        @SuppressWarnings("nullability")
         Object tzFromField = tzField.get(null);
         if (defaultTz == null || !defaultTz.equals(tzFromField)) {
           tzField = null;
@@ -1063,7 +1062,6 @@ public class TimestampUtils {
     // Fast path to getting the default timezone.
     if (DEFAULT_TIME_ZONE_FIELD != null) {
       try {
-        @SuppressWarnings("nullability")
         TimeZone defaultTimeZone = (TimeZone) DEFAULT_TIME_ZONE_FIELD.get(null);
         if (defaultTimeZone == prevDefaultZoneFieldValue) {
           return castNonNull(defaultTimeZoneCache);

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc42/GetObject310Test.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc42/GetObject310Test.java
@@ -355,7 +355,7 @@ public class GetObject310Test extends BaseTest4 {
 
   @Test
   public void testBcTimestamp() throws SQLException {
-    try(Statement stmt = con.createStatement(); ResultSet rs = stmt.executeQuery("SELECT '1582-09-30 12:34:56 BC'::timestamp")) {
+    try (Statement stmt = con.createStatement(); ResultSet rs = stmt.executeQuery("SELECT '1582-09-30 12:34:56 BC'::timestamp")) {
       assertTrue(rs.next());
       LocalDateTime expected = LocalDateTime.of(1582, 9, 30, 12, 34, 56)
           .with(ChronoField.ERA, IsoEra.BCE.getValue());

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc42/GetObject310Test.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc42/GetObject310Test.java
@@ -174,7 +174,7 @@ public class GetObject310Test extends BaseTest4 {
           OffsetTime offsetTime = OffsetTime.parse(time);
           assertEquals(offsetTime, rs.getObject("time_with_time_zone_column", OffsetTime.class));
           assertEquals(offsetTime, rs.getObject(1, OffsetTime.class));
-          
+
           //Also test that we get the correct values when retrieving the data as OffsetDateTime objects on EPOCH (required by JDBC)
           OffsetDateTime offsetDT = offsetTime.atDate(LocalDate.of(1970, 1, 1));
           assertEquals(offsetDT, rs.getObject("time_with_time_zone_column", OffsetDateTime.class));

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc42/GetObject310Test.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc42/GetObject310Test.java
@@ -8,6 +8,7 @@ package org.postgresql.test.jdbc42;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 
@@ -41,7 +42,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.TimeZone;
-import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -179,6 +179,10 @@ public class GetObject310Test extends BaseTest4 {
           OffsetDateTime offsetDT = offsetTime.atDate(LocalDate.of(1970, 1, 1));
           assertEquals(offsetDT, rs.getObject("time_with_time_zone_column", OffsetDateTime.class));
           assertEquals(offsetDT, rs.getObject(1, OffsetDateTime.class));
+
+          assertDataTypeMismatch(rs, "time_with_time_zone_column", LocalDate.class);
+          assertDataTypeMismatch(rs, "time_with_time_zone_column", LocalTime.class);
+          assertDataTypeMismatch(rs, "time_with_time_zone_column", LocalDateTime.class);
         }
         stmt.executeUpdate("DELETE FROM table1");
       }
@@ -190,17 +194,21 @@ public class GetObject310Test extends BaseTest4 {
    */
   @Test
   public void testGetLocalTime() throws SQLException {
-    Statement stmt = con.createStatement();
-    stmt.executeUpdate(TestUtil.insertSQL("table1","time_without_time_zone_column","TIME '04:05:06.123456'"));
+    try (Statement stmt = con.createStatement(); ) {
+      stmt.executeUpdate(TestUtil.insertSQL("table1","time_without_time_zone_column","TIME '04:05:06.123456'"));
 
-    ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("table1", "time_without_time_zone_column"));
-    try {
-      assertTrue(rs.next());
-      LocalTime localTime = LocalTime.of(4, 5, 6, 123456000);
-      assertEquals(localTime, rs.getObject("time_without_time_zone_column", LocalTime.class));
-      assertEquals(localTime, rs.getObject(1, LocalTime.class));
-    } finally {
-      rs.close();
+      try (ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("table1", "time_without_time_zone_column"))) {
+        assertTrue(rs.next());
+        LocalTime localTime = LocalTime.of(4, 5, 6, 123456000);
+        assertEquals(localTime, rs.getObject("time_without_time_zone_column", LocalTime.class));
+        assertEquals(localTime, rs.getObject(1, LocalTime.class));
+
+        assertDataTypeMismatch(rs, "time_without_time_zone_column", OffsetTime.class);
+        assertDataTypeMismatch(rs, "time_without_time_zone_column", OffsetDateTime.class);
+        assertDataTypeMismatch(rs, "time_without_time_zone_column", LocalDate.class);
+        assertDataTypeMismatch(rs, "time_without_time_zone_column", LocalDateTime.class);
+      }
+      stmt.executeUpdate("DELETE FROM table1");
     }
   }
 
@@ -209,44 +217,33 @@ public class GetObject310Test extends BaseTest4 {
    */
   @Test
   public void testGetLocalTimeNull() throws SQLException {
-    Statement stmt = con.createStatement();
-    stmt.executeUpdate(TestUtil.insertSQL("table1","time_without_time_zone_column","NULL"));
+    try (Statement stmt = con.createStatement(); ) {
+      stmt.executeUpdate(TestUtil.insertSQL("table1","time_without_time_zone_column","NULL"));
 
-    ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("table1", "time_without_time_zone_column"));
-    try {
-      assertTrue(rs.next());
-      assertNull(rs.getObject("time_without_time_zone_column", LocalTime.class));
-      assertNull(rs.getObject(1, LocalTime.class));
-    } finally {
-      rs.close();
+      try (ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("table1", "time_without_time_zone_column"))) {
+        assertTrue(rs.next());
+        assertNull(rs.getObject("time_without_time_zone_column", LocalTime.class));
+        assertNull(rs.getObject(1, LocalTime.class));
+      }
+      stmt.executeUpdate("DELETE FROM table1");
     }
   }
 
   /**
-   * Test the behavior getObject for time columns with null.
+   * Test the behavior getObject for time columns with invalid type.
    */
   @Test
   public void testGetLocalTimeInvalidType() throws SQLException {
-    Statement stmt = con.createStatement();
-    stmt.executeUpdate(TestUtil.insertSQL("table1","time_with_time_zone_column", "TIME '04:05:06.123456-08:00'"));
+    try (Statement stmt = con.createStatement(); ) {
+      stmt.executeUpdate(TestUtil.insertSQL("table1","time_with_time_zone_column", "TIME '04:05:06.123456-08:00'"));
 
-    ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("table1", "time_with_time_zone_column"));
-    try {
-      assertTrue(rs.next());
-      try {
-        assertNull(rs.getObject("time_with_time_zone_column", LocalTime.class));
-      } catch (PSQLException e) {
-        assertTrue(e.getSQLState().equals(PSQLState.DATA_TYPE_MISMATCH.getState())
-                || e.getSQLState().equals(PSQLState.BAD_DATETIME_FORMAT.getState()));
+      try (ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("table1", "time_with_time_zone_column"))) {
+        assertTrue(rs.next());
+        assertDataTypeMismatch(rs, "time_with_time_zone_column", LocalTime.class);
+        assertDataTypeMismatch(rs, "time_with_time_zone_column", LocalDateTime.class);
+        assertDataTypeMismatch(rs, "time_with_time_zone_column", LocalDate.class);
       }
-      try {
-        assertNull(rs.getObject(1, LocalTime.class));
-      } catch (PSQLException e) {
-        assertTrue(e.getSQLState().equals(PSQLState.DATA_TYPE_MISMATCH.getState())
-                || e.getSQLState().equals(PSQLState.BAD_DATETIME_FORMAT.getState()));
-      }
-    } finally {
-      rs.close();
+      stmt.executeUpdate("DELETE FROM table1");
     }
   }
 
@@ -305,12 +302,10 @@ public class GetObject310Test extends BaseTest4 {
 
   public void localTimestamps(ZoneId zoneId, String timestamp) throws SQLException {
     TimeZone.setDefault(TimeZone.getTimeZone(zoneId));
-    Statement stmt = con.createStatement();
-    try {
+    try (Statement stmt = con.createStatement()) {
       stmt.executeUpdate(TestUtil.insertSQL("table1","timestamp_without_time_zone_column","TIMESTAMP '" + timestamp + "'"));
 
-      ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("table1", "timestamp_without_time_zone_column"));
-      try {
+      try (ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("table1", "timestamp_without_time_zone_column"))) {
         assertTrue(rs.next());
         LocalDateTime localDateTime = LocalDateTime.parse(timestamp);
         assertEquals(localDateTime, rs.getObject("timestamp_without_time_zone_column", LocalDateTime.class));
@@ -319,12 +314,12 @@ public class GetObject310Test extends BaseTest4 {
         //Also test that we get the correct values when retrieving the data as LocalDate objects
         assertEquals(localDateTime.toLocalDate(), rs.getObject("timestamp_without_time_zone_column", LocalDate.class));
         assertEquals(localDateTime.toLocalDate(), rs.getObject(1, LocalDate.class));
-      } finally {
-        rs.close();
+
+        assertDataTypeMismatch(rs, "timestamp_without_time_zone_column", OffsetTime.class);
+        // TODO: this should also not work, but that's an open discussion (see https://github.com/pgjdbc/pgjdbc/pull/2467):
+        // assertDataTypeMismatch(rs, "timestamp_without_time_zone_column", OffsetDateTime.class);
       }
       stmt.executeUpdate("DELETE FROM table1");
-    } finally {
-      stmt.close();
     }
   }
 
@@ -340,60 +335,46 @@ public class GetObject310Test extends BaseTest4 {
   }
 
   private void runGetOffsetDateTime(ZoneOffset offset) throws SQLException {
-    Statement stmt = con.createStatement();
-    try {
+    try (Statement stmt = con.createStatement()) {
       stmt.executeUpdate(TestUtil.insertSQL("table1","timestamp_with_time_zone_column","TIMESTAMP WITH TIME ZONE '2004-10-19 10:23:54.123456" + offset.toString() + "'"));
 
-      ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("table1", "timestamp_with_time_zone_column"));
-      try {
+      try (ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("table1", "timestamp_with_time_zone_column"))) {
         assertTrue(rs.next());
         LocalDateTime localDateTime = LocalDateTime.of(2004, 10, 19, 10, 23, 54, 123456000);
 
         OffsetDateTime offsetDateTime = localDateTime.atOffset(offset).withOffsetSameInstant(ZoneOffset.UTC);
         assertEquals(offsetDateTime, rs.getObject("timestamp_with_time_zone_column", OffsetDateTime.class));
         assertEquals(offsetDateTime, rs.getObject(1, OffsetDateTime.class));
-      } finally {
-        rs.close();
+
+        assertDataTypeMismatch(rs, "timestamp_with_time_zone_column", LocalTime.class);
+        assertDataTypeMismatch(rs, "timestamp_with_time_zone_column", LocalDateTime.class);
       }
       stmt.executeUpdate("DELETE FROM table1");
-    } finally {
-      stmt.close();
     }
   }
 
   @Test
   public void testBcTimestamp() throws SQLException {
-
-    Statement stmt = con.createStatement();
-    ResultSet rs = stmt.executeQuery("SELECT '1582-09-30 12:34:56 BC'::timestamp");
-    try {
+    try(Statement stmt = con.createStatement(); ResultSet rs = stmt.executeQuery("SELECT '1582-09-30 12:34:56 BC'::timestamp")) {
       assertTrue(rs.next());
       LocalDateTime expected = LocalDateTime.of(1582, 9, 30, 12, 34, 56)
           .with(ChronoField.ERA, IsoEra.BCE.getValue());
       LocalDateTime actual = rs.getObject(1, LocalDateTime.class);
       assertEquals(expected, actual);
       assertFalse(rs.next());
-    } finally {
-      rs.close();
-      stmt.close();
     }
   }
 
   @Test
   public void testBcTimestamptz() throws SQLException {
-
-    Statement stmt = con.createStatement();
-    ResultSet rs = stmt.executeQuery("SELECT '1582-09-30 12:34:56Z BC'::timestamp");
-    try {
+    try (Statement stmt = con.createStatement();
+        ResultSet rs = stmt.executeQuery("SELECT '1582-09-30 12:34:56Z BC'::timestamp")) {
       assertTrue(rs.next());
       OffsetDateTime expected = OffsetDateTime.of(1582, 9, 30, 12, 34, 56, 0, UTC)
           .with(ChronoField.ERA, IsoEra.BCE.getValue());
       OffsetDateTime actual = rs.getObject(1, OffsetDateTime.class);
       assertEquals(expected, actual);
       assertFalse(rs.next());
-    } finally {
-      rs.close();
-      stmt.close();
     }
   }
 
@@ -404,7 +385,7 @@ public class GetObject310Test extends BaseTest4 {
     LocalDateTime start = LocalDate.of(1582, 9, 30).atStartOfDay();
     LocalDateTime end = LocalDate.of(1582, 10, 16).atStartOfDay();
     long numberOfDays = Duration.between(start, end).toDays() + 1L;
-    List<LocalDateTime> range = Stream.iterate(start, new LocalDateTimePlusOneDay())
+    List<LocalDateTime> range = Stream.iterate(start, x -> x.plusDays(1))
         .limit(numberOfDays)
         .collect(Collectors.toList());
 
@@ -418,7 +399,7 @@ public class GetObject310Test extends BaseTest4 {
     OffsetDateTime start = LocalDate.of(1582, 9, 30).atStartOfDay().atOffset(UTC);
     OffsetDateTime end = LocalDate.of(1582, 10, 16).atStartOfDay().atOffset(UTC);
     long numberOfDays = Duration.between(start, end).toDays() + 1L;
-    List<OffsetDateTime> range = Stream.iterate(start, new OffsetDateTimePlusOneDay())
+    List<OffsetDateTime> range = Stream.iterate(start, x -> x.plusDays(1))
         .limit(numberOfDays)
         .collect(Collectors.toList());
 
@@ -428,34 +409,23 @@ public class GetObject310Test extends BaseTest4 {
   private <T extends Temporal> void runProlepticTests(Class<T> clazz, String selectRange, List<T> range) throws SQLException {
     List<T> temporals = new ArrayList<>(range.size());
 
-    PreparedStatement stmt = con.prepareStatement("SELECT * FROM generate_series(" + selectRange + ", '1 day');");
-    ResultSet rs = stmt.executeQuery();
-    try {
+    try (PreparedStatement stmt = con.prepareStatement("SELECT * FROM generate_series(" + selectRange + ", '1 day');");
+        ResultSet rs = stmt.executeQuery()) {
       while (rs.next()) {
         T temporal = rs.getObject(1, clazz);
         temporals.add(temporal);
       }
       assertEquals(range, temporals);
-    } finally {
-      rs.close();
-      stmt.close();
     }
   }
 
-  private static class LocalDateTimePlusOneDay implements UnaryOperator<LocalDateTime> {
+  /** checks if getObject with given column name or index 1 throws an exception with DATA_TYPE_MISMATCH as SQLState */
+  private static void assertDataTypeMismatch(ResultSet rs, String columnName, Class<?> typeToGet) {
+    PSQLException ex = assertThrows(PSQLException.class, () -> rs.getObject(columnName, typeToGet));
+    assertEquals(PSQLState.DATA_TYPE_MISMATCH.getState(), ex.getSQLState());
 
-    @Override
-    public LocalDateTime apply(LocalDateTime x) {
-      return x.plusDays(1);
-    }
-  }
-
-  private static class OffsetDateTimePlusOneDay implements UnaryOperator<OffsetDateTime> {
-
-    @Override
-    public OffsetDateTime apply(OffsetDateTime x) {
-      return x.plusDays(1);
-    }
+    ex = assertThrows(PSQLException.class, () -> rs.getObject(1, typeToGet));
+    assertEquals(PSQLState.DATA_TYPE_MISMATCH.getState(), ex.getSQLState());
   }
 
 }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc42/SetObject310Test.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc42/SetObject310Test.java
@@ -29,6 +29,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
+import java.time.OffsetTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.chrono.IsoChronology;
@@ -144,7 +145,7 @@ public class SetObject310Test extends BaseTest4 {
     insert(data, columnName, null);
   }
 
-  private <T> T insertThenReadWithoutType(Object data, String columnName, Class<T> expectedType) throws SQLException {
+  private <T> T insertThenReadWithoutType(Object data, String columnName, Class<T> type) throws SQLException {
     PreparedStatement ps = con.prepareStatement(TestUtil.insertSQL("table1", columnName, "?"));
     try {
       ps.setObject(1, data);
@@ -160,7 +161,7 @@ public class SetObject310Test extends BaseTest4 {
         assertNotNull(rs);
 
         assertTrue(rs.next());
-        return expectedType.cast(rs.getObject(1));
+        return type.cast(rs.getObject(1, type));
       } finally {
         rs.close();
       }
@@ -169,7 +170,7 @@ public class SetObject310Test extends BaseTest4 {
     }
   }
 
-  private <T> T insertThenReadWithType(Object data, int sqlType, String columnName, Class<T> expectedType) throws SQLException {
+  private <T> T insertThenReadWithType(Object data, int sqlType, String columnName, Class<T> type) throws SQLException {
     PreparedStatement ps = con.prepareStatement(TestUtil.insertSQL("table1", columnName, "?"));
     try {
       ps.setObject(1, data, sqlType);
@@ -185,7 +186,7 @@ public class SetObject310Test extends BaseTest4 {
         assertNotNull(rs);
 
         assertTrue(rs.next());
-        return expectedType.cast(rs.getObject(1));
+        return type.cast(rs.getObject(1, type));
       } finally {
         rs.close();
       }
@@ -426,6 +427,46 @@ public class SetObject310Test extends BaseTest4 {
     Time actual = insertThenReadWithoutType(data, "time_without_time_zone_column", Time.class);
     Time expected = Time.valueOf("16:21:51");
     assertEquals(expected, actual);
+  }
+
+  /**
+   * Test the behavior setObject for time columns.
+   */
+  @Test
+  public void testSetLocalTimeWithType2() throws SQLException {
+    LocalTime data = LocalTime.parse("16:21:51");
+    LocalTime actual = insertThenReadWithType(data, Types.TIME, "time_without_time_zone_column", LocalTime.class);
+    assertEquals(data, actual);
+  }
+
+  /**
+   * Test the behavior setObject for time columns.
+   */
+  @Test
+  public void testSetLocalTimeWithoutType2() throws SQLException {
+    LocalTime data = LocalTime.parse("16:21:51");
+    LocalTime actual = insertThenReadWithoutType(data, "time_without_time_zone_column", LocalTime.class);
+    assertEquals(data, actual);
+  }
+
+  /**
+   * Test the behavior setObject for time columns.
+   */
+  @Test
+  public void testSetOffsetTimeWithType() throws SQLException {
+    OffsetTime data = OffsetTime.parse("16:21:51+12:34");
+    OffsetTime actual = insertThenReadWithType(data, Types.TIME, "time_with_time_zone_column", OffsetTime.class);
+    assertEquals(data, actual);
+  }
+
+  /**
+   * Test the behavior setObject for time columns.
+   */
+  @Test
+  public void testSetOffsetTimeWithoutType() throws SQLException {
+    OffsetTime data = OffsetTime.parse("16:21:51+12:34");
+    OffsetTime actual = insertThenReadWithoutType(data, "time_with_time_zone_column", OffsetTime.class);
+    assertEquals(data, actual);
   }
 
 }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc42/SetObject310Test.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc42/SetObject310Test.java
@@ -145,11 +145,11 @@ public class SetObject310Test extends BaseTest4 {
     insert(data, columnName, null);
   }
 
-  private <T> T insertThenReadWithoutType(Object data, String columnName, Class<T> expected) throws SQLException {
-    return insertThenReadWithoutType(data, columnName, expected, true);
+  private <T> T insertThenReadWithoutType(Object data, String columnName, Class<T> expectedType) throws SQLException {
+    return insertThenReadWithoutType(data, columnName, expectedType, true);
   }
 
-  private <T> T insertThenReadWithoutType(Object data, String columnName, Class<T> expected, boolean checkRoundtrip) throws SQLException {
+  private <T> T insertThenReadWithoutType(Object data, String columnName, Class<T> expectedType, boolean checkRoundtrip) throws SQLException {
     PreparedStatement ps = con.prepareStatement(TestUtil.insertSQL("table1", columnName, "?"));
     try {
       ps.setObject(1, data);
@@ -169,7 +169,7 @@ public class SetObject310Test extends BaseTest4 {
           assertEquals("Roundtrip set/getObject with type should return same result",
               data, rs.getObject(1, data.getClass()));
         }
-        return expected.cast(rs.getObject(1));
+        return expectedType.cast(rs.getObject(1));
       } finally {
         rs.close();
       }
@@ -178,11 +178,11 @@ public class SetObject310Test extends BaseTest4 {
     }
   }
 
-  private <T> T insertThenReadWithType(Object data, int sqlType, String columnName, Class<T> expected) throws SQLException {
-    return insertThenReadWithType(data, sqlType, columnName, expected, true);
+  private <T> T insertThenReadWithType(Object data, int sqlType, String columnName, Class<T> expectedType) throws SQLException {
+    return insertThenReadWithType(data, sqlType, columnName, expectedType, true);
   }
 
-  private <T> T insertThenReadWithType(Object data, int sqlType, String columnName, Class<T> expected, boolean checkRoundtrip) throws SQLException {
+  private <T> T insertThenReadWithType(Object data, int sqlType, String columnName, Class<T> expectedType, boolean checkRoundtrip) throws SQLException {
     PreparedStatement ps = con.prepareStatement(TestUtil.insertSQL("table1", columnName, "?"));
     try {
       ps.setObject(1, data, sqlType);
@@ -202,7 +202,7 @@ public class SetObject310Test extends BaseTest4 {
           assertEquals("Roundtrip set/getObject with type should return same result",
               data, rs.getObject(1, data.getClass()));
         }
-        return expected.cast(rs.getObject(1));
+        return expectedType.cast(rs.getObject(1));
       } finally {
         rs.close();
       }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc42/TimestampUtilsTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc42/TimestampUtilsTest.java
@@ -36,15 +36,15 @@ public class TimestampUtilsTest {
     assertToStringOfLocalTime("00:00:00.123456", "00:00:00.123456");
 
     assertToStringOfLocalTime("00:00:00.999999", "00:00:00.999999");
-    assertToStringOfLocalTime("00:00:00.999999", "00:00:00.999999499");
-    assertToStringOfLocalTime("00:00:01", "00:00:00.999999500");
+    assertToStringOfLocalTime("00:00:00.999999", "00:00:00.999999499"); // 499 NanoSeconds
+    assertToStringOfLocalTime("00:00:01", "00:00:00.999999500"); // 500 NanoSeconds
 
     assertToStringOfLocalTime("23:59:59", "23:59:59");
 
     assertToStringOfLocalTime("23:59:59.999999", "23:59:59.999999");
-    assertToStringOfLocalTime("23:59:59.999999", "23:59:59.999999499");
-    assertToStringOfLocalTime("24:00:00", "23:59:59.999999500");
-    assertToStringOfLocalTime("24:00:00", "23:59:59.999999999");
+    assertToStringOfLocalTime("23:59:59.999999", "23:59:59.999999499"); // 499 NanoSeconds
+    assertToStringOfLocalTime("24:00:00", "23:59:59.999999500"); // 500 NanoSeconds
+    assertToStringOfLocalTime("24:00:00", "23:59:59.999999999"); // 999 NanoSeconds
   }
 
   private void assertToStringOfLocalTime(String expectedOutput, String inputTime) {
@@ -66,10 +66,10 @@ public class TimestampUtilsTest {
     assertToLocalTime("00:00:00.999999", "00:00:00.999999");
 
     assertToLocalTime("23:59:59", "23:59:59");
-    assertToLocalTime("23:59:59.999999", "23:59:59.999999");
-    assertToLocalTime("23:59:59.9999999", "23:59:59.9999999");
-    assertToLocalTime("23:59:59.99999999", "23:59:59.99999999");
-    assertToLocalTime("23:59:59.999999998", "23:59:59.999999998");
+    assertToLocalTime("23:59:59.999999", "23:59:59.999999"); // 0 NanoSeconds
+    assertToLocalTime("23:59:59.9999999", "23:59:59.9999999"); // 900 NanoSeconds
+    assertToLocalTime("23:59:59.99999999", "23:59:59.99999999"); // 990 NanoSeconds
+    assertToLocalTime("23:59:59.999999998", "23:59:59.999999998"); // 998 NanoSeconds
     assertToLocalTime(LocalTime.MAX.toString(), "24:00:00");
   }
 
@@ -93,9 +93,9 @@ public class TimestampUtilsTest {
     assertToStringOfOffsetTime("23:59:59+01", "23:59:59+01:00");
 
     assertToStringOfOffsetTime("23:59:59.999999+01", "23:59:59.999999+01:00");
-    assertToStringOfOffsetTime("23:59:59.999999+01", "23:59:59.999999499+01:00");
-    assertToStringOfOffsetTime("24:00:00+01", "23:59:59.999999500+01:00");
-    assertToStringOfOffsetTime("24:00:00+01", "23:59:59.999999999+01:00");
+    assertToStringOfOffsetTime("23:59:59.999999+01", "23:59:59.999999499+01:00"); // 499 NanoSeconds
+    assertToStringOfOffsetTime("24:00:00+01", "23:59:59.999999500+01:00"); // 500 NanoSeconds
+    assertToStringOfOffsetTime("24:00:00+01", "23:59:59.999999999+01:00"); // 999 NanoSeconds
   }
 
   private void assertToStringOfOffsetTime(String expectedOutput, String inputTime) {
@@ -115,10 +115,10 @@ public class TimestampUtilsTest {
     assertToOffsetTime("00:00:00.123456+01:30", "00:00:00.123456+01:30");
     assertToOffsetTime("00:00:00.123456-12:34", "00:00:00.123456-12:34");
 
-    assertToOffsetTime("23:59:59.999999+01:00", "23:59:59.999999+01");
-    assertToOffsetTime("23:59:59.9999999+01:00", "23:59:59.9999999+01");
-    assertToOffsetTime("23:59:59.99999999+01:00", "23:59:59.99999999+01");
-    assertToOffsetTime("23:59:59.999999998+01:00", "23:59:59.999999998+01");
+    assertToOffsetTime("23:59:59.999999+01:00", "23:59:59.999999+01"); // 0 NanoSeconds
+    assertToOffsetTime("23:59:59.9999999+01:00", "23:59:59.9999999+01"); // 900 NanoSeconds
+    assertToOffsetTime("23:59:59.99999999+01:00", "23:59:59.99999999+01"); // 990 NanoSeconds
+    assertToOffsetTime("23:59:59.999999998+01:00", "23:59:59.999999998+01"); // 998 NanoSeconds
     assertToOffsetTime(OffsetTime.MAX.toString(), "24:00:00+01");
   }
 

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc42/TimestampUtilsTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc42/TimestampUtilsTest.java
@@ -31,8 +31,8 @@ public class TimestampUtilsTest {
     assertEquals("00:00:00.123456", timestampUtils.toString(LocalTime.parse("00:00:00.123456")));
 
     assertEquals("00:00:00.999999", timestampUtils.toString(LocalTime.parse("00:00:00.999999")));
-    assertEquals("00:00:00.999999", timestampUtils.toString(LocalTime.parse("00:00:00.999999499"))); // 499 NanoSeconds
-    assertEquals("00:00:01", timestampUtils.toString(LocalTime.parse("00:00:00.999999500"))); // 500 NanoSeconds
+    assertEquals("499 nanosecs difference should round down", "00:00:00.999999", timestampUtils.toString(LocalTime.parse("00:00:00.999999499")));
+    assertEquals("500 nanosecs difference should round up", "00:00:01", timestampUtils.toString(LocalTime.parse("00:00:00.999999500")));
 
     assertEquals("23:59:59", timestampUtils.toString(LocalTime.parse("23:59:59")));
 

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc42/TimestampUtilsTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc42/TimestampUtilsTest.java
@@ -35,10 +35,11 @@ public class TimestampUtilsTest {
     assertEquals("00:00:01", timestampUtils.toString(LocalTime.parse("00:00:00.999999500"))); // 500 NanoSeconds
 
     assertEquals("23:59:59", timestampUtils.toString(LocalTime.parse("23:59:59")));
-    assertEquals("23:59:59.999999", timestampUtils.toString(LocalTime.parse("23:59:59.999999"))); // 0 NanoSeconds
-    assertEquals("23:59:59.999999", timestampUtils.toString(LocalTime.parse("23:59:59.999999499"))); // 499 NanoSeconds
-    assertEquals("24:00:00", timestampUtils.toString(LocalTime.parse("23:59:59.999999500")));// 500 NanoSeconds
-    assertEquals("24:00:00", timestampUtils.toString(LocalTime.parse("23:59:59.999999999")));// 999 NanoSeconds
+
+    assertEquals("0 nanosecs difference should stay identical", "23:59:59.999999", timestampUtils.toString(LocalTime.parse("23:59:59.999999")));
+    assertEquals("499 nanosecs difference should round down", "23:59:59.999999", timestampUtils.toString(LocalTime.parse("23:59:59.999999499")));
+    assertEquals("500 nanosecs difference should map to special time 24:00:00", "24:00:00", timestampUtils.toString(LocalTime.parse("23:59:59.999999500")));
+    assertEquals("999 nanosecs difference should map to special time 24:00:00", "24:00:00", timestampUtils.toString(LocalTime.parse("23:59:59.999999999")));
   }
 
   @Test
@@ -56,11 +57,11 @@ public class TimestampUtilsTest {
     assertEquals(LocalTime.parse("00:00:00.999999"), timestampUtils.toLocalTime("00:00:00.999999"));
 
     assertEquals(LocalTime.parse("23:59:59"), timestampUtils.toLocalTime("23:59:59"));
-    assertEquals(LocalTime.parse("23:59:59.999999"), timestampUtils.toLocalTime("23:59:59.999999")); // 0 NanoSeconds
-    assertEquals(LocalTime.parse("23:59:59.9999999"), timestampUtils.toLocalTime("23:59:59.9999999")); // 900 NanoSeconds
-    assertEquals(LocalTime.parse("23:59:59.99999999"), timestampUtils.toLocalTime("23:59:59.99999999")); // 990 NanoSeconds
-    assertEquals(LocalTime.parse("23:59:59.999999998"), timestampUtils.toLocalTime("23:59:59.999999998")); // 998 NanoSeconds
-    assertEquals(LocalTime.parse("23:59:59.999999999"), timestampUtils.toLocalTime("24:00:00"));
+    assertEquals("0 nanosecs difference", LocalTime.parse("23:59:59.999999"), timestampUtils.toLocalTime("23:59:59.999999"));
+    assertEquals("900 nanosecs difference", LocalTime.parse("23:59:59.9999999"), timestampUtils.toLocalTime("23:59:59.9999999"));
+    assertEquals("990 nanosecs difference", LocalTime.parse("23:59:59.99999999"), timestampUtils.toLocalTime("23:59:59.99999999"));
+    assertEquals("998 nanosecs difference", LocalTime.parse("23:59:59.999999998"), timestampUtils.toLocalTime("23:59:59.999999998"));
+    assertEquals("special time 24:00:00 should be mapped to OffsetTime.MAX", LocalTime.MAX, timestampUtils.toLocalTime("24:00:00"));
   }
 
   @Test
@@ -77,10 +78,11 @@ public class TimestampUtilsTest {
     assertEquals("00:00:00.123456-12:34", timestampUtils.toString(OffsetTime.parse("00:00:00.123456-12:34")));
 
     assertEquals("23:59:59+01", timestampUtils.toString(OffsetTime.parse("23:59:59+01:00")));
-    assertEquals("23:59:59.999999+01", timestampUtils.toString(OffsetTime.parse("23:59:59.999999+01:00"))); // 0 NanoSeconds
-    assertEquals("23:59:59.999999+01", timestampUtils.toString(OffsetTime.parse("23:59:59.999999499+01:00"))); // 499 NanoSeconds
-    assertEquals("24:00:00+01", timestampUtils.toString(OffsetTime.parse("23:59:59.999999500+01:00")));// 500 NanoSeconds
-    assertEquals("24:00:00+01", timestampUtils.toString(OffsetTime.parse("23:59:59.999999999+01:00")));// 999 NanoSeconds
+
+    assertEquals("0 nanosecs difference should stay identical", "23:59:59.999999+01", timestampUtils.toString(OffsetTime.parse("23:59:59.999999+01:00")));
+    assertEquals("499 nanosecs difference should round down", "23:59:59.999999+01", timestampUtils.toString(OffsetTime.parse("23:59:59.999999499+01:00")));
+    assertEquals("500 nanosecs difference should map to special time 24:00:00", "24:00:00+01", timestampUtils.toString(OffsetTime.parse("23:59:59.999999500+01:00")));
+    assertEquals("999 nanosecs difference should map to special time 24:00:00", "24:00:00+01", timestampUtils.toString(OffsetTime.parse("23:59:59.999999999+01:00")));
   }
 
   @Test
@@ -96,11 +98,11 @@ public class TimestampUtilsTest {
     assertEquals(OffsetTime.parse("00:00:00.123456+01:30"), timestampUtils.toOffsetTime("00:00:00.123456+01:30"));
     assertEquals(OffsetTime.parse("00:00:00.123456-12:34"), timestampUtils.toOffsetTime("00:00:00.123456-12:34"));
 
-    assertEquals(OffsetTime.parse("23:59:59.999999+01:00"), timestampUtils.toOffsetTime("23:59:59.999999+01")); // 0 NanoSeconds
-    assertEquals(OffsetTime.parse("23:59:59.9999999+01:00"), timestampUtils.toOffsetTime("23:59:59.9999999+01")); // 900 NanoSeconds
-    assertEquals(OffsetTime.parse("23:59:59.99999999+01:00"), timestampUtils.toOffsetTime("23:59:59.99999999+01")); // 990 NanoSeconds
-    assertEquals(OffsetTime.parse("23:59:59.999999998+01:00"), timestampUtils.toOffsetTime("23:59:59.999999998+01")); // 998 NanoSeconds
-    assertEquals(OffsetTime.MAX, timestampUtils.toOffsetTime("24:00:00+01"));// 999 NanoSeconds
+    assertEquals("0 nanosecs difference", OffsetTime.parse("23:59:59.999999+01:00"), timestampUtils.toOffsetTime("23:59:59.999999+01"));
+    assertEquals("900 nanosecs difference", OffsetTime.parse("23:59:59.9999999+01:00"), timestampUtils.toOffsetTime("23:59:59.9999999+01"));
+    assertEquals("990 nanosecs difference", OffsetTime.parse("23:59:59.99999999+01:00"), timestampUtils.toOffsetTime("23:59:59.99999999+01"));
+    assertEquals("998 nanosecs difference", OffsetTime.parse("23:59:59.999999998+01:00"), timestampUtils.toOffsetTime("23:59:59.999999998+01"));
+    assertEquals("special time 24:00:00 should be mapped to OffsetTime.MAX", OffsetTime.MAX, timestampUtils.toOffsetTime("24:00:00+01"));
   }
 
   private TimestampUtils createTimestampUtils() {

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc42/TimestampUtilsTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc42/TimestampUtilsTest.java
@@ -7,9 +7,9 @@ package org.postgresql.test.jdbc42;
 
 import static org.junit.Assert.assertEquals;
 
-import org.postgresql.core.Provider;
 import org.postgresql.jdbc.TimestampUtils;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import java.sql.SQLException;
@@ -18,94 +18,113 @@ import java.time.OffsetTime;
 import java.util.TimeZone;
 
 public class TimestampUtilsTest {
+  private TimestampUtils timestampUtils;
+
+  @Before
+  public void setUp() {
+    timestampUtils = new TimestampUtils(true, TimeZone::getDefault);
+  }
+
   @Test
   public void testToStringOfLocalTime() {
-    TimestampUtils timestampUtils = createTimestampUtils();
+    assertToStringOfLocalTime("00:00:00", "00:00:00");
+    assertToStringOfLocalTime("00:00:00.1", "00:00:00.1");
+    assertToStringOfLocalTime("00:00:00.12", "00:00:00.12");
+    assertToStringOfLocalTime("00:00:00.123", "00:00:00.123");
+    assertToStringOfLocalTime("00:00:00.1234", "00:00:00.1234");
+    assertToStringOfLocalTime("00:00:00.12345", "00:00:00.12345");
+    assertToStringOfLocalTime("00:00:00.123456", "00:00:00.123456");
 
-    assertEquals("00:00:00", timestampUtils.toString(LocalTime.parse("00:00:00")));
-    assertEquals("00:00:00.1", timestampUtils.toString(LocalTime.parse("00:00:00.1")));
-    assertEquals("00:00:00.12", timestampUtils.toString(LocalTime.parse("00:00:00.12")));
-    assertEquals("00:00:00.123", timestampUtils.toString(LocalTime.parse("00:00:00.123")));
-    assertEquals("00:00:00.1234", timestampUtils.toString(LocalTime.parse("00:00:00.1234")));
-    assertEquals("00:00:00.12345", timestampUtils.toString(LocalTime.parse("00:00:00.12345")));
-    assertEquals("00:00:00.123456", timestampUtils.toString(LocalTime.parse("00:00:00.123456")));
+    assertToStringOfLocalTime("00:00:00.999999", "00:00:00.999999");
+    assertToStringOfLocalTime("00:00:00.999999", "00:00:00.999999499");
+    assertToStringOfLocalTime("00:00:01", "00:00:00.999999500");
 
-    assertEquals("00:00:00.999999", timestampUtils.toString(LocalTime.parse("00:00:00.999999")));
-    assertEquals("499 nanosecs difference should round down", "00:00:00.999999", timestampUtils.toString(LocalTime.parse("00:00:00.999999499")));
-    assertEquals("500 nanosecs difference should round up", "00:00:01", timestampUtils.toString(LocalTime.parse("00:00:00.999999500")));
+    assertToStringOfLocalTime("23:59:59", "23:59:59");
 
-    assertEquals("23:59:59", timestampUtils.toString(LocalTime.parse("23:59:59")));
+    assertToStringOfLocalTime("23:59:59.999999", "23:59:59.999999");
+    assertToStringOfLocalTime("23:59:59.999999", "23:59:59.999999499");
+    assertToStringOfLocalTime("24:00:00", "23:59:59.999999500");
+    assertToStringOfLocalTime("24:00:00", "23:59:59.999999999");
+  }
 
-    assertEquals("0 nanosecs difference should stay identical", "23:59:59.999999", timestampUtils.toString(LocalTime.parse("23:59:59.999999")));
-    assertEquals("499 nanosecs difference should round down", "23:59:59.999999", timestampUtils.toString(LocalTime.parse("23:59:59.999999499")));
-    assertEquals("500 nanosecs difference should map to special time 24:00:00", "24:00:00", timestampUtils.toString(LocalTime.parse("23:59:59.999999500")));
-    assertEquals("999 nanosecs difference should map to special time 24:00:00", "24:00:00", timestampUtils.toString(LocalTime.parse("23:59:59.999999999")));
+  private void assertToStringOfLocalTime(String expectedOutput, String inputTime) {
+    assertEquals("timestampUtils.toString(LocalTime.parse(" + inputTime + "))",
+        expectedOutput,
+        timestampUtils.toString(LocalTime.parse(inputTime)));
   }
 
   @Test
   public void testToLocalTime() throws SQLException {
-    TimestampUtils timestampUtils = createTimestampUtils();
+    assertToLocalTime("00:00:00", "00:00:00");
 
-    assertEquals(LocalTime.parse("00:00:00"), timestampUtils.toLocalTime("00:00:00"));
+    assertToLocalTime("00:00:00.1", "00:00:00.1");
+    assertToLocalTime("00:00:00.12", "00:00:00.12");
+    assertToLocalTime("00:00:00.123", "00:00:00.123");
+    assertToLocalTime("00:00:00.1234", "00:00:00.1234");
+    assertToLocalTime("00:00:00.12345", "00:00:00.12345");
+    assertToLocalTime("00:00:00.123456", "00:00:00.123456");
+    assertToLocalTime("00:00:00.999999", "00:00:00.999999");
 
-    assertEquals(LocalTime.parse("00:00:00.1"), timestampUtils.toLocalTime("00:00:00.1"));
-    assertEquals(LocalTime.parse("00:00:00.12"), timestampUtils.toLocalTime("00:00:00.12"));
-    assertEquals(LocalTime.parse("00:00:00.123"), timestampUtils.toLocalTime("00:00:00.123"));
-    assertEquals(LocalTime.parse("00:00:00.1234"), timestampUtils.toLocalTime("00:00:00.1234"));
-    assertEquals(LocalTime.parse("00:00:00.12345"), timestampUtils.toLocalTime("00:00:00.12345"));
-    assertEquals(LocalTime.parse("00:00:00.123456"), timestampUtils.toLocalTime("00:00:00.123456"));
-    assertEquals(LocalTime.parse("00:00:00.999999"), timestampUtils.toLocalTime("00:00:00.999999"));
+    assertToLocalTime("23:59:59", "23:59:59");
+    assertToLocalTime("23:59:59.999999", "23:59:59.999999");
+    assertToLocalTime("23:59:59.9999999", "23:59:59.9999999");
+    assertToLocalTime("23:59:59.99999999", "23:59:59.99999999");
+    assertToLocalTime("23:59:59.999999998", "23:59:59.999999998");
+    assertToLocalTime(LocalTime.MAX.toString(), "24:00:00");
+  }
 
-    assertEquals(LocalTime.parse("23:59:59"), timestampUtils.toLocalTime("23:59:59"));
-    assertEquals("0 nanosecs difference", LocalTime.parse("23:59:59.999999"), timestampUtils.toLocalTime("23:59:59.999999"));
-    assertEquals("900 nanosecs difference", LocalTime.parse("23:59:59.9999999"), timestampUtils.toLocalTime("23:59:59.9999999"));
-    assertEquals("990 nanosecs difference", LocalTime.parse("23:59:59.99999999"), timestampUtils.toLocalTime("23:59:59.99999999"));
-    assertEquals("998 nanosecs difference", LocalTime.parse("23:59:59.999999998"), timestampUtils.toLocalTime("23:59:59.999999998"));
-    assertEquals("special time 24:00:00 should be mapped to OffsetTime.MAX", LocalTime.MAX, timestampUtils.toLocalTime("24:00:00"));
+  private void assertToLocalTime(String expectedOutput, String inputTime) throws SQLException {
+    assertEquals("timestampUtils.toLocalTime(" + inputTime + ")",
+        LocalTime.parse(expectedOutput),
+        timestampUtils.toLocalTime(inputTime));
   }
 
   @Test
   public void testToStringOfOffsetTime() {
-    TimestampUtils timestampUtils = createTimestampUtils();
+    assertToStringOfOffsetTime("00:00:00+00", "00:00:00+00:00");
+    assertToStringOfOffsetTime("00:00:00.1+01", "00:00:00.1+01:00");
+    assertToStringOfOffsetTime("00:00:00.12+12", "00:00:00.12+12:00");
+    assertToStringOfOffsetTime("00:00:00.123-01", "00:00:00.123-01:00");
+    assertToStringOfOffsetTime("00:00:00.1234-02", "00:00:00.1234-02:00");
+    assertToStringOfOffsetTime("00:00:00.12345-12", "00:00:00.12345-12:00");
+    assertToStringOfOffsetTime("00:00:00.123456+01:30", "00:00:00.123456+01:30");
+    assertToStringOfOffsetTime("00:00:00.123456-12:34", "00:00:00.123456-12:34");
 
-    assertEquals("00:00:00+00", timestampUtils.toString(OffsetTime.parse("00:00:00+00:00")));
-    assertEquals("00:00:00.1+01", timestampUtils.toString(OffsetTime.parse("00:00:00.1+01:00")));
-    assertEquals("00:00:00.12+12", timestampUtils.toString(OffsetTime.parse("00:00:00.12+12:00")));
-    assertEquals("00:00:00.123-01", timestampUtils.toString(OffsetTime.parse("00:00:00.123-01:00")));
-    assertEquals("00:00:00.1234-02", timestampUtils.toString(OffsetTime.parse("00:00:00.1234-02:00")));
-    assertEquals("00:00:00.12345-12", timestampUtils.toString(OffsetTime.parse("00:00:00.12345-12:00")));
-    assertEquals("00:00:00.123456+01:30", timestampUtils.toString(OffsetTime.parse("00:00:00.123456+01:30")));
-    assertEquals("00:00:00.123456-12:34", timestampUtils.toString(OffsetTime.parse("00:00:00.123456-12:34")));
+    assertToStringOfOffsetTime("23:59:59+01", "23:59:59+01:00");
 
-    assertEquals("23:59:59+01", timestampUtils.toString(OffsetTime.parse("23:59:59+01:00")));
+    assertToStringOfOffsetTime("23:59:59.999999+01", "23:59:59.999999+01:00");
+    assertToStringOfOffsetTime("23:59:59.999999+01", "23:59:59.999999499+01:00");
+    assertToStringOfOffsetTime("24:00:00+01", "23:59:59.999999500+01:00");
+    assertToStringOfOffsetTime("24:00:00+01", "23:59:59.999999999+01:00");
+  }
 
-    assertEquals("0 nanosecs difference should stay identical", "23:59:59.999999+01", timestampUtils.toString(OffsetTime.parse("23:59:59.999999+01:00")));
-    assertEquals("499 nanosecs difference should round down", "23:59:59.999999+01", timestampUtils.toString(OffsetTime.parse("23:59:59.999999499+01:00")));
-    assertEquals("500 nanosecs difference should map to special time 24:00:00", "24:00:00+01", timestampUtils.toString(OffsetTime.parse("23:59:59.999999500+01:00")));
-    assertEquals("999 nanosecs difference should map to special time 24:00:00", "24:00:00+01", timestampUtils.toString(OffsetTime.parse("23:59:59.999999999+01:00")));
+  private void assertToStringOfOffsetTime(String expectedOutput, String inputTime) {
+    assertEquals("timestampUtils.toString(OffsetTime.parse(" + inputTime + "))",
+        expectedOutput,
+        timestampUtils.toString(OffsetTime.parse(inputTime)));
   }
 
   @Test
   public void testToOffsetTime() throws SQLException {
-    TimestampUtils timestampUtils = createTimestampUtils();
+    assertToOffsetTime("00:00:00+00:00", "00:00:00+00");
+    assertToOffsetTime("00:00:00.1+01:00", "00:00:00.1+01");
+    assertToOffsetTime("00:00:00.12+12:00", "00:00:00.12+12");
+    assertToOffsetTime("00:00:00.123-01:00", "00:00:00.123-01");
+    assertToOffsetTime("00:00:00.1234-02:00", "00:00:00.1234-02");
+    assertToOffsetTime("00:00:00.12345-12:00", "00:00:00.12345-12");
+    assertToOffsetTime("00:00:00.123456+01:30", "00:00:00.123456+01:30");
+    assertToOffsetTime("00:00:00.123456-12:34", "00:00:00.123456-12:34");
 
-    assertEquals(OffsetTime.parse("00:00:00+00:00"), timestampUtils.toOffsetTime("00:00:00+00"));
-    assertEquals(OffsetTime.parse("00:00:00.1+01:00"), timestampUtils.toOffsetTime("00:00:00.1+01"));
-    assertEquals(OffsetTime.parse("00:00:00.12+12:00"), timestampUtils.toOffsetTime("00:00:00.12+12"));
-    assertEquals(OffsetTime.parse("00:00:00.123-01:00"), timestampUtils.toOffsetTime("00:00:00.123-01"));
-    assertEquals(OffsetTime.parse("00:00:00.1234-02:00"), timestampUtils.toOffsetTime("00:00:00.1234-02"));
-    assertEquals(OffsetTime.parse("00:00:00.12345-12:00"), timestampUtils.toOffsetTime("00:00:00.12345-12"));
-    assertEquals(OffsetTime.parse("00:00:00.123456+01:30"), timestampUtils.toOffsetTime("00:00:00.123456+01:30"));
-    assertEquals(OffsetTime.parse("00:00:00.123456-12:34"), timestampUtils.toOffsetTime("00:00:00.123456-12:34"));
-
-    assertEquals("0 nanosecs difference", OffsetTime.parse("23:59:59.999999+01:00"), timestampUtils.toOffsetTime("23:59:59.999999+01"));
-    assertEquals("900 nanosecs difference", OffsetTime.parse("23:59:59.9999999+01:00"), timestampUtils.toOffsetTime("23:59:59.9999999+01"));
-    assertEquals("990 nanosecs difference", OffsetTime.parse("23:59:59.99999999+01:00"), timestampUtils.toOffsetTime("23:59:59.99999999+01"));
-    assertEquals("998 nanosecs difference", OffsetTime.parse("23:59:59.999999998+01:00"), timestampUtils.toOffsetTime("23:59:59.999999998+01"));
-    assertEquals("special time 24:00:00 should be mapped to OffsetTime.MAX", OffsetTime.MAX, timestampUtils.toOffsetTime("24:00:00+01"));
+    assertToOffsetTime("23:59:59.999999+01:00", "23:59:59.999999+01");
+    assertToOffsetTime("23:59:59.9999999+01:00", "23:59:59.9999999+01");
+    assertToOffsetTime("23:59:59.99999999+01:00", "23:59:59.99999999+01");
+    assertToOffsetTime("23:59:59.999999998+01:00", "23:59:59.999999998+01");
+    assertToOffsetTime(OffsetTime.MAX.toString(), "24:00:00+01");
   }
 
-  private TimestampUtils createTimestampUtils() {
-    return new TimestampUtils(true, (Provider<TimeZone>) TimeZone::getDefault);
+  private void assertToOffsetTime(String expectedOutput, String inputTime) throws SQLException {
+    assertEquals("timestampUtils.toOffsetTime(" + inputTime + ")",
+        OffsetTime.parse(expectedOutput),
+        timestampUtils.toOffsetTime(inputTime));
   }
 }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc42/TimestampUtilsTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc42/TimestampUtilsTest.java
@@ -14,6 +14,7 @@ import org.junit.Test;
 
 import java.sql.SQLException;
 import java.time.LocalTime;
+import java.time.OffsetTime;
 import java.util.TimeZone;
 
 public class TimestampUtilsTest {
@@ -60,6 +61,46 @@ public class TimestampUtilsTest {
     assertEquals(LocalTime.parse("23:59:59.99999999"), timestampUtils.toLocalTime("23:59:59.99999999")); // 990 NanoSeconds
     assertEquals(LocalTime.parse("23:59:59.999999998"), timestampUtils.toLocalTime("23:59:59.999999998")); // 998 NanoSeconds
     assertEquals(LocalTime.parse("23:59:59.999999999"), timestampUtils.toLocalTime("24:00:00"));
+  }
+
+  @Test
+  public void testToStringOfOffsetTime() {
+    TimestampUtils timestampUtils = createTimestampUtils();
+
+    assertEquals("00:00:00+00", timestampUtils.toString(OffsetTime.parse("00:00:00+00:00")));
+    assertEquals("00:00:00.1+01", timestampUtils.toString(OffsetTime.parse("00:00:00.1+01:00")));
+    assertEquals("00:00:00.12+12", timestampUtils.toString(OffsetTime.parse("00:00:00.12+12:00")));
+    assertEquals("00:00:00.123-01", timestampUtils.toString(OffsetTime.parse("00:00:00.123-01:00")));
+    assertEquals("00:00:00.1234-02", timestampUtils.toString(OffsetTime.parse("00:00:00.1234-02:00")));
+    assertEquals("00:00:00.12345-12", timestampUtils.toString(OffsetTime.parse("00:00:00.12345-12:00")));
+    assertEquals("00:00:00.123456+01:30", timestampUtils.toString(OffsetTime.parse("00:00:00.123456+01:30")));
+    assertEquals("00:00:00.123456-12:34", timestampUtils.toString(OffsetTime.parse("00:00:00.123456-12:34")));
+
+    assertEquals("23:59:59+01", timestampUtils.toString(OffsetTime.parse("23:59:59+01:00")));
+    assertEquals("23:59:59.999999+01", timestampUtils.toString(OffsetTime.parse("23:59:59.999999+01:00"))); // 0 NanoSeconds
+    assertEquals("23:59:59.999999+01", timestampUtils.toString(OffsetTime.parse("23:59:59.999999499+01:00"))); // 499 NanoSeconds
+    assertEquals("24:00:00+01", timestampUtils.toString(OffsetTime.parse("23:59:59.999999500+01:00")));// 500 NanoSeconds
+    assertEquals("24:00:00+01", timestampUtils.toString(OffsetTime.parse("23:59:59.999999999+01:00")));// 999 NanoSeconds
+  }
+
+  @Test
+  public void testToOffsetTime() throws SQLException {
+    TimestampUtils timestampUtils = createTimestampUtils();
+
+    assertEquals(OffsetTime.parse("00:00:00+00:00"), timestampUtils.toOffsetTime("00:00:00+00"));
+    assertEquals(OffsetTime.parse("00:00:00.1+01:00"), timestampUtils.toOffsetTime("00:00:00.1+01"));
+    assertEquals(OffsetTime.parse("00:00:00.12+12:00"), timestampUtils.toOffsetTime("00:00:00.12+12"));
+    assertEquals(OffsetTime.parse("00:00:00.123-01:00"), timestampUtils.toOffsetTime("00:00:00.123-01"));
+    assertEquals(OffsetTime.parse("00:00:00.1234-02:00"), timestampUtils.toOffsetTime("00:00:00.1234-02"));
+    assertEquals(OffsetTime.parse("00:00:00.12345-12:00"), timestampUtils.toOffsetTime("00:00:00.12345-12"));
+    assertEquals(OffsetTime.parse("00:00:00.123456+01:30"), timestampUtils.toOffsetTime("00:00:00.123456+01:30"));
+    assertEquals(OffsetTime.parse("00:00:00.123456-12:34"), timestampUtils.toOffsetTime("00:00:00.123456-12:34"));
+
+    assertEquals(OffsetTime.parse("23:59:59.999999+01:00"), timestampUtils.toOffsetTime("23:59:59.999999+01")); // 0 NanoSeconds
+    assertEquals(OffsetTime.parse("23:59:59.9999999+01:00"), timestampUtils.toOffsetTime("23:59:59.9999999+01")); // 900 NanoSeconds
+    assertEquals(OffsetTime.parse("23:59:59.99999999+01:00"), timestampUtils.toOffsetTime("23:59:59.99999999+01")); // 990 NanoSeconds
+    assertEquals(OffsetTime.parse("23:59:59.999999998+01:00"), timestampUtils.toOffsetTime("23:59:59.999999998+01")); // 998 NanoSeconds
+    assertEquals(OffsetTime.MAX, timestampUtils.toOffsetTime("24:00:00+01"));// 999 NanoSeconds
   }
 
   private TimestampUtils createTimestampUtils() {


### PR DESCRIPTION
After #2464 I took care about the remaining conversions between Postgres wire format, legacy calendars and Timestamp/Date/Time and the modern java.time APIs.

This PR especially takes care of TIMETZ, which was converted from/to calendars and `java.sql.Time`. This implements a parser for the `TIMETZ` wire format and also allows them to get using `ResultSet#getObject(col, OffsetTime.class)`, which preserves the original server-stored timezone!

This also fixes `TimestampUtils#parseBackendTimestamp()` to use a `ZoneOffset` instead of allocating and modifying legacy calendar instances. This allows to easier read also the old legacy code but also the wire format parsers, because you don't need to calculate with raw offsets. This also removes state from `TimestampUtils`.

### All Submissions:

* [X] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [X] Does your submission pass tests?
2. [X] Does `./gradlew autostyleCheck checkstyleAll` pass ?
3. [X] Have you added your new test classes to an existing test suite in alphabetical order?
