### PR TITLE
test: increase timeouts for resolving Maven dependencies in OSGi tests

### DIFF
--- a/pgjdbc-osgi-test/src/test/java/org/postgresql/test/osgi/DefaultPgjdbcOsgiOptions.java
+++ b/pgjdbc-osgi-test/src/test/java/org/postgresql/test/osgi/DefaultPgjdbcOsgiOptions.java
@@ -22,6 +22,9 @@ public class DefaultPgjdbcOsgiOptions {
         // It is pgjdbc built in the current build + central for other dependencies
         systemProperty("org.ops4j.pax.url.mvn.repositories")
             .value(System.getProperty("pgjdbc.org.ops4j.pax.url.mvn.repositories")),
+        systemProperty("org.ops4j.pax.url.mvn.timeout").value("15000"),
+        systemProperty("org.ops4j.pax.url.mvn.socket.connectionTimeout").value("15000"),
+        systemProperty("org.ops4j.pax.url.mvn.socket.readTimeout").value("60000"),
         // This is a repository where osgi container would cache resolved maven artifacts
         systemProperty("org.ops4j.pax.url.mvn.localRepository")
             .value(System.getProperty("pgjdbc.org.ops4j.pax.url.mvn.localRepository")),


### PR DESCRIPTION
The default timeouts were 5 seconds, so let's check if increasing helps to prevent test failures