### PR TITLE
removes usage of checkstyle's ant classpath which is being removed

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -218,10 +218,6 @@ allprojects {
         }
 
         val checkstyleTasks = tasks.withType<Checkstyle>()
-        checkstyleTasks.configureEach {
-            // Checkstyle 8.26 does not need classpath, see https://github.com/gradle/gradle/issues/14227
-            classpath = files()
-        }
 
         tasks.register("checkstyleAll") {
             dependsOn(checkstyleTasks)

--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -863,9 +863,9 @@ public enum PGProperty {
   /**
    * Returns the value of the connection parameter from the given {@link Properties} or the
    * default value
-   * @deprecated use {@link #getOrDefault(Properties)} instead
    * @param properties properties to take actual value from
    * @return evaluated value for this connection parameter or null
+   * @deprecated use {@link #getOrDefault(Properties)} instead
    */
   @Deprecated
   public @Nullable String get(Properties properties) {


### PR DESCRIPTION
As part of https://github.com/checkstyle/checkstyle/issues/12338 and identified at https://github.com/checkstyle/checkstyle/pull/12392#issuecomment-1312321382 ,

Checkstyle is removing Ant's classpath as its main functonality was removed some time ago and has not been doing anything really.