### PR TITLE
fix: make ConnectTimeoutTest to handle Exceptions correctly

### DIFF
--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ConnectTimeoutTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ConnectTimeoutTest.java
@@ -56,7 +56,7 @@ public class ConnectTimeoutTest {
        * We treat this as a skipped test, as the test didn't really "succeed"
        * in testing the original behaviour, but it didn't fail either.
        */
-      Assume.assumeTrue("Host fast-failed connection to unreachable address "
+      Assume.assumeFalse("Host fast-failed connection to unreachable address "
                         + UNREACHABLE_HOST + " after " + interval + " ms, "
                         + " before timeout should have triggered.",
                         e.getCause() instanceof NoRouteToHostException


### PR DESCRIPTION

make sure ConnectTimeoutTest use Assume.assumeFalse() 
to handle NoRouteToHostException and SocketTimeoutException correctly

Currently, ConnectTimeoutTest is not working as expected, the details are following:

- When NoRouteToHostException is thrown,
  this test is expected to be ignored and SKIPed, but this test is failed actually.
- When SocketTimeoutException is thrown,
  this test is expected to be succeeded, but this test is ignored and SKIPed actually.

So, current ConnectTimeoutTest is not succeed in any case.
Seeing following junit documentation, I find that Assume.assumeFalse() should be used
instead of Assume.assumeTrue() to handle NoRouteToHostException.

https://junit.org/junit4/javadoc/4.13/org/junit/Assume.html#assumeTrue(boolean)
```
assumeTrue
 public static void assumeTrue(boolean b)
  If called with an expression evaluating to false, the test will halt and be ignored.

assumeFalse
 public static void assumeFalse(boolean b)
  The inverse of assumeTrue(boolean).
```

After merging this PR, the behavior will be as follows.
- When NoRouteToHostException is thrown, the expression evaluating becomes "true",
  so the test halts at Assume.assumeFalse() and is ignored and SKIPed.
- When SocketTimeoutException is thrown, the expression evaluating becomes "false",
  so the test continues to the next step and eventually succeeds.

This is related to #1526.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
