### PR TITLE
Use KeepAlive to confirm LSNs

### DIFF
--- a/docker/postgres-server/scripts/post-startup.sh
+++ b/docker/postgres-server/scripts/post-startup.sh
@@ -65,6 +65,10 @@ main () {
     psql_super "${POSTGRES_DB}" "
       CREATE DATABASE test OWNER test
     "
+    # Create additional database for some LSN testing
+    psql_super "${POSTGRES_DB}" "
+      CREATE DATABASE test_2 OWNER test
+    "
 
     if ! is_pg_version_at_least "9.0"; then
         # Older versions do not have plpgsql so we explicitly install it

--- a/pgjdbc/src/test/java/org/postgresql/replication/LogicalReplicationStatusTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/replication/LogicalReplicationStatusTest.java
@@ -42,14 +42,18 @@ public class LogicalReplicationStatusTest {
 
   private Connection replicationConnection;
   private Connection sqlConnection;
+  private Connection secondSqlConnection;
 
   @Before
   public void setUp() throws Exception {
     //statistic available only for privileged user
     sqlConnection = TestUtil.openPrivilegedDB();
+    secondSqlConnection = TestUtil.openPrivilegedDB("test_2");
     //DriverManager.setLogWriter(new PrintWriter(System.out));
     replicationConnection = TestUtil.openReplicationConnection();
     TestUtil.createTable(sqlConnection, "test_logic_table",
+        "pk serial primary key, name varchar(100)");
+    TestUtil.createTable(secondSqlConnection, "test_logic_table",
         "pk serial primary key, name varchar(100)");
 
     TestUtil.recreateLogicalReplicationSlot(sqlConnection, SLOT_NAME, "test_decoding");
@@ -59,7 +63,9 @@ public class LogicalReplicationStatusTest {
   public void tearDown() throws Exception {
     replicationConnection.close();
     TestUtil.dropTable(sqlConnection, "test_logic_table");
+    TestUtil.dropTable(secondSqlConnection, "test_logic_table");
     TestUtil.dropReplicationSlot(sqlConnection, SLOT_NAME);
+    secondSqlConnection.close();
     sqlConnection.close();
   }
 
@@ -420,6 +426,56 @@ public class LogicalReplicationStatusTest {
             + "by default it parameter equals to 10 second, but in current test we change it on few millisecond "
             + "and wait that set status on stream will be auto send to backend",
         flushLSN, equalTo(waitLSN)
+    );
+  }
+
+  @Test()
+  public void testKeepAliveServerLSNCanBeUsedToAdvanceFlushLSN() throws Exception {
+    PGConnection pgConnection = (PGConnection) replicationConnection;
+
+    LogSequenceNumber startLSN = getCurrentLSN();
+
+    PGReplicationStream stream =
+        pgConnection
+            .getReplicationAPI()
+            .replicationStream()
+            .logical()
+            .withSlotName(SLOT_NAME)
+            .withStartPosition(startLSN)
+            .start();
+
+    // create replication changes and poll for messages
+    Statement st = sqlConnection.createStatement();
+    st.execute("insert into test_logic_table(name) values('previous changes')");
+    st.close();
+
+    receiveMessageWithoutBlock(stream, 3);
+
+    // client confirms flush of these changes. At this point we're in sync with server
+    LogSequenceNumber confirmedClientFlushLSN = stream.getLastReceiveLSN();
+    stream.setFlushedLSN(confirmedClientFlushLSN);
+    stream.forceUpdateStatus();
+
+    // now insert something into other DB (without replication) to generate WAL
+    System.out.println("Writing to quiet table");
+    Statement st2 = secondSqlConnection.createStatement();
+    st2.execute("insert into test_logic_table(name) values('previous changes')");
+    st2.close();
+
+    // read KeepAlive messages - lastServerLSN will have advanced and we can safely confirm it
+    stream.readPending();
+
+    LogSequenceNumber lastFlushedLSN = stream.getLastFlushedLSN();
+    LogSequenceNumber lastReceivedLSN = stream.getLastReceiveLSN();
+
+    assertThat("Activity in other database will generate WAL but no XLogData "
+            + " messages. Received LSN will begin to advance beyond of confirmed flushLSN",
+        confirmedClientFlushLSN, not(equalTo(lastReceivedLSN))
+    );
+
+    assertThat("When all XLogData messages have been processed, we can confirm "
+            + " flush of Server LSNs in the KeepAlive messages",
+        lastFlushedLSN, equalTo(lastReceivedLSN)
     );
   }
 

--- a/pgjdbc/src/test/java/org/postgresql/test/TestUtil.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/TestUtil.java
@@ -58,7 +58,11 @@ public class TestUtil {
    * Returns the Test database JDBC URL
    */
   public static String getURL() {
-    return getURL(getServer(), + getPort());
+    return getURL(getServer(), getPort());
+  }
+
+  public static String getURL(String database) {
+    return getURL(getServer() + ":" + getPort(), database);
   }
 
   public static String getURL(String server, int port) {
@@ -317,6 +321,18 @@ public class TestUtil {
     PGProperty.PASSWORD.set(properties, getPrivilegedPassword());
     PGProperty.OPTIONS.set(properties, "-c synchronous_commit=on");
     return DriverManager.getConnection(getURL(), properties);
+
+  }
+
+  public static Connection openPrivilegedDB(String databaseName) throws SQLException {
+    initDriver();
+    Properties properties = new Properties();
+
+    PGProperty.GSS_ENC_MODE.set(properties,getGSSEncMode().value);
+    PGProperty.USER.set(properties, getPrivilegedUser());
+    PGProperty.PASSWORD.set(properties, getPrivilegedPassword());
+    PGProperty.OPTIONS.set(properties, "-c synchronous_commit=on");
+    return DriverManager.getConnection(getURL(databaseName), properties);
 
   }
 


### PR DESCRIPTION
When we have two databases on one server, one of which (A) is publishing logical changes and the other (B) is not publishing, we can observe runaway WAL growth when A receives no database activity for a long time but B does. The cause behind this is that the changes on B generate WAL but the replication slot for A cannot advance it's LSN cursors since pgjdbc does not confirm these LSNs. Postgres cannot recycle the old WAL (which isn't actually needed by anyone) and this will continue until a change is made which triggers a replication message.

What we can do is track the LSN of the most recent replication message. If this change was confirmed by the client, then we can use the server LSN of the KeepAlive message to advance the flush LSN without loss of data.

This may also solve the issue outlined in #1490 whereby Postgres cannot shut down as the server and application LSNs are out of sync