### PR TITLE
fedora/rpm: move source build to java-17-openjdk-devel

### DIFF
--- a/packaging/rpm/postgresql-jdbc.spec.tpl
+++ b/packaging/rpm/postgresql-jdbc.spec.tpl
@@ -51,13 +51,14 @@ Summary:	JDBC driver for PostgreSQL
 Name:		postgresql-jdbc
 Version:	GENERATED
 Release:	GENERATED
-License:	BSD
+License:	BSD-2-Clause
 URL:		http://jdbc.postgresql.org/
 
 Source0:	https://repo1.maven.org/maven2/org/postgresql/postgresql/%{version}/postgresql-%{version}-jdbc-src.tar.gz
 Provides:	pgjdbc = %version-%release
 
 BuildArch:	noarch
+ExclusiveArch:  %{java_arches} noarch
 BuildRequires:	java-devel >= 1.8
 BuildRequires:	maven-local
 BuildRequires:	maven-plugin-bundle

--- a/packaging/rpm/setup-copr/copr-setup
+++ b/packaging/rpm/setup-copr/copr-setup
@@ -11,7 +11,7 @@ PROJECT_PUSH=@pgjdbc/pgjdbc
 
 build_deps=(
     git
-    java-11-openjdk-devel
+    java-17-openjdk-devel
 )
 
 copr_cmd=(


### PR DESCRIPTION
Relates to #3026.