### PR TITLE
Regression: add box type to cache to ensure that we dont have to query the database on initial connections

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/Oid.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/Oid.java
@@ -73,6 +73,7 @@ public class Oid {
   public static final int POINT = 600;
   public static final int POINT_ARRAY = 1017;
   public static final int BOX = 603;
+  public static final int BOX_ARRAY = 1020;
   public static final int JSONB = 3802;
   public static final int JSONB_ARRAY = 3807;
   public static final int JSON = 114;

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
@@ -106,7 +106,8 @@ public class TypeInfoCache implements TypeInfo {
           Oid.TIMESTAMPTZ_ARRAY},
       {"refcursor", Oid.REF_CURSOR, Types.REF_CURSOR, "java.sql.ResultSet", Oid.REF_CURSOR_ARRAY},
       {"json", Oid.JSON, Types.OTHER, "org.postgresql.util.PGobject", Oid.JSON_ARRAY},
-      {"point", Oid.POINT, Types.OTHER, "org.postgresql.geometric.PGpoint", Oid.POINT_ARRAY}
+      {"point", Oid.POINT, Types.OTHER, "org.postgresql.geometric.PGpoint", Oid.POINT_ARRAY},
+      {"box", Oid.BOX, Types.OTHER, "org.postgresql.geometric.PGBox", Oid.BOX_ARRAY}
   };
 
   /**
@@ -183,6 +184,9 @@ public class TypeInfoCache implements TypeInfo {
       // the box datatype and it's not a JDBC core type.
       //
       Character delim = ',';
+      if (pgTypeName.equals("box")) {
+        delim = ';';
+      }
       arrayOidToDelimiter.put(oid, delim);
       arrayOidToDelimiter.put(arrayOid, delim);
 


### PR DESCRIPTION
This is the same as PR # 2747 just on master