### PR TITLE
Change the signature of the PGResultSet.toDouble(String) method so that it is not static

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/ArrayDecoding.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/ArrayDecoding.java
@@ -232,7 +232,7 @@ final class ArrayDecoding {
 
     @Override
     Object parseValue(String stringVal, BaseConnection connection) throws SQLException {
-      return PgResultSet.toDouble(stringVal);
+      return PgResultSet.toDoubleReference(stringVal);
     }
   };
 

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
@@ -3286,10 +3286,14 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
     return 0; // SQL NULL
   }
 
-  public static double toDouble(@Nullable String s) throws SQLException {
+
+  public double toDouble(@Nullable String s) throws SQLException {
+    return toDoubleReference(s);
+  }
+
+  public static double toDoubleReference(@Nullable String s) throws SQLException {
     if (s != null) {
       try {
-        s = s.trim();
         return Double.parseDouble(s);
       } catch (NumberFormatException e) {
         throw new PSQLException(GT.tr("Bad value for type {0} : {1}", "double", s),

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
@@ -3286,7 +3286,6 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
     return 0; // SQL NULL
   }
 
-
   public double toDouble(@Nullable String s) throws SQLException {
     return toDoubleReference(s);
   }


### PR DESCRIPTION
Change the signature of the PGResultSet.toDouble(String) method so that it is not static

The toDouble(String) method instead calls a static reference implementation.    This change will allow code,
which might extend this class, to provide an alternative implementation.   One possible example alternative
is the code in https://github.com/wrandelshofer/FastDoubleParser.

A simple test program like this:

```java
        for (int i = 0; i < 50; i++) {
            Statement st = conn.createStatement();
            ResultSet rs = st.executeQuery("select random() as one from generate_series(1,500000);");

            while (rs.next()) {
                double j = rs.getDouble(1);
                total += j;
            }
        }
```

runs in 9.2s for standard JDK runtime, and only 5.9s when using FastDoubleParser in place of Total memory allocations drop from 11.4GB to 4.8GB as measured using Java Flight Recorder. These were measured using JDK19 on a Apple M1 Max Mac Book Pro.

The call to String.trim() isn't needed as the Double.parseDouble(String) method already makes that call.

For database client code which is using large data sets (and which are stored in a data warehouse as text types) this change is a simple change to the API of PgResultSet, and which allows significant improvements to the performance of the JDBC driver.

Thank you for considering this PR.
