### PR TITLE
Add a utility to alter the password using either scram or md5

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/util/MD5Digest.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/MD5Digest.java
@@ -26,7 +26,7 @@ public class MD5Digest {
    * @param salt actually the user name
    * @return hex representation of the password
    */
-  public static byte[] encryptPassword (byte [] password, byte [] salt) {
+  public static byte[] encryptPassword(byte [] password, byte [] salt) {
     try {
       final MessageDigest md = MessageDigest.getInstance("MD5");
 

--- a/pgjdbc/src/main/java/org/postgresql/util/MD5Digest.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/MD5Digest.java
@@ -21,6 +21,32 @@ public class MD5Digest {
   }
 
   /**
+   * Encrypts a password the way PostgreSQL encrypts it.
+   * @param password secrete
+   * @param salt actually the user name
+   * @return hex representation of the password
+   */
+  public static byte[] encryptPassword (byte [] password, byte [] salt) {
+    try {
+      final MessageDigest md = MessageDigest.getInstance("MD5");
+
+      md.update(password);
+      md.update(salt);
+      byte[] digest = md.digest();
+
+      final byte[] hexDigest = new byte[35];
+      bytesToHex(digest, hexDigest, 3);
+      hexDigest[0] = (byte) 'm';
+      hexDigest[1] = (byte) 'd';
+      hexDigest[2] = (byte) '5';
+
+      return hexDigest;
+    } catch (NoSuchAlgorithmException e) {
+      throw new IllegalStateException("Unable to encode password with MD5", e);
+    }
+  }
+
+  /**
    * Encodes user/password/salt information in the following way: MD5(MD5(password + user) + salt).
    *
    * @param user The connecting user.

--- a/pgjdbc/src/main/java/org/postgresql/util/PasswordUtil.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/PasswordUtil.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2023, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.util;
+
+import com.ongres.scram.common.ScramFunctions;
+import com.ongres.scram.common.ScramMechanisms;
+import com.ongres.scram.common.bouncycastle.base64.Base64;
+import com.ongres.scram.common.stringprep.StringPreparations;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.security.SecureRandom;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+public class PasswordUtil {
+
+  private static final String SCRAM_ENCRYPTION = "scram-sha-256";
+  private static final String MD5 = "md5";
+
+  private static final int SEED_LENGTH = 16;
+  private static final int ITERATIONS = 4096;
+
+  public static String encodeScram(String password, int seedLength, int iterations) {
+    SecureRandom rng = new SecureRandom();
+    byte[] salt = rng.generateSeed(seedLength);
+    byte [] saltedPassword = ScramFunctions.saltedPassword(ScramMechanisms.SCRAM_SHA_256, StringPreparations.SASL_PREPARATION, password,salt, iterations);
+    byte [] clientKey = ScramFunctions.clientKey(ScramMechanisms.SCRAM_SHA_256, saltedPassword);
+    byte [] storedKey = ScramFunctions.storedKey(ScramMechanisms.SCRAM_SHA_256, clientKey);
+    byte [] serverKey = ScramFunctions.serverKey(ScramMechanisms.SCRAM_SHA_256,saltedPassword);
+
+    StringBuffer sb =  new StringBuffer("SCRAM-SHA-256").append('$')
+        .append(iterations).append(':')
+        .append(Base64.toBase64String(salt)).append('$')
+        .append(Base64.toBase64String(storedKey)).append(':')
+        .append(Base64.toBase64String(serverKey));
+    return sb.toString();
+  }
+
+  public static String encodeScram(String password) {
+    return encodeScram( password, SEED_LENGTH, ITERATIONS);
+  }
+
+  public static void alterPassword(Connection con, String user, String password, @Nullable String encryptionType) throws SQLException {
+    String encodedPassword;
+    String encryption;
+    if (encryptionType == null ) {
+      encryption = getEncryption(con);
+    } else if ( !MD5.equalsIgnoreCase(encryptionType) && !SCRAM_ENCRYPTION.equalsIgnoreCase(encryptionType)) {
+      throw new IllegalArgumentException("Encryption type " + encryptionType + " not supported");
+    } else {
+      encryption = encryptionType;
+    }
+    if ( encryption.equalsIgnoreCase( SCRAM_ENCRYPTION)) {
+      encodedPassword = encodeScram(password);
+    } else if (encryption.equalsIgnoreCase(MD5)) {
+      // libpq uses the user as the salt...
+      encodedPassword = new String(MD5Digest.encode(user.getBytes(), password.getBytes(), user.getBytes()));
+    } else {
+      throw new PSQLException("Unable to determine the encryption type ", PSQLState.SYSTEM_ERROR);
+    }
+    try (Statement statement = con.createStatement()) {
+      statement.execute("ALTER USER " + user + " PASSWORD " + encodedPassword);
+    }
+  }
+
+  public static String  getEncryption( Connection con) throws SQLException {
+    try (Statement statement = con.createStatement()) {
+      try (ResultSet rs = statement.executeQuery("show password_encryption ")) {
+        if (rs.next()) {
+          String passwordEncryption = rs.getString(1);
+
+          switch (passwordEncryption) {
+            case "on":
+            case "off":
+            case "md5":
+              return "md5";
+            case "scram-sha-256":
+              return "scram-sha-256";
+            default:
+              throw new PSQLException("Unable to determine encryption type", PSQLState.SYSTEM_ERROR);
+          }
+        }
+      }
+    }
+    throw new PSQLException("Unable to determine encryption type", PSQLState.SYSTEM_ERROR);
+  }
+}

--- a/pgjdbc/src/main/java/org/postgresql/util/PasswordUtil.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/PasswordUtil.java
@@ -67,7 +67,6 @@ public class PasswordUtil {
       throw new PSQLException("Unable to determine the encryption type ", PSQLState.SYSTEM_ERROR);
     }
     try (Statement statement = con.createStatement()) {
-      System.err.println("Executing " + "ALTER USER " + user + " PASSWORD \'" + encodedPassword + '\'');
       statement.execute("ALTER USER " + user + " PASSWORD \'" + encodedPassword + '\'');
     }
   }

--- a/pgjdbc/src/main/java/org/postgresql/util/PasswordUtil.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/PasswordUtil.java
@@ -7,13 +7,13 @@ package org.postgresql.util;
 
 import static org.postgresql.util.internal.Nullness.castNonNull;
 
+import org.postgresql.jdbc.PgConnection;
+
 import com.ongres.scram.common.ScramFunctions;
 import com.ongres.scram.common.ScramMechanisms;
 import com.ongres.scram.common.bouncycastle.base64.Base64;
 import com.ongres.scram.common.stringprep.StringPreparations;
 import org.checkerframework.checker.nullness.qual.Nullable;
-
-import org.postgresql.jdbc.PgConnection;
 
 import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;

--- a/pgjdbc/src/main/java/org/postgresql/util/PasswordUtil.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/PasswordUtil.java
@@ -13,6 +13,8 @@ import com.ongres.scram.common.bouncycastle.base64.Base64;
 import com.ongres.scram.common.stringprep.StringPreparations;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
+import org.postgresql.jdbc.PgConnection;
+
 import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 import java.sql.Connection;
@@ -51,6 +53,7 @@ public class PasswordUtil {
   public static void alterPassword(Connection con, String user, String password, @Nullable String encryptionType) throws SQLException {
     String encodedPassword;
     String encryption;
+
     if (encryptionType == null ) {
       encryption = getEncryption(con);
     } else if ( !MD5.equalsIgnoreCase(encryptionType) && !SCRAM_ENCRYPTION.equalsIgnoreCase(encryptionType)) {
@@ -66,6 +69,7 @@ public class PasswordUtil {
     } else {
       throw new PSQLException("Unable to determine the encryption type ", PSQLState.SYSTEM_ERROR);
     }
+    encodedPassword = ((PgConnection)con).escapeLiteral(encodedPassword);
     try (Statement statement = con.createStatement()) {
       statement.execute("ALTER USER " + user + " PASSWORD \'" + encodedPassword + '\'');
     }

--- a/pgjdbc/src/main/java/org/postgresql/util/PasswordUtil.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/PasswordUtil.java
@@ -5,6 +5,8 @@
 
 package org.postgresql.util;
 
+import static org.postgresql.util.internal.Nullness.castNonNull;
+
 import com.ongres.scram.common.ScramFunctions;
 import com.ongres.scram.common.ScramMechanisms;
 import com.ongres.scram.common.bouncycastle.base64.Base64;
@@ -74,15 +76,15 @@ public class PasswordUtil {
     try (Statement statement = con.createStatement()) {
       try (ResultSet rs = statement.executeQuery("show password_encryption ")) {
         if (rs.next()) {
-          String passwordEncryption = rs.getString(1);
+          String passwordEncryption = castNonNull(rs.getString(1));
 
           switch (passwordEncryption) {
             case "on":
             case "off":
-            case "md5":
-              return "md5";
-            case "scram-sha-256":
-              return "scram-sha-256";
+            case PasswordUtil.MD5:
+              return PasswordUtil.MD5;
+            case PasswordUtil.SCRAM_ENCRYPTION:
+              return PasswordUtil.SCRAM_ENCRYPTION;
             default:
               throw new PSQLException("Unable to determine encryption type", PSQLState.SYSTEM_ERROR);
           }

--- a/pgjdbc/src/main/java/org/postgresql/util/PasswordUtil.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/PasswordUtil.java
@@ -65,7 +65,7 @@ public class PasswordUtil {
       throw new PSQLException("Unable to determine the encryption type ", PSQLState.SYSTEM_ERROR);
     }
     try (Statement statement = con.createStatement()) {
-      statement.execute("ALTER USER '" + user + "' PASSWORD \'" + encodedPassword + '\'');
+      statement.execute("ALTER USER " + user + " PASSWORD \'" + encodedPassword + '\'');
     }
   }
 

--- a/pgjdbc/src/main/java/org/postgresql/util/PasswordUtil.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/PasswordUtil.java
@@ -62,7 +62,7 @@ public class PasswordUtil {
       encodedPassword = encodeScram(password);
     } else if (encryption.equalsIgnoreCase(MD5)) {
       // libpq uses the user as the salt...
-      encodedPassword = new String(MD5Digest.encode(user.getBytes(StandardCharsets.UTF_8), password.getBytes(StandardCharsets.UTF_8), user.getBytes(StandardCharsets.UTF_8)));
+      encodedPassword = new String(MD5Digest.encryptPassword(password.getBytes(StandardCharsets.UTF_8), user.getBytes(StandardCharsets.UTF_8)));
     } else {
       throw new PSQLException("Unable to determine the encryption type ", PSQLState.SYSTEM_ERROR);
     }

--- a/pgjdbc/src/main/java/org/postgresql/util/PasswordUtil.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/PasswordUtil.java
@@ -64,7 +64,7 @@ public class PasswordUtil {
       throw new PSQLException("Unable to determine the encryption type ", PSQLState.SYSTEM_ERROR);
     }
     try (Statement statement = con.createStatement()) {
-      statement.execute("ALTER USER " + user + " PASSWORD " + encodedPassword);
+      statement.execute("ALTER USER " + user + " PASSWORD \'" + encodedPassword + '\'');
     }
   }
 

--- a/pgjdbc/src/main/java/org/postgresql/util/PasswordUtil.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/PasswordUtil.java
@@ -11,6 +11,7 @@ import com.ongres.scram.common.bouncycastle.base64.Base64;
 import com.ongres.scram.common.stringprep.StringPreparations;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
+import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 import java.sql.Connection;
 import java.sql.ResultSet;
@@ -59,12 +60,12 @@ public class PasswordUtil {
       encodedPassword = encodeScram(password);
     } else if (encryption.equalsIgnoreCase(MD5)) {
       // libpq uses the user as the salt...
-      encodedPassword = new String(MD5Digest.encode(user.getBytes(), password.getBytes(), user.getBytes()));
+      encodedPassword = new String(MD5Digest.encode(user.getBytes(StandardCharsets.UTF_8), password.getBytes(StandardCharsets.UTF_8), user.getBytes(StandardCharsets.UTF_8)));
     } else {
       throw new PSQLException("Unable to determine the encryption type ", PSQLState.SYSTEM_ERROR);
     }
     try (Statement statement = con.createStatement()) {
-      statement.execute("ALTER USER " + user + " PASSWORD \'" + encodedPassword + '\'');
+      statement.execute("ALTER USER '" + user + "' PASSWORD \'" + encodedPassword + '\'');
     }
   }
 

--- a/pgjdbc/src/main/java/org/postgresql/util/PasswordUtil.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/PasswordUtil.java
@@ -20,8 +20,8 @@ import java.sql.Statement;
 
 public class PasswordUtil {
 
-  private static final String SCRAM_ENCRYPTION = "scram-sha-256";
-  private static final String MD5 = "md5";
+  public static final String SCRAM_ENCRYPTION = "scram-sha-256";
+  public static final String MD5 = "md5";
 
   private static final int SEED_LENGTH = 16;
   private static final int ITERATIONS = 4096;

--- a/pgjdbc/src/main/java/org/postgresql/util/PasswordUtil.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/PasswordUtil.java
@@ -58,7 +58,7 @@ public class PasswordUtil {
     } else {
       encryption = encryptionType;
     }
-    if ( encryption.equalsIgnoreCase( SCRAM_ENCRYPTION)) {
+    if ( encryption.equalsIgnoreCase(SCRAM_ENCRYPTION)) {
       encodedPassword = encodeScram(password);
     } else if (encryption.equalsIgnoreCase(MD5)) {
       // libpq uses the user as the salt...

--- a/pgjdbc/src/main/java/org/postgresql/util/PasswordUtil.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/PasswordUtil.java
@@ -65,6 +65,7 @@ public class PasswordUtil {
       throw new PSQLException("Unable to determine the encryption type ", PSQLState.SYSTEM_ERROR);
     }
     try (Statement statement = con.createStatement()) {
+      System.err.println("Executing " + "ALTER USER " + user + " PASSWORD \'" + encodedPassword + '\'');
       statement.execute("ALTER USER " + user + " PASSWORD \'" + encodedPassword + '\'');
     }
   }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ConnectionTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ConnectionTest.java
@@ -44,7 +44,7 @@ public class ConnectionTest {
   // Set up the fixture for this testcase: the tables for this test.
   @Before
   public void setUp() throws Exception {
-    con = TestUtil.openDB();
+    con = TestUtil.openPrivilegedDB();
 
     TestUtil.createTable(con, "test_a", "imagename name,image oid,id int4");
     TestUtil.createTable(con, "test_c", "source text,cost money,imageid int4");
@@ -57,7 +57,7 @@ public class ConnectionTest {
   public void tearDown() throws Exception {
     TestUtil.closeDB(con);
 
-    con = TestUtil.openDB();
+    con = TestUtil.openPrivilegedDB();
 
     TestUtil.dropTable(con, "test_a");
     TestUtil.dropTable(con, "test_c");

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ConnectionTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ConnectionTest.java
@@ -44,7 +44,7 @@ public class ConnectionTest {
   // Set up the fixture for this testcase: the tables for this test.
   @Before
   public void setUp() throws Exception {
-    con = TestUtil.openPrivilegedDB();
+    con = TestUtil.openDB();
 
     TestUtil.createTable(con, "test_a", "imagename name,image oid,id int4");
     TestUtil.createTable(con, "test_c", "source text,cost money,imageid int4");
@@ -57,7 +57,7 @@ public class ConnectionTest {
   public void tearDown() throws Exception {
     TestUtil.closeDB(con);
 
-    con = TestUtil.openPrivilegedDB();
+    con = TestUtil.openDB();
 
     TestUtil.dropTable(con, "test_a");
     TestUtil.dropTable(con, "test_c");

--- a/pgjdbc/src/test/java/org/postgresql/test/util/PasswordUtilTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/util/PasswordUtilTest.java
@@ -37,7 +37,7 @@ public class PasswordUtilTest {
   public void tearDown() throws SQLException {
     con.close();
   }
-  
+
   public void testGetEncryption() throws SQLException {
     if (TestUtil.haveMinimumServerVersion(con, ServerVersion.v10)) {
       setEncryption("scram-sha-256");
@@ -76,11 +76,12 @@ public class PasswordUtilTest {
       pstatement.setString(1, user);
       try (ResultSet rs = pstatement.executeQuery()) {
         while (rs.next()) {
-          String encryption = rs.getString(1);
+          String passwd = rs.getString(1);
+          System.err.println("password is: " + passwd);
           if (rs.wasNull()) {
             return "none";
           } else {
-            if (encryption.startsWith("md5")) {
+            if (passwd.startsWith("md5")) {
               return PasswordUtil.MD5;
             } else {
               return PasswordUtil.SCRAM_ENCRYPTION;

--- a/pgjdbc/src/test/java/org/postgresql/test/util/PasswordUtilTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/util/PasswordUtilTest.java
@@ -50,10 +50,11 @@ public class PasswordUtilTest {
   @Test
   public void testScramPassword() throws SQLException {
     if (TestUtil.haveMinimumServerVersion(con, ServerVersion.v10)) {
-      System.err.println(getPgShadow());
-      System.err.println( "Encryption: " + getEncryption());
-      System.err.println( "Changing password for user: " + TestUtil.getUser() + " to: " + TestUtil.getPassword());
-      PasswordUtil.alterPassword(con, TestUtil.getUser(), TestUtil.getPassword(), null);
+      PasswordUtil.alterPassword(con, TestUtil.getUser(), TestUtil.getPassword(), PasswordUtil.SCRAM_ENCRYPTION);
+      con.close();
+      con = TestUtil.openDB();
+    } else {
+      PasswordUtil.alterPassword(con, TestUtil.getUser(), TestUtil.getPassword(), PasswordUtil.MD5);
       con.close();
       con = TestUtil.openDB();
     }
@@ -70,22 +71,6 @@ public class PasswordUtilTest {
     return "";
   }
 
-  private String getPgShadow() throws SQLException {
-    StringBuffer sb = new StringBuffer();
-    try (Connection conn = TestUtil.openPrivilegedDB();
-          Statement statement = conn.createStatement();
-          ResultSet rs = statement.executeQuery("table pg_shadow")){
-      while (rs.next()) {
-        sb.append("user: ")
-            .append(rs.getString(1))
-            .append(" password: ")
-            .append(rs.getString(7))
-            .append('\n');
-      }
-
-      return sb.toString();
-    }
-  }
   private void setEncryption(String encryption) throws SQLException {
     try (Statement statement = con.createStatement()) {
       statement.execute("set password_encryption to " + encryption);

--- a/pgjdbc/src/test/java/org/postgresql/test/util/PasswordUtilTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/util/PasswordUtilTest.java
@@ -16,7 +16,11 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.sql.*;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.Properties;
 
 public class PasswordUtilTest {
@@ -51,6 +55,8 @@ public class PasswordUtilTest {
     if (encryption.equalsIgnoreCase("none")) {
       return;
     }
+    // the default encryption may be different
+    setEncryption(encryption);
     PasswordUtil.alterPassword(con, TestUtil.getUser(), TestUtil.getPassword(), encryption);
     con.close();
     con = TestUtil.openDB();

--- a/pgjdbc/src/test/java/org/postgresql/test/util/PasswordUtilTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/util/PasswordUtilTest.java
@@ -50,6 +50,7 @@ public class PasswordUtilTest {
   @Test
   public void testScramPassword() throws SQLException {
     if (TestUtil.haveMinimumServerVersion(con, ServerVersion.v10)) {
+      System.err.println(getPgShadow());
       System.err.println( "Encryption: " + getEncryption());
       System.err.println( "Changing password for user: " + TestUtil.getUser() + " to: " + TestUtil.getPassword());
       PasswordUtil.alterPassword(con, TestUtil.getUser(), TestUtil.getPassword(), null);
@@ -67,6 +68,23 @@ public class PasswordUtilTest {
       }
     }
     return "";
+  }
+
+  private String getPgShadow() throws SQLException {
+    StringBuffer sb = new StringBuffer();
+    try (Connection conn = TestUtil.openPrivilegedDB();
+          Statement statement = conn.createStatement();
+          ResultSet rs = statement.executeQuery("table pg_shadow")){
+      while (rs.next()) {
+        sb.append("user: ")
+            .append(rs.getString(1))
+            .append(" password: ")
+            .append(rs.getString(7))
+            .append('\n');
+      }
+
+      return sb.toString();
+    }
   }
   private void setEncryption(String encryption) throws SQLException {
     try (Statement statement = con.createStatement()) {

--- a/pgjdbc/src/test/java/org/postgresql/test/util/PasswordUtilTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/util/PasswordUtilTest.java
@@ -50,16 +50,18 @@ public class PasswordUtilTest {
 
   @Test
   public void testScramPassword() throws SQLException {
-    String user = TestUtil.getUser();
-    String encryption = getEncryptionForUser(user);
-    if (encryption.equalsIgnoreCase("none")) {
-      return;
+    if ( TestUtil.haveMinimumServerVersion(con, ServerVersion.v10)) {
+      String user = TestUtil.getUser();
+      String encryption = getEncryptionForUser(user);
+      if (encryption.equalsIgnoreCase("none")) {
+        return;
+      }
+      // the default encryption may be different
+      setEncryption(encryption);
+      PasswordUtil.alterPassword(con, TestUtil.getUser(), TestUtil.getPassword(), encryption);
+      con.close();
+      con = TestUtil.openDB();
     }
-    // the default encryption may be different
-    setEncryption(encryption);
-    PasswordUtil.alterPassword(con, TestUtil.getUser(), TestUtil.getPassword(), encryption);
-    con.close();
-    con = TestUtil.openDB();
   }
 
   /***

--- a/pgjdbc/src/test/java/org/postgresql/test/util/PasswordUtilTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/util/PasswordUtilTest.java
@@ -77,7 +77,6 @@ public class PasswordUtilTest {
       try (ResultSet rs = pstatement.executeQuery()) {
         while (rs.next()) {
           String passwd = rs.getString(1);
-          System.err.println("password is: " + passwd);
           if (rs.wasNull()) {
             return "none";
           } else {
@@ -95,7 +94,7 @@ public class PasswordUtilTest {
 
   private void setEncryption(String encryption) throws SQLException {
     try (Statement statement = con.createStatement()) {
-      statement.execute("set password_encryption to '" + encryption +"'");
+      statement.execute("set password_encryption to '" + encryption + "'");
     }
   }
 }

--- a/pgjdbc/src/test/java/org/postgresql/test/util/PasswordUtilTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/util/PasswordUtilTest.java
@@ -17,6 +17,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.sql.Connection;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Properties;
@@ -49,12 +50,24 @@ public class PasswordUtilTest {
   @Test
   public void testScramPassword() throws SQLException {
     if (TestUtil.haveMinimumServerVersion(con, ServerVersion.v10)) {
+      System.err.println( "Encryption: " + getEncryption());
+      System.err.println( "Changing password for user: " + TestUtil.getUser() + "to: " + TestUtil.getPassword());
       PasswordUtil.alterPassword(con, TestUtil.getUser(), TestUtil.getPassword(), null);
       con.close();
       con = TestUtil.openDB();
     }
   }
 
+  private String getEncryption() throws SQLException {
+    try (Statement statement = con.createStatement()) {
+      try (ResultSet rs = statement.executeQuery("show password_encryption")){
+        if (rs.next()) {
+          return rs.getString(1);
+        }
+      }
+    }
+    return "";
+  }
   private void setEncryption(String encryption) throws SQLException {
     try (Statement statement = con.createStatement()) {
       statement.execute("set password_encryption to " + encryption);

--- a/pgjdbc/src/test/java/org/postgresql/test/util/PasswordUtilTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/util/PasswordUtilTest.java
@@ -8,6 +8,7 @@ package org.postgresql.test.util;
 import static org.junit.Assert.assertEquals;
 
 import org.postgresql.PGProperty;
+import org.postgresql.core.ServerVersion;
 import org.postgresql.test.TestUtil;
 import org.postgresql.util.PasswordUtil;
 
@@ -37,17 +38,21 @@ public class PasswordUtilTest {
 
   @Test
   public void testGetEncryption() throws SQLException {
-    assertEquals("scram-sha-256", PasswordUtil.getEncryption(con));
-    setEncryption("md5");
-    assertEquals("md5", PasswordUtil.getEncryption(con));
-    setEncryption("\"scram-sha-256\"");
+    if (TestUtil.haveMinimumServerVersion(con, ServerVersion.v10)) {
+      assertEquals("scram-sha-256", PasswordUtil.getEncryption(con));
+      setEncryption("md5");
+      assertEquals("md5", PasswordUtil.getEncryption(con));
+      setEncryption("\"scram-sha-256\"");
+    }
   }
 
   @Test
   public void testScramPassword() throws SQLException {
-    PasswordUtil.alterPassword(con, TestUtil.getUser(), TestUtil.getPassword(), null);
-    con.close();
-    con = TestUtil.openDB();
+    if (TestUtil.haveMinimumServerVersion(con, ServerVersion.v10)) {
+      PasswordUtil.alterPassword(con, TestUtil.getUser(), TestUtil.getPassword(), null);
+      con.close();
+      con = TestUtil.openDB();
+    }
   }
 
   private void setEncryption(String encryption) throws SQLException {

--- a/pgjdbc/src/test/java/org/postgresql/test/util/PasswordUtilTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/util/PasswordUtilTest.java
@@ -37,14 +37,13 @@ public class PasswordUtilTest {
   public void tearDown() throws SQLException {
     con.close();
   }
-
-  @Test
+  
   public void testGetEncryption() throws SQLException {
     if (TestUtil.haveMinimumServerVersion(con, ServerVersion.v10)) {
+      setEncryption("scram-sha-256");
       assertEquals("scram-sha-256", PasswordUtil.getEncryption(con));
       setEncryption("md5");
       assertEquals("md5", PasswordUtil.getEncryption(con));
-      setEncryption("\"scram-sha-256\"");
     }
   }
 
@@ -95,7 +94,7 @@ public class PasswordUtilTest {
 
   private void setEncryption(String encryption) throws SQLException {
     try (Statement statement = con.createStatement()) {
-      statement.execute("set password_encryption to " + encryption);
+      statement.execute("set password_encryption to '" + encryption +"'");
     }
   }
 }

--- a/pgjdbc/src/test/java/org/postgresql/test/util/PasswordUtilTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/util/PasswordUtilTest.java
@@ -51,7 +51,7 @@ public class PasswordUtilTest {
   public void testScramPassword() throws SQLException {
     if (TestUtil.haveMinimumServerVersion(con, ServerVersion.v10)) {
       System.err.println( "Encryption: " + getEncryption());
-      System.err.println( "Changing password for user: " + TestUtil.getUser() + "to: " + TestUtil.getPassword());
+      System.err.println( "Changing password for user: " + TestUtil.getUser() + " to: " + TestUtil.getPassword());
       PasswordUtil.alterPassword(con, TestUtil.getUser(), TestUtil.getPassword(), null);
       con.close();
       con = TestUtil.openDB();

--- a/pgjdbc/src/test/java/org/postgresql/test/util/PasswordUtilTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/util/PasswordUtilTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2023, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.test.util;
+
+import static org.junit.Assert.assertEquals;
+
+import org.postgresql.PGProperty;
+import org.postgresql.test.TestUtil;
+import org.postgresql.util.PasswordUtil;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Properties;
+
+public class PasswordUtilTest {
+  Connection con;
+
+  @Before
+  public void setUp() throws Exception {
+    Properties properties = new Properties();
+    PGProperty.PREFER_QUERY_MODE.set(properties, "simple");
+    con = TestUtil.openDB(properties);
+  }
+
+  @After
+  public void tearDown() throws SQLException {
+    con.close();
+  }
+
+  @Test
+  public void testGetEncryption() throws SQLException {
+    assertEquals("scram-sha-256", PasswordUtil.getEncryption(con));
+    setEncryption("md5");
+    assertEquals("md5", PasswordUtil.getEncryption(con));
+    setEncryption("\"scram-sha-256\"");
+  }
+
+  @Test
+  public void testScramPassword() throws SQLException {
+    PasswordUtil.alterPassword(con, TestUtil.getUser(), TestUtil.getPassword(), null);
+    con.close();
+    con = TestUtil.openDB();
+  }
+
+  private void setEncryption(String encryption) throws SQLException {
+    try (Statement statement = con.createStatement()) {
+      statement.execute("set password_encryption to " + encryption);
+    }
+  }
+}


### PR DESCRIPTION
this is analagous to the \password facility of psql.

The idea being that the user can change the password without the clear text password showing up in the logs

### All Submissions:

* [ ] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Does `./gradlew styleCheck` pass ?
3. [ ] Have you added your new test classes to an existing test suite in alphabetical order?

### Changes to Existing Features:

* [ ] Does this break existing behaviour? If so please explain.
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
