### PR TITLE
proposal: Plugin Manager

### DIFF
--- a/benchmarks/src/jmh/java/org/postgresql/benchmark/pluginmanager/BindArray.java
+++ b/benchmarks/src/jmh/java/org/postgresql/benchmark/pluginmanager/BindArray.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) 2022, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.benchmark.pluginmanager;
+
+import org.postgresql.benchmark.profilers.FlightRecorderProfiler;
+import org.postgresql.util.ConnectionUtil;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.sql.Array;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Types;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+@Fork(value = 5, jvmArgsPrepend = "-Xmx128m")
+@Measurement(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class BindArray {
+  Integer[] ints;
+  int arraySize = 1000;
+  private Connection connectionNoPm;
+  private Connection connectionPm0;
+  private Connection connectionPm1;
+  private Connection connectionPm10;
+  private PreparedStatement psNoPm;
+  private PreparedStatement psPm0;
+  private PreparedStatement psPm1;
+  private PreparedStatement psPm10;
+
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder()
+        .include(org.postgresql.benchmark.statement.BindArray.class.getSimpleName())
+        .addProfiler(GCProfiler.class)
+        .addProfiler(FlightRecorderProfiler.class)
+        .detectJvmArgs()
+        .build();
+
+    new Runner(opt).run();
+  }
+
+  @Setup(Level.Trial)
+  public void setUp() throws SQLException {
+    Properties props = ConnectionUtil.getProperties();
+    props.setProperty("useConnectionPlugins", "false");
+    connectionNoPm = DriverManager.getConnection(ConnectionUtil.getURL(), props);
+    psNoPm = connectionNoPm.prepareStatement("SELECT ?");
+    ints = new Integer[arraySize];
+    for (int i = 0; i < arraySize; i++) {
+      ints[i] = i + 1;
+    }
+
+    props = ConnectionUtil.getProperties();
+    props.setProperty("useConnectionPlugins", "true");
+    props.setProperty("connectionPluginFactories", ""); // explicitly sets no plugin
+    connectionPm0 = DriverManager.getConnection(ConnectionUtil.getURL(), props);
+    psPm0 = connectionPm0.prepareStatement("SELECT ?");
+    ints = new Integer[arraySize];
+    for (int i = 0; i < arraySize; i++) {
+      ints[i] = i + 1;
+    }
+
+    props = ConnectionUtil.getProperties();
+    props.setProperty("useConnectionPlugins", "true");
+    props.setProperty("connectionPluginFactories",
+        "org.postgresql.pluginManager.simple.DummyConnectionPluginFactory");
+    connectionPm1 = DriverManager.getConnection(ConnectionUtil.getURL(), props);
+    psPm1 = connectionPm1.prepareStatement("SELECT ?");
+    ints = new Integer[arraySize];
+    for (int i = 0; i < arraySize; i++) {
+      ints[i] = i + 1;
+    }
+
+    props = ConnectionUtil.getProperties();
+    props.setProperty("useConnectionPlugins", "true");
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < 10; i++) {
+      if (i > 0) {
+        sb.append(",");
+      }
+      sb.append("org.postgresql.pluginManager.simple.DummyConnectionPluginFactory");
+    }
+    props.setProperty("connectionPluginFactories", sb.toString());
+    connectionPm10 = DriverManager.getConnection(ConnectionUtil.getURL(), props);
+    psPm10 = connectionPm10.prepareStatement("SELECT ?");
+    ints = new Integer[arraySize];
+    for (int i = 0; i < arraySize; i++) {
+      ints[i] = i + 1;
+    }
+  }
+
+  @TearDown(Level.Trial)
+  public void tearDown() throws SQLException {
+    psNoPm.close();
+    connectionNoPm.close();
+
+    psPm0.close();
+    connectionPm0.close();
+
+    psPm1.close();
+    connectionPm1.close();
+
+    psPm10.close();
+    connectionPm10.close();
+  }
+
+  @Benchmark
+  public Statement setObject_disabled() throws SQLException {
+    Array sqlInts = connectionNoPm.createArrayOf("int", ints);
+    psNoPm.setObject(1, sqlInts, Types.ARRAY);
+    return psNoPm;
+  }
+
+  @Benchmark
+  public Statement setObject_0() throws SQLException {
+    Array sqlInts = connectionPm0.createArrayOf("int", ints);
+    psPm0.setObject(1, sqlInts, Types.ARRAY);
+    return psPm0;
+  }
+
+  @Benchmark
+  public Statement setObject_1() throws SQLException {
+    Array sqlInts = connectionPm1.createArrayOf("int", ints);
+    psPm1.setObject(1, sqlInts, Types.ARRAY);
+    return psPm1;
+  }
+
+  @Benchmark
+  public Statement setObject_10() throws SQLException {
+    Array sqlInts = connectionPm10.createArrayOf("int", ints);
+    psPm10.setObject(1, sqlInts, Types.ARRAY);
+    return psPm10;
+  }
+
+  @Benchmark
+  public Statement setArray_disabled() throws SQLException {
+    Array sqlInts = connectionNoPm.createArrayOf("int", ints);
+    psNoPm.setArray(1, sqlInts);
+    return psNoPm;
+  }
+
+  @Benchmark
+  public Statement setArray_0() throws SQLException {
+    Array sqlInts = connectionPm0.createArrayOf("int", ints);
+    psPm0.setArray(1, sqlInts);
+    return psPm0;
+  }
+
+  @Benchmark
+  public Statement setArray_1() throws SQLException {
+    Array sqlInts = connectionPm1.createArrayOf("int", ints);
+    psPm1.setArray(1, sqlInts);
+    return psPm1;
+  }
+
+  @Benchmark
+  public Statement setArray_10() throws SQLException {
+    Array sqlInts = connectionPm10.createArrayOf("int", ints);
+    psPm10.setArray(1, sqlInts);
+    return psPm10;
+  }
+}

--- a/benchmarks/src/jmh/java/org/postgresql/benchmark/pluginmanager/FinalizeConnection.java
+++ b/benchmarks/src/jmh/java/org/postgresql/benchmark/pluginmanager/FinalizeConnection.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2022, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.benchmark.pluginmanager;
+
+import org.postgresql.util.ConnectionUtil;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.sql.Connection;
+import java.sql.Driver;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Tests the time and memory required to create a connection. Note: due to TCP socket's turning into
+ * TIME_WAIT state on close, it is rather hard to test lots of connection creations, so only 50
+ * iterations are performed.
+ *
+ * <p>To run this and other benchmarks (you can run the class from within IDE):
+ *
+ * <blockquote> <code>mvn package &amp;&amp; java -classpath postgresql-driver
+ * .jar:target/benchmarks.jar
+ * -Duser=postgres -Dpassword=postgres -Dport=5433  -wi 10 -i 10 -f 1</code> </blockquote>
+ *
+ * <p>To run with profiling:
+ *
+ * <blockquote> <code>java -classpath postgresql-driver.jar:target/benchmarks.jar -prof gc -f 1 -wi
+ * 10 -i 10</code> </blockquote>
+ */
+@Fork(1)
+@Measurement(iterations = 50)
+@Warmup(iterations = 10)
+@State(Scope.Thread)
+@Threads(1)
+@BenchmarkMode(Mode.SingleShotTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+public class FinalizeConnection {
+  private Properties connectionPropertiesNoPm;
+  private Properties connectionPropertiesPm0;
+  private Properties connectionPropertiesPm1;
+  private Properties connectionPropertiesPm10;
+  private String connectionUrl;
+  private Driver driver;
+
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder()
+        .include(org.postgresql.benchmark.connection.FinalizeConnection.class.getSimpleName())
+        .addProfiler(GCProfiler.class)
+        .detectJvmArgs()
+        .build();
+
+    new Runner(opt).run();
+  }
+
+  @Setup(Level.Trial)
+  public void setUp() throws SQLException {
+    // Plugin Manager is disabled
+    connectionPropertiesNoPm = ConnectionUtil.getProperties();
+    connectionPropertiesNoPm.setProperty("useConnectionPlugins", "false");
+
+    // Plugin Manager is enabled
+    // No user plugins are loaded
+    connectionPropertiesPm0 = ConnectionUtil.getProperties();
+    connectionPropertiesPm0.setProperty("useConnectionPlugins", "true");
+    connectionPropertiesPm0.setProperty("connectionPluginFactories",
+        ""); // explicitly sets no plugin
+
+    // Plugin Manager is enabled
+    // A single dummy user plugin is loaded
+    connectionPropertiesPm1 = ConnectionUtil.getProperties();
+    connectionPropertiesPm1.setProperty("useConnectionPlugins", "true");
+    connectionPropertiesPm1.setProperty("connectionPluginFactories",
+        "org.postgresql.plugins.demo.DummyConnectionPluginFactory");
+
+    // Plugin Manager is enabled
+    // 10 dummy user plugins are loaded
+    connectionPropertiesPm10 = ConnectionUtil.getProperties();
+    connectionPropertiesPm10.setProperty("useConnectionPlugins", "true");
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < 10; i++) {
+      if (i > 0) {
+        sb.append(",");
+      }
+      sb.append("org.postgresql.plugins.demo.DummyConnectionPluginFactory");
+    }
+    connectionPropertiesPm10.setProperty("connectionPluginFactories", sb.toString());
+
+    connectionUrl = ConnectionUtil.getURL();
+    driver = DriverManager.getDriver(connectionUrl);
+  }
+
+  @Benchmark
+  public void baseline() throws SQLException {
+  }
+
+  @Benchmark
+  public Connection createAndClose_disabled() throws SQLException {
+    Connection connection = driver.connect(connectionUrl, connectionPropertiesNoPm);
+    connection.close();
+    return connection;
+  }
+
+  @Benchmark
+  public Connection createAndClose_0() throws SQLException {
+    Connection connection = driver.connect(connectionUrl, connectionPropertiesPm0);
+    connection.close();
+    return connection;
+  }
+
+  @Benchmark
+  public Connection createAndClose_1() throws SQLException {
+    Connection connection = driver.connect(connectionUrl, connectionPropertiesPm1);
+    connection.close();
+    return connection;
+  }
+
+  @Benchmark
+  public Connection createAndClose_10() throws SQLException {
+    Connection connection = driver.connect(connectionUrl, connectionPropertiesPm10);
+    connection.close();
+    return connection;
+  }
+}

--- a/benchmarks/src/jmh/java/org/postgresql/benchmark/pluginmanager/FinalizeStatement.java
+++ b/benchmarks/src/jmh/java/org/postgresql/benchmark/pluginmanager/FinalizeStatement.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2022, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.benchmark.pluginmanager;
+
+import org.postgresql.util.ConnectionUtil;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Properties;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Here we measure the time it takes to create and close a dummy statement.
+ *
+ * <p>To run this and other benchmarks (you can run the class from within IDE):
+ *
+ * <blockquote> <code>mvn package &amp;&amp; java -classpath postgresql-driver
+ * .jar:target/benchmarks.jar
+ * -Duser=postgres -Dpassword=postgres -Dport=5433  -wi 10 -i 10 -f 1</code> </blockquote>
+ *
+ * <p>To run with profiling:
+ *
+ * <blockquote> <code>java -classpath postgresql-driver.jar:target/benchmarks.jar -prof gc -f 1 -wi
+ * 10 -i 10</code> </blockquote>
+ */
+@Fork(value = 5, jvmArgsPrepend = "-Xmx128m")
+@Measurement(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class FinalizeStatement {
+  @Param({"0", "1", "10", "100"})
+  private int leakPct;
+
+  private float leakPctFloat;
+
+  private Connection connectionNoPm;
+  private Connection connectionPm0;
+  private Connection connectionPm1;
+  private Connection connectionPm10;
+
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder()
+        .include(org.postgresql.benchmark.statement.FinalizeStatement.class.getSimpleName())
+        .addProfiler(GCProfiler.class)
+        .detectJvmArgs()
+        .build();
+
+    new Runner(opt).run();
+  }
+
+  @Setup(Level.Trial)
+  public void setUp() throws SQLException {
+    Properties props = ConnectionUtil.getProperties();
+    props.setProperty("useConnectionPlugins", "false");
+    connectionNoPm = DriverManager.getConnection(ConnectionUtil.getURL(), props);
+
+    props = ConnectionUtil.getProperties();
+    props.setProperty("useConnectionPlugins", "true");
+    props.setProperty("connectionPluginFactories", ""); // explicitly sets no plugin
+    connectionPm0 = DriverManager.getConnection(ConnectionUtil.getURL(), props);
+
+    props = ConnectionUtil.getProperties();
+    props.setProperty("useConnectionPlugins", "true");
+    props.setProperty("connectionPluginFactories",
+        "org.postgresql.plugins.demo.DummyConnectionPluginFactory");
+    connectionPm1 = DriverManager.getConnection(ConnectionUtil.getURL(), props);
+
+    props = ConnectionUtil.getProperties();
+    props.setProperty("useConnectionPlugins", "true");
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < 10; i++) {
+      if (i > 0) {
+        sb.append(",");
+      }
+      sb.append("org.postgresql.plugins.demo.DummyConnectionPluginFactory");
+    }
+    props.setProperty("connectionPluginFactories", sb.toString());
+    connectionPm10 = DriverManager.getConnection(ConnectionUtil.getURL(), props);
+
+    leakPctFloat = 0.01f * leakPct;
+  }
+
+  @TearDown(Level.Trial)
+  public void tearDown() throws SQLException {
+    connectionNoPm.close();
+    connectionPm0.close();
+    connectionPm1.close();
+    connectionPm10.close();
+  }
+
+  @Benchmark
+  public Statement createAndLeak_disabled() throws SQLException {
+    Statement statement = connectionNoPm.createStatement();
+    Random rnd;
+    rnd = java.util.concurrent.ThreadLocalRandom.current();
+    if (rnd.nextFloat() >= leakPctFloat) {
+      statement.close();
+    }
+    return statement;
+  }
+
+  @Benchmark
+  public Statement createAndLeak_0() throws SQLException {
+    Statement statement = connectionPm0.createStatement();
+    Random rnd;
+    rnd = java.util.concurrent.ThreadLocalRandom.current();
+    if (rnd.nextFloat() >= leakPctFloat) {
+      statement.close();
+    }
+    return statement;
+  }
+
+  @Benchmark
+  public Statement createAndLeak_1() throws SQLException {
+    Statement statement = connectionPm1.createStatement();
+    Random rnd;
+    rnd = java.util.concurrent.ThreadLocalRandom.current();
+    if (rnd.nextFloat() >= leakPctFloat) {
+      statement.close();
+    }
+    return statement;
+  }
+
+  @Benchmark
+  public Statement createAndLeak_10() throws SQLException {
+    Statement statement = connectionPm10.createStatement();
+    Random rnd;
+    rnd = java.util.concurrent.ThreadLocalRandom.current();
+    if (rnd.nextFloat() >= leakPctFloat) {
+      statement.close();
+    }
+    return statement;
+  }
+}

--- a/pgjdbc/src/main/java/org/postgresql/Driver.java
+++ b/pgjdbc/src/main/java/org/postgresql/Driver.java
@@ -8,6 +8,7 @@ package org.postgresql;
 import static org.postgresql.util.internal.Nullness.castNonNull;
 
 import org.postgresql.jdbc.PgConnection;
+import org.postgresql.pluginmanager.ConnectionWrapper;
 import org.postgresql.util.DriverInfo;
 import org.postgresql.util.GT;
 import org.postgresql.util.HostSpec;
@@ -399,7 +400,13 @@ public class Driver implements java.sql.Driver {
    * @throws SQLException if the connection could not be made
    */
   private static Connection makeConnection(String url, Properties props) throws SQLException {
-    return new PgConnection(hostSpecs(props), props, url);
+    HostSpec[] hostSpecs = hostSpecs(props);
+
+    if (PGProperty.USE_CONNECTION_PLUGINS.getBoolean(props)) {
+      return new ConnectionWrapper(hostSpecs, props, url);
+    } else {
+      return new PgConnection(hostSpecs, props, url);
+    }
   }
 
   /**

--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -744,6 +744,62 @@ public enum PGProperty {
       "",
       "Factory class to instantiate factories for XML processing"),
 
+  /**
+   * Use connection plugins.
+   */
+  USE_CONNECTION_PLUGINS(
+      "useConnectionPlugins",
+      "true",
+      "Use connection plugins"),
+
+  /**
+   * A list of connection plugin factory class names.
+   */
+  CONNECTION_PLUGIN_FACTORIES(
+      "connectionPluginFactories",
+      null,
+      "Coma separated list of connection plugin factories"),
+
+  /**
+   * Interval in milliseconds for a monitor to be considered inactive and to be disposed.
+   */
+  MONITOR_DISPOSAL_TIME(
+      "monitorDisposalTime",
+      Integer.toString(60000),
+      "Interval in milliseconds for a monitor to be considered inactive and to be disposed."),
+
+  /**
+   * Enable failure detection logic (aka node monitoring thread).
+   */
+  FAILURE_DETECTION_ENABLED(
+      "failureDetectionEnabled",
+      "true",
+      "Enable failure detection logic (aka node monitoring thread)."),
+
+  /**
+   * Interval in millis between sending SQL to the server and the first probe to database node.
+   */
+  FAILURE_DETECTION_TIME(
+      "failureDetectionTime",
+      Integer.toString(30000),
+      "Interval in millis between sending SQL to the server and the first probe to database node."),
+
+  /**
+   * Interval in millis between probes to database node.
+   */
+  FAILURE_DETECTION_INTERVAL(
+      "failureDetectionInterval",
+      Integer.toString(5000),
+      "Interval in millis between probes to database node."),
+
+  /**
+   * Number of failed connection checks before considering database node unhealthy.
+   */
+  FAILURE_DETECTION_COUNT(
+      "failureDetectionCount",
+      Integer.toString(3),
+      "Number of failed connection checks before considering database node unhealthy."),
+
   ;
 
   private final String name;

--- a/pgjdbc/src/main/java/org/postgresql/pluginmanager/BasicConnectionProvider.java
+++ b/pgjdbc/src/main/java/org/postgresql/pluginmanager/BasicConnectionProvider.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2022, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.pluginmanager;
+
+import org.postgresql.core.BaseConnection;
+import org.postgresql.jdbc.PgConnection;
+import org.postgresql.util.HostSpec;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Properties;
+
+/**
+ * This class is a basic implementation of IConnectionProvider interface. It creates and returns an
+ * instance of PgConnection.
+ */
+public class BasicConnectionProvider implements ConnectionProvider {
+
+  /**
+   * Called to create a connection.
+   *
+   * @param hostSpecs The HostSpec containing the host-port information for the host to connect to
+   * @param props     The Properties to use for the connection
+   * @param url       The connection URL
+   * @return {@link Connection} resulting from the given connection information
+   * @throws SQLException if an error occurs
+   */
+  @Override
+  public BaseConnection connect(HostSpec[] hostSpecs, Properties props, @Nullable String url)
+      throws SQLException {
+    return new PgConnection(hostSpecs, props, url == null ? "" : url);
+  }
+}

--- a/pgjdbc/src/main/java/org/postgresql/pluginmanager/CallableStatementWrapper.java
+++ b/pgjdbc/src/main/java/org/postgresql/pluginmanager/CallableStatementWrapper.java
@@ -1,0 +1,2240 @@
+/*
+ * Copyright (c) 2022, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.pluginmanager;
+
+import java.io.InputStream;
+import java.io.Reader;
+import java.math.BigDecimal;
+import java.net.URL;
+import java.sql.Array;
+import java.sql.Blob;
+import java.sql.CallableStatement;
+import java.sql.Clob;
+import java.sql.Connection;
+import java.sql.Date;
+import java.sql.NClob;
+import java.sql.ParameterMetaData;
+import java.sql.Ref;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.RowId;
+import java.sql.SQLException;
+import java.sql.SQLType;
+import java.sql.SQLWarning;
+import java.sql.SQLXML;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.util.Calendar;
+import java.util.Map;
+
+public class CallableStatementWrapper implements CallableStatement {
+
+  protected CallableStatement statement;
+  protected Class<?> statementClass;
+  protected ConnectionPluginManager pluginManager;
+
+  public CallableStatementWrapper(CallableStatement statement,
+      ConnectionPluginManager pluginManager) {
+    if (statement == null) {
+      throw new IllegalArgumentException("statement");
+    }
+    if (pluginManager == null) {
+      throw new IllegalArgumentException("pluginManager");
+    }
+
+    this.statement = statement;
+    this.statementClass = this.statement.getClass();
+    this.pluginManager = pluginManager;
+  }
+
+  @Override
+  public void registerOutParameter(int parameterIndex, int sqlType) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.registerOutParameter",
+        () -> {
+          this.statement.registerOutParameter(parameterIndex, sqlType);
+          return null;
+        });
+  }
+
+  @Override
+  public void registerOutParameter(int parameterIndex, int sqlType, int scale) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.registerOutParameter",
+        () -> {
+          this.statement.registerOutParameter(parameterIndex, sqlType, scale);
+          return null;
+        });
+  }
+
+  @Override
+  public boolean wasNull() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.wasNull",
+        () -> this.statement.wasNull());
+  }
+
+  @Override
+  public String getString(int parameterIndex) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getString",
+        () -> this.statement.getString(parameterIndex));
+  }
+
+  @Override
+  public boolean getBoolean(int parameterIndex) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getBoolean",
+        () -> this.statement.getBoolean(parameterIndex));
+  }
+
+  @Override
+  public byte getByte(int parameterIndex) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getByte",
+        () -> this.statement.getByte(parameterIndex));
+  }
+
+  @Override
+  public short getShort(int parameterIndex) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getShort",
+        () -> this.statement.getShort(parameterIndex));
+  }
+
+  @Override
+  public int getInt(int parameterIndex) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getInt",
+        () -> this.statement.getInt(parameterIndex));
+  }
+
+  @Override
+  public long getLong(int parameterIndex) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getLong",
+        () -> this.statement.getLong(parameterIndex));
+  }
+
+  @Override
+  public float getFloat(int parameterIndex) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getFloat",
+        () -> this.statement.getFloat(parameterIndex));
+  }
+
+  @Override
+  public double getDouble(int parameterIndex) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getDouble",
+        () -> this.statement.getDouble(parameterIndex));
+  }
+
+  @Override
+  @SuppressWarnings("deprecation")
+  public BigDecimal getBigDecimal(int parameterIndex, int scale) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getBigDecimal",
+        () -> this.statement.getBigDecimal(parameterIndex, scale));
+  }
+
+  @Override
+  public byte[] getBytes(int parameterIndex) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getBytes",
+        () -> this.statement.getBytes(parameterIndex));
+  }
+
+  @Override
+  public Date getDate(int parameterIndex) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getDate",
+        () -> this.statement.getDate(parameterIndex));
+  }
+
+  @Override
+  public Time getTime(int parameterIndex) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getTime",
+        () -> this.statement.getTime(parameterIndex));
+  }
+
+  @Override
+  public Timestamp getTimestamp(int parameterIndex) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getTimestamp",
+        () -> this.statement.getTimestamp(parameterIndex));
+  }
+
+  @Override
+  public Object getObject(int parameterIndex) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getObject",
+        () -> this.statement.getObject(parameterIndex));
+  }
+
+  @Override
+  public BigDecimal getBigDecimal(int parameterIndex) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getBigDecimal",
+        () -> this.statement.getBigDecimal(parameterIndex));
+  }
+
+  @Override
+  public Object getObject(int parameterIndex, Map<String, Class<?>> map) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getObject",
+        () -> this.statement.getObject(parameterIndex, map));
+  }
+
+  @Override
+  public Ref getRef(int parameterIndex) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getRef",
+        () -> this.statement.getRef(parameterIndex));
+  }
+
+  @Override
+  public Blob getBlob(int parameterIndex) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getBlob",
+        () -> this.statement.getBlob(parameterIndex));
+  }
+
+  @Override
+  public Clob getClob(int parameterIndex) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getClob",
+        () -> this.statement.getClob(parameterIndex));
+  }
+
+  @Override
+  public Array getArray(int parameterIndex) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getArray",
+        () -> this.statement.getArray(parameterIndex));
+  }
+
+  @Override
+  public Date getDate(int parameterIndex, Calendar cal) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getDate",
+        () -> this.statement.getDate(parameterIndex, cal));
+  }
+
+  @Override
+  public Time getTime(int parameterIndex, Calendar cal) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getTime",
+        () -> this.statement.getTime(parameterIndex, cal));
+  }
+
+  @Override
+  public Timestamp getTimestamp(int parameterIndex, Calendar cal) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getTimestamp",
+        () -> this.statement.getTimestamp(parameterIndex, cal));
+  }
+
+  @Override
+  public void registerOutParameter(int parameterIndex, int sqlType, String typeName)
+      throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.registerOutParameter",
+        () -> {
+          this.statement.registerOutParameter(parameterIndex, sqlType, typeName);
+          return null;
+        });
+  }
+
+  @Override
+  public void registerOutParameter(String parameterName, int sqlType) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.registerOutParameter",
+        () -> {
+          this.statement.registerOutParameter(parameterName, sqlType);
+          return null;
+        });
+  }
+
+  @Override
+  public void registerOutParameter(String parameterName, int sqlType, int scale)
+      throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.registerOutParameter",
+        () -> {
+          this.statement.registerOutParameter(parameterName, sqlType, scale);
+          return null;
+        });
+  }
+
+  @Override
+  public void registerOutParameter(String parameterName, int sqlType, String typeName)
+      throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.registerOutParameter",
+        () -> {
+          this.statement.registerOutParameter(parameterName, sqlType, typeName);
+          return null;
+        });
+  }
+
+  @Override
+  public URL getURL(int parameterIndex) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getURL",
+        () -> this.statement.getURL(parameterIndex));
+  }
+
+  @Override
+  public void setURL(String parameterName, URL val) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setURL",
+        () -> {
+          this.statement.setURL(parameterName, val);
+          return null;
+        });
+  }
+
+  @Override
+  public void setNull(String parameterName, int sqlType) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setNull",
+        () -> {
+          this.statement.setNull(parameterName, sqlType);
+          return null;
+        });
+  }
+
+  @Override
+  public void setBoolean(String parameterName, boolean x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setBoolean",
+        () -> {
+          this.statement.setBoolean(parameterName, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void setByte(String parameterName, byte x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setByte",
+        () -> {
+          this.statement.setByte(parameterName, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void setShort(String parameterName, short x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setShort",
+        () -> {
+          this.statement.setShort(parameterName, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void setInt(String parameterName, int x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setInt",
+        () -> {
+          this.statement.setInt(parameterName, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void setLong(String parameterName, long x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setLong",
+        () -> {
+          this.statement.setLong(parameterName, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void setFloat(String parameterName, float x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setFloat",
+        () -> {
+          this.statement.setFloat(parameterName, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void setDouble(String parameterName, double x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setDouble",
+        () -> {
+          this.statement.setDouble(parameterName, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void setBigDecimal(String parameterName, BigDecimal x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setBigDecimal",
+        () -> {
+          this.statement.setBigDecimal(parameterName, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void setString(String parameterName, String x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setString",
+        () -> {
+          this.statement.setString(parameterName, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void setBytes(String parameterName, byte[] x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setBytes",
+        () -> {
+          this.statement.setBytes(parameterName, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void setDate(String parameterName, Date x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setDate",
+        () -> {
+          this.statement.setDate(parameterName, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void setTime(String parameterName, Time x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setTime",
+        () -> {
+          this.statement.setTime(parameterName, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void setTimestamp(String parameterName, Timestamp x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setTimestamp",
+        () -> {
+          this.statement.setTimestamp(parameterName, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void setAsciiStream(String parameterName, InputStream x, int length) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setAsciiStream",
+        () -> {
+          this.statement.setAsciiStream(parameterName, x, length);
+          return null;
+        });
+  }
+
+  @Override
+  public void setBinaryStream(String parameterName, InputStream x, int length) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setBinaryStream",
+        () -> {
+          this.statement.setBinaryStream(parameterName, x, length);
+          return null;
+        });
+  }
+
+  @Override
+  public void setObject(String parameterName, Object x, int targetSqlType, int scale)
+      throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setObject",
+        () -> {
+          this.statement.setObject(parameterName, x, targetSqlType, scale);
+          return null;
+        });
+  }
+
+  @Override
+  public void setObject(String parameterName, Object x, int targetSqlType) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setObject",
+        () -> {
+          this.statement.setObject(parameterName, x, targetSqlType);
+          return null;
+        });
+  }
+
+  @Override
+  public void setObject(String parameterName, Object x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setObject",
+        () -> {
+          this.statement.setObject(parameterName, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void setCharacterStream(String parameterName, Reader reader, int length)
+      throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setCharacterStream",
+        () -> {
+          this.statement.setCharacterStream(parameterName, reader, length);
+          return null;
+        });
+  }
+
+  @Override
+  public void setDate(String parameterName, Date x, Calendar cal) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setDate",
+        () -> {
+          this.statement.setDate(parameterName, x, cal);
+          return null;
+        });
+  }
+
+  @Override
+  public void setTime(String parameterName, Time x, Calendar cal) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setTime",
+        () -> {
+          this.statement.setTime(parameterName, x, cal);
+          return null;
+        });
+  }
+
+  @Override
+  public void setTimestamp(String parameterName, Timestamp x, Calendar cal) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setTimestamp",
+        () -> {
+          this.statement.setTimestamp(parameterName, x, cal);
+          return null;
+        });
+  }
+
+  @Override
+  public void setNull(String parameterName, int sqlType, String typeName) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setNull",
+        () -> {
+          this.statement.setNull(parameterName, sqlType, typeName);
+          return null;
+        });
+  }
+
+  @Override
+  public String getString(String parameterName) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getString",
+        () -> this.statement.getString(parameterName));
+  }
+
+  @Override
+  public boolean getBoolean(String parameterName) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getBoolean",
+        () -> this.statement.getBoolean(parameterName));
+  }
+
+  @Override
+  public byte getByte(String parameterName) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getByte",
+        () -> this.statement.getByte(parameterName));
+  }
+
+  @Override
+  public short getShort(String parameterName) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getShort",
+        () -> this.statement.getShort(parameterName));
+  }
+
+  @Override
+  public int getInt(String parameterName) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getInt",
+        () -> this.statement.getInt(parameterName));
+  }
+
+  @Override
+  public long getLong(String parameterName) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getLong",
+        () -> this.statement.getLong(parameterName));
+  }
+
+  @Override
+  public float getFloat(String parameterName) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getFloat",
+        () -> this.statement.getFloat(parameterName));
+  }
+
+  @Override
+  public double getDouble(String parameterName) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getDouble",
+        () -> this.statement.getDouble(parameterName));
+  }
+
+  @Override
+  public byte[] getBytes(String parameterName) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getBytes",
+        () -> this.statement.getBytes(parameterName));
+  }
+
+  @Override
+  public Date getDate(String parameterName) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getDate",
+        () -> this.statement.getDate(parameterName));
+  }
+
+  @Override
+  public Time getTime(String parameterName) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getTime",
+        () -> this.statement.getTime(parameterName));
+  }
+
+  @Override
+  public Timestamp getTimestamp(String parameterName) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getTimestamp",
+        () -> this.statement.getTimestamp(parameterName));
+  }
+
+  @Override
+  public Object getObject(String parameterName) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getObject",
+        () -> this.statement.getObject(parameterName));
+  }
+
+  @Override
+  public BigDecimal getBigDecimal(String parameterName) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getBigDecimal",
+        () -> this.statement.getBigDecimal(parameterName));
+  }
+
+  @Override
+  public Object getObject(String parameterName, Map<String, Class<?>> map) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getObject",
+        () -> this.statement.getObject(parameterName, map));
+  }
+
+  @Override
+  public Ref getRef(String parameterName) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getRef",
+        () -> this.statement.getRef(parameterName));
+  }
+
+  @Override
+  public Blob getBlob(String parameterName) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getBlob",
+        () -> this.statement.getBlob(parameterName));
+  }
+
+  @Override
+  public Clob getClob(String parameterName) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getClob",
+        () -> this.statement.getClob(parameterName));
+  }
+
+  @Override
+  public Array getArray(String parameterName) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getArray",
+        () -> this.statement.getArray(parameterName));
+  }
+
+  @Override
+  public Date getDate(String parameterName, Calendar cal) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getDate",
+        () -> this.statement.getDate(parameterName, cal));
+  }
+
+  @Override
+  public Time getTime(String parameterName, Calendar cal) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getTime",
+        () -> this.statement.getTime(parameterName, cal));
+  }
+
+  @Override
+  public Timestamp getTimestamp(String parameterName, Calendar cal) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getTimestamp",
+        () -> this.statement.getTimestamp(parameterName, cal));
+  }
+
+  @Override
+  public URL getURL(String parameterName) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getURL",
+        () -> this.statement.getURL(parameterName));
+  }
+
+  @Override
+  public RowId getRowId(int parameterIndex) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getRowId",
+        () -> this.statement.getRowId(parameterIndex));
+  }
+
+  @Override
+  public RowId getRowId(String parameterName) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getRowId",
+        () -> this.statement.getRowId(parameterName));
+  }
+
+  @Override
+  public void setRowId(String parameterName, RowId x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setRowId",
+        () -> {
+          this.statement.setRowId(parameterName, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void setNString(String parameterName, String value) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setNString",
+        () -> {
+          this.statement.setNString(parameterName, value);
+          return null;
+        });
+  }
+
+  @Override
+  public void setNCharacterStream(String parameterName, Reader value, long length)
+      throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setNCharacterStream",
+        () -> {
+          this.statement.setNCharacterStream(parameterName, value, length);
+          return null;
+        });
+  }
+
+  @Override
+  public void setNClob(String parameterName, NClob value) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setNClob",
+        () -> {
+          this.statement.setNClob(parameterName, value);
+          return null;
+        });
+  }
+
+  @Override
+  public void setClob(String parameterName, Reader reader, long length) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setClob",
+        () -> {
+          this.statement.setClob(parameterName, reader, length);
+          return null;
+        });
+  }
+
+  @Override
+  public void setBlob(String parameterName, InputStream inputStream, long length)
+      throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setBlob",
+        () -> {
+          this.statement.setBlob(parameterName, inputStream, length);
+          return null;
+        });
+  }
+
+  @Override
+  public void setNClob(String parameterName, Reader reader, long length) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setNClob",
+        () -> {
+          this.statement.setNClob(parameterName, reader, length);
+          return null;
+        });
+  }
+
+  @Override
+  public NClob getNClob(int parameterIndex) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getNClob",
+        () -> this.statement.getNClob(parameterIndex));
+  }
+
+  @Override
+  public NClob getNClob(String parameterName) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getNClob",
+        () -> this.statement.getNClob(parameterName));
+  }
+
+  @Override
+  public void setSQLXML(String parameterName, SQLXML xmlObject) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setSQLXML",
+        () -> {
+          this.statement.setSQLXML(parameterName, xmlObject);
+          return null;
+        });
+  }
+
+  @Override
+  public SQLXML getSQLXML(int parameterIndex) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getSQLXML",
+        () -> this.statement.getSQLXML(parameterIndex));
+  }
+
+  @Override
+  public SQLXML getSQLXML(String parameterName) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getSQLXML",
+        () -> this.statement.getSQLXML(parameterName));
+  }
+
+  @Override
+  public String getNString(int parameterIndex) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getNString",
+        () -> this.statement.getNString(parameterIndex));
+  }
+
+  @Override
+  public String getNString(String parameterName) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getNString",
+        () -> this.statement.getNString(parameterName));
+  }
+
+  @Override
+  public Reader getNCharacterStream(int parameterIndex) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getNCharacterStream",
+        () -> this.statement.getNCharacterStream(parameterIndex));
+  }
+
+  @Override
+  public Reader getNCharacterStream(String parameterName) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getNCharacterStream",
+        () -> this.statement.getNCharacterStream(parameterName));
+  }
+
+  @Override
+  public Reader getCharacterStream(int parameterIndex) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getCharacterStream",
+        () -> this.statement.getCharacterStream(parameterIndex));
+  }
+
+  @Override
+  public Reader getCharacterStream(String parameterName) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getCharacterStream",
+        () -> this.statement.getCharacterStream(parameterName));
+  }
+
+  @Override
+  public void setBlob(String parameterName, Blob x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setBlob",
+        () -> {
+          this.statement.setBlob(parameterName, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void setClob(String parameterName, Clob x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setClob",
+        () -> {
+          this.statement.setClob(parameterName, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void setAsciiStream(String parameterName, InputStream x, long length) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setAsciiStream",
+        () -> {
+          this.statement.setAsciiStream(parameterName, x, length);
+          return null;
+        });
+  }
+
+  @Override
+  public void setBinaryStream(String parameterName, InputStream x, long length)
+      throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setBinaryStream",
+        () -> {
+          this.statement.setBinaryStream(parameterName, x, length);
+          return null;
+        });
+  }
+
+  @Override
+  public void setCharacterStream(String parameterName, Reader reader, long length)
+      throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setCharacterStream",
+        () -> {
+          this.statement.setCharacterStream(parameterName, reader, length);
+          return null;
+        });
+  }
+
+  @Override
+  public void setAsciiStream(String parameterName, InputStream x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setAsciiStream",
+        () -> {
+          this.statement.setAsciiStream(parameterName, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void setBinaryStream(String parameterName, InputStream x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setBinaryStream",
+        () -> {
+          this.statement.setBinaryStream(parameterName, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void setCharacterStream(String parameterName, Reader reader) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setCharacterStream",
+        () -> {
+          this.statement.setCharacterStream(parameterName, reader);
+          return null;
+        });
+  }
+
+  @Override
+  public void setNCharacterStream(String parameterName, Reader value) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setNCharacterStream",
+        () -> {
+          this.statement.setNCharacterStream(parameterName, value);
+          return null;
+        });
+  }
+
+  @Override
+  public void setClob(String parameterName, Reader reader) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setClob",
+        () -> {
+          this.statement.setClob(parameterName, reader);
+          return null;
+        });
+  }
+
+  @Override
+  public void setBlob(String parameterName, InputStream inputStream) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setBlob",
+        () -> {
+          this.statement.setBlob(parameterName, inputStream);
+          return null;
+        });
+  }
+
+  @Override
+  public void setNClob(String parameterName, Reader reader) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setNClob",
+        () -> {
+          this.statement.setNClob(parameterName, reader);
+          return null;
+        });
+  }
+
+  @Override
+  public <T> T getObject(int parameterIndex, Class<T> type) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getObject",
+        () -> this.statement.getObject(parameterIndex, type));
+  }
+
+  @Override
+  public <T> T getObject(String parameterName, Class<T> type) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getObject",
+        () -> this.statement.getObject(parameterName, type));
+  }
+
+  @Override
+  public void setObject(String parameterName, Object x, SQLType targetSqlType, int scaleOrLength)
+      throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setObject",
+        () -> {
+          this.statement.setObject(parameterName, x, targetSqlType, scaleOrLength);
+          return null;
+        });
+  }
+
+  @Override
+  public void setObject(String parameterName, Object x, SQLType targetSqlType) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setObject",
+        () -> {
+          this.statement.setObject(parameterName, x, targetSqlType);
+          return null;
+        });
+  }
+
+  @Override
+  public void registerOutParameter(int parameterIndex, SQLType sqlType) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.registerOutParameter",
+        () -> {
+          this.statement.registerOutParameter(parameterIndex, sqlType);
+          return null;
+        });
+  }
+
+  @Override
+  public void registerOutParameter(int parameterIndex, SQLType sqlType, int scale)
+      throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.registerOutParameter",
+        () -> {
+          this.statement.registerOutParameter(parameterIndex, sqlType, scale);
+          return null;
+        });
+  }
+
+  @Override
+  public void registerOutParameter(int parameterIndex, SQLType sqlType, String typeName)
+      throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.registerOutParameter",
+        () -> {
+          this.statement.registerOutParameter(parameterIndex, sqlType, typeName);
+          return null;
+        });
+  }
+
+  @Override
+  public void registerOutParameter(String parameterName, SQLType sqlType) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.registerOutParameter",
+        () -> {
+          this.statement.registerOutParameter(parameterName, sqlType);
+          return null;
+        });
+  }
+
+  @Override
+  public void registerOutParameter(String parameterName, SQLType sqlType, int scale)
+      throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.registerOutParameter",
+        () -> {
+          this.statement.registerOutParameter(parameterName, sqlType, scale);
+          return null;
+        });
+  }
+
+  @Override
+  public void registerOutParameter(String parameterName, SQLType sqlType, String typeName)
+      throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.registerOutParameter",
+        () -> {
+          this.statement.registerOutParameter(parameterName, sqlType, typeName);
+          return null;
+        });
+  }
+
+  // -------------------------
+
+  @Override
+  public ResultSet executeQuery() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.executeQuery",
+        () -> this.statement.executeQuery());
+  }
+
+  @Override
+  public int executeUpdate() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.executeUpdate",
+        () -> this.statement.executeUpdate());
+  }
+
+  @Override
+  public void setNull(int parameterIndex, int sqlType) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setNull",
+        () -> {
+          this.statement.setNull(parameterIndex, sqlType);
+          return null;
+        });
+  }
+
+  @Override
+  public void setBoolean(int parameterIndex, boolean x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setBoolean",
+        () -> {
+          this.statement.setBoolean(parameterIndex, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void setByte(int parameterIndex, byte x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setByte",
+        () -> {
+          this.statement.setByte(parameterIndex, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void setShort(int parameterIndex, short x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setShort",
+        () -> {
+          this.statement.setShort(parameterIndex, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void setInt(int parameterIndex, int x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setInt",
+        () -> {
+          this.statement.setInt(parameterIndex, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void setLong(int parameterIndex, long x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setLong",
+        () -> {
+          this.statement.setLong(parameterIndex, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void setFloat(int parameterIndex, float x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setFloat",
+        () -> {
+          this.statement.setFloat(parameterIndex, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void setDouble(int parameterIndex, double x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setDouble",
+        () -> {
+          this.statement.setDouble(parameterIndex, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void setBigDecimal(int parameterIndex, BigDecimal x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setBigDecimal",
+        () -> {
+          this.statement.setBigDecimal(parameterIndex, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void setString(int parameterIndex, String x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setString",
+        () -> {
+          this.statement.setString(parameterIndex, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void setBytes(int parameterIndex, byte[] x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setBytes",
+        () -> {
+          this.statement.setBytes(parameterIndex, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void setDate(int parameterIndex, Date x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setDate",
+        () -> {
+          this.statement.setDate(parameterIndex, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void setTime(int parameterIndex, Time x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setTime",
+        () -> {
+          this.statement.setTime(parameterIndex, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void setTimestamp(int parameterIndex, Timestamp x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setTimestamp",
+        () -> {
+          this.statement.setTimestamp(parameterIndex, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void setAsciiStream(int parameterIndex, InputStream x, int length) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setAsciiStream",
+        () -> {
+          this.statement.setAsciiStream(parameterIndex, x);
+          return null;
+        });
+  }
+
+  @Override
+  @SuppressWarnings("deprecation")
+  public void setUnicodeStream(int parameterIndex, InputStream x, int length) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setUnicodeStream",
+        () -> {
+          this.statement.setUnicodeStream(parameterIndex, x, length);
+          return null;
+        });
+  }
+
+  @Override
+  public void setBinaryStream(int parameterIndex, InputStream x, int length) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setBinaryStream",
+        () -> {
+          this.statement.setBinaryStream(parameterIndex, x, length);
+          return null;
+        });
+  }
+
+  @Override
+  public void clearParameters() throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.clearParameters",
+        () -> {
+          this.statement.clearParameters();
+          return null;
+        });
+  }
+
+  @Override
+  public void setObject(int parameterIndex, Object x, int targetSqlType) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setObject",
+        () -> {
+          this.statement.setObject(parameterIndex, x, targetSqlType);
+          return null;
+        });
+  }
+
+  @Override
+  public void setObject(int parameterIndex, Object x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setObject",
+        () -> {
+          this.statement.setObject(parameterIndex, x);
+          return null;
+        });
+  }
+
+  @Override
+  public boolean execute() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.execute",
+        () -> this.statement.execute());
+  }
+
+  @Override
+  public void addBatch() throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.addBatch",
+        () -> {
+          this.statement.addBatch();
+          return null;
+        });
+  }
+
+  @Override
+  public void setCharacterStream(int parameterIndex, Reader reader, int length)
+      throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setCharacterStream",
+        () -> {
+          this.statement.setCharacterStream(parameterIndex, reader, length);
+          return null;
+        });
+  }
+
+  @Override
+  public void setRef(int parameterIndex, Ref x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setRef",
+        () -> {
+          this.statement.setRef(parameterIndex, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void setBlob(int parameterIndex, Blob x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setBlob",
+        () -> {
+          this.statement.setBlob(parameterIndex, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void setClob(int parameterIndex, Clob x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setClob",
+        () -> {
+          this.statement.setClob(parameterIndex, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void setArray(int parameterIndex, Array x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setArray",
+        () -> {
+          this.statement.setArray(parameterIndex, x);
+          return null;
+        });
+  }
+
+  @Override
+  public ResultSetMetaData getMetaData() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getMetaData",
+        () -> this.statement.getMetaData());
+  }
+
+  @Override
+  public void setDate(int parameterIndex, Date x, Calendar cal) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setDate",
+        () -> {
+          this.statement.setDate(parameterIndex, x, cal);
+          return null;
+        });
+  }
+
+  @Override
+  public void setTime(int parameterIndex, Time x, Calendar cal) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setTime",
+        () -> {
+          this.statement.setTime(parameterIndex, x, cal);
+          return null;
+        });
+  }
+
+  @Override
+  public void setTimestamp(int parameterIndex, Timestamp x, Calendar cal) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setTimestamp",
+        () -> {
+          this.statement.setTimestamp(parameterIndex, x, cal);
+          return null;
+        });
+  }
+
+  @Override
+  public void setNull(int parameterIndex, int sqlType, String typeName) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setNull",
+        () -> {
+          this.statement.setNull(parameterIndex, sqlType, typeName);
+          return null;
+        });
+  }
+
+  @Override
+  public void setURL(int parameterIndex, URL x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setURL",
+        () -> {
+          this.statement.setURL(parameterIndex, x);
+          return null;
+        });
+  }
+
+  @Override
+  public ParameterMetaData getParameterMetaData() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getParameterMetaData",
+        () -> this.statement.getParameterMetaData());
+  }
+
+  @Override
+  public void setRowId(int parameterIndex, RowId x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setRowId",
+        () -> {
+          this.statement.setRowId(parameterIndex, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void setNString(int parameterIndex, String value) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setNString",
+        () -> {
+          this.statement.setNString(parameterIndex, value);
+          return null;
+        });
+  }
+
+  @Override
+  public void setNCharacterStream(int parameterIndex, Reader value, long length)
+      throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setNCharacterStream",
+        () -> {
+          this.statement.setNCharacterStream(parameterIndex, value, length);
+          return null;
+        });
+  }
+
+  @Override
+  public void setNClob(int parameterIndex, NClob value) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setNClob",
+        () -> {
+          this.statement.setNClob(parameterIndex, value);
+          return null;
+        });
+  }
+
+  @Override
+  public void setClob(int parameterIndex, Reader reader, long length) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setClob",
+        () -> {
+          this.statement.setClob(parameterIndex, reader, length);
+          return null;
+        });
+  }
+
+  @Override
+  public void setBlob(int parameterIndex, InputStream inputStream, long length)
+      throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setBlob",
+        () -> {
+          this.statement.setBlob(parameterIndex, inputStream, length);
+          return null;
+        });
+  }
+
+  @Override
+  public void setNClob(int parameterIndex, Reader reader, long length) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setNClob",
+        () -> {
+          this.statement.setNClob(parameterIndex, reader, length);
+          return null;
+        });
+  }
+
+  @Override
+  public void setSQLXML(int parameterIndex, SQLXML xmlObject) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setSQLXML",
+        () -> {
+          this.statement.setSQLXML(parameterIndex, xmlObject);
+          return null;
+        });
+  }
+
+  @Override
+  public void setObject(int parameterIndex, Object x, int targetSqlType, int scaleOrLength)
+      throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setObject",
+        () -> {
+          this.statement.setObject(parameterIndex, x, targetSqlType, scaleOrLength);
+          return null;
+        });
+  }
+
+  @Override
+  public void setAsciiStream(int parameterIndex, InputStream x, long length) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setAsciiStream",
+        () -> {
+          this.statement.setAsciiStream(parameterIndex, x, length);
+          return null;
+        });
+  }
+
+  @Override
+  public void setBinaryStream(int parameterIndex, InputStream x, long length) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setBinaryStream",
+        () -> {
+          this.statement.setBinaryStream(parameterIndex, x, length);
+          return null;
+        });
+  }
+
+  @Override
+  public void setCharacterStream(int parameterIndex, Reader reader, long length)
+      throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setCharacterStream",
+        () -> {
+          this.statement.setCharacterStream(parameterIndex, reader, length);
+          return null;
+        });
+  }
+
+  @Override
+  public void setAsciiStream(int parameterIndex, InputStream x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setAsciiStream",
+        () -> {
+          this.statement.setAsciiStream(parameterIndex, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void setBinaryStream(int parameterIndex, InputStream x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setBinaryStream",
+        () -> {
+          this.statement.setBinaryStream(parameterIndex, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void setCharacterStream(int parameterIndex, Reader reader) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setCharacterStream",
+        () -> {
+          this.statement.setCharacterStream(parameterIndex, reader);
+          return null;
+        });
+  }
+
+  @Override
+  public void setNCharacterStream(int parameterIndex, Reader value) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setNCharacterStream",
+        () -> {
+          this.statement.setNCharacterStream(parameterIndex, value);
+          return null;
+        });
+  }
+
+  @Override
+  public void setClob(int parameterIndex, Reader reader) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setClob",
+        () -> {
+          this.statement.setClob(parameterIndex, reader);
+          return null;
+        });
+  }
+
+  @Override
+  public void setBlob(int parameterIndex, InputStream inputStream) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setBlob",
+        () -> {
+          this.statement.setBlob(parameterIndex, inputStream);
+          return null;
+        });
+  }
+
+  @Override
+  public void setNClob(int parameterIndex, Reader reader) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setNClob",
+        () -> {
+          this.statement.setNClob(parameterIndex, reader);
+          return null;
+        });
+  }
+
+  @Override
+  public void setObject(int parameterIndex, Object x, SQLType targetSqlType, int scaleOrLength)
+      throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setObject",
+        () -> {
+          this.statement.setObject(parameterIndex, x, targetSqlType, scaleOrLength);
+          return null;
+        });
+  }
+
+  @Override
+  public void setObject(int parameterIndex, Object x, SQLType targetSqlType) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setObject",
+        () -> {
+          this.statement.setObject(parameterIndex, x, targetSqlType);
+          return null;
+        });
+  }
+
+  @Override
+  public long executeLargeUpdate() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.executeLargeUpdate",
+        () -> this.statement.executeLargeUpdate());
+  }
+
+  @Override
+  public ResultSet executeQuery(String sql) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.executeQuery",
+        () -> this.statement.executeQuery(sql));
+  }
+
+  @Override
+  public int executeUpdate(String sql) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.executeUpdate",
+        () -> this.statement.executeUpdate(sql));
+  }
+
+  @Override
+  public void close() throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.close",
+        () -> {
+          this.statement.close();
+          return null;
+        });
+  }
+
+  @Override
+  public int getMaxFieldSize() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getMaxFieldSize",
+        () -> this.statement.getMaxFieldSize());
+  }
+
+  @Override
+  public void setMaxFieldSize(int max) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setMaxFieldSize",
+        () -> {
+          this.statement.setMaxFieldSize(max);
+          return null;
+        });
+  }
+
+  @Override
+  public int getMaxRows() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getMaxRows",
+        () -> this.statement.getMaxRows());
+  }
+
+  @Override
+  public void setMaxRows(int max) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setMaxRows",
+        () -> {
+          this.statement.setMaxRows(max);
+          return null;
+        });
+  }
+
+  @Override
+  public void setEscapeProcessing(boolean enable) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setEscapeProcessing",
+        () -> {
+          this.statement.setEscapeProcessing(enable);
+          return null;
+        });
+  }
+
+  @Override
+  public int getQueryTimeout() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getQueryTimeout",
+        () -> this.statement.getQueryTimeout());
+  }
+
+  @Override
+  public void setQueryTimeout(int seconds) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setQueryTimeout",
+        () -> {
+          this.statement.setQueryTimeout(seconds);
+          return null;
+        });
+  }
+
+  @Override
+  public void cancel() throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.cancel",
+        () -> {
+          this.statement.cancel();
+          return null;
+        });
+  }
+
+  @Override
+  public SQLWarning getWarnings() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getWarnings",
+        () -> this.statement.getWarnings());
+  }
+
+  @Override
+  public void clearWarnings() throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.clearWarnings",
+        () -> {
+          this.statement.clearWarnings();
+          return null;
+        });
+  }
+
+  @Override
+  public void setCursorName(String name) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setCursorName",
+        () -> {
+          this.statement.setCursorName(name);
+          return null;
+        });
+  }
+
+  @Override
+  public boolean execute(String sql) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.execute",
+        () -> this.statement.execute(sql));
+  }
+
+  @Override
+  public ResultSet getResultSet() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getResultSet",
+        () -> this.statement.getResultSet());
+  }
+
+  @Override
+  public int getUpdateCount() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getUpdateCount",
+        () -> this.statement.getUpdateCount());
+  }
+
+  @Override
+  public boolean getMoreResults() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getMoreResults",
+        () -> this.statement.getMoreResults());
+  }
+
+  @Override
+  public int getFetchDirection() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getFetchDirection",
+        () -> this.statement.getFetchDirection());
+  }
+
+  @Override
+  public void setFetchDirection(int direction) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setFetchDirection",
+        () -> {
+          this.statement.setFetchDirection(direction);
+          return null;
+        });
+  }
+
+  @Override
+  public int getFetchSize() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getFetchSize",
+        () -> this.statement.getFetchSize());
+  }
+
+  @Override
+  public void setFetchSize(int rows) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setFetchSize",
+        () -> {
+          this.statement.setFetchSize(rows);
+          return null;
+        });
+  }
+
+  @Override
+  public int getResultSetConcurrency() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getResultSetConcurrency",
+        () -> this.statement.getResultSetConcurrency());
+  }
+
+  @Override
+  public int getResultSetType() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getResultSetType",
+        () -> this.statement.getResultSetType());
+  }
+
+  @Override
+  public void addBatch(String sql) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.addBatch",
+        () -> {
+          this.statement.addBatch(sql);
+          return null;
+        });
+  }
+
+  @Override
+  public void clearBatch() throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.clearBatch",
+        () -> {
+          this.statement.clearBatch();
+          return null;
+        });
+  }
+
+  @Override
+  public int[] executeBatch() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.executeBatch",
+        () -> this.statement.executeBatch());
+  }
+
+  @Override
+  public Connection getConnection() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getConnection",
+        () -> this.statement.getConnection());
+  }
+
+  @Override
+  public boolean getMoreResults(int current) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getMoreResults",
+        () -> this.statement.getMoreResults(current));
+  }
+
+  @Override
+  public ResultSet getGeneratedKeys() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getGeneratedKeys",
+        () -> this.statement.getGeneratedKeys());
+  }
+
+  @Override
+  public int executeUpdate(String sql, int autoGeneratedKeys) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.executeUpdate",
+        () -> this.statement.executeUpdate(sql, autoGeneratedKeys));
+  }
+
+  @Override
+  public int executeUpdate(String sql, int[] columnIndexes) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.executeUpdate",
+        () -> this.statement.executeUpdate(sql, columnIndexes));
+  }
+
+  @Override
+  public int executeUpdate(String sql, String[] columnNames) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.executeUpdate",
+        () -> this.statement.executeUpdate(sql, columnNames));
+  }
+
+  @Override
+  public boolean execute(String sql, int autoGeneratedKeys) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.execute",
+        () -> this.statement.execute(sql, autoGeneratedKeys));
+  }
+
+  @Override
+  public boolean execute(String sql, int[] columnIndexes) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.execute",
+        () -> this.statement.execute(sql, columnIndexes));
+  }
+
+  @Override
+  public boolean execute(String sql, String[] columnNames) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.execute",
+        () -> this.statement.execute(sql, columnNames));
+  }
+
+  @Override
+  public int getResultSetHoldability() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.getResultSetHoldability",
+        () -> this.statement.getResultSetHoldability());
+  }
+
+  @Override
+  public boolean isClosed() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.isClosed",
+        () -> this.statement.isClosed());
+  }
+
+  @Override
+  public boolean isPoolable() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.isPoolable",
+        () -> this.statement.isPoolable());
+  }
+
+  @Override
+  public void setPoolable(boolean poolable) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.setPoolable",
+        () -> {
+          this.statement.setPoolable(poolable);
+          return null;
+        });
+  }
+
+  @Override
+  public void closeOnCompletion() throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.closeOnCompletion",
+        () -> {
+          this.statement.closeOnCompletion();
+          return null;
+        });
+  }
+
+  @Override
+  public boolean isCloseOnCompletion() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "CallableStatement.isCloseOnCompletion",
+        () -> this.statement.isCloseOnCompletion());
+  }
+
+  @Override
+  public <T> T unwrap(Class<T> iface) throws SQLException {
+    return this.statement.unwrap(iface);
+  }
+
+  @Override
+  public boolean isWrapperFor(Class<?> iface) throws SQLException {
+    return this.statement.isWrapperFor(iface);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    return this.statement.equals(obj);
+  }
+
+  @Override
+  public int hashCode() {
+    return this.statement.hashCode();
+  }
+
+}

--- a/pgjdbc/src/main/java/org/postgresql/pluginmanager/ConnectionPlugin.java
+++ b/pgjdbc/src/main/java/org/postgresql/pluginmanager/ConnectionPlugin.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2022, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.pluginmanager;
+
+import org.postgresql.util.HostSpec;
+
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.Callable;
+
+/**
+ * Interface for connection plugins. This class implements ways to execute a JDBC method
+ * and to clean up resources used before closing the plugin.
+ */
+public interface ConnectionPlugin {
+  Set<String> getSubscribedMethods();
+
+  Object execute(Class<?> methodInvokeOn, String methodName, Callable<?> executeSqlFunc,
+      Object[] args)
+      throws Exception;
+
+  void openInitialConnection(HostSpec[] hostSpecs, Properties props, String url,
+      Callable<Void> openInitialConnectionFunc) throws Exception;
+
+  void releaseResources();
+}

--- a/pgjdbc/src/main/java/org/postgresql/pluginmanager/ConnectionPluginFactory.java
+++ b/pgjdbc/src/main/java/org/postgresql/pluginmanager/ConnectionPluginFactory.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2022, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.pluginmanager;
+
+import java.util.Properties;
+
+/**
+ * Interface for connection plugin factories. This class implements ways to initialize a
+ * connection plugin.
+ */
+public interface ConnectionPluginFactory {
+  ConnectionPlugin getInstance(CurrentConnectionProvider currentConnectionProvider,
+                               Properties props);
+}

--- a/pgjdbc/src/main/java/org/postgresql/pluginmanager/ConnectionPluginManager.java
+++ b/pgjdbc/src/main/java/org/postgresql/pluginmanager/ConnectionPluginManager.java
@@ -1,0 +1,263 @@
+/*
+ * Copyright (c) 2022, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.pluginmanager;
+
+import org.postgresql.PGProperty;
+import org.postgresql.pluginmanager.efm.NodeMonitoringConnectionPlugin;
+import org.postgresql.pluginmanager.efm.NodeMonitoringConnectionPluginFactory;
+import org.postgresql.util.HostSpec;
+import org.postgresql.util.PSQLException;
+import org.postgresql.util.PSQLState;
+import org.postgresql.util.Util;
+
+import java.sql.SQLClientInfoException;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Properties;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * This class creates and handles a chain of {@link ConnectionPlugin} for each connection.
+ */
+public class ConnectionPluginManager {
+
+  /* THIS CLASS IS NOT MULTI-THREADING SAFE */
+  /* IT'S EXPECTED TO HAVE ONE INSTANCE OF THIS MANAGER PER JDBC CONNECTION */
+
+  protected static final String DEFAULT_PLUGIN_FACTORIES =
+      NodeMonitoringConnectionPluginFactory.class.getName();
+  protected static final Queue<ConnectionPluginManager> instances = new ConcurrentLinkedQueue<>();
+
+  private static final transient Logger LOGGER =
+      Logger.getLogger(ConnectionPluginManager.class.getName());
+  private static final String ALL_METHODS = "*";
+  private static final String OPEN_INITIAL_CONNECTION_METHOD = "openInitialConnection";
+
+  protected Properties props = new Properties();
+  protected ArrayList<ConnectionPlugin> plugins;
+  protected CurrentConnectionProvider currentConnectionProvider;
+
+  public ConnectionPluginManager() {
+  }
+
+  /**
+   * Release all dangling resources for all connection plugin managers.
+   */
+  public static void releaseAllResources() {
+    instances.forEach(ConnectionPluginManager::releaseResources);
+  }
+
+  /**
+   * Initialize a chain of {@link ConnectionPlugin} using their corresponding
+   * {@link ConnectionPluginFactory}.
+   * If {@code PropertyKey.connectionPluginFactories} is provided by the user, initialize
+   * the chain with the given connection plugins in the order they are specified. Otherwise,
+   * initialize the {@link NodeMonitoringConnectionPlugin} instead.
+   *
+   * <p>The {@link DefaultConnectionPlugin} will always be initialized and attached as the
+   * last connection plugin in the chain.
+   *
+   * @param currentConnectionProvider The connection the plugins are associated with.
+   * @param props                     The configuration of the connection.
+   * @throws PSQLException if errors occurred during the execution.
+   */
+  public void init(CurrentConnectionProvider currentConnectionProvider, Properties props)
+      throws PSQLException {
+    instances.add(this);
+    this.currentConnectionProvider = currentConnectionProvider;
+    this.props = props;
+
+    String factoryClazzNames = PGProperty.CONNECTION_PLUGIN_FACTORIES.get(props);
+
+    if (factoryClazzNames == null) {
+      factoryClazzNames = DEFAULT_PLUGIN_FACTORIES;
+    }
+
+    if (!Util.isNullOrEmpty(factoryClazzNames)) {
+      try {
+        ConnectionPluginFactory[] factories = Util.<ConnectionPluginFactory>loadClasses(
+                factoryClazzNames,
+                "Unable to load connection plugin factory '%s'.")
+            .toArray(new ConnectionPluginFactory[0]);
+
+        // make a chain of connection plugins
+
+        this.plugins = new ArrayList<>(factories.length + 1);
+
+        for (int i = 0; i < factories.length; i++) {
+          this.plugins.add(factories[i].getInstance(
+              this.currentConnectionProvider,
+              this.props));
+        }
+
+      } catch (InstantiationException instEx) {
+        throw new PSQLException(instEx.getMessage(), PSQLState.UNKNOWN_STATE, instEx);
+      }
+    } else {
+      this.plugins = new ArrayList<>(1); // one spot for default connection plugin
+    }
+
+    // add default connection plugin to the tail
+
+    this.plugins.add(new DefaultConnectionPluginFactory()
+        .getInstance(
+            this.currentConnectionProvider,
+            this.props));
+  }
+
+  public void openInitialConnection(HostSpec[] hostSpecs, Properties props, String url)
+      throws SQLException {
+
+    try {
+      openInitialConnectionOneLevel(0,
+          hostSpecs, props, url,
+          () -> {
+            return null;
+          });
+    } catch (SQLException ex) {
+      throw ex;
+    } catch (RuntimeException ex) {
+      throw ex;
+    } catch (Exception ex) {
+      throw new PSQLException(ex.getMessage(), PSQLState.UNKNOWN_STATE, ex);
+    }
+  }
+
+  protected void openInitialConnectionOneLevel(int pluginIndex,
+      HostSpec[] hostSpecs, Properties props, String url,
+      Callable<Void> openInitialConnectionFunc) throws Exception {
+
+    ConnectionPlugin plugin;
+    boolean isSubscribed;
+
+    do {
+      plugin = this.plugins.get(pluginIndex);
+      Set<String> pluginSubscribedMethods = plugin.getSubscribedMethods();
+      isSubscribed = pluginSubscribedMethods.contains(OPEN_INITIAL_CONNECTION_METHOD);
+      pluginIndex++;
+    } while (!isSubscribed && pluginIndex <= this.plugins.size() - 1);
+
+    Callable<Void> func;
+    if (pluginIndex == this.plugins.size()) {
+      // last plugin in the plugin chain
+      // execute actual openInitialConnection() on this plugin
+      if (!isSubscribed) {
+        throw new Exception(
+            "Default connection plugin should handle all methods."); // shouldn't be here
+      }
+      func = openInitialConnectionFunc;
+    } else {
+      // not last plugin
+      // execute a function that redirects to a next plugin in chain
+      final int nextPluginIndex = pluginIndex;
+      func = () -> {
+        openInitialConnectionOneLevel(nextPluginIndex, hostSpecs, props, url,
+            openInitialConnectionFunc);
+        return null;
+      };
+    }
+
+    plugin.openInitialConnection(hostSpecs, props, url, func);
+  }
+
+  protected <T> T executeOneLevel(int pluginIndex,
+      Class<?> methodInvokeOn,
+      String methodName,
+      Callable<T> executeSqlFunc,
+      Object[] args) throws Exception {
+
+    ConnectionPlugin plugin;
+    boolean isSubscribed;
+
+    do {
+      plugin = this.plugins.get(pluginIndex);
+      Set<String> pluginSubscribedMethods = plugin.getSubscribedMethods();
+      isSubscribed =
+          pluginSubscribedMethods.contains(ALL_METHODS) || pluginSubscribedMethods.contains(
+              methodName);
+      pluginIndex++;
+    } while (!isSubscribed && pluginIndex <= this.plugins.size() - 1);
+
+    Callable<T> func;
+    if (pluginIndex == this.plugins.size()) {
+      // last plugin in the plugin chain
+      // execute actual JDBC method inside this plugin
+      if (!isSubscribed) {
+        throw new Exception(
+            "Default connection plugin should handle all methods."); // shouldn't be here
+      }
+      func = executeSqlFunc;
+    } else {
+      // not last plugin
+      // execute a function that redirects JDBC method to a next plugin in chain
+      final int nextPluginIndex = pluginIndex;
+      func = () -> {
+        return executeOneLevel(nextPluginIndex, methodInvokeOn, methodName, executeSqlFunc, args);
+      };
+    }
+
+    return (T) plugin.execute(methodInvokeOn, methodName, func, args);
+  }
+
+  public <T> T execute(Class<?> methodInvokeOn,
+      String methodName,
+      Callable<T> executeSqlFunc,
+      Object[] args) throws Exception {
+
+    return executeOneLevel(0, methodInvokeOn, methodName, executeSqlFunc, args);
+  }
+
+  public <T> T execute_SQLException(Class<?> methodInvokeOn,
+      String methodName,
+      Callable<T> executeSqlFunc,
+      Object[] args) throws SQLException {
+
+    try {
+      return executeOneLevel(0, methodInvokeOn, methodName, executeSqlFunc, args);
+    } catch (SQLException ex) {
+      throw ex;
+    } catch (RuntimeException ex) {
+      throw ex;
+    } catch (Exception ex) {
+      throw new PSQLException(ex.getMessage(), PSQLState.UNKNOWN_STATE, ex);
+    }
+  }
+
+  public <T> T execute_SQLClientInfoException(Class<?> methodInvokeOn,
+      String methodName,
+      Callable<T> executeSqlFunc,
+      Object[] args) throws SQLClientInfoException {
+
+    try {
+      return executeOneLevel(0, methodInvokeOn, methodName, executeSqlFunc, args);
+    } catch (SQLClientInfoException ex) {
+      throw ex;
+    } catch (RuntimeException ex) {
+      throw ex;
+    } catch (Exception ex) {
+      throw new RuntimeException(ex);
+    }
+  }
+
+  /**
+   * Release all dangling resources held by the connection plugins associated with
+   * a single connection.
+   */
+  public void releaseResources() {
+    instances.remove(this);
+    LOGGER.log(Level.FINE, "releasing resources");
+
+    // This step allows all connection plugins a chance to clean up any dangling resources or
+    // perform any
+    // last tasks before shutting down.
+    this.plugins.forEach(ConnectionPlugin::releaseResources);
+  }
+}

--- a/pgjdbc/src/main/java/org/postgresql/pluginmanager/ConnectionProvider.java
+++ b/pgjdbc/src/main/java/org/postgresql/pluginmanager/ConnectionProvider.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2022, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.pluginmanager;
+
+import org.postgresql.core.BaseConnection;
+import org.postgresql.util.HostSpec;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Properties;
+
+/**
+ * Implement this interface in order to handle physical connection creation process.
+ */
+public interface ConnectionProvider {
+  /**
+   * Called once per connection that needs to be created.
+   *
+   * @param hostSpecs The HostSpec containing the host-port information for the host to connect to
+   * @param props     The Properties to use for the connection
+   * @param url       The connection URL
+   * @return {@link Connection} resulting from the given connection information
+   * @throws SQLException if an error occurs
+   */
+  BaseConnection connect(HostSpec[] hostSpecs, Properties props, @Nullable String url)
+      throws SQLException;
+}

--- a/pgjdbc/src/main/java/org/postgresql/pluginmanager/ConnectionWrapper.java
+++ b/pgjdbc/src/main/java/org/postgresql/pluginmanager/ConnectionWrapper.java
@@ -1,0 +1,592 @@
+/*
+ * Copyright (c) 2022, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.pluginmanager;
+
+import org.postgresql.core.BaseConnection;
+import org.postgresql.util.HostSpec;
+import org.postgresql.util.PSQLException;
+import org.postgresql.util.PSQLState;
+
+import java.sql.Array;
+import java.sql.Blob;
+import java.sql.CallableStatement;
+import java.sql.Clob;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.NClob;
+import java.sql.PreparedStatement;
+import java.sql.SQLClientInfoException;
+import java.sql.SQLException;
+import java.sql.SQLWarning;
+import java.sql.SQLXML;
+import java.sql.Savepoint;
+import java.sql.Statement;
+import java.sql.Struct;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.Executor;
+import java.util.function.Supplier;
+import java.util.logging.Logger;
+
+public class ConnectionWrapper implements Connection, CurrentConnectionProvider {
+
+  private static final transient Logger LOGGER =
+      Logger.getLogger(ConnectionWrapper.class.getName());
+
+  protected BaseConnection currentConnection;
+  protected Class<?> currentConnectionClass;
+  protected HostSpec hostSpec;
+  protected HostSpec[] hostSpecs;
+  protected ConnectionPluginManager pluginManager;
+
+  public ConnectionWrapper(HostSpec[] hostSpecs, Properties props, String url) throws SQLException {
+    this(null, hostSpecs, props, url, ConnectionPluginManager::new);
+  }
+
+  public ConnectionWrapper(BaseConnection connection, HostSpec[] hostSpecs, Properties props,
+      String url) throws SQLException {
+    this(connection, hostSpecs, props, url, ConnectionPluginManager::new);
+  }
+
+  ConnectionWrapper(BaseConnection connection, HostSpec[] hostSpecs, Properties props, String url,
+      Supplier<ConnectionPluginManager> connectionPluginManagerInitializer) throws SQLException {
+
+    if (hostSpecs == null) {
+      throw new IllegalArgumentException("hostSpec");
+    }
+
+    this.currentConnection = connection;
+    this.hostSpecs = hostSpecs;
+    this.pluginManager = connectionPluginManagerInitializer.get();
+
+    if (this.pluginManager == null) {
+      throw new IllegalArgumentException("pluginManager");
+    }
+
+    this.pluginManager.init(this, props);
+    if (this.currentConnection == null) {
+      this.pluginManager.openInitialConnection(hostSpecs, props, url);
+
+      if (this.currentConnection == null) {
+        throw new PSQLException("Initial connection isn't open.", PSQLState.UNKNOWN_STATE);
+      }
+    }
+
+    this.currentConnectionClass = this.currentConnection.getClass();
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    return this.currentConnection.equals(obj);
+  }
+
+  @Override
+  public int hashCode() {
+    return this.currentConnection.hashCode();
+  }
+
+  @Override
+  public Statement createStatement() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.currentConnectionClass,
+        "Connection.createStatement",
+        () -> this.currentConnection.createStatement());
+  }
+
+  @Override
+  public PreparedStatement prepareStatement(String sql) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.currentConnectionClass,
+        "Connection.prepareStatement",
+        () -> this.currentConnection.prepareStatement(sql));
+  }
+
+  @Override
+  public CallableStatement prepareCall(String sql) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.currentConnectionClass,
+        "Connection.prepareCall",
+        () -> this.currentConnection.prepareCall(sql));
+  }
+
+  @Override
+  public String nativeSQL(String sql) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.currentConnectionClass,
+        "Connection.nativeSQL",
+        () -> this.currentConnection.nativeSQL(sql));
+  }
+
+  @Override
+  public boolean getAutoCommit() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.currentConnectionClass,
+        "Connection.getAutoCommit",
+        () -> this.currentConnection.getAutoCommit());
+  }
+
+  @Override
+  public void setAutoCommit(boolean autoCommit) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.currentConnectionClass,
+        "Connection.setAutoCommit",
+        () -> {
+          this.currentConnection.setAutoCommit(autoCommit);
+          return null;
+        });
+  }
+
+  @Override
+  public void commit() throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.currentConnectionClass,
+        "Connection.commit",
+        () -> {
+          this.currentConnection.commit();
+          return null;
+        });
+  }
+
+  @Override
+  public void rollback() throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.currentConnectionClass,
+        "Connection.rollback",
+        () -> {
+          this.currentConnection.rollback();
+          return null;
+        });
+  }
+
+  @Override
+  public void close() throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.currentConnectionClass,
+        "Connection.close",
+        () -> {
+          this.currentConnection.close();
+          return null;
+        });
+  }
+
+  @Override
+  public boolean isClosed() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.currentConnectionClass,
+        "Connection.isClosed",
+        () -> this.currentConnection.isClosed());
+  }
+
+  @Override
+  public DatabaseMetaData getMetaData() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.currentConnectionClass,
+        "Connection.getMetaData",
+        () -> this.currentConnection.getMetaData());
+  }
+
+  @Override
+  public boolean isReadOnly() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.currentConnectionClass,
+        "Connection.isReadOnly",
+        () -> this.currentConnection.isReadOnly());
+  }
+
+  @Override
+  public void setReadOnly(boolean readOnly) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.currentConnectionClass,
+        "Connection.setReadOnly",
+        () -> {
+          this.currentConnection.setReadOnly(readOnly);
+          return null;
+        });
+  }
+
+  @Override
+  public String getCatalog() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.currentConnectionClass,
+        "Connection.getCatalog",
+        () -> this.currentConnection.getCatalog());
+  }
+
+  @Override
+  public void setCatalog(String catalog) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.currentConnectionClass,
+        "Connection.setCatalog",
+        () -> {
+          this.currentConnection.setCatalog(catalog);
+          return null;
+        });
+  }
+
+  @Override
+  public int getTransactionIsolation() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.currentConnectionClass,
+        "Connection.getTransactionIsolation",
+        () -> this.currentConnection.getTransactionIsolation());
+  }
+
+  @Override
+  public void setTransactionIsolation(int level) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.currentConnectionClass,
+        "Connection.setTransactionIsolation",
+        () -> {
+          this.currentConnection.setTransactionIsolation(level);
+          return null;
+        });
+  }
+
+  @Override
+  public synchronized SQLWarning getWarnings() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.currentConnectionClass,
+        "Connection.getWarnings",
+        () -> this.currentConnection.getWarnings());
+  }
+
+  @Override
+  public synchronized void clearWarnings() throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.currentConnectionClass,
+        "Connection.clearWarnings",
+        () -> {
+          this.currentConnection.clearWarnings();
+          return null;
+        });
+  }
+
+  @Override
+  public Statement createStatement(int resultSetType, int resultSetConcurrency)
+      throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.currentConnectionClass,
+        "Connection.createStatement",
+        () -> this.currentConnection.createStatement(resultSetType, resultSetConcurrency));
+  }
+
+  @Override
+  public PreparedStatement prepareStatement(String sql, int resultSetType,
+      int resultSetConcurrency) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.currentConnectionClass,
+        "Connection.prepareStatement",
+        () -> this.currentConnection.prepareStatement(sql, resultSetType, resultSetConcurrency));
+  }
+
+  @Override
+  public CallableStatement prepareCall(String sql, int resultSetType, int resultSetConcurrency)
+      throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.currentConnectionClass,
+        "Connection.prepareCall",
+        () -> this.currentConnection.prepareCall(sql, resultSetType, resultSetConcurrency));
+  }
+
+  @Override
+  public Map<String, Class<?>> getTypeMap() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.currentConnectionClass,
+        "Connection.getTypeMap",
+        () -> this.currentConnection.getTypeMap());
+  }
+
+  @Override
+  public void setTypeMap(Map<String, Class<?>> map) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.currentConnectionClass,
+        "Connection.setTypeMap",
+        () -> {
+          this.currentConnection.setTypeMap(map);
+          return null;
+        });
+  }
+
+  @Override
+  public int getHoldability() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.currentConnectionClass,
+        "Connection.getHoldability",
+        () -> this.currentConnection.getHoldability());
+  }
+
+  @Override
+  public void setHoldability(int holdability) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.currentConnectionClass,
+        "Connection.setHoldability",
+        () -> {
+          this.currentConnection.setHoldability(holdability);
+          return null;
+        });
+  }
+
+  @Override
+  public Savepoint setSavepoint() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.currentConnectionClass,
+        "Connection.setSavepoint",
+        () -> this.currentConnection.setSavepoint());
+  }
+
+  @Override
+  public Savepoint setSavepoint(String name) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.currentConnectionClass,
+        "Connection.setSavepoint",
+        () -> this.currentConnection.setSavepoint(name));
+  }
+
+  @Override
+  public void rollback(Savepoint savepoint) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.currentConnectionClass,
+        "Connection.rollback",
+        () -> {
+          this.currentConnection.rollback(savepoint);
+          return null;
+        });
+  }
+
+  @Override
+  public void releaseSavepoint(Savepoint savepoint) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.currentConnectionClass,
+        "Connection.releaseSavepoint",
+        () -> {
+          this.currentConnection.releaseSavepoint(savepoint);
+          return null;
+        });
+  }
+
+  @Override
+  public Statement createStatement(int resultSetType, int resultSetConcurrency,
+      int resultSetHoldability) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.currentConnectionClass,
+        "Connection.createStatement",
+        () -> this.currentConnection.createStatement(resultSetType, resultSetConcurrency,
+            resultSetHoldability));
+  }
+
+  @Override
+  public PreparedStatement prepareStatement(String sql, int resultSetType,
+      int resultSetConcurrency, int resultSetHoldability) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.currentConnectionClass,
+        "Connection.prepareStatement",
+        () -> this.currentConnection.prepareStatement(sql, resultSetType, resultSetConcurrency,
+            resultSetHoldability));
+  }
+
+  @Override
+  public CallableStatement prepareCall(String sql, int resultSetType, int resultSetConcurrency,
+      int resultSetHoldability) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.currentConnectionClass,
+        "Connection.prepareCall",
+        () -> this.currentConnection.prepareCall(sql, resultSetType, resultSetConcurrency,
+            resultSetHoldability));
+  }
+
+  @Override
+  public PreparedStatement prepareStatement(String sql, int autoGeneratedKeys) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.currentConnectionClass,
+        "Connection.prepareStatement",
+        () -> this.currentConnection.prepareStatement(sql, autoGeneratedKeys));
+  }
+
+  @Override
+  public PreparedStatement prepareStatement(String sql, int[] columnIndexes) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.currentConnectionClass,
+        "Connection.prepareStatement",
+        () -> this.currentConnection.prepareStatement(sql, columnIndexes));
+  }
+
+  @Override
+  public PreparedStatement prepareStatement(String sql, String[] columnNames) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.currentConnectionClass,
+        "Connection.prepareStatement",
+        () -> this.currentConnection.prepareStatement(sql, columnNames));
+  }
+
+  @Override
+  public Clob createClob() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.currentConnectionClass,
+        "Connection.createClob",
+        () -> this.currentConnection.createClob());
+  }
+
+  @Override
+  public Blob createBlob() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.currentConnectionClass,
+        "Connection.createBlob",
+        () -> this.currentConnection.createBlob());
+  }
+
+  @Override
+  public NClob createNClob() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.currentConnectionClass,
+        "Connection.createNClob",
+        () -> this.currentConnection.createNClob());
+  }
+
+  @Override
+  public SQLXML createSQLXML() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.currentConnectionClass,
+        "Connection.createSQLXML",
+        () -> this.currentConnection.createSQLXML());
+  }
+
+  @Override
+  public boolean isValid(int timeout) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.currentConnectionClass,
+        "Connection.isValid",
+        () -> this.currentConnection.isValid(timeout));
+  }
+
+  @Override
+  public void setClientInfo(String name, String value) throws SQLClientInfoException {
+    WrapperUtils.executeWithPlugins_SQLClientInfoException(this.pluginManager,
+        this.currentConnectionClass,
+        "Connection.setClientInfo",
+        () -> {
+          this.currentConnection.setClientInfo(name, value);
+          return null;
+        });
+  }
+
+  @Override
+  public String getClientInfo(String name) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.currentConnectionClass,
+        "Connection.getClientInfo",
+        () -> this.currentConnection.getClientInfo(name));
+  }
+
+  @Override
+  public Properties getClientInfo() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.currentConnectionClass,
+        "Connection.getClientInfo",
+        () -> this.currentConnection.getClientInfo());
+  }
+
+  @Override
+  public void setClientInfo(Properties properties) throws SQLClientInfoException {
+    WrapperUtils.executeWithPlugins_SQLClientInfoException(this.pluginManager,
+        this.currentConnectionClass,
+        "Connection.setClientInfo",
+        () -> {
+          this.currentConnection.setClientInfo(properties);
+          return null;
+        });
+  }
+
+  @Override
+  public Array createArrayOf(String typeName, Object[] elements) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.currentConnectionClass,
+        "Connection.createArrayOf",
+        () -> this.currentConnection.createArrayOf(typeName, elements));
+  }
+
+  @Override
+  public Struct createStruct(String typeName, Object[] attributes) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.currentConnectionClass,
+        "Connection.createStruct",
+        () -> this.currentConnection.createStruct(typeName, attributes));
+  }
+
+  @Override
+  public String getSchema() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.currentConnectionClass,
+        "Connection.getSchema",
+        () -> this.currentConnection.getSchema());
+  }
+
+  @Override
+  public void setSchema(String schema) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.currentConnectionClass,
+        "Connection.setSchema",
+        () -> {
+          this.currentConnection.setSchema(schema);
+          return null;
+        });
+  }
+
+  @Override
+  public void abort(Executor executor) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.currentConnectionClass,
+        "Connection.abort",
+        () -> {
+          this.currentConnection.abort(executor);
+          return null;
+        });
+  }
+
+  @Override
+  public void setNetworkTimeout(Executor executor, int milliseconds) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.currentConnectionClass,
+        "Connection.setNetworkTimeout",
+        () -> {
+          this.currentConnection.setNetworkTimeout(executor, milliseconds);
+          return null;
+        });
+  }
+
+  @Override
+  public int getNetworkTimeout() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.currentConnectionClass,
+        "Connection.getNetworkTimeout",
+        () -> this.currentConnection.getNetworkTimeout());
+  }
+
+  @Override
+  public <T> T unwrap(Class<T> iface) throws SQLException {
+    return this.currentConnection.unwrap(iface);
+  }
+
+  @Override
+  public boolean isWrapperFor(Class<?> iface) throws SQLException {
+    return this.currentConnection.isWrapperFor(iface);
+  }
+
+  @Override
+  public BaseConnection getCurrentConnection() {
+    return this.currentConnection;
+  }
+
+  @Override
+  public HostSpec getCurrentHostSpec() {
+    return this.hostSpec;
+  }
+
+  @Override
+  public void setCurrentConnection(BaseConnection connection, HostSpec hostSpec) {
+    this.currentConnection = connection;
+    this.hostSpec = hostSpec;
+  }
+}

--- a/pgjdbc/src/main/java/org/postgresql/pluginmanager/CurrentConnectionProvider.java
+++ b/pgjdbc/src/main/java/org/postgresql/pluginmanager/CurrentConnectionProvider.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2022, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.pluginmanager;
+
+import org.postgresql.core.BaseConnection;
+import org.postgresql.util.HostSpec;
+
+import java.sql.Connection;
+
+/**
+ * Interface for retrieving the current active {@link Connection} and its {@link HostSpec}.
+ */
+public interface CurrentConnectionProvider {
+  BaseConnection getCurrentConnection();
+
+  HostSpec getCurrentHostSpec();
+
+  void setCurrentConnection(BaseConnection connection, HostSpec hostSpec);
+}

--- a/pgjdbc/src/main/java/org/postgresql/pluginmanager/DefaultConnectionPlugin.java
+++ b/pgjdbc/src/main/java/org/postgresql/pluginmanager/DefaultConnectionPlugin.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2022, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.pluginmanager;
+
+import org.postgresql.core.BaseConnection;
+import org.postgresql.util.HostSpec;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * This connection plugin will always be the last plugin in the connection plugin chain,
+ * and will invoke the JDBC method passed down the chain.
+ */
+public final class DefaultConnectionPlugin implements ConnectionPlugin {
+
+  private static final transient Logger LOGGER =
+      Logger.getLogger(DefaultConnectionPlugin.class.getName());
+  private static final Set<String> subscribedMethods =
+      Collections.unmodifiableSet(new HashSet<>(Arrays.asList("*", "openInitialConnection")));
+
+  protected final ConnectionProvider connectionProvider;
+  protected final CurrentConnectionProvider currentConnectionProvider;
+
+  public DefaultConnectionPlugin(CurrentConnectionProvider currentConnectionProvider) {
+    this(currentConnectionProvider, new BasicConnectionProvider());
+  }
+
+  public DefaultConnectionPlugin(CurrentConnectionProvider currentConnectionProvider,
+      ConnectionProvider connectionProvider) {
+    if (currentConnectionProvider == null) {
+      throw new IllegalArgumentException("currentConnectionProvider");
+    }
+    if (connectionProvider == null) {
+      throw new IllegalArgumentException("connectionProvider");
+    }
+
+    this.currentConnectionProvider = currentConnectionProvider;
+    this.connectionProvider = connectionProvider;
+  }
+
+  @Override
+  public Set<String> getSubscribedMethods() {
+    return subscribedMethods;
+  }
+
+  @Override
+  public Object execute(Class<?> methodInvokeOn, String methodName, Callable<?> executeSqlFunc,
+      Object[] args) throws Exception {
+    try {
+      return executeSqlFunc.call();
+    } catch (InvocationTargetException invocationTargetException) {
+      Throwable targetException = invocationTargetException.getTargetException();
+      LOGGER.log(
+          Level.FINEST,
+          String.format("method=%s, exception: ", methodName),
+          targetException);
+
+      if (targetException instanceof Error) {
+        throw (Error) targetException;
+      }
+      throw (Exception) targetException;
+    } catch (Exception ex) {
+      LOGGER.log(
+          Level.FINEST,
+          String.format("method=%s, exception: ", methodName),
+          ex);
+      throw ex;
+    }
+  }
+
+  @Override
+  public void openInitialConnection(HostSpec[] hostSpecs, Properties props, String url,
+      Callable<Void> openInitialConnectionFunc) throws Exception {
+
+    if (hostSpecs == null || hostSpecs.length == 0) {
+      throw new IllegalArgumentException("hostSpecs");
+    }
+
+    if (this.currentConnectionProvider.getCurrentConnection() != null) {
+      // Connection has already opened by a prior plugin in a plugin chain
+      // Execution of openInitialConnectionFunc can be skipped since this plugin is guaranteed
+      // the last one in the plugin chain
+      return;
+    }
+
+    BaseConnection conn = this.connectionProvider.connect(hostSpecs, props, url);
+    this.currentConnectionProvider.setCurrentConnection(conn, hostSpecs[0]);
+
+    // Execution of openInitialConnectionFunc can be skipped since this plugin is guaranteed the
+    // last one in the plugin chain
+  }
+
+  @Override
+  public void releaseResources() {
+    // do nothing
+  }
+}

--- a/pgjdbc/src/main/java/org/postgresql/pluginmanager/DefaultConnectionPluginFactory.java
+++ b/pgjdbc/src/main/java/org/postgresql/pluginmanager/DefaultConnectionPluginFactory.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2022, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.pluginmanager;
+
+import java.util.Properties;
+
+/**
+ * Initialize a {@link DefaultConnectionPlugin}.
+ */
+public final class DefaultConnectionPluginFactory implements ConnectionPluginFactory {
+  @Override
+  public ConnectionPlugin getInstance(
+      CurrentConnectionProvider currentConnectionProvider,
+      Properties props) {
+    return new DefaultConnectionPlugin(currentConnectionProvider);
+  }
+}

--- a/pgjdbc/src/main/java/org/postgresql/pluginmanager/PreparedStatementWrapper.java
+++ b/pgjdbc/src/main/java/org/postgresql/pluginmanager/PreparedStatementWrapper.java
@@ -1,0 +1,1077 @@
+/*
+ * Copyright (c) 2022, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.pluginmanager;
+
+import java.io.InputStream;
+import java.io.Reader;
+import java.math.BigDecimal;
+import java.net.URL;
+import java.sql.Array;
+import java.sql.Blob;
+import java.sql.Clob;
+import java.sql.Connection;
+import java.sql.Date;
+import java.sql.NClob;
+import java.sql.ParameterMetaData;
+import java.sql.PreparedStatement;
+import java.sql.Ref;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.RowId;
+import java.sql.SQLException;
+import java.sql.SQLType;
+import java.sql.SQLWarning;
+import java.sql.SQLXML;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.util.Calendar;
+
+public class PreparedStatementWrapper implements PreparedStatement {
+
+  protected PreparedStatement statement;
+  protected Class<?> statementClass;
+  protected ConnectionPluginManager pluginManager;
+
+  public PreparedStatementWrapper(PreparedStatement statement,
+      ConnectionPluginManager pluginManager) {
+    if (statement == null) {
+      throw new IllegalArgumentException("statement");
+    }
+    if (pluginManager == null) {
+      throw new IllegalArgumentException("pluginManager");
+    }
+
+    this.statement = statement;
+    this.statementClass = this.statement.getClass();
+    this.pluginManager = pluginManager;
+  }
+
+  @Override
+  public ResultSet executeQuery() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.executeQuery",
+        () -> this.statement.executeQuery());
+  }
+
+  @Override
+  public int executeUpdate() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.executeUpdate",
+        () -> this.statement.executeUpdate());
+  }
+
+  @Override
+  public void setNull(int parameterIndex, int sqlType) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.setNull",
+        () -> {
+          this.statement.setNull(parameterIndex, sqlType);
+          return null;
+        });
+  }
+
+  @Override
+  public void setBoolean(int parameterIndex, boolean x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.setBoolean",
+        () -> {
+          this.statement.setBoolean(parameterIndex, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void setByte(int parameterIndex, byte x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.setByte",
+        () -> {
+          this.statement.setByte(parameterIndex, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void setShort(int parameterIndex, short x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.setShort",
+        () -> {
+          this.statement.setShort(parameterIndex, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void setInt(int parameterIndex, int x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.setInt",
+        () -> {
+          this.statement.setInt(parameterIndex, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void setLong(int parameterIndex, long x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.setLong",
+        () -> {
+          this.statement.setLong(parameterIndex, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void setFloat(int parameterIndex, float x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.setFloat",
+        () -> {
+          this.statement.setFloat(parameterIndex, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void setDouble(int parameterIndex, double x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.setDouble",
+        () -> {
+          this.statement.setDouble(parameterIndex, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void setBigDecimal(int parameterIndex, BigDecimal x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.setBigDecimal",
+        () -> {
+          this.statement.setBigDecimal(parameterIndex, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void setString(int parameterIndex, String x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.setString",
+        () -> {
+          this.statement.setString(parameterIndex, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void setBytes(int parameterIndex, byte[] x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.setBytes",
+        () -> {
+          this.statement.setBytes(parameterIndex, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void setDate(int parameterIndex, Date x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.setDate",
+        () -> {
+          this.statement.setDate(parameterIndex, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void setTime(int parameterIndex, Time x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.setTime",
+        () -> {
+          this.statement.setTime(parameterIndex, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void setTimestamp(int parameterIndex, Timestamp x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.setTimestamp",
+        () -> {
+          this.statement.setTimestamp(parameterIndex, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void setAsciiStream(int parameterIndex, InputStream x, int length) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.setAsciiStream",
+        () -> {
+          this.statement.setAsciiStream(parameterIndex, x);
+          return null;
+        });
+  }
+
+  @Override
+  @SuppressWarnings("deprecation")
+  public void setUnicodeStream(int parameterIndex, InputStream x, int length) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.setUnicodeStream",
+        () -> {
+          this.statement.setUnicodeStream(parameterIndex, x, length);
+          return null;
+        });
+  }
+
+  @Override
+  public void setBinaryStream(int parameterIndex, InputStream x, int length) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.setBinaryStream",
+        () -> {
+          this.statement.setBinaryStream(parameterIndex, x, length);
+          return null;
+        });
+  }
+
+  @Override
+  public void clearParameters() throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.clearParameters",
+        () -> {
+          this.statement.clearParameters();
+          return null;
+        });
+  }
+
+  @Override
+  public void setObject(int parameterIndex, Object x, int targetSqlType) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.setObject",
+        () -> {
+          this.statement.setObject(parameterIndex, x, targetSqlType);
+          return null;
+        });
+  }
+
+  @Override
+  public void setObject(int parameterIndex, Object x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.setObject",
+        () -> {
+          this.statement.setObject(parameterIndex, x);
+          return null;
+        });
+  }
+
+  @Override
+  public boolean execute() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.execute",
+        () -> this.statement.execute());
+  }
+
+  @Override
+  public void addBatch() throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.addBatch",
+        () -> {
+          this.statement.addBatch();
+          return null;
+        });
+  }
+
+  @Override
+  public void setCharacterStream(int parameterIndex, Reader reader, int length)
+      throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.setCharacterStream",
+        () -> {
+          this.statement.setCharacterStream(parameterIndex, reader, length);
+          return null;
+        });
+  }
+
+  @Override
+  public void setRef(int parameterIndex, Ref x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.setRef",
+        () -> {
+          this.statement.setRef(parameterIndex, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void setBlob(int parameterIndex, Blob x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.setBlob",
+        () -> {
+          this.statement.setBlob(parameterIndex, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void setClob(int parameterIndex, Clob x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.setClob",
+        () -> {
+          this.statement.setClob(parameterIndex, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void setArray(int parameterIndex, Array x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.setArray",
+        () -> {
+          this.statement.setArray(parameterIndex, x);
+          return null;
+        });
+  }
+
+  @Override
+  public ResultSetMetaData getMetaData() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.getMetaData",
+        () -> this.statement.getMetaData());
+  }
+
+  @Override
+  public void setDate(int parameterIndex, Date x, Calendar cal) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.setDate",
+        () -> {
+          this.statement.setDate(parameterIndex, x, cal);
+          return null;
+        });
+  }
+
+  @Override
+  public void setTime(int parameterIndex, Time x, Calendar cal) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.setTime",
+        () -> {
+          this.statement.setTime(parameterIndex, x, cal);
+          return null;
+        });
+  }
+
+  @Override
+  public void setTimestamp(int parameterIndex, Timestamp x, Calendar cal) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.setTimestamp",
+        () -> {
+          this.statement.setTimestamp(parameterIndex, x, cal);
+          return null;
+        });
+  }
+
+  @Override
+  public void setNull(int parameterIndex, int sqlType, String typeName) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.setNull",
+        () -> {
+          this.statement.setNull(parameterIndex, sqlType, typeName);
+          return null;
+        });
+  }
+
+  @Override
+  public void setURL(int parameterIndex, URL x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.setURL",
+        () -> {
+          this.statement.setURL(parameterIndex, x);
+          return null;
+        });
+  }
+
+  @Override
+  public ParameterMetaData getParameterMetaData() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.getParameterMetaData",
+        () -> this.statement.getParameterMetaData());
+  }
+
+  @Override
+  public void setRowId(int parameterIndex, RowId x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.setRowId",
+        () -> {
+          this.statement.setRowId(parameterIndex, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void setNString(int parameterIndex, String value) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.setNString",
+        () -> {
+          this.statement.setNString(parameterIndex, value);
+          return null;
+        });
+  }
+
+  @Override
+  public void setNCharacterStream(int parameterIndex, Reader value, long length)
+      throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.setNCharacterStream",
+        () -> {
+          this.statement.setNCharacterStream(parameterIndex, value, length);
+          return null;
+        });
+  }
+
+  @Override
+  public void setNClob(int parameterIndex, NClob value) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.setNClob",
+        () -> {
+          this.statement.setNClob(parameterIndex, value);
+          return null;
+        });
+  }
+
+  @Override
+  public void setClob(int parameterIndex, Reader reader, long length) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.setClob",
+        () -> {
+          this.statement.setClob(parameterIndex, reader, length);
+          return null;
+        });
+  }
+
+  @Override
+  public void setBlob(int parameterIndex, InputStream inputStream, long length)
+      throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.setBlob",
+        () -> {
+          this.statement.setBlob(parameterIndex, inputStream, length);
+          return null;
+        });
+  }
+
+  @Override
+  public void setNClob(int parameterIndex, Reader reader, long length) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.setNClob",
+        () -> {
+          this.statement.setNClob(parameterIndex, reader, length);
+          return null;
+        });
+  }
+
+  @Override
+  public void setSQLXML(int parameterIndex, SQLXML xmlObject) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.setSQLXML",
+        () -> {
+          this.statement.setSQLXML(parameterIndex, xmlObject);
+          return null;
+        });
+  }
+
+  @Override
+  public void setObject(int parameterIndex, Object x, int targetSqlType, int scaleOrLength)
+      throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.setObject",
+        () -> {
+          this.statement.setObject(parameterIndex, x, targetSqlType, scaleOrLength);
+          return null;
+        });
+  }
+
+  @Override
+  public void setAsciiStream(int parameterIndex, InputStream x, long length) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.setAsciiStream",
+        () -> {
+          this.statement.setAsciiStream(parameterIndex, x, length);
+          return null;
+        });
+  }
+
+  @Override
+  public void setBinaryStream(int parameterIndex, InputStream x, long length) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.setBinaryStream",
+        () -> {
+          this.statement.setBinaryStream(parameterIndex, x, length);
+          return null;
+        });
+  }
+
+  @Override
+  public void setCharacterStream(int parameterIndex, Reader reader, long length)
+      throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.setCharacterStream",
+        () -> {
+          this.statement.setCharacterStream(parameterIndex, reader, length);
+          return null;
+        });
+  }
+
+  @Override
+  public void setAsciiStream(int parameterIndex, InputStream x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.setAsciiStream",
+        () -> {
+          this.statement.setAsciiStream(parameterIndex, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void setBinaryStream(int parameterIndex, InputStream x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.setBinaryStream",
+        () -> {
+          this.statement.setBinaryStream(parameterIndex, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void setCharacterStream(int parameterIndex, Reader reader) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.setCharacterStream",
+        () -> {
+          this.statement.setCharacterStream(parameterIndex, reader);
+          return null;
+        });
+  }
+
+  @Override
+  public void setNCharacterStream(int parameterIndex, Reader value) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.setNCharacterStream",
+        () -> {
+          this.statement.setNCharacterStream(parameterIndex, value);
+          return null;
+        });
+  }
+
+  @Override
+  public void setClob(int parameterIndex, Reader reader) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.setClob",
+        () -> {
+          this.statement.setClob(parameterIndex, reader);
+          return null;
+        });
+  }
+
+  @Override
+  public void setBlob(int parameterIndex, InputStream inputStream) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.setBlob",
+        () -> {
+          this.statement.setBlob(parameterIndex, inputStream);
+          return null;
+        });
+  }
+
+  @Override
+  public void setNClob(int parameterIndex, Reader reader) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.setNClob",
+        () -> {
+          this.statement.setNClob(parameterIndex, reader);
+          return null;
+        });
+  }
+
+  @Override
+  public void setObject(int parameterIndex, Object x, SQLType targetSqlType, int scaleOrLength)
+      throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.setObject",
+        () -> {
+          this.statement.setObject(parameterIndex, x, targetSqlType, scaleOrLength);
+          return null;
+        });
+  }
+
+  @Override
+  public void setObject(int parameterIndex, Object x, SQLType targetSqlType) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.setObject",
+        () -> {
+          this.statement.setObject(parameterIndex, x, targetSqlType);
+          return null;
+        });
+  }
+
+  @Override
+  public long executeLargeUpdate() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.executeLargeUpdate",
+        () -> this.statement.executeLargeUpdate());
+  }
+
+  @Override
+  public ResultSet executeQuery(String sql) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.executeQuery",
+        () -> this.statement.executeQuery(sql));
+  }
+
+  @Override
+  public int executeUpdate(String sql) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.executeUpdate",
+        () -> this.statement.executeUpdate(sql));
+  }
+
+  @Override
+  public void close() throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.close",
+        () -> {
+          this.statement.close();
+          return null;
+        });
+  }
+
+  @Override
+  public int getMaxFieldSize() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.getMaxFieldSize",
+        () -> this.statement.getMaxFieldSize());
+  }
+
+  @Override
+  public void setMaxFieldSize(int max) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.setMaxFieldSize",
+        () -> {
+          this.statement.setMaxFieldSize(max);
+          return null;
+        });
+  }
+
+  @Override
+  public int getMaxRows() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.getMaxRows",
+        () -> this.statement.getMaxRows());
+  }
+
+  @Override
+  public void setMaxRows(int max) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.setMaxRows",
+        () -> {
+          this.statement.setMaxRows(max);
+          return null;
+        });
+  }
+
+  @Override
+  public void setEscapeProcessing(boolean enable) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.setEscapeProcessing",
+        () -> {
+          this.statement.setEscapeProcessing(enable);
+          return null;
+        });
+  }
+
+  @Override
+  public int getQueryTimeout() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.getQueryTimeout",
+        () -> this.statement.getQueryTimeout());
+  }
+
+  @Override
+  public void setQueryTimeout(int seconds) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.setQueryTimeout",
+        () -> {
+          this.statement.setQueryTimeout(seconds);
+          return null;
+        });
+  }
+
+  @Override
+  public void cancel() throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.cancel",
+        () -> {
+          this.statement.cancel();
+          return null;
+        });
+  }
+
+  @Override
+  public SQLWarning getWarnings() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.getWarnings",
+        () -> this.statement.getWarnings());
+  }
+
+  @Override
+  public void clearWarnings() throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.clearWarnings",
+        () -> {
+          this.statement.clearWarnings();
+          return null;
+        });
+  }
+
+  @Override
+  public void setCursorName(String name) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.setCursorName",
+        () -> {
+          this.statement.setCursorName(name);
+          return null;
+        });
+  }
+
+  @Override
+  public boolean execute(String sql) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.execute",
+        () -> this.statement.execute(sql));
+  }
+
+  @Override
+  public ResultSet getResultSet() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.getResultSet",
+        () -> this.statement.getResultSet());
+  }
+
+  @Override
+  public int getUpdateCount() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.getUpdateCount",
+        () -> this.statement.getUpdateCount());
+  }
+
+  @Override
+  public boolean getMoreResults() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.getMoreResults",
+        () -> this.statement.getMoreResults());
+  }
+
+  @Override
+  public int getFetchDirection() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.getFetchDirection",
+        () -> this.statement.getFetchDirection());
+  }
+
+  @Override
+  public void setFetchDirection(int direction) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.setFetchDirection",
+        () -> {
+          this.statement.setFetchDirection(direction);
+          return null;
+        });
+  }
+
+  @Override
+  public int getFetchSize() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.getFetchSize",
+        () -> this.statement.getFetchSize());
+  }
+
+  @Override
+  public void setFetchSize(int rows) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.setFetchSize",
+        () -> {
+          this.statement.setFetchSize(rows);
+          return null;
+        });
+  }
+
+  @Override
+  public int getResultSetConcurrency() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.getResultSetConcurrency",
+        () -> this.statement.getResultSetConcurrency());
+  }
+
+  @Override
+  public int getResultSetType() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.getResultSetType",
+        () -> this.statement.getResultSetType());
+  }
+
+  @Override
+  public void addBatch(String sql) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.addBatch",
+        () -> {
+          this.statement.addBatch(sql);
+          return null;
+        });
+  }
+
+  @Override
+  public void clearBatch() throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.clearBatch",
+        () -> {
+          this.statement.clearBatch();
+          return null;
+        });
+  }
+
+  @Override
+  public int[] executeBatch() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.executeBatch",
+        () -> this.statement.executeBatch());
+  }
+
+  @Override
+  public Connection getConnection() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.getConnection",
+        () -> this.statement.getConnection());
+  }
+
+  @Override
+  public boolean getMoreResults(int current) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.getMoreResults",
+        () -> this.statement.getMoreResults(current));
+  }
+
+  @Override
+  public ResultSet getGeneratedKeys() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.getGeneratedKeys",
+        () -> this.statement.getGeneratedKeys());
+  }
+
+  @Override
+  public int executeUpdate(String sql, int autoGeneratedKeys) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.executeUpdate",
+        () -> this.statement.executeUpdate(sql, autoGeneratedKeys));
+  }
+
+  @Override
+  public int executeUpdate(String sql, int[] columnIndexes) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.executeUpdate",
+        () -> this.statement.executeUpdate(sql, columnIndexes));
+  }
+
+  @Override
+  public int executeUpdate(String sql, String[] columnNames) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.executeUpdate",
+        () -> this.statement.executeUpdate(sql, columnNames));
+  }
+
+  @Override
+  public boolean execute(String sql, int autoGeneratedKeys) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.execute",
+        () -> this.statement.execute(sql, autoGeneratedKeys));
+  }
+
+  @Override
+  public boolean execute(String sql, int[] columnIndexes) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.execute",
+        () -> this.statement.execute(sql, columnIndexes));
+  }
+
+  @Override
+  public boolean execute(String sql, String[] columnNames) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.execute",
+        () -> this.statement.execute(sql, columnNames));
+  }
+
+  @Override
+  public int getResultSetHoldability() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.getResultSetHoldability",
+        () -> this.statement.getResultSetHoldability());
+  }
+
+  @Override
+  public boolean isClosed() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.isClosed",
+        () -> this.statement.isClosed());
+  }
+
+  @Override
+  public boolean isPoolable() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.isPoolable",
+        () -> this.statement.isPoolable());
+  }
+
+  @Override
+  public void setPoolable(boolean poolable) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.setPoolable",
+        () -> {
+          this.statement.setPoolable(poolable);
+          return null;
+        });
+  }
+
+  @Override
+  public void closeOnCompletion() throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.closeOnCompletion",
+        () -> {
+          this.statement.closeOnCompletion();
+          return null;
+        });
+  }
+
+  @Override
+  public boolean isCloseOnCompletion() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "PreparedStatement.isCloseOnCompletion",
+        () -> this.statement.isCloseOnCompletion());
+  }
+
+  @Override
+  public <T> T unwrap(Class<T> iface) throws SQLException {
+    return this.statement.unwrap(iface);
+  }
+
+  @Override
+  public boolean isWrapperFor(Class<?> iface) throws SQLException {
+    return this.statement.isWrapperFor(iface);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    return this.statement.equals(obj);
+  }
+
+  @Override
+  public int hashCode() {
+    return this.statement.hashCode();
+  }
+
+}

--- a/pgjdbc/src/main/java/org/postgresql/pluginmanager/ResultSetWrapper.java
+++ b/pgjdbc/src/main/java/org/postgresql/pluginmanager/ResultSetWrapper.java
@@ -1,0 +1,1922 @@
+/*
+ * Copyright (c) 2022, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.pluginmanager;
+
+import java.io.InputStream;
+import java.io.Reader;
+import java.math.BigDecimal;
+import java.net.URL;
+import java.sql.Array;
+import java.sql.Blob;
+import java.sql.Clob;
+import java.sql.Date;
+import java.sql.NClob;
+import java.sql.Ref;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.RowId;
+import java.sql.SQLException;
+import java.sql.SQLType;
+import java.sql.SQLWarning;
+import java.sql.SQLXML;
+import java.sql.Statement;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.util.Calendar;
+import java.util.Map;
+
+public class ResultSetWrapper implements ResultSet {
+
+  protected ResultSet resultSet;
+  protected Class<?> resultSetClass;
+  protected ConnectionPluginManager pluginManager;
+
+  public ResultSetWrapper(ResultSet resultSet, ConnectionPluginManager pluginManager) {
+    if (resultSet == null) {
+      throw new IllegalArgumentException("resultSet");
+    }
+    if (pluginManager == null) {
+      throw new IllegalArgumentException("pluginManager");
+    }
+
+    this.resultSet = resultSet;
+    this.resultSetClass = this.resultSet.getClass();
+    this.pluginManager = pluginManager;
+  }
+
+  @Override
+  public boolean next() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.next",
+        () -> this.resultSet.next());
+  }
+
+  @Override
+  public void close() throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.close",
+        () -> {
+          this.resultSet.close();
+          return null;
+        });
+  }
+
+  @Override
+  public boolean wasNull() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.wasNull",
+        () -> this.resultSet.wasNull());
+  }
+
+  @Override
+  public String getString(int columnIndex) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getString",
+        () -> this.resultSet.getString(columnIndex));
+  }
+
+  @Override
+  public boolean getBoolean(int columnIndex) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getBoolean",
+        () -> this.resultSet.getBoolean(columnIndex));
+  }
+
+  @Override
+  public byte getByte(int columnIndex) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getByte",
+        () -> this.resultSet.getByte(columnIndex));
+  }
+
+  @Override
+  public short getShort(int columnIndex) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getShort",
+        () -> this.resultSet.getShort(columnIndex));
+  }
+
+  @Override
+  public int getInt(int columnIndex) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getInt",
+        () -> this.resultSet.getInt(columnIndex));
+  }
+
+  @Override
+  public long getLong(int columnIndex) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getLong",
+        () -> this.resultSet.getLong(columnIndex));
+  }
+
+  @Override
+  public float getFloat(int columnIndex) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getFloat",
+        () -> this.resultSet.getFloat(columnIndex));
+  }
+
+  @Override
+  public double getDouble(int columnIndex) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getDouble",
+        () -> this.resultSet.getDouble(columnIndex));
+  }
+
+  @Override
+  public BigDecimal getBigDecimal(int columnIndex, int scale) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getBigDecimal",
+        () -> this.resultSet.getBigDecimal(columnIndex, scale));
+  }
+
+  @Override
+  public byte[] getBytes(int columnIndex) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getBytes",
+        () -> this.resultSet.getBytes(columnIndex));
+  }
+
+  @Override
+  public Date getDate(int columnIndex) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getDate",
+        () -> this.resultSet.getDate(columnIndex));
+  }
+
+  @Override
+  public Time getTime(int columnIndex) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getTime",
+        () -> this.resultSet.getTime(columnIndex));
+  }
+
+  @Override
+  public Timestamp getTimestamp(int columnIndex) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getTimestamp",
+        () -> this.resultSet.getTimestamp(columnIndex));
+  }
+
+  @Override
+  public InputStream getAsciiStream(int columnIndex) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getAsciiStream",
+        () -> this.resultSet.getAsciiStream(columnIndex));
+  }
+
+  @Override
+  public InputStream getUnicodeStream(int columnIndex) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getUnicodeStream",
+        () -> this.resultSet.getUnicodeStream(columnIndex));
+  }
+
+  @Override
+  public InputStream getBinaryStream(int columnIndex) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getBinaryStream",
+        () -> this.resultSet.getBinaryStream(columnIndex));
+  }
+
+  @Override
+  public String getString(String columnLabel) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getString",
+        () -> this.resultSet.getString(columnLabel));
+  }
+
+  @Override
+  public boolean getBoolean(String columnLabel) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getBoolean",
+        () -> this.resultSet.getBoolean(columnLabel));
+  }
+
+  @Override
+  public byte getByte(String columnLabel) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getByte",
+        () -> this.resultSet.getByte(columnLabel));
+  }
+
+  @Override
+  public short getShort(String columnLabel) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getShort",
+        () -> this.resultSet.getShort(columnLabel));
+  }
+
+  @Override
+  public int getInt(String columnLabel) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getInt",
+        () -> this.resultSet.getInt(columnLabel));
+  }
+
+  @Override
+  public long getLong(String columnLabel) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getLong",
+        () -> this.resultSet.getLong(columnLabel));
+  }
+
+  @Override
+  public float getFloat(String columnLabel) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getFloat",
+        () -> this.resultSet.getFloat(columnLabel));
+  }
+
+  @Override
+  public double getDouble(String columnLabel) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getDouble",
+        () -> this.resultSet.getDouble(columnLabel));
+  }
+
+  @Override
+  public BigDecimal getBigDecimal(String columnLabel, int scale) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getBigDecimal",
+        () -> this.resultSet.getBigDecimal(columnLabel, scale));
+  }
+
+  @Override
+  public byte[] getBytes(String columnLabel) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getBytes",
+        () -> this.resultSet.getBytes(columnLabel));
+  }
+
+  @Override
+  public Date getDate(String columnLabel) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getDate",
+        () -> this.resultSet.getDate(columnLabel));
+  }
+
+  @Override
+  public Time getTime(String columnLabel) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getTime",
+        () -> this.resultSet.getTime(columnLabel));
+  }
+
+  @Override
+  public Timestamp getTimestamp(String columnLabel) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getTimestamp",
+        () -> this.resultSet.getTimestamp(columnLabel));
+  }
+
+  @Override
+  public InputStream getAsciiStream(String columnLabel) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getAsciiStream",
+        () -> this.resultSet.getAsciiStream(columnLabel));
+  }
+
+  @Override
+  public InputStream getUnicodeStream(String columnLabel) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getUnicodeStream",
+        () -> this.resultSet.getUnicodeStream(columnLabel));
+  }
+
+  @Override
+  public InputStream getBinaryStream(String columnLabel) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getBinaryStream",
+        () -> this.resultSet.getBinaryStream(columnLabel));
+  }
+
+  @Override
+  public SQLWarning getWarnings() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getWarnings",
+        () -> this.resultSet.getWarnings());
+  }
+
+  @Override
+  public void clearWarnings() throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.clearWarnings",
+        () -> {
+          this.resultSet.clearWarnings();
+          return null;
+        });
+  }
+
+  @Override
+  public String getCursorName() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getCursorName",
+        () -> this.resultSet.getCursorName());
+  }
+
+  @Override
+  public ResultSetMetaData getMetaData() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getMetaData",
+        () -> this.resultSet.getMetaData());
+  }
+
+  @Override
+  public Object getObject(int columnIndex) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getObject",
+        () -> this.resultSet.getObject(columnIndex));
+  }
+
+  @Override
+  public Object getObject(String columnLabel) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getObject",
+        () -> this.resultSet.getObject(columnLabel));
+  }
+
+  @Override
+  public int findColumn(String columnLabel) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.findColumn",
+        () -> this.resultSet.findColumn(columnLabel));
+  }
+
+  @Override
+  public Reader getCharacterStream(int columnIndex) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getCharacterStream",
+        () -> this.resultSet.getCharacterStream(columnIndex));
+  }
+
+  @Override
+  public Reader getCharacterStream(String columnLabel) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getCharacterStream",
+        () -> this.resultSet.getCharacterStream(columnLabel));
+  }
+
+  @Override
+  public BigDecimal getBigDecimal(int columnIndex) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getBigDecimal",
+        () -> this.resultSet.getBigDecimal(columnIndex));
+  }
+
+  @Override
+  public BigDecimal getBigDecimal(String columnLabel) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getBigDecimal",
+        () -> this.resultSet.getBigDecimal(columnLabel));
+  }
+
+  @Override
+  public boolean isBeforeFirst() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.isBeforeFirst",
+        () -> this.resultSet.isBeforeFirst());
+  }
+
+  @Override
+  public boolean isAfterLast() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.isAfterLast",
+        () -> this.resultSet.isAfterLast());
+  }
+
+  @Override
+  public boolean isFirst() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.isFirst",
+        () -> this.resultSet.isFirst());
+  }
+
+  @Override
+  public boolean isLast() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.isLast",
+        () -> this.resultSet.isLast());
+  }
+
+  @Override
+  public void beforeFirst() throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.beforeFirst",
+        () -> {
+          this.resultSet.beforeFirst();
+          return null;
+        });
+  }
+
+  @Override
+  public void afterLast() throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.afterLast",
+        () -> {
+          this.resultSet.afterLast();
+          return null;
+        });
+  }
+
+  @Override
+  public boolean first() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.first",
+        () -> this.resultSet.first());
+  }
+
+  @Override
+  public boolean last() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.last",
+        () -> this.resultSet.last());
+  }
+
+  @Override
+  public int getRow() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getRow",
+        () -> this.resultSet.getRow());
+  }
+
+  @Override
+  public boolean absolute(int row) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.absolute",
+        () -> this.resultSet.absolute(row));
+  }
+
+  @Override
+  public boolean relative(int rows) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.relative",
+        () -> this.resultSet.relative(rows));
+  }
+
+  @Override
+  public boolean previous() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.previous",
+        () -> this.resultSet.previous());
+  }
+
+  @Override
+  public int getFetchDirection() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getFetchDirection",
+        () -> this.resultSet.getFetchDirection());
+  }
+
+  @Override
+  public void setFetchDirection(int direction) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.setFetchDirection",
+        () -> {
+          this.resultSet.setFetchDirection(direction);
+          return null;
+        });
+  }
+
+  @Override
+  public int getFetchSize() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getFetchSize",
+        () -> this.resultSet.getFetchSize());
+  }
+
+  @Override
+  public void setFetchSize(int rows) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.setFetchSize",
+        () -> {
+          this.resultSet.setFetchSize(rows);
+          return null;
+        });
+  }
+
+  @Override
+  public int getType() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getType",
+        () -> this.resultSet.getType());
+  }
+
+  @Override
+  public int getConcurrency() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getConcurrency",
+        () -> this.resultSet.getConcurrency());
+  }
+
+  @Override
+  public boolean rowUpdated() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.rowUpdated",
+        () -> this.resultSet.rowUpdated());
+  }
+
+  @Override
+  public boolean rowInserted() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.rowInserted",
+        () -> this.resultSet.rowInserted());
+  }
+
+  @Override
+  public boolean rowDeleted() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.rowDeleted",
+        () -> this.resultSet.rowDeleted());
+  }
+
+  @Override
+  public void updateNull(int columnIndex) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateNull",
+        () -> {
+          this.resultSet.updateNull(columnIndex);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateBoolean(int columnIndex, boolean x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateBoolean",
+        () -> {
+          this.resultSet.updateBoolean(columnIndex, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateByte(int columnIndex, byte x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateByte",
+        () -> {
+          this.resultSet.updateByte(columnIndex, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateShort(int columnIndex, short x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateShort",
+        () -> {
+          this.resultSet.updateShort(columnIndex, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateInt(int columnIndex, int x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateInt",
+        () -> {
+          this.resultSet.updateInt(columnIndex, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateLong(int columnIndex, long x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateLong",
+        () -> {
+          this.resultSet.updateLong(columnIndex, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateFloat(int columnIndex, float x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateFloat",
+        () -> {
+          this.resultSet.updateFloat(columnIndex, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateDouble(int columnIndex, double x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateDouble",
+        () -> {
+          this.resultSet.updateDouble(columnIndex, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateBigDecimal(int columnIndex, BigDecimal x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateBigDecimal",
+        () -> {
+          this.resultSet.updateBigDecimal(columnIndex, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateString(int columnIndex, String x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateString",
+        () -> {
+          this.resultSet.updateString(columnIndex, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateBytes(int columnIndex, byte[] x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateBytes",
+        () -> {
+          this.resultSet.updateBytes(columnIndex, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateDate(int columnIndex, Date x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateDate",
+        () -> {
+          this.resultSet.updateDate(columnIndex, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateTime(int columnIndex, Time x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateTime",
+        () -> {
+          this.resultSet.updateTime(columnIndex, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateTimestamp(int columnIndex, Timestamp x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateTimestamp",
+        () -> {
+          this.resultSet.updateTimestamp(columnIndex, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateAsciiStream(int columnIndex, InputStream x, int length) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateAsciiStream",
+        () -> {
+          this.resultSet.updateAsciiStream(columnIndex, x, length);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateBinaryStream(int columnIndex, InputStream x, int length) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateBinaryStream",
+        () -> {
+          this.resultSet.updateBinaryStream(columnIndex, x, length);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateCharacterStream(int columnIndex, Reader x, int length) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateCharacterStream",
+        () -> {
+          this.resultSet.updateCharacterStream(columnIndex, x, length);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateObject(int columnIndex, Object x, int scaleOrLength) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateObject",
+        () -> {
+          this.resultSet.updateObject(columnIndex, x, scaleOrLength);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateObject(int columnIndex, Object x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateObject",
+        () -> {
+          this.resultSet.updateObject(columnIndex, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateNull(String columnLabel) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateNull",
+        () -> {
+          this.resultSet.updateNull(columnLabel);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateBoolean(String columnLabel, boolean x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateBoolean",
+        () -> {
+          this.resultSet.updateBoolean(columnLabel, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateByte(String columnLabel, byte x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateByte",
+        () -> {
+          this.resultSet.updateByte(columnLabel, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateShort(String columnLabel, short x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateShort",
+        () -> {
+          this.resultSet.updateShort(columnLabel, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateInt(String columnLabel, int x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateInt",
+        () -> {
+          this.resultSet.updateInt(columnLabel, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateLong(String columnLabel, long x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateLong",
+        () -> {
+          this.resultSet.updateLong(columnLabel, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateFloat(String columnLabel, float x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateFloat",
+        () -> {
+          this.resultSet.updateFloat(columnLabel, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateDouble(String columnLabel, double x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateDouble",
+        () -> {
+          this.resultSet.updateDouble(columnLabel, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateBigDecimal(String columnLabel, BigDecimal x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateBigDecimal",
+        () -> {
+          this.resultSet.updateBigDecimal(columnLabel, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateString(String columnLabel, String x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateString",
+        () -> {
+          this.resultSet.updateString(columnLabel, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateBytes(String columnLabel, byte[] x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateBytes",
+        () -> {
+          this.resultSet.updateBytes(columnLabel, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateDate(String columnLabel, Date x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateDate",
+        () -> {
+          this.resultSet.updateDate(columnLabel, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateTime(String columnLabel, Time x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateTime",
+        () -> {
+          this.resultSet.updateTime(columnLabel, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateTimestamp(String columnLabel, Timestamp x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateTimestamp",
+        () -> {
+          this.resultSet.updateTimestamp(columnLabel, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateAsciiStream(String columnLabel, InputStream x, int length) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateAsciiStream",
+        () -> {
+          this.resultSet.updateAsciiStream(columnLabel, x, length);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateBinaryStream(String columnLabel, InputStream x, int length)
+      throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateBinaryStream",
+        () -> {
+          this.resultSet.updateBinaryStream(columnLabel, x, length);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateCharacterStream(String columnLabel, Reader reader, int length)
+      throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateCharacterStream",
+        () -> {
+          this.resultSet.updateCharacterStream(columnLabel, reader, length);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateObject(String columnLabel, Object x, int scaleOrLength) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateObject",
+        () -> {
+          this.resultSet.updateObject(columnLabel, x, scaleOrLength);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateObject(String columnLabel, Object x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateObject",
+        () -> {
+          this.resultSet.updateObject(columnLabel, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void insertRow() throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.insertRow",
+        () -> {
+          this.resultSet.insertRow();
+          return null;
+        });
+  }
+
+  @Override
+  public void updateRow() throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateRow",
+        () -> {
+          this.resultSet.updateRow();
+          return null;
+        });
+  }
+
+  @Override
+  public void deleteRow() throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.deleteRow",
+        () -> {
+          this.resultSet.deleteRow();
+          return null;
+        });
+  }
+
+  @Override
+  public void refreshRow() throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.refreshRow",
+        () -> {
+          this.resultSet.refreshRow();
+          return null;
+        });
+  }
+
+  @Override
+  public void cancelRowUpdates() throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.cancelRowUpdates",
+        () -> {
+          this.resultSet.cancelRowUpdates();
+          return null;
+        });
+  }
+
+  @Override
+  public void moveToInsertRow() throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.moveToInsertRow",
+        () -> {
+          this.resultSet.moveToInsertRow();
+          return null;
+        });
+  }
+
+  @Override
+  public void moveToCurrentRow() throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.moveToCurrentRow",
+        () -> {
+          this.resultSet.moveToCurrentRow();
+          return null;
+        });
+  }
+
+  @Override
+  public Statement getStatement() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getStatement",
+        () -> this.resultSet.getStatement());
+  }
+
+  @Override
+  public Object getObject(int columnIndex, Map<String, Class<?>> map) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getObject",
+        () -> this.resultSet.getObject(columnIndex, map));
+  }
+
+  @Override
+  public Ref getRef(int columnIndex) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getRef",
+        () -> this.resultSet.getRef(columnIndex));
+  }
+
+  @Override
+  public Blob getBlob(int columnIndex) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getBlob",
+        () -> this.resultSet.getBlob(columnIndex));
+  }
+
+  @Override
+  public Clob getClob(int columnIndex) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getClob",
+        () -> this.resultSet.getClob(columnIndex));
+  }
+
+  @Override
+  public Array getArray(int columnIndex) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getArray",
+        () -> this.resultSet.getArray(columnIndex));
+  }
+
+  @Override
+  public Object getObject(String columnLabel, Map<String, Class<?>> map) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getObject",
+        () -> this.resultSet.getObject(columnLabel, map));
+  }
+
+  @Override
+  public Ref getRef(String columnLabel) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getRef",
+        () -> this.resultSet.getRef(columnLabel));
+  }
+
+  @Override
+  public Blob getBlob(String columnLabel) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getBlob",
+        () -> this.resultSet.getBlob(columnLabel));
+  }
+
+  @Override
+  public Clob getClob(String columnLabel) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getClob",
+        () -> this.resultSet.getClob(columnLabel));
+  }
+
+  @Override
+  public Array getArray(String columnLabel) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getArray",
+        () -> this.resultSet.getArray(columnLabel));
+  }
+
+  @Override
+  public Date getDate(int columnIndex, Calendar cal) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getDate",
+        () -> this.resultSet.getDate(columnIndex, cal));
+  }
+
+  @Override
+  public Date getDate(String columnLabel, Calendar cal) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getDate",
+        () -> this.resultSet.getDate(columnLabel, cal));
+  }
+
+  @Override
+  public Time getTime(int columnIndex, Calendar cal) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getTime",
+        () -> this.resultSet.getTime(columnIndex, cal));
+  }
+
+  @Override
+  public Time getTime(String columnLabel, Calendar cal) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getTime",
+        () -> this.resultSet.getTime(columnLabel, cal));
+  }
+
+  @Override
+  public Timestamp getTimestamp(int columnIndex, Calendar cal) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getTimestamp",
+        () -> this.resultSet.getTimestamp(columnIndex, cal));
+  }
+
+  @Override
+  public Timestamp getTimestamp(String columnLabel, Calendar cal) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getTimestamp",
+        () -> this.resultSet.getTimestamp(columnLabel, cal));
+  }
+
+  @Override
+  public URL getURL(int columnIndex) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getURL",
+        () -> this.resultSet.getURL(columnIndex));
+  }
+
+  @Override
+  public URL getURL(String columnLabel) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getURL",
+        () -> this.resultSet.getURL(columnLabel));
+  }
+
+  @Override
+  public void updateRef(int columnIndex, Ref x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateRef",
+        () -> {
+          this.resultSet.updateRef(columnIndex, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateRef(String columnLabel, Ref x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateRef",
+        () -> {
+          this.resultSet.updateRef(columnLabel, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateBlob(int columnIndex, Blob x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateBlob",
+        () -> {
+          this.resultSet.updateBlob(columnIndex, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateBlob(String columnLabel, Blob x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateBlob",
+        () -> {
+          this.resultSet.updateBlob(columnLabel, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateClob(int columnIndex, Clob x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateClob",
+        () -> {
+          this.resultSet.updateClob(columnIndex, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateClob(String columnLabel, Clob x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateClob",
+        () -> {
+          this.resultSet.updateClob(columnLabel, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateArray(int columnIndex, Array x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateArray",
+        () -> {
+          this.resultSet.updateArray(columnIndex, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateArray(String columnLabel, Array x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateArray",
+        () -> {
+          this.resultSet.updateArray(columnLabel, x);
+          return null;
+        });
+  }
+
+  @Override
+  public RowId getRowId(int columnIndex) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getRowId",
+        () -> this.resultSet.getRowId(columnIndex));
+  }
+
+  @Override
+  public RowId getRowId(String columnLabel) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getRowId",
+        () -> this.resultSet.getRowId(columnLabel));
+  }
+
+  @Override
+  public void updateRowId(int columnIndex, RowId x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateRowId",
+        () -> {
+          this.resultSet.updateRowId(columnIndex, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateRowId(String columnLabel, RowId x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateRowId",
+        () -> {
+          this.resultSet.updateRowId(columnLabel, x);
+          return null;
+        });
+  }
+
+  @Override
+  public int getHoldability() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getHoldability",
+        () -> this.resultSet.getHoldability());
+  }
+
+  @Override
+  public boolean isClosed() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.isClosed",
+        () -> this.resultSet.isClosed());
+  }
+
+  @Override
+  public void updateNString(int columnIndex, String nString) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateNString",
+        () -> {
+          this.resultSet.updateNString(columnIndex, nString);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateNString(String columnLabel, String nString) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateNString",
+        () -> {
+          this.resultSet.updateNString(columnLabel, nString);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateNClob(int columnIndex, NClob nClob) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateNClob",
+        () -> {
+          this.resultSet.updateNClob(columnIndex, nClob);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateNClob(String columnLabel, NClob nClob) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateNClob",
+        () -> {
+          this.resultSet.updateNClob(columnLabel, nClob);
+          return null;
+        });
+  }
+
+  @Override
+  public NClob getNClob(int columnIndex) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getNClob",
+        () -> this.resultSet.getNClob(columnIndex));
+  }
+
+  @Override
+  public NClob getNClob(String columnLabel) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getNClob",
+        () -> this.resultSet.getNClob(columnLabel));
+  }
+
+  @Override
+  public SQLXML getSQLXML(int columnIndex) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getSQLXML",
+        () -> this.resultSet.getSQLXML(columnIndex));
+  }
+
+  @Override
+  public SQLXML getSQLXML(String columnLabel) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getSQLXML",
+        () -> this.resultSet.getSQLXML(columnLabel));
+  }
+
+  @Override
+  public void updateSQLXML(int columnIndex, SQLXML xmlObject) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateSQLXML",
+        () -> {
+          this.resultSet.updateSQLXML(columnIndex, xmlObject);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateSQLXML(String columnLabel, SQLXML xmlObject) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateSQLXML",
+        () -> {
+          this.resultSet.updateSQLXML(columnLabel, xmlObject);
+          return null;
+        });
+  }
+
+  @Override
+  public String getNString(int columnIndex) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getNString",
+        () -> this.resultSet.getNString(columnIndex));
+  }
+
+  @Override
+  public String getNString(String columnLabel) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getNString",
+        () -> this.resultSet.getNString(columnLabel));
+  }
+
+  @Override
+  public Reader getNCharacterStream(int columnIndex) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getNCharacterStream",
+        () -> this.resultSet.getNCharacterStream(columnIndex));
+  }
+
+  @Override
+  public Reader getNCharacterStream(String columnLabel) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getNCharacterStream",
+        () -> this.resultSet.getNCharacterStream(columnLabel));
+  }
+
+  @Override
+  public void updateNCharacterStream(int columnIndex, Reader x, long length) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateNCharacterStream",
+        () -> {
+          this.resultSet.updateNCharacterStream(columnIndex, x, length);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateNCharacterStream(String columnLabel, Reader reader, long length)
+      throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateNCharacterStream",
+        () -> {
+          this.resultSet.updateNCharacterStream(columnLabel, reader, length);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateAsciiStream(int columnIndex, InputStream x, long length) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateAsciiStream",
+        () -> {
+          this.resultSet.updateAsciiStream(columnIndex, x, length);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateBinaryStream(int columnIndex, InputStream x, long length) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateBinaryStream",
+        () -> {
+          this.resultSet.updateBinaryStream(columnIndex, x, length);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateCharacterStream(int columnIndex, Reader x, long length) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateCharacterStream",
+        () -> {
+          this.resultSet.updateCharacterStream(columnIndex, x, length);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateAsciiStream(String columnLabel, InputStream x, long length)
+      throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateAsciiStream",
+        () -> {
+          this.resultSet.updateAsciiStream(columnLabel, x, length);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateBinaryStream(String columnLabel, InputStream x, long length)
+      throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateBinaryStream",
+        () -> {
+          this.resultSet.updateBinaryStream(columnLabel, x, length);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateCharacterStream(String columnLabel, Reader reader, long length)
+      throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateCharacterStream",
+        () -> {
+          this.resultSet.updateCharacterStream(columnLabel, reader, length);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateBlob(int columnIndex, InputStream inputStream, long length)
+      throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateBlob",
+        () -> {
+          this.resultSet.updateBlob(columnIndex, inputStream, length);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateBlob(String columnLabel, InputStream inputStream, long length)
+      throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateBlob",
+        () -> {
+          this.resultSet.updateBlob(columnLabel, inputStream, length);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateClob(int columnIndex, Reader reader, long length) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateClob",
+        () -> {
+          this.resultSet.updateClob(columnIndex, reader, length);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateClob(String columnLabel, Reader reader, long length) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateClob",
+        () -> {
+          this.resultSet.updateClob(columnLabel, reader, length);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateNClob(int columnIndex, Reader reader, long length) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateNClob",
+        () -> {
+          this.resultSet.updateNClob(columnIndex, reader, length);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateNClob(String columnLabel, Reader reader, long length) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateNClob",
+        () -> {
+          this.resultSet.updateNClob(columnLabel, reader, length);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateNCharacterStream(int columnIndex, Reader x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateNCharacterStream",
+        () -> {
+          this.resultSet.updateNCharacterStream(columnIndex, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateNCharacterStream(String columnLabel, Reader reader) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateNCharacterStream",
+        () -> {
+          this.resultSet.updateNCharacterStream(columnLabel, reader);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateAsciiStream(int columnIndex, InputStream x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateAsciiStream",
+        () -> {
+          this.resultSet.updateAsciiStream(columnIndex, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateBinaryStream(int columnIndex, InputStream x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateBinaryStream",
+        () -> {
+          this.resultSet.updateBinaryStream(columnIndex, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateCharacterStream(int columnIndex, Reader x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateCharacterStream",
+        () -> {
+          this.resultSet.updateCharacterStream(columnIndex, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateAsciiStream(String columnLabel, InputStream x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateAsciiStream",
+        () -> {
+          this.resultSet.updateAsciiStream(columnLabel, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateBinaryStream(String columnLabel, InputStream x) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateBinaryStream",
+        () -> {
+          this.resultSet.updateBinaryStream(columnLabel, x);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateCharacterStream(String columnLabel, Reader reader) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateCharacterStream",
+        () -> {
+          this.resultSet.updateCharacterStream(columnLabel, reader);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateBlob(int columnIndex, InputStream inputStream) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateBlob",
+        () -> {
+          this.resultSet.updateBlob(columnIndex, inputStream);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateBlob(String columnLabel, InputStream inputStream) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateBlob",
+        () -> {
+          this.resultSet.updateBlob(columnLabel, inputStream);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateClob(int columnIndex, Reader reader) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateClob",
+        () -> {
+          this.resultSet.updateClob(columnIndex, reader);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateClob(String columnLabel, Reader reader) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateClob",
+        () -> {
+          this.resultSet.updateClob(columnLabel, reader);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateNClob(int columnIndex, Reader reader) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateNClob",
+        () -> {
+          this.resultSet.updateNClob(columnIndex, reader);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateNClob(String columnLabel, Reader reader) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateNClob",
+        () -> {
+          this.resultSet.updateNClob(columnLabel, reader);
+          return null;
+        });
+  }
+
+  @Override
+  public <T> T getObject(int columnIndex, Class<T> type) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getObject",
+        () -> this.resultSet.getObject(columnIndex, type));
+  }
+
+  @Override
+  public <T> T getObject(String columnLabel, Class<T> type) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.getObject",
+        () -> this.resultSet.getObject(columnLabel, type));
+  }
+
+  @Override
+  public void updateObject(int columnIndex, Object x, SQLType targetSqlType, int scaleOrLength)
+      throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateObject",
+        () -> {
+          this.resultSet.updateObject(columnIndex, x, targetSqlType, scaleOrLength);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateObject(String columnLabel, Object x, SQLType targetSqlType,
+      int scaleOrLength) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateObject",
+        () -> {
+          this.resultSet.updateObject(columnLabel, x, targetSqlType, scaleOrLength);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateObject(int columnIndex, Object x, SQLType targetSqlType) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateObject",
+        () -> {
+          this.resultSet.updateObject(columnIndex, x, targetSqlType);
+          return null;
+        });
+  }
+
+  @Override
+  public void updateObject(String columnLabel, Object x, SQLType targetSqlType)
+      throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.resultSetClass,
+        "ResultSet.updateObject",
+        () -> {
+          this.resultSet.updateObject(columnLabel, x, targetSqlType);
+          return null;
+        });
+  }
+
+  @Override
+  public <T> T unwrap(Class<T> iface) throws SQLException {
+    return this.resultSet.unwrap(iface);
+  }
+
+  @Override
+  public boolean isWrapperFor(Class<?> iface) throws SQLException {
+    return this.resultSet.isWrapperFor(iface);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    return this.resultSet.equals(obj);
+  }
+
+  @Override
+  public int hashCode() {
+    return this.resultSet.hashCode();
+  }
+
+}

--- a/pgjdbc/src/main/java/org/postgresql/pluginmanager/StatementWrapper.java
+++ b/pgjdbc/src/main/java/org/postgresql/pluginmanager/StatementWrapper.java
@@ -1,0 +1,431 @@
+/*
+ * Copyright (c) 2022, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.pluginmanager;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.SQLWarning;
+import java.sql.Statement;
+
+public class StatementWrapper implements Statement {
+
+  protected Statement statement;
+  protected Class<?> statementClass;
+  protected ConnectionPluginManager pluginManager;
+
+  public StatementWrapper(Statement statement, ConnectionPluginManager pluginManager) {
+    if (statement == null) {
+      throw new IllegalArgumentException("statement");
+    }
+    if (pluginManager == null) {
+      throw new IllegalArgumentException("pluginManager");
+    }
+
+    this.statement = statement;
+    this.statementClass = this.statement.getClass();
+    this.pluginManager = pluginManager;
+  }
+
+  @Override
+  public ResultSet executeQuery(String sql) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "Statement.executeQuery",
+        () -> this.statement.executeQuery(sql));
+  }
+
+  @Override
+  public int executeUpdate(String sql) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "Statement.executeUpdate",
+        () -> this.statement.executeUpdate(sql));
+  }
+
+  @Override
+  public void close() throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "Statement.close",
+        () -> {
+          this.statement.close();
+          return null;
+        });
+  }
+
+  @Override
+  public int getMaxFieldSize() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "Statement.getMaxFieldSize",
+        () -> this.statement.getMaxFieldSize());
+  }
+
+  @Override
+  public void setMaxFieldSize(int max) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "Statement.setMaxFieldSize",
+        () -> {
+          this.statement.setMaxFieldSize(max);
+          return null;
+        });
+  }
+
+  @Override
+  public int getMaxRows() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "Statement.getMaxRows",
+        () -> this.statement.getMaxRows());
+  }
+
+  @Override
+  public void setMaxRows(int max) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "Statement.setMaxRows",
+        () -> {
+          this.statement.setMaxRows(max);
+          return null;
+        });
+  }
+
+  @Override
+  public void setEscapeProcessing(boolean enable) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "Statement.setEscapeProcessing",
+        () -> {
+          this.statement.setEscapeProcessing(enable);
+          return null;
+        });
+  }
+
+  @Override
+  public int getQueryTimeout() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "Statement.getQueryTimeout",
+        () -> this.statement.getQueryTimeout());
+  }
+
+  @Override
+  public void setQueryTimeout(int seconds) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "Statement.setQueryTimeout",
+        () -> {
+          this.statement.setQueryTimeout(seconds);
+          return null;
+        });
+  }
+
+  @Override
+  public void cancel() throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "Statement.cancel",
+        () -> {
+          this.statement.cancel();
+          return null;
+        });
+  }
+
+  @Override
+  public SQLWarning getWarnings() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "Statement.getWarnings",
+        () -> this.statement.getWarnings());
+  }
+
+  @Override
+  public void clearWarnings() throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "Statement.clearWarnings",
+        () -> {
+          this.statement.clearWarnings();
+          return null;
+        });
+  }
+
+  @Override
+  public void setCursorName(String name) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "Statement.setCursorName",
+        () -> {
+          this.statement.setCursorName(name);
+          return null;
+        });
+  }
+
+  @Override
+  public boolean execute(String sql) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "Statement.execute",
+        () -> this.statement.execute(sql));
+  }
+
+  @Override
+  public ResultSet getResultSet() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "Statement.getResultSet",
+        () -> this.statement.getResultSet());
+  }
+
+  @Override
+  public int getUpdateCount() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "Statement.getUpdateCount",
+        () -> this.statement.getUpdateCount());
+  }
+
+  @Override
+  public boolean getMoreResults() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "Statement.getMoreResults",
+        () -> this.statement.getMoreResults());
+  }
+
+  @Override
+  public int getFetchDirection() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "Statement.getFetchDirection",
+        () -> this.statement.getFetchDirection());
+  }
+
+  @Override
+  public void setFetchDirection(int direction) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "Statement.setFetchDirection",
+        () -> {
+          this.statement.setFetchDirection(direction);
+          return null;
+        });
+  }
+
+  @Override
+  public int getFetchSize() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "Statement.getFetchSize",
+        () -> this.statement.getFetchSize());
+  }
+
+  @Override
+  public void setFetchSize(int rows) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "Statement.setFetchSize",
+        () -> {
+          this.statement.setFetchSize(rows);
+          return null;
+        });
+  }
+
+  @Override
+  public int getResultSetConcurrency() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "Statement.getResultSetConcurrency",
+        () -> this.statement.getResultSetConcurrency());
+  }
+
+  @Override
+  public int getResultSetType() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "Statement.getResultSetType",
+        () -> this.statement.getResultSetType());
+  }
+
+  @Override
+  public void addBatch(String sql) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "Statement.addBatch",
+        () -> {
+          this.statement.addBatch(sql);
+          return null;
+        });
+  }
+
+  @Override
+  public void clearBatch() throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "Statement.clearBatch",
+        () -> {
+          this.statement.clearBatch();
+          return null;
+        });
+  }
+
+  @Override
+  public int[] executeBatch() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "Statement.executeBatch",
+        () -> this.statement.executeBatch());
+  }
+
+  @Override
+  public Connection getConnection() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "Statement.getConnection",
+        () -> this.statement.getConnection());
+  }
+
+  @Override
+  public boolean getMoreResults(int current) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "Statement.getMoreResults",
+        () -> this.statement.getMoreResults(current));
+  }
+
+  @Override
+  public ResultSet getGeneratedKeys() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "Statement.getGeneratedKeys",
+        () -> this.statement.getGeneratedKeys());
+  }
+
+  @Override
+  public int executeUpdate(String sql, int autoGeneratedKeys) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "Statement.executeUpdate",
+        () -> this.statement.executeUpdate(sql, autoGeneratedKeys));
+  }
+
+  @Override
+  public int executeUpdate(String sql, int[] columnIndexes) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "Statement.executeUpdate",
+        () -> this.statement.executeUpdate(sql, columnIndexes));
+  }
+
+  @Override
+  public int executeUpdate(String sql, String[] columnNames) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "Statement.executeUpdate",
+        () -> this.statement.executeUpdate(sql, columnNames));
+  }
+
+  @Override
+  public boolean execute(String sql, int autoGeneratedKeys) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "Statement.execute",
+        () -> this.statement.execute(sql, autoGeneratedKeys));
+  }
+
+  @Override
+  public boolean execute(String sql, int[] columnIndexes) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "Statement.execute",
+        () -> this.statement.execute(sql, columnIndexes));
+  }
+
+  @Override
+  public boolean execute(String sql, String[] columnNames) throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "Statement.execute",
+        () -> this.statement.execute(sql, columnNames));
+  }
+
+  @Override
+  public int getResultSetHoldability() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "Statement.getResultSetHoldability",
+        () -> this.statement.getResultSetHoldability());
+  }
+
+  @Override
+  public boolean isClosed() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "Statement.isClosed",
+        () -> this.statement.isClosed());
+  }
+
+  @Override
+  public boolean isPoolable() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "Statement.isPoolable",
+        () -> this.statement.isPoolable());
+  }
+
+  @Override
+  public void setPoolable(boolean poolable) throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "Statement.setPoolable",
+        () -> {
+          this.statement.setPoolable(poolable);
+          return null;
+        });
+  }
+
+  @Override
+  public void closeOnCompletion() throws SQLException {
+    WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "Statement.closeOnCompletion",
+        () -> {
+          this.statement.closeOnCompletion();
+          return null;
+        });
+  }
+
+  @Override
+  public boolean isCloseOnCompletion() throws SQLException {
+    return WrapperUtils.executeWithPlugins(this.pluginManager,
+        this.statementClass,
+        "Statement.isCloseOnCompletion",
+        () -> this.statement.isCloseOnCompletion());
+  }
+
+  @Override
+  public <T> T unwrap(Class<T> iface) throws SQLException {
+    return this.statement.unwrap(iface);
+  }
+
+  @Override
+  public boolean isWrapperFor(Class<?> iface) throws SQLException {
+    return this.statement.isWrapperFor(iface);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    return this.statement.equals(obj);
+  }
+
+  @Override
+  public int hashCode() {
+    return this.statement.hashCode();
+  }
+
+}

--- a/pgjdbc/src/main/java/org/postgresql/pluginmanager/WrapperUtils.java
+++ b/pgjdbc/src/main/java/org/postgresql/pluginmanager/WrapperUtils.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) 2022, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.pluginmanager;
+
+import org.postgresql.util.Util;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.sql.CallableStatement;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLClientInfoException;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Arrays;
+import java.util.concurrent.Callable;
+
+public class WrapperUtils {
+
+  public static synchronized <T> T executeWithPlugins(ConnectionPluginManager pluginManager,
+      Class<?> methodInvokeOn, String methodName,
+      Callable<T> executeSqlFunc, Object... args) throws SQLException {
+
+    Object[] argsCopy = args == null ? null : Arrays.copyOf(args, args.length);
+
+    T result;
+    try {
+      result = pluginManager.execute_SQLException(
+          methodInvokeOn,
+          methodName,
+          executeSqlFunc,
+          argsCopy);
+      result = wrapWithProxyIfNeeded(result, pluginManager);
+    } catch (SQLException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+    return result;
+  }
+
+  public static synchronized <T> T executeWithPlugins_SQLClientInfoException(
+      ConnectionPluginManager pluginManager,
+      Class<?> methodInvokeOn, String methodName,
+      Callable<T> executeSqlFunc, Object... args) throws SQLClientInfoException {
+
+    Object[] argsCopy = args == null ? null : Arrays.copyOf(args, args.length);
+
+    T result;
+    try {
+      result = pluginManager.execute_SQLClientInfoException(
+          methodInvokeOn,
+          methodName,
+          executeSqlFunc,
+          argsCopy);
+      result = wrapWithProxyIfNeeded(result, pluginManager);
+    } catch (SQLClientInfoException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+    return result;
+  }
+
+  protected static @Nullable <T> T wrapWithProxyIfNeeded(@Nullable T toProxy,
+      ConnectionPluginManager pluginManager) {
+    if (toProxy == null) {
+      return null;
+    }
+
+    if (toProxy instanceof ConnectionWrapper
+        || toProxy instanceof CallableStatementWrapper
+        || toProxy instanceof PreparedStatementWrapper
+        || toProxy instanceof StatementWrapper
+        || toProxy instanceof ResultSetWrapper) {
+      return toProxy;
+    }
+
+    if (toProxy instanceof Connection) {
+      throw new UnsupportedOperationException("Shouldn't be here");
+    }
+
+    if (toProxy instanceof CallableStatement) {
+      return (T) new CallableStatementWrapper((CallableStatement) toProxy, pluginManager);
+    }
+
+    if (toProxy instanceof PreparedStatement) {
+      return (T) new PreparedStatementWrapper((PreparedStatement) toProxy, pluginManager);
+    }
+
+    if (toProxy instanceof Statement) {
+      return (T) new StatementWrapper((Statement) toProxy, pluginManager);
+    }
+
+    if (toProxy instanceof ResultSet) {
+      return (T) new ResultSetWrapper((ResultSet) toProxy, pluginManager);
+    }
+
+    if (!Util.isJdbcInterface(toProxy.getClass())) {
+      return toProxy;
+    }
+
+    // Add more custom wrapper support here
+
+    Class<?> toProxyClass = toProxy.getClass();
+    return (T) java.lang.reflect.Proxy.newProxyInstance(toProxyClass.getClassLoader(),
+        Util.getImplementedInterfaces(toProxyClass),
+        new WrapperUtils.Proxy(pluginManager, toProxy));
+  }
+
+  /**
+   * This class is a proxy for objects created through the proxied connection (for example,
+   * {@link java.sql.Statement} and
+   * {@link java.sql.ResultSet}. Similarly to ClusterAwareConnectionProxy, this proxy class
+   * monitors the underlying object
+   * for communications exceptions and initiates failover when required.
+   */
+  public static class Proxy implements InvocationHandler {
+    static final String METHOD_EQUALS = "equals";
+    static final String METHOD_HASH_CODE = "hashCode";
+
+    Object invocationTarget;
+    ConnectionPluginManager pluginManager;
+
+    Proxy(ConnectionPluginManager pluginManager, Object invocationTarget) {
+      this.pluginManager = pluginManager;
+      this.invocationTarget = invocationTarget;
+    }
+
+    public @Nullable Object invoke(Object proxy, Method method, @Nullable Object[] args)
+        throws Throwable {
+      if (METHOD_EQUALS.equals(method.getName()) && args != null && args[0] != null) {
+        return args[0].equals(this);
+      }
+
+      if (METHOD_HASH_CODE.equals(method.getName())) {
+        return this.hashCode();
+      }
+
+      synchronized (WrapperUtils.Proxy.this) {
+        Object result;
+        Object[] argsCopy = args == null ? null : Arrays.copyOf(args, args.length);
+
+        try {
+          result = this.pluginManager.execute(
+              this.invocationTarget.getClass(),
+              method.getName(),
+              () -> method.invoke(this.invocationTarget, args),
+              argsCopy);
+          result = wrapWithProxyIfNeeded(method.getReturnType(), result);
+        } catch (InvocationTargetException e) {
+          throw e.getTargetException() == null ? e : e.getTargetException();
+        } catch (IllegalStateException e) {
+          throw e.getCause() == null ? e : e.getCause();
+        }
+
+        return result;
+      }
+    }
+
+    protected @Nullable Object wrapWithProxyIfNeeded(Class<?> returnType,
+        @Nullable Object toProxy) {
+      if (toProxy == null) {
+        return null;
+      }
+
+      if (toProxy instanceof ConnectionWrapper
+          || toProxy instanceof CallableStatementWrapper
+          || toProxy instanceof PreparedStatementWrapper
+          || toProxy instanceof StatementWrapper
+          || toProxy instanceof ResultSetWrapper) {
+        return toProxy;
+      }
+
+      // Add custom wrapper support here
+
+      if (!Util.isJdbcInterface(returnType)) {
+        return toProxy;
+      }
+
+      Class<?> toProxyClass = toProxy.getClass();
+      return java.lang.reflect.Proxy.newProxyInstance(toProxyClass.getClassLoader(),
+          Util.getImplementedInterfaces(toProxyClass),
+          new WrapperUtils.Proxy(this.pluginManager, toProxy));
+    }
+
+  }
+}

--- a/pgjdbc/src/main/java/org/postgresql/pluginmanager/efm/DefaultMonitorService.java
+++ b/pgjdbc/src/main/java/org/postgresql/pluginmanager/efm/DefaultMonitorService.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2022, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.pluginmanager.efm;
+
+import org.postgresql.PGProperty;
+import org.postgresql.core.BaseConnection;
+import org.postgresql.pluginmanager.BasicConnectionProvider;
+import org.postgresql.util.HostSpec;
+import org.postgresql.util.PSQLException;
+
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.logging.Logger;
+
+/**
+ * This class handles the creation and clean up of monitoring threads to servers with one
+ * or more active connections.
+ */
+public class DefaultMonitorService implements IMonitorService {
+
+  private static final transient Logger LOGGER =
+      Logger.getLogger(DefaultMonitorService.class.getName());
+  final IMonitorInitializer monitorInitializer;
+  MonitorThreadContainer threadContainer;
+
+  public DefaultMonitorService() {
+    this((hostInfo, props, monitorService) -> {
+      int monitorDisposalTime =
+          Integer.parseInt(PGProperty.MONITOR_DISPOSAL_TIME.getDefaultValue());
+      try {
+        monitorDisposalTime = PGProperty.MONITOR_DISPOSAL_TIME.getInt(props);
+      } catch (PSQLException ex) {
+        LOGGER.warning(
+            "Invalid value for property ''monitorDisposalTime''. Use default value instead.");
+      }
+
+      return new Monitor(
+          new BasicConnectionProvider(),
+          hostInfo,
+          props,
+          monitorDisposalTime,
+          monitorService);
+    }, Executors::newCachedThreadPool);
+  }
+
+  DefaultMonitorService(
+      IMonitorInitializer monitorInitializer,
+      IExecutorServiceInitializer executorServiceInitializer) {
+
+    this.monitorInitializer = monitorInitializer;
+    this.threadContainer = MonitorThreadContainer.getInstance(executorServiceInitializer);
+  }
+
+  @Override
+  public MonitorConnectionContext startMonitoring(
+      BaseConnection connectionToAbort,
+      Set<String> nodeKeys,
+      HostSpec hostSpec,
+      Properties props,
+      int failureDetectionTimeMillis,
+      int failureDetectionIntervalMillis,
+      int failureDetectionCount) {
+
+    if (nodeKeys.isEmpty()) {
+      throw new IllegalArgumentException(
+          "Empty NodeKey set passed into DefaultMonitorService. Set should not be empty.");
+    }
+
+    final IMonitor monitor = getMonitor(nodeKeys, hostSpec, props);
+
+    final MonitorConnectionContext context = new MonitorConnectionContext(
+        connectionToAbort,
+        nodeKeys,
+        failureDetectionTimeMillis,
+        failureDetectionIntervalMillis,
+        failureDetectionCount);
+
+    monitor.startMonitoring(context);
+    this.threadContainer.addTask(monitor);
+
+    return context;
+  }
+
+  @Override
+  public void stopMonitoring(MonitorConnectionContext context) {
+    if (context == null) {
+      LOGGER.warning(ErrorMessageUtil.getMessage("context"));
+      return;
+    }
+
+    // Any 1 node is enough to find the monitor containing the context
+    // All nodes will map to the same monitor
+    final String node = this.threadContainer.getNode(context.getNodeKeys());
+
+    if (node == null) {
+      LOGGER.warning(
+          "Invalid context passed into DefaultMonitorService. Could not find any NodeKey from "
+              + "context.");
+      return;
+    }
+
+    this.threadContainer.getMonitor(node).stopMonitoring(context);
+  }
+
+  @Override
+  public void stopMonitoringForAllConnections(Set<String> nodeKeys) {
+    final String node = this.threadContainer.getNode(nodeKeys);
+    if (node == null) {
+      LOGGER.warning(
+          "Invalid node key passed into DefaultMonitorService. No existing monitor for the given "
+              + "set of node keys.");
+      return;
+    }
+    final IMonitor monitor = this.threadContainer.getMonitor(node);
+    monitor.clearContexts();
+    this.threadContainer.resetResource(monitor);
+  }
+
+  @Override
+  public void releaseResources() {
+    this.threadContainer = null;
+    MonitorThreadContainer.releaseInstance();
+  }
+
+  @Override
+  public synchronized void notifyUnused(IMonitor monitor) {
+    if (monitor == null) {
+      LOGGER.warning(ErrorMessageUtil.getMessage("monitor"));
+      return;
+    }
+
+    // Remove monitor from the maps
+    this.threadContainer.releaseResource(monitor);
+  }
+
+  /**
+   * Get or create a {@link IMonitor} for a server.
+   *
+   * @param nodeKeys All references to the server requiring monitoring.
+   * @param hostSpec Information such as hostname of the server.
+   * @param props    The user configuration for the current connection.
+   * @return A {@link IMonitor} object associated with a specific server.
+   */
+  protected IMonitor getMonitor(Set<String> nodeKeys, HostSpec hostSpec, Properties props) {
+    return this.threadContainer.getOrCreateMonitor(nodeKeys,
+        () -> monitorInitializer.createMonitor(hostSpec, props, this));
+  }
+}

--- a/pgjdbc/src/main/java/org/postgresql/pluginmanager/efm/ErrorMessageUtil.java
+++ b/pgjdbc/src/main/java/org/postgresql/pluginmanager/efm/ErrorMessageUtil.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2022, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.pluginmanager.efm;
+
+/**
+ * Utility class constructing messages for null arguments.
+ */
+public class ErrorMessageUtil {
+
+  /**
+   * Return a message indicating the given {@code paramName} is null.
+   *
+   * @param paramName The name of the parameter that is null.
+   * @return a message the parameter passed to the caller method is null.
+   */
+  public static String getMessage(String paramName) {
+    return String.format("Parameter ''%s'' must not be null", paramName);
+  }
+}

--- a/pgjdbc/src/main/java/org/postgresql/pluginmanager/efm/IExecutorServiceInitializer.java
+++ b/pgjdbc/src/main/java/org/postgresql/pluginmanager/efm/IExecutorServiceInitializer.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2022, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.pluginmanager.efm;
+
+import java.util.concurrent.ExecutorService;
+
+/**
+ * Interface for passing a specific {@link ExecutorService} to use by the
+ * {@link MonitorThreadContainer}.
+ */
+@FunctionalInterface
+public interface IExecutorServiceInitializer {
+  ExecutorService createExecutorService();
+}

--- a/pgjdbc/src/main/java/org/postgresql/pluginmanager/efm/IMonitor.java
+++ b/pgjdbc/src/main/java/org/postgresql/pluginmanager/efm/IMonitor.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2022, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.pluginmanager.efm;
+
+/**
+ * Interface for monitors. This class uses background threads to monitor servers with one
+ * or more connections for more efficient failure detection during method execution.
+ */
+public interface IMonitor extends Runnable {
+  void startMonitoring(MonitorConnectionContext context);
+
+  void stopMonitoring(MonitorConnectionContext context);
+
+  /**
+   * Clear all {@link MonitorConnectionContext} associated with this {@link IMonitor} instance.
+   */
+  void clearContexts();
+
+  /**
+   * Whether this {@link IMonitor} has stopped monitoring a particular server.
+   *
+   * @return true if the monitoring has stopped; false otherwise.
+   */
+  boolean isStopped();
+}

--- a/pgjdbc/src/main/java/org/postgresql/pluginmanager/efm/IMonitorInitializer.java
+++ b/pgjdbc/src/main/java/org/postgresql/pluginmanager/efm/IMonitorInitializer.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2022, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.pluginmanager.efm;
+
+import org.postgresql.util.HostSpec;
+
+import java.util.Properties;
+
+/**
+ * Interface for initialize a new {@link Monitor}.
+ */
+@FunctionalInterface
+public interface IMonitorInitializer {
+  IMonitor createMonitor(HostSpec hostSpec, Properties props, IMonitorService monitorService);
+}

--- a/pgjdbc/src/main/java/org/postgresql/pluginmanager/efm/IMonitorService.java
+++ b/pgjdbc/src/main/java/org/postgresql/pluginmanager/efm/IMonitorService.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2022, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.pluginmanager.efm;
+
+import org.postgresql.core.BaseConnection;
+import org.postgresql.util.HostSpec;
+
+import java.util.Properties;
+import java.util.Set;
+
+/**
+ * Interface for monitor services. This class implements ways to start and stop monitoring
+ * servers when connections are created.
+ */
+public interface IMonitorService {
+  MonitorConnectionContext startMonitoring(
+      BaseConnection connectionToAbort,
+      Set<String> nodeKeys,
+      HostSpec hostSpec,
+      Properties props,
+      int failureDetectionTimeMillis,
+      int failureDetectionIntervalMillis,
+      int failureDetectionCount);
+
+  /**
+   * Stop monitoring for a connection represented by the given
+   * {@link MonitorConnectionContext}. Removes the context from the {@link Monitor}.
+   *
+   * @param context The {@link MonitorConnectionContext} representing a connection.
+   */
+  void stopMonitoring(MonitorConnectionContext context);
+
+  /**
+   * Stop monitoring the node for all connections represented by the given set of node keys.
+   *
+   * @param nodeKeys All known references to a server.
+   */
+  void stopMonitoringForAllConnections(Set<String> nodeKeys);
+
+  void releaseResources();
+
+  /**
+   * Handle unused {@link IMonitor}.
+   *
+   * @param monitor The {@link IMonitor} in idle.
+   */
+  void notifyUnused(IMonitor monitor);
+}

--- a/pgjdbc/src/main/java/org/postgresql/pluginmanager/efm/Monitor.java
+++ b/pgjdbc/src/main/java/org/postgresql/pluginmanager/efm/Monitor.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright (c) 2022, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.pluginmanager.efm;
+
+import org.postgresql.PGProperty;
+import org.postgresql.core.BaseConnection;
+import org.postgresql.pluginmanager.ConnectionProvider;
+import org.postgresql.util.HostSpec;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Comparator;
+import java.util.Properties;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.logging.Logger;
+
+/**
+ * This class uses a background thread to monitor a particular server with one or more
+ * active {@link Connection}.
+ */
+public class Monitor implements IMonitor {
+
+  private static final transient Logger LOGGER = Logger.getLogger(Monitor.class.getName());
+  private static final int THREAD_SLEEP_WHEN_INACTIVE_MILLIS = 100;
+  private static final String MONITORING_PROPERTY_PREFIX = "monitoring-";
+  private final Queue<MonitorConnectionContext> contexts = new ConcurrentLinkedQueue<>();
+  private final ConnectionProvider connectionProvider;
+  private final HostSpec hostSpec;
+  private final AtomicLong lastContextUsedTimestamp = new AtomicLong();
+  private final int monitorDisposalTime;
+  private final IMonitorService monitorService;
+  private final AtomicBoolean stopped = new AtomicBoolean(true);
+  private Properties props;
+  private @Nullable BaseConnection monitoringConn = null;
+  private int connectionCheckIntervalMillis = Integer.MAX_VALUE;
+
+  /**
+   * Store the monitoring configuration for a connection.
+   *
+   * @param connectionProvider  A provider for creating new connections.
+   * @param hostSpec            The {@link HostSpec} of the server this {@link Monitor} instance is
+   *                            monitoring.
+   * @param props               The {@link Properties} containing additional monitoring
+   *                            configuration.
+   * @param monitorDisposalTime Time before stopping the monitoring thread where there are
+   *                            no active connection to the server this {@link Monitor}
+   *                            instance is monitoring.
+   * @param monitorService      A reference to the {@link DefaultMonitorService} implementation
+   *                            that initialized this class.
+   */
+  public Monitor(
+      ConnectionProvider connectionProvider,
+      HostSpec hostSpec,
+      Properties props,
+      int monitorDisposalTime,
+      IMonitorService monitorService) {
+    this.connectionProvider = connectionProvider;
+    this.hostSpec = hostSpec;
+    this.props = props;
+    this.monitorDisposalTime = monitorDisposalTime;
+    this.monitorService = monitorService;
+  }
+
+  @Override
+  public synchronized void startMonitoring(MonitorConnectionContext context) {
+    this.connectionCheckIntervalMillis = Math.min(
+        this.connectionCheckIntervalMillis,
+        context.getFailureDetectionIntervalMillis());
+    final long currentTime = this.getCurrentTimeMillis();
+    context.setStartMonitorTime(currentTime);
+    this.lastContextUsedTimestamp.set(currentTime);
+    this.contexts.add(context);
+  }
+
+  @Override
+  public synchronized void stopMonitoring(@Nullable MonitorConnectionContext context) {
+    if (context == null) {
+      LOGGER.warning(ErrorMessageUtil.getMessage("context"));
+      return;
+    }
+    synchronized (context) {
+      this.contexts.remove(context);
+      context.invalidate();
+    }
+    this.connectionCheckIntervalMillis = findShortestIntervalMillis();
+  }
+
+  public synchronized void clearContexts() {
+    this.contexts.clear();
+    this.connectionCheckIntervalMillis = findShortestIntervalMillis();
+  }
+
+  @Override
+  public void run() {
+    try {
+      this.stopped.set(false);
+      while (true) {
+        if (!this.contexts.isEmpty()) {
+          final long currentTime = this.getCurrentTimeMillis();
+          this.lastContextUsedTimestamp.set(currentTime);
+
+          final ConnectionStatus status =
+              checkConnectionStatus(this.getConnectionCheckIntervalMillis());
+
+          for (MonitorConnectionContext monitorContext : this.contexts) {
+            monitorContext.updateConnectionStatus(
+                currentTime,
+                status.isValid);
+          }
+
+          TimeUnit.MILLISECONDS.sleep(
+              Math.max(0, this.getConnectionCheckIntervalMillis() - status.elapsedTime));
+        } else {
+          if ((this.getCurrentTimeMillis() - this.lastContextUsedTimestamp.get())
+              >= this.monitorDisposalTime) {
+            monitorService.notifyUnused(this);
+            break;
+          }
+          TimeUnit.MILLISECONDS.sleep(THREAD_SLEEP_WHEN_INACTIVE_MILLIS);
+        }
+      }
+    } catch (InterruptedException intEx) {
+      // do nothing; exit thread
+    } finally {
+      if (this.monitoringConn != null) {
+        try {
+          this.monitoringConn.close();
+        } catch (SQLException ex) {
+          // ignore
+        }
+      }
+      this.stopped.set(true);
+    }
+  }
+
+  /**
+   * Check the status of the monitored server by sending a ping.
+   *
+   * @param shortestFailureDetectionIntervalMillis The shortest failure detection interval
+   *                                               used by all the connections to this server.
+   *                                               This value is used as the maximum time
+   *                                               to wait for a response from the server.
+   * @return whether the server is still alive and the elapsed time spent checking.
+   */
+  ConnectionStatus checkConnectionStatus(final int shortestFailureDetectionIntervalMillis) {
+    long start = this.getCurrentTimeMillis();
+    try {
+      if (this.monitoringConn == null || this.monitoringConn.isClosed()) {
+        // open a new connection
+        Properties monitoringProps = new Properties();
+        monitoringProps.setProperty(PGProperty.USER.getName(), PGProperty.USER.get(props));
+        monitoringProps.setProperty(PGProperty.PASSWORD.getName(), PGProperty.PASSWORD.get(props));
+        monitoringProps.setProperty("PGDBNAME", props.getProperty("PGDBNAME"));
+
+        this.props.stringPropertyNames().stream()
+            .filter(p -> p.startsWith(MONITORING_PROPERTY_PREFIX))
+            .forEach(p -> monitoringProps.setProperty(
+                p.substring(MONITORING_PROPERTY_PREFIX.length()),
+                this.props.getProperty(p)));
+
+        start = this.getCurrentTimeMillis();
+        this.monitoringConn = this.connectionProvider.connect(
+            new HostSpec[]{new HostSpec(this.hostSpec.getHost(), this.hostSpec.getPort())},
+            monitoringProps,
+            null);
+        return new ConnectionStatus(true, this.getCurrentTimeMillis() - start);
+      }
+
+      start = this.getCurrentTimeMillis();
+      boolean isValid =
+          this.monitoringConn.isValid(shortestFailureDetectionIntervalMillis / 1000);
+      return new ConnectionStatus(isValid, this.getCurrentTimeMillis() - start);
+    } catch (SQLException sqlEx) {
+      return new ConnectionStatus(false, this.getCurrentTimeMillis() - start);
+    }
+  }
+
+  // This method helps to organize unit tests.
+  long getCurrentTimeMillis() {
+    return System.currentTimeMillis();
+  }
+
+  int getConnectionCheckIntervalMillis() {
+    if (this.connectionCheckIntervalMillis == Integer.MAX_VALUE) {
+      // connectionCheckIntervalMillis is at Integer.MAX_VALUE because there are no contexts
+      // available.
+      return 0;
+    }
+    return this.connectionCheckIntervalMillis;
+  }
+
+  @Override
+  public boolean isStopped() {
+    return this.stopped.get();
+  }
+
+  private int findShortestIntervalMillis() {
+    if (this.contexts.isEmpty()) {
+      return Integer.MAX_VALUE;
+    }
+
+    return this.contexts.stream()
+        .min(Comparator.comparing(MonitorConnectionContext::getFailureDetectionIntervalMillis))
+        .map(MonitorConnectionContext::getFailureDetectionIntervalMillis)
+        .orElse(0);
+  }
+
+  static class ConnectionStatus {
+    boolean isValid;
+    long elapsedTime;
+
+    ConnectionStatus(boolean isValid, long elapsedTime) {
+      this.isValid = isValid;
+      this.elapsedTime = elapsedTime;
+    }
+  }
+}

--- a/pgjdbc/src/main/java/org/postgresql/pluginmanager/efm/MonitorConnectionContext.java
+++ b/pgjdbc/src/main/java/org/postgresql/pluginmanager/efm/MonitorConnectionContext.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright (c) 2022, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.pluginmanager.efm;
+
+import org.postgresql.core.BaseConnection;
+
+import java.sql.SQLException;
+import java.util.Set;
+import java.util.logging.Logger;
+
+/**
+ * Monitoring context for each connection. This contains each connection's criteria for
+ * whether a server should be considered unhealthy.
+ */
+public class MonitorConnectionContext {
+
+  private static final transient Logger LOGGER =
+      Logger.getLogger(MonitorConnectionContext.class.getName());
+
+  private final int failureDetectionIntervalMillis;
+  private final int failureDetectionTimeMillis;
+  private final int failureDetectionCount;
+
+  private final Set<String> nodeKeys;
+  private final BaseConnection connectionToAbort;
+
+  private long startMonitorTime;
+  private long invalidNodeStartTime;
+  private int failureCount;
+  private boolean nodeUnhealthy;
+  private boolean activeContext = true;
+
+  /**
+   * Constructor.
+   *
+   * @param connectionToAbort              A reference to the connection associated with this
+   *                                       context
+   *                                       that will be aborted in case of server failure.
+   * @param nodeKeys                       All valid references to the server.
+   * @param failureDetectionTimeMillis     Grace period after which node monitoring starts.
+   * @param failureDetectionIntervalMillis Interval between each failed connection check.
+   * @param failureDetectionCount          Number of failed connection checks before considering
+   *                                       database node as unhealthy.
+   */
+  public MonitorConnectionContext(
+      BaseConnection connectionToAbort,
+      Set<String> nodeKeys,
+      int failureDetectionTimeMillis,
+      int failureDetectionIntervalMillis,
+      int failureDetectionCount) {
+    this.connectionToAbort = connectionToAbort;
+    this.nodeKeys = nodeKeys;
+    this.failureDetectionTimeMillis = failureDetectionTimeMillis;
+    this.failureDetectionIntervalMillis = failureDetectionIntervalMillis;
+    this.failureDetectionCount = failureDetectionCount;
+  }
+
+  void setStartMonitorTime(long startMonitorTime) {
+    this.startMonitorTime = startMonitorTime;
+  }
+
+  Set<String> getNodeKeys() {
+    return this.nodeKeys;
+  }
+
+  public int getFailureDetectionTimeMillis() {
+    return failureDetectionTimeMillis;
+  }
+
+  public int getFailureDetectionIntervalMillis() {
+    return failureDetectionIntervalMillis;
+  }
+
+  public int getFailureDetectionCount() {
+    return failureDetectionCount;
+  }
+
+  public int getFailureCount() {
+    return this.failureCount;
+  }
+
+  void setFailureCount(int failureCount) {
+    this.failureCount = failureCount;
+  }
+
+  void resetInvalidNodeStartTime() {
+    this.invalidNodeStartTime = 0;
+  }
+
+  boolean isInvalidNodeStartTimeDefined() {
+    return this.invalidNodeStartTime > 0;
+  }
+
+  public long getInvalidNodeStartTime() {
+    return this.invalidNodeStartTime;
+  }
+
+  void setInvalidNodeStartTime(long invalidNodeStartTimeMillis) {
+    this.invalidNodeStartTime = invalidNodeStartTimeMillis;
+  }
+
+  public boolean isNodeUnhealthy() {
+    return this.nodeUnhealthy;
+  }
+
+  void setNodeUnhealthy(boolean nodeUnhealthy) {
+    this.nodeUnhealthy = nodeUnhealthy;
+  }
+
+  public boolean isActiveContext() {
+    return this.activeContext;
+  }
+
+  public void invalidate() {
+    this.activeContext = false;
+  }
+
+  synchronized void abortConnection() {
+    if (this.connectionToAbort == null || !this.activeContext) {
+      return;
+    }
+
+    try {
+      this.connectionToAbort.close(); // TODO: should we do abort()?
+    } catch (SQLException sqlEx) {
+      // ignore
+      LOGGER.finest(String.format("Exception during aborting connection: %s", sqlEx.getMessage()));
+    }
+  }
+
+  /**
+   * Update whether the connection is still valid if the total elapsed time has passed the
+   * grace period.
+   *
+   * @param currentTime The time when this method is called.
+   * @param isValid     Whether the connection is valid.
+   */
+  public void updateConnectionStatus(
+      long currentTime,
+      boolean isValid) {
+    if (!this.activeContext) {
+      return;
+    }
+
+    final long totalElapsedTimeMillis = currentTime - this.startMonitorTime;
+
+    if (totalElapsedTimeMillis > this.failureDetectionTimeMillis) {
+      this.setConnectionValid(isValid, currentTime);
+    }
+  }
+
+  /**
+   * Set whether the connection to the server is still valid based on the monitoring
+   * settings set in the {@link BaseConnection}.
+   *
+   * <p>These monitoring settings include:
+   * <ul>
+   *   <li>{@code failureDetectionInterval}</li>
+   *   <li>{@code failureDetectionTime}</li>
+   *   <li>{@code failureDetectionCount}</li>
+   * </ul>
+   *
+   * @param connectionValid Boolean indicating whether the server is still responsive.
+   * @param currentTime     The time when this method is invoked in milliseconds.
+   */
+  void setConnectionValid(
+      boolean connectionValid,
+      long currentTime) {
+    if (!connectionValid) {
+      this.failureCount++;
+
+      if (!this.isInvalidNodeStartTimeDefined()) {
+        this.setInvalidNodeStartTime(currentTime);
+      }
+
+      final long invalidNodeDurationMillis = currentTime - this.getInvalidNodeStartTime();
+      final long maxInvalidNodeDurationMillis =
+          (long) this.getFailureDetectionIntervalMillis() * this.getFailureDetectionCount();
+
+      if (invalidNodeDurationMillis >= maxInvalidNodeDurationMillis) {
+        LOGGER.fine(String.format("Node '%s' is *dead*.", nodeKeys));
+        this.setNodeUnhealthy(true);
+        this.abortConnection();
+        return;
+      }
+
+      LOGGER.fine(String.format("Node '%s' is not *responding* (%d).", nodeKeys,
+          this.getFailureCount()));
+      return;
+    }
+
+    this.setFailureCount(0);
+    this.resetInvalidNodeStartTime();
+    this.setNodeUnhealthy(false);
+
+    LOGGER.fine(String.format("Node '%s' is *alive*.", nodeKeys));
+  }
+}

--- a/pgjdbc/src/main/java/org/postgresql/pluginmanager/efm/MonitorThreadContainer.java
+++ b/pgjdbc/src/main/java/org/postgresql/pluginmanager/efm/MonitorThreadContainer.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2022, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.pluginmanager.efm;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
+/**
+ * This singleton class keeps track of all the monitoring threads and handles the creation
+ * and clean up of each monitoring thread.
+ */
+public class MonitorThreadContainer {
+  private static final AtomicInteger CLASS_USAGE_COUNT = new AtomicInteger();
+  private static final Object LOCK_OBJECT = new Object();
+  private static MonitorThreadContainer singleton = null;
+  private final Map<String, IMonitor> monitorMap = new ConcurrentHashMap<>();
+  private final Map<IMonitor, Future<?>> tasksMap = new ConcurrentHashMap<>();
+  private final Queue<IMonitor> availableMonitors = new ConcurrentLinkedDeque<>();
+  private final ExecutorService threadPool;
+
+  private MonitorThreadContainer(IExecutorServiceInitializer executorServiceInitializer) {
+    this.threadPool = executorServiceInitializer.createExecutorService();
+  }
+
+  /**
+   * Create an instance of the {@link MonitorThreadContainer}.
+   *
+   * @return a singleton instance of the {@link MonitorThreadContainer}.
+   */
+  public static MonitorThreadContainer getInstance() {
+    return getInstance(Executors::newCachedThreadPool);
+  }
+
+  static MonitorThreadContainer getInstance(
+      IExecutorServiceInitializer executorServiceInitializer) {
+    if (singleton == null) {
+      synchronized (LOCK_OBJECT) {
+        singleton = new MonitorThreadContainer(executorServiceInitializer);
+      }
+      CLASS_USAGE_COUNT.set(0);
+    }
+    CLASS_USAGE_COUNT.getAndIncrement();
+    return singleton;
+  }
+
+  /**
+   * Release resources held in the {@link MonitorThreadContainer} and clear references
+   * to the container.
+   */
+  public static void releaseInstance() {
+    if (singleton == null) {
+      return;
+    }
+
+    if (CLASS_USAGE_COUNT.decrementAndGet() <= 0) {
+      synchronized (LOCK_OBJECT) {
+        singleton.releaseResources();
+        singleton = null;
+      }
+    }
+  }
+
+  public Map<String, IMonitor> getMonitorMap() {
+    return monitorMap;
+  }
+
+  public Map<IMonitor, Future<?>> getTasksMap() {
+    return tasksMap;
+  }
+
+  public ExecutorService getThreadPool() {
+    return threadPool;
+  }
+
+  String getNode(Set<String> nodeKeys) {
+    return getNode(nodeKeys, null);
+  }
+
+  String getNode(Set<String> nodeKeys, String defaultValue) {
+    return nodeKeys
+        .stream().filter(monitorMap::containsKey)
+        .findAny()
+        .orElse(defaultValue);
+  }
+
+  IMonitor getMonitor(String node) {
+    return monitorMap.get(node);
+  }
+
+  IMonitor getOrCreateMonitor(Set<String> nodeKeys, Supplier<IMonitor> monitorSupplier) {
+    final String node = getNode(nodeKeys, nodeKeys.iterator().next());
+    final IMonitor monitor = monitorMap.computeIfAbsent(node, k -> {
+      if (!availableMonitors.isEmpty()) {
+        final IMonitor availableMonitor = availableMonitors.remove();
+        if (!availableMonitor.isStopped()) {
+          return availableMonitor;
+        }
+        tasksMap.computeIfPresent(availableMonitor, (key, v) -> {
+          v.cancel(true);
+          return null;
+        });
+      }
+
+      return monitorSupplier.get();
+    });
+
+    populateMonitorMap(nodeKeys, monitor);
+    return monitor;
+  }
+
+  private void populateMonitorMap(Set<String> nodeKeys, IMonitor monitor) {
+    for (String nodeKey : nodeKeys) {
+      monitorMap.putIfAbsent(nodeKey, monitor);
+    }
+  }
+
+  void addTask(IMonitor monitor) {
+    tasksMap.computeIfAbsent(monitor, k -> threadPool.submit(monitor));
+  }
+
+  /**
+   * Clear all references used by the given monitor.
+   * Put the monitor in to a queue waiting to be reused.
+   *
+   * @param monitor The monitor to reset.
+   */
+  public void resetResource(IMonitor monitor) {
+    if (monitor == null) {
+      return;
+    }
+
+    final List<IMonitor> monitorList = Collections.singletonList(monitor);
+    monitorMap.values().removeAll(monitorList);
+    availableMonitors.add(monitor);
+  }
+
+  /**
+   * Remove references to the given {@link Monitor} object and stop the background monitoring
+   * thread.
+   *
+   * @param monitor The {@link Monitor} representing a monitoring thread.
+   */
+  public void releaseResource(IMonitor monitor) {
+    if (monitor == null) {
+      return;
+    }
+
+    final List<IMonitor> monitorList = Collections.singletonList(monitor);
+    monitorMap.values().removeAll(monitorList);
+    tasksMap.computeIfPresent(monitor, (k, v) -> {
+      v.cancel(true);
+      return null;
+    });
+  }
+
+  private void releaseResources() {
+    monitorMap.clear();
+    tasksMap.values().stream()
+        .filter(val -> !val.isDone() && !val.isCancelled())
+        .forEach(val -> val.cancel(true));
+
+    if (threadPool != null) {
+      threadPool.shutdownNow();
+    }
+  }
+}

--- a/pgjdbc/src/main/java/org/postgresql/pluginmanager/efm/NodeMonitoringConnectionPlugin.java
+++ b/pgjdbc/src/main/java/org/postgresql/pluginmanager/efm/NodeMonitoringConnectionPlugin.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright (c) 2022, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.pluginmanager.efm;
+
+import static org.postgresql.util.internal.Nullness.castNonNull;
+
+import org.postgresql.PGProperty;
+import org.postgresql.core.BaseConnection;
+import org.postgresql.pluginmanager.ConnectionPlugin;
+import org.postgresql.pluginmanager.CurrentConnectionProvider;
+import org.postgresql.util.HostSpec;
+import org.postgresql.util.PSQLException;
+import org.postgresql.util.PSQLState;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.function.Supplier;
+import java.util.logging.Logger;
+
+/**
+ * Monitor the server while the connection is executing methods for more sophisticated
+ * failure detection.
+ */
+public class NodeMonitoringConnectionPlugin implements ConnectionPlugin {
+
+  private static final String RETRIEVE_HOST_PORT_SQL =
+      "SELECT CONCAT(inet_server_addr( ), ':', inet_server_port( ))";
+  private static final List<String> METHODS_STARTING_WITH = Arrays.asList("get", "abort");
+  private static final List<String> METHODS_EQUAL_TO = Arrays.asList("close", "next");
+
+  private static final transient Logger LOGGER =
+      Logger.getLogger(NodeMonitoringConnectionPlugin.class.getName());
+  private static final Set<String> subscribedMethods =
+      Collections.unmodifiableSet(new HashSet<>(Arrays.asList("Statement.executeQuery")));
+  private final Supplier<IMonitorService> monitorServiceSupplier;
+  private final Set<String> nodeKeys = new HashSet<>();
+  private final CurrentConnectionProvider currentConnectionProvider;
+  protected Properties props;
+  private @Nullable IMonitorService monitorService;
+  private BaseConnection connection;
+
+  /**
+   * Initialize the node monitoring plugin.
+   *
+   * @param currentConnectionProvider A provider allowing the plugin to retrieve the
+   *                                  current active connection and its connection settings.
+   * @param props                     The property set used to initialize the active connection.
+   */
+  public NodeMonitoringConnectionPlugin(
+      CurrentConnectionProvider currentConnectionProvider,
+      Properties props) {
+    this(
+        currentConnectionProvider,
+        props,
+        DefaultMonitorService::new);
+  }
+
+  NodeMonitoringConnectionPlugin(
+      CurrentConnectionProvider currentConnectionProvider,
+      Properties props,
+      Supplier<IMonitorService> monitorServiceSupplier) {
+
+    assertArgumentIsNotNull(currentConnectionProvider, "currentConnectionProvider");
+    assertArgumentIsNotNull(props, "props");
+
+    this.currentConnectionProvider = currentConnectionProvider;
+    this.connection = currentConnectionProvider.getCurrentConnection();
+    this.props = props;
+    this.monitorServiceSupplier = monitorServiceSupplier;
+
+    generateNodeKeys(this.currentConnectionProvider.getCurrentConnection());
+  }
+
+  @Override
+  public Set<String> getSubscribedMethods() {
+    // TODO: adjust according to the code
+    return subscribedMethods;
+  }
+
+  /**
+   * Executes the given SQL function with {@link Monitor} if connection monitoring is enabled.
+   * Otherwise, executes the SQL function directly.
+   *
+   * @param methodInvokeOn Class of an object that method to monitor to be invoked on.
+   * @param methodName     Name of the method to monitor.
+   * @param executeSqlFunc {@link Callable} SQL function.
+   * @param args           method arguments.
+   * @return Results of the {@link Callable} SQL function.
+   * @throws Exception if an error occurs.
+   */
+  @Override
+  public Object execute(
+      Class<?> methodInvokeOn,
+      String methodName,
+      Callable<?> executeSqlFunc,
+      Object[] args) throws Exception {
+    // update config settings since they may change
+    final boolean isEnabled = PGProperty.FAILURE_DETECTION_ENABLED.getBoolean(props);
+
+    if (!isEnabled || !this.doesNeedMonitoring(methodInvokeOn, methodName)) {
+      // do direct call
+      return executeSqlFunc.call();
+    }
+    // ... otherwise, use a separate thread to execute method
+
+    final int failureDetectionTimeMillis = PGProperty.FAILURE_DETECTION_TIME.getInt(props);
+    final int failureDetectionIntervalMillis = PGProperty.FAILURE_DETECTION_INTERVAL.getInt(props);
+    final int failureDetectionCount = PGProperty.FAILURE_DETECTION_COUNT.getInt(props);
+
+    initMonitorService();
+
+    Object result;
+    MonitorConnectionContext monitorContext = null;
+
+    try {
+      LOGGER.fine(String.format(
+          "method=%s.%s, monitoring is activated",
+          methodInvokeOn.getName(),
+          methodName));
+
+      this.checkIfChanged(this.currentConnectionProvider.getCurrentConnection());
+
+      monitorContext = castNonNull(this.monitorService).startMonitoring(
+          this.connection, //abort current connection if needed
+          this.nodeKeys,
+          this.currentConnectionProvider.getCurrentHostSpec(),
+          this.props,
+          failureDetectionTimeMillis,
+          failureDetectionIntervalMillis,
+          failureDetectionCount);
+
+      result = executeSqlFunc.call();
+
+    } finally {
+      if (monitorContext != null) {
+        this.monitorService.stopMonitoring(monitorContext);
+        synchronized (monitorContext) {
+          if (monitorContext.isNodeUnhealthy() && !this.connection.isClosed()) {
+            abortConnection();
+            throw new PSQLException("Node is unavailable.", PSQLState.CONNECTION_FAILURE);
+          }
+        }
+      }
+      LOGGER.fine(String.format(
+          "method=%s.%s, monitoring is deactivated",
+          methodInvokeOn.getName(),
+          methodName));
+    }
+
+    return result;
+  }
+
+  void abortConnection() {
+    try {
+      this.connection.close(); //TODO: should we abort()
+    } catch (SQLException sqlEx) {
+      // ignore
+    }
+  }
+
+  /**
+   * Checks whether the JDBC method passed to this connection plugin requires monitoring.
+   *
+   * @param methodInvokeOn The class of the JDBC method.
+   * @param methodName     Name of the JDBC method.
+   * @return true if the method requires monitoring; false otherwise.
+   */
+  protected boolean doesNeedMonitoring(Class<?> methodInvokeOn, String methodName) {
+    // It's possible to use the following, or similar, expressions to verify method invocation class
+    //
+    // boolean isJdbcConnection = JdbcConnection.class.isAssignableFrom(methodInvokeOn) ||
+    // ClusterAwareConnectionProxy.class.isAssignableFrom(methodInvokeOn);
+    // boolean isJdbcStatement = Statement.class.isAssignableFrom(methodInvokeOn);
+    // boolean isJdbcResultSet = ResultSet.class.isAssignableFrom(methodInvokeOn);
+
+    for (final String method : METHODS_STARTING_WITH) {
+      if (methodName.startsWith(method)) {
+        return false;
+      }
+    }
+
+    for (final String method : METHODS_EQUAL_TO) {
+      if (method.equals(methodName)) {
+        return false;
+      }
+    }
+
+    // Monitor all the other methods
+    return true;
+  }
+
+  private void initMonitorService() {
+    if (this.monitorService == null) {
+      this.monitorService = this.monitorServiceSupplier.get();
+    }
+  }
+
+  @Override
+  public void openInitialConnection(HostSpec[] hostSpecs, Properties props, String url,
+      Callable<Void> openInitialConnectionFunc) throws Exception {
+    // Intentionally do nothing.
+    // This plugin is not subscribed for "openInitialConnection" method so this method won't be
+    // ever called.
+  }
+
+  /**
+   * Call this plugin's monitor service to release all resources associated with this
+   * plugin.
+   */
+  @Override
+  public void releaseResources() {
+    if (this.monitorService != null) {
+      this.monitorService.releaseResources();
+    }
+
+    this.monitorService = null;
+  }
+
+  private void assertArgumentIsNotNull(Object param, String paramName) {
+    if (param == null) {
+      throw new IllegalArgumentException(ErrorMessageUtil.getMessage(paramName));
+    }
+  }
+
+  /**
+   * Check if the connection has changed.
+   * If so, remove monitor's references to that node and
+   * regenerate the set of node keys referencing the node that requires monitoring.
+   *
+   * @param newConnection The connection used by {@link CurrentConnectionProvider}.
+   */
+  private void checkIfChanged(BaseConnection newConnection) {
+    final boolean isSameConnection = this.connection.equals(newConnection);
+    if (!isSameConnection) {
+      castNonNull(this.monitorService).stopMonitoringForAllConnections(this.nodeKeys);
+      this.connection = newConnection;
+      generateNodeKeys(this.connection);
+    }
+  }
+
+  /**
+   * Generate a set of node keys representing the node to monitor.
+   *
+   * @param connection the connection to a specific node.
+   */
+  private void generateNodeKeys(BaseConnection connection) {
+    this.nodeKeys.clear();
+    try (Statement stmt = connection.createStatement()) {
+      try (ResultSet rs = stmt.executeQuery(RETRIEVE_HOST_PORT_SQL)) {
+        while (rs.next()) {
+          this.nodeKeys.add(rs.getString(1));
+        }
+      }
+    } catch (SQLException sqlException) {
+      // log and ignore
+      LOGGER.finest("Could not retrieve Host:Port from querying");
+    }
+
+    final HostSpec hostSpec = this.currentConnectionProvider.getCurrentHostSpec();
+    this.nodeKeys.add(String.format("%s:%s", hostSpec.getHost(), hostSpec.getPort()));
+    LOGGER.fine("Node keys: " + this.nodeKeys);
+  }
+}

--- a/pgjdbc/src/main/java/org/postgresql/pluginmanager/efm/NodeMonitoringConnectionPluginFactory.java
+++ b/pgjdbc/src/main/java/org/postgresql/pluginmanager/efm/NodeMonitoringConnectionPluginFactory.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2022, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.pluginmanager.efm;
+
+import org.postgresql.pluginmanager.ConnectionPlugin;
+import org.postgresql.pluginmanager.ConnectionPluginFactory;
+import org.postgresql.pluginmanager.CurrentConnectionProvider;
+
+import java.util.Properties;
+
+/**
+ * Class initializing a {@link NodeMonitoringConnectionPlugin}.
+ */
+public class NodeMonitoringConnectionPluginFactory implements ConnectionPluginFactory {
+  @Override
+  public ConnectionPlugin getInstance(
+      CurrentConnectionProvider currentConnectionProvider,
+      Properties props) {
+    return new NodeMonitoringConnectionPlugin(currentConnectionProvider, props);
+  }
+}

--- a/pgjdbc/src/main/java/org/postgresql/pluginmanager/simple/DummyConnectionPlugin.java
+++ b/pgjdbc/src/main/java/org/postgresql/pluginmanager/simple/DummyConnectionPlugin.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2022, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.pluginmanager.simple;
+
+import org.postgresql.pluginmanager.ConnectionPlugin;
+import org.postgresql.util.HostSpec;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.logging.Logger;
+
+public class DummyConnectionPlugin implements ConnectionPlugin {
+
+  private static final transient Logger LOGGER =
+      Logger.getLogger(DummyConnectionPlugin.class.getName());
+  private static final Set<String> subscribedMethods =
+      Collections.unmodifiableSet(new HashSet<>(Arrays.asList("*")));
+
+  @Override
+  public Set<String> getSubscribedMethods() {
+    return subscribedMethods;
+  }
+
+  @Override
+  public Object execute(
+      Class<?> methodInvokeOn,
+      String methodName,
+      Callable<?> executeJdbcMethod, Object[] args)
+      throws Exception {
+
+    return executeJdbcMethod.call();
+  }
+
+  @Override
+  public void openInitialConnection(HostSpec[] hostSpecs, Properties props, String url,
+      Callable<Void> openInitialConnectionFunc) throws Exception {
+
+    // Intentionally do nothing.
+    // This plugin is not subscribed for "openInitialConnection" method so this method won't be
+    // ever called.
+  }
+
+  @Override
+  public void releaseResources() {
+    // no resources to release
+  }
+}

--- a/pgjdbc/src/main/java/org/postgresql/pluginmanager/simple/DummyConnectionPluginFactory.java
+++ b/pgjdbc/src/main/java/org/postgresql/pluginmanager/simple/DummyConnectionPluginFactory.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2022, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.pluginmanager.simple;
+
+import org.postgresql.pluginmanager.ConnectionPlugin;
+import org.postgresql.pluginmanager.ConnectionPluginFactory;
+import org.postgresql.pluginmanager.CurrentConnectionProvider;
+
+import java.util.Properties;
+
+/**
+ * Class initializing a {@link ExecutionTimeConnectionPlugin}.
+ */
+public class DummyConnectionPluginFactory implements ConnectionPluginFactory {
+  @Override
+  public ConnectionPlugin getInstance(
+      CurrentConnectionProvider currentConnectionProvider,
+      Properties props) {
+    return new DummyConnectionPlugin();
+  }
+}

--- a/pgjdbc/src/main/java/org/postgresql/pluginmanager/simple/ExecutionTimeConnectionPlugin.java
+++ b/pgjdbc/src/main/java/org/postgresql/pluginmanager/simple/ExecutionTimeConnectionPlugin.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2022, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.pluginmanager.simple;
+
+import org.postgresql.pluginmanager.ConnectionPlugin;
+import org.postgresql.util.HostSpec;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * This connection plugin tracks the execution time of all the given JDBC method throughout
+ * the lifespan of the current connection.
+ *
+ * <p>During the cleanup phase when {@link ExecutionTimeConnectionPlugin#releaseResources()}
+ * is called, this plugin logs all the methods executed and time spent on each execution
+ * in milliseconds.
+ */
+public class ExecutionTimeConnectionPlugin implements ConnectionPlugin {
+
+  private static final transient Logger LOGGER =
+      Logger.getLogger(ExecutionTimeConnectionPlugin.class.getName());
+  private static final Set<String> subscribedMethods =
+      Collections.unmodifiableSet(new HashSet<>(Arrays.asList("*")));
+
+  final long initializeTime;
+  private final Map<String, Long> methodExecutionTimes = new HashMap<>();
+
+  public ExecutionTimeConnectionPlugin() {
+    initializeTime = System.nanoTime();
+  }
+
+  @Override
+  public Set<String> getSubscribedMethods() {
+    return subscribedMethods;
+  }
+
+  @Override
+  public Object execute(
+      Class<?> methodInvokeOn,
+      String methodName,
+      Callable<?> executeJdbcMethod, Object[] args)
+      throws Exception {
+
+    // This `execute` measures the time it takes for the remaining connection plugins to
+    // execute the given method call.
+    final long startTime = System.nanoTime();
+
+    final Object executeResult = executeJdbcMethod.call();
+
+    final long elapsedTime = System.nanoTime() - startTime;
+    methodExecutionTimes.merge(
+        methodName,
+        elapsedTime / 1000000,
+        Long::sum);
+
+    if (methodName == "Connection.close") {
+      printExecutionTimes();
+    }
+    return executeResult;
+  }
+
+  @Override
+  public void openInitialConnection(HostSpec[] hostSpecs, Properties props, String url,
+      Callable<Void> openInitialConnectionFunc) throws Exception {
+
+    // Intentionally do nothing.
+    // This plugin is not subscribed for "openInitialConnection" method so this method won't be
+    // ever called.
+  }
+
+  @Override
+  public void releaseResources() {
+    printExecutionTimes();
+  }
+
+  protected void printExecutionTimes() {
+    // Output the aggregated information from all methods called throughout the lifespan
+    // of the current connection.
+    final long connectionUptime = System.nanoTime() - initializeTime;
+    final String leftAlignFormat = "| %-40s | %10s |\n";
+    final StringBuilder logMessage = new StringBuilder();
+
+    logMessage.append("** ExecutionTimeConnectionPlugin Summary **\n");
+    logMessage.append(String.format(
+        "Connection Uptime: %d ms\n",
+        connectionUptime / 1000000
+    ));
+
+    logMessage
+        .append("** Method Execution Time **\n")
+        .append("+------------------------------------------+------------+\n")
+        .append("| Method Executed                          | Total Time |\n")
+        .append("+------------------------------------------+------------+\n");
+
+    methodExecutionTimes.forEach((key, val) -> logMessage.append(String.format(
+        leftAlignFormat,
+        key,
+        val + " ms")));
+    logMessage.append("+------------------------------------------+------------+\n");
+    LOGGER.log(Level.INFO, logMessage.toString());
+
+    methodExecutionTimes.clear();
+  }
+}

--- a/pgjdbc/src/main/java/org/postgresql/pluginmanager/simple/ExecutionTimeConnectionPluginFactory.java
+++ b/pgjdbc/src/main/java/org/postgresql/pluginmanager/simple/ExecutionTimeConnectionPluginFactory.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2022, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.pluginmanager.simple;
+
+import org.postgresql.pluginmanager.ConnectionPlugin;
+import org.postgresql.pluginmanager.ConnectionPluginFactory;
+import org.postgresql.pluginmanager.CurrentConnectionProvider;
+
+import java.util.Properties;
+
+/**
+ * Class initializing a {@link ExecutionTimeConnectionPlugin}.
+ */
+public class ExecutionTimeConnectionPluginFactory implements ConnectionPluginFactory {
+  @Override
+  public ConnectionPlugin getInstance(
+      CurrentConnectionProvider currentConnectionProvider,
+      Properties props) {
+    return new ExecutionTimeConnectionPlugin();
+  }
+}

--- a/pgjdbc/src/main/java/org/postgresql/util/Util.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/Util.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright (c) 2022, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.util;
+
+import org.checkerframework.checker.nullness.qual.EnsuresNonNullIf;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class Util {
+
+  private static final ConcurrentMap<Class<?>, Class<?>[]> getImplementedInterfacesCache = new ConcurrentHashMap<>();
+  private static final ConcurrentMap<Class<?>, Boolean> isJdbcInterfaceCache = new ConcurrentHashMap<>();
+
+  /**
+   * Check whether the given package is a JDBC package
+   *
+   * @param packageName the name of the package to analyze
+   * @return true if the given package is a JDBC package
+   */
+  public static boolean isJdbcPackage(@Nullable String packageName) {
+    return packageName != null
+        && (packageName.startsWith("java.sql")
+        || packageName.startsWith("javax.sql")
+        || packageName.startsWith("org.postgresql"));
+  }
+
+  /**
+   * Check whether the given class implements a JDBC interface defined in a JDBC package. See {@link #isJdbcPackage(String)}
+   * Calls to this function are cached for improved efficiency.
+   *
+   * @param clazz the class to analyze
+   * @return true if the given class implements a JDBC interface
+   */
+  public static boolean isJdbcInterface(Class<?> clazz) {
+    if (Util.isJdbcInterfaceCache.containsKey(clazz)) {
+      return (Util.isJdbcInterfaceCache.get(clazz));
+    }
+
+    if (clazz.isInterface()) {
+      try {
+        Package classPackage = clazz.getPackage();
+        if (classPackage != null && isJdbcPackage(classPackage.getName())) {
+          Util.isJdbcInterfaceCache.putIfAbsent(clazz, true);
+          return true;
+        }
+      } catch (Exception ex) {
+        // Ignore any exceptions since they're caused by runtime-generated classes, or due to class load issues.
+      }
+    }
+
+    for (Class<?> iface : clazz.getInterfaces()) {
+      if (isJdbcInterface(iface)) {
+        Util.isJdbcInterfaceCache.putIfAbsent(clazz, true);
+        return true;
+      }
+    }
+
+    if (clazz.getSuperclass() != null && isJdbcInterface(clazz.getSuperclass())) {
+      Util.isJdbcInterfaceCache.putIfAbsent(clazz, true);
+      return true;
+    }
+
+    Util.isJdbcInterfaceCache.putIfAbsent(clazz, false);
+    return false;
+  }
+
+  /**
+   * Get the {@link Class} objects corresponding to the interfaces implemented by the given class. Calls to this function
+   * are cached for improved efficiency.
+   *
+   * @param clazz the class to analyze
+   * @return the interfaces implemented by the given class
+   */
+  public static Class<?>[] getImplementedInterfaces(Class<?> clazz) {
+    Class<?>[] implementedInterfaces = Util.getImplementedInterfacesCache.get(clazz);
+    if (implementedInterfaces != null) {
+      return implementedInterfaces;
+    }
+
+    Set<Class<?>> interfaces = new LinkedHashSet<>();
+    Class<?> superClass = clazz;
+    do {
+      Collections.addAll(interfaces, superClass.getInterfaces());
+    } while ((superClass = superClass.getSuperclass()) != null);
+
+    implementedInterfaces = interfaces.toArray(new Class<?>[0]);
+    Class<?>[] oldValue = Util.getImplementedInterfacesCache.putIfAbsent(clazz, implementedInterfaces);
+    if (oldValue != null) {
+      implementedInterfaces = oldValue;
+    }
+
+    return implementedInterfaces;
+  }
+
+  /**
+   * For the given {@link Throwable}, return a formatted string representation of the stack trace. This method is
+   * provided for logging purposes.
+   *
+   * @param t the throwable containing the stack trace that we want to transform into a string
+   * @param callingClass the class that is calling this method
+   * @return the formatted string representation of the stack trace attached to the given {@link Throwable}
+   */
+  public static String stackTraceToString(Throwable t, Class callingClass) {
+    StringBuilder buffer = new StringBuilder();
+    buffer.append("\n\n========== [");
+    buffer.append(callingClass.getName());
+    buffer.append("]: Exception Detected: ==========\n\n");
+
+    buffer.append(t.getClass().getName());
+
+    String exceptionMessage = t.getMessage();
+
+    if (exceptionMessage != null) {
+      buffer.append("Message: ");
+      buffer.append(exceptionMessage);
+    }
+
+    StringWriter out = new StringWriter();
+
+    PrintWriter printOut = new PrintWriter(out);
+
+    t.printStackTrace(printOut);
+
+    buffer.append("Stack Trace:\n\n");
+    buffer.append(out.toString());
+    buffer.append("============================\n\n\n");
+
+    return buffer.toString();
+  }
+
+  /**
+   * Check if the supplied string is null or empty
+   *
+   * @param s the string to analyze
+   * @return true if the supplied string is null or empty
+   */
+  @EnsuresNonNullIf(expression = "#1", result = false)
+  public static boolean isNullOrEmpty(@Nullable String s) {
+    return s == null || s.equals("");
+  }
+
+  public static <T> List<T> loadClasses(String extensionClassNames, String errorMessage) throws InstantiationException {
+
+    List<T> instances = new LinkedList<>();
+    List<String> interceptorsToCreate = split(extensionClassNames, ",", true);
+    String className = null;
+
+    try {
+      for (int i = 0, s = interceptorsToCreate.size(); i < s; i++) {
+        className = interceptorsToCreate.get(i);
+        @SuppressWarnings("unchecked")
+        T instance = (T) Class.forName(className).newInstance();
+
+        instances.add(instance);
+      }
+
+    } catch (Throwable t) {
+      throw new InstantiationException(String.format(errorMessage, className));
+    }
+
+    return instances;
+  }
+
+  /**
+   * Splits stringToSplit into a list, using the given delimiter
+   *
+   * @param stringToSplit
+   *            the string to split
+   * @param delimiter
+   *            the string to split on
+   * @param trim
+   *            should the split strings be whitespace trimmed?
+   *
+   * @return the list of strings, split by delimiter
+   *
+   * @throws IllegalArgumentException
+   *             if an error occurs
+   */
+  public static List<String> split(String stringToSplit, String delimiter, boolean trim) {
+    if (stringToSplit == null) {
+      return new ArrayList<>();
+    }
+
+    if (delimiter == null) {
+      throw new IllegalArgumentException();
+    }
+
+    String[] tokens = stringToSplit.split(delimiter, -1);
+    Stream<String> tokensStream = Arrays.asList(tokens).stream();
+    if (trim) {
+      tokensStream = tokensStream.map(String::trim);
+    }
+    return tokensStream.collect(Collectors.toList());
+  }
+
+}


### PR DESCRIPTION
# PGJDBC Plugin Manager: Support for Custom Workflows

## Background

The PGJDBC driver lacks a standard interface to extend driver functionality. Developers are unable to extend driver functionality in a flexible way while keeping main driver functionality intact.

While we have a common interface for the extension of authentication methods, it does not support new features outside of authentication that bring value to the driver. Without a common way to support additional functionality, developers are often required to develop these features in their own and potentially incompatible way. This may result in unnecessary driver forks to support custom functionality. In addition, there is no way for developers to take advantage of pre-existing functional features/extensions and "combine" them into a single driver that fits their particular use case.

## Proposal

A plugin manager is presented in this section and is an initiative to bring some structure to future driver development. Plugins can be designed and developed by 3rd party developers and can be easily shared as modular plugins where potential consumers can find a driver plugin (extension) and tailor their driver specifically to their use case.

The range of possible plugins to be developed is practically unlimited. Some potential ideas:

* **Performance Plugin:** Can intercept certain JDBC calls and gather required performance metrics. Such plugins can do analysis internally or send raw data to 3rd party systems for further deep analysis.
* **Cache Plugin**: Can intercept calls to *executeSql()*, detect a SQL statement to be executed, and to decide whether cached values may be used. Such plugins may implement a cache internally, or could be a gateway to external distributed cache systems like Redis, etc.
* **Failover Connection Plugin:** For example, this plugin could leverage the high availability cluster management that and failover transparently without the need of developers handling the logic explicitly. The Patroni cluster management system would be a good candidate for such a plugin.

The core of the plugin manager is the ***ConnectionWrapper*** class that intercepts all JDBC calls. An instance of this class is returned to the user application instead of the regular ***PGConnection*** instance. ***ConnectionWrapper*** holds an original connection instance and re-routes all calls through the plugin manager (***ConnectionPluginManager***) that is responsible for instantiating a chain of plugins and putting a JDBC call through it. In a bare minimal configuration, a ***ConnectionPluginManager*** loads an instance of ***DefaultConnectionPlugin***. This class executes the original JDBC call. The plugin manager will always put this plugin at the tail of the plugin chain and it guarantees that all plugins "wrap over" the original JDBC call and the call is properly executed.

For example, a plugin configuration is presented below. The chain of plugins may include a Failover Connection Plugin (that is shown in dotted lines since it isn't implemented), DB instance monitoring plugin, a cache plugin, and other plugins. A plugin sitting in a left position receives data output of a plugin on the right. It also can catch all exceptions that the plugin on the right can throw. Thus, an order of plugins in a chain is important and can be controlled through the driver connection string parameters. 
 
A user may decide what plugin should be at the top level (leftmost position) and which one should be taking another exact position in the chain. A good example explaining this concept is a performance plugin that may reside right before ***DefaultConnectionPlugin*** and gather performance metrics purely for JDBC calls. Or, it may take the leftmost position and measure performance of the entire plugin chain.

![PostgreSql driver plugins 2](https://user-images.githubusercontent.com/75754709/167742222-7eff1d59-f013-46c6-a661-90d2de9a3d9a.png)

One of the goals of the plugin manager design is to prevent any dangerous side effects by having  plugins (3rd party developed, not-to-be-trusted) as part of the driver. The plugin code has no access to actual JDBC call details and it only knows the called method name on a target class (**ConnectionPlugin** interface). The plugin receives no target object reference thus eliminating any continuous attempt (or the one made by mistake) to harm original JDBC calls.

Another goal of plugin manager design is to avoid using reflection since its performance implications.  
 
Since the interface between a plugin and the driver is well defined, plugin testing could be done by classic unit tests and in isolation. Plugins can be packaged and delivered separately from the driver and that greatly simplifies testing, deployment and licensing.

## Implementation Notes

* Important classes to pay attention to in the review:

    * **ConnectionPlugin**
    * **ConnectionPluginManager**
    * **ConnectionWrapper**
    * **DummyConnectionPlugin** *(Sample Plugin)*
    * **ExecutionTimeConnectionPlugin** *(Sample Plugin)*

* In order to load and specify the order of plugins in the plugin chain, you must use the connection string parameter **connectionPluginFactories**. Some examples:
    * If we wanted to load the ExecutionTimeConnectionPlugin plugin, the connection string would look like this: `jdbc:postgresql://localhost/?connectionPluginFactories=org.postgresql.pluginmanager.simple.ExecutionTimeConnectionPluginFactory`
    * If we wanted to load multiple plugins, order will matter in the comma separated list: `jdbc:postgresql://localhost/?connectionPluginFactories=org.sample.PluginFactoryOne,org.sample.PluginFactoryTwo,org.sample.PluginFactoryThree`

## Questions/Next Steps

* Is there a community interest in an extendable and modular JDBC driver that supports customized workflows?
* Are there any functionality that we can think of that wouldn't be extendable via the Plugin Manager?

If there is interest in the Plugin Manager, the next steps could include:

* Security and vulnerability assessment.
* Continue development on the proposal to include applicable unit, integration, and performance tests. The focus is to turn the proof of concept into a complete implementation given community feedback.
* Collect community feedback and use cases to determine high demand plugins.