### PR TITLE
fix: img src in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img height="90" alt="Slonik Duke" align="right" src="docs/media/img/slonik_duke.png" />
+<img height="90" alt="Slonik Duke" align="right" src="docs/_site/media/img/slonik_duke.png" />
 
 # PostgreSQL JDBC Driver
 


### PR DESCRIPTION
# Changed img src in README
* The image did not load because the specified src did not exist
* Only the alt text was showing so I changed the src to where I found the image

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?