### PR TITLE
feat: return all catalogs for getCatalogs metadata query (#2949)

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
@@ -1457,20 +1457,11 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
     return createMetaDataStatement().executeQuery(sql);
   }
 
-  /**
-   * PostgreSQL does not support multiple catalogs from a single connection, so to reduce confusion
-   * we only return the current catalog. {@inheritDoc}
-   */
   @Override
   public ResultSet getCatalogs() throws SQLException {
-    Field[] f = new Field[1];
-    List<Tuple> v = new ArrayList<Tuple>();
-    f[0] = new Field("TABLE_CAT", Oid.VARCHAR);
-    byte[] @Nullable [] tuple = new byte[1][];
-    tuple[0] = connection.encodeString(connection.getCatalog());
-    v.add(new Tuple(tuple));
-
-    return ((BaseStatement) createMetaDataStatement()).createDriverResultSet(f, v);
+    String sql = "SELECT datname AS TABLE_CAT FROM pg_catalog.pg_database"
+        + " WHERE datallowconn = true";
+    return createMetaDataStatement().executeQuery(sql);
   }
 
   @Override

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseMetaDataTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseMetaDataTest.java
@@ -1057,9 +1057,26 @@ public class DatabaseMetaDataTest {
   public void testCatalogs() throws SQLException {
     DatabaseMetaData dbmd = con.getMetaData();
     ResultSet rs = dbmd.getCatalogs();
-    assertTrue(rs.next());
-    assertEquals(con.getCatalog(), rs.getString(1));
-    assertTrue(!rs.next());
+
+    boolean foundDefault = false;
+    boolean foundTest = false;
+    int count;
+
+    for (count = 0; rs.next(); count++) {
+      String catalog = rs.getString("TABLE_CAT");
+      if ("test".equals(catalog)) {
+        foundTest = true;
+      }
+      if ("postgres".equals(catalog)) {
+        foundDefault = true;
+      }
+    }
+
+    rs.close();
+
+    assertTrue(count >= 2);
+    assertTrue(foundDefault);
+    assertTrue(foundTest);
   }
 
   @Test


### PR DESCRIPTION
Use the pg.catalog.pg_database table present in all catalogs to return
the list of available catalogs, instead of just the current one the
connection uses. The table is filtered to include only the
catalogs that can be connected to.

closes pgjdbc#2949

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Does `./gradlew autostyleCheck` pass ?

### Changes to Existing Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
