### PR TITLE
Add Windows and MacOS native certificate support

### DIFF
--- a/.github/workflows/ssl-native.yml
+++ b/.github/workflows/ssl-native.yml
@@ -1,0 +1,88 @@
+name: Native keystore SSL factories
+
+# Exercises the platform-backed SSLSocketFactory implementations against a real
+# client certificate imported into the operating system store. These providers
+# (Apple KeychainStore, Windows SunMSCAPI) only exist on their own OS, so the
+# checks run on macOS and Windows runners rather than the Linux test matrix.
+
+on:
+  push:
+    branches: [ master ]
+    paths:
+      - 'pgjdbc/src/main/java/org/postgresql/ssl/**'
+      - 'pgjdbc/src/test/java/org/postgresql/test/ssl/**'
+      - '.github/workflows/ssl-native.yml'
+  pull_request:
+    paths:
+      - 'pgjdbc/src/main/java/org/postgresql/ssl/**'
+      - 'pgjdbc/src/test/java/org/postgresql/test/ssl/**'
+      - '.github/workflows/ssl-native.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  macos-keychain:
+    name: macOS Keychain
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          java-version: 21
+          distribution: temurin
+      - name: Import test client certificate into a throwaway keychain
+        shell: bash
+        env:
+          # Keep the keychain under the runner temp dir.
+          PGJDBC_TEST_KEYCHAIN: ${{ runner.temp }}/pgjdbc-test.keychain
+        run: ./certdir/macos-keychain.sh setup
+      - name: Run native keychain tests
+        shell: bash
+        env:
+          PGJDBC_KEYCHAIN_IMPORTED: 'true'
+        # language=bash
+        run: |
+          ./gradlew --no-daemon --console=plain :postgresql:test \
+            --tests 'org.postgresql.test.ssl.SSLFactoryTest' \
+            --tests 'org.postgresql.test.ssl.KeychainCertTest'
+      - name: Upload test results
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: macos-keychain-test-results
+          path: pgjdbc/build/reports/tests/**
+
+  # The Windows MSCAPI counterpart is provided for completeness. It mirrors the
+  # macOS job but uses the current-user certificate store. It has not been
+  # validated end to end yet; enable it once a SunMSCAPI-backed test exists.
+  windows-mscapi:
+    name: Windows MSCAPI
+    runs-on: windows-latest
+    if: ${{ false }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          java-version: 21
+          distribution: temurin
+      - name: Import test client certificate into the current-user store
+        shell: pwsh
+        run: |
+          # Build a throwaway PKCS#12 from the checked-in test key and
+          # certificate, protected with a random per-job password.
+          $p12pw = -join ((48..57) + (97..122) | Get-Random -Count 24 | ForEach-Object {[char]$_})
+          $p12 = Join-Path $env:RUNNER_TEMP 'goodclient.p12'
+          openssl pkcs12 -export -inkey certdir/goodclient.key -in certdir/goodclient.crt `
+            -passout "pass:$p12pw" -out $p12
+          $secure = ConvertTo-SecureString -String $p12pw -AsPlainText -Force
+          Import-PfxCertificate -FilePath $p12 `
+            -CertStoreLocation Cert:\CurrentUser\My -Password $secure
+      - name: Run native MSCAPI tests
+        shell: bash
+        env:
+          PGJDBC_MSCAPI_IMPORTED: 'true'
+        run: |
+          ./gradlew --no-daemon --console=plain :postgresql:test \
+            --tests 'org.postgresql.test.ssl.SSLFactoryTest'

--- a/certdir/macos-keychain.sh
+++ b/certdir/macos-keychain.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+#
+# Import the pgjdbc test client certificate into a throwaway macOS keychain so
+# the Apple "KeychainStore" provider exposes it to the JVM.
+#
+# No system or login-keychain password is required: a dedicated keychain is
+# created with a random password we choose, the certificate is built on the fly
+# from the checked-in test key and certificate with another random password, and
+# the private-key ACL is pre-authorised non-interactively. The user login
+# keychain is never modified; only the keychain search list is touched, and
+# "teardown" restores it.
+#
+#   ./certdir/macos-keychain.sh setup
+#   PGJDBC_KEYCHAIN_IMPORTED=true ./gradlew :postgresql:test --tests '*KeychainCertTest'
+#   ./certdir/macos-keychain.sh teardown
+#
+set -euo pipefail
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+KC="${PGJDBC_TEST_KEYCHAIN:-${TMPDIR:-/tmp}/pgjdbc-test.keychain}"
+SAVED="$KC.search-list"
+
+case "${1:-}" in
+  setup)
+    kcpw=$(openssl rand -hex 16)
+    p12pw=$(openssl rand -hex 16)
+    p12="${KC%.keychain}.p12"
+    openssl pkcs12 -export -inkey "$DIR/goodclient.key" -in "$DIR/goodclient.crt" \
+      -passout "pass:$p12pw" -out "$p12"
+
+    security delete-keychain "$KC" 2>/dev/null || true
+    security create-keychain -p "$kcpw" "$KC"
+    security unlock-keychain -p "$kcpw" "$KC"
+    security set-keychain-settings "$KC"
+    security import "$p12" -k "$KC" -P "$p12pw" -A -f pkcs12
+    # Pre-authorise non-interactive access to the imported private key.
+    security set-key-partition-list -S apple-tool:,apple:,unsigned: -k "$kcpw" "$KC" >/dev/null
+    rm -f "$p12"
+
+    # Remember the current search list, then prepend the test keychain so the
+    # Apple KeychainStore provider can see the imported certificate.
+    security list-keychains -d user | sed -e 's/^[[:space:]]*//' -e 's/"//g' > "$SAVED"
+    # shellcheck disable=SC2046
+    security list-keychains -d user -s "$KC" $(cat "$SAVED")
+    echo "Keychain ready: $KC"
+    ;;
+  teardown)
+    if [ -f "$SAVED" ]; then
+      # shellcheck disable=SC2046
+      security list-keychains -d user -s $(cat "$SAVED")
+      rm -f "$SAVED"
+    fi
+    security delete-keychain "$KC" 2>/dev/null || true
+    echo "Keychain removed, search list restored"
+    ;;
+  *)
+    echo "usage: $0 {setup|teardown}" >&2
+    exit 2
+    ;;
+esac

--- a/docs/content/documentation/ssl.md
+++ b/docs/content/documentation/ssl.md
@@ -45,12 +45,12 @@ The following implementations of SSLSocketFactory are shipped with the driver.
 |sslfactory|Description|
 |---|---|
 |org.postgresql.ssl.DefaultJavaSSLFactory|Use the JDK default implementation.|
+|org.postgresql.ssl.KeychainSSLFactory|Use certificates and keys from the MacOS keychain. If the MacOS truststore is unsupported by the JDK, we fall back to the default cacerts JKS truststore.|
 |org.postgresql.ssl.LibPQFactory|Use the same certificates and keys as the libpq library. The key must be in DER encoded PKCS8 format. This is the default when sslfactory is unspecified.|
 |org.postgresql.ssl.MSCAPILocalMachineSSLFactory|Use certificates and keys from the Windows local machine certificate manager.|
 |org.postgresql.ssl.MSCAPISSLFactory|Use certificates and keys from the Windows certificate manager belonging to the current user.|
-|org.postgresql.ssl.KeychainSSLFactory|Use certificates and keys from the MacOS keychain. If the MacOS truststore is unsupported by the JDK, we fall back to the default cacerts JKS truststore.|
-|org.postgresql.ssl.SingleCertValidatingFactory|Accept the pinned server certificate specified in the sslfactoryarg parameter.|
 |org.postgresql.ssl.NonValidatingFactory|Connect to anyone without checking. No validation is performed.|
+|org.postgresql.ssl.SingleCertValidatingFactory|Accept the pinned server certificate specified in the sslfactoryarg parameter.|
 
 ## Configuring the Client
 

--- a/docs/content/documentation/ssl.md
+++ b/docs/content/documentation/ssl.md
@@ -42,7 +42,8 @@ and the source to the `NonValidatingFactory` provided by the JDBC driver.
 
 The following implementations of SSLSocketFactory are shipped with the driver.
 
-|sslfactory|description|
+|sslfactory|Description|
+|---|---|
 |org.postgresql.ssl.DefaultJavaSSLFactory|Use the JDK default implementation.|
 |org.postgresql.ssl.LibPQFactory|Use the same certificates and keys as the libpq library. The key must be in DER encoded PKCS8 format. This is the default when sslfactory is unspecified.|
 |org.postgresql.ssl.MSCAPILocalMachineSSLFactory|Use certificates and keys from the Windows local machine certificate manager.|

--- a/docs/content/documentation/ssl.md
+++ b/docs/content/documentation/ssl.md
@@ -38,6 +38,19 @@ Information on how to actually implement such a class is beyond the scope of thi
 are the [JSSE Reference Guide](https://docs.oracle.com/javase/8/docs/technotes/guides/security/jsse/JSSERefGuide.html)
 and the source to the `NonValidatingFactory` provided by the JDBC driver.
 
+## Available SSLSocketFactory Implementations
+
+The following implementations of SSLSocketFactory are shipped with the driver.
+
+|sslfactory|description|
+|org.postgresql.ssl.DefaultJavaSSLFactory|Use the JDK default implementation.|
+|org.postgresql.ssl.LibPQFactory|Use the same certificates and keys as the libpq library. The key must be in DER encoded PKCS8 format. This is the default when sslfactory is unspecified.|
+|org.postgresql.ssl.MSCAPILocalMachineSSLFactory|Use certificates and keys from the Windows local machine certificate manager.|
+|org.postgresql.ssl.MSCAPISSLFactory|Use certificates and keys from the Windows certificate manager belonging to the current user.|
+|org.postgresql.ssl.KeychainSSLFactory|Use certificates and keys from the MacOS keychain. If the MacOS truststore is unsupported by the JDK, we fall back to the default cacerts JKS truststore.|
+|org.postgresql.ssl.SingleCertValidatingFactory|Accept the pinned server certificate specified in the sslfactoryarg parameter.|
+|org.postgresql.ssl.NonValidatingFactory|Connect to anyone without checking. No validation is performed.|
+
 ## Configuring the Client
 
 There are a number of connection parameters for configuring the client for SSL. See [SSL Connection parameters](/documentation/use/#connection-parameters/)
@@ -132,6 +145,10 @@ When starting your Java application you must specify this keystore and password 
  `java -Djavax.net.ssl.trustStore=mystore -Djavax.net.ssl.trustStorePassword=mypassword com.mycompany.MyApp`
 
 In the event of problems extra debugging information is available by adding `-Djavax.net.debug=ssl` to your command line.
+
+### Choosing a Specific Certificate
+
+When using the Keychain or MSCAPI factories, and more than one client certificate matches during SSL negotiation, the first negotiated certificate will be chosen. To control which of many negotiated certificates will be returned, the sslsubject parameter can be used to set the subject of the certificate to be chosen. Note that sslsubject chooses from the list of negotiated certificates, it does not override the negotiation mechanism. If there is no match, no certificate will be sent to the server.
 
 ### Using SSL without Certificate Validation
 

--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -865,12 +865,12 @@ public enum PGProperty {
       "The location of the root certificate for authenticating the server."),
 
   /**
-   * The alias of the desired client certificate in a store containing many certificates.
+   * The subject of the desired client certificate in a store containing many certificates.
    */
   SSL_SUBJECT(
-      "sslAlias",
+      "sslsubject",
       null,
-      "The alias of the desired client certificate in a store with many certificates."),
+      "The subject of the desired client certificate in a store with many certificates."),
 
   /**
    * Specifies the name of the SSPI service class that forms the service class part of the SPN. The

--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -865,6 +865,14 @@ public enum PGProperty {
       "The location of the root certificate for authenticating the server."),
 
   /**
+   * The alias of the desired client certificate in a store containing many certificates.
+   */
+  SSL_SUBJECT(
+      "sslAlias",
+      null,
+      "The alias of the desired client certificate in a store with many certificates."),
+
+  /**
    * Specifies the name of the SSPI service class that forms the service class part of the SPN. The
    * default, {@code POSTGRES}, is almost always correct.
    */

--- a/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
+++ b/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
@@ -818,6 +818,22 @@ public abstract class BaseDataSource implements CommonDataSource, Referenceable 
   }
 
   /**
+   * @return SSL subject
+   * @see PGProperty#SSL_SUBJECT
+   */
+  public @Nullable String getSslSubject() {
+    return PGProperty.SSL_SUBJECT.getOrDefault(properties);
+  }
+
+  /**
+   * @param file SSL subject
+   * @see PGProperty#SSL_SUBJECT
+   */
+  public void setSslSubject(@Nullable String file) {
+    PGProperty.SSL_SUBJECT.set(properties, file);
+  }
+
+  /**
    * @param applicationName application name
    * @see PGProperty#APPLICATION_NAME
    */

--- a/pgjdbc/src/main/java/org/postgresql/ssl/KeychainSSLFactory.java
+++ b/pgjdbc/src/main/java/org/postgresql/ssl/KeychainSSLFactory.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2024, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.ssl;
+
+import org.postgresql.util.PSQLException;
+
+import java.util.Properties;
+
+/**
+ * <p>Provides a SSLSocketFactory that authenticates the remote server against
+ * the keychain provided by MacOS.</p>
+ *
+ * <p>Older versions of the JDK support MacOS key stores but not trust stores.
+ * If the trust store implementation is not found, this factory falls back to
+ * the default JDK trust store in <code>cacerts</code>.
+ *
+ * <p>When multiple certificates match for the given connection, the optional
+ * <code>sslsubject</code> connection property can be used to choose the
+ * desired certificate from the matching set. Note that this property does not
+ * override the certificate selection outside of the matching set.
+ */
+public class KeychainSSLFactory extends SSLFactory {
+
+  public KeychainSSLFactory(Properties info) throws PSQLException {
+    super(info, "TLS", "PKIX", "Apple",
+                "KeychainStore",
+                "Apple", "KeychainStore-ROOT");
+  }
+
+}

--- a/pgjdbc/src/main/java/org/postgresql/ssl/KeychainSSLFactory.java
+++ b/pgjdbc/src/main/java/org/postgresql/ssl/KeychainSSLFactory.java
@@ -10,8 +10,8 @@ import org.postgresql.util.PSQLException;
 import java.util.Properties;
 
 /**
- * <p>Provides a SSLSocketFactory that authenticates the remote server against
- * the keychain provided by MacOS.</p>
+ * Provides an SSLSocketFactory that authenticates the remote server against
+ * the keychain provided by macOS.
  *
  * <p>Older versions of the JDK support MacOS key stores but not trust stores.
  * If the trust store implementation is not found, this factory falls back to
@@ -22,7 +22,7 @@ import java.util.Properties;
  * desired certificate from the matching set. Note that this property does not
  * override the certificate selection outside of the matching set.
  */
-public class KeychainSSLFactory extends SSLFactory {
+public class KeychainSSLFactory extends ProviderKeyStoreSSLFactory {
 
   public KeychainSSLFactory(Properties info) throws PSQLException {
     super(info, "TLS", "PKIX", "Apple",

--- a/pgjdbc/src/main/java/org/postgresql/ssl/MSCAPILocalMachineSSLFactory.java
+++ b/pgjdbc/src/main/java/org/postgresql/ssl/MSCAPILocalMachineSSLFactory.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2024, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.ssl;
+
+import org.postgresql.util.PSQLException;
+
+import java.util.Properties;
+
+/**
+ * <p>Provides a SSLSocketFactory that authenticates the remote server against
+ * the local machine's certificate store provided by Windows.</p>
+ *
+ * <p>The remote certificate is validated against the local machine's
+ * certificate trust store.</p>
+ *
+ * <p>When multiple certificates match for the given connection, the optional
+ * <code>sslsubject</code> connection property can be used to choose the
+ * desired certificate from the matching set. Note that this property does not
+ * override the certificate selection outside of the matching set.
+ */
+public class MSCAPILocalMachineSSLFactory extends SSLFactory {
+
+  public MSCAPILocalMachineSSLFactory(Properties info) throws PSQLException {
+    super(info, "TLS", "PKIX", "SunMSCAPI",
+            "Windows-MY-LOCALMACHINE",
+            "SunMSCAPI", "Windows-ROOT");
+  }
+
+}

--- a/pgjdbc/src/main/java/org/postgresql/ssl/MSCAPILocalMachineSSLFactory.java
+++ b/pgjdbc/src/main/java/org/postgresql/ssl/MSCAPILocalMachineSSLFactory.java
@@ -10,8 +10,8 @@ import org.postgresql.util.PSQLException;
 import java.util.Properties;
 
 /**
- * <p>Provides a SSLSocketFactory that authenticates the remote server against
- * the local machine's certificate store provided by Windows.</p>
+ * Provides an SSLSocketFactory that authenticates the remote server against
+ * the local machine's certificate store provided by Windows.
  *
  * <p>The remote certificate is validated against the local machine's
  * certificate trust store.</p>
@@ -21,7 +21,7 @@ import java.util.Properties;
  * desired certificate from the matching set. Note that this property does not
  * override the certificate selection outside of the matching set.
  */
-public class MSCAPILocalMachineSSLFactory extends SSLFactory {
+public class MSCAPILocalMachineSSLFactory extends ProviderKeyStoreSSLFactory {
 
   public MSCAPILocalMachineSSLFactory(Properties info) throws PSQLException {
     super(info, "TLS", "PKIX", "SunMSCAPI",

--- a/pgjdbc/src/main/java/org/postgresql/ssl/MSCAPISSLFactory.java
+++ b/pgjdbc/src/main/java/org/postgresql/ssl/MSCAPISSLFactory.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2024, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.ssl;
+
+import org.postgresql.util.PSQLException;
+
+import java.util.Properties;
+
+/**
+ * <p>Provides a SSLSocketFactory that authenticates the remote server against
+ * the logged in user's certificate store provided by Windows.</p>
+ *
+ * <p>The remote certificate is validated against the logged in user's
+ * certificate trust store.</p>
+ *
+ * <p>When multiple certificates match for the given connection, the optional
+ * <code>sslsubject</code> connection property can be used to choose the
+ * desired certificate from the matching set. Note that this property does not
+ * override the certificate selection outside of the matching set.
+ */
+public class MSCAPISSLFactory extends SSLFactory {
+
+  public MSCAPISSLFactory(Properties info) throws PSQLException {
+    super(info, "TLS", "PKIX", "SunMSCAPI",
+            "Windows-MY",
+            "SunMSCAPI", "Windows-ROOT");
+  }
+
+}

--- a/pgjdbc/src/main/java/org/postgresql/ssl/MSCAPISSLFactory.java
+++ b/pgjdbc/src/main/java/org/postgresql/ssl/MSCAPISSLFactory.java
@@ -10,8 +10,8 @@ import org.postgresql.util.PSQLException;
 import java.util.Properties;
 
 /**
- * <p>Provides a SSLSocketFactory that authenticates the remote server against
- * the logged in user's certificate store provided by Windows.</p>
+ * Provides an SSLSocketFactory that authenticates the remote server against
+ * the logged-in user's certificate store provided by Windows.
  *
  * <p>The remote certificate is validated against the logged in user's
  * certificate trust store.</p>
@@ -21,7 +21,7 @@ import java.util.Properties;
  * desired certificate from the matching set. Note that this property does not
  * override the certificate selection outside of the matching set.
  */
-public class MSCAPISSLFactory extends SSLFactory {
+public class MSCAPISSLFactory extends ProviderKeyStoreSSLFactory {
 
   public MSCAPISSLFactory(Properties info) throws PSQLException {
     super(info, "TLS", "PKIX", "SunMSCAPI",

--- a/pgjdbc/src/main/java/org/postgresql/ssl/ProviderKeyStoreSSLFactory.java
+++ b/pgjdbc/src/main/java/org/postgresql/ssl/ProviderKeyStoreSSLFactory.java
@@ -34,9 +34,9 @@ import javax.security.auth.x500.X500Principal;
  * stores, like the native Windows "SunMSCAPI" or native Apple "Apple"
  * providers.
  */
-public class SSLFactory extends WrappedFactory {
+public abstract class ProviderKeyStoreSSLFactory extends WrappedFactory {
 
-  protected SSLFactory(Properties info, final String protocol, final String algorithm, final String keyStoreProvider, final String keyStoreType, final String trustStoreProvider, final String trustStoreType) throws PSQLException {
+  protected ProviderKeyStoreSSLFactory(Properties info, final String protocol, final String algorithm, final String keyStoreProvider, final String keyStoreType, final String trustStoreProvider, final String trustStoreType) throws PSQLException {
 
     SSLContext ctx;
     final KeyStore keyStore;

--- a/pgjdbc/src/main/java/org/postgresql/ssl/ProviderKeyStoreSSLFactory.java
+++ b/pgjdbc/src/main/java/org/postgresql/ssl/ProviderKeyStoreSSLFactory.java
@@ -21,6 +21,8 @@ import java.security.NoSuchProviderException;
 import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
 import java.util.Properties;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactory;
@@ -36,7 +38,15 @@ import javax.security.auth.x500.X500Principal;
  */
 public abstract class ProviderKeyStoreSSLFactory extends WrappedFactory {
 
-  protected ProviderKeyStoreSSLFactory(Properties info, final String protocol, final String algorithm, final String keyStoreProvider, final String keyStoreType, final String trustStoreProvider, final String trustStoreType) throws PSQLException {
+  private static final Logger LOGGER = Logger.getLogger(ProviderKeyStoreSSLFactory.class.getName());
+
+  protected ProviderKeyStoreSSLFactory(Properties info, final String protocol, final String algorithm,
+      final String keyStoreProvider, final String keyStoreType,
+      final String trustStoreProvider, final String trustStoreType) throws PSQLException {
+
+    LOGGER.log(Level.FINE,
+        "Initializing SSL context from key store {0} (provider {1}) and trust store {2} (provider {3})",
+        new Object[]{keyStoreType, keyStoreProvider, trustStoreType, trustStoreProvider});
 
     SSLContext ctx;
     final KeyStore keyStore;
@@ -48,150 +58,130 @@ public abstract class ProviderKeyStoreSSLFactory extends WrappedFactory {
     final TrustManagerFactory trustManagerFactory;
 
     try {
-
       keyStore = KeyStore.getInstance(keyStoreType, keyStoreProvider);
-
-    } catch (KeyStoreException ex) {
-      throw new PSQLException(GT.tr("SSL keystore {0} not available.",
-                keyStoreType), PSQLState.CONNECTION_FAILURE, ex);
-    } catch (NoSuchProviderException ex) {
-      throw new PSQLException(GT.tr("SSL keystore {0} not available.",
-                keyStoreType), PSQLState.CONNECTION_FAILURE, ex);
+    } catch (KeyStoreException | NoSuchProviderException ex) {
+      throw new PSQLException(GT.tr("SSL keystore {0} not available.", keyStoreType),
+          PSQLState.CONNECTION_FAILURE, ex);
     }
 
     try {
-
       keyStore.load(null, null);
-
-    } catch (CertificateException ex) {
-      throw new PSQLException(GT.tr("SSL keystore {0} could not be loaded.",
-                keyStoreType), PSQLState.CONNECTION_FAILURE, ex);
-    } catch (IOException ex) {
-      throw new PSQLException(GT.tr("SSL keystore {0} could not be loaded.",
-                keyStoreType), PSQLState.CONNECTION_FAILURE, ex);
+    } catch (CertificateException | IOException ex) {
+      throw new PSQLException(GT.tr("SSL keystore {0} could not be loaded.", keyStoreType),
+          PSQLState.CONNECTION_FAILURE, ex);
     } catch (NoSuchAlgorithmException ex) {
-      throw new PSQLException(GT.tr("Could not find a Java cryptographic algorithm: {0}.",
-                ex.getMessage()), PSQLState.CONNECTION_FAILURE, ex);
+      throw noSuchAlgorithm(ex);
     }
 
     try {
-
-      keyManagerFactory = KeyManagerFactory
-              .getInstance(algorithm);
-
+      keyManagerFactory = KeyManagerFactory.getInstance(algorithm);
     } catch (NoSuchAlgorithmException ex) {
-      throw new PSQLException(GT.tr("Could not find a Java cryptographic algorithm: {0}.",
-                ex.getMessage()), PSQLState.CONNECTION_FAILURE, ex);
+      throw noSuchAlgorithm(ex);
     }
 
     try {
-
       keyManagerFactory.init(keyStore, keyPassphrase);
-
     } catch (NoSuchAlgorithmException ex) {
-      throw new PSQLException(GT.tr("Could not find a Java cryptographic algorithm: {0}.",
-                ex.getMessage()), PSQLState.CONNECTION_FAILURE, ex);
+      throw noSuchAlgorithm(ex);
     } catch (KeyStoreException ex) {
       throw new PSQLException(GT.tr("Could not initialize SSL keystore."),
-                PSQLState.CONNECTION_FAILURE, ex);
+          PSQLState.CONNECTION_FAILURE, ex);
     } catch (UnrecoverableKeyException ex) {
       throw new PSQLException(GT.tr("Could not read SSL key."),
-                PSQLState.CONNECTION_FAILURE, ex);
+          PSQLState.CONNECTION_FAILURE, ex);
     }
 
     try {
-
       trustStore = KeyStore.getInstance(trustStoreType, trustStoreProvider);
-
     } catch (KeyStoreException ex) {
-      // On the Mac, the truststore is new and won't be available
-      // on old versions of the JDK. In these cases fall back to
-      // the default truststore in cacerts.
+      // On older JDKs the native trust store may not be available
+      // (notably the macOS KeychainStore-ROOT). Fall back to the default
+      // cacerts trust store in that case.
       if (ex.getCause() instanceof NoSuchAlgorithmException) {
+        LOGGER.log(Level.WARNING,
+            "SSL trust store {0} (provider {1}) is not available on this JVM; falling back to the "
+            + "default cacerts trust store. Server certificates will be validated against cacerts "
+            + "rather than the operating system trust store.",
+            new Object[]{trustStoreType, trustStoreProvider});
         trustStore = null;
       } else {
-        throw new PSQLException(GT.tr("SSL truststore {0} not available.",
-                    trustStoreType), PSQLState.CONNECTION_FAILURE, ex);
+        throw new PSQLException(GT.tr("SSL truststore {0} not available.", trustStoreType),
+            PSQLState.CONNECTION_FAILURE, ex);
       }
     } catch (NoSuchProviderException ex) {
-      throw new PSQLException(GT.tr("SSL truststore {0} not available.",
-                trustStoreType), PSQLState.CONNECTION_FAILURE, ex);
+      throw new PSQLException(GT.tr("SSL truststore {0} not available.", trustStoreType),
+          PSQLState.CONNECTION_FAILURE, ex);
     }
 
     try {
-
       if (trustStore != null) {
         trustStore.load(null, null);
       }
-
-    } catch (CertificateException ex) {
-      throw new PSQLException(GT.tr("SSL truststore {0} could not be loaded.",
-                trustStoreType), PSQLState.CONNECTION_FAILURE, ex);
-    } catch (IOException ex) {
-      throw new PSQLException(GT.tr("SSL truststore {0} could not be loaded.",
-                trustStoreType), PSQLState.CONNECTION_FAILURE, ex);
+    } catch (CertificateException | IOException ex) {
+      throw new PSQLException(GT.tr("SSL truststore {0} could not be loaded.", trustStoreType),
+          PSQLState.CONNECTION_FAILURE, ex);
     } catch (NoSuchAlgorithmException ex) {
-      throw new PSQLException(GT.tr("Could not find a Java cryptographic algorithm: {0}.",
-                ex.getMessage()), PSQLState.CONNECTION_FAILURE, ex);
+      throw noSuchAlgorithm(ex);
     }
 
     try {
-
-      trustManagerFactory = TrustManagerFactory
-              .getInstance(algorithm);
-
+      trustManagerFactory = TrustManagerFactory.getInstance(algorithm);
     } catch (NoSuchAlgorithmException ex) {
-      throw new PSQLException(GT.tr("Could not find a Java cryptographic algorithm: {0}.",
-                ex.getMessage()), PSQLState.CONNECTION_FAILURE, ex);
+      throw noSuchAlgorithm(ex);
     }
 
     try {
-
       trustManagerFactory.init(trustStore);
-
     } catch (KeyStoreException ex) {
       throw new PSQLException(GT.tr("Could not initialize SSL truststore."),
-                PSQLState.CONNECTION_FAILURE, ex);
+          PSQLState.CONNECTION_FAILURE, ex);
     }
 
     try {
-
       ctx = SSLContext.getInstance(protocol);
-
     } catch (NoSuchAlgorithmException ex) {
-      throw new PSQLException(GT.tr("Could not find a Java cryptographic algorithm: {0}.",
-                ex.getMessage()), PSQLState.CONNECTION_FAILURE, ex);
+      throw noSuchAlgorithm(ex);
     }
 
     try {
-
       if (sslsubject != null && sslsubject.length() != 0) {
         subject = new X500Principal(sslsubject);
       } else {
         subject = null;
       }
-
     } catch (IllegalArgumentException ex) {
       throw new PSQLException(GT.tr("Could not parse sslsubject {0}: {1}.",
-              sslsubject, ex.getMessage()), PSQLState.CONNECTION_FAILURE, ex);
+          sslsubject, ex.getMessage()), PSQLState.CONNECTION_FAILURE, ex);
+    }
+
+    KeyManager[] keyManagers = keyManagerFactory.getKeyManagers();
+    if (keyManagers.length == 0) {
+      throw new PSQLException(GT.tr("SSL keystore {0} produced no key managers.", keyStoreType),
+          PSQLState.CONNECTION_FAILURE);
+    }
+    KeyManager km = keyManagers[0];
+
+    if (subject != null) {
+      if (!(km instanceof X509KeyManager)) {
+        throw new PSQLException(
+            GT.tr("sslsubject is set, but SSL keystore {0} did not provide an X509KeyManager.",
+                keyStoreType), PSQLState.CONNECTION_FAILURE);
+      }
+      km = new SubjectKeyManager((X509KeyManager) km, subject);
     }
 
     try {
-
-      KeyManager km = keyManagerFactory.getKeyManagers()[0];
-
-      if (subject != null) {
-        km = new SubjectKeyManager(X509KeyManager.class.cast(km), subject);
-      }
-
-      ctx.init(new KeyManager[] { km }, null, null);
-
+      ctx.init(new KeyManager[]{ km }, null, null);
     } catch (KeyManagementException ex) {
       throw new PSQLException(GT.tr("Could not initialize SSL keystore/truststore."),
-                PSQLState.CONNECTION_FAILURE, ex);
+          PSQLState.CONNECTION_FAILURE, ex);
     }
 
     factory = ctx.getSocketFactory();
+  }
 
+  private static PSQLException noSuchAlgorithm(NoSuchAlgorithmException ex) {
+    return new PSQLException(GT.tr("Could not find a Java cryptographic algorithm: {0}.",
+        ex.getMessage()), PSQLState.CONNECTION_FAILURE, ex);
   }
 }

--- a/pgjdbc/src/main/java/org/postgresql/ssl/SSLFactory.java
+++ b/pgjdbc/src/main/java/org/postgresql/ssl/SSLFactory.java
@@ -10,6 +10,8 @@ import org.postgresql.util.GT;
 import org.postgresql.util.PSQLException;
 import org.postgresql.util.PSQLState;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 import java.io.IOException;
 import java.security.KeyManagementException;
 import java.security.KeyStore;
@@ -39,9 +41,9 @@ public class SSLFactory extends WrappedFactory {
     SSLContext ctx;
     final KeyStore keyStore;
     KeyStore trustStore;
-    final char[] keyPassphrase = null;
+    final char[] keyPassphrase = new char[0];
     final String sslsubject = PGProperty.SSL_SUBJECT.getOrDefault(info);
-    final X500Principal subject;
+    final @Nullable X500Principal subject;
     final KeyManagerFactory keyManagerFactory;
     final TrustManagerFactory trustManagerFactory;
 

--- a/pgjdbc/src/main/java/org/postgresql/ssl/SSLFactory.java
+++ b/pgjdbc/src/main/java/org/postgresql/ssl/SSLFactory.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) 2024, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.ssl;
+
+import org.postgresql.PGProperty;
+import org.postgresql.util.GT;
+import org.postgresql.util.PSQLException;
+import org.postgresql.util.PSQLState;
+
+import java.io.IOException;
+import java.security.KeyManagementException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.CertificateException;
+import java.util.Properties;
+
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509KeyManager;
+import javax.security.auth.x500.X500Principal;
+
+/**
+ * Socket factory that uses typical "zero configuration" key and trust
+ * stores, like the native Windows "SunMSCAPI" or native Apple "Apple"
+ * providers.
+ */
+public class SSLFactory extends WrappedFactory {
+
+  protected SSLFactory(Properties info, final String protocol, final String algorithm, final String keyStoreProvider, final String keyStoreType, final String trustStoreProvider, final String trustStoreType) throws PSQLException {
+
+    SSLContext ctx;
+    final KeyStore keyStore;
+    KeyStore trustStore;
+    final char[] keyPassphrase = null;
+    final String sslsubject = PGProperty.SSL_SUBJECT.getOrDefault(info);
+    final X500Principal subject;
+    final KeyManagerFactory keyManagerFactory;
+    final TrustManagerFactory trustManagerFactory;
+
+    try {
+
+      keyStore = KeyStore.getInstance(keyStoreType, keyStoreProvider);
+
+    } catch (KeyStoreException ex) {
+      throw new PSQLException(GT.tr("SSL keystore {0} not available.",
+                keyStoreType), PSQLState.CONNECTION_FAILURE, ex);
+    } catch (NoSuchProviderException ex) {
+      throw new PSQLException(GT.tr("SSL keystore {0} not available.",
+                keyStoreType), PSQLState.CONNECTION_FAILURE, ex);
+    }
+
+    try {
+
+      keyStore.load(null, null);
+
+    } catch (CertificateException ex) {
+      throw new PSQLException(GT.tr("SSL keystore {0} could not be loaded.",
+                keyStoreType), PSQLState.CONNECTION_FAILURE, ex);
+    } catch (IOException ex) {
+      throw new PSQLException(GT.tr("SSL keystore {0} could not be loaded.",
+                keyStoreType), PSQLState.CONNECTION_FAILURE, ex);
+    } catch (NoSuchAlgorithmException ex) {
+      throw new PSQLException(GT.tr("Could not find a java cryptographic algorithm: {0}.",
+                ex.getMessage()), PSQLState.CONNECTION_FAILURE, ex);
+    }
+
+    try {
+
+      keyManagerFactory = KeyManagerFactory
+              .getInstance(algorithm);
+
+    } catch (NoSuchAlgorithmException ex) {
+      throw new PSQLException(GT.tr("Could not find a java cryptographic algorithm: {0}.",
+                ex.getMessage()), PSQLState.CONNECTION_FAILURE, ex);
+    }
+
+    try {
+
+      keyManagerFactory.init(keyStore, keyPassphrase);
+
+    } catch (NoSuchAlgorithmException ex) {
+      throw new PSQLException(GT.tr("Could not find a java cryptographic algorithm: {0}.",
+                ex.getMessage()), PSQLState.CONNECTION_FAILURE, ex);
+    } catch (KeyStoreException ex) {
+      throw new PSQLException(GT.tr("Could not initialize SSL keystore."),
+                PSQLState.CONNECTION_FAILURE, ex);
+    } catch (UnrecoverableKeyException ex) {
+      throw new PSQLException(GT.tr("Could not read SSL key."),
+                PSQLState.CONNECTION_FAILURE, ex);
+    }
+
+    try {
+
+      trustStore = KeyStore.getInstance(trustStoreType, trustStoreProvider);
+
+    } catch (KeyStoreException ex) {
+      // On the Mac, the truststore is new and won't be available
+      // on old versions of the JDK. In these cases fall back to
+      // the default truststore in cacerts.
+      if (ex.getCause() instanceof NoSuchAlgorithmException) {
+        trustStore = null;
+      } else {
+        throw new PSQLException(GT.tr("SSL truststore {0} not available.",
+                    trustStoreType), PSQLState.CONNECTION_FAILURE, ex);
+      }
+    } catch (NoSuchProviderException ex) {
+      throw new PSQLException(GT.tr("SSL truststore {0} not available.",
+                trustStoreType), PSQLState.CONNECTION_FAILURE, ex);
+    }
+
+    try {
+
+      if (trustStore != null) {
+        trustStore.load(null, null);
+      }
+
+    } catch (CertificateException ex) {
+      throw new PSQLException(GT.tr("SSL truststore {0} could not be loaded.",
+                trustStoreType), PSQLState.CONNECTION_FAILURE, ex);
+    } catch (IOException ex) {
+      throw new PSQLException(GT.tr("SSL truststore {0} could not be loaded.",
+                trustStoreType), PSQLState.CONNECTION_FAILURE, ex);
+    } catch (NoSuchAlgorithmException ex) {
+      throw new PSQLException(GT.tr("Could not find a java cryptographic algorithm: {0}.",
+                ex.getMessage()), PSQLState.CONNECTION_FAILURE, ex);
+    }
+
+    try {
+
+      trustManagerFactory = TrustManagerFactory
+              .getInstance(algorithm);
+
+    } catch (NoSuchAlgorithmException ex) {
+      throw new PSQLException(GT.tr("Could not find a java cryptographic algorithm: {0}.",
+                ex.getMessage()), PSQLState.CONNECTION_FAILURE, ex);
+    }
+
+    try {
+
+      trustManagerFactory.init(trustStore);
+
+    } catch (KeyStoreException ex) {
+      throw new PSQLException(GT.tr("Could not initialize SSL truststore."),
+                PSQLState.CONNECTION_FAILURE, ex);
+    }
+
+    try {
+
+      ctx = SSLContext.getInstance(protocol);
+
+    } catch (NoSuchAlgorithmException ex) {
+      throw new PSQLException(GT.tr("Could not find a java cryptographic algorithm: {0}.",
+                ex.getMessage()), PSQLState.CONNECTION_FAILURE, ex);
+    }
+
+    try {
+
+      if (sslsubject != null && sslsubject.length() != 0) {
+        subject = new X500Principal(sslsubject);
+      } else {
+        subject = null;
+      }
+
+    } catch (IllegalArgumentException ex) {
+      throw new PSQLException(GT.tr("Could not parse sslsubject {0}: {1}.",
+              sslsubject, ex.getMessage()), PSQLState.CONNECTION_FAILURE, ex);
+    }
+
+    try {
+
+      KeyManager km = keyManagerFactory.getKeyManagers()[0];
+
+      if (subject != null) {
+        km = new SubjectKeyManager(X509KeyManager.class.cast(km), subject);
+      }
+
+      ctx.init(new KeyManager[] { km }, null, null);
+
+    } catch (KeyManagementException ex) {
+      throw new PSQLException(GT.tr("Could not initialize SSL keystore/truststore."),
+                PSQLState.CONNECTION_FAILURE, ex);
+    }
+
+    factory = ctx.getSocketFactory();
+
+  }
+}

--- a/pgjdbc/src/main/java/org/postgresql/ssl/SSLFactory.java
+++ b/pgjdbc/src/main/java/org/postgresql/ssl/SSLFactory.java
@@ -68,7 +68,7 @@ public class SSLFactory extends WrappedFactory {
       throw new PSQLException(GT.tr("SSL keystore {0} could not be loaded.",
                 keyStoreType), PSQLState.CONNECTION_FAILURE, ex);
     } catch (NoSuchAlgorithmException ex) {
-      throw new PSQLException(GT.tr("Could not find a java cryptographic algorithm: {0}.",
+      throw new PSQLException(GT.tr("Could not find a Java cryptographic algorithm: {0}.",
                 ex.getMessage()), PSQLState.CONNECTION_FAILURE, ex);
     }
 
@@ -78,7 +78,7 @@ public class SSLFactory extends WrappedFactory {
               .getInstance(algorithm);
 
     } catch (NoSuchAlgorithmException ex) {
-      throw new PSQLException(GT.tr("Could not find a java cryptographic algorithm: {0}.",
+      throw new PSQLException(GT.tr("Could not find a Java cryptographic algorithm: {0}.",
                 ex.getMessage()), PSQLState.CONNECTION_FAILURE, ex);
     }
 
@@ -87,7 +87,7 @@ public class SSLFactory extends WrappedFactory {
       keyManagerFactory.init(keyStore, keyPassphrase);
 
     } catch (NoSuchAlgorithmException ex) {
-      throw new PSQLException(GT.tr("Could not find a java cryptographic algorithm: {0}.",
+      throw new PSQLException(GT.tr("Could not find a Java cryptographic algorithm: {0}.",
                 ex.getMessage()), PSQLState.CONNECTION_FAILURE, ex);
     } catch (KeyStoreException ex) {
       throw new PSQLException(GT.tr("Could not initialize SSL keystore."),
@@ -129,7 +129,7 @@ public class SSLFactory extends WrappedFactory {
       throw new PSQLException(GT.tr("SSL truststore {0} could not be loaded.",
                 trustStoreType), PSQLState.CONNECTION_FAILURE, ex);
     } catch (NoSuchAlgorithmException ex) {
-      throw new PSQLException(GT.tr("Could not find a java cryptographic algorithm: {0}.",
+      throw new PSQLException(GT.tr("Could not find a Java cryptographic algorithm: {0}.",
                 ex.getMessage()), PSQLState.CONNECTION_FAILURE, ex);
     }
 
@@ -139,7 +139,7 @@ public class SSLFactory extends WrappedFactory {
               .getInstance(algorithm);
 
     } catch (NoSuchAlgorithmException ex) {
-      throw new PSQLException(GT.tr("Could not find a java cryptographic algorithm: {0}.",
+      throw new PSQLException(GT.tr("Could not find a Java cryptographic algorithm: {0}.",
                 ex.getMessage()), PSQLState.CONNECTION_FAILURE, ex);
     }
 
@@ -157,7 +157,7 @@ public class SSLFactory extends WrappedFactory {
       ctx = SSLContext.getInstance(protocol);
 
     } catch (NoSuchAlgorithmException ex) {
-      throw new PSQLException(GT.tr("Could not find a java cryptographic algorithm: {0}.",
+      throw new PSQLException(GT.tr("Could not find a Java cryptographic algorithm: {0}.",
                 ex.getMessage()), PSQLState.CONNECTION_FAILURE, ex);
     }
 

--- a/pgjdbc/src/main/java/org/postgresql/ssl/SubjectKeyManager.java
+++ b/pgjdbc/src/main/java/org/postgresql/ssl/SubjectKeyManager.java
@@ -22,7 +22,7 @@ import javax.security.auth.x500.X500Principal;
 public class SubjectKeyManager implements X509KeyManager {
 
   private final X509KeyManager km;
-  private final X500Principal subject;
+  private final @Nullable X500Principal subject;
 
   /**
    * <p>
@@ -81,27 +81,27 @@ public class SubjectKeyManager implements X509KeyManager {
   }
 
   @Override
-  public String[] getClientAliases(String keyType, Principal[] issuers) {
+  public String @Nullable [] getClientAliases(String keyType, Principal @Nullable [] issuers) {
     return this.km.getClientAliases(keyType, issuers);
   }
 
   @Override
-  public String[] getServerAliases(String keyType, Principal[] issuers) {
+  public String @Nullable [] getServerAliases(String keyType, Principal@Nullable [] issuers) {
     return this.km.getServerAliases(keyType, issuers);
   }
 
   @Override
-  public String chooseServerAlias(String keyType, Principal[] issuers, Socket socket) {
+  public @Nullable  String chooseServerAlias(String keyType, Principal @Nullable [] issuers, @Nullable Socket socket) {
     return this.km.chooseServerAlias(keyType, issuers, socket);
   }
 
   @Override
-  public X509Certificate[] getCertificateChain(String alias) {
+  public X509Certificate @Nullable[] getCertificateChain(String alias) {
     return this.km.getCertificateChain(alias);
   }
 
   @Override
-  public PrivateKey getPrivateKey(String alias) {
+  public @Nullable PrivateKey getPrivateKey(String alias) {
     return this.km.getPrivateKey(alias);
   }
 

--- a/pgjdbc/src/main/java/org/postgresql/ssl/SubjectKeyManager.java
+++ b/pgjdbc/src/main/java/org/postgresql/ssl/SubjectKeyManager.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2024, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.ssl;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.net.Socket;
+import java.security.Principal;
+import java.security.PrivateKey;
+import java.security.cert.X509Certificate;
+
+import javax.net.ssl.X509KeyManager;
+import javax.security.auth.x500.X500Principal;
+
+/**
+ * The SubjectKeyManager limits candidate certificates to
+ * the certificate subject specified in "sslsubject".
+ */
+public class SubjectKeyManager implements X509KeyManager {
+
+  private final X509KeyManager km;
+  private final X500Principal subject;
+
+  /**
+   * <p>
+   * Wrap the provided key manager with this one, limiting
+   * certificates to those matching the given subject.
+   * </p>
+   *
+   * <p>
+   * If subject is null, this key manager gives way to the
+   * wrapped key manager and does nothing.
+   * </p>
+   * @param km Wrapped key manager
+   * @param subject Subject distinguished name of the chosen
+   *     certificate
+   */
+  public SubjectKeyManager(X509KeyManager km, @Nullable X500Principal subject) {
+
+    this.km = km;
+    this.subject = subject;
+
+  }
+
+  @Override
+  public @Nullable String chooseClientAlias(String[] keyTypes, Principal @Nullable [] issuers,
+      @Nullable Socket socket) {
+
+    if (subject == null) {
+      return this.km.chooseClientAlias(keyTypes, issuers, socket);
+    }
+
+    for (String keyType: keyTypes) {
+      String[] aliases = getClientAliases(keyType, issuers);
+
+      if (aliases == null) {
+        continue;
+      }
+
+      for (String alias: aliases) {
+
+        X509Certificate[] certchain = getCertificateChain(alias);
+        if (certchain == null || certchain.length == 0) {
+          continue;
+        }
+
+        X509Certificate leaf = certchain[0];
+        X500Principal oursubject = leaf.getSubjectX500Principal();
+        if (!oursubject.equals(subject)) {
+          continue;
+        }
+
+        return alias;
+      }
+    }
+
+    return null;
+  }
+
+  @Override
+  public String[] getClientAliases(String keyType, Principal[] issuers) {
+    return this.km.getClientAliases(keyType, issuers);
+  }
+
+  @Override
+  public String[] getServerAliases(String keyType, Principal[] issuers) {
+    return this.km.getServerAliases(keyType, issuers);
+  }
+
+  @Override
+  public String chooseServerAlias(String keyType, Principal[] issuers, Socket socket) {
+    return this.km.chooseServerAlias(keyType, issuers, socket);
+  }
+
+  @Override
+  public X509Certificate[] getCertificateChain(String alias) {
+    return this.km.getCertificateChain(alias);
+  }
+
+  @Override
+  public PrivateKey getPrivateKey(String alias) {
+    return this.km.getPrivateKey(alias);
+  }
+
+}

--- a/pgjdbc/src/main/java/org/postgresql/ssl/SubjectKeyManager.java
+++ b/pgjdbc/src/main/java/org/postgresql/ssl/SubjectKeyManager.java
@@ -11,6 +11,8 @@ import java.net.Socket;
 import java.security.Principal;
 import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import javax.net.ssl.X509KeyManager;
 import javax.security.auth.x500.X500Principal;
@@ -20,6 +22,8 @@ import javax.security.auth.x500.X500Principal;
  * the certificate subject specified in "sslsubject".
  */
 public class SubjectKeyManager implements X509KeyManager {
+
+  private static final Logger LOGGER = Logger.getLogger(SubjectKeyManager.class.getName());
 
   private final X509KeyManager km;
   private final @Nullable X500Principal subject;
@@ -70,10 +74,14 @@ public class SubjectKeyManager implements X509KeyManager {
           continue;
         }
 
+        LOGGER.log(Level.FINE, "Selected client certificate alias {0} matching sslsubject {1}",
+            new Object[]{alias, subject});
         return alias;
       }
     }
 
+    LOGGER.log(Level.FINE, "No client certificate matched sslsubject {0}; "
+        + "no certificate will be sent to the server", subject);
     return null;
   }
 

--- a/pgjdbc/src/main/java/org/postgresql/ssl/SubjectKeyManager.java
+++ b/pgjdbc/src/main/java/org/postgresql/ssl/SubjectKeyManager.java
@@ -25,15 +25,12 @@ public class SubjectKeyManager implements X509KeyManager {
   private final @Nullable X500Principal subject;
 
   /**
-   * <p>
    * Wrap the provided key manager with this one, limiting
    * certificates to those matching the given subject.
-   * </p>
    *
-   * <p>
-   * If subject is null, this key manager gives way to the
-   * wrapped key manager and does nothing.
-   * </p>
+   * <p>If subject is null, this key manager gives way to the
+   * wrapped key manager and does nothing.</p>
+   *
    * @param km Wrapped key manager
    * @param subject Subject distinguished name of the chosen
    *     certificate

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PGPropertyTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PGPropertyTest.java
@@ -248,6 +248,7 @@ class PGPropertyTest {
     excluded.add("SSL_ROOT_CERT"); // ssl[r]oot[c]ert
     excluded.add("SSL_PASSWORD"); // ssl[p]assword
     excluded.add("SSL_PASSWORD_CALLBACK"); // ssl[p]assword[c]allback
+    excluded.add("SSL_SUBJECT"); // ssl[s]ubject
     excluded.add("APPLICATION_NAME"); // [A]pplicationName
     excluded.add("GSS_LIB"); // gss[l]ib
     excluded.add("REWRITE_BATCHED_INSERTS"); // re[W]riteBatchedInserts

--- a/pgjdbc/src/test/java/org/postgresql/test/ssl/KeychainCertTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/ssl/KeychainCertTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2024, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.test.ssl;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import org.postgresql.PGProperty;
+import org.postgresql.core.SocketFactoryFactory;
+import org.postgresql.ssl.SubjectKeyManager;
+
+import org.junit.jupiter.api.Test;
+
+import java.security.KeyStore;
+import java.util.Locale;
+import java.util.Properties;
+
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.X509KeyManager;
+import javax.security.auth.x500.X500Principal;
+
+/**
+ * Verifies KeychainSSLFactory against a client certificate that has been
+ * imported into the macOS keychain. The certificate is not present by default,
+ * so the test only runs when the PGJDBC_KEYCHAIN_IMPORTED environment variable
+ * is set; the CI job imports {@code certdir/goodclient.p12} before running it.
+ *
+ * <p>To run locally on macOS without touching the login keychain, use the
+ * helper script, which creates a throwaway keychain and restores the search
+ * list afterwards:</p>
+ *
+ * <pre>
+ *   ./certdir/macos-keychain.sh setup
+ *   PGJDBC_KEYCHAIN_IMPORTED=true ./gradlew :postgresql:test --tests '*KeychainCertTest'
+ *   ./certdir/macos-keychain.sh teardown
+ * </pre>
+ */
+class KeychainCertTest {
+
+  private static final String OS = System.getProperty("os.name", "").toLowerCase(Locale.ROOT);
+
+  // Subject of the leaf certificate inside certdir/goodclient.p12.
+  private static final X500Principal CERT_SUBJECT =
+      new X500Principal("CN=test, O=PgJdbc tests, ST=CA, C=US");
+
+  private static void assumeKeychainImported() {
+    assumeTrue(OS.contains("mac"), "KeychainStore is only available on macOS");
+    assumeTrue("true".equalsIgnoreCase(System.getenv("PGJDBC_KEYCHAIN_IMPORTED")),
+        "set PGJDBC_KEYCHAIN_IMPORTED=true after importing goodclient.p12 into a keychain");
+  }
+
+  @Test
+  void keychainExposesImportedCertificate() throws Exception {
+    assumeKeychainImported();
+
+    KeyStore keyStore = KeyStore.getInstance("KeychainStore", "Apple");
+    keyStore.load(null, null);
+
+    KeyManagerFactory kmf = KeyManagerFactory.getInstance("PKIX");
+    kmf.init(keyStore, new char[0]);
+    X509KeyManager km = (X509KeyManager) kmf.getKeyManagers()[0];
+
+    // The imported certificate must be selected when its subject is requested,
+    // and no certificate must be returned for a subject that does not match.
+    String matched = new SubjectKeyManager(km, CERT_SUBJECT)
+        .chooseClientAlias(new String[]{"RSA"}, null, null);
+    assertNotNull(matched, "Imported keychain certificate should match its own subject");
+
+    X500Principal otherSubject = new X500Principal("CN=absent, O=PgJdbc tests, ST=CA, C=US");
+    String unmatched = new SubjectKeyManager(km, otherSubject)
+        .chooseClientAlias(new String[]{"RSA"}, null, null);
+    assertNull(unmatched, "No certificate should match a subject that is not in the keychain");
+  }
+
+  @Test
+  void keychainFactoryBuildsWithSslSubject() throws Exception {
+    assumeKeychainImported();
+
+    Properties props = new Properties();
+    PGProperty.SSL_FACTORY.set(props, "org.postgresql.ssl.KeychainSSLFactory");
+    PGProperty.SSL_SUBJECT.set(props, CERT_SUBJECT.getName());
+
+    assertNotNull(SocketFactoryFactory.getSslSocketFactory(props));
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/test/ssl/SSLFactoryTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/ssl/SSLFactoryTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2024, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.test.ssl;
+
+import org.postgresql.PGProperty;
+import org.postgresql.core.SocketFactoryFactory;
+import org.postgresql.test.TestUtil;
+import org.postgresql.util.PSQLException;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.InvocationTargetException;
+import java.security.NoSuchProviderException;
+import java.util.Properties;
+
+class SSLFactoryTest {
+
+  @Test
+  void TestDefault() throws Exception {
+    TestUtil.assumeSslTestsEnabled();
+
+    Properties props = new Properties();
+    PGProperty.SSL_FACTORY.set(props, "org.postgresql.ssl.DefaultJavaSSLFactory");
+
+    try {
+      SocketFactoryFactory.getSslSocketFactory(props);
+    } catch (Throwable t) {
+      /* ignore NoSuchProviderException */
+      if (!(t instanceof PSQLException)
+              || (!(t.getCause() instanceof InvocationTargetException))
+              || (!(t.getCause().getCause() instanceof PSQLException))
+              || (!(t.getCause().getCause().getCause() instanceof NoSuchProviderException))
+      ) {
+        throw t;
+      }
+    }
+
+  }
+
+  @Test
+  void TestKeychain() throws Exception {
+    TestUtil.assumeSslTestsEnabled();
+
+    Properties props = new Properties();
+    PGProperty.SSL_FACTORY.set(props, "org.postgresql.ssl.KeychainSSLFactory");
+
+    try {
+      SocketFactoryFactory.getSslSocketFactory(props);
+    } catch (Throwable t) {
+      /* ignore NoSuchProviderException */
+      if (!(t instanceof PSQLException)
+              || (!(t.getCause() instanceof InvocationTargetException))
+              || (!(t.getCause().getCause() instanceof PSQLException))
+              || (!(t.getCause().getCause().getCause() instanceof NoSuchProviderException))
+      ) {
+        throw t;
+      }
+    }
+
+  }
+
+  @Test
+  void TestMSCurrentUserSSLFactory() throws Exception {
+    TestUtil.assumeSslTestsEnabled();
+
+    Properties props = new Properties();
+    PGProperty.SSL_FACTORY.set(props, "org.postgresql.ssl.MSCAPISSLFactory");
+
+    try {
+      SocketFactoryFactory.getSslSocketFactory(props);
+    } catch (Throwable t) {
+      /* ignore NoSuchProviderException */
+      if (!(t instanceof PSQLException)
+              || (!(t.getCause() instanceof InvocationTargetException))
+              || (!(t.getCause().getCause() instanceof PSQLException))
+              || (!(t.getCause().getCause().getCause() instanceof NoSuchProviderException))
+      ) {
+        throw t;
+      }
+    }
+
+  }
+
+  @Test
+  void TestMSLocalMachineSSLFactory() throws Exception {
+    TestUtil.assumeSslTestsEnabled();
+
+    Properties props = new Properties();
+    PGProperty.SSL_FACTORY.set(props, "org.postgresql.ssl.MSCAPILocalMachineSSLFactory");
+
+    try {
+      SocketFactoryFactory.getSslSocketFactory(props);
+    } catch (Throwable t) {
+      /* ignore NoSuchProviderException */
+      if (!(t instanceof PSQLException)
+              || (!(t.getCause() instanceof InvocationTargetException))
+              || (!(t.getCause().getCause() instanceof PSQLException))
+              || (!(t.getCause().getCause().getCause() instanceof NoSuchProviderException))
+      ) {
+        throw t;
+      }
+    }
+
+  }
+
+}

--- a/pgjdbc/src/test/java/org/postgresql/test/ssl/SSLFactoryTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/ssl/SSLFactoryTest.java
@@ -5,105 +5,58 @@
 
 package org.postgresql.test.ssl;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
 import org.postgresql.PGProperty;
 import org.postgresql.core.SocketFactoryFactory;
-import org.postgresql.test.TestUtil;
-import org.postgresql.util.PSQLException;
 
 import org.junit.jupiter.api.Test;
 
-import java.lang.reflect.InvocationTargetException;
-import java.security.NoSuchProviderException;
+import java.util.Locale;
 import java.util.Properties;
 
+import javax.net.ssl.SSLSocketFactory;
+
+/**
+ * Verifies that the bundled SSLSocketFactory implementations can build an
+ * SSLContext from the platform key and trust stores. The native factories only
+ * work on the operating system that provides the underlying security provider,
+ * so each test runs only on the matching platform and is skipped elsewhere.
+ *
+ * <p>These tests exercise factory construction only; they do not open a
+ * connection, so they do not require a running server or SSL test setup.</p>
+ */
 class SSLFactoryTest {
 
-  @Test
-  void TestDefault() throws Exception {
-    TestUtil.assumeSslTestsEnabled();
+  private static final String OS = System.getProperty("os.name", "").toLowerCase(Locale.ROOT);
 
+  private static SSLSocketFactory build(String factoryClass) throws Exception {
     Properties props = new Properties();
-    PGProperty.SSL_FACTORY.set(props, "org.postgresql.ssl.DefaultJavaSSLFactory");
-
-    try {
-      SocketFactoryFactory.getSslSocketFactory(props);
-    } catch (Throwable t) {
-      /* ignore NoSuchProviderException */
-      if (!(t instanceof PSQLException)
-              || (!(t.getCause() instanceof InvocationTargetException))
-              || (!(t.getCause().getCause() instanceof PSQLException))
-              || (!(t.getCause().getCause().getCause() instanceof NoSuchProviderException))
-      ) {
-        throw t;
-      }
-    }
-
+    PGProperty.SSL_FACTORY.set(props, factoryClass);
+    return SocketFactoryFactory.getSslSocketFactory(props);
   }
 
   @Test
-  void TestKeychain() throws Exception {
-    TestUtil.assumeSslTestsEnabled();
-
-    Properties props = new Properties();
-    PGProperty.SSL_FACTORY.set(props, "org.postgresql.ssl.KeychainSSLFactory");
-
-    try {
-      SocketFactoryFactory.getSslSocketFactory(props);
-    } catch (Throwable t) {
-      /* ignore NoSuchProviderException */
-      if (!(t instanceof PSQLException)
-              || (!(t.getCause() instanceof InvocationTargetException))
-              || (!(t.getCause().getCause() instanceof PSQLException))
-              || (!(t.getCause().getCause().getCause() instanceof NoSuchProviderException))
-      ) {
-        throw t;
-      }
-    }
-
+  void defaultJavaFactory() throws Exception {
+    assertNotNull(build("org.postgresql.ssl.DefaultJavaSSLFactory"));
   }
 
   @Test
-  void TestMSCurrentUserSSLFactory() throws Exception {
-    TestUtil.assumeSslTestsEnabled();
-
-    Properties props = new Properties();
-    PGProperty.SSL_FACTORY.set(props, "org.postgresql.ssl.MSCAPISSLFactory");
-
-    try {
-      SocketFactoryFactory.getSslSocketFactory(props);
-    } catch (Throwable t) {
-      /* ignore NoSuchProviderException */
-      if (!(t instanceof PSQLException)
-              || (!(t.getCause() instanceof InvocationTargetException))
-              || (!(t.getCause().getCause() instanceof PSQLException))
-              || (!(t.getCause().getCause().getCause() instanceof NoSuchProviderException))
-      ) {
-        throw t;
-      }
-    }
-
+  void keychainFactoryOnMac() throws Exception {
+    assumeTrue(OS.contains("mac"), "KeychainSSLFactory requires the macOS Apple provider");
+    assertNotNull(build("org.postgresql.ssl.KeychainSSLFactory"));
   }
 
   @Test
-  void TestMSLocalMachineSSLFactory() throws Exception {
-    TestUtil.assumeSslTestsEnabled();
-
-    Properties props = new Properties();
-    PGProperty.SSL_FACTORY.set(props, "org.postgresql.ssl.MSCAPILocalMachineSSLFactory");
-
-    try {
-      SocketFactoryFactory.getSslSocketFactory(props);
-    } catch (Throwable t) {
-      /* ignore NoSuchProviderException */
-      if (!(t instanceof PSQLException)
-              || (!(t.getCause() instanceof InvocationTargetException))
-              || (!(t.getCause().getCause() instanceof PSQLException))
-              || (!(t.getCause().getCause().getCause() instanceof NoSuchProviderException))
-      ) {
-        throw t;
-      }
-    }
-
+  void mscapiCurrentUserFactoryOnWindows() throws Exception {
+    assumeTrue(OS.contains("windows"), "MSCAPISSLFactory requires the Windows SunMSCAPI provider");
+    assertNotNull(build("org.postgresql.ssl.MSCAPISSLFactory"));
   }
 
+  @Test
+  void mscapiLocalMachineFactoryOnWindows() throws Exception {
+    assumeTrue(OS.contains("windows"), "MSCAPILocalMachineSSLFactory requires the Windows SunMSCAPI provider");
+    assertNotNull(build("org.postgresql.ssl.MSCAPILocalMachineSSLFactory"));
+  }
 }

--- a/pgjdbc/src/test/java/org/postgresql/test/ssl/SubjectKeyManagerTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/ssl/SubjectKeyManagerTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2024, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.test.ssl;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.postgresql.ssl.PKCS12KeyManager;
+import org.postgresql.ssl.SubjectKeyManager;
+import org.postgresql.test.TestUtil;
+import org.postgresql.test.ssl.PKCS12KeyTest.TestCallbackHandler;
+
+import org.junit.jupiter.api.Test;
+
+import javax.security.auth.x500.X500Principal;
+
+class SubjectKeyManagerTest {
+
+  @Test
+  void TestChooseClientAlias() throws Exception {
+    PKCS12KeyManager pkcs12KeyManager = new PKCS12KeyManager(TestUtil.getSslTestCertPath("goodclient.p12"), new TestCallbackHandler("sslpwd"));
+    X500Principal testPrincipal = new X500Principal("CN=root certificate, O=PgJdbc test, ST=CA, C=US");
+    X500Principal[] issuers = new X500Principal[]{testPrincipal};
+
+    String validKeyType = pkcs12KeyManager.chooseClientAlias(new String[]{"RSA"}, issuers, null);
+    assertNotNull(validKeyType);
+
+    X500Principal testSubject = new X500Principal("CN=test, O=PgJdbc tests, ST=CA, C=US");
+    SubjectKeyManager subjectKeyManager = new SubjectKeyManager(pkcs12KeyManager, testSubject);
+
+    String filteredKeyType = subjectKeyManager.chooseClientAlias(new String[]{"rsa"}, issuers, null);
+    assertNotNull(filteredKeyType);
+
+    X500Principal badSubject = new X500Principal("CN=bad, O=PgJdbc tests, ST=CA, C=US");
+    SubjectKeyManager badSubjectKeyManager = new SubjectKeyManager(pkcs12KeyManager, badSubject);
+
+    String badKeyType = badSubjectKeyManager.chooseClientAlias(new String[]{"rsa"}, issuers, null);
+    assertNull(badKeyType);
+  }
+}


### PR DESCRIPTION
Add three new SSLSocketFactory implementations to support native keystores on Windows and Mac.

org.postgresql.ssl.MSCAPILocalMachineSSLFactory
org.postgresql.ssl.MSCAPISSLFactory
org.postgresql.ssl.KeychainSSLFactory

Add the sslsubject parameter to limit the chosen certificate where more than one certificate might match for a given connection.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Does `./gradlew styleCheck` pass ?
3. [x] Have you added your new test classes to an existing test suite in alphabetical order?

### Changes to Existing Features:

* [ ] Does this break existing behaviour? If so please explain.
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
