### PR TITLE
fix: improve thread safety of PgResultSet#getTimestamp

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/BaseConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/BaseConnection.java
@@ -147,6 +147,7 @@ public interface BaseConnection extends PGConnection, Connection {
   boolean getStandardConformingStrings();
 
   // Ew. Quick hack to give access to the connection-specific utils implementation.
+  @Deprecated
   TimestampUtils getTimestampUtils();
 
   // Get the per-connection logger.

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
@@ -434,6 +434,7 @@ public class PgConnection implements BaseConnection {
 
   private final TimestampUtils timestampUtils;
 
+  @Deprecated
   public TimestampUtils getTimestampUtils() {
     return timestampUtils;
   }

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
@@ -597,10 +597,10 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
       if (oid == Oid.TIMESTAMPTZ || oid == Oid.TIMESTAMP) {
         boolean hasTimeZone = oid == Oid.TIMESTAMPTZ;
         TimeZone tz = cal.getTimeZone();
-        return connection.getTimestampUtils().toTimestampBin(tz, castNonNull(row), hasTimeZone);
+        return getTimestampUtils().toTimestampBin(tz, castNonNull(row), hasTimeZone);
       } else if (oid == Oid.TIME) {
         // JDBC spec says getTimestamp of Time and Date must be supported
-        Timestamp tsWithMicros = connection.getTimestampUtils().toTimestampBin(cal.getTimeZone(), castNonNull(row), false);
+        Timestamp tsWithMicros = getTimestampUtils().toTimestampBin(cal.getTimeZone(), castNonNull(row), false);
         // If server sends us a TIME, we ensure java counterpart has date of 1970-01-01
         Timestamp tsUnixEpochDate = new Timestamp(castNonNull(getTime(i, cal)).getTime());
         tsUnixEpochDate.setNanos(tsWithMicros.getNanos());
@@ -608,7 +608,7 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
       } else if (oid == Oid.TIMETZ) {
         TimeZone tz = cal.getTimeZone();
         byte[] timeBytesWithoutTimeZone = Arrays.copyOfRange(castNonNull(row), 0, 8);
-        Timestamp tsWithMicros = connection.getTimestampUtils().toTimestampBin(tz, timeBytesWithoutTimeZone, false);
+        Timestamp tsWithMicros = getTimestampUtils().toTimestampBin(tz, timeBytesWithoutTimeZone, false);
         // If server sends us a TIMETZ, we ensure java counterpart has date of 1970-01-01
         Timestamp tsUnixEpochDate = new Timestamp(castNonNull(getTime(i, cal)).getTime());
         tsUnixEpochDate.setNanos(tsWithMicros.getNanos());
@@ -629,13 +629,13 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
     String string = castNonNull(getString(i));
     if (oid == Oid.TIME || oid == Oid.TIMETZ) {
       // If server sends us a TIME, we ensure java counterpart has date of 1970-01-01
-      Timestamp tsWithMicros = connection.getTimestampUtils().toTimestamp(cal, string);
-      Timestamp tsUnixEpochDate = new Timestamp(connection.getTimestampUtils().toTime(cal, string).getTime());
+      Timestamp tsWithMicros = getTimestampUtils().toTimestamp(cal, string);
+      Timestamp tsUnixEpochDate = new Timestamp(getTimestampUtils().toTime(cal, string).getTime());
       tsUnixEpochDate.setNanos(tsWithMicros.getNanos());
       return tsUnixEpochDate;
     }
 
-    return connection.getTimestampUtils().toTimestamp(cal, string);
+    return getTimestampUtils().toTimestamp(cal, string);
 
   }
 

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ResultSetTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ResultSetTest.java
@@ -1172,7 +1172,7 @@ public class ResultSetTest extends BaseTest4 {
     }
 
     @Override
-    public Boolean call() {
+    public Boolean call() throws SQLException {
       try (Statement statement = connection.createStatement()) {
         for (int i = 0; i < 10; i++) {
           try (ResultSet resultSet = statement.executeQuery(
@@ -1187,9 +1187,6 @@ public class ResultSetTest extends BaseTest4 {
             }
           }
         }
-      } catch (SQLException sqlException) {
-        fail(sqlException.getMessage());
-        return false;
       }
       return true;
     }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ResultSetTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ResultSetTest.java
@@ -1188,6 +1188,7 @@ public class ResultSetTest extends BaseTest4 {
           }
         }
       } catch (SQLException sqlException) {
+        fail(sqlException.getMessage());
         return false;
       }
       return true;


### PR DESCRIPTION
TimestampUtil is not thread safe. It raises exeptions when multiple threads use ResultSets of one connection. If PgResultSet uses its own TimestampUtil, no synchronization is needed.

Fix for Issue: ArrayIndexOutOfBoundsException with postgresql driver version 42.5.1 (https://github.com/pgjdbc/pgjdbc/issues/2723)