### PR TITLE
Return correct default from PgDatabaseMetaData.getDefaultTransactionIsolation

### DIFF
--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseMetaDataPropertiesTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseMetaDataPropertiesTest.java
@@ -148,6 +148,41 @@ public class DatabaseMetaDataPropertiesTest {
   }
 
   @Test
+  public void testDefaultTransactionIsolation() throws SQLException {
+    DatabaseMetaData dbmd = con.getMetaData();
+    assertNotNull(dbmd);
+
+    int transactionIsolation = dbmd.getDefaultTransactionIsolation();
+    assertEquals(Connection.TRANSACTION_READ_COMMITTED, transactionIsolation);
+
+    String [] isolationLevels = {"\"read committed\"","\"read uncommitted\"", "\"repeatable read\"","serializable"};
+    try {
+      for (int i = 0; i < isolationLevels.length; i++) {
+        con.createStatement().execute("alter database test set default_transaction_isolation to " + isolationLevels[i]);
+        try (Connection con1 = TestUtil.openDB()) {
+          transactionIsolation = con1.getMetaData().getDefaultTransactionIsolation();
+          switch (i) {
+            case 0:
+              assertEquals(Connection.TRANSACTION_READ_COMMITTED, transactionIsolation);
+              break;
+            case 1:
+              assertEquals(Connection.TRANSACTION_READ_UNCOMMITTED, transactionIsolation);
+              break;
+            case 2:
+              assertEquals(Connection.TRANSACTION_REPEATABLE_READ, transactionIsolation);
+              break;
+            case 3:
+              assertEquals(Connection.TRANSACTION_SERIALIZABLE, transactionIsolation);
+              break;
+          }
+        }
+      }
+    } finally {
+      con.createStatement().execute("alter database test set default_transaction_isolation to DEFAULT");
+    }
+  }
+
+  @Test
   public void testTables() throws SQLException {
     DatabaseMetaData dbmd = con.getMetaData();
     assertNotNull(dbmd);


### PR DESCRIPTION
Fixes: #2991

This commit updates `PgDatabaseMetaData.getDefaultTransactionIsolation` to query the database for the default transaction isolation level, instead of assuming that the default isolation level is READ COMMITTED.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Does `./gradlew styleCheck` pass ?

### Changes to Existing Features:

* [x] Does this break existing behaviour? If so please explain.
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
