### PR TITLE
fix: fix testGetSQLTypeQueryCache by searching for xid type instead of box. 

### DIFF
--- a/pgjdbc/src/test/java/org/postgresql/core/OidValuesCorrectnessTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/core/OidValuesCorrectnessTest.java
@@ -61,6 +61,7 @@ public class OidValuesCorrectnessTest extends BaseTest4 {
    * Helps in situation when variable name in Oid class isn't the same as typname in pg_type table.
    */
   private static Map<String, String> oidTypeNames = new HashMap<String, String>() {{
+      put("BOX_ARRAY", "_BOX");
       put("INT2_ARRAY", "_INT2");
       put("INT4_ARRAY", "_INT4");
       put("INT8_ARRAY", "_INT8");

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseMetaDataCacheTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseMetaDataCacheTest.java
@@ -62,11 +62,11 @@ public class DatabaseMetaDataCacheTest {
     List<LogRecord> typeQueries = log.getRecordsMatching(SQL_TYPE_QUERY_LOG_FILTER);
     assertEquals(0, typeQueries.size());
 
-    ti.getSQLType("box");  // this must be a type not in the hardcoded 'types' list
+    ti.getSQLType("xid");  // this must be a type not in the hardcoded 'types' list
     typeQueries = log.getRecordsMatching(SQL_TYPE_QUERY_LOG_FILTER);
     assertEquals(1, typeQueries.size());
 
-    ti.getSQLType("box");  // this time it should be retrieved from the cache
+    ti.getSQLType("xid");  // this time it should be retrieved from the cache
     typeQueries = log.getRecordsMatching(SQL_TYPE_QUERY_LOG_FILTER);
     assertEquals(1, typeQueries.size());
   }


### PR DESCRIPTION
We used to search for box type but it is now cached

fix OidValueCorrectnessTest BOX_ARRAY OID, by adding BOX_ARRAY to the oidTypeName map

