### PR TITLE
Added create/dropExtension to TestUtil

### DIFF
--- a/pgjdbc/src/test/java/org/postgresql/test/TestUtil.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/TestUtil.java
@@ -781,6 +781,15 @@ public class TestUtil {
     }
   }
 
+  public static void assumeExtensionInstalled(Connection conn, String extensionName) throws SQLException {
+    try (PreparedStatement pstmt = conn.prepareStatement("select * from pg_extension where extname = ?")) {
+      pstmt.setString(1, extensionName);
+      try (ResultSet rs = pstmt.executeQuery()) {
+        Assume.assumeTrue(rs.next());
+      }
+    }
+  }
+
   public static boolean haveMinimumJVMVersion(String version) {
     String jvm = java.lang.System.getProperty("java.version");
     return (jvm.compareTo(version) >= 0);
@@ -1164,6 +1173,34 @@ public class TestUtil {
   public static void execute(Connection connection, String sql) throws SQLException {
     try (Statement stmt = connection.createStatement()) {
       stmt.execute(sql);
+    }
+  }
+
+  /**
+   * Creates named extension
+   *
+   * @param con Connection we are connected to
+   * @param extension name of the extension to load
+   * @throws SQLException
+   *
+   */
+  public static void createExtension(Connection con, String extension) throws  SQLException {
+    try (Statement stmt = con.createStatement()) {
+      stmt.execute("create extension " + extension);
+    }
+  }
+
+  /**
+   * Drops named extension
+   *
+   * @param con connection we are connected to
+   * @param extension name of the extension
+   * @throws SQLException
+   *
+   */
+  public static void dropExtension(Connection con, String extension) throws SQLException {
+    try (Statement stmt = con.createStatement()) {
+      stmt.execute("drop extension " + extension);
     }
   }
 }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BaseTest4.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BaseTest4.java
@@ -149,4 +149,8 @@ public class BaseTest4 {
     assertEquals(message.get() + ", useBinaryForSend(oid=" + oid + ")", expected,
         con.unwrap(BaseConnection.class).getQueryExecutor().useBinaryForSend(oid));
   }
+
+  public  void assumeExtensionInstalled(String extension) throws SQLException {
+    TestUtil.assumeExtensionInstalled(con, extension);
+  }
 }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BaseTest4.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BaseTest4.java
@@ -150,7 +150,4 @@ public class BaseTest4 {
         con.unwrap(BaseConnection.class).getQueryExecutor().useBinaryForSend(oid));
   }
 
-  public  void assumeExtensionInstalled(String extension) throws SQLException {
-    TestUtil.assumeExtensionInstalled(con, extension);
-  }
 }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/StringTypeUnspecifiedArrayTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/StringTypeUnspecifiedArrayTest.java
@@ -7,8 +7,11 @@ package org.postgresql.test.jdbc2;
 
 import org.postgresql.PGProperty;
 import org.postgresql.geometric.PGbox;
+import org.postgresql.test.TestUtil;
 
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -20,6 +23,25 @@ import java.util.Properties;
 
 @RunWith(Parameterized.class)
 public class StringTypeUnspecifiedArrayTest extends BaseTest4 {
+
+  @Before
+  public void createExtension() {
+    try {
+      TestUtil.createExtension(con, "cube");
+    } catch (Exception ex) {
+      // we can ignore this as the test won't run if the extension isn't loaded
+    }
+  }
+
+  @After
+  public void dropExtension() {
+    try {
+      TestUtil.dropExtension(con, "cube");
+    } catch (Exception ex) {
+      // we can ignore this as the test won't run if the extension isn't loaded
+    }
+  }
+
   public StringTypeUnspecifiedArrayTest(BinaryMode binaryMode) {
     setBinaryMode(binaryMode);
   }
@@ -39,10 +61,15 @@ public class StringTypeUnspecifiedArrayTest extends BaseTest4 {
     super.updateProperties(props);
   }
 
+  /*
+  This test relies on the presence of the cube contrib extension
+   */
+
   @Test
   public void testCreateArrayWithNonCachedType() throws Exception {
+    assumeExtensionInstalled("cube");
     PGbox[] in = new PGbox[0];
-    Array a = con.createArrayOf("box", in);
+    Array a = con.createArrayOf("cube", in);
     Assert.assertEquals(1111, a.getBaseType());
   }
 }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/StringTypeUnspecifiedArrayTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/StringTypeUnspecifiedArrayTest.java
@@ -9,9 +9,10 @@ import org.postgresql.PGProperty;
 import org.postgresql.geometric.PGbox;
 import org.postgresql.test.TestUtil;
 
-import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.Before;
+import org.junit.Assume;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -24,16 +25,16 @@ import java.util.Properties;
 @RunWith(Parameterized.class)
 public class StringTypeUnspecifiedArrayTest extends BaseTest4 {
 
-  @Before
+  @BeforeClass
   public void createExtension() {
     try {
       TestUtil.createExtension(con, "cube");
     } catch (Exception ex) {
-      // we can ignore this as the test won't run if the extension isn't loaded
+      Assume.assumeTrue(false);
     }
   }
 
-  @After
+  @AfterClass
   public void dropExtension() {
     try {
       TestUtil.dropExtension(con, "cube");
@@ -67,7 +68,6 @@ public class StringTypeUnspecifiedArrayTest extends BaseTest4 {
 
   @Test
   public void testCreateArrayWithNonCachedType() throws Exception {
-    assumeExtensionInstalled("cube");
     PGbox[] in = new PGbox[0];
     Array a = con.createArrayOf("cube", in);
     Assert.assertEquals(1111, a.getBaseType());


### PR DESCRIPTION
Added assumeExtensionInstalled to TestUtil and BaseTest4 
Use cube extension for testCreateArrayWithNonCachedType as it is not cached

