### PR TITLE
correct mapping for postgres timestamptz type to sql type TIMESTAMP_W…

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
@@ -238,6 +238,7 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
         return getDate(columnIndex);
       case Types.TIME:
         return getTime(columnIndex);
+      case Types.TIMESTAMP_WITH_TIMEZONE:
       case Types.TIMESTAMP:
         return getTimestamp(columnIndex, null);
       case Types.BINARY:

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
@@ -101,7 +101,7 @@ public class TypeInfoCache implements TypeInfo {
       {"time", Oid.TIME, Types.TIME, "java.sql.Time", Oid.TIME_ARRAY},
       {"timetz", Oid.TIMETZ, Types.TIME, "java.sql.Time", Oid.TIMETZ_ARRAY},
       {"timestamp", Oid.TIMESTAMP, Types.TIMESTAMP, "java.sql.Timestamp", Oid.TIMESTAMP_ARRAY},
-      {"timestamptz", Oid.TIMESTAMPTZ, Types.TIMESTAMP, "java.sql.Timestamp",
+      {"timestamptz", Oid.TIMESTAMPTZ, Types.TIMESTAMP_WITH_TIMEZONE, "java.sql.Timestamp",
           Oid.TIMESTAMPTZ_ARRAY},
       {"refcursor", Oid.REF_CURSOR, Types.REF_CURSOR, "java.sql.ResultSet", Oid.REF_CURSOR_ARRAY},
       {"json", Oid.JSON, Types.OTHER, "org.postgresql.util.PGobject", Oid.JSON_ARRAY},

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseMetaDataTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseMetaDataTest.java
@@ -270,7 +270,7 @@ public class DatabaseMetaDataTest {
     assertTrue(rs.next());
     assertEquals("metadatatest", rs.getString("TABLE_NAME"));
     assertEquals("updated", rs.getString("COLUMN_NAME"));
-    assertEquals(java.sql.Types.TIMESTAMP, rs.getInt("DATA_TYPE"));
+    assertEquals(Types.TIMESTAMP_WITH_TIMEZONE, rs.getInt("DATA_TYPE"));
   }
 
   @Test
@@ -962,7 +962,7 @@ public class DatabaseMetaDataTest {
     assertTrue(rs.next());
     assertEquals("c", rs.getString(4));
     assertEquals(DatabaseMetaData.procedureColumnOut, rs.getInt(5));
-    assertEquals(Types.TIMESTAMP, rs.getInt(6));
+    assertEquals(Types.TIMESTAMP_WITH_TIMEZONE, rs.getInt(6));
 
     rs.close();
   }
@@ -990,7 +990,7 @@ public class DatabaseMetaDataTest {
     assertTrue(rs.next());
     assertEquals("updated", rs.getString(4));
     assertEquals(DatabaseMetaData.procedureColumnResult, rs.getInt(5));
-    assertEquals(Types.TIMESTAMP, rs.getInt(6));
+    assertEquals(Types.TIMESTAMP_WITH_TIMEZONE, rs.getInt(6));
 
     assertTrue(rs.next());
     assertEquals("colour", rs.getString(4));


### PR DESCRIPTION
…ITH_TIMEZONE and not to TIMESTAMP

### All Submissions:

* [ ] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

PR is solving this the issue described here https://github.com/pgjdbc/pgjdbc/issues/1766 .

This PR solves the problem for the applications that use column metadata to find out whether the column is TIMESTAMP or TIMESTAMP WITH TIME ZONE and based on that info they convert the value they want to store.
