### PR TITLE
Add FINE logging for adaptiveFetch updates

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/v3/adaptivefetch/AdaptiveFetchCache.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/adaptivefetch/AdaptiveFetchCache.java
@@ -89,9 +89,9 @@ public class AdaptiveFetchCache {
           int previousFetchSize = adaptiveFetchCacheEntry.getSize();
           if (newFetchSize != previousFetchSize && LOGGER.isLoggable(Level.FINE)) {
             LOGGER.log(Level.FINE,
-                "Updating adaptiveFetch fetch size from {0} to {1} for query hash {2}. " +
-                    "maximumResultBufferSizeBytes={3} maximumRowSizeBytes={4} " +
-                    "minimumAdaptiveFetchSize={5} maximumAdaptiveFetchSize={6}",
+                "Updating adaptiveFetch fetch size from {0} to {1} for query hash {2}. "
+                    + "maximumResultBufferSizeBytes={3} maximumRowSizeBytes={4} "
+                    + "minimumAdaptiveFetchSize={5} maximumAdaptiveFetchSize={6}",
                 new Object[]{previousFetchSize, newFetchSize, query.hashCode(),
                     maximumResultBufferSize, maximumRowSizeBytes,
                     minimumAdaptiveFetchSize, maximumAdaptiveFetchSize});

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/adaptivefetch/AdaptiveFetchCache.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/adaptivefetch/AdaptiveFetchCache.java
@@ -14,6 +14,8 @@ import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * The main purpose of this class is to handle adaptive fetching process. Adaptive fetching is used
@@ -26,6 +28,8 @@ import java.util.Properties;
  * size. Property adaptiveFetch need properties defaultRowFetchSize and maxResultBuffer to work.
  */
 public class AdaptiveFetchCache {
+
+  private static final Logger LOGGER = Logger.getLogger(AdaptiveFetchCache.class.getName());
 
   private final Map<String, AdaptiveFetchCacheEntry> adaptiveFetchInfoMap;
   private boolean adaptiveFetch = false;
@@ -81,6 +85,17 @@ public class AdaptiveFetchCache {
         if (adaptiveMaximumRowSize < maximumRowSizeBytes && maximumRowSizeBytes > 0) {
           int newFetchSize = (int) (maximumResultBufferSize / maximumRowSizeBytes);
           newFetchSize = adjustFetchSize(newFetchSize);
+
+          int previousFetchSize = adaptiveFetchCacheEntry.getSize();
+          if (newFetchSize != previousFetchSize && LOGGER.isLoggable(Level.FINE)) {
+            LOGGER.log(Level.FINE,
+                "Updating adaptiveFetch fetch size from {0} to {1} for query hash {2}. " +
+                    "maximumResultBufferSizeBytes={3} maximumRowSizeBytes={4} " +
+                    "minimumAdaptiveFetchSize={5} maximumAdaptiveFetchSize={6}",
+                new Object[]{previousFetchSize, newFetchSize, query.hashCode(),
+                    maximumResultBufferSize, maximumRowSizeBytes,
+                    minimumAdaptiveFetchSize, maximumAdaptiveFetchSize});
+          }
 
           adaptiveFetchCacheEntry.setMaximumRowSizeBytes(maximumRowSizeBytes);
           adaptiveFetchCacheEntry.setSize(newFetchSize);


### PR DESCRIPTION
## Summary

This PR creates new FINE-level log statements in the adaptive fetch codepath that emit the old and new values of the fetch size, along with the relevant parameters for how it was computed.

## Background

AdaptiveFetch is a feature previously added in PR https://github.com/pgjdbc/pgjdbc/pull/1707.  It dynamically changes the fetchSize() based on the largest row seen so far, to fit in the maximumResultBufferSize.

However, it does not work in all cases, and I'm in the process of debugging one.

`
Caused by: java.lang.Throwable: Result set exceeded maxResultBuffer limit. Received: 103887670; Current limit: 103887667
`

I believe the problem is that when rows are small for a long time, and then all at once become large, the adaptive fetch gets over-confident and sets too high of a fetch size, exceeding the maximumResultBufferSize when the next batch of records comes back.  To confirm this hypothesis, I went to turn on debug logs for the values that adaptive fetch was computing, but discovered there are none.

I chose FINE level to match the typical levels already in use in this project.  This is expected to emit one log statement every time a fetch encounters a new largest row size in the query.  So this will typically be emitted less frequently than once per fetch, and certainly much less frequently than once per row.

Current distribution of log statement levels in source code:
```zsh
$ rg --no-filename -o 'LOGGER.log\(Level.[A-Z]+' | sort | uniq -c | sort -nr
 115 LOGGER.log(Level.FINEST
  55 LOGGER.log(Level.FINE
  22 LOGGER.log(Level.WARNING
   9 LOGGER.log(Level.SEVERE
   2 LOGGER.log(Level.FINER
   1 LOGGER.log(Level.INFO
```

These logs are expected to be irrelevant for all users except those actively debugging an inadequate adaptive fetch configuration.

I expect that for my scenario, this change's logging will reveal that in addition to my current settings..
```
                        "adaptiveFetch", "true",
                        "defaultRowFetchSize", "10",
                        "maxResultBuffer", "10percent",
```
..I will likely need to additionally set `adaptiveFetchMaximum` to some sane value.  I've tried with `524288` rows, which is about how many of my 128 byte rows fit into 10% my 1GiB heap.  Potentially a saner value will be 10,000 or 1,000.

### All Submissions:

* [X] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes to Existing Features:

* [X] Does this break existing behaviour? If so please explain.
No
* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
Yes
* [X] Have you written new tests for your core changes, as applicable?
No test coverage for added log statements
* [X] Have you successfully run tests with your changes locally?
Not yet
