### PR TITLE
Pull fixes for PR#2556 into master

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/Oid.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/Oid.java
@@ -73,6 +73,7 @@ public class Oid {
   public static final int POINT = 600;
   public static final int POINT_ARRAY = 1017;
   public static final int BOX = 603;
+  public static final int BOX_ARRAY = 1020;
   public static final int JSONB = 3802;
   public static final int JSONB_ARRAY = 3807;
   public static final int JSON = 114;

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
@@ -106,7 +106,8 @@ public class TypeInfoCache implements TypeInfo {
           Oid.TIMESTAMPTZ_ARRAY},
       {"refcursor", Oid.REF_CURSOR, Types.REF_CURSOR, "java.sql.ResultSet", Oid.REF_CURSOR_ARRAY},
       {"json", Oid.JSON, Types.OTHER, "org.postgresql.util.PGobject", Oid.JSON_ARRAY},
-      {"point", Oid.POINT, Types.OTHER, "org.postgresql.geometric.PGpoint", Oid.POINT_ARRAY}
+      {"point", Oid.POINT, Types.OTHER, "org.postgresql.geometric.PGpoint", Oid.POINT_ARRAY},
+      {"box", Oid.BOX, Types.OTHER, "org.postgresql.geometric.PGBox", Oid.BOX_ARRAY}
   };
 
   /**
@@ -183,6 +184,9 @@ public class TypeInfoCache implements TypeInfo {
       // the box datatype and it's not a JDBC core type.
       //
       Character delim = ',';
+      if (pgTypeName.equals("box")) {
+        delim = ';';
+      }
       arrayOidToDelimiter.put(oid, delim);
       arrayOidToDelimiter.put(arrayOid, delim);
 

--- a/pgjdbc/src/test/java/org/postgresql/core/OidValuesCorrectnessTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/core/OidValuesCorrectnessTest.java
@@ -61,6 +61,7 @@ public class OidValuesCorrectnessTest extends BaseTest4 {
    * Helps in situation when variable name in Oid class isn't the same as typname in pg_type table.
    */
   private static Map<String, String> oidTypeNames = new HashMap<String, String>() {{
+      put("BOX_ARRAY", "_BOX");
       put("INT2_ARRAY", "_INT2");
       put("INT4_ARRAY", "_INT4");
       put("INT8_ARRAY", "_INT8");

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseMetaDataCacheTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseMetaDataCacheTest.java
@@ -62,11 +62,11 @@ public class DatabaseMetaDataCacheTest {
     List<LogRecord> typeQueries = log.getRecordsMatching(SQL_TYPE_QUERY_LOG_FILTER);
     assertEquals(0, typeQueries.size());
 
-    ti.getSQLType("box");  // this must be a type not in the hardcoded 'types' list
+    ti.getSQLType("xid");  // this must be a type not in the hardcoded 'types' list
     typeQueries = log.getRecordsMatching(SQL_TYPE_QUERY_LOG_FILTER);
     assertEquals(1, typeQueries.size());
 
-    ti.getSQLType("box");  // this time it should be retrieved from the cache
+    ti.getSQLType("xid");  // this time it should be retrieved from the cache
     typeQueries = log.getRecordsMatching(SQL_TYPE_QUERY_LOG_FILTER);
     assertEquals(1, typeQueries.size());
   }


### PR DESCRIPTION
PR #2556 introduced a regression. The regression was that a query was added on every new connection.
The fix for this was to add the box type to the cache, however that caused 2 tests to fail.
This PR addresses these issues