### PR TITLE
refactor:(loom) replace the usages of synchronized with ReentrantLock

### DIFF
--- a/config/forbidden-apis/forbidden-apis.txt
+++ b/config/forbidden-apis/forbidden-apis.txt
@@ -1,3 +1,15 @@
 @defaultMessage Use toLowerCase(Locale.ROOT) and toUpperCase(Locale.ROOT)
 java.lang.String#toUpperCase()
 java.lang.String#toLowerCase()
+
+@defaultMessage Use ResourceLock.newCondition() and lockCondition.await() instead of Object.wait()
+java.lang.Object#wait()
+
+@defaultMessage Use ResourceLock.newCondition() and lockCondition.await(long, TimeUnit) instead of Object.wait(int)
+java.lang.Object#wait(long)
+
+@defaultMessage Use ResourceLock.newCondition() and lockCondition.signal() instead of Object.notify()
+java.lang.Object#notify()
+
+@defaultMessage Use ResourceLock.newCondition() and lockCondition.signalAll() instead of Object.notifyAll()
+java.lang.Object#notifyAll()

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/CopyOperationImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/CopyOperationImpl.java
@@ -49,9 +49,7 @@ public abstract class CopyOperationImpl implements CopyOperation {
   }
 
   public boolean isActive() {
-    synchronized (castNonNull(queryExecutor)) {
-      return queryExecutor.hasLock(this);
-    }
+    return castNonNull(queryExecutor).hasLockOn(this);
   }
 
   public void handleCommandStatus(String status) throws PSQLException {

--- a/pgjdbc/src/main/java/org/postgresql/hostchooser/GlobalHostStatusTracker.java
+++ b/pgjdbc/src/main/java/org/postgresql/hostchooser/GlobalHostStatusTracker.java
@@ -5,6 +5,7 @@
 
 package org.postgresql.hostchooser;
 
+import org.postgresql.jdbc.ResourceLock;
 import org.postgresql.util.HostSpec;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -20,6 +21,7 @@ import java.util.Map;
 public class GlobalHostStatusTracker {
   private static final Map<HostSpec, HostSpecStatus> hostStatusMap =
       new HashMap<HostSpec, HostSpecStatus>();
+  private static final ResourceLock lock = new ResourceLock();
 
   /**
    * Store the actual observed host status.
@@ -29,7 +31,7 @@ public class GlobalHostStatusTracker {
    */
   public static void reportHostStatus(HostSpec hostSpec, HostStatus hostStatus) {
     long now = System.nanoTime() / 1000000;
-    synchronized (hostStatusMap) {
+    try (ResourceLock ignore = lock.obtain()) {
       HostSpecStatus hostSpecStatus = hostStatusMap.get(hostSpec);
       if (hostSpecStatus == null) {
         hostSpecStatus = new HostSpecStatus(hostSpec);
@@ -52,7 +54,7 @@ public class GlobalHostStatusTracker {
       HostRequirement targetServerType, long hostRecheckMillis) {
     List<HostSpec> candidates = new ArrayList<HostSpec>(hostSpecs.length);
     long latestAllowedUpdate = System.nanoTime() / 1000000 - hostRecheckMillis;
-    synchronized (hostStatusMap) {
+    try (ResourceLock ignore = lock.obtain()) {
       for (HostSpec hostSpec : hostSpecs) {
         HostSpecStatus hostInfo = hostStatusMap.get(hostSpec);
         // candidates are nodes we do not know about and the nodes with correct type

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/AbstractBlobClob.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/AbstractBlobClob.java
@@ -41,6 +41,7 @@ public abstract class AbstractBlobClob {
    */
   private @Nullable ArrayList<LargeObject> subLOs = new ArrayList<LargeObject>();
 
+  protected final ResourceLock lock = new ResourceLock();
   private final long oid;
 
   public AbstractBlobClob(BaseConnection conn, long oid) throws SQLException {
@@ -51,18 +52,20 @@ public abstract class AbstractBlobClob {
     support64bit = conn.haveMinimumServerVersion(90300);
   }
 
-  public synchronized void free() throws SQLException {
-    if (currentLo != null) {
-      currentLo.close();
-      currentLo = null;
-      currentLoIsWriteable = false;
-    }
-    if (subLOs != null) {
-      for (LargeObject subLO : subLOs) {
-        subLO.close();
+  public void free() throws SQLException {
+    try (ResourceLock ignore = lock.obtain()) {
+      if (currentLo != null) {
+        currentLo.close();
+        currentLo = null;
+        currentLoIsWriteable = false;
       }
+      if (subLOs != null) {
+        for (LargeObject subLO : subLOs) {
+          subLO.close();
+        }
+      }
+      subLOs = null;
     }
-    subLOs = null;
   }
 
   /**
@@ -73,59 +76,69 @@ public abstract class AbstractBlobClob {
    * @param len maximum length
    * @throws SQLException if operation fails
    */
-  public synchronized void truncate(long len) throws SQLException {
-    checkFreed();
-    if (!conn.haveMinimumServerVersion(ServerVersion.v8_3)) {
-      throw new PSQLException(
-          GT.tr("Truncation of large objects is only implemented in 8.3 and later servers."),
-          PSQLState.NOT_IMPLEMENTED);
-    }
+  public void truncate(long len) throws SQLException {
+    try (ResourceLock ignore = lock.obtain()) {
+      checkFreed();
+      if (!conn.haveMinimumServerVersion(ServerVersion.v8_3)) {
+        throw new PSQLException(
+            GT.tr("Truncation of large objects is only implemented in 8.3 and later servers."),
+            PSQLState.NOT_IMPLEMENTED);
+      }
 
-    if (len < 0) {
-      throw new PSQLException(GT.tr("Cannot truncate LOB to a negative length."),
-          PSQLState.INVALID_PARAMETER_VALUE);
-    }
-    if (len > Integer.MAX_VALUE) {
-      if (support64bit) {
-        getLo(true).truncate64(len);
-      } else {
-        throw new PSQLException(GT.tr("PostgreSQL LOBs can only index to: {0}", Integer.MAX_VALUE),
+      if (len < 0) {
+        throw new PSQLException(GT.tr("Cannot truncate LOB to a negative length."),
             PSQLState.INVALID_PARAMETER_VALUE);
       }
-    } else {
-      getLo(true).truncate((int) len);
+      if (len > Integer.MAX_VALUE) {
+        if (support64bit) {
+          getLo(true).truncate64(len);
+        } else {
+          throw new PSQLException(GT.tr("PostgreSQL LOBs can only index to: {0}", Integer.MAX_VALUE),
+              PSQLState.INVALID_PARAMETER_VALUE);
+        }
+      } else {
+        getLo(true).truncate((int) len);
+      }
     }
   }
 
-  public synchronized long length() throws SQLException {
-    checkFreed();
-    if (support64bit) {
-      return getLo(false).size64();
-    } else {
-      return getLo(false).size();
+  public long length() throws SQLException {
+    try (ResourceLock ignore = lock.obtain()) {
+      checkFreed();
+      if (support64bit) {
+        return getLo(false).size64();
+      } else {
+        return getLo(false).size();
+      }
     }
   }
 
-  public synchronized byte[] getBytes(long pos, int length) throws SQLException {
-    assertPosition(pos);
-    getLo(false).seek((int) (pos - 1), LargeObject.SEEK_SET);
-    return getLo(false).read(length);
+  public byte[] getBytes(long pos, int length) throws SQLException {
+    try (ResourceLock ignore = lock.obtain()) {
+      assertPosition(pos);
+      getLo(false).seek((int) (pos - 1), LargeObject.SEEK_SET);
+      return getLo(false).read(length);
+    }
   }
 
-  public synchronized InputStream getBinaryStream() throws SQLException {
-    checkFreed();
-    LargeObject subLO = getLo(false).copy();
-    addSubLO(subLO);
-    subLO.seek(0, LargeObject.SEEK_SET);
-    return subLO.getInputStream();
+  public InputStream getBinaryStream() throws SQLException {
+    try (ResourceLock ignore = lock.obtain()) {
+      checkFreed();
+      LargeObject subLO = getLo(false).copy();
+      addSubLO(subLO);
+      subLO.seek(0, LargeObject.SEEK_SET);
+      return subLO.getInputStream();
+    }
   }
 
-  public synchronized OutputStream setBinaryStream(long pos) throws SQLException {
-    assertPosition(pos);
-    LargeObject subLO = getLo(true).copy();
-    addSubLO(subLO);
-    subLO.seek((int) (pos - 1));
-    return subLO.getOutputStream();
+  public OutputStream setBinaryStream(long pos) throws SQLException {
+    try (ResourceLock ignore = lock.obtain()) {
+      assertPosition(pos);
+      LargeObject subLO = getLo(true).copy();
+      addSubLO(subLO);
+      subLO.seek((int) (pos - 1));
+      return subLO.getOutputStream();
+    }
   }
 
   /**
@@ -136,31 +149,33 @@ public abstract class AbstractBlobClob {
    * @return position of the specified pattern
    * @throws SQLException if something wrong happens
    */
-  public synchronized long position(byte[] pattern, long start) throws SQLException {
-    assertPosition(start, pattern.length);
+  public long position(byte[] pattern, long start) throws SQLException {
+    try (ResourceLock ignore = lock.obtain()) {
+      assertPosition(start, pattern.length);
 
-    int position = 1;
-    int patternIdx = 0;
-    long result = -1;
-    int tmpPosition = 1;
+      int position = 1;
+      int patternIdx = 0;
+      long result = -1;
+      int tmpPosition = 1;
 
-    for (LOIterator i = new LOIterator(start - 1); i.hasNext(); position++) {
-      byte b = i.next();
-      if (b == pattern[patternIdx]) {
-        if (patternIdx == 0) {
-          tmpPosition = position;
+      for (LOIterator i = new LOIterator(start - 1); i.hasNext(); position++) {
+        byte b = i.next();
+        if (b == pattern[patternIdx]) {
+          if (patternIdx == 0) {
+            tmpPosition = position;
+          }
+          patternIdx++;
+          if (patternIdx == pattern.length) {
+            result = tmpPosition;
+            break;
+          }
+        } else {
+          patternIdx = 0;
         }
-        patternIdx++;
-        if (patternIdx == pattern.length) {
-          result = tmpPosition;
-          break;
-        }
-      } else {
-        patternIdx = 0;
       }
-    }
 
-    return result;
+      return result;
+    }
   }
 
   /**
@@ -201,7 +216,7 @@ public abstract class AbstractBlobClob {
    * @return position of given pattern
    * @throws SQLException if something goes wrong
    */
-  public synchronized long position(Blob pattern, long start) throws SQLException {
+  public long position(Blob pattern, long start) throws SQLException {
     return position(pattern.getBytes(1, (int) pattern.length()), start);
   }
 
@@ -248,30 +263,32 @@ public abstract class AbstractBlobClob {
     }
   }
 
-  protected synchronized LargeObject getLo(boolean forWrite) throws SQLException {
-    LargeObject currentLo = this.currentLo;
-    if (currentLo != null) {
-      if (forWrite && !currentLoIsWriteable) {
-        // Reopen the stream in read-write, at the same pos.
-        int currentPos = currentLo.tell();
+  protected LargeObject getLo(boolean forWrite) throws SQLException {
+    try (ResourceLock ignore = lock.obtain()) {
+      LargeObject currentLo = this.currentLo;
+      if (currentLo != null) {
+        if (forWrite && !currentLoIsWriteable) {
+          // Reopen the stream in read-write, at the same pos.
+          int currentPos = currentLo.tell();
 
-        LargeObjectManager lom = conn.getLargeObjectAPI();
-        LargeObject newLo = lom.open(oid, LargeObjectManager.READWRITE);
-        castNonNull(subLOs).add(currentLo);
-        this.currentLo = currentLo = newLo;
+          LargeObjectManager lom = conn.getLargeObjectAPI();
+          LargeObject newLo = lom.open(oid, LargeObjectManager.READWRITE);
+          castNonNull(subLOs).add(currentLo);
+          this.currentLo = currentLo = newLo;
 
-        if (currentPos != 0) {
-          currentLo.seek(currentPos);
+          if (currentPos != 0) {
+            currentLo.seek(currentPos);
+          }
         }
-      }
 
+        return currentLo;
+      }
+      LargeObjectManager lom = conn.getLargeObjectAPI();
+      this.currentLo = currentLo =
+          lom.open(oid, forWrite ? LargeObjectManager.READWRITE : LargeObjectManager.READ);
+      currentLoIsWriteable = forWrite;
       return currentLo;
     }
-    LargeObjectManager lom = conn.getLargeObjectAPI();
-    this.currentLo = currentLo =
-        lom.open(oid, forWrite ? LargeObjectManager.READWRITE : LargeObjectManager.READ);
-    currentLoIsWriteable = forWrite;
-    return currentLo;
   }
 
   protected void addSubLO(LargeObject subLO) {

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgBlob.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgBlob.java
@@ -15,28 +15,32 @@ public class PgBlob extends AbstractBlobClob implements java.sql.Blob {
     super(conn, oid);
   }
 
-  public synchronized java.io.InputStream getBinaryStream(long pos, long length)
+  public java.io.InputStream getBinaryStream(long pos, long length)
       throws SQLException {
-    checkFreed();
-    LargeObject subLO = getLo(false).copy();
-    addSubLO(subLO);
-    if (pos > Integer.MAX_VALUE) {
-      subLO.seek64(pos - 1, LargeObject.SEEK_SET);
-    } else {
-      subLO.seek((int) pos - 1, LargeObject.SEEK_SET);
+    try (ResourceLock ignore = lock.obtain()) {
+      checkFreed();
+      LargeObject subLO = getLo(false).copy();
+      addSubLO(subLO);
+      if (pos > Integer.MAX_VALUE) {
+        subLO.seek64(pos - 1, LargeObject.SEEK_SET);
+      } else {
+        subLO.seek((int) pos - 1, LargeObject.SEEK_SET);
+      }
+      return subLO.getInputStream(length);
     }
-    return subLO.getInputStream(length);
   }
 
-  public synchronized int setBytes(long pos, byte[] bytes) throws SQLException {
+  public int setBytes(long pos, byte[] bytes) throws SQLException {
     return setBytes(pos, bytes, 0, bytes.length);
   }
 
-  public synchronized int setBytes(long pos, byte[] bytes, int offset, int len)
+  public int setBytes(long pos, byte[] bytes, int offset, int len)
       throws SQLException {
-    assertPosition(pos);
-    getLo(true).seek((int) (pos - 1));
-    getLo(true).write(bytes, offset, len);
-    return len;
+    try (ResourceLock ignore = lock.obtain()) {
+      assertPosition(pos);
+      getLo(true).seek((int) (pos - 1));
+      getLo(true).write(bytes, offset, len);
+      return len;
+    }
   }
 }

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgCallableStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgCallableStatement.java
@@ -80,7 +80,7 @@ class PgCallableStatement extends PgPreparedStatement implements CallableStateme
 
   @Override
   public boolean executeWithFlags(int flags) throws SQLException {
-    synchronized (this) {
+    try (ResourceLock ignore = lock.obtain()) {
       boolean hasResultSet = super.executeWithFlags(flags);
       int[] functionReturnType = this.functionReturnType;
       if (!isFunction || !returnTypeSet || functionReturnType == null) {

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgClob.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgClob.java
@@ -20,60 +20,78 @@ public class PgClob extends AbstractBlobClob implements java.sql.Clob {
     super(conn, oid);
   }
 
-  public synchronized Reader getCharacterStream(long pos, long length) throws SQLException {
-    checkFreed();
-    throw org.postgresql.Driver.notImplemented(this.getClass(), "getCharacterStream(long, long)");
+  public Reader getCharacterStream(long pos, long length) throws SQLException {
+    try (ResourceLock ignore = lock.obtain()) {
+      checkFreed();
+      throw org.postgresql.Driver.notImplemented(this.getClass(), "getCharacterStream(long, long)");
+    }
   }
 
-  public synchronized int setString(long pos, String str) throws SQLException {
-    checkFreed();
-    throw org.postgresql.Driver.notImplemented(this.getClass(), "setString(long,str)");
+  public int setString(long pos, String str) throws SQLException {
+    try (ResourceLock ignore = lock.obtain()) {
+      checkFreed();
+      throw org.postgresql.Driver.notImplemented(this.getClass(), "setString(long,str)");
+    }
   }
 
-  public synchronized int setString(long pos, String str, int offset, int len) throws SQLException {
-    checkFreed();
-    throw org.postgresql.Driver.notImplemented(this.getClass(), "setString(long,String,int,int)");
+  public int setString(long pos, String str, int offset, int len) throws SQLException {
+    try (ResourceLock ignore = lock.obtain()) {
+      checkFreed();
+      throw org.postgresql.Driver.notImplemented(this.getClass(), "setString(long,String,int,int)");
+    }
   }
 
-  public synchronized java.io.OutputStream setAsciiStream(long pos) throws SQLException {
-    checkFreed();
-    throw org.postgresql.Driver.notImplemented(this.getClass(), "setAsciiStream(long)");
+  public java.io.OutputStream setAsciiStream(long pos) throws SQLException {
+    try (ResourceLock ignore = lock.obtain()) {
+      checkFreed();
+      throw org.postgresql.Driver.notImplemented(this.getClass(), "setAsciiStream(long)");
+    }
   }
 
-  public synchronized java.io.Writer setCharacterStream(long pos) throws SQLException {
-    checkFreed();
-    throw org.postgresql.Driver.notImplemented(this.getClass(), "setCharacterStream(long)");
+  public java.io.Writer setCharacterStream(long pos) throws SQLException {
+    try (ResourceLock ignore = lock.obtain()) {
+      checkFreed();
+      throw org.postgresql.Driver.notImplemented(this.getClass(), "setCharacterStream(long)");
+    }
   }
 
-  public synchronized InputStream getAsciiStream() throws SQLException {
+  public InputStream getAsciiStream() throws SQLException {
     return getBinaryStream();
   }
 
-  public synchronized Reader getCharacterStream() throws SQLException {
-    Charset connectionCharset = Charset.forName(conn.getEncoding().name());
-    return new InputStreamReader(getBinaryStream(), connectionCharset);
+  public Reader getCharacterStream() throws SQLException {
+    try (ResourceLock ignore = lock.obtain()) {
+      Charset connectionCharset = Charset.forName(conn.getEncoding().name());
+      return new InputStreamReader(getBinaryStream(), connectionCharset);
+    }
   }
 
-  public synchronized String getSubString(long i, int j) throws SQLException {
-    assertPosition(i, j);
-    LargeObject lo = getLo(false);
-    lo.seek((int) i - 1);
-    return new String(lo.read(j));
+  public String getSubString(long i, int j) throws SQLException {
+    try (ResourceLock ignore = lock.obtain()) {
+      assertPosition(i, j);
+      LargeObject lo = getLo(false);
+      lo.seek((int) i - 1);
+      return new String(lo.read(j));
+    }
   }
 
   /**
    * For now, this is not implemented.
    */
-  public synchronized long position(String pattern, long start) throws SQLException {
-    checkFreed();
-    throw org.postgresql.Driver.notImplemented(this.getClass(), "position(String,long)");
+  public long position(String pattern, long start) throws SQLException {
+    try (ResourceLock ignore = lock.obtain()) {
+      checkFreed();
+      throw org.postgresql.Driver.notImplemented(this.getClass(), "position(String,long)");
+    }
   }
 
   /**
    * This should be simply passing the byte value of the pattern Blob.
    */
-  public synchronized long position(Clob pattern, long start) throws SQLException {
-    checkFreed();
-    throw org.postgresql.Driver.notImplemented(this.getClass(), "position(Clob,start)");
+  public long position(Clob pattern, long start) throws SQLException {
+    try (ResourceLock ignore = lock.obtain()) {
+      checkFreed();
+      throw org.postgresql.Driver.notImplemented(this.getClass(), "position(Clob,start)");
+    }
   }
 }

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
@@ -83,6 +83,7 @@ import java.util.StringTokenizer;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.Executor;
+import java.util.concurrent.locks.Condition;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -118,6 +119,9 @@ public class PgConnection implements BaseConnection {
     transaction,
     always;
   }
+
+  private final ResourceLock lock = new ResourceLock();
+  private final Condition lockCondition = lock.newCondition();
 
   //
   // Data initialized on construction:
@@ -442,6 +446,21 @@ public class PgConnection implements BaseConnection {
    * The current type mappings.
    */
   protected Map<String, Class<?>> typemap = new HashMap<String, Class<?>>();
+
+  /**
+   * Obtain the connection lock and return it. Callers must use try-with-resources to ensure that
+   * unlock() is performed on the lock.
+   */
+  final ResourceLock obtainLock() {
+    return lock.obtain();
+  }
+
+  /**
+   * Return the lock condition for this connection.
+   */
+  final Condition lockCondition() {
+    return lockCondition;
+  }
 
   @Override
   public Statement createStatement() throws SQLException {
@@ -783,24 +802,28 @@ public class PgConnection implements BaseConnection {
   }
 
   @Override
-  public synchronized @Nullable SQLWarning getWarnings() throws SQLException {
-    checkClosed();
-    SQLWarning newWarnings = queryExecutor.getWarnings(); // NB: also clears them.
-    if (firstWarning == null) {
-      firstWarning = newWarnings;
-    } else if (newWarnings != null) {
-      firstWarning.setNextWarning(newWarnings); // Chain them on.
-    }
+  public @Nullable SQLWarning getWarnings() throws SQLException {
+    try (ResourceLock ignore = lock.obtain()) {
+      checkClosed();
+      SQLWarning newWarnings = queryExecutor.getWarnings(); // NB: also clears them.
+      if (firstWarning == null) {
+        firstWarning = newWarnings;
+      } else if (newWarnings != null) {
+        firstWarning.setNextWarning(newWarnings); // Chain them on.
+      }
 
-    return firstWarning;
+      return firstWarning;
+    }
   }
 
   @Override
-  public synchronized void clearWarnings() throws SQLException {
-    checkClosed();
-    //noinspection ThrowableNotThrown
-    queryExecutor.getWarnings(); // Clear and discard.
-    firstWarning = null;
+  public void clearWarnings() throws SQLException {
+    try (ResourceLock ignore = lock.obtain()) {
+      checkClosed();
+      //noinspection ThrowableNotThrown
+      queryExecutor.getWarnings(); // Clear and discard.
+      firstWarning = null;
+    }
   }
 
   @Override
@@ -1242,17 +1265,21 @@ public class PgConnection implements BaseConnection {
     queryExecutor.abort();
   }
 
-  private synchronized Timer getTimer() {
-    if (cancelTimer == null) {
-      cancelTimer = Driver.getSharedTimer().getTimer();
+  private Timer getTimer() {
+    try (ResourceLock ignore = lock.obtain()) {
+      if (cancelTimer == null) {
+        cancelTimer = Driver.getSharedTimer().getTimer();
+      }
+      return cancelTimer;
     }
-    return cancelTimer;
   }
 
-  private synchronized void releaseTimer() {
-    if (cancelTimer != null) {
-      cancelTimer = null;
-      Driver.getSharedTimer().releaseTimer();
+  private void releaseTimer() {
+    try (ResourceLock ignore = lock.obtain()) {
+      if (cancelTimer != null) {
+        cancelTimer = null;
+        Driver.getSharedTimer().releaseTimer();
+      }
     }
   }
 
@@ -1455,7 +1482,7 @@ public class PgConnection implements BaseConnection {
           statement.close();
         } else {
           PreparedStatement checkConnectionQuery;
-          synchronized (this) {
+          try (ResourceLock ignore = lock.obtain()) {
             checkConnectionQuery = this.checkConnectionQuery;
             if (checkConnectionQuery == null) {
               checkConnectionQuery = prepareStatement("");

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
@@ -130,7 +130,7 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
    */
   @Override
   public ResultSet executeQuery() throws SQLException {
-    synchronized (this) {
+    try (ResourceLock ignore = lock.obtain()) {
       if (!executeWithFlags(0)) {
         throw new PSQLException(GT.tr("No results were returned by the query."), PSQLState.NO_DATA);
       }
@@ -148,7 +148,7 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
 
   @Override
   public int executeUpdate() throws SQLException {
-    synchronized (this) {
+    try (ResourceLock ignore = lock.obtain()) {
       executeWithFlags(QueryExecutor.QUERY_NO_RESULTS);
       checkNoResultUpdate();
       return getUpdateCount();
@@ -157,7 +157,7 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
 
   @Override
   public long executeLargeUpdate() throws SQLException {
-    synchronized (this) {
+    try (ResourceLock ignore = lock.obtain()) {
       executeWithFlags(QueryExecutor.QUERY_NO_RESULTS);
       checkNoResultUpdate();
       return getLargeUpdateCount();
@@ -173,14 +173,14 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
 
   @Override
   public boolean execute() throws SQLException {
-    synchronized (this) {
+    try (ResourceLock ignore = lock.obtain()) {
       return executeWithFlags(0);
     }
   }
 
   public boolean executeWithFlags(int flags) throws SQLException {
     try {
-      synchronized (this) {
+      try (ResourceLock ignore = lock.obtain()) {
         checkClosed();
 
         if (connection.getPreferQueryMode() == PreferQueryMode.SIMPLE) {

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgSQLXML.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgSQLXML.java
@@ -52,6 +52,7 @@ import javax.xml.transform.stream.StreamSource;
 
 public class PgSQLXML implements SQLXML {
 
+  private final ResourceLock lock = new ResourceLock();
   private final BaseConnection conn;
   private @Nullable String data; // The actual data contained.
   private boolean initialized; // Has someone assigned the data for this object?
@@ -86,41 +87,47 @@ public class PgSQLXML implements SQLXML {
   }
 
   @Override
-  public synchronized void free() {
-    freed = true;
-    data = null;
-  }
-
-  @Override
-  public synchronized @Nullable InputStream getBinaryStream() throws SQLException {
-    checkFreed();
-    ensureInitialized();
-
-    if (data == null) {
-      return null;
-    }
-
-    try {
-      return new ByteArrayInputStream(conn.getEncoding().encode(data));
-    } catch (IOException ioe) {
-      // This should be a can't happen exception. We just
-      // decoded this data, so it would be surprising that
-      // we couldn't encode it.
-      // For this reason don't make it translatable.
-      throw new PSQLException("Failed to re-encode xml data.", PSQLState.DATA_ERROR, ioe);
+  public void free() {
+    try (ResourceLock ignore = lock.obtain()) {
+      freed = true;
+      data = null;
     }
   }
 
   @Override
-  public synchronized @Nullable Reader getCharacterStream() throws SQLException {
-    checkFreed();
-    ensureInitialized();
+  public @Nullable InputStream getBinaryStream() throws SQLException {
+    try (ResourceLock ignore = lock.obtain()) {
+      checkFreed();
+      ensureInitialized();
 
-    if (data == null) {
-      return null;
+      if (data == null) {
+        return null;
+      }
+
+      try {
+        return new ByteArrayInputStream(conn.getEncoding().encode(data));
+      } catch (IOException ioe) {
+        // This should be a can't happen exception. We just
+        // decoded this data, so it would be surprising that
+        // we couldn't encode it.
+        // For this reason don't make it translatable.
+        throw new PSQLException("Failed to re-encode xml data.", PSQLState.DATA_ERROR, ioe);
+      }
     }
+  }
 
-    return new StringReader(data);
+  @Override
+  public @Nullable Reader getCharacterStream() throws SQLException {
+    try (ResourceLock ignore = lock.obtain()) {
+      checkFreed();
+      ensureInitialized();
+
+      if (data == null) {
+        return null;
+      }
+
+      return new StringReader(data);
+    }
   }
 
   // We must implement this unsafely because that's what the
@@ -130,116 +137,128 @@ public class PgSQLXML implements SQLXML {
   // ensure they are the same.
   //
   @Override
-  public synchronized <T extends Source> @Nullable T getSource(@Nullable Class<T> sourceClass)
+  public <T extends Source> @Nullable T getSource(@Nullable Class<T> sourceClass)
       throws SQLException {
-    checkFreed();
-    ensureInitialized();
+    try (ResourceLock ignore = lock.obtain()) {
+      checkFreed();
+      ensureInitialized();
 
-    String data = this.data;
-    if (data == null) {
-      return null;
-    }
-
-    try {
-      if (sourceClass == null || DOMSource.class.equals(sourceClass)) {
-        DocumentBuilder builder = getXmlFactoryFactory().newDocumentBuilder();
-        InputSource input = new InputSource(new StringReader(data));
-        DOMSource domSource = new DOMSource(builder.parse(input));
-        //noinspection unchecked
-        return (T) domSource;
-      } else if (SAXSource.class.equals(sourceClass)) {
-        XMLReader reader = getXmlFactoryFactory().createXMLReader();
-        InputSource is = new InputSource(new StringReader(data));
-        return sourceClass.cast(new SAXSource(reader, is));
-      } else if (StreamSource.class.equals(sourceClass)) {
-        return sourceClass.cast(new StreamSource(new StringReader(data)));
-      } else if (StAXSource.class.equals(sourceClass)) {
-        XMLInputFactory xif = getXmlFactoryFactory().newXMLInputFactory();
-        XMLStreamReader xsr = xif.createXMLStreamReader(new StringReader(data));
-        return sourceClass.cast(new StAXSource(xsr));
+      String data = this.data;
+      if (data == null) {
+        return null;
       }
-    } catch (Exception e) {
-      throw new PSQLException(GT.tr("Unable to decode xml data."), PSQLState.DATA_ERROR, e);
-    }
 
-    throw new PSQLException(GT.tr("Unknown XML Source class: {0}", sourceClass),
-        PSQLState.INVALID_PARAMETER_TYPE);
-  }
-
-  @Override
-  public synchronized @Nullable String getString() throws SQLException {
-    checkFreed();
-    ensureInitialized();
-    return data;
-  }
-
-  @Override
-  public synchronized OutputStream setBinaryStream() throws SQLException {
-    checkFreed();
-    initialize();
-    active = true;
-    byteArrayOutputStream = new ByteArrayOutputStream();
-    return byteArrayOutputStream;
-  }
-
-  @Override
-  public synchronized Writer setCharacterStream() throws SQLException {
-    checkFreed();
-    initialize();
-    active = true;
-    stringWriter = new StringWriter();
-    return stringWriter;
-  }
-
-  @Override
-  public synchronized <T extends Result> T setResult(Class<T> resultClass) throws SQLException {
-    checkFreed();
-    initialize();
-
-    if (resultClass == null || DOMResult.class.equals(resultClass)) {
-      domResult = new DOMResult();
-      active = true;
-      //noinspection unchecked
-      return (T) domResult;
-    } else if (SAXResult.class.equals(resultClass)) {
       try {
-        SAXTransformerFactory transformerFactory = getXmlFactoryFactory().newSAXTransformerFactory();
-        TransformerHandler transformerHandler = transformerFactory.newTransformerHandler();
-        stringWriter = new StringWriter();
-        transformerHandler.setResult(new StreamResult(stringWriter));
-        active = true;
-        return resultClass.cast(new SAXResult(transformerHandler));
-      } catch (TransformerException te) {
-        throw new PSQLException(GT.tr("Unable to create SAXResult for SQLXML."),
-            PSQLState.UNEXPECTED_ERROR, te);
+        if (sourceClass == null || DOMSource.class.equals(sourceClass)) {
+          DocumentBuilder builder = getXmlFactoryFactory().newDocumentBuilder();
+          InputSource input = new InputSource(new StringReader(data));
+          DOMSource domSource = new DOMSource(builder.parse(input));
+          //noinspection unchecked
+          return (T) domSource;
+        } else if (SAXSource.class.equals(sourceClass)) {
+          XMLReader reader = getXmlFactoryFactory().createXMLReader();
+          InputSource is = new InputSource(new StringReader(data));
+          return sourceClass.cast(new SAXSource(reader, is));
+        } else if (StreamSource.class.equals(sourceClass)) {
+          return sourceClass.cast(new StreamSource(new StringReader(data)));
+        } else if (StAXSource.class.equals(sourceClass)) {
+          XMLInputFactory xif = getXmlFactoryFactory().newXMLInputFactory();
+          XMLStreamReader xsr = xif.createXMLStreamReader(new StringReader(data));
+          return sourceClass.cast(new StAXSource(xsr));
+        }
+      } catch (Exception e) {
+        throw new PSQLException(GT.tr("Unable to decode xml data."), PSQLState.DATA_ERROR, e);
       }
-    } else if (StreamResult.class.equals(resultClass)) {
+
+      throw new PSQLException(GT.tr("Unknown XML Source class: {0}", sourceClass),
+          PSQLState.INVALID_PARAMETER_TYPE);
+    }
+  }
+
+  @Override
+  public @Nullable String getString() throws SQLException {
+    try (ResourceLock ignore = lock.obtain()) {
+      checkFreed();
+      ensureInitialized();
+      return data;
+    }
+  }
+
+  @Override
+  public OutputStream setBinaryStream() throws SQLException {
+    try (ResourceLock ignore = lock.obtain()) {
+      checkFreed();
+      initialize();
+      active = true;
+      byteArrayOutputStream = new ByteArrayOutputStream();
+      return byteArrayOutputStream;
+    }
+  }
+
+  @Override
+  public Writer setCharacterStream() throws SQLException {
+    try (ResourceLock ignore = lock.obtain()) {
+      checkFreed();
+      initialize();
+      active = true;
       stringWriter = new StringWriter();
-      active = true;
-      return resultClass.cast(new StreamResult(stringWriter));
-    } else if (StAXResult.class.equals(resultClass)) {
-      StringWriter stringWriter = new StringWriter();
-      this.stringWriter = stringWriter;
-      try {
-        XMLOutputFactory xof = getXmlFactoryFactory().newXMLOutputFactory();
-        XMLStreamWriter xsw = xof.createXMLStreamWriter(stringWriter);
-        active = true;
-        return resultClass.cast(new StAXResult(xsw));
-      } catch (XMLStreamException xse) {
-        throw new PSQLException(GT.tr("Unable to create StAXResult for SQLXML"),
-            PSQLState.UNEXPECTED_ERROR, xse);
-      }
+      return stringWriter;
     }
-
-    throw new PSQLException(GT.tr("Unknown XML Result class: {0}", resultClass),
-        PSQLState.INVALID_PARAMETER_TYPE);
   }
 
   @Override
-  public synchronized void setString(String value) throws SQLException {
-    checkFreed();
-    initialize();
-    data = value;
+  public <T extends Result> T setResult(Class<T> resultClass) throws SQLException {
+    try (ResourceLock ignore = lock.obtain()) {
+      checkFreed();
+      initialize();
+
+      if (resultClass == null || DOMResult.class.equals(resultClass)) {
+        domResult = new DOMResult();
+        active = true;
+        //noinspection unchecked
+        return (T) domResult;
+      } else if (SAXResult.class.equals(resultClass)) {
+        try {
+          SAXTransformerFactory transformerFactory = getXmlFactoryFactory().newSAXTransformerFactory();
+          TransformerHandler transformerHandler = transformerFactory.newTransformerHandler();
+          stringWriter = new StringWriter();
+          transformerHandler.setResult(new StreamResult(stringWriter));
+          active = true;
+          return resultClass.cast(new SAXResult(transformerHandler));
+        } catch (TransformerException te) {
+          throw new PSQLException(GT.tr("Unable to create SAXResult for SQLXML."),
+              PSQLState.UNEXPECTED_ERROR, te);
+        }
+      } else if (StreamResult.class.equals(resultClass)) {
+        stringWriter = new StringWriter();
+        active = true;
+        return resultClass.cast(new StreamResult(stringWriter));
+      } else if (StAXResult.class.equals(resultClass)) {
+        StringWriter stringWriter = new StringWriter();
+        this.stringWriter = stringWriter;
+        try {
+          XMLOutputFactory xof = getXmlFactoryFactory().newXMLOutputFactory();
+          XMLStreamWriter xsw = xof.createXMLStreamWriter(stringWriter);
+          active = true;
+          return resultClass.cast(new StAXResult(xsw));
+        } catch (XMLStreamException xse) {
+          throw new PSQLException(GT.tr("Unable to create StAXResult for SQLXML"),
+              PSQLState.UNEXPECTED_ERROR, xse);
+        }
+      }
+
+      throw new PSQLException(GT.tr("Unknown XML Result class: {0}", resultClass),
+          PSQLState.INVALID_PARAMETER_TYPE);
+    }
+  }
+
+  @Override
+  public void setString(String value) throws SQLException {
+    try (ResourceLock ignore = lock.obtain()) {
+      checkFreed();
+      initialize();
+      data = value;
+    }
   }
 
   private void checkFreed() throws SQLException {

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/ResourceLock.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/ResourceLock.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2004, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.jdbc;
+
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Extends a ReentrantLock for use in try-with-resources block.
+ *
+ * <h2>Example use</h2>
+ * <pre>{@code
+ *
+ *   try (ResourceLock ignore = lock.obtain()) {
+ *     // do something while holding the resource lock
+ *   }
+ *
+ * }</pre>
+ */
+public final class ResourceLock extends ReentrantLock implements AutoCloseable {
+
+  /**
+   * Obtain a lock and return the ResourceLock for use in try-with-resources block.
+   */
+  public ResourceLock obtain() {
+    lock();
+    return this;
+  }
+
+  /**
+   * Unlock on exit of try-with-resources block.
+   */
+  @Override
+  public void close() {
+    this.unlock();
+  }
+}

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
@@ -73,6 +73,7 @@ public class TypeInfoCache implements TypeInfo {
   private @Nullable PreparedStatement getArrayDelimiterStatement;
   private @Nullable PreparedStatement getTypeInfoStatement;
   private @Nullable PreparedStatement getAllTypeInfoStatement;
+  private final ResourceLock lock = new ResourceLock();
 
   // basic pg types info:
   // 0 - type name
@@ -166,42 +167,46 @@ public class TypeInfoCache implements TypeInfo {
     pgNameToJavaClass.put("hstore", Map.class.getName());
   }
 
-  public synchronized void addCoreType(String pgTypeName, Integer oid, Integer sqlType,
+  public void addCoreType(String pgTypeName, Integer oid, Integer sqlType,
       String javaClass, Integer arrayOid) {
-    pgNameToJavaClass.put(pgTypeName, javaClass);
-    pgNameToOid.put(pgTypeName, oid);
-    oidToPgName.put(oid, pgTypeName);
-    javaArrayTypeToOid.put(javaClass, arrayOid);
-    pgArrayToPgType.put(arrayOid, oid);
-    pgNameToSQLType.put(pgTypeName, sqlType);
-    oidToSQLType.put(oid, sqlType);
+    try (ResourceLock ignore = lock.obtain()) {
+      pgNameToJavaClass.put(pgTypeName, javaClass);
+      pgNameToOid.put(pgTypeName, oid);
+      oidToPgName.put(oid, pgTypeName);
+      javaArrayTypeToOid.put(javaClass, arrayOid);
+      pgArrayToPgType.put(arrayOid, oid);
+      pgNameToSQLType.put(pgTypeName, sqlType);
+      oidToSQLType.put(oid, sqlType);
 
-    // Currently we hardcode all core types array delimiter
-    // to a comma. In a stock install the only exception is
-    // the box datatype and it's not a JDBC core type.
-    //
-    Character delim = ',';
-    arrayOidToDelimiter.put(oid, delim);
-    arrayOidToDelimiter.put(arrayOid, delim);
+      // Currently we hardcode all core types array delimiter
+      // to a comma. In a stock install the only exception is
+      // the box datatype and it's not a JDBC core type.
+      //
+      Character delim = ',';
+      arrayOidToDelimiter.put(oid, delim);
+      arrayOidToDelimiter.put(arrayOid, delim);
 
-    String pgArrayTypeName = pgTypeName + "[]";
-    pgNameToJavaClass.put(pgArrayTypeName, "java.sql.Array");
-    pgNameToSQLType.put(pgArrayTypeName, Types.ARRAY);
-    oidToSQLType.put(arrayOid, Types.ARRAY);
-    pgNameToOid.put(pgArrayTypeName, arrayOid);
-    pgArrayTypeName = "_" + pgTypeName;
-    if (!pgNameToJavaClass.containsKey(pgArrayTypeName)) {
+      String pgArrayTypeName = pgTypeName + "[]";
       pgNameToJavaClass.put(pgArrayTypeName, "java.sql.Array");
       pgNameToSQLType.put(pgArrayTypeName, Types.ARRAY);
+      oidToSQLType.put(arrayOid, Types.ARRAY);
       pgNameToOid.put(pgArrayTypeName, arrayOid);
-      oidToPgName.put(arrayOid, pgArrayTypeName);
+      pgArrayTypeName = "_" + pgTypeName;
+      if (!pgNameToJavaClass.containsKey(pgArrayTypeName)) {
+        pgNameToJavaClass.put(pgArrayTypeName, "java.sql.Array");
+        pgNameToSQLType.put(pgArrayTypeName, Types.ARRAY);
+        pgNameToOid.put(pgArrayTypeName, arrayOid);
+        oidToPgName.put(arrayOid, pgArrayTypeName);
+      }
     }
   }
 
-  public synchronized void addDataType(String type, Class<? extends PGobject> klass)
+  public void addDataType(String type, Class<? extends PGobject> klass)
       throws SQLException {
-    pgNameToPgObject.put(type, klass);
-    pgNameToJavaClass.put(type, klass.getName());
+    try (ResourceLock ignore = lock.obtain()) {
+      pgNameToPgObject.put(type, klass);
+      pgNameToJavaClass.put(type, klass.getName());
+    }
   }
 
   public Iterator<String> getPGTypeNamesWithSQLTypes() {
@@ -301,69 +306,75 @@ public class TypeInfoCache implements TypeInfo {
     return getTypeInfoStatement;
   }
 
-  public synchronized int getSQLType(String pgTypeName) throws SQLException {
-    /*
-    Get a few things out of the way such as arrays and known types
-     */
-    if (pgTypeName.endsWith("[]")) {
-      return Types.ARRAY;
-    }
-    Integer i = this.pgNameToSQLType.get(pgTypeName);
-    if (i != null) {
+  public int getSQLType(String pgTypeName) throws SQLException {
+    try (ResourceLock ignore = lock.obtain()) {
+      /*
+        Get a few things out of the way such as arrays and known types
+      */
+      if (pgTypeName.endsWith("[]")) {
+        return Types.ARRAY;
+      }
+      Integer i = this.pgNameToSQLType.get(pgTypeName);
+      if (i != null) {
+        return i;
+      }
+
+      /*
+        All else fails then we will query the database.
+        save for future calls
+      */
+      i = getSQLType(castNonNull(getPGType(pgTypeName)));
+
+      pgNameToSQLType.put(pgTypeName, i);
       return i;
     }
-
-    /*
-      All else fails then we will query the database.
-      save for future calls
-    */
-    i = getSQLType(castNonNull(getPGType(pgTypeName)));
-
-    pgNameToSQLType.put(pgTypeName, i);
-    return i;
   }
 
   @Override
-  public synchronized int getJavaArrayType(String className) throws SQLException {
-    Integer oid = javaArrayTypeToOid.get(className);
-    if (oid == null) {
-      return Oid.UNSPECIFIED;
+  public int getJavaArrayType(String className) throws SQLException {
+    try (ResourceLock ignore = lock.obtain()) {
+      Integer oid = javaArrayTypeToOid.get(className);
+      if (oid == null) {
+        return Oid.UNSPECIFIED;
+      }
+      return oid;
     }
-    return oid;
   }
 
-  public synchronized int getSQLType(int typeOid) throws SQLException {
-    if (typeOid == Oid.UNSPECIFIED) {
-      return Types.OTHER;
+  public int getSQLType(int typeOid) throws SQLException {
+    try (ResourceLock ignore = lock.obtain()) {
+      if (typeOid == Oid.UNSPECIFIED) {
+        return Types.OTHER;
+      }
+
+      Integer i = oidToSQLType.get(typeOid);
+      if (i != null) {
+        return i;
+      }
+
+      LOGGER.log(Level.FINEST, "querying SQL typecode for pg type oid '{0}'", intOidToLong(typeOid));
+
+      PreparedStatement getTypeInfoStatement = prepareGetTypeInfoStatement();
+
+      getTypeInfoStatement.setLong(1, intOidToLong(typeOid));
+
+      // Go through BaseStatement to avoid transaction start.
+      if (!((BaseStatement) getTypeInfoStatement)
+          .executeWithFlags(QueryExecutor.QUERY_SUPPRESS_BEGIN)) {
+        throw new PSQLException(GT.tr("No results were returned by the query."), PSQLState.NO_DATA);
+      }
+
+      ResultSet rs = castNonNull(getTypeInfoStatement.getResultSet());
+
+      int sqlType = Types.OTHER;
+      if (rs.next()) {
+        sqlType = getSQLTypeFromQueryResult(rs);
+      }
+      rs.close();
+
+      oidToSQLType.put(typeOid, sqlType);
+      return sqlType;
     }
-
-    Integer i = oidToSQLType.get(typeOid);
-    if (i != null) {
-      return i;
-    }
-
-    LOGGER.log(Level.FINEST, "querying SQL typecode for pg type oid '{0}'", intOidToLong(typeOid));
-
-    PreparedStatement getTypeInfoStatement = prepareGetTypeInfoStatement();
-
-    getTypeInfoStatement.setLong(1, intOidToLong(typeOid));
-
-    // Go through BaseStatement to avoid transaction start.
-    if (!((BaseStatement) getTypeInfoStatement)
-        .executeWithFlags(QueryExecutor.QUERY_SUPPRESS_BEGIN)) {
-      throw new PSQLException(GT.tr("No results were returned by the query."), PSQLState.NO_DATA);
-    }
-
-    ResultSet rs = castNonNull(getTypeInfoStatement.getResultSet());
-
-    int sqlType = Types.OTHER;
-    if (rs.next()) {
-      sqlType = getSQLTypeFromQueryResult(rs);
-    }
-    rs.close();
-
-    oidToSQLType.put(typeOid, sqlType);
-    return sqlType;
   }
 
   private PreparedStatement getOidStatement(String pgTypeName) throws SQLException {
@@ -472,82 +483,86 @@ public class TypeInfoCache implements TypeInfo {
     return oidStatementComplex;
   }
 
-  public synchronized int getPGType(String pgTypeName) throws SQLException {
-    // there really isn't anything else to return other than UNSPECIFIED here.
-    if ( pgTypeName == null ) {
-      return Oid.UNSPECIFIED;
-    }
+  public int getPGType(String pgTypeName) throws SQLException {
+    try (ResourceLock ignore = lock.obtain()) {
+      // there really isn't anything else to return other than UNSPECIFIED here.
+      if (pgTypeName == null) {
+        return Oid.UNSPECIFIED;
+      }
 
-    Integer oid = pgNameToOid.get(pgTypeName);
-    if (oid != null) {
-      return oid;
-    }
+      Integer oid = pgNameToOid.get(pgTypeName);
+      if (oid != null) {
+        return oid;
+      }
 
-    PreparedStatement oidStatement = getOidStatement(pgTypeName);
+      PreparedStatement oidStatement = getOidStatement(pgTypeName);
 
-    // Go through BaseStatement to avoid transaction start.
-    if (!((BaseStatement) oidStatement).executeWithFlags(QueryExecutor.QUERY_SUPPRESS_BEGIN)) {
-      throw new PSQLException(GT.tr("No results were returned by the query."), PSQLState.NO_DATA);
-    }
+      // Go through BaseStatement to avoid transaction start.
+      if (!((BaseStatement) oidStatement).executeWithFlags(QueryExecutor.QUERY_SUPPRESS_BEGIN)) {
+        throw new PSQLException(GT.tr("No results were returned by the query."), PSQLState.NO_DATA);
+      }
 
-    oid = Oid.UNSPECIFIED;
-    ResultSet rs = castNonNull(oidStatement.getResultSet());
-    if (rs.next()) {
-      oid = (int) rs.getLong(1);
-      String internalName = castNonNull(rs.getString(2));
-      oidToPgName.put(oid, internalName);
-      pgNameToOid.put(internalName, oid);
-    }
-    pgNameToOid.put(pgTypeName, oid);
-    rs.close();
-
-    return oid;
-  }
-
-  public synchronized @Nullable String getPGType(int oid) throws SQLException {
-    if (oid == Oid.UNSPECIFIED) {
-      // TODO: it would be great to forbid UNSPECIFIED argument, and make the return type non-nullable
-      return null;
-    }
-
-    String pgTypeName = oidToPgName.get(oid);
-    if (pgTypeName != null) {
-      return pgTypeName;
-    }
-
-    PreparedStatement getNameStatement = prepareGetNameStatement();
-
-    getNameStatement.setInt(1, oid);
-
-    // Go through BaseStatement to avoid transaction start.
-    if (!((BaseStatement) getNameStatement).executeWithFlags(QueryExecutor.QUERY_SUPPRESS_BEGIN)) {
-      throw new PSQLException(GT.tr("No results were returned by the query."), PSQLState.NO_DATA);
-    }
-
-    ResultSet rs = castNonNull(getNameStatement.getResultSet());
-    if (rs.next()) {
-      boolean onPath = rs.getBoolean(1);
-      String schema = castNonNull(rs.getString(2), "schema");
-      String name = castNonNull(rs.getString(3), "name");
-      if (onPath) {
-        pgTypeName = name;
-        pgNameToOid.put(schema + "." + name, oid);
-      } else {
-        // TODO: escaping !?
-        pgTypeName = "\"" + schema + "\".\"" + name + "\"";
-        // if all is lowercase add special type info
-        // TODO: should probably check for all special chars
-        if (schema.equals(schema.toLowerCase(Locale.ROOT)) && schema.indexOf('.') == -1
-            && name.equals(name.toLowerCase(Locale.ROOT)) && name.indexOf('.') == -1) {
-          pgNameToOid.put(schema + "." + name, oid);
-        }
+      oid = Oid.UNSPECIFIED;
+      ResultSet rs = castNonNull(oidStatement.getResultSet());
+      if (rs.next()) {
+        oid = (int) rs.getLong(1);
+        String internalName = castNonNull(rs.getString(2));
+        oidToPgName.put(oid, internalName);
+        pgNameToOid.put(internalName, oid);
       }
       pgNameToOid.put(pgTypeName, oid);
-      oidToPgName.put(oid, pgTypeName);
-    }
-    rs.close();
+      rs.close();
 
-    return pgTypeName;
+      return oid;
+    }
+  }
+
+  public @Nullable String getPGType(int oid) throws SQLException {
+    try (ResourceLock ignore = lock.obtain()) {
+      if (oid == Oid.UNSPECIFIED) {
+        // TODO: it would be great to forbid UNSPECIFIED argument, and make the return type non-nullable
+        return null;
+      }
+
+      String pgTypeName = oidToPgName.get(oid);
+      if (pgTypeName != null) {
+        return pgTypeName;
+      }
+
+      PreparedStatement getNameStatement = prepareGetNameStatement();
+
+      getNameStatement.setInt(1, oid);
+
+      // Go through BaseStatement to avoid transaction start.
+      if (!((BaseStatement) getNameStatement).executeWithFlags(QueryExecutor.QUERY_SUPPRESS_BEGIN)) {
+        throw new PSQLException(GT.tr("No results were returned by the query."), PSQLState.NO_DATA);
+      }
+
+      ResultSet rs = castNonNull(getNameStatement.getResultSet());
+      if (rs.next()) {
+        boolean onPath = rs.getBoolean(1);
+        String schema = castNonNull(rs.getString(2), "schema");
+        String name = castNonNull(rs.getString(3), "name");
+        if (onPath) {
+          pgTypeName = name;
+          pgNameToOid.put(schema + "." + name, oid);
+        } else {
+          // TODO: escaping !?
+          pgTypeName = "\"" + schema + "\".\"" + name + "\"";
+          // if all is lowercase add special type info
+          // TODO: should probably check for all special chars
+          if (schema.equals(schema.toLowerCase(Locale.ROOT)) && schema.indexOf('.') == -1
+              && name.equals(name.toLowerCase(Locale.ROOT)) && name.indexOf('.') == -1) {
+            pgNameToOid.put(schema + "." + name, oid);
+          }
+        }
+        pgNameToOid.put(pgTypeName, oid);
+        oidToPgName.put(oid, pgTypeName);
+      }
+      rs.close();
+
+      return pgTypeName;
+    }
   }
 
   private PreparedStatement prepareGetNameStatement() throws SQLException {
@@ -577,47 +592,51 @@ public class TypeInfoCache implements TypeInfo {
    * @param oid input oid
    * @return oid of the array's base element or the provided oid (if not array)
    */
-  protected synchronized int convertArrayToBaseOid(int oid) {
-    Integer i = pgArrayToPgType.get(oid);
-    if (i == null) {
-      return oid;
+  protected int convertArrayToBaseOid(int oid) {
+    try (ResourceLock ignore = lock.obtain()) {
+      Integer i = pgArrayToPgType.get(oid);
+      if (i == null) {
+        return oid;
+      }
+      return i;
     }
-    return i;
   }
 
-  public synchronized char getArrayDelimiter(int oid) throws SQLException {
-    if (oid == Oid.UNSPECIFIED) {
-      return ',';
-    }
+  public char getArrayDelimiter(int oid) throws SQLException {
+    try (ResourceLock ignore = lock.obtain()) {
+      if (oid == Oid.UNSPECIFIED) {
+        return ',';
+      }
 
-    Character delim = arrayOidToDelimiter.get(oid);
-    if (delim != null) {
+      Character delim = arrayOidToDelimiter.get(oid);
+      if (delim != null) {
+        return delim;
+      }
+
+      PreparedStatement getArrayDelimiterStatement = prepareGetArrayDelimiterStatement();
+
+      getArrayDelimiterStatement.setInt(1, oid);
+
+      // Go through BaseStatement to avoid transaction start.
+      if (!((BaseStatement) getArrayDelimiterStatement)
+          .executeWithFlags(QueryExecutor.QUERY_SUPPRESS_BEGIN)) {
+        throw new PSQLException(GT.tr("No results were returned by the query."), PSQLState.NO_DATA);
+      }
+
+      ResultSet rs = castNonNull(getArrayDelimiterStatement.getResultSet());
+      if (!rs.next()) {
+        throw new PSQLException(GT.tr("No results were returned by the query."), PSQLState.NO_DATA);
+      }
+
+      String s = castNonNull(rs.getString(1));
+      delim = s.charAt(0);
+
+      arrayOidToDelimiter.put(oid, delim);
+
+      rs.close();
+
       return delim;
     }
-
-    PreparedStatement getArrayDelimiterStatement = prepareGetArrayDelimiterStatement();
-
-    getArrayDelimiterStatement.setInt(1, oid);
-
-    // Go through BaseStatement to avoid transaction start.
-    if (!((BaseStatement) getArrayDelimiterStatement)
-        .executeWithFlags(QueryExecutor.QUERY_SUPPRESS_BEGIN)) {
-      throw new PSQLException(GT.tr("No results were returned by the query."), PSQLState.NO_DATA);
-    }
-
-    ResultSet rs = castNonNull(getArrayDelimiterStatement.getResultSet());
-    if (!rs.next()) {
-      throw new PSQLException(GT.tr("No results were returned by the query."), PSQLState.NO_DATA);
-    }
-
-    String s = castNonNull(rs.getString(1));
-    delim = s.charAt(0);
-
-    arrayOidToDelimiter.put(oid, delim);
-
-    rs.close();
-
-    return delim;
   }
 
   private PreparedStatement prepareGetArrayDelimiterStatement() throws SQLException {
@@ -631,50 +650,52 @@ public class TypeInfoCache implements TypeInfo {
     return getArrayDelimiterStatement;
   }
 
-  public synchronized int getPGArrayElement(int oid) throws SQLException {
-    if (oid == Oid.UNSPECIFIED) {
-      return Oid.UNSPECIFIED;
-    }
+  public int getPGArrayElement(int oid) throws SQLException {
+    try (ResourceLock ignore = lock.obtain()) {
+      if (oid == Oid.UNSPECIFIED) {
+        return Oid.UNSPECIFIED;
+      }
 
-    Integer pgType = pgArrayToPgType.get(oid);
+      Integer pgType = pgArrayToPgType.get(oid);
 
-    if (pgType != null) {
+      if (pgType != null) {
+        return pgType;
+      }
+
+      PreparedStatement getArrayElementOidStatement = prepareGetArrayElementOidStatement();
+
+      getArrayElementOidStatement.setInt(1, oid);
+
+      // Go through BaseStatement to avoid transaction start.
+      if (!((BaseStatement) getArrayElementOidStatement)
+          .executeWithFlags(QueryExecutor.QUERY_SUPPRESS_BEGIN)) {
+        throw new PSQLException(GT.tr("No results were returned by the query."), PSQLState.NO_DATA);
+      }
+
+      ResultSet rs = castNonNull(getArrayElementOidStatement.getResultSet());
+      if (!rs.next()) {
+        throw new PSQLException(GT.tr("No results were returned by the query."), PSQLState.NO_DATA);
+      }
+
+      pgType = (int) rs.getLong(1);
+      boolean onPath = rs.getBoolean(2);
+      String schema = rs.getString(3);
+      String name = castNonNull(rs.getString(4));
+      pgArrayToPgType.put(oid, pgType);
+      pgNameToOid.put(schema + "." + name, pgType);
+      String fullName = "\"" + schema + "\".\"" + name + "\"";
+      pgNameToOid.put(fullName, pgType);
+      if (onPath && name.equals(name.toLowerCase(Locale.ROOT))) {
+        oidToPgName.put(pgType, name);
+        pgNameToOid.put(name, pgType);
+      } else {
+        oidToPgName.put(pgType, fullName);
+      }
+
+      rs.close();
+
       return pgType;
     }
-
-    PreparedStatement getArrayElementOidStatement = prepareGetArrayElementOidStatement();
-
-    getArrayElementOidStatement.setInt(1, oid);
-
-    // Go through BaseStatement to avoid transaction start.
-    if (!((BaseStatement) getArrayElementOidStatement)
-        .executeWithFlags(QueryExecutor.QUERY_SUPPRESS_BEGIN)) {
-      throw new PSQLException(GT.tr("No results were returned by the query."), PSQLState.NO_DATA);
-    }
-
-    ResultSet rs = castNonNull(getArrayElementOidStatement.getResultSet());
-    if (!rs.next()) {
-      throw new PSQLException(GT.tr("No results were returned by the query."), PSQLState.NO_DATA);
-    }
-
-    pgType = (int) rs.getLong(1);
-    boolean onPath = rs.getBoolean(2);
-    String schema = rs.getString(3);
-    String name = castNonNull(rs.getString(4));
-    pgArrayToPgType.put(oid, pgType);
-    pgNameToOid.put(schema + "." + name, pgType);
-    String fullName = "\"" + schema + "\".\"" + name + "\"";
-    pgNameToOid.put(fullName, pgType);
-    if (onPath && name.equals(name.toLowerCase(Locale.ROOT))) {
-      oidToPgName.put(pgType, name);
-      pgNameToOid.put(name, pgType);
-    } else {
-      oidToPgName.put(pgType, fullName);
-    }
-
-    rs.close();
-
-    return pgType;
   }
 
   private PreparedStatement prepareGetArrayElementOidStatement() throws SQLException {
@@ -689,30 +710,34 @@ public class TypeInfoCache implements TypeInfo {
     return getArrayElementOidStatement;
   }
 
-  public synchronized @Nullable Class<? extends PGobject> getPGobject(String type) {
-    return pgNameToPgObject.get(type);
+  public @Nullable Class<? extends PGobject> getPGobject(String type) {
+    try (ResourceLock ignore = lock.obtain()) {
+      return pgNameToPgObject.get(type);
+    }
   }
 
-  public synchronized String getJavaClass(int oid) throws SQLException {
-    String pgTypeName = getPGType(oid);
-    if (pgTypeName == null) {
-      // Technically speaking, we should not be here
-      // null result probably means oid == UNSPECIFIED which has no clear way
-      // to map to Java
-      return "java.lang.String";
-    }
+  public String getJavaClass(int oid) throws SQLException {
+    try (ResourceLock ignore = lock.obtain()) {
+      String pgTypeName = getPGType(oid);
+      if (pgTypeName == null) {
+        // Technically speaking, we should not be here
+        // null result probably means oid == UNSPECIFIED which has no clear way
+        // to map to Java
+        return "java.lang.String";
+      }
 
-    String result = pgNameToJavaClass.get(pgTypeName);
-    if (result != null) {
-      return result;
-    }
+      String result = pgNameToJavaClass.get(pgTypeName);
+      if (result != null) {
+        return result;
+      }
 
-    if (getSQLType(pgTypeName) == Types.ARRAY) {
-      result = "java.sql.Array";
-      pgNameToJavaClass.put(pgTypeName, result);
-    }
+      if (getSQLType(pgTypeName) == Types.ARRAY) {
+        result = "java.sql.Array";
+        pgNameToJavaClass.put(pgTypeName, result);
+      }
 
-    return result == null ? "java.lang.String" : result;
+      return result == null ? "java.lang.String" : result;
+    }
   }
 
   public @Nullable String getTypeForAlias(@Nullable String alias) {

--- a/pgjdbc/src/main/java/org/postgresql/util/SharedTimer.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/SharedTimer.java
@@ -5,6 +5,8 @@
 
 package org.postgresql.util;
 
+import org.postgresql.jdbc.ResourceLock;
+
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.Timer;
@@ -19,6 +21,7 @@ public class SharedTimer {
   private static final Logger LOGGER = Logger.getLogger(SharedTimer.class.getName());
   private volatile @Nullable Timer timer;
   private final AtomicInteger refCount = new AtomicInteger(0);
+  private final ResourceLock lock = new ResourceLock();
 
   public SharedTimer() {
   }
@@ -27,48 +30,52 @@ public class SharedTimer {
     return refCount.get();
   }
 
-  public synchronized Timer getTimer() {
-    Timer timer = this.timer;
-    if (timer == null) {
-      int index = timerCount.incrementAndGet();
+  public Timer getTimer() {
+    try (ResourceLock ignore = lock.obtain()) {
+      Timer timer = this.timer;
+      if (timer == null) {
+        int index = timerCount.incrementAndGet();
 
-      /*
-       Temporarily switch contextClassLoader to the one that loaded this driver to avoid TimerThread preventing current
-       contextClassLoader - which may be the ClassLoader of a web application - from being GC:ed.
-       */
-      final ClassLoader prevContextCL = Thread.currentThread().getContextClassLoader();
-      try {
         /*
-         Scheduled tasks should not need to use .getContextClassLoader, so we just reset it to null
+         Temporarily switch contextClassLoader to the one that loaded this driver to avoid TimerThread preventing current
+         contextClassLoader - which may be the ClassLoader of a web application - from being GC:ed.
          */
-        Thread.currentThread().setContextClassLoader(null);
+        final ClassLoader prevContextCL = Thread.currentThread().getContextClassLoader();
+        try {
+          /*
+           Scheduled tasks should not need to use .getContextClassLoader, so we just reset it to null
+           */
+          Thread.currentThread().setContextClassLoader(null);
 
-        this.timer = timer = new Timer("PostgreSQL-JDBC-SharedTimer-" + index, true);
-      } finally {
-        Thread.currentThread().setContextClassLoader(prevContextCL);
+          this.timer = timer = new Timer("PostgreSQL-JDBC-SharedTimer-" + index, true);
+        } finally {
+          Thread.currentThread().setContextClassLoader(prevContextCL);
+        }
       }
+      refCount.incrementAndGet();
+      return timer;
     }
-    refCount.incrementAndGet();
-    return timer;
   }
 
-  public synchronized void releaseTimer() {
-    int count = refCount.decrementAndGet();
-    if (count > 0) {
-      // There are outstanding references to the timer so do nothing
-      LOGGER.log(Level.FINEST, "Outstanding references still exist so not closing shared Timer");
-    } else if (count == 0) {
-      // This is the last usage of the Timer so cancel it so it's resources can be release.
-      LOGGER.log(Level.FINEST, "No outstanding references to shared Timer, will cancel and close it");
-      if (timer != null) {
-        timer.cancel();
-        timer = null;
+  public void releaseTimer() {
+    try (ResourceLock ignore = lock.obtain()) {
+      int count = refCount.decrementAndGet();
+      if (count > 0) {
+        // There are outstanding references to the timer so do nothing
+        LOGGER.log(Level.FINEST, "Outstanding references still exist so not closing shared Timer");
+      } else if (count == 0) {
+        // This is the last usage of the Timer so cancel it so it's resources can be release.
+        LOGGER.log(Level.FINEST, "No outstanding references to shared Timer, will cancel and close it");
+        if (timer != null) {
+          timer.cancel();
+          timer = null;
+        }
+      } else {
+        // Should not get here under normal circumstance, probably a bug in app code.
+        LOGGER.log(Level.WARNING,
+            "releaseTimer() called too many times; there is probably a bug in the calling code");
+        refCount.set(0);
       }
-    } else {
-      // Should not get here under normal circumstance, probably a bug in app code.
-      LOGGER.log(Level.WARNING,
-          "releaseTimer() called too many times; there is probably a bug in the calling code");
-      refCount.set(0);
     }
   }
 }

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/ResourceLockTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/ResourceLockTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2004, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.jdbc;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class ResourceLockTest {
+  @Test
+  void testObtainClose() {
+    final ResourceLock lock = new ResourceLock();
+
+    assertFalse(lock.isLocked(),
+        "lock.isLocked(). The newly created resource lock should be unlocked");
+    assertFalse(lock.isHeldByCurrentThread(),
+        "lock.isHeldByCurrentThread(). The newly created resource lock should not be held by the current thread");
+
+    try (ResourceLock ignore = lock.obtain()) {
+      assertTrue(lock.isLocked(),
+          "lock.isLocked(). Obtained lock should be locked");
+      assertTrue(lock.isHeldByCurrentThread(),
+          "lock.isHeldByCurrentThread(). Obtained lock should be held by the current thread");
+    }
+
+    assertFalse(lock.isLocked(), "lock.isLocked(). Closed resource lock should be unlocked");
+    assertFalse(lock.isHeldByCurrentThread(),
+        "lock.isHeldByCurrentThread(). Closed resource lock should not be held by the current thread");
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/CopyLargeFileTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/CopyLargeFileTest.java
@@ -104,7 +104,7 @@ public class CopyLargeFileTest {
           + seed + " to reproduce the test";
       t.addSuppressed(new Throwable(message) {
         @Override
-        public synchronized Throwable fillInStackTrace() {
+        public Throwable fillInStackTrace() {
           return this;
         }
       });


### PR DESCRIPTION
Referencing https://github.com/pgjdbc/pgjdbc/issues/1951 for outline / motivation which is to improve compatibility with loom.

Change PgStatement, PgPreparedStatement and PgCallableStatement replacing synchronized (this) blocks with use of ReentrantLock to be compatible with loom.

In doing this change for PgStatement this PR must include:

All synchronized (this) blocks in PgStatement
All synchronized (this) blocks in it's sub types (PgPreparedStatement and PgCallableStatement)
I confirm that this PR includes all synchronized (this) blocks across PgStatement and all it's sub types.

Note that this PR does not add any new tests or change any existing tests. I do not believe either is required.