### PR TITLE
chore: set "read" permissions for GitHub actions

### DIFF
--- a/.github/workflows/buildcache.yml
+++ b/.github/workflows/buildcache.yml
@@ -9,6 +9,9 @@ on:
       - '**/*.md'
       - 'appveyor.xml'
 
+permissions:
+  contents: read
+
 concurrency:
   # Push to the same branch (ref is like refs/heads/release) should stop previous buildcache
   # workflows for the branch.

--- a/.github/workflows/debezium.yml
+++ b/.github/workflows/debezium.yml
@@ -3,6 +3,9 @@ name: Test Debezium
 # only on push or allow us to do this manually using workflow dispatch
 on: [workflow_dispatch]
 
+permissions:
+  contents: read
+
 jobs:
   snapshot:
     name: Debezium

--- a/.github/workflows/fedora-copr-build.yml
+++ b/.github/workflows/fedora-copr-build.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Submit a Copr build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,9 @@ on:
       - '.travis.yml'
       - '.travis/**'
 
+permissions:
+  contents: read
+
 # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/software-installed-on-github-hosted-runners
 # GitHub Actions does not support Docker, PostgreSQL server on Windows, macOS :(
 

--- a/.github/workflows/nightlysnapshot.yml
+++ b/.github/workflows/nightlysnapshot.yml
@@ -7,6 +7,9 @@ on:
       - master
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   check_secrets:
     name: Check if required secrets are available

--- a/.github/workflows/omni.yml
+++ b/.github/workflows/omni.yml
@@ -35,6 +35,9 @@ on:
   schedule:
     - cron: "0 6 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   matrix_prep:
     name: Matrix Preparation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 ### Added
+chore: added Gradle Wrapper Validation for verifying gradle-wrapper.jar
+chore: added "permissions: contents: read" for GitHub Actions to avoid unintentional modifications by the CI
 
 ### Fixed
 


### PR DESCRIPTION
Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

See
https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions
https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
