### PR TITLE
chore: pass "same hashcode" to test task only

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -189,13 +189,14 @@ jobs:
       env:
         S3_BUILD_CACHE_ACCESS_KEY_ID: ${{ secrets.S3_BUILD_CACHE_ACCESS_KEY_ID }}
         S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.S3_BUILD_CACHE_SECRET_KEY }}
-        _JAVA_OPTIONS: ${{ matrix.testExtraJvmArgs }}
+        _JAVA_OPTIONS: ${{ matrix.extraJvmArgs }}
       with:
         read-only: ${{ matrix.os == 'self-hosted' }}
         job-id: jdk${{ matrix.java_version }}
         arguments: --scan --no-parallel --no-daemon jandex test ${{ matrix.extraGradleArgs }}
         properties: |
           includeTestTags=${{ matrix.includeTestTags }}
+          testExtraJvmArgs=${{ matrix.testExtraJvmArgs }}
 
     - name: 'Install krb5 for GSS tests'
       if: ${{ matrix.gss == 'yes' }}

--- a/.github/workflows/matrix.js
+++ b/.github/workflows/matrix.js
@@ -248,7 +248,10 @@ include.forEach(v => {
     v.extraGradleArgs = gradleArgs.join(' ');
 });
 include.forEach(v => {
+  // Arguments passed to all the JVMs via _JAVA_OPTIONS
   let jvmArgs = [];
+  // Extra JVM arguments passed to test execution
+  let testJvmArgs = [];
   v.replication = v.replication.value;
   v.slow_tests = v.slow_tests.value;
   v.xa = v.xa.value;
@@ -278,7 +281,10 @@ include.forEach(v => {
       v.deploy_to_maven_local = true
   }
   if (v.hash.value === 'same') {
-    jvmArgs.push('-XX:+UnlockExperimentalVMOptions', '-XX:hashCode=2');
+    // "same hashcode" causes issue for javac, and kotlinc,
+    // so we pass it to test execution only
+    // See https://github.com/pgjdbc/pgjdbc/pull/2821#issuecomment-1436013284
+    testJvmArgs.push('-XX:+UnlockExperimentalVMOptions', '-XX:hashCode=2');
   }
   // Gradle does not work in tr_TR locale, so pass locale to test only: https://github.com/gradle/gradle/issues/17361
   jvmArgs.push(`-Duser.country=${v.locale.country}`);
@@ -307,7 +313,8 @@ include.forEach(v => {
       jvmArgs.push('-XX:+StressCCP');
     }
   }
-  v.testExtraJvmArgs = jvmArgs.join(' ');
+  v.extraJvmArgs = jvmArgs.join(' ');
+  v.testExtraJvmArgs = testJvmArgs.join(' ::: ');
   delete v.hash;
 });
 

--- a/build-logic/jvm/src/main/kotlin/build-logic.test-base.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/build-logic.test-base.gradle.kts
@@ -1,4 +1,5 @@
 import com.github.vlsi.gradle.dsl.configureEach
+import com.github.vlsi.gradle.properties.dsl.props
 import org.gradle.api.tasks.testing.Test
 
 plugins {
@@ -20,6 +21,9 @@ tasks.configureEach<Test> {
     exclude("**/*Suite*")
     jvmArgs("-Xmx1536m")
     jvmArgs("-Djdk.net.URLClassPath.disableClassPathURLCheck=true")
+    props.string("testExtraJvmArgs").trim().takeIf { it.isNotBlank() }?.let {
+        jvmArgs(it.split(" ::: "))
+    }
     // Pass the property to tests
     fun passProperty(name: String, default: String? = null) {
         val value = System.getProperty(name) ?: default


### PR DESCRIPTION
javac and kotlinc have issues with hashcode collision, so it becomes impractical to test with that setting.

Javac produces compilation failure, while Kotilnc 1.8.10 becomes slow
