### PR TITLE
PGProperty.BINARY_TRANSFER_ENABLE and PGProperty.BINARY_TRANSFER_DISABLE, both say they accept Oid's or string values for the type. Neither did.

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -123,7 +123,8 @@ public enum PGProperty {
   BINARY_TRANSFER_DISABLE(
       "binaryTransferDisable",
       "",
-      "Comma separated list of types to disable binary transfer. Either OID numbers or names. Overrides values in the driver default set and values set with binaryTransferEnable."),
+      "Comma separated list of types to disable binary transfer. Either OID numbers or names. "
+          + "Overrides values in the driver default set and values set with binaryTransferEnable."),
 
   /**
    * Comma separated list of types to enable binary transfer. Either OID numbers or names

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
@@ -425,7 +425,7 @@ public class PgConnection implements BaseConnection {
    * @return oids for which binary transfer can be enabled
    * @throws PSQLException if any oid is not valid
    */
-  private static Set<Integer> getBinaryEnabledOids(Properties info) throws PSQLException {
+  public Set<Integer> getBinaryEnabledOids(Properties info) throws SQLException {
     // check if binary transfer should be enabled for built-in types
     boolean binaryTransfer = PGProperty.BINARY_TRANSFER.getBoolean(info);
     // get formats that currently have binary protocol support
@@ -448,17 +448,18 @@ public class PgConnection implements BaseConnection {
    * @return oids for which binary transfer should be disabled
    * @throws PSQLException if any oid is not valid
    */
-  private static Set<? extends Integer> getBinaryDisabledOids(Properties info)
-      throws PSQLException {
+  public Set<? extends Integer> getBinaryDisabledOids(Properties info)
+      throws SQLException {
     // check for oids that should explicitly be disabled
     String oids = PGProperty.BINARY_TRANSFER_DISABLE.getOrDefault(info);
+
     if (oids == null) {
       return Collections.emptySet();
     }
     return getOidSet(oids);
   }
 
-  private static Set<? extends Integer> getOidSet(String oidList) throws PSQLException {
+  private Set<? extends Integer> getOidSet(String oidList) throws SQLException {
     if (oidList.isEmpty()) {
       return Collections.emptySet();
     }
@@ -466,7 +467,12 @@ public class PgConnection implements BaseConnection {
     StringTokenizer tokenizer = new StringTokenizer(oidList, ",");
     while (tokenizer.hasMoreTokens()) {
       String oid = tokenizer.nextToken();
-      oids.add(Oid.valueOf(oid));
+      if (Character.isDigit(oid.charAt(0))) {
+        oids.add(Oid.valueOf(oid));
+      } else {
+        // look up oid
+        oids.add(typeCache.getPGType(oid));
+      }
     }
     return oids;
   }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ConnectionTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ConnectionTest.java
@@ -33,6 +33,7 @@ import java.sql.Statement;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 
 /**
  * TestCase to test the internal functionality of org.postgresql.jdbc2.Connection and it's
@@ -544,6 +545,26 @@ public class ConnectionTest {
     assertTrue(newStream.getSocket().getKeepAlive());
 
     TestUtil.closeDB(con);
+  }
+
+  @Test
+  public void testGetBinaryDisabledOidWithName() throws  Exception {
+    try (Connection con = TestUtil.openDB()) {
+      Properties properties = new Properties();
+      PGProperty.BINARY_TRANSFER_DISABLE.set(properties, "text");
+      Set<?> oids = con.unwrap(PgConnection.class).getBinaryDisabledOids(properties);
+      assertTrue("Should contain the oid for text (25)", oids.contains(25));
+    }
+  }
+
+  @Test
+  public void testGetBinaryEnabledOidWithName() throws  Exception {
+    try (Connection con = TestUtil.openDB()){
+      Properties properties = new Properties();
+      PGProperty.BINARY_TRANSFER_ENABLE.set(properties, "text");
+      Set<?> oids = con.unwrap(PgConnection.class).getBinaryEnabledOids(properties);
+      assertTrue("Should contain the oid for text (25)", oids.contains(25));
+    }
   }
 
   private static void assertStringContains(String orig, String toContain) {

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ConnectionTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ConnectionTest.java
@@ -559,7 +559,7 @@ public class ConnectionTest {
 
   @Test
   public void testGetBinaryEnabledOidWithName() throws  Exception {
-    try (Connection con = TestUtil.openDB()){
+    try (Connection con = TestUtil.openDB()) {
       Properties properties = new Properties();
       PGProperty.BINARY_TRANSFER_ENABLE.set(properties, "text");
       Set<?> oids = con.unwrap(PgConnection.class).getBinaryEnabledOids(properties);


### PR DESCRIPTION

This fixes that and adds a test
getBinaryDisabledOids is no longer static to allow access to the typecache getBinaryDisabledOids is now public to facilitate tests getBinaryEnabledOids is no longer static to allow access to the typecache getBinaryEnabledOids is now public to facilitate tests

