### PR TITLE
Fix failing tests for version 16. 

### DIFF
--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseMetaDataTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseMetaDataTest.java
@@ -217,7 +217,11 @@ public class DatabaseMetaDataTest {
       assertTrue(res.next());
       assertEquals("__custom", res.getString("TYPE_NAME"));
       assertTrue(res.next());
-      assertEquals("___custom", res.getString("TYPE_NAME"));
+      if (TestUtil.haveMinimumServerVersion(con, ServerVersion.v16)) {
+        assertEquals("__custom_1", res.getString("TYPE_NAME"));
+      } else {
+        assertEquals("___custom", res.getString("TYPE_NAME"));
+      }
     }
     if (TestUtil.haveMinimumServerVersion(con, ServerVersion.v8_3)) {
       con.createArrayOf("custom", new Object[]{});

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseMetaDataTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseMetaDataTest.java
@@ -233,7 +233,11 @@ public class DatabaseMetaDataTest {
       assertTrue(res.next());
       assertEquals("__custom", res.getString("TYPE_NAME"));
       assertTrue(res.next());
-      assertEquals("___custom", res.getString("TYPE_NAME"));
+      if (TestUtil.haveMinimumServerVersion(con, ServerVersion.v16)) {
+        assertEquals("__custom_1", res.getString("TYPE_NAME"));
+      } else {
+        assertEquals("___custom", res.getString("TYPE_NAME"));
+      }
     }
   }
 

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc42/DatabaseMetaDataTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc42/DatabaseMetaDataTest.java
@@ -9,6 +9,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import org.postgresql.core.ServerVersion;
 import org.postgresql.core.TypeInfo;
 import org.postgresql.jdbc.PgConnection;
 import org.postgresql.test.TestUtil;
@@ -102,7 +103,11 @@ public class DatabaseMetaDataTest {
     assertTrue(rs.next());
     assertEquals("c", rs.getString("COLUMN_NAME"));
     // = array of TYPE test_enum AS ENUM ('value')
-    assertEquals("Correctly detects shadowed array type name","___test_enum", rs.getString("TYPE_NAME"));
+    if (TestUtil.haveMinimumServerVersion(conn, ServerVersion.v16)) {
+      assertEquals("Correctly detects shadowed array type name", "_test_enum_1", rs.getString("TYPE_NAME"));
+    } else {
+      assertEquals("Correctly detects shadowed array type name", "___test_enum", rs.getString("TYPE_NAME"));
+    }
     assertEquals("Correctly detects type of shadowed name", Types.ARRAY, rs.getInt("DATA_TYPE"));
 
     assertFalse(rs.next());


### PR DESCRIPTION
It seems that the way names are created for shadowed types has changed

Instead of prepending _ to a shadowed name they now append _N where N is an integer

