### PR TITLE
feat: fetch size for RefCursor

### DIFF
--- a/docs/content/documentation/callproc.md
+++ b/docs/content/documentation/callproc.md
@@ -61,11 +61,9 @@ When calling a function that returns a refcursor you must cast the return type o
 
 > **NOTE**
 >
-> One notable limitation of the current support for a `ResultSet` created from a refcursor is that even though it is a
-> cursor backed `ResultSet` , all data will be retrieved and cached on the client. The `Statement` fetch size parameter
-> described in the section called [Getting results based on a cursor](/documentation/query/#getting-results-based-on-a-cursor)
-> is ignored. This limitation is a deficiency of the JDBC driver, not the server, and it is technically possible to remove
-> it, we just haven't found the time.
+> The `Statement` fetch size parameter described in the section called [“Getting results based on a cursor”](query.html#query-with-cursor)
+can be used to improve memory usage and performance on large data sets.
+> 
 
 ##### Example 6.3. Getting refcursor Value From a Function
 

--- a/pgjdbc/src/main/java/org/postgresql/core/QueryExecutor.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/QueryExecutor.java
@@ -587,7 +587,7 @@ public interface QueryExecutor extends TypeTransferModeRegistry {
    *                      Portal class.
    * @return fetch size computed by adaptive fetch size for given query passed inside cursor
    */
-  int getAdaptiveFetchSize(boolean adaptiveFetch, ResultCursor cursor);
+  int getAdaptiveFetchSize(boolean adaptiveFetch, @Nullable ResultCursor cursor);
 
   /**
    * Get state of adaptive fetch inside QueryExecutor.

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -2609,7 +2609,7 @@ public class QueryExecutorImpl extends QueryExecutorBase {
   }
 
   @Override
-  public int getAdaptiveFetchSize(boolean adaptiveFetch, ResultCursor cursor) {
+  public int getAdaptiveFetchSize(boolean adaptiveFetch, @Nullable ResultCursor cursor) {
     if (cursor instanceof Portal) {
       Query query = ((Portal) cursor).getQuery();
       if (Objects.nonNull(query)) {

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
@@ -2321,9 +2321,7 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
       cursor.close();
       cursor = null;
     }
-    if (fetchSize > 0) {
-      closeRefCursor();
-    }
+    closeRefCursor();
   }
 
   /**

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
@@ -315,10 +315,6 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
     // we could close in rs.close(), but if the transaction is closed before the result set,
     // then
     // the cursor no longer exists
-    if (fetchSize <= 0) {
-      closeCursor(cursorName);
-    }
-
     rs.setFetchSize(fetchSize);
     ((PgResultSet) rs).setRefCursor(cursorName);
     return rs;

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
@@ -15,6 +15,7 @@ import org.postgresql.core.Field;
 import org.postgresql.core.Oid;
 import org.postgresql.core.Provider;
 import org.postgresql.core.Query;
+import org.postgresql.core.QueryExecutor;
 import org.postgresql.core.ResultCursor;
 import org.postgresql.core.ResultHandlerBase;
 import org.postgresql.core.TransactionState;
@@ -269,31 +270,7 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
 
         // Specialized support for ref cursors is neater.
         if (type.equals("refcursor")) {
-          // Fetch all results.
-          String cursorName = castNonNull(getString(columnIndex));
-
-          StringBuilder sb = new StringBuilder("FETCH ALL IN ");
-          Utils.escapeIdentifier(sb, cursorName);
-
-          // nb: no BEGIN triggered here. This is fine. If someone
-          // committed, and the cursor was not holdable (closing the
-          // cursor), we avoid starting a new xact and promptly causing
-          // it to fail. If the cursor *was* holdable, we don't want a
-          // new xact anyway since holdable cursor state isn't affected
-          // by xact boundaries. If our caller didn't commit at all, or
-          // autocommit was on, then we wouldn't issue a BEGIN anyway.
-          //
-          // We take the scrollability from the statement, but until
-          // we have updatable cursors it must be readonly.
-          ResultSet rs =
-              connection.execSQLQuery(sb.toString(), resultsettype, ResultSet.CONCUR_READ_ONLY);
-          ((PgResultSet) rs).setRefCursor(cursorName);
-          // In long-running transactions these backend cursors take up memory space
-          // we could close in rs.close(), but if the transaction is closed before the result set,
-          // then
-          // the cursor no longer exists
-          ((PgResultSet) rs).closeRefCursor();
-          return rs;
+          return getRefCursor(columnIndex);
         }
         if ("hstore".equals(type)) {
           if (isBinary(columnIndex)) {
@@ -306,6 +283,45 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
         // Caller determines what to do (JDBC3 overrides in this case)
         return null;
     }
+  }
+
+  private Object getRefCursor(int columnIndex) throws SQLException {
+    String cursorName = getString(columnIndex);
+    castNonNull(cursorName, "cursorName");
+    StringBuilder sb = new StringBuilder("FETCH ");
+    if (fetchSize > 0) {
+      sb.append("FORWARD ");
+      sb.append(fetchSize);
+      sb.append(" IN ");
+    } else {
+      sb.append("ALL IN ");
+    }
+    Utils.escapeIdentifier(sb, cursorName);
+
+    // nb: no BEGIN triggered here. This is fine. If someone
+    // committed, and the cursor was not holdable (closing the
+    // cursor), we avoid starting a new xact and promptly causing
+    // it to fail. If the cursor *was* holdable, we don't want a
+    // new xact anyway since holdable cursor state isn't affected
+    // by xact boundaries. If our caller didn't commit at all, or
+    // autocommit was on, then we wouldn't issue a BEGIN anyway.
+    //
+    // We take the scrollability from the statement, but until
+    // we have updatable cursors it must be readonly.
+    ResultSet rs =
+        connection.execSQLQuery(sb.toString(), resultsettype, ResultSet.CONCUR_READ_ONLY);
+    //
+    // In long running transactions these backend cursors take up memory space
+    // we could close in rs.close(), but if the transaction is closed before the result set,
+    // then
+    // the cursor no longer exists
+    if (fetchSize <= 0) {
+      closeCursor(cursorName);
+    }
+
+    rs.setFetchSize(fetchSize);
+    ((PgResultSet) rs).setRefCursor(cursorName);
+    return rs;
   }
 
   @Pure
@@ -2204,9 +2220,10 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
           PSQLState.INVALID_CURSOR_STATE);
     }
 
-    if (currentRow + 1 >= rows.size()) {
-      ResultCursor cursor = this.cursor;
-      if (cursor == null || (maxRows > 0 && rowOffset + rows.size() >= maxRows)) {
+    if (rows != null && currentRow + 1 >= rows.size()) {
+      ResultCursor resultCursor = this.cursor;
+
+      if (checkEndOfResult() && rows != null) {
         currentRow = rows.size();
         thisRow = null;
         rowBuffer = null;
@@ -2214,11 +2231,12 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
       }
 
       // Ask for some more data.
+      castNonNull(rows, "rows");
       rowOffset += rows.size(); // We are discarding some data.
 
       int fetchRows = fetchSize;
       int adaptiveFetchRows = connection.getQueryExecutor()
-          .getAdaptiveFetchSize(adaptiveFetch, cursor);
+          .getAdaptiveFetchSize(adaptiveFetch, resultCursor);
 
       if (adaptiveFetchRows != -1) {
         fetchRows = adaptiveFetchRows;
@@ -2232,12 +2250,28 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
       }
 
       // Execute the fetch and update this resultset.
-      connection.getQueryExecutor()
-          .fetch(cursor, new CursorResultHandler(), fetchRows, adaptiveFetch);
+      if (refCursorName == null || refCursorName.isEmpty()) {
+        castNonNull(resultCursor, "resultCursor");
+        connection.getQueryExecutor()
+            .fetch(resultCursor, new CursorResultHandler(), fetchRows, adaptiveFetch);
+        // .fetch(...) could update this.cursor, and cursor==null means
+        // there are no more rows to fetch
 
-      // .fetch(...) could update this.cursor, and cursor==null means
-      // there are no more rows to fetch
-      closeRefCursor();
+      } else {
+        StringBuilder sb = new StringBuilder("FETCH FORWARD ");
+        sb.append(fetchRows);
+        sb.append(" IN ");
+        castNonNull(refCursorName, "refCursorName");
+        Utils.escapeIdentifier(sb, refCursorName);
+        final Query cursorForward = connection.getQueryExecutor().createSimpleQuery(sb.toString());
+        // pass maxRows=0 since fetchSize has already been corrected to account for maxRows
+        connection.getQueryExecutor().execute(cursorForward, null, new CursorResultHandler(), 0, fetchSize, QueryExecutor.QUERY_ONESHOT | QueryExecutor.QUERY_SUPPRESS_BEGIN
+            | QueryExecutor.QUERY_EXECUTE_AS_SIMPLE );
+        // we did not receive any data so close the cursor
+        if (rows == null || rows.isEmpty()) {
+          closeRefCursor();
+        }
+      }
 
       // After fetch, update last used fetch size (could be useful for adaptive fetch).
       lastUsedFetchSize = fetchRows;
@@ -2256,6 +2290,12 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
 
     initRowBuffer();
     return true;
+  }
+
+  private boolean checkEndOfResult() {
+    return cursor == null && refCursorName == null
+        || (refCursorName != null && fetchSize == 0) // all data fetched
+        || (rows != null) && (maxRows > 0 && rowOffset + rows.size() >= maxRows);
   }
 
   public void close() throws SQLException {
@@ -2281,7 +2321,9 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
       cursor.close();
       cursor = null;
     }
-    closeRefCursor();
+    if (fetchSize > 0) {
+      closeRefCursor();
+    }
   }
 
   /**
@@ -2294,13 +2336,17 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
       return;
     }
     try {
-      if (connection.getTransactionState() == TransactionState.OPEN) {
-        StringBuilder sb = new StringBuilder("CLOSE ");
-        Utils.escapeIdentifier(sb, refCursorName);
-        connection.execSQLUpdate(sb.toString());
-      }
+      closeCursor(refCursorName);
     } finally {
       this.refCursorName = null;
+    }
+  }
+
+  private void closeCursor(String cursorName) throws SQLException {
+    if (connection.getTransactionState() == TransactionState.OPEN) {
+      StringBuilder sb = new StringBuilder("CLOSE ");
+      Utils.escapeIdentifier(sb, cursorName);
+      connection.execSQLUpdate(sb.toString());
     }
   }
 

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
@@ -2182,6 +2182,10 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
       throw new PSQLException(GT.tr("Fetch size must be a value greater to or equal to 0."),
           PSQLState.INVALID_PARAMETER_VALUE);
     }
+    // ignore request to set fetchSize to 0 if it is currently > 0
+    if (fetchSize > 0 && rows == 0) {
+      return;
+    }
     fetchSize = rows;
   }
 

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/CursorFetchTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/CursorFetchTest.java
@@ -59,11 +59,9 @@ public class CursorFetchTest extends BaseTest4 {
   }
 
   protected void createRows(int count) throws Exception {
-    PreparedStatement stmt = con.prepareStatement("insert into test_fetch(value) values(?)");
-    for (int i = 0; i < count; ++i) {
-      stmt.setInt(1, i);
-      stmt.executeUpdate();
-    }
+    PreparedStatement stmt = con.prepareStatement("insert into test_fetch(value) select  generate_series(0,?)");
+    stmt.setInt(1, count - 1);
+    stmt.executeUpdate();
   }
 
   // Test various fetchsizes.

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/RefCursorFetchTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/RefCursorFetchTest.java
@@ -52,10 +52,10 @@ public class RefCursorFetchTest extends BaseTest4 {
     Collection<Object[]> ids = new ArrayList<>();
     for (BinaryMode binaryMode : BinaryMode.values()) {
       for (int numRows : new int[]{0, 10, 101}) {
-        for (Integer defaultFetchSize : new Integer[]{null, 9, 50}) {
+        for (Integer defaultFetchSize : new Integer[]{null, 0, 9, 50}) {
           for (AutoCommit autoCommit : AutoCommit.values()) {
             for (boolean commitAfterExecute : new boolean[]{true, false}) {
-              for (Integer resultSetFetchSize : new Integer[]{null, 9, 50}) {
+              for (Integer resultSetFetchSize : new Integer[]{null, 0, 9, 50}) {
                 ids.add(new Object[]{binaryMode, numRows, defaultFetchSize, resultSetFetchSize, autoCommit, commitAfterExecute});
               }
             }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/RefCursorFetchTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/RefCursorFetchTest.java
@@ -52,10 +52,10 @@ public class RefCursorFetchTest extends BaseTest4 {
     Collection<Object[]> ids = new ArrayList<>();
     for (BinaryMode binaryMode : BinaryMode.values()) {
       for (int numRows : new int[]{0, 10, 101}) {
-        for (Integer defaultFetchSize : new Integer[]{null, 0, 9, 50}) {
+        for (Integer defaultFetchSize : new Integer[]{null, 9, 50}) {
           for (AutoCommit autoCommit : AutoCommit.values()) {
             for (boolean commitAfterExecute : new boolean[]{true, false}) {
-              for (Integer resultSetFetchSize : new Integer[]{null, 0, 9, 50}) {
+              for (Integer resultSetFetchSize : new Integer[]{null, 9, 50}) {
                 ids.add(new Object[]{binaryMode, numRows, defaultFetchSize, resultSetFetchSize, autoCommit, commitAfterExecute});
               }
             }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/RefCursorTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/RefCursorTest.java
@@ -96,33 +96,37 @@ public class RefCursorTest extends BaseTest4 {
 
   @Test
   public void testResult() throws SQLException {
-    CallableStatement call = con.prepareCall("{ ? = call testspg__getRefcursor () }");
-    call.registerOutParameter(1, cursorType);
-    call.execute();
-    ResultSet rs = (ResultSet) call.getObject(1);
+    checkAndRunResult(null);
+  }
 
-    assertTrue(rs.next());
-    assertEquals(1, rs.getInt(1));
+  @Test
+  public void testFetchSizeZero() throws SQLException {
+    checkAndRunResult(0);
+  }
 
-    assertTrue(rs.next());
-    assertEquals(2, rs.getInt(1));
+  @Test
+  public void testFetchSizeOne() throws SQLException {
+    checkAndRunResult(1);
+  }
 
-    assertTrue(rs.next());
-    assertEquals(3, rs.getInt(1));
+  @Test
+  public void testFetchSize() throws SQLException {
+    checkAndRunResult(3);
+  }
 
-    assertTrue(rs.next());
-    assertEquals(4, rs.getInt(1));
+  @Test
+  public void testFetchHighBoundDecrease1() throws SQLException {
+    checkAndRunResult(5);
+  }
 
-    assertTrue(rs.next());
-    assertEquals(6, rs.getInt(1));
+  @Test
+  public void testFetchHighBound() throws SQLException {
+    checkAndRunResult(6);
+  }
 
-    assertTrue(rs.next());
-    assertEquals(9, rs.getInt(1));
-
-    assertFalse(rs.next());
-    rs.close();
-
-    call.close();
+  @Test
+  public void testFetchHighBoundIncrease1() throws SQLException {
+    checkAndRunResult(7);
   }
 
   @Test
@@ -168,6 +172,39 @@ public class RefCursorTest extends BaseTest4 {
 
     assertTrue(rs.last());
     assertEquals(6, rs.getRow());
+    rs.close();
+    call.close();
+  }
+
+  private void checkAndRunResult(Integer fetchSize) throws SQLException {
+    assumeCallableStatementsSupported();
+    CallableStatement call = con.prepareCall("{ ? = call testspg__getRefcursor () }");
+    call.registerOutParameter(1, cursorType);
+    if (fetchSize != null) {
+      call.setFetchSize(fetchSize);
+    }
+    call.execute();
+    ResultSet rs = (ResultSet) call.getObject(1);
+
+    assertTrue(rs.next());
+    assertEquals(1, rs.getInt(1));
+
+    assertTrue(rs.next());
+    assertEquals(2, rs.getInt(1));
+
+    assertTrue(rs.next());
+    assertEquals(3, rs.getInt(1));
+
+    assertTrue(rs.next());
+    assertEquals(4, rs.getInt(1));
+
+    assertTrue(rs.next());
+    assertEquals(6, rs.getInt(1));
+
+    assertTrue(rs.next());
+    assertEquals(9, rs.getInt(1));
+
+    assertFalse(rs.next());
     rs.close();
     call.close();
   }


### PR DESCRIPTION
This replaces the original PR #925 originally written by @rhavermans It was easier to pull in the changes from his PR instead of rebasing the original. This is entirely his code.

We now support setting the fetch size on a RefCursor.

### All Submissions:

* [ ] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Does `./gradlew autostyleCheck checkstyleAll` pass ?
3. [ ] Have you added your new test classes to an existing test suite in alphabetical order?

### Changes to Existing Features:

* [ ] Does this break existing behaviour? If so please explain.
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
