### PR TITLE
 Do not send auto savepoint in simpleQuery mode fixes Issue 3107

### DIFF
--- a/docs/content/documentation/server-prepare.md
+++ b/docs/content/documentation/server-prepare.md
@@ -402,7 +402,7 @@ following might be helpful to debug the case.
 
 1. Client logging. If you add `loggerLevel=TRACE&loggerFile=pgjdbc-trace.log`, you would get trace
 of the messages send between the driver and the backend
-1. You might check `org.postgresql.test.jdbc2.AutoRollbackTestSuite` as it verifies lots of combinations
+1. You might check `org.postgresql.test.jdbc2.AutoRollbackTest` as it verifies lots of combinations
 
 ##### Example 9.3. Using server side prepared statements
 

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -430,9 +430,6 @@ public class QueryExecutorImpl extends QueryExecutorBase {
        */
       sendOneQuery(autoSaveQuery, SimpleQuery.NO_PARAMETERS, 1, 0,
           QUERY_NO_RESULTS | QUERY_NO_METADATA);
-              // PostgreSQL does not support bind, exec, simple, sync message flow,
-              // so we force autosavepoint to use simple if the main query is using simple
-              //| QUERY_EXECUTE_AS_SIMPLE);
       return true;
     }
     return false;
@@ -445,7 +442,6 @@ public class QueryExecutorImpl extends QueryExecutorBase {
       try {
         sendOneQuery(releaseAutoSave, SimpleQuery.NO_PARAMETERS, 1, 0,
             QUERY_NO_RESULTS | QUERY_NO_METADATA);
-                //| QUERY_EXECUTE_AS_SIMPLE);
 
       } catch (IOException ex) {
         throw  new PSQLException(GT.tr("Error releasing savepoint"), PSQLState.IO_ERROR);

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -429,10 +429,10 @@ public class QueryExecutorImpl extends QueryExecutorBase {
       SAVEPOINTS.
        */
       sendOneQuery(autoSaveQuery, SimpleQuery.NO_PARAMETERS, 1, 0,
-          QUERY_NO_RESULTS | QUERY_NO_METADATA
+          QUERY_NO_RESULTS | QUERY_NO_METADATA);
               // PostgreSQL does not support bind, exec, simple, sync message flow,
               // so we force autosavepoint to use simple if the main query is using simple
-              | QUERY_EXECUTE_AS_SIMPLE);
+              //| QUERY_EXECUTE_AS_SIMPLE);
       return true;
     }
     return false;
@@ -444,8 +444,8 @@ public class QueryExecutorImpl extends QueryExecutorBase {
         && getTransactionState() == TransactionState.OPEN) {
       try {
         sendOneQuery(releaseAutoSave, SimpleQuery.NO_PARAMETERS, 1, 0,
-            QUERY_NO_RESULTS | QUERY_NO_METADATA
-                | QUERY_EXECUTE_AS_SIMPLE);
+            QUERY_NO_RESULTS | QUERY_NO_METADATA);
+                //| QUERY_EXECUTE_AS_SIMPLE);
 
       } catch (IOException ex) {
         throw  new PSQLException(GT.tr("Error releasing savepoint"), PSQLState.IO_ERROR);

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/AutoRollbackTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/AutoRollbackTest.java
@@ -34,7 +34,7 @@ import java.util.Properties;
 import java.util.concurrent.atomic.AtomicInteger;
 
 @RunWith(Parameterized.class)
-public class AutoRollbackTestSuite extends BaseTest4 {
+public class AutoRollbackTest extends BaseTest4 {
   private static final AtomicInteger counter = new AtomicInteger();
 
   private enum CleanSavePoint {
@@ -125,7 +125,7 @@ public class AutoRollbackTestSuite extends BaseTest4 {
   private final TestStatement testSql;
   private final ReturnColumns cols;
 
-  public AutoRollbackTestSuite(AutoSave autoSave, CleanSavePoint cleanSavePoint, AutoCommit autoCommit,
+  public AutoRollbackTest(AutoSave autoSave, CleanSavePoint cleanSavePoint, AutoCommit autoCommit,
       FailMode failMode, ContinueMode continueMode, boolean flushCacheOnDeallocate,
       boolean trans, TestStatement testSql, ReturnColumns cols) {
     this.autoSave = autoSave;


### PR DESCRIPTION
Change name of AutoRollBackTestSuite to AutoRollBackTest so that it would run. There are exclude rules to stop *Suite* tests from running

