### PR TITLE
Bump GitHub action versions, replace deprecated set-output usage

### DIFF
--- a/.github/workflows/buildcache.yml
+++ b/.github/workflows/buildcache.yml
@@ -32,9 +32,9 @@ jobs:
       - id: set-matrix
         run: |
           if [[ -n "${S3_BUILD_CACHE_ACCESS_KEY_ID:-}" ]] && [[ -n "${S3_BUILD_CACHE_SECRET_KEY:-}" ]]; then
-            echo "::set-output name=secrets_available::true"
+            echo "secrets_available=true" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=secrets_available::false"
+            echo "secrets_available=false" >> $GITHUB_OUTPUT
           fi
 
   seed-build-cache:
@@ -48,7 +48,7 @@ jobs:
     name: '${{ matrix.os }}, ${{ matrix.jdk }} seed build cache'
     runs-on: ${{ matrix.os }}-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 50
       - name: 'Set up JDK ${{ matrix.jdk }}'

--- a/.github/workflows/debezium.yml
+++ b/.github/workflows/debezium.yml
@@ -16,11 +16,11 @@ jobs:
       ACTIONS_STEP_DEBUG: true
       ACTIONS_RUNNER_DEBUG: true
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 50
       - name: 'Set up JDK 11'
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: zulu
           java-version: 11

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -193,7 +193,7 @@ jobs:
       with:
         read-only: ${{ matrix.os == 'self-hosted' }}
         job-id: jdk${{ matrix.java_version }}
-        arguments: --scan --no-parallel --no-daemon jandex test
+        arguments: --scan --no-parallel --no-daemon jandex test ${{ matrix.extraGradleArgs }}
         properties: |
           includeTestTags=${{ matrix.includeTestTags }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,11 +41,11 @@ jobs:
       ACTIONS_STEP_DEBUG: true
       ACTIONS_RUNNER_DEBUG: true
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 50
     - name: 'Set up JDK 8'
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         distribution: zulu
         java-version: 8
@@ -62,11 +62,11 @@ jobs:
     name: 'CheckerFramework'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 50
       - name: 'Set up JDK 11'
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: zulu
           java-version: 11
@@ -84,14 +84,14 @@ jobs:
     name: 'Source distribution (JDK 11)'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 50
       - name: Start PostgreSQL
         working-directory: docker/postgres-server
         run: docker-compose up -d && docker-compose logs
       - name: 'Set up JDK 11'
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: zulu
           java-version: 11
@@ -118,7 +118,7 @@ jobs:
     env:
       MATRIX_JOBS: 7
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 50
     - id: set-matrix
@@ -137,7 +137,7 @@ jobs:
       ACTIONS_RUNNER_DEBUG: true
       TZ: ${{ matrix.tz }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 50
     - name: Start PostgreSQL PGV=${{ matrix.pg_version }} TZ=${{ matrix.server_tz }} XA=${{ matrix.xa }} SSL=${{ matrix.ssl }} SCRAM=${{ matrix.scram }} CREATE_REPLICAS=${{ matrix.replication }}
@@ -158,11 +158,11 @@ jobs:
         docker-compose up -d
         docker-compose logs
     - name: 'Get test node ARCH'
-      run: echo "::set-output name=arch_name::$(uname -i)"
+      run: echo "arch_name=$(uname -i)" >> $GITHUB_OUTPUT
       id: get_arch_name
     - name: Set up Java ${{ matrix.java_version }}, ${{ matrix.java_distribution }}
       if: ${{ steps.get_arch_name.outputs.arch_name != 'aarch64' }}
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         java-version: ${{ matrix.java_version }}
         distribution: ${{ matrix.java_distribution }}

--- a/.github/workflows/matrix.js
+++ b/.github/workflows/matrix.js
@@ -240,6 +240,14 @@ if (include.length === 0) {
 }
 include.sort((a, b) => a.name.localeCompare(b.name, undefined, {numeric: true}));
 include.forEach(v => {
+    let gradleArgs = [];
+    if (v.java_version == 11) {
+        // JavaDoc 11 can't parse package annotations: https://bugs.openjdk.org/browse/JDK-8222091
+        gradleArgs.push('-PskipJavadoc')
+    }
+    v.extraGradleArgs = gradleArgs.join(' ');
+});
+include.forEach(v => {
   let jvmArgs = [];
   v.replication = v.replication.value;
   v.slow_tests = v.slow_tests.value;

--- a/.github/workflows/matrix.js
+++ b/.github/workflows/matrix.js
@@ -1,6 +1,8 @@
 // The script generates a random subset of valid jdk, os, timezone, and other axes.
 // You can preview the results by running "node matrix.js"
 // See https://github.com/vlsi/github-actions-random-matrix
+let fs = require('fs');
+let os = require('os');
 let {MatrixBuilder} = require('./matrix_builder');
 const matrix = new MatrixBuilder();
 
@@ -302,4 +304,10 @@ include.forEach(v => {
 });
 
 console.log(include);
-console.log('::set-output name=matrix::' + JSON.stringify({include}));
+
+let filePath = process.env['GITHUB_OUTPUT'] || '';
+if (filePath) {
+    fs.appendFileSync(filePath, `matrix<<MATRIX_BODY${os.EOL}${JSON.stringify({include})}${os.EOL}MATRIX_BODY${os.EOL}`, {
+        encoding: 'utf8'
+    });
+}

--- a/.github/workflows/nightlysnapshot.yml
+++ b/.github/workflows/nightlysnapshot.yml
@@ -23,9 +23,9 @@ jobs:
       - id: set-matrix
         run: |
           if [[ -n "${NEXUS_USERNAME:-}" ]] && [[ -n "${NEXUS_PASSWORD:-}" ]]; then
-            echo "::set-output name=secrets_available::true"
+            echo "secrets_available=true" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=secrets_available::false"
+            echo "secrets_available=false" >> $GITHUB_OUTPUT
           fi
 
   snapshot:
@@ -37,11 +37,11 @@ jobs:
       ACTIONS_STEP_DEBUG: true
       ACTIONS_RUNNER_DEBUG: true
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 50
       - name: 'Set up JDK 8'
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: zulu
           java-version: 8

--- a/.github/workflows/omni.yml
+++ b/.github/workflows/omni.yml
@@ -54,6 +54,8 @@ jobs:
       MATRIX_DEFAULT_TEST_GROUP: '${{ github.event.inputs.matrix_default_test_group }}'
       # Script as an environment variable so we don't have to worry shell substitutions
       MATRIX_GENERATION_NODE_JS_SCRIPT: |
+        let fs = require('fs');
+        let os = require('os');
         const DEFAULT_TEST_GROUP = process.env.MATRIX_DEFAULT_TEST_GROUP || 'fast';
 
         const JDK_OPTIONS = [
@@ -260,7 +262,12 @@ jobs:
         // Sort so that all the experimental jobs appear at the end of the list
         include.sort((a, b) => (a.experimental ? 1 : 0) - (b.experimental ? 1 : 0))
 
-        console.log('::set-output name=matrix::' + JSON.stringify({ include }));
+        let filePath = process.env['GITHUB_OUTPUT'] || '';
+        if (filePath) {
+            fs.appendFileSync(filePath, `matrix<<MATRIX_BODY${os.EOL}${JSON.stringify({include})}${os.EOL}MATRIX_BODY${os.EOL}`, {
+                encoding: 'utf8'
+            });
+        }
     steps:
     - id: set-matrix
       run: |
@@ -286,7 +293,7 @@ jobs:
       env:
           MATRIX_JSON: ${{ toJSON(matrix) }}
       run: echo "${MATRIX_JSON}"
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 50
 
@@ -298,7 +305,7 @@ jobs:
 
     # Install built-in JDK
     - name: 'Set up JDK ${{ matrix.jdk_version }} / ${{ matrix.jdk_distribution }}'
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       if: ${{ matrix.jdk_distribution != 'jdkfile' }}
       with:
         distribution: ${{ matrix.jdk_distribution }}
@@ -311,7 +318,7 @@ jobs:
         jdk_url="${{ matrix.jdk_url }}"
         wget -nv -O "${{ runner.temp }}/java_package.tar.gz" "${jdk_url}"
     - name: 'Set up JDK ${{ matrix.jdk_version }} / ${{ matrix.jdk_url }}'
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       if: ${{ matrix.jdk_distribution == 'jdkfile' }}
       with:
         distribution: ${{ matrix.jdk_distribution }}
@@ -366,14 +373,14 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 50
     - name: Compile and start PostgreSQL
       working-directory: docker/postgres-head
       run: docker-compose up -d && docker-compose logs
     - name: Set up JDK
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         distribution: zulu
         java-version: 11

--- a/.github/workflows/omni.yml
+++ b/.github/workflows/omni.yml
@@ -411,7 +411,7 @@ jobs:
     - name: Test
       uses: burrunan/gradle-cache-action@v1
       with:
-        arguments: --no-parallel --no-daemon --scan jandex test jacocoReport
+        arguments: --no-parallel --no-daemon --scan jandex test jacocoReport -PskipJavadoc
         properties: |
           includeTestTags=!org.postgresql.test.SlowTests & !org.postgresql.test.Replication
     - name: 'Upload code coverage'


### PR DESCRIPTION
See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
See https://github.com/actions/toolkit/blob/6c1f9eaae833355a0b212b66c5f2e3ac366de185/packages/core/src/core.ts#L192
