### PR TITLE
Use canonical DateStyle name

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java
@@ -375,7 +375,7 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
     paramList.add(new StartupParam("user", user));
     paramList.add(new StartupParam("database", database));
     paramList.add(new StartupParam("client_encoding", "UTF8"));
-    paramList.add(new StartupParam("DateStyle", "ISO"));
+    paramList.add(new StartupParam("DateStyle", "ISO, MDY"));
     paramList.add(new StartupParam("TimeZone", createPostgresTimeZone()));
 
     Version assumeVersion = ServerVersion.from(PGProperty.ASSUME_MIN_SERVER_VERSION.getOrDefault(info));


### PR DESCRIPTION
(I'm one of the PgBouncer maintainers)

This makes variable caching in PgBouncer more efficient, because now the client is setting the same values that the server reports.

See these PgBouncer issues/PRs for details:
https://github.com/pgbouncer/pgbouncer/issues/776
https://github.com/pgbouncer/pgbouncer/pull/879

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests? **Not sure, I don't use Java normally so I'm hoping that CI will find any issues**
2. [ ] Does `./gradlew autostyleCheck checkstyleAll` pass ? **See 1**
3. [ ] Have you added your new test classes to an existing test suite in alphabetical order? **I did not add any tests**

### Changes to Existing Features:

* [ ] Does this break existing behaviour? If so please explain. **Maybe, this will not only change the output format but also the date interpretation order. If the date interpretation order of the system is for instance DMY, then this will change it to MDY.**
* [x] Have you added an explanation of what your changes do and why you'd like us to include them? **Yes**
* [ ] Have you written new tests for your core changes, as applicable? **No, seems small enough change and I'm unfamilliar with Java**
* [ ] Have you successfully run tests with your changes locally? **No**
