### PR TITLE
fix: Replace FilterOutputStream with custom impl

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/PGStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/PGStream.java
@@ -21,7 +21,6 @@ import org.ietf.jgss.MessageProp;
 import java.io.BufferedOutputStream;
 import java.io.Closeable;
 import java.io.EOFException;
-import java.io.FilterOutputStream;
 import java.io.Flushable;
 import java.io.IOException;
 import java.io.InputStream;
@@ -306,12 +305,31 @@ public class PGStream implements Closeable, Flushable {
 
     // Intercept flush() downcalls from the writer; our caller
     // will call PGStream.flush() as needed.
-    OutputStream interceptor = new FilterOutputStream(pgOutput) {
+    OutputStream interceptor = new OutputStream() {
+      OutputStream dst = pgOutput;
+
+      @Override
+      public void write(int b) throws IOException {
+        dst.write(b);
+      }
+
+      @Override
+      public void write(byte[] b) throws IOException {
+        dst.write(b);
+      }
+
+      @Override
+      public void write(byte[] b, int off, int len) throws IOException {
+        dst.write(b, off, len);
+      }
+
+      @Override
       public void flush() throws IOException {
       }
 
+      @Override
       public void close() throws IOException {
-        super.flush();
+        dst.flush();
       }
     };
 


### PR DESCRIPTION
All write operations implemented in FilterOutputStream write to destination stream one byte at a time. Benchmark #2963 showed that HotSpot might not be able to optimize this behavior.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes to Existing Features:

* [ ] Does this break existing behaviour? If so please explain.
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
