### PR TITLE
fix: support waffle-jna 2.x and 3.x by using reflective approach for ManagedSecBufferDesc

### DIFF
--- a/docs/content/documentation/use.md
+++ b/docs/content/documentation/use.md
@@ -296,19 +296,24 @@ Permissible values are auto (default, see below), sspi (force SSPI) or gssapi (f
 If this parameter is auto, SSPI is attempted if the server requests SSPI authentication, the JDBC client is running on Windows, and the Waffle libraries required for SSPI are on the CLASSPATH. 
 Otherwise Kerberos/GSSAPI via JSSE is used.
 
+  > **Note**
+  >
+  > This behaviour does not exactly match that of libpq, which uses Windows' SSPI libraries for Kerberos (GSSAPI) requests by default when on Windows.
+
+  gssapi mode forces JSSE's GSSAPI to be used even if SSPI is available, matching the pre-9.4 behaviour. On non-Windows platforms or where SSPI is unavailable, forcing sspi mode will fail with a PSQLException. 
+
+  To use SSPI with PgJDBC you must ensure that [the `waffle-jna` library](https://mvnrepository.com/artifact/com.github.waffle/waffle-jna/) and its dependencies are present on the `CLASSPATH`. pgJDBC does **not** bundle `waffle-jna` in the pgJDBC jar.
+
+  Compatibility matrix:
+
+  | pgjdbc      | waffle-jna |
+  |-------------|------------|
+  | &lt; 42.7.1 | &lt; 2.0.0 |
+  | &ge; 42.7.1 | &ge; 1.0.0 |
+
 * **`gssResponseTimeout (`*Integer*`)`** *Default `5000`*\
 Time in milliseconds to wait for a response after requesting a GSS encrypted connection from the server. If this is greater than the current connectTimeout then connectTimeout will be used.
-
-> **Note**
->
-> This behaviour does not exactly match that of libpq, which uses Windows' SSPI libraries for Kerberos (GSSAPI) requests by default when on Windows.
-
-gssapi mode forces JSSE's GSSAPI to be used even if SSPI is available, matching the pre-9.4 behaviour.
-
-On non-Windows platforms or where SSPI is unavailable, forcing sspi mode will fail with a PSQLException.
-To use SSPI with PgJDBC you must ensure that [the `waffle-jna` library](https://mvnrepository.com/artifact/com.github.waffle/waffle-jna/) and its dependencies are present on the `CLASSPATH` . pgJDBC does **not** bundle `waffle-jna` in the pgJDBC jar.
-
-Since: 9.4
+  Since: 9.4
 
 * **`sspiServiceClass (`*String*`)`** *Default `POSTGRES`*\
 Specifies the name of the Windows SSPI service class that forms the service class part of the SPN. The default, POSTGRES, is almost always correct.


### PR DESCRIPTION
For compatibility with environments where JNA 5 is used, such as certain IDEs.

This is a work in progress because additional modifications, at least to packaging, are required. As it is, this code attempts to use a class that is not available from the declared dependencies (i.e. JNA 4).

Fixes #2690.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes to Existing Features:

* [ ] Does this break existing behaviour? If so please explain.
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?

  The existing tests will cover the new behavior when supplied with the correct JNA version.

* [x] Have you successfully run tests with your changes locally?