### PR TITLE
Fix Issue #2928 number of ports not equal to number of servers in datasource

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
+++ b/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
@@ -1337,8 +1337,14 @@ public abstract class BaseDataSource implements CommonDataSource, Referenceable 
         url.append(",");
       }
       url.append(serverNames[i]);
-      if (portNumbers != null && portNumbers.length >= i && portNumbers[i] != 0) {
-        url.append(":").append(portNumbers[i]);
+      if (portNumbers != null) {
+        if (serverNames.length == portNumbers.length) {
+          if (portNumbers.length >= i && portNumbers[i] != 0) {
+            url.append(":").append(portNumbers[i]);
+          }
+        } else {
+          throw new IllegalArgumentException("Invalid argument: number of port entries must equal number of serverNames");
+        }
       }
     }
     url.append("/");

--- a/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
+++ b/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
@@ -1338,13 +1338,15 @@ public abstract class BaseDataSource implements CommonDataSource, Referenceable 
       }
       url.append(serverNames[i]);
       if (portNumbers != null) {
-        if (serverNames.length == portNumbers.length) {
-          if (portNumbers.length >= i && portNumbers[i] != 0) {
-            url.append(":").append(portNumbers[i]);
-          }
-        } else {
-          throw new IllegalArgumentException("Invalid argument: number of port entries must equal number of serverNames");
+        if (serverNames.length != portNumbers.length) {
+          throw new IllegalArgumentException(
+              String.format("Invalid argument: number of port %s entries must equal number of serverNames %s",
+                  Arrays.toString(portNumbers), Arrays.toString(serverNames)));
         }
+        if (portNumbers.length >= i && portNumbers[i] != 0) {
+          url.append(":").append(portNumbers[i]);
+        }
+
       }
     }
     url.append("/");

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/optional/BaseDataSourceFailoverUrlsTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/optional/BaseDataSourceFailoverUrlsTest.java
@@ -75,7 +75,7 @@ public class BaseDataSourceFailoverUrlsTest {
     bds.setServerNames(new String[] {"localhost", "localhost1"});
     bds.setPortNumbers(new int[] {6432});
     assertThrows("Number of ports not equal to the number of servers should throw an exception",
-        IllegalArgumentException.class, ()->bds.getUrl());
+        IllegalArgumentException.class, () -> bds.getUrl());
   }
   private BaseDataSource newDS() {
     return new BaseDataSource() {

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/optional/BaseDataSourceFailoverUrlsTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/optional/BaseDataSourceFailoverUrlsTest.java
@@ -77,6 +77,7 @@ public class BaseDataSourceFailoverUrlsTest {
     assertThrows("Number of ports not equal to the number of servers should throw an exception",
         IllegalArgumentException.class, () -> bds.getUrl());
   }
+  
   private BaseDataSource newDS() {
     return new BaseDataSource() {
       @Override

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/optional/BaseDataSourceFailoverUrlsTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/optional/BaseDataSourceFailoverUrlsTest.java
@@ -6,6 +6,7 @@
 package org.postgresql.test.jdbc2.optional;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import org.postgresql.ds.common.BaseDataSource;
 
@@ -67,6 +68,15 @@ public class BaseDataSourceFailoverUrlsTest {
     assertEquals(0, bds.getPortNumbers()[0]);
   }
 
+  @Test
+  public void testWrongNumberOfPorts() {
+    BaseDataSource bds = newDS();
+    bds.setDatabaseName("database");
+    bds.setServerNames(new String[] {"localhost", "localhost1"});
+    bds.setPortNumbers(new int[] {6432});
+    assertThrows("Number of ports not equal to the number of servers should throw an exception",
+        IllegalArgumentException.class, ()->bds.getUrl());
+  }
   private BaseDataSource newDS() {
     return new BaseDataSource() {
       @Override

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/optional/BaseDataSourceFailoverUrlsTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/optional/BaseDataSourceFailoverUrlsTest.java
@@ -77,7 +77,7 @@ public class BaseDataSourceFailoverUrlsTest {
     assertThrows("Number of ports not equal to the number of servers should throw an exception",
         IllegalArgumentException.class, () -> bds.getUrl());
   }
-  
+
   private BaseDataSource newDS() {
     return new BaseDataSource() {
       @Override


### PR DESCRIPTION
In BaseDataSource, check to make sure the number of servers is equal to the number of ports.

Throw an IllegalArgumentException if they are not. Added test case to ensure

Fixes #2928 

