### PR TITLE
fix - binary conversion of (very) long numeric values

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/util/ByteConverter.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/ByteConverter.java
@@ -127,8 +127,8 @@ public class ByteConverter {
       throw new IllegalArgumentException("number of bytes should be at-least 8");
     }
 
-    //number of 2-byte shorts representing 4 decimal digits
-    short len = ByteConverter.int2(bytes, pos);
+    //number of 2-byte shorts representing 4 decimal digits - should be treated as unsigned
+    int len = (ByteConverter.int2(bytes, pos) & 0xFFFF);
     //0 based number of 4 decimal digits (i.e. 2-byte shorts) before the decimal
     //a value <= 0 indicates an absolute value < 1.
     short weight = ByteConverter.int2(bytes, pos + 2);

--- a/pgjdbc/src/test/java/org/postgresql/util/BigDecimalByteConverterTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/util/BigDecimalByteConverterTest.java
@@ -75,6 +75,7 @@ public class BigDecimalByteConverterTest {
     numbers.add(new Object[] {new BigDecimal("1000000").setScale(31)});
     numbers.add(new Object[] {new BigDecimal("10000000000000000000000000000000000000").setScale(14)});
     numbers.add(new Object[] {new BigDecimal("90000000000000000000000000000000000000")});
+    numbers.add(new Object[] {new BigDecimal(BigInteger.TEN.pow(131072).subtract(BigInteger.ONE))});
     return numbers;
   }
 


### PR DESCRIPTION
fix binary conversion of numeric values longer than 4 * 2^15 digits

fixes https://github.com/pgjdbc/pgjdbc/issues/2695

### All Submissions:

* [ ] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Does `./gradlew autostyleCheck checkstyleAll` pass ?
3. [ ] Have you added your new test classes to an existing test suite in alphabetical order?

### Changes to Existing Features:

* [ ] Does this break existing behaviour? If so please explain.
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
