### PR TITLE
chore: tune down the number of CI jobs for PR builds from 7 to 5

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -116,7 +116,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     env:
-      MATRIX_JOBS: 7
+      MATRIX_JOBS: 5
     steps:
     - uses: actions/checkout@v3
       with:


### PR DESCRIPTION
It might be 5 is good enough.