### PR TITLE
feat: support SET statements combining with other queries with semicolon in PreparedStatement

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/Parser.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/Parser.java
@@ -235,6 +235,8 @@ public class Parser {
             currentCommandType = SqlCommandType.SELECT;
           } else if (wordLength == 4 && parseWithKeyword(aChars, keywordStart)) {
             currentCommandType = SqlCommandType.WITH;
+          } else if (wordLength == 3 && parseSetKeyword(aChars, keywordStart)) {
+            currentCommandType = SqlCommandType.SET;
           } else if (wordLength == 6 && parseInsertKeyword(aChars, keywordStart)) {
             if (!isInsertPresent && (nativeQueries == null || nativeQueries.isEmpty())) {
               // Only allow rewrite for insert command starting with the insert keyword.
@@ -730,6 +732,23 @@ public class Parser {
         && (query[offset + 3] | 32) == 'e'
         && (query[offset + 4] | 32) == 'c'
         && (query[offset + 5] | 32) == 't';
+  }
+
+  /**
+   * Parse string to check presence of SET keyword regardless of case.
+   *
+   * @param query char[] of the query statement
+   * @param offset position of query to start checking
+   * @return boolean indicates presence of word
+   */
+  public static boolean parseSetKeyword(final char[] query, int offset) {
+    if (query.length < (offset + 3)) {
+      return false;
+    }
+
+    return (query[offset] | 32) == 's'
+        && (query[offset + 1] | 32) == 'e'
+        && (query[offset + 2] | 32) == 't';
   }
 
   /**

--- a/pgjdbc/src/main/java/org/postgresql/core/SqlCommandType.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/SqlCommandType.java
@@ -25,5 +25,24 @@ public enum SqlCommandType {
   SELECT,
   WITH,
   CREATE,
-  ALTER;
+  ALTER,
+  SET;
+
+  private static final SqlCommandType[] SQL_COMMAND_TYPES = SqlCommandType.values();
+
+  /**
+   * Returns the SqlCommandType for the given command status.
+   * Returns BLANK if the no match is found.
+   *
+   * @param commandStatus the command status
+   * @return the SqlCommandType for the given command status
+   */
+  public static SqlCommandType fromCommandStatus(String commandStatus) {
+    for (SqlCommandType type : SQL_COMMAND_TYPES) {
+      if (type.name().equalsIgnoreCase(commandStatus)) {
+        return type;
+      }
+    }
+    return SqlCommandType.BLANK;
+  }
 }

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/BatchResultHandler.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/BatchResultHandler.java
@@ -98,14 +98,19 @@ public class BatchResultHandler extends ResultHandlerBase {
       this.latestGeneratedRows = null;
     }
 
-    if (resultIndex >= queries.length) {
+    //SET commands can be ignored for the purposes of update counts
+    boolean statusIsFromSet = status.regionMatches(true, 0, "SET", 0, 3);
+
+    if (!statusIsFromSet && resultIndex >= queries.length) {
       handleError(new PSQLException(GT.tr("Too many update results were returned."),
           PSQLState.TOO_MANY_RESULTS));
       return;
     }
     latestGeneratedKeysRs = null;
 
-    longUpdateCounts[resultIndex++] = updateCount;
+    if (!statusIsFromSet) {
+      longUpdateCounts[resultIndex++] = updateCount;
+    }
   }
 
   private boolean isAutoCommit() {

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgStatement.java
@@ -19,6 +19,7 @@ import org.postgresql.core.QueryExecutor;
 import org.postgresql.core.ResultCursor;
 import org.postgresql.core.ResultHandlerBase;
 import org.postgresql.core.SqlCommand;
+import org.postgresql.core.SqlCommandType;
 import org.postgresql.core.Tuple;
 import org.postgresql.util.GT;
 import org.postgresql.util.PSQLException;
@@ -213,7 +214,7 @@ public class PgStatement implements Statement, BaseStatement {
       if (results == null) {
         lastResult = results = newResult;
       } else {
-        castNonNull(lastResult).append(newResult);
+        lastResult = results = castNonNull(lastResult).append(newResult);
       }
     }
 
@@ -222,15 +223,23 @@ public class PgStatement implements Statement, BaseStatement {
         @Nullable ResultCursor cursor) {
       try {
         ResultSet rs = PgStatement.this.createResultSet(fromQuery, fields, tuples, cursor);
-        append(new ResultWrapper(rs));
+        append(new ResultWrapper(rs, commandTypeOfQuery(fromQuery)));
       } catch (SQLException e) {
         handleError(e);
       }
     }
 
+    private SqlCommandType commandTypeOfQuery(Query query) {
+      SqlCommand sqlCommand = query.getSqlCommand();
+      if (sqlCommand == null) {
+        return SqlCommandType.BLANK;
+      }
+      return sqlCommand.getType();
+    }
+
     @Override
     public void handleCommandStatus(String status, long updateCount, long insertOID) {
-      append(new ResultWrapper(updateCount, insertOID));
+      append(new ResultWrapper(updateCount, insertOID, SqlCommandType.fromCommandStatus(status)));
     }
 
     @Override
@@ -901,7 +910,7 @@ public class PgStatement implements Statement, BaseStatement {
       try (ResourceLock ignore = lock.obtain()) {
         checkClosed();
         if (wantsGeneratedKeysAlways) {
-          generatedKeys = new ResultWrapper(handler.getGeneratedKeys());
+          generatedKeys = new ResultWrapper(handler.getGeneratedKeys(), SqlCommandType.BLANK);
         }
       }
     }

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/ResultWrapper.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/ResultWrapper.java
@@ -6,6 +6,8 @@
 
 package org.postgresql.jdbc;
 
+import org.postgresql.core.SqlCommandType;
+
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.dataflow.qual.Pure;
 
@@ -18,13 +20,15 @@ import java.sql.ResultSet;
  * @author Oliver Jowett (oliver@opencloud.com)
  */
 public class ResultWrapper {
-  public ResultWrapper(@Nullable ResultSet rs) {
+  public ResultWrapper(@Nullable ResultSet rs, SqlCommandType commandType) {
     this.rs = rs;
+    this.commandType = commandType;
     this.updateCount = -1;
     this.insertOID = -1;
   }
 
-  public ResultWrapper(long updateCount, long insertOID) {
+  public ResultWrapper(long updateCount, long insertOID, SqlCommandType commandType) {
+    this.commandType = commandType;
     this.rs = null;
     this.updateCount = updateCount;
     this.insertOID = insertOID;
@@ -47,17 +51,35 @@ public class ResultWrapper {
     return next;
   }
 
-  public void append(ResultWrapper newResult) {
+  /**
+   * Append a result to its internal chain of results.
+   * It has a special behavior for {@code SET} commands as {@code SET} is discarded if there are
+   * other results in the chain.
+   * If this is a {@code SET} command, the {@code newResult} is returned has the new head of
+   * the chain.
+   * If the newResult is a {@code SET} command, it's not appended and this is returned.
+   *
+   * @param newResult the result to append
+   * @return the head of the chain
+   */
+  public ResultWrapper append(ResultWrapper newResult) {
+    if (commandType == SqlCommandType.SET) {
+      return newResult;
+    }
+    if (newResult.commandType == SqlCommandType.SET) {
+      return this;
+    }
     ResultWrapper tail = this;
     while (tail.next != null) {
       tail = tail.next;
     }
-
     tail.next = newResult;
+    return this;
   }
 
   private final @Nullable ResultSet rs;
   private final long updateCount;
   private final long insertOID;
+  private final SqlCommandType commandType;
   private @Nullable ResultWrapper next;
 }

--- a/pgjdbc/src/test/java/org/postgresql/core/ParserTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/core/ParserTest.java
@@ -13,6 +13,8 @@ import org.postgresql.jdbc.EscapeSyntaxCallMode;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.sql.SQLException;
 import java.util.List;
@@ -112,6 +114,16 @@ public class ParserTest {
     assertTrue("Failed to correctly parse mixed case command.", Parser.parseSelectKeyword(command, 0));
     "select".getChars(0, 6, command, 0);
     assertTrue("Failed to correctly parse lower case command.", Parser.parseSelectKeyword(command, 0));
+  }
+
+  /**
+   * Test SET command parsing.
+   */
+  @ParameterizedTest
+  @ValueSource(strings = {"SET", "set", "sEt", "seT", "Set", "sET", "SeT", "seT"})
+  public void testSetCommandParsing(String set) {
+    char[] command = set.toCharArray();
+    assertTrue("Parser.parseSetKeyword(\"" + set + "\", 0)", Parser.parseSetKeyword(command, 0));
   }
 
   @Test
@@ -228,6 +240,15 @@ public class ParserTest {
     SqlCommand command = qry.get(0).getCommand();
     Assert.assertEquals(34, command.getBatchRewriteValuesBraceOpenPosition());
     Assert.assertEquals(56, command.getBatchRewriteValuesBraceClosePosition());
+  }
+
+  @Test
+  public void setVariable() throws SQLException {
+    String query =
+        "set search_path to 'public'";
+    List<NativeQuery> qry = Parser.parseJdbcSql(query, true, true, true, true, true);
+    SqlCommand command = qry.get(0).getCommand();
+    Assert.assertEquals("command type of " + query, SqlCommandType.SET, command.getType());
   }
 
   @Test

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PreparedStatementWithSetTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PreparedStatementWithSetTest.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2023, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.test.jdbc2;
+
+import static org.junit.Assert.assertEquals;
+
+import org.postgresql.test.TestUtil;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+
+@RunWith(Parameterized.class)
+public class PreparedStatementWithSetTest extends BaseTest4 {
+  private final int setBefore;
+  private final int setAfter;
+  private final Operation operation;
+  private final BatchMode batchMode;
+
+  enum Operation {
+    SELECT,
+    INSERT,
+    UPDATE,
+    DELETE,
+  }
+
+  enum BatchMode {
+    YES,
+    NO,
+  }
+
+  public PreparedStatementWithSetTest(BinaryMode binaryMode, int setBefore, int setAfter,
+      Operation operation, BatchMode batchMode) {
+    setBinaryMode(binaryMode);
+    this.setBefore = setBefore;
+    this.setAfter = setAfter;
+    this.operation = operation;
+    this.batchMode = batchMode;
+  }
+
+  @Parameterized.Parameters(name = "binary = {0}, setBefore = {1}, setAfter = {2}, operation = "
+      + "{3}, batchMode = {4}")
+  public static Iterable<Object[]> data() {
+    Collection<Object[]> ids = new ArrayList<Object[]>();
+    for (BinaryMode binaryMode : BinaryMode.values()) {
+      for (int setBefore : new int[]{0, 1, 2}) {
+        for (int setAfter : new int[]{0, 1, 2}) {
+          for (Operation operation : Operation.values()) {
+            for (BatchMode batchMode : BatchMode.values()) {
+              if (batchMode == BatchMode.YES && operation == Operation.SELECT) {
+                continue;
+              }
+              ids.add(new Object[]{binaryMode, setBefore, setAfter, operation, batchMode});
+            }
+          }
+        }
+      }
+    }
+    return ids;
+  }
+
+  @BeforeClass
+  public static void createTestTable() throws SQLException {
+    try (Connection con = TestUtil.openDB()) {
+      TestUtil.createTable(con, "inttable", "a int, b int");
+    }
+  }
+
+  @AfterClass
+  public static void dropTestTable() throws SQLException {
+    try (Connection con = TestUtil.openDB()) {
+      TestUtil.dropTable(con, "inttable");
+    }
+  }
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    try (Statement st = con.createStatement()) {
+      st.execute("DELETE FROM inttable");
+    }
+  }
+
+  @Test
+  public void test() throws SQLException {
+    StringBuilder sb = new StringBuilder();
+    addSetSearchPath(sb, setBefore);
+    switch (operation) {
+      case SELECT:
+        sb.append("SELECT * FROM inttable WHERE a>? AND a<? order by a");
+        break;
+      case INSERT:
+        sb.append("INSERT INTO inttable VALUES (?, 1)");
+        break;
+      case UPDATE:
+        sb.append("UPDATE inttable SET b=b where a=?");
+        break;
+      case DELETE:
+        sb.append("DELETE FROM inttable WHERE a=?");
+        break;
+    }
+    sb.append(';');
+    addSetSearchPath(sb, setAfter);
+    // Remove the trailing ;
+    sb.setLength(sb.length() - 1);
+
+    if (operation != Operation.INSERT) {
+      // Other operations require data to process
+      try (PreparedStatement pstmt = con.prepareStatement("insert into inttable values (1, 1), "
+          + "(2, 1)")) {
+        pstmt.execute();
+      }
+    }
+
+    // Actual test
+    try (PreparedStatement pstmt = con.prepareStatement(sb.toString())) {
+      switch (operation) {
+        case SELECT:
+          pstmt.setInt(1, 0);
+          pstmt.setInt(2, 5);
+          try (ResultSet rs = pstmt.executeQuery();) {
+            assertEquals(
+                "pstmt.executeQuery() results",
+                "1,1\n2,1",
+                TestUtil.join(TestUtil.resultSetToLines(rs))
+            );
+          }
+          break;
+        case INSERT:
+        case UPDATE:
+        case DELETE:
+          pstmt.setInt(1, 1);
+          if (batchMode == BatchMode.NO) {
+            assertEquals(
+                "pstmt.executeUpdate()",
+                1,
+                pstmt.executeUpdate()
+            );
+          } else {
+            pstmt.addBatch();
+            pstmt.setInt(1, 2);
+            pstmt.addBatch();
+            assertEquals(
+                "pstmt.executeBatch()",
+                "[1, 1]",
+                Arrays.toString(pstmt.executeBatch())
+            );
+          }
+          break;
+      }
+    }
+  }
+
+  private void addSetSearchPath(StringBuilder sb, int numberOfCommands) {
+    for (int i = 0; i < numberOfCommands; i++) {
+      sb.append("SET search_path = 'public';");
+    }
+  }
+}


### PR DESCRIPTION
## Inline SET statement with followings

Regarding #2966 this PR allows to write SET statements before INSERT/UPDATE/DELETE/UPDATE.
It was possible to run these SET statements in a separate query, but it's more convenient to have them in the same query.
* It avoids round-trip to the server
* We can use local variables in the SET statements
* It allows to use `StatementInspector` to add SET statements in Hibernate

### Example

```sql
SET SESSION var.nb_test=10;
SET LOCAL var.test_value=42;
INSERT INTO test_statement
SELECT current_setting('var.test_value')::int
FROM generate_series(1, current_setting('var.nb_test')::int);
```