### PR TITLE
fix: reduce memory overhead of .finalize() methods in PgConnection and StreamWrapper

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/QueryExecutor.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/QueryExecutor.java
@@ -17,6 +17,7 @@ import org.postgresql.util.HostSpec;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.sql.SQLException;
 import java.sql.SQLWarning;
@@ -444,6 +445,15 @@ public interface QueryExecutor extends TypeTransferModeRegistry {
    * Close this connection cleanly.
    */
   void close();
+
+  /**
+   * Returns an action that would close the connection cleanly.
+   * The returned object should refer only the minimum subset of objects required
+   * for proper resource cleanup. For instance, it should better not hold a strong reference to
+   * {@link QueryExecutor}.
+   * @return action that would close the connection cleanly.
+   */
+  Closeable getCloseAction();
 
   /**
    * Check if this connection is closed.

--- a/pgjdbc/src/main/java/org/postgresql/core/QueryExecutorCloseAction.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/QueryExecutorCloseAction.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2023, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.core;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * The action performs connection cleanup, so it is properly terminated from the backend
+ * point of view.
+ * Implementation note: it should keep only the minimum number of object references
+ * to reduce heap usage in case the user abandons connection without closing it first.
+ */
+public class QueryExecutorCloseAction implements Closeable {
+  private static final Logger LOGGER = Logger.getLogger(QueryExecutorBase.class.getName());
+
+  private static final AtomicReferenceFieldUpdater<QueryExecutorCloseAction, @Nullable PGStream> PG_STREAM_UPDATER =
+      AtomicReferenceFieldUpdater.<QueryExecutorCloseAction, @Nullable PGStream>newUpdater(
+          QueryExecutorCloseAction.class, PGStream.class, "pgStream");
+
+  private volatile @Nullable PGStream pgStream;
+
+  public QueryExecutorCloseAction(PGStream pgStream) {
+    this.pgStream = pgStream;
+  }
+
+  public boolean isClosed() {
+    PGStream pgStream = this.pgStream;
+    return pgStream == null || pgStream.isClosed();
+  }
+
+  public void abort() {
+    PGStream pgStream = this.pgStream;
+    if (pgStream == null || !PG_STREAM_UPDATER.compareAndSet(this, pgStream, null)) {
+      // The connection has already been closed
+      return;
+    }
+    try {
+      LOGGER.log(Level.FINEST, " FE=> close socket");
+      pgStream.getSocket().close();
+    } catch (IOException e) {
+      // ignore
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    LOGGER.log(Level.FINEST, " FE=> Terminate");
+    PGStream pgStream = this.pgStream;
+    if (pgStream == null || !PG_STREAM_UPDATER.compareAndSet(this, pgStream, null)) {
+      // The connection has already been closed
+      return;
+    }
+    sendCloseMessage(pgStream);
+
+    // Technically speaking, this check should not be needed,
+    // however org.postgresql.test.jdbc2.ConnectionTest.testPGStreamSettings
+    // closes pgStream reflectively, so here's an extra check to prevent failures
+    // when getNetworkTimeout is called on a closed stream
+    if (pgStream.isClosed()) {
+      return;
+    }
+    pgStream.flush();
+    pgStream.close();
+  }
+
+  public void sendCloseMessage(PGStream pgStream) throws IOException {
+    // Technically speaking, this check should not be needed,
+    // however org.postgresql.test.jdbc2.ConnectionTest.testPGStreamSettings
+    // closes pgStream reflectively, so here's an extra check to prevent failures
+    // when getNetworkTimeout is called on a closed stream
+    if (pgStream.isClosed()) {
+      return;
+    }
+    // Prevent blocking the thread for too long
+    // The connection will be discarded anyway, so there's no much sense in waiting long
+    int timeout = pgStream.getNetworkTimeout();
+    if (timeout == 0 || timeout > 1000) {
+      pgStream.setNetworkTimeout(1000);
+    }
+    pgStream.sendChar('X');
+    pgStream.sendInteger4(4);
+  }
+}

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -2786,9 +2786,9 @@ public class QueryExecutorImpl extends QueryExecutorBase {
   }
 
   @Override
+  @SuppressWarnings("deprecation")
   protected void sendCloseMessage() throws IOException {
-    pgStream.sendChar('X');
-    pgStream.sendInteger4(4);
+    closeAction.sendCloseMessage(pgStream);
   }
 
   public void readStartupMessages() throws IOException, SQLException {

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/SimpleParameterList.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/SimpleParameterList.java
@@ -413,7 +413,9 @@ class SimpleParameterList implements V3ParameterList {
 
     // Binary-format bytea?
     if (paramValue instanceof StreamWrapper) {
-      streamBytea(pgStream, (StreamWrapper) paramValue);
+      try (StreamWrapper streamWrapper = (StreamWrapper) paramValue;) {
+        streamBytea(pgStream, streamWrapper);
+      }
       return;
     }
 

--- a/pgjdbc/src/main/java/org/postgresql/util/StreamWrapperFinalizeAction.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/StreamWrapperFinalizeAction.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2023, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.util;
+
+import static org.postgresql.util.internal.Nullness.castNonNull;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * The action deletes temporary file in case the user submits a large input stream,
+ * and then abandons the statement.
+ */
+class StreamWrapperFinalizeAction implements Closeable {
+  private @Nullable InputStream stream;
+  private @Nullable Path tempFile;
+
+  StreamWrapperFinalizeAction(Path tempFile) {
+    this.tempFile = tempFile;
+  }
+
+  public InputStream getStream() throws IOException {
+    InputStream stream = this.stream;
+    if (stream == null) {
+      stream = Files.newInputStream(castNonNull(tempFile));
+      this.stream = stream;
+    }
+    return stream;
+  }
+
+  @Override
+  public void close() throws IOException {
+    Path tempFile = this.tempFile;
+    if (tempFile != null) {
+      tempFile.toFile().delete();
+      this.tempFile = null;
+    }
+    InputStream stream = this.stream;
+    if (stream != null) {
+      stream.close();
+      this.stream = null;
+    }
+  }
+
+  @Override
+  @SuppressWarnings("deprecation")
+  protected void finalize() throws Throwable {
+    close();
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/CopyTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/CopyTest.java
@@ -489,6 +489,11 @@ public class CopyTest {
   }
 
   private void acceptIOCause(SQLException e) throws SQLException {
+    if (e.getSQLState().equals(PSQLState.CONNECTION_FAILURE.getState())
+        || e.getSQLState().equals(PSQLState.CONNECTION_DOES_NOT_EXIST.getState())) {
+      // The test expects network exception, so CONNECTION_FAILURE looks good
+      return;
+    }
     if (!(e.getCause() instanceof IOException)) {
       throw e;
     }


### PR DESCRIPTION
Previously, an abandoned PgConnection could retain a significant amount of heap. Now the bare minimum is moved to a separate class, so the abandoned connections can be removed from the heap earlier.

This does not remove the use of `.finalize()`, and it only reduces the amount of retained heap memory.
