### PR TITLE
feat: Define binary transfer for custom types dynamically (#2554)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -42,6 +42,7 @@ ij_any_spaces_around_relational_operators = true
 ij_any_spaces_around_shift_operators = true
 ij_continuation_indent_size = 4
 ij_java_align_multiline_parameters = false
+ij_java_binary_operation_sign_on_next_line = true
 ij_java_if_brace_force = always
 ij_java_indent_case_from_switch = false
 ij_java_line_comment_add_space = true

--- a/pgjdbc/src/main/java/org/postgresql/core/QueryExecutor.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/QueryExecutor.java
@@ -336,11 +336,61 @@ public interface QueryExecutor extends TypeTransferModeRegistry {
   int getProtocolVersion();
 
   /**
+   * Adds a single oid that should be received using binary encoding.
+   *
+   * @param oid The oid to request with binary encoding.
+   */
+  void addBinaryReceiveOid(int oid);
+
+  /**
+   * Remove given oid from the list of oids for binary receive encoding.
+   * <p>Note: the binary receive for the oid can be re-activated later.</p>
+   *
+   * @param oid The oid to request with binary encoding.
+   */
+  void removeBinaryReceiveOid(int oid);
+
+  /**
+   * Gets the oids that should be received using binary encoding.
+   * <p>Note: this returns an unmodifiable set, and its contents might not reflect the current state.</p>
+   *
+   * @return The oids to request with binary encoding.
+   * @deprecated the method returns a copy of the set, so it is not efficient. Use {@link #useBinaryForReceive(int)}
+   */
+  @Deprecated
+  Set<? extends Integer> getBinaryReceiveOids();
+
+  /**
    * Sets the oids that should be received using binary encoding.
    *
    * @param useBinaryForOids The oids to request with binary encoding.
    */
   void setBinaryReceiveOids(Set<Integer> useBinaryForOids);
+
+  /**
+   * Adds a single oid that should be sent using binary encoding.
+   *
+   * @param oid The oid to send with binary encoding.
+   */
+  void addBinarySendOid(int oid);
+
+  /**
+   * Remove given oid from the list of oids for binary send encoding.
+   * <p>Note: the binary send for the oid can be re-activated later.</p>
+   *
+   * @param oid The oid to send with binary encoding.
+   */
+  void removeBinarySendOid(int oid);
+
+  /**
+   * Gets the oids that should be sent using binary encoding.
+   * <p>Note: this returns an unmodifiable set, and its contents might not reflect the current state.</p>
+   *
+   * @return useBinaryForOids The oids to send with binary encoding.
+   * @deprecated the method returns a copy of the set, so it is not efficient. Use {@link #useBinaryForSend(int)}
+   */
+  @Deprecated
+  Set<? extends Integer> getBinarySendOids();
 
   /**
    * Sets the oids that should be sent using binary encoding.

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -2913,25 +2913,77 @@ public class QueryExecutorImpl extends QueryExecutorBase {
   }
 
   @Override
+  public void addBinaryReceiveOid(int oid) {
+    synchronized (useBinaryReceiveForOids) {
+      useBinaryReceiveForOids.add(oid);
+    }
+  }
+
+  @Override
+  public void removeBinaryReceiveOid(int oid) {
+    synchronized (useBinaryReceiveForOids) {
+      useBinaryReceiveForOids.remove(oid);
+    }
+  }
+
+  @Override
+  public Set<? extends Integer> getBinaryReceiveOids() {
+    // copy the values to prevent ConcurrentModificationException when reader accesses the elements
+    synchronized (useBinaryReceiveForOids) {
+      return new HashSet<>(useBinaryReceiveForOids);
+    }
+  }
+
+  @Override
   public boolean useBinaryForReceive(int oid) {
-    return useBinaryReceiveForOids.contains(oid);
+    synchronized (useBinaryReceiveForOids) {
+      return useBinaryReceiveForOids.contains(oid);
+    }
   }
 
   @Override
   public void setBinaryReceiveOids(Set<Integer> oids) {
-    useBinaryReceiveForOids.clear();
-    useBinaryReceiveForOids.addAll(oids);
+    synchronized (useBinaryReceiveForOids) {
+      useBinaryReceiveForOids.clear();
+      useBinaryReceiveForOids.addAll(oids);
+    }
+  }
+
+  @Override
+  public void addBinarySendOid(int oid) {
+    synchronized (useBinarySendForOids) {
+      useBinarySendForOids.add(oid);
+    }
+  }
+
+  @Override
+  public void removeBinarySendOid(int oid) {
+    synchronized (useBinarySendForOids) {
+      useBinarySendForOids.remove(oid);
+    }
+  }
+
+  @Override
+  public Set<? extends Integer> getBinarySendOids() {
+    // copy the values to prevent ConcurrentModificationException when reader accesses the elements
+    synchronized (useBinarySendForOids) {
+      return new HashSet<>(useBinarySendForOids);
+    }
   }
 
   @Override
   public boolean useBinaryForSend(int oid) {
-    return useBinarySendForOids.contains(oid);
+    synchronized (useBinarySendForOids) {
+      return useBinarySendForOids.contains(oid);
+    }
   }
 
   @Override
   public void setBinarySendOids(Set<Integer> oids) {
-    useBinarySendForOids.clear();
-    useBinarySendForOids.addAll(oids);
+    synchronized (useBinarySendForOids) {
+      useBinarySendForOids.clear();
+      useBinarySendForOids.addAll(oids);
+    }
   }
 
   private void setIntegerDateTimes(boolean state) {

--- a/pgjdbc/src/test/java/org/postgresql/test/core/QueryExecutorTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/core/QueryExecutorTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2023, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.test.core;
+
+import org.postgresql.core.BaseConnection;
+import org.postgresql.core.QueryExecutor;
+import org.postgresql.test.jdbc2.BaseTest4;
+
+import org.junit.Test;
+
+import java.sql.SQLException;
+import java.util.Set;
+
+/**
+ * TestCase to test handling of binary types.
+ */
+public class QueryExecutorTest extends BaseTest4 {
+  /**
+   * Make sure the functions for adding binary transfer OIDs for custom types are correct.
+   *
+   * @throws SQLException if a database error occurs
+   */
+  @Test
+  public void testBinaryTransferOids() throws SQLException {
+    QueryExecutor queryExecutor = con.unwrap(BaseConnection.class).getQueryExecutor();
+    // get current OIDs (make a copy of them)
+    @SuppressWarnings("deprecation")
+    Set<? extends Integer> oidsReceive = queryExecutor.getBinaryReceiveOids();
+    @SuppressWarnings("deprecation")
+    Set<? extends Integer> oidsSend = queryExecutor.getBinarySendOids();
+    // add a new OID to be transferred as binary data
+    int customTypeOid = 91716;
+    assertBinaryForReceive(customTypeOid, false,
+        () -> "Custom type OID should not be binary for receive by default");
+    // first for receiving
+    queryExecutor.addBinaryReceiveOid(customTypeOid);
+    // Verify
+    assertBinaryForReceive(customTypeOid, true,
+        () -> "Just added oid via addBinaryReceiveOid");
+    assertBinaryForSend(customTypeOid, false,
+        () -> "Just added oid via addBinaryReceiveOid");
+    for (int oid : oidsReceive) {
+      assertBinaryForReceive(oid, true,
+          () -> "Previously registered BinaryReceiveOids should be intact after "
+              + "addBinaryReceiveOid(" + customTypeOid + ")");
+    }
+    for (int oid : oidsSend) {
+      assertBinaryForSend(oid, true,
+          () -> "Previously registered BinarySendOids should be intact after "
+              + "addBinaryReceiveOid(" + customTypeOid + ")");
+    }
+    // then for sending
+    queryExecutor.addBinarySendOid(customTypeOid);
+    // check new OID
+    assertBinaryForReceive(customTypeOid, true, () -> "added oid via addBinaryReceiveOid and "
+        + "addBinarySendOid");
+    assertBinaryForSend(customTypeOid, true, () -> "added oid via addBinaryReceiveOid and "
+        + "addBinarySendOid");
+    for (int oid : oidsReceive) {
+      assertBinaryForReceive(oid, true, () -> "Previously registered BinaryReceiveOids should be "
+          + "intact after addBinaryReceiveOid(" + customTypeOid + ") and addBinarySendOid(" + customTypeOid + ")");
+    }
+    for (int oid : oidsSend) {
+      assertBinaryForSend(oid, true, () -> "Previously registered BinarySendOids should be intact"
+          + " after addBinaryReceiveOid(" + customTypeOid + ")");
+    }
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BaseTest4.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BaseTest4.java
@@ -5,8 +5,11 @@
 
 package org.postgresql.test.jdbc2;
 
+import static org.junit.Assert.assertEquals;
+
 import org.postgresql.PGConnection;
 import org.postgresql.PGProperty;
+import org.postgresql.core.BaseConnection;
 import org.postgresql.core.Oid;
 import org.postgresql.core.Version;
 import org.postgresql.jdbc.PreferQueryMode;
@@ -20,6 +23,7 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Locale;
 import java.util.Properties;
+import java.util.function.Supplier;
 
 public class BaseTest4 {
 
@@ -136,4 +140,13 @@ public class BaseTest4 {
     Assume.assumeTrue(TestUtil.haveMinimumServerVersion(con, version));
   }
 
+  protected void assertBinaryForReceive(int oid, boolean expected, Supplier<String> message) throws SQLException {
+    assertEquals(message.get() + ", useBinaryForReceive(oid=" + oid + ")", expected,
+        con.unwrap(BaseConnection.class).getQueryExecutor().useBinaryForReceive(oid));
+  }
+
+  protected void assertBinaryForSend(int oid, boolean expected, Supplier<String> message) throws SQLException {
+    assertEquals(message.get() + ", useBinaryForSend(oid=" + oid + ")", expected,
+        con.unwrap(BaseConnection.class).getQueryExecutor().useBinaryForSend(oid));
+  }
 }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/CustomTypeWithBinaryTransferTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/CustomTypeWithBinaryTransferTest.java
@@ -1,0 +1,251 @@
+/*
+ * Copyright (c) 2023, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.test.jdbc2;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.postgresql.PGConnection;
+import org.postgresql.core.BaseConnection;
+import org.postgresql.core.Oid;
+import org.postgresql.core.QueryExecutor;
+import org.postgresql.jdbc.PreferQueryMode;
+import org.postgresql.test.TestUtil;
+import org.postgresql.util.PGBinaryObject;
+import org.postgresql.util.PGobject;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Collection;
+
+/**
+ * TestCase to test handling of binary types for custom objects.
+ */
+@RunWith(Parameterized.class)
+public class CustomTypeWithBinaryTransferTest extends BaseTest4 {
+  // define an oid of a binary type for testing, POINT is used here as it already exists in the
+  // database and requires no complex own type definition
+  private static final int CUSTOM_TYPE_OID = Oid.POINT;
+
+  public CustomTypeWithBinaryTransferTest(BinaryMode binaryMode) {
+    setBinaryMode(binaryMode);
+  }
+
+  @Parameterized.Parameters(name = "binary = {0}")
+  public static Iterable<Object[]> data() {
+    Collection<Object[]> ids = new ArrayList<>();
+    for (BinaryMode binaryMode : BinaryMode.values()) {
+      ids.add(new Object[]{binaryMode});
+    }
+    return ids;
+  }
+
+  /**
+   * Set up the fixture for this testcase: the tables for this test.
+   *
+   * @throws SQLException if a database error occurs
+   */
+  @BeforeClass
+  public static void createTestTable() throws SQLException {
+    try (Connection con = TestUtil.openDB()) {
+      TestUtil.createTable(con, "test_binary_pgobject", "id integer,name text,geom point");
+    }
+  }
+
+  /**
+   * Tear down the fixture for this test case.
+   *
+   * @throws SQLException if a database error occurs
+   */
+  @AfterClass
+  public static void dropTestTable() throws SQLException {
+    try (Connection con = TestUtil.openDB()) {
+      TestUtil.dropTable(con, "test_binary_pgobject");
+    }
+  }
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    QueryExecutor queryExecutor = con.unwrap(BaseConnection.class).getQueryExecutor();
+    queryExecutor.removeBinarySendOid(CUSTOM_TYPE_OID);
+    queryExecutor.removeBinaryReceiveOid(CUSTOM_TYPE_OID);
+    assertBinaryForReceive(CUSTOM_TYPE_OID, false,
+        () -> "Binary transfer for point type should be disabled since we've deactivated it in "
+            + "updateProperties");
+
+    assertBinaryForSend(CUSTOM_TYPE_OID, false,
+        () -> "Binary transfer for point type should be disabled since we've deactivated it in "
+            + "updateProperties");
+    try (Statement st = con.createStatement()) {
+      st.execute("DELETE FROM test_binary_pgobject");
+      st.execute("INSERT INTO test_binary_pgobject(id,name,geom) values(1,'Test',Point(1,2))");
+    }
+  }
+
+  /**
+   * Make sure custom binary types are handled automatically.
+   *
+   * @throws SQLException if a database error occurs
+   */
+  @Test
+  public void testCustomBinaryTypes() throws SQLException {
+    PGConnection pgconn = con.unwrap(PGConnection.class);
+
+    // make sure the test type implements PGBinaryObject
+    assertTrue("test type should implement PGBinaryObject",
+        PGBinaryObject.class.isAssignableFrom(TestCustomType.class));
+
+    // now define a custom type, which will add it to the binary sent/received OIDs (if the type
+    // implements PGBinaryObject)
+    pgconn.addDataType("point", TestCustomType.class);
+    // check if the type was marked for binary transfer
+    if (preferQueryMode != PreferQueryMode.SIMPLE) {
+      assertBinaryForReceive(CUSTOM_TYPE_OID, true,
+          () -> "Binary transfer for point type should be activated by addDataType(..., "
+              + "TestCustomType.class)");
+      assertBinaryForSend(CUSTOM_TYPE_OID, true,
+          () -> "Binary transfer for point type should be activated by addDataType(..., "
+              + "TestCustomType.class)");
+    }
+
+    TestCustomType co;
+    // Try with PreparedStatement
+    try (PreparedStatement pst = con.prepareStatement("SELECT geom FROM test_binary_pgobject WHERE id=?")) {
+      pst.setInt(1, 1);
+      try (ResultSet rs = pst.executeQuery()) {
+        assertTrue("rs.next()", rs.next());
+        Object o = rs.getObject(1);
+        co = (TestCustomType) o;
+        // now binary transfer should be working
+        if (preferQueryMode == PreferQueryMode.SIMPLE) {
+          assertEquals(
+              "reading via prepared statement: TestCustomType.wasReadBinary() should use text encoding since preferQueryMode=SIMPLE",
+              "text",
+              co.wasReadBinary() ? "binary" : "text");
+        } else {
+          assertEquals(
+              "reading via prepared statement: TestCustomType.wasReadBinary() should use match binary mode requested by the test",
+              binaryMode == BinaryMode.FORCE ? "binary" : "text",
+              co.wasReadBinary() ? "binary" : "text");
+        }
+      }
+    }
+
+    // ensure flag is still unset
+    assertFalse("wasWrittenBinary should be false since we have not written the object yet",
+        co.wasWrittenBinary());
+    // now try to write it
+    try (PreparedStatement pst =
+             con.prepareStatement("INSERT INTO test_binary_pgobject(id,geom) VALUES(?,?)")) {
+      pst.setInt(1, 2);
+      pst.setObject(2, co);
+      pst.executeUpdate();
+      // make sure transfer was binary
+      if (preferQueryMode == PreferQueryMode.SIMPLE) {
+        assertEquals(
+            "writing via prepared statement: TestCustomType.wasWrittenBinary() should use text encoding since preferQueryMode=SIMPLE",
+            "text",
+            co.wasWrittenBinary() ? "binary" : "text");
+      } else {
+        assertEquals(
+            "writing via prepared statement: TestCustomType.wasWrittenBinary() should use match binary mode requested by the test",
+            binaryMode == BinaryMode.FORCE ? "binary" : "text",
+            co.wasWrittenBinary() ? "binary" : "text");
+      }
+    }
+  }
+
+  /**
+   * Custom type that supports binary format.
+   */
+  @SuppressWarnings("serial")
+  public static class TestCustomType extends PGobject implements PGBinaryObject {
+    private byte @Nullable [] byteValue;
+    private boolean wasReadBinary;
+    private boolean wasWrittenBinary;
+
+    @Override
+    public @Nullable String getValue() {
+      // set flag
+      this.wasWrittenBinary = false;
+      return super.getValue();
+    }
+
+    @Override
+    public int lengthInBytes() {
+      if (byteValue != null) {
+        return byteValue.length;
+      } else {
+        return 0;
+      }
+    }
+
+    @Override
+    public void setByteValue(byte[] value, int offset) throws SQLException {
+      this.wasReadBinary = true;
+      // remember the byte value
+      byteValue = new byte[value.length - offset];
+      System.arraycopy(value, offset, byteValue, 0, byteValue.length);
+    }
+
+    @Override
+    public void setValue(@Nullable String value) throws SQLException {
+      super.setValue(value);
+      // set flag
+      this.wasReadBinary = false;
+    }
+
+    @Override
+    public void toBytes(byte[] bytes, int offset) {
+      if (byteValue != null) {
+        // make sure array is large enough
+        if ((bytes.length - offset) <= byteValue.length) {
+          // copy data
+          System.arraycopy(byteValue, 0, bytes, offset, byteValue.length);
+        } else {
+          throw new IllegalArgumentException(
+              "byte array is too small, expected: " + byteValue.length + " got: "
+                  + (bytes.length - offset));
+        }
+      } else {
+        throw new IllegalStateException("no geometry has been set");
+      }
+      // set flag
+      this.wasWrittenBinary = true;
+    }
+
+    /**
+     * Checks, if this type was read in binary mode.
+     *
+     * @return true for binary mode, else false
+     */
+    public boolean wasReadBinary() {
+      return this.wasReadBinary;
+    }
+
+    /**
+     * Checks, if this type was written in binary mode.
+     *
+     * @return true for binary mode, else false
+     */
+    public boolean wasWrittenBinary() {
+      return this.wasWrittenBinary;
+    }
+  }
+}


### PR DESCRIPTION
* Get existing oids for binary transfer of custom types from QueryExecutor
* Add new oids for binary transfer of custom types to QueryExecutor
* Unit test to make sure oids are correctly set

https://github.com/pgjdbc/pgjdbc/issues/2554

### All Submissions:

* [X] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### New Feature Submissions:

1. [X] Does your submission pass tests?
2. [X] Does `./gradlew autostyleCheck checkstyleAll` pass ?
3. [X] Have you added your new test classes to an existing test suite in alphabetical order?
