### PR TITLE
Revert "Use canonical DateStyle name (#2925)"

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java
@@ -375,7 +375,7 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
     paramList.add(new StartupParam("user", user));
     paramList.add(new StartupParam("database", database));
     paramList.add(new StartupParam("client_encoding", "UTF8"));
-    paramList.add(new StartupParam("DateStyle", "ISO, MDY"));
+    paramList.add(new StartupParam("DateStyle", "ISO"));
     paramList.add(new StartupParam("TimeZone", createPostgresTimeZone()));
 
     Version assumeVersion = ServerVersion.from(PGProperty.ASSUME_MIN_SERVER_VERSION.getOrDefault(info));


### PR DESCRIPTION
This reverts commit 258cff34e32f8b5fe5d71f7553f7ac5f30690f85.

Fixes https://github.com/pgjdbc/pgjdbc/issues/3008
