### PR TITLE
chore: print a proper failure message when user executes Checkstyle with pre-11 Java

### DIFF
--- a/build-logic/verification/src/main/kotlin/build-logic.checkstyle.gradle.kts
+++ b/build-logic/verification/src/main/kotlin/build-logic.checkstyle.gradle.kts
@@ -28,5 +28,7 @@ checkstyleTasks.configureEach {
 }
 
 tasks.register("checkstyleAll") {
+    group = LifecycleBasePlugin.VERIFICATION_GROUP
+    description = "Runs Checkstyle source code verifications"
     dependsOn(checkstyleTasks)
 }

--- a/build-logic/verification/src/main/kotlin/build-logic.style.gradle.kts
+++ b/build-logic/verification/src/main/kotlin/build-logic.style.gradle.kts
@@ -9,13 +9,20 @@ if (!buildParameters.skipAutostyle) {
     apply(plugin = "build-logic.autostyle")
 }
 
-val skipCheckstyle = buildParameters.skipCheckstyle || run {
-    logger.info("Checkstyle requires Java 11+")
-    !JavaVersion.current().isJava11Compatible
-}
+val javaIsGoodForCheckstyle = JavaVersion.current().isJava11Compatible
+
+val skipCheckstyle = buildParameters.skipCheckstyle || !javaIsGoodForCheckstyle
 
 if (!skipCheckstyle) {
     apply(plugin = "build-logic.checkstyle")
+} else if (!javaIsGoodForCheckstyle) {
+    tasks.register("checkstyleAll") {
+        group = LifecycleBasePlugin.VERIFICATION_GROUP
+        description = "Runs Checkstyle source code verifications. Java 11+ is needed. The current Java is ${JavaVersion.current()}"
+        doLast {
+            throw IllegalArgumentException("Checkstyle requires Java 11+, the current Java is ${JavaVersion.current()}")
+        }
+    }
 }
 
 if (!buildParameters.skipForbiddenApis) {


### PR DESCRIPTION
Checkstyle requires Java 11, so if the users calls checkstyleAll when running with Java 1.8, then it shuld fail with a proper clarification
