### PR TITLE
Method getFastLong should be able to parse all longs

### DIFF
--- a/benchmarks/src/jmh/java/org/postgresql/benchmark/util/LongParser.java
+++ b/benchmarks/src/jmh/java/org/postgresql/benchmark/util/LongParser.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2023, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.benchmark.util;
+
+import org.postgresql.util.NumberParser;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+@Fork(value = 5, jvmArgsPrepend = "-Xmx128m")
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class LongParser {
+  byte[][] testSet = Stream.of(
+      "0",
+      "1",
+      "-1",
+      "123",
+      "-234",
+      "3241234",
+      "32412343241.234",
+      "324123432234.",
+      "-3241234",
+      "-32412343241234",
+      Long.toString(Long.MIN_VALUE),
+      Long.toString(Long.MAX_VALUE)
+  ).map(String::getBytes).toArray(byte[][]::new);
+
+  @Benchmark
+  public void getFastLong(Blackhole bh) {
+    for (byte[] bytes : testSet) {
+      bh.consume(NumberParser.getFastLong(bytes, Long.MIN_VALUE, Long.MAX_VALUE));
+    }
+  }
+
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder()
+        .include(LongParser.class.getSimpleName())
+        .detectJvmArgs()
+        .build();
+
+    new Runner(opt).run();
+  }
+}

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
@@ -25,6 +25,7 @@ import org.postgresql.util.ByteConverter;
 import org.postgresql.util.GT;
 import org.postgresql.util.HStoreConverter;
 import org.postgresql.util.JdbcBlackHole;
+import org.postgresql.util.NumberParser;
 import org.postgresql.util.PGbytea;
 import org.postgresql.util.PGobject;
 import org.postgresql.util.PGtokenizer;
@@ -2420,7 +2421,7 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
     Encoding encoding = connection.getEncoding();
     if (encoding.hasAsciiNumbers()) {
       try {
-        return (byte) getFastLong(value, Byte.MIN_VALUE, Byte.MAX_VALUE);
+        return (byte) NumberParser.getFastLong(value, Byte.MIN_VALUE, Byte.MAX_VALUE);
       } catch (NumberFormatException ignored) {
       }
     }
@@ -2477,7 +2478,7 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
     Encoding encoding = connection.getEncoding();
     if (encoding.hasAsciiNumbers()) {
       try {
-        return (short) getFastLong(value, Short.MIN_VALUE, Short.MAX_VALUE);
+        return (short) NumberParser.getFastLong(value, Short.MIN_VALUE, Short.MAX_VALUE);
       } catch (NumberFormatException ignored) {
       }
     }
@@ -2505,7 +2506,7 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
     Encoding encoding = connection.getEncoding();
     if (encoding.hasAsciiNumbers()) {
       try {
-        return (int) getFastLong(value, Integer.MIN_VALUE, Integer.MAX_VALUE);
+        return (int) NumberParser.getFastLong(value, Integer.MIN_VALUE, Integer.MAX_VALUE);
       } catch (NumberFormatException ignored) {
       }
     }
@@ -2533,7 +2534,7 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
     Encoding encoding = connection.getEncoding();
     if (encoding.hasAsciiNumbers()) {
       try {
-        return getFastLong(value, Long.MIN_VALUE, Long.MAX_VALUE);
+        return NumberParser.getFastLong(value, Long.MIN_VALUE, Long.MAX_VALUE);
       } catch (NumberFormatException ignored) {
       }
     }
@@ -2557,75 +2558,6 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
       return this;
     }
   };
-
-  private static final long MAX_LONG_DIV_TEN = Long.MAX_VALUE / 10;
-
-  /**
-   * Optimised byte[] to number parser. This code does not handle null values, so the caller must do
-   * checkResultSet and handle null values prior to calling this function. Fraction part is
-   * discarded.
-   *
-   * @param bytes integer represented as a sequence of ASCII bytes
-   * @return The parsed number.
-   * @throws NumberFormatException If the number is invalid or the out of range for fast parsing.
-   *         The value must then be parsed by {@link #toLong(String)}.
-   */
-  private long getFastLong(byte[] bytes, long minVal, long maxVal) throws NumberFormatException {
-    int len = bytes.length;
-    if (len == 0) {
-      throw FAST_NUMBER_FAILED;
-    }
-
-    boolean neg = bytes[0] == '-';
-
-    long val = 0;
-    int start = neg ? 1 : 0;
-    while (start < len) {
-      byte b = bytes[start++];
-      if (b < '0' || b > '9') {
-        if (b == '.') {
-          if (neg && len == 2 || !neg && len == 1) {
-            // we have to check that string is not "." or "-."
-            throw FAST_NUMBER_FAILED;
-          }
-          while (start < len) {
-            b = bytes[start++];
-            if (b < '0' || b > '9') {
-              throw FAST_NUMBER_FAILED;
-            }
-          }
-          break;
-        } else {
-          throw FAST_NUMBER_FAILED;
-        }
-      }
-
-      if (val <= MAX_LONG_DIV_TEN) {
-        val *= 10;
-        val += b - '0';
-      } else {
-        throw FAST_NUMBER_FAILED;
-      }
-    }
-
-    if (val < 0) {
-      // It is possible to get overflow in two situations:
-      // 1. for MIN_VALUE, because abs(MIN_VALUE)=MAX_VALUE+1. In this situation thanks to
-      //    complement arithmetic we got correct result and shouldn't do anything with it.
-      // 2. for incorrect string, representing a number greater than MAX_VALUE, for example
-      //    "9223372036854775809", it this case we have to throw exception
-      if (!(neg && val == Long.MIN_VALUE)) {
-        throw FAST_NUMBER_FAILED;
-      }
-    } else if (neg) {
-      val = -val;
-    }
-
-    if (val < minVal || val > maxVal) {
-      throw FAST_NUMBER_FAILED;
-    }
-    return val;
-  }
 
   /**
    * Optimised byte[] to number parser. This code does not handle null values, so the caller must do

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
@@ -2558,9 +2558,12 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
     }
   };
 
+  private static final long MAX_LONG_DIV_TEN = Long.MAX_VALUE / 10;
+
   /**
    * Optimised byte[] to number parser. This code does not handle null values, so the caller must do
-   * checkResultSet and handle null values prior to calling this function.
+   * checkResultSet and handle null values prior to calling this function. Fraction part is
+   * discarded.
    *
    * @param bytes integer represented as a sequence of ASCII bytes
    * @return The parsed number.
@@ -2568,50 +2571,53 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
    *         The value must then be parsed by {@link #toLong(String)}.
    */
   private long getFastLong(byte[] bytes, long minVal, long maxVal) throws NumberFormatException {
-    if (bytes.length == 0) {
+    int len = bytes.length;
+    if (len == 0) {
       throw FAST_NUMBER_FAILED;
     }
 
-    long val = 0;
-    int start;
-    boolean neg;
-    if (bytes[0] == '-') {
-      neg = true;
-      start = 1;
-      if (bytes.length == 1 || bytes.length > 19) {
-        throw FAST_NUMBER_FAILED;
-      }
-    } else {
-      start = 0;
-      neg = false;
-      if (bytes.length > 18) {
-        throw FAST_NUMBER_FAILED;
-      }
-    }
+    boolean neg = bytes[0] == '-';
 
-    int periodsSeen = 0;
-    while (start < bytes.length) {
+    long val = 0;
+    int start = neg ? 1 : 0;
+    while (start < len) {
       byte b = bytes[start++];
       if (b < '0' || b > '9') {
-        if (b == '.' && periodsSeen == 0) {
-          periodsSeen++;
-          continue;
+        if (b == '.') {
+          if (neg && len == 2 || !neg && len == 1) {
+            // we have to check that string is not "." or "-."
+            throw FAST_NUMBER_FAILED;
+          }
+          while (start < len) {
+            b = bytes[start++];
+            if (b < '0' || b > '9') {
+              throw FAST_NUMBER_FAILED;
+            }
+          }
+          break;
         } else {
           throw FAST_NUMBER_FAILED;
         }
       }
-      if (periodsSeen == 0) {
+
+      if (val <= MAX_LONG_DIV_TEN) {
         val *= 10;
         val += b - '0';
+      } else {
+        throw FAST_NUMBER_FAILED;
       }
     }
 
-    int numNonSignChars = neg ? bytes.length - 1 : bytes.length;
-    if (periodsSeen > 1 || periodsSeen == numNonSignChars) {
-      throw FAST_NUMBER_FAILED;
-    }
-
-    if (neg) {
+    if (val < 0) {
+      // It is possible to get overflow in two situations:
+      // 1. for MIN_VALUE, because abs(MIN_VALUE)=MAX_VALUE+1. In this situation thanks to
+      //    complement arithmetic we got correct result and shouldn't do anything with it.
+      // 2. for incorrect string, representing a number greater than MAX_VALUE, for example
+      //    "9223372036854775809", it this case we have to throw exception
+      if (!(neg && val == Long.MIN_VALUE)) {
+        throw FAST_NUMBER_FAILED;
+      }
+    } else if (neg) {
       val = -val;
     }
 

--- a/pgjdbc/src/main/java/org/postgresql/util/NumberParser.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/NumberParser.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2023, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.util;
+
+/**
+ * Optimised byte[] to number parser.
+ */
+public class NumberParser {
+  private static final NumberFormatException FAST_NUMBER_FAILED = new NumberFormatException() {
+    @Override
+    public Throwable fillInStackTrace() {
+      return this;
+    }
+  };
+
+  private static final long MAX_LONG_DIV_TEN = Long.MAX_VALUE / 10;
+
+  /**
+   * Optimised byte[] to number parser. This code does not handle null values, so the caller must do
+   * checkResultSet and handle null values prior to calling this function. Fraction part is
+   * discarded.
+   *
+   * @param bytes integer represented as a sequence of ASCII bytes
+   * @return The parsed number.
+   * @throws NumberFormatException If the number is invalid or the out of range for fast parsing.
+   *                               The value must then be parsed by another (less optimised) method.
+   */
+  public static long getFastLong(byte[] bytes, long minVal, long maxVal) throws NumberFormatException {
+    int len = bytes.length;
+    if (len == 0) {
+      throw FAST_NUMBER_FAILED;
+    }
+
+    boolean neg = bytes[0] == '-';
+
+    long val = 0;
+    int start = neg ? 1 : 0;
+    while (start < len) {
+      byte b = bytes[start++];
+      if (b < '0' || b > '9') {
+        if (b == '.') {
+          if (neg && len == 2 || !neg && len == 1) {
+            // we have to check that string is not "." or "-."
+            throw FAST_NUMBER_FAILED;
+          }
+          // check that the rest of the buffer contains only digits
+          while (start < len) {
+            b = bytes[start++];
+            if (b < '0' || b > '9') {
+              throw FAST_NUMBER_FAILED;
+            }
+          }
+          break;
+        } else {
+          throw FAST_NUMBER_FAILED;
+        }
+      }
+
+      if (val <= MAX_LONG_DIV_TEN) {
+        val *= 10;
+        val += b - '0';
+      } else {
+        throw FAST_NUMBER_FAILED;
+      }
+    }
+
+    if (val < 0) {
+      // It is possible to get overflow in two situations:
+      // 1. for MIN_VALUE, because abs(MIN_VALUE)=MAX_VALUE+1. In this situation thanks to
+      //    complement arithmetic we got correct result and shouldn't do anything with it.
+      // 2. for incorrect string, representing a number greater than MAX_VALUE, for example
+      //    "9223372036854775809", it this case we have to throw exception
+      if (!(neg && val == Long.MIN_VALUE)) {
+        throw FAST_NUMBER_FAILED;
+      }
+    } else if (neg) {
+      val = -val;
+    }
+
+    if (val < minVal || val > maxVal) {
+      throw FAST_NUMBER_FAILED;
+    }
+    return val;
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/util/NumberParserTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/util/NumberParserTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2023, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class NumberParserTest {
+  @Test
+  public void testGetFastLong_normalLongs() {
+    List<Long> tests = new ArrayList<>();
+    for (long base : new long[]{0, 42, 65536, -65536, Long.MAX_VALUE}) {
+      for (int diff = -10; diff <= 10; diff++) {
+        tests.add(base + diff);
+      }
+    }
+
+    for (Long test : tests) {
+      assertGetLongResult(Long.toString(test), test);
+    }
+  }
+
+  @Test
+  public void testGetFastLong_discardsFractionalPart() {
+    assertGetLongResult("234.435", 234);
+    assertGetLongResult("-234234.", -234234);
+  }
+
+  @Test
+  public void testGetFastLong_failOnIncorrectStrings() {
+    assertGetLongFail("");
+    assertGetLongFail("-234.12542.");
+    assertGetLongFail(".");
+    assertGetLongFail("-.");
+    assertGetLongFail(Long.toString(Long.MIN_VALUE).substring(1));
+  }
+
+  private void assertGetLongResult(String s, long expected) {
+    try {
+      assertEquals(
+          "string \"" + s + "\" parsed well to number " + expected,
+          expected,
+          NumberParser.getFastLong(s.getBytes(), Long.MIN_VALUE, Long.MAX_VALUE)
+      );
+    } catch (NumberFormatException nfe) {
+      fail("failed to parse(NumberFormatException) string \"" + s + "\", expected result " + expected);
+    }
+  }
+
+  private void assertGetLongFail(String s) {
+    try {
+      long ret = NumberParser.getFastLong(s.getBytes(), Long.MIN_VALUE, Long.MAX_VALUE);
+      fail("Expected NumberFormatException on parsing \"" + s + "\", but result: " + ret);
+    } catch (NumberFormatException nfe) {
+      // ok
+    }
+  }
+}


### PR DESCRIPTION
We met situation when a lot of cpu in some cases consumes by PgResultSet.getLong (according to async-profiler flame graph).
The reason is that current optimised function getFastLong can't work with long numbers with more than 59 significant bits, because of `len(str(2 ** 60)) -> 19`, and we have check of byte[] length.
https://github.com/pgjdbc/pgjdbc/blob/29414ab886553d212b39f94b125662989d270b6e/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java#L2587

We have a lot of numbers, which are exceeds this restriction (almost all ids are generated like `Random.nextLong()`).

This PR modifies getFastLong to be able to process all longs from MIN_VALUE to MAX_VALUE.
Corresponding tests were added, fallback to `toLong()` left in place.

I had to move the method to a separate class for testing and benchmark purposes.

### All Submissions:

* [+] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [+] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes to Existing Features:

* [-] Does this break existing behaviour? If so please explain.
* [+] Have you added an explanation of what your changes do and why you'd like us to include them?
* [+] Have you written new tests for your core changes, as applicable?
* [+] Have you successfully run tests with your changes locally?
