### PR TITLE
fix: validate catalog parameter of metadata queries (pgjdbc#2947)

### DIFF
--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseMetaDataTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseMetaDataTest.java
@@ -15,6 +15,7 @@ import org.postgresql.PGProperty;
 import org.postgresql.core.ServerVersion;
 import org.postgresql.test.TestUtil;
 import org.postgresql.test.jdbc2.BaseTest4.BinaryMode;
+import org.postgresql.util.PSQLException;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -47,6 +48,9 @@ import java.util.Set;
  */
 @RunWith(Parameterized.class)
 public class DatabaseMetaDataTest {
+  private static final String INVALID_CATALOG_MESSAGE =
+      "PostgreSQL only supports metadata queries related to the connection's catalog.";
+
   private Connection con;
   private final BinaryMode binaryMode;
 
@@ -282,6 +286,16 @@ public class DatabaseMetaDataTest {
   }
 
   @Test
+  public void testTablesInvalidCatalog() throws Exception {
+    DatabaseMetaData dbmd = con.getMetaData();
+    assertNotNull(dbmd);
+
+    Assert.assertThrows(INVALID_CATALOG_MESSAGE, PSQLException.class, () -> {
+      dbmd.getTables("invalid", null, "metadatates%", new String[]{"TABLE"});
+    });
+  }
+
+  @Test
   public void testCrossReference() throws Exception {
     Connection con1 = TestUtil.openDB();
 
@@ -327,6 +341,19 @@ public class DatabaseMetaDataTest {
     TestUtil.dropTable(con1, "vv");
     TestUtil.dropTable(con1, "ww");
     TestUtil.closeDB(con1);
+  }
+
+  @Test
+  public void testCrossReferenceInvalidCatalog() throws Exception {
+    DatabaseMetaData dbmd = con.getMetaData();
+    assertNotNull(dbmd);
+
+    Assert.assertThrows(INVALID_CATALOG_MESSAGE, PSQLException.class, () -> {
+      dbmd.getCrossReference("invalid", "", "vv", null, "", "ww");
+    });
+    Assert.assertThrows(INVALID_CATALOG_MESSAGE, PSQLException.class, () -> {
+      dbmd.getCrossReference(null, "", "vv", "invalid", "", "ww");
+    });
   }
 
   @Test
@@ -565,6 +592,16 @@ public class DatabaseMetaDataTest {
   }
 
   @Test
+  public void testColumnsInvalidCatalog() throws SQLException {
+    DatabaseMetaData dbmd = con.getMetaData();
+    assertNotNull(dbmd);
+
+    Assert.assertThrows(INVALID_CATALOG_MESSAGE, PSQLException.class, () -> {
+      dbmd.getColumns("invalid", null, "pg_class", null);
+    });
+  }
+
+  @Test
   public void testDroppedColumns() throws SQLException {
     if (!TestUtil.haveMinimumServerVersion(con, ServerVersion.v8_4)) {
       return;
@@ -648,6 +685,16 @@ public class DatabaseMetaDataTest {
     rs.close();
   }
 
+  @Test
+  public void testColumnPrivilegesInvalidCatalog() throws SQLException {
+    DatabaseMetaData dbmd = con.getMetaData();
+    assertNotNull(dbmd);
+
+    Assert.assertThrows(INVALID_CATALOG_MESSAGE, PSQLException.class, () -> {
+      dbmd.getColumnPrivileges("invalid", null, "pg_statistic", null);
+    });
+  }
+
   /*
    * Helper function - this logic is used several times to test relation privileges
    */
@@ -705,12 +752,32 @@ public class DatabaseMetaDataTest {
   }
 
   @Test
+  public void testTablePrivilegesInvalidCatalog() throws SQLException {
+    DatabaseMetaData dbmd = con.getMetaData();
+    assertNotNull(dbmd);
+
+    Assert.assertThrows(INVALID_CATALOG_MESSAGE, PSQLException.class, () -> {
+      dbmd.getTablePrivileges("invalid", null, "metadatatest");
+    });
+  }
+
+  @Test
   public void testPrimaryKeys() throws SQLException {
     // At the moment just test that no exceptions are thrown KJ
     DatabaseMetaData dbmd = con.getMetaData();
     assertNotNull(dbmd);
     ResultSet rs = dbmd.getPrimaryKeys(null, null, "pg_class");
     rs.close();
+  }
+
+  @Test
+  public void testPrimaryKeysInvalidCatalog() throws SQLException {
+    DatabaseMetaData dbmd = con.getMetaData();
+    assertNotNull(dbmd);
+
+    Assert.assertThrows(INVALID_CATALOG_MESSAGE, PSQLException.class, () -> {
+      dbmd.getPrimaryKeys("invalid", null, "pg_class");
+    });
   }
 
   @Test
@@ -766,6 +833,16 @@ public class DatabaseMetaDataTest {
     assertTrue(!rs.next());
 
     rs.close();
+  }
+
+  @Test
+  public void testIndexInfoInvalidCatalog() throws SQLException {
+    DatabaseMetaData dbmd = con.getMetaData();
+    assertNotNull(dbmd);
+
+    Assert.assertThrows(INVALID_CATALOG_MESSAGE, PSQLException.class, () -> {
+      dbmd.getIndexInfo("invalid", null, "metadatatest", false, false);
+    });
   }
 
   /**
@@ -910,6 +987,16 @@ public class DatabaseMetaDataTest {
   }
 
   @Test
+  public void testProcedureColumnsInvalidCatalog() throws SQLException {
+    DatabaseMetaData dbmd = con.getMetaData();
+    assertNotNull(dbmd);
+
+    Assert.assertThrows(INVALID_CATALOG_MESSAGE, PSQLException.class, () -> {
+      dbmd.getProcedureColumns("invalid", null, "f1", null);
+    });
+  }
+
+  @Test
   public void testFuncWithoutNames() throws SQLException {
     DatabaseMetaData dbmd = con.getMetaData();
     assertNotNull(dbmd);
@@ -1043,6 +1130,16 @@ public class DatabaseMetaDataTest {
   }
 
   @Test
+  public void testVersionColumnsInvalidCatalog() throws SQLException {
+    DatabaseMetaData dbmd = con.getMetaData();
+    assertNotNull(dbmd);
+
+    Assert.assertThrows(INVALID_CATALOG_MESSAGE, PSQLException.class, () -> {
+      dbmd.getVersionColumns("invalid", null, "pg_class");
+    });
+  }
+
+  @Test
   public void testBestRowIdentifier() throws SQLException {
     // At the moment just test that no exceptions are thrown KJ
     DatabaseMetaData dbmd = con.getMetaData();
@@ -1053,12 +1150,32 @@ public class DatabaseMetaDataTest {
   }
 
   @Test
+  public void testBestRowIdentifierInvalidCatalog() throws SQLException {
+    DatabaseMetaData dbmd = con.getMetaData();
+    assertNotNull(dbmd);
+
+    Assert.assertThrows(INVALID_CATALOG_MESSAGE, PSQLException.class, () -> {
+      dbmd.getBestRowIdentifier("invalid", null, "pg_type", DatabaseMetaData.bestRowSession, false);
+    });
+  }
+
+  @Test
   public void testProcedures() throws SQLException {
     // At the moment just test that no exceptions are thrown KJ
     DatabaseMetaData dbmd = con.getMetaData();
     assertNotNull(dbmd);
     ResultSet rs = dbmd.getProcedures(null, null, null);
     rs.close();
+  }
+
+  @Test
+  public void testProceduresInvalidCatalog() throws SQLException {
+    DatabaseMetaData dbmd = con.getMetaData();
+    assertNotNull(dbmd);
+
+    Assert.assertThrows(INVALID_CATALOG_MESSAGE, PSQLException.class, () -> {
+      dbmd.getProcedures("invalid", null, null);
+    });
   }
 
   @Test
@@ -1170,7 +1287,7 @@ public class DatabaseMetaDataTest {
       assertEquals("schema name ", "jdbc", schema);
 
       // now test to see if the fully qualified stuff works as planned
-      rs = dbmd.getUDTs("catalog", "public", "catalog.jdbc.testint8", null);
+      rs = dbmd.getUDTs(con.getCatalog(), "public", con.getCatalog() + ".jdbc.testint8", null);
       assertTrue(rs.next());
       cat = rs.getString("type_cat");
       schema = rs.getString("type_schem");
@@ -1193,6 +1310,16 @@ public class DatabaseMetaDataTest {
       }
     }
 
+  }
+
+  @Test
+  public void testGetUDTsInvalidCatalog() throws SQLException {
+    DatabaseMetaData dbmd = con.getMetaData();
+    assertNotNull(dbmd);
+
+    Assert.assertThrows(INVALID_CATALOG_MESSAGE, PSQLException.class, () -> {
+      dbmd.getUDTs("invalid", null, "doesnotexist", null);
+    });
   }
 
   @Test
@@ -1638,6 +1765,16 @@ public class DatabaseMetaDataTest {
     assertTrue(!rs.next());
 
     rs.close();
+  }
+
+  @Test
+  public void testFunctionColumnsInvalidCatalog() throws SQLException {
+    DatabaseMetaData dbmd = con.getMetaData();
+    assertNotNull(dbmd);
+
+    Assert.assertThrows(INVALID_CATALOG_MESSAGE, PSQLException.class, () -> {
+      dbmd.getFunctionColumns("invalid", null, "f1", null);
+    });
   }
 
   @Test

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc3/DatabaseMetaDataTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc3/DatabaseMetaDataTest.java
@@ -44,7 +44,7 @@ public class DatabaseMetaDataTest {
   public void testGetColumnsForDomain() throws Exception {
     DatabaseMetaData dbmd = conn.getMetaData();
 
-    ResultSet rs = dbmd.getColumns("%", "%", "domtab", "%");
+    ResultSet rs = dbmd.getColumns(null, "%", "domtab", "%");
     assertTrue(rs.next());
     assertEquals("a", rs.getString("COLUMN_NAME"));
     assertEquals(Types.DISTINCT, rs.getInt("DATA_TYPE"));

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc42/DatabaseMetaDataTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc42/DatabaseMetaDataTest.java
@@ -56,7 +56,7 @@ public class DatabaseMetaDataTest {
   public void testGetColumnsForNullScale() throws Exception {
     DatabaseMetaData dbmd = conn.getMetaData();
 
-    ResultSet rs = dbmd.getColumns("%", "%", "decimaltest", "%");
+    ResultSet rs = dbmd.getColumns(null, "%", "decimaltest", "%");
     assertTrue(rs.next());
     assertEquals("a", rs.getString("COLUMN_NAME"));
     assertEquals(0, rs.getInt("DECIMAL_DIGITS"));
@@ -74,7 +74,7 @@ public class DatabaseMetaDataTest {
   public void testGetCorrectSQLTypeForOffPathTypes() throws Exception {
     DatabaseMetaData dbmd = conn.getMetaData();
 
-    ResultSet rs = dbmd.getColumns("%", "%", "off_path_table", "%");
+    ResultSet rs = dbmd.getColumns(null, "%", "off_path_table", "%");
     assertTrue(rs.next());
     assertEquals("var", rs.getString("COLUMN_NAME"));
     assertEquals("Detects correct off-path type name", "\"test_schema\".\"_test_enum\"", rs.getString("TYPE_NAME"));
@@ -87,7 +87,7 @@ public class DatabaseMetaDataTest {
   public void testGetCorrectSQLTypeForShadowedTypes() throws Exception {
     DatabaseMetaData dbmd = conn.getMetaData();
 
-    ResultSet rs = dbmd.getColumns("%", "%", "on_path_table", "%");
+    ResultSet rs = dbmd.getColumns(null, "%", "on_path_table", "%");
 
     assertTrue(rs.next());
     assertEquals("a", rs.getString("COLUMN_NAME"));


### PR DESCRIPTION
Report an error if the catalog parameter is not null or empty, but does
not equal the catalog the current connection applies to. This is a
breaking change.

NOTE: Even with this change, we are not 100% compatible with the JDBC
API, since it would dictate treating an empty String catalog parameter
differently from a null one. (The former should query entities that are
not associated with any catalog.) Since such entities do not exist in
PostgreSQL, returning an empty result would be ideal.
However, since the current metadata implementation treats empty
schema/table/column/etc. filters no differently from null ones,
returning empty results for queries with an empty catalog value would
make the driver's behavior inconsistent. (Adjusting how the other
filters work, on the other hand, would be a much larger breaking change.)

closes pgjdbc#2947

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Does `./gradlew autostyleCheck` pass ?

### Changes to Existing Features:

* [x] Does this break existing behaviour? If so please explain.

The relevant API calls in PgDatabaseMetaData will no longer accept any kind of string as an input for the catalog filter, as they did previously. (Since previously the value was simply ignored.)

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
