### PR TITLE
perf: enable tcpNoDelay by default

### DIFF
--- a/docs/documentation/head/connect.md
+++ b/docs/documentation/head/connect.md
@@ -340,7 +340,7 @@ Connection conn = DriverManager.getConnection(url);
 
 * **tcpNoDelay** = boolean
 
-  Enable or disable TCP nodelay. The default is `false`.
+  Enable or disable TCP nodelay. The default is `true`.
 
 * **unknownLength** = int
 

--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -705,8 +705,8 @@ public enum PGProperty {
 
   TCP_NO_DELAY(
       "tcpNoDelay",
-      "false",
-      "Enable or disable TCP no delay. The default is (@code false}."
+      "true",
+      "Enable or disable TCP no delay. The default is (@code true}."
   ),
   /**
    * Specifies the length to return for types of unknown length.

--- a/pgjdbc/src/main/java/org/postgresql/core/PGStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/PGStream.java
@@ -113,7 +113,7 @@ public class PGStream implements Closeable, Flushable {
     int receiveBufferSize = 1024;
     int soTimeout = 0;
     boolean keepAlive = false;
-    boolean tcpNoDelay = false;
+    boolean tcpNoDelay = true;
 
     /*
     Get the existing values before closing the stream


### PR DESCRIPTION
In [#2341](https://github.com/pgjdbc/pgjdbc/pull/2341) the option to
configure tcpNoDelay was added, with a default value of false.

The previous value of this setting was true, as set in
PGStream.changeSocket(Socket) with the following code:
```
    // Submitted by Jason Venner <jason@idiom.com>. Disable Nagle
    // as we are selective about flushing output only when we
    // really need to.
    connection.setTcpNoDelay(true);
```

`changeSocket()` is called from the `PGStream` constructor, which is
called in `ConnectionFactoryImpl`, and then later we overwrite the value
with the one from the properties.

We had a performance issue when upgrading from 42.2.24 to 42.3.3, and we suspected the
issue in 42.3.2 and confirmed that by passing the property `tcpNoDelay=true` to the driver,
the performance issue was fixed.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes to Existing Features:

* [x] Does this break existing behaviour? If so please explain.
no breaking change
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
no need
* [x] Have you successfully run tests with your changes locally?
