### PR TITLE
Deprecate for removal a trivial dependency to `java.desktop` module

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/geometric/PGpoint.java
+++ b/pgjdbc/src/main/java/org/postgresql/geometric/PGpoint.java
@@ -207,7 +207,10 @@ public class PGpoint extends PGobject implements PGBinaryObject, Serializable, C
    *
    * @param p Point to move to
    * @see java.awt.Point
+   *
+   * @deprecated Will be removed for avoiding a dependency to the {@code java.desktop} module.
    */
+  @Deprecated
   public void setLocation(Point p) {
     setLocation(p.x, p.y);
   }


### PR DESCRIPTION
This pull request deprecates the following method:

```
org.postgresql.geometric.PGpoint.setLocation(Point)
```

This is in anticipation for possible modularisation of PostgreSQL JDBC driver as described in #2657. That method was the only dependency to the huge `java.desktop` module, because of the `java.awt.Point` argument. Removing that dependency would allow PgJDBC users to depend on a much smaller subset of the Java environment. There is no need to provide a replacement, because the implementation is trivial.
