### PR TITLE
fix: A database name can contain a slash. Fixes Issue #2694

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/Driver.java
+++ b/pgjdbc/src/main/java/org/postgresql/Driver.java
@@ -548,11 +548,6 @@ public class Driver implements java.sql.Driver {
       urlServer = "";
     } else if (urlServer.startsWith("//")) {
       urlServer = urlServer.substring(2);
-      long slashCount = urlServer.chars().filter(ch -> ch == '/').count();
-      if (slashCount > 1) {
-        LOGGER.log(Level.WARNING, "JDBC URL contains too many / characters: {0}", url);
-        return null;
-      }
       int slash = urlServer.indexOf('/');
       if (slash == -1) {
         LOGGER.log(Level.WARNING, "JDBC URL must contain a / at the end of the host or port: {0}", url);

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PGPropertyTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PGPropertyTest.java
@@ -232,6 +232,13 @@ public class PGPropertyTest {
   }
 
   @Test
+  public void testSlashPath() {
+    String databaseName = "aaa/bbb";
+    String url = "jdbc:postgresql://localhost/" + databaseName;
+    Properties parsed = Driver.parseURL(url, new Properties());
+    assertEquals("database", databaseName, PGProperty.PG_DBNAME.getOrDefault(parsed));
+  }
+  @Test
   public void testLowerCamelCase() {
     // These are legacy properties excluded for backward compatibility.
     ArrayList<String> excluded = new ArrayList<String>();


### PR DESCRIPTION
Previously we counted slashes and if there were more than 2 we threw an error.
It would have been possible to have the user fix this by encoding the database name.
From what I can tell whether path names have slashes or not is up to the service. If the service is not hierarchical then slashes can be part of the resource name.

Curious if this breaks stuff.