### PR TITLE
fix: make setObject accept UUID array

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/TypeInfo.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/TypeInfo.java
@@ -36,6 +36,8 @@ public interface TypeInfo {
    */
   int getSQLType(String pgTypeName) throws SQLException;
 
+  int getJavaArrayType(String className) throws SQLException;
+
   /**
    * Look up the oid for a given postgresql type name. This is the inverse of
    * {@link #getPGType(int)}.

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
@@ -52,6 +52,8 @@ public class TypeInfoCache implements TypeInfo {
   // pgname (String) -> oid (Integer)
   private Map<String, Integer> pgNameToOid;
 
+  private Map<String, Integer> javaArrayTypeToOid;
+
   // pgname (String) -> extension pgobject (Class)
   private Map<String, Class<? extends PGobject>> pgNameToPgObject;
 
@@ -140,6 +142,7 @@ public class TypeInfoCache implements TypeInfo {
     this.unknownLength = unknownLength;
     oidToPgName = new HashMap<Integer, String>((int) Math.round(types.length * 1.5));
     pgNameToOid = new HashMap<String, Integer>((int) Math.round(types.length * 1.5));
+    javaArrayTypeToOid = new HashMap<String, Integer>((int) Math.round(types.length * 1.5));
     pgNameToJavaClass = new HashMap<String, String>((int) Math.round(types.length * 1.5));
     pgNameToPgObject = new HashMap<String, Class<? extends PGobject>>((int) Math.round(types.length * 1.5));
     pgArrayToPgType = new HashMap<Integer, Integer>((int) Math.round(types.length * 1.5));
@@ -168,6 +171,7 @@ public class TypeInfoCache implements TypeInfo {
     pgNameToJavaClass.put(pgTypeName, javaClass);
     pgNameToOid.put(pgTypeName, oid);
     oidToPgName.put(oid, pgTypeName);
+    javaArrayTypeToOid.put(javaClass, arrayOid);
     pgArrayToPgType.put(arrayOid, oid);
     pgNameToSQLType.put(pgTypeName, sqlType);
     oidToSQLType.put(oid, sqlType);
@@ -317,6 +321,15 @@ public class TypeInfoCache implements TypeInfo {
 
     pgNameToSQLType.put(pgTypeName, i);
     return i;
+  }
+
+  @Override
+  public synchronized int getJavaArrayType(String className) throws SQLException {
+    Integer oid = javaArrayTypeToOid.get(className);
+    if (oid == null) {
+      return Oid.UNSPECIFIED;
+    }
+    return oid;
   }
 
   public synchronized int getSQLType(int typeOid) throws SQLException {

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/ArraysTestSuite.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/ArraysTestSuite.java
@@ -24,7 +24,8 @@ import org.junit.runners.Suite;
     LongObjectArraysTest.class,
     ShortArraysTest.class,
     ShortObjectArraysTest.class,
-    StringArraysTest.class
+    StringArraysTest.class,
+    UUIDArrayTest.class
 })
 public class ArraysTestSuite {
 }

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/UUIDArrayTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/UUIDArrayTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, PostgreSQL Global Development Group
+ * Copyright (c) 2022, PostgreSQL Global Development Group
  * See the LICENSE file in the project root for more information.
  */
 

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/UUIDArrayTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/UUIDArrayTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2021, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.jdbc;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import org.postgresql.core.ServerVersion;
+import org.postgresql.test.TestUtil;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.UUID;
+
+class UUIDArrayTest {
+
+  private static Connection con;
+  private static final String TABLE_NAME = "uuid_table";
+  private static final String INSERT1 = "INSERT INTO " + TABLE_NAME
+      + " (id, data1) VALUES (?, ?)";
+  private static final String INSERT2 = "INSERT INTO " + TABLE_NAME
+      + " (id, data2) VALUES (?, ?)";
+  private static final String SELECT1 = "SELECT data1 FROM " + TABLE_NAME
+      + " WHERE id = ?";
+  private static final String SELECT2 = "SELECT data2 FROM " + TABLE_NAME
+      + " WHERE id = ?";
+  private static final UUID[] uids1 = new UUID[]{UUID.randomUUID(), UUID.randomUUID()};
+  private static final UUID[][] uids2 = new UUID[][]{uids1};
+
+  @BeforeAll
+  public static void setUp() throws Exception {
+    con = TestUtil.openDB();
+    assumeTrue(TestUtil.haveMinimumServerVersion(con, ServerVersion.v9_6));
+    try (Statement stmt = con.createStatement()) {
+      stmt.execute("CREATE TABLE " + TABLE_NAME
+          + " (id int PRIMARY KEY, data1 UUID[], data2 UUID[][])");
+    }
+  }
+
+  @AfterAll
+  public static void tearDown() throws Exception {
+    try (Statement stmt = con.createStatement()) {
+      stmt.execute("DROP TABLE IF EXISTS " + TABLE_NAME);
+    }
+    TestUtil.closeDB(con);
+  }
+
+  @Test
+  void test1DWithCreateArrayOf() throws SQLException {
+    try (Connection c = assertDoesNotThrow(() -> TestUtil.openDB());
+        PreparedStatement stmt1 = c.prepareStatement(INSERT1);
+        PreparedStatement stmt2 = c.prepareStatement(SELECT1)) {
+      stmt1.setInt(1, 100);
+      stmt1.setArray(2, c.createArrayOf("uuid", uids1));
+      stmt1.execute();
+
+      stmt2.setInt(1, 100);
+      stmt2.execute();
+      try (ResultSet rs = stmt2.getResultSet()) {
+        assertTrue(rs.next());
+        UUID[] array = (UUID[])rs.getArray(1).getArray();
+        assertEquals(uids1[0], array[0]);
+        assertEquals(uids1[1], array[1]);
+      }
+    }
+  }
+
+  @Test
+  void test1DWithSetObject() throws SQLException {
+    try (Connection c = assertDoesNotThrow(() -> TestUtil.openDB());
+         PreparedStatement stmt1 = c.prepareStatement(INSERT1);
+         PreparedStatement stmt2 = c.prepareStatement(SELECT1)) {
+      stmt1.setInt(1, 101);
+      stmt1.setObject(2, uids1);
+      stmt1.execute();
+
+      stmt2.setInt(1, 101);
+      stmt2.execute();
+      try (ResultSet rs = stmt2.getResultSet()) {
+        assertTrue(rs.next());
+        UUID[] array = (UUID[])rs.getArray(1).getArray();
+        assertEquals(uids1[0], array[0]);
+        assertEquals(uids1[1], array[1]);
+      }
+    }
+  }
+
+  @Test
+  void test2DWithCreateArrayOf() throws SQLException {
+    try (Connection c = assertDoesNotThrow(() -> TestUtil.openDB());
+         PreparedStatement stmt1 = c.prepareStatement(INSERT2);
+         PreparedStatement stmt2 = c.prepareStatement(SELECT2)) {
+      stmt1.setInt(1, 200);
+      stmt1.setArray(2, c.createArrayOf("uuid", uids2));
+      stmt1.execute();
+
+      stmt2.setInt(1, 200);
+      stmt2.execute();
+      try (ResultSet rs = stmt2.getResultSet()) {
+        assertTrue(rs.next());
+        UUID[][] array = (UUID[][])rs.getArray(1).getArray();
+        assertEquals(uids2[0][0], array[0][0]);
+        assertEquals(uids2[0][1], array[0][1]);
+      }
+    }
+  }
+
+  @Test
+  void test2DWithSetObject() throws SQLException {
+    try (Connection c = assertDoesNotThrow(() -> TestUtil.openDB());
+         PreparedStatement stmt1 = c.prepareStatement(INSERT2);
+         PreparedStatement stmt2 = c.prepareStatement(SELECT2)) {
+      stmt1.setInt(1, 201);
+      stmt1.setObject(2, uids2);
+      stmt1.execute();
+
+      stmt2.setInt(1, 201);
+      stmt2.execute();
+      try (ResultSet rs = stmt2.getResultSet()) {
+        assertTrue(rs.next());
+        UUID[][] array = (UUID[][])rs.getArray(1).getArray();
+        assertEquals(uids2[0][0], array[0][0]);
+        assertEquals(uids2[0][1], array[0][1]);
+      }
+    }
+  }
+}


### PR DESCRIPTION
Hello,

pgjdbc has had issue for some time that calling .setObject on PreparedStatement only works for some kind of arrays (arrays listed in `ArrayEncoding.ARRAY_CLASS_TO_ENCODER`. Unfortunately, UUID is not in that list. 

Using `stmt.setArray(parameterPosition, con.createArrayOf("uuid", myUuidArray))` works, but unfortunately connection can sometimes be buried deep in multiple abstraction layers and not really accessible to caller (i.e. when using spring NamedParameterJdbcTemplate). 

Since I am not deeply familiar with pgjdbc design philosophy, I tried to make something that could be useful starting point for proper fix, but I am sure that maintainers will have better and more elegant way of solving this issue. 

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests? 
Yes, at least tests relevant to my changes that I could run locally.
3. [x] Does `./gradlew autostyleCheck checkstyleAll` pass ?
4. [x] Have you added your new test classes to an existing test suite in alphabetical order?

### Changes to Existing Features:

* [ ] Does this break existing behaviour? If so please explain.
I hope not. 
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
