### PR TITLE
docs: Document the need to encode reserved characters in the connection URL

### DIFF
--- a/docs/content/documentation/use.md
+++ b/docs/content/documentation/use.md
@@ -52,6 +52,10 @@ The parameters have the following meanings:
 To connect, you need to get a `Connection` instance from JDBC. To do this, you use the `DriverManager.getConnection()` method:
  `Connection db = DriverManager.getConnection(url, username, password)`
 
+> **Important**
+> 
+> Any reserved characters for URLs (for example, /, :, @, (, ), [, ], &, #, =, ?, and space) that appear in any part of the connection URL must be percent encoded. see [RFC 3986](https://www.rfc-editor.org/rfc/rfc3986#section-2) for details.
+
 ### Connection Parameters
 
 In addition to the standard connection parameters the driver supports a number of additional properties which can be used to specify additional driver behaviour specific to PostgreSQL®. These properties may be specified in either the connection


### PR DESCRIPTION
fixes: Issue #2694