### PR TITLE
bug: Parser does not handle new version 14 function definition syntax

### DIFF
--- a/pgjdbc/src/test/java/org/postgresql/core/ParserTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/core/ParserTest.java
@@ -284,4 +284,18 @@ public class ParserTest {
     Assert.assertFalse("No returning keyword should be present", command.isReturningKeywordPresent());
     Assert.assertEquals(SqlCommandType.ALTER, command.getType());
   }
+
+  @Test
+  public void testParseV14functions() throws SQLException {
+    String[] returningColumns = {"*"};
+    String query = "CREATE OR REPLACE FUNCTION asterisks(n int)\n"
+        + "  RETURNS SETOF text\n"
+        + "  LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE\n"
+        + "BEGIN ATOMIC\n"
+        + "SELECT repeat('*', g) FROM generate_series (1, n) g; \n" 
+        + "END;";
+    List<NativeQuery> qry = Parser.parseJdbcSql(query, true, true, true, true, true, returningColumns);
+    Assert.assertNotNull(qry);
+    Assert.assertEquals("There should only be one query returned here", 1, qry.size());
+  }
 }

--- a/pgjdbc/src/test/java/org/postgresql/core/ParserTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/core/ParserTest.java
@@ -292,7 +292,7 @@ public class ParserTest {
         + "  RETURNS SETOF text\n"
         + "  LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE\n"
         + "BEGIN ATOMIC\n"
-        + "SELECT repeat('*', g) FROM generate_series (1, n) g; \n" 
+        + "SELECT repeat('*', g) FROM generate_series (1, n) g; \n"
         + "END;";
     List<NativeQuery> qry = Parser.parseJdbcSql(query, true, true, true, true, true, returningColumns);
     Assert.assertNotNull(qry);


### PR DESCRIPTION
The npgsql folks ran into this https://github.com/npgsql/npgsql/issues/4445
Apparently multi-line functions can be defined without using $$ and semicolons are legal
This provides a failing test for same
There is some discussion about providing a connection parameter to pass the provided SQL  as is without rewriting it in https://github.com/pgjdbc/pgjdbc/pull/1946. This may solve the problem somewhat