### PR TITLE
feat: add transaction isolation mode

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -805,8 +805,8 @@ public enum PGProperty {
       "transactionIsolationMode",
       "session",
       "Controls the behavior when a transaction isolation level is set, one of 'transaction', or 'session' "
-          + "When 'transaction' setting isolation level will cause transactions to BEGIN ISOLATION LEVEL if autocommit is 'false'. "
-          + "When 'session' setting readOnly to setting isolation level will set it as the session characteristics.",
+          + "When 'transaction' setting isolation level will cause transactions to BEGIN ISOLATION LEVEL if autocommit is 'false'."
+          + "When 'session' setting isolation level will set it as the session characteristic.",
       false,
       new String[] {"transaction", "session"}),
 

--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -796,6 +796,20 @@ public enum PGProperty {
       "true",
       "Enable or disable TCP no delay. The default is (@code true}."
   ),
+
+  /**
+   * Connection parameter to control behavior when
+   * {@link Connection#setTransactionIsolation(int)} is set.
+   */
+  TRANSACTION_ISOLATION_MODE(
+      "transactionIsolationMode",
+      "session",
+      "Controls the behavior when a transaction isolation level is set, one of 'transaction', or 'session' "
+          + "When 'transaction' setting isolation level will cause transactions to BEGIN ISOLATION LEVEL if autocommit is 'false'. "
+          + "When 'session' setting readOnly to setting isolation level will set it as the session characteristics.",
+      false,
+      new String[] {"transaction", "session"}),
+
   /**
    * Specifies the length to return for types of unknown length.
    */

--- a/pgjdbc/src/main/java/org/postgresql/core/BaseConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/BaseConnection.java
@@ -238,7 +238,7 @@ public interface BaseConnection extends PGConnection, Connection {
    * @see QueryExecutor#QUERY_ISOLATION_LEVEL_HIGH
    * @see QueryExecutor#QUERY_ISOLATION_LEVEL_LOW
    */
-  int addIsolationLevelFlags(int flags);
+  int addIsolationLevelFlags(int flags) throws SQLException;
 
 
   /**

--- a/pgjdbc/src/main/java/org/postgresql/core/BaseConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/BaseConnection.java
@@ -225,6 +225,23 @@ public interface BaseConnection extends PGConnection, Connection {
   boolean hintReadOnly();
 
   /**
+   * Indicates if transaction isolation level should be set during transaction creation
+   *
+   * @see PGProperty#TRANSACTION_ISOLATION_MODE
+   */
+  boolean isIsolationInTransactionMode();
+
+
+  /**
+   * Adds flags that indicate transaction isolation level
+   *
+   * @see QueryExecutor#QUERY_ISOLATION_LEVEL_HIGH
+   * @see QueryExecutor#QUERY_ISOLATION_LEVEL_LOW
+   */
+  int addIsolationLevelFlags(int flags);
+
+
+  /**
    * Retrieve the factory to instantiate XML processing factories.
    *
    * @return The factory to use to instantiate XML processing factories

--- a/pgjdbc/src/main/java/org/postgresql/core/QueryExecutor.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/QueryExecutor.java
@@ -131,6 +131,24 @@ public interface QueryExecutor extends TypeTransferModeRegistry {
   int QUERY_READ_ONLY_HINT = 2048;
 
   /**
+   * Two flags indicating transaction isolation level
+   *
+   * <p>High/Low
+   * READ UNCOMMITTED - 0/0
+   * READ COMMITTED - 0/1
+   * REPEATABLE READ - 1/0
+   * SERIALIZABLE - 1/1
+   */
+  int QUERY_ISOLATION_LEVEL_HIGH = 4096;
+  int QUERY_ISOLATION_LEVEL_LOW = 8192;
+
+  /**
+   * Flag indicating that when beginning a transaction the isolation level should be set to it
+   */
+  int QUERY_ISOLATION_TRANSACTION_MODE = 16384;
+
+
+  /**
    * Execute a Query, passing results to a provided ResultHandler.
    *
    * @param query the query to execute; must be a query returned from calling

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -87,6 +87,20 @@ public class QueryExecutorImpl extends QueryExecutorBase {
 
   private static final Field[] NO_FIELDS = new Field[0];
 
+  private static final String BEGIN = "BEGIN";
+
+  private static final String READ_ONLY = " READ ONLY";
+
+  private static final String ISOLATION_LEVEL = " ISOLATION LEVEL";
+
+  private static final String READ_UNCOMMITTED = " READ UNCOMMITTED";
+
+  private static final String READ_COMMITTED = " READ COMMITTED";
+
+  private static final String REPEATABLE_READ = " REPEATABLE READ";
+
+  private static final String SERIALIZABLE = " SERIALIZABLE";
+
   static {
     //canonicalize commonly seen strings to reduce memory and speed comparisons
     Encoding.canonicalize("application_name");
@@ -619,7 +633,7 @@ public class QueryExecutorImpl extends QueryExecutorBase {
 
     beginFlags = updateQueryMode(beginFlags);
 
-    final SimpleQuery beginQuery = (flags & QueryExecutor.QUERY_READ_ONLY_HINT) == 0 ? beginTransactionQuery : beginReadOnlyTransactionQuery;
+    final SimpleQuery beginQuery = getBeginTransactionQuery(flags);
 
     sendOneQuery(beginQuery, SimpleQuery.NO_PARAMETERS, 0, 0, beginFlags);
 
@@ -648,6 +662,41 @@ public class QueryExecutorImpl extends QueryExecutorBase {
         }
       }
     };
+  }
+
+  private SimpleQuery getBeginTransactionQuery(int flags) {
+    if ((flags & QueryExecutor.QUERY_ISOLATION_TRANSACTION_MODE) == 0) {
+      if ((flags & QueryExecutor.QUERY_READ_ONLY_HINT) != 0) {
+        return beginReadOnlyTransactionQuery;
+      } else {
+        return beginTransactionQuery;
+      }
+    }
+
+    String beginQueryString = BEGIN;
+    switch (flags / QueryExecutor.QUERY_ISOLATION_LEVEL_HIGH & 0b11) {
+      default:
+      case 0:
+        beginQueryString += ISOLATION_LEVEL + READ_UNCOMMITTED;
+        break;
+      case 1:
+        beginQueryString += ISOLATION_LEVEL + READ_COMMITTED;
+        break;
+      case 2:
+        beginQueryString += ISOLATION_LEVEL + REPEATABLE_READ;
+        break;
+      case 3:
+        beginQueryString += ISOLATION_LEVEL + SERIALIZABLE;
+        break;
+    }
+
+    if ((flags & QueryExecutor.QUERY_READ_ONLY_HINT) != 0) {
+      beginQueryString += READ_ONLY;
+    }
+
+    return new SimpleQuery(
+        new NativeQuery(beginQueryString, new int[0], false, SqlCommand.BLANK),
+        null, false);
   }
 
   //

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -674,7 +674,9 @@ public class QueryExecutorImpl extends QueryExecutorBase {
     }
 
     String beginQueryString = BEGIN;
-    switch (flags / QueryExecutor.QUERY_ISOLATION_LEVEL_HIGH & 0b11) {
+
+    int isolationFlags = flags & (QUERY_ISOLATION_LEVEL_HIGH | QUERY_ISOLATION_LEVEL_LOW);
+    switch (isolationFlags >> 12) {
       default:
       case 0:
         beginQueryString += ISOLATION_LEVEL + READ_UNCOMMITTED;

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -676,7 +676,7 @@ public class QueryExecutorImpl extends QueryExecutorBase {
     String beginQueryString = BEGIN;
 
     int isolationFlags = flags & (QUERY_ISOLATION_LEVEL_HIGH | QUERY_ISOLATION_LEVEL_LOW);
-    switch (isolationFlags >> 12) {
+    switch ((isolationFlags >> 12) & 3) {
       default:
       case 0:
         beginQueryString += ISOLATION_LEVEL + READ_UNCOMMITTED;

--- a/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
+++ b/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
@@ -1023,6 +1023,22 @@ public abstract class BaseDataSource implements CommonDataSource, Referenceable 
   }
 
   /**
+   * @return The behavior when transaction isolation level is set
+   * @see PGProperty#TRANSACTION_ISOLATION_MODE
+   */
+  public String getTransactionIsolationMode() {
+    return castNonNull(PGProperty.TRANSACTION_ISOLATION_MODE.get(properties));
+  }
+
+  /**
+   * @param mode The behavior when transaction isolation level is set
+   * @see PGProperty#TRANSACTION_ISOLATION_MODE
+   */
+  public void setTransactionIsolationMode(/* @Nullable */ String mode) {
+    PGProperty.TRANSACTION_ISOLATION_MODE.set(properties, mode);
+  }
+
+  /**
    * @return The behavior when set read only
    * @see PGProperty#READ_ONLY_MODE
    */

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
@@ -415,7 +415,10 @@ public class PgConnection implements BaseConnection {
     }
   }
 
-  private static TransactionIsolationBehavior getTransactionIsolationBehavior(String property) {
+  private static TransactionIsolationBehavior getTransactionIsolationBehavior(@Nullable String property) {
+    if (property == null) {
+      return TransactionIsolationBehavior.session;
+    }
     try {
       return TransactionIsolationBehavior.valueOf(property);
     } catch (IllegalArgumentException e) {

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
@@ -1127,14 +1127,6 @@ public class PgConnection implements BaseConnection {
     }
   }
 
-  protected String getSessionIsolationQuery(int level) {
-    String levelName = getIsolationLevelName(level);
-    if (levelName == null) {
-      levelName = DEFAULT_ISOLATION_LEVEL_NAME;
-    }
-    return SESSION_ISOLATION_QUERY_BASE + levelName;
-  }
-
   protected String getSessionIsolationQuery(String levelName) {
     return SESSION_ISOLATION_QUERY_BASE + levelName;
   }

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgStatement.java
@@ -482,6 +482,11 @@ public class PgStatement implements Statement, BaseStatement {
       flags |= QueryExecutor.QUERY_READ_ONLY_HINT;
     }
 
+    if (connection.isIsolationInTransactionMode()) {
+      flags |= QueryExecutor.QUERY_ISOLATION_TRANSACTION_MODE;
+      flags = connection.addIsolationLevelFlags(flags);
+    }
+
     // updateable result sets do not yet support binary updates
     if (concurrency != ResultSet.CONCUR_READ_ONLY) {
       flags |= QueryExecutor.QUERY_NO_BINARY_TRANSFER;
@@ -875,6 +880,11 @@ public class PgStatement implements Statement, BaseStatement {
     }
     if (connection.hintReadOnly()) {
       flags |= QueryExecutor.QUERY_READ_ONLY_HINT;
+    }
+
+    if (connection.isIsolationInTransactionMode()) {
+      flags |= QueryExecutor.QUERY_ISOLATION_TRANSACTION_MODE;
+      flags = connection.addIsolationLevelFlags(flags);
     }
 
     BatchResultHandler handler;

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/AbstractArraysTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/AbstractArraysTest.java
@@ -1093,6 +1093,22 @@ public abstract class AbstractArraysTest<A> {
      * {@inheritDoc}
      */
     @Override
+    public boolean isIsolationInTransactionMode() {
+      return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int addIsolationLevelFlags(int flags) {
+      return 0;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public void setAdaptiveFetch(boolean adaptiveFetch) {
       throw new UnsupportedOperationException();
     }


### PR DESCRIPTION
add transaction isolation mode to be able to work with transaction pooling tools like pgbouncer

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Does `./gradlew autostyleCheck checkstyleAll` pass ?
3. [x] Have you added your new test classes to an existing test suite in alphabetical order?

### Transaction isolation mode
Adding this functionality discussed here https://github.com/pgjdbc/pgjdbc/issues/1880. Currently isolation level is set on connection level. This solution doesn't work with transaction pooling because the connection can be replaced after setting isolation.

Proposed solution adds transaction isolation mode, which can be on of `transaction` or `session`, by default it's session. 
If the mode set to `transaction` then all `BEGIN` statements appended with isolation level like `BEGIN ISOLATION LEVEL SERIALIZABLE`

The solution also works with READ ONLY modifier which was added in earlier versions.

Implementation requires 3 flags, one for mode (0 - session mode, 1 - transaction mode) and two for isolation level (00 - READ UNCOMMITTED, 01 - READ COMMITTED, 10 - REPEATABLE READ, 11 - SERIALIZABLE)

--- 

Solves https://github.com/pgjdbc/pgjdbc/issues/1880
Related to this PR, but it's already outdated and solved https://github.com/pgjdbc/pgjdbc/issues/848