### PR TITLE
chore: add styleCheck Gradle task to report style violations

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,7 @@
 ### New Feature Submissions:
 
 1. [ ] Does your submission pass tests?
-2. [ ] Does `./gradlew autostyleCheck checkstyleAll` pass ?
+2. [ ] Does `./gradlew styleCheck` pass ?
 3. [ ] Have you added your new test classes to an existing test suite in alphabetical order?
 
 ### Changes to Existing Features:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,7 +56,7 @@ jobs:
         S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.S3_BUILD_CACHE_SECRET_KEY }}
       with:
         job-id: jdk17
-        arguments: autostyleCheck checkstyleAll jandex
+        arguments: styleCheck jandex
 
   linux-checkerframework:
     name: 'CheckerFramework'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,7 +104,7 @@ on a command line (the outputs are located in the relevant:
 
     ./gradlew check # verify code style, execute tests
     ./gradlew style # update code formatting (for auto-correctable cases) and verify style
-    ./gradlew autostyleCheck checkstyleAll # report code style violations
+    ./gradlew styleCheck # report code style violations
 
     ./gradlew test # execute tests
     ./gradlew test --tests org.postgresql.test.ssl.SslTest # execute test by class

--- a/build-logic/verification/src/main/kotlin/build-logic.style.gradle.kts
+++ b/build-logic/verification/src/main/kotlin/build-logic.style.gradle.kts
@@ -1,3 +1,4 @@
+import com.github.autostyle.gradle.AutostyleTask
 import org.gradle.kotlin.dsl.apply
 import org.gradle.language.base.plugins.LifecycleBasePlugin
 
@@ -7,6 +8,11 @@ plugins {
 
 if (!buildParameters.skipAutostyle) {
     apply(plugin = "build-logic.autostyle")
+    if (!buildParameters.skipCheckstyle) {
+        tasks.withType<Checkstyle>().configureEach {
+            mustRunAfter(tasks.withType<AutostyleTask>())
+        }
+    }
 }
 
 val skipCheckstyle = buildParameters.skipCheckstyle || run {
@@ -40,6 +46,19 @@ if (!buildParameters.skipAutostyle || !skipCheckstyle || !buildParameters.skipFo
         description = "Formats code (license header, import order, whitespace at end of line, ...) and executes Checkstyle verifications"
         if (!buildParameters.skipAutostyle) {
             dependsOn("autostyleApply")
+        }
+        if (!skipCheckstyle) {
+            dependsOn("checkstyleAll")
+        }
+        if (!buildParameters.skipForbiddenApis) {
+            dependsOn("forbiddenApis")
+        }
+    }
+    tasks.register("styleCheck") {
+        group = LifecycleBasePlugin.VERIFICATION_GROUP
+        description = "Report code style violations (license header, import order, whitespace at end of line, ...)"
+        if (!buildParameters.skipAutostyle) {
+            dependsOn("autostyleCheck")
         }
         if (!skipCheckstyle) {
             dependsOn("checkstyleAll")


### PR DESCRIPTION
The mnemonics is:
* `style`: fix code style
* `styleCheck`: report style violations

Most of the time, `./gradlew style` should be good enough.
