### PR TITLE
fix: support PreparedStatement.setBlob(1, Blob) and PreparedStatement.setClob(1, Clob) for lobs that return -1 for length

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
@@ -1258,7 +1258,14 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
 
     InputStream inStream = x.getBinaryStream();
     try {
-      long oid = createBlob(i, inStream, x.length());
+      long maxLength = x.length();
+      if (maxLength < 0) {
+        // Hibernate used to create blob instances that report -1 length, so we ignore the length
+        // and assume we need to read all the data from the stream.
+        // See https://github.com/pgjdbc/pgjdbc/issues/3134
+        maxLength = Long.MAX_VALUE;
+      }
+      long oid = createBlob(i, inStream, maxLength);
       setLong(i, oid);
     } finally {
       try {
@@ -1321,6 +1328,10 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
 
     Reader inStream = x.getCharacterStream();
     int length = (int) x.length();
+    if (length < 0) {
+      // See #setBlob(int, Blob)
+      length = Integer.MAX_VALUE;
+    }
     LargeObjectManager lom = connection.getLargeObjectAPI();
     long oid = lom.createLO();
     LargeObject lob = lom.open(oid);


### PR DESCRIPTION
Historically, Hibernate was creating such clobs and it relied on the fact that pgjdbc did not use the length in case it was -1.

Now the negative length is treated as if it was infinite (no eplicit limit) The length of 0 means "empty lob".

Fixes https://github.com/pgjdbc/pgjdbc/issues/3134
