### PR TITLE
BlobInputStream improvements

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/largeobject/BlobInputStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/largeobject/BlobInputStream.java
@@ -356,6 +356,8 @@ public class BlobInputStream extends InputStream {
    *     In particular, this will throw if attempting to skip beyond the maximum length
    *     of a large object, which by default is 4,398,046,509,056 bytes.
    * @see java.io.InputStream#skip(long)
+   * @see <a href="https://www.postgresql.org/docs/14/lo-implementation.html">
+   *   Large Objects: Implementation Features</a>
    */
   @Override
   public long skip(long n) throws IOException {

--- a/pgjdbc/src/main/java/org/postgresql/largeobject/BlobInputStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/largeobject/BlobInputStream.java
@@ -320,13 +320,13 @@ public class BlobInputStream extends InputStream {
     try (ResourceLock ignore = lock.obtain()) {
       LargeObject lo = getLo();
       long loId = lo.getLongOID();
+      buffer = null;
       try {
         if (markPosition <= Integer.MAX_VALUE) {
           lo.seek((int) markPosition);
         } else {
           lo.seek64(markPosition, LargeObject.SEEK_SET);
         }
-        buffer = null;
         absolutePosition = markPosition;
       } catch (SQLException e) {
         throw new IOException(
@@ -385,6 +385,7 @@ public class BlobInputStream extends InputStream {
       if (buffer != null && buffer.length - bufferPosition > skipped) {
         bufferPosition += (int) skipped;
       } else {
+        buffer = null;
         try {
           if (targetPosition <= Integer.MAX_VALUE) {
             lo.seek((int) targetPosition, LargeObject.SEEK_SET);
@@ -397,7 +398,6 @@ public class BlobInputStream extends InputStream {
                   loId, n, currentPosition),
               e);
         }
-        buffer = null;
       }
       absolutePosition = targetPosition;
       return skipped;

--- a/pgjdbc/src/main/java/org/postgresql/largeobject/BlobInputStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/largeobject/BlobInputStream.java
@@ -5,6 +5,8 @@
 
 package org.postgresql.largeobject;
 
+import static org.postgresql.util.internal.Nullness.castNonNull;
+
 import org.postgresql.jdbc.ResourceLock;
 import org.postgresql.util.GT;
 
@@ -400,10 +402,10 @@ public class BlobInputStream extends InputStream {
   }
 
   private LargeObject getLo() throws IOException {
-    if (lo == null) {
+    if (this.lo == null) {
       throw new IOException("BlobOutputStream is closed");
     }
-
+    LargeObject lo = castNonNull(this.lo);
     assert lock.isLocked();
 
     if (absolutePosition < 0) {

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BlobTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BlobTest.java
@@ -416,7 +416,6 @@ class BlobTest {
     InputStream bis = blob.getInputStream();
     assertEquals(0, bis.read());
     assertThrows(IOException.class, () -> bis.skip(Long.MAX_VALUE / 2));
-    assertEquals(0, bis.read());
     assertThrows(IOException.class, () -> {
       while (bis.read() != -1) {
         // consume stream
@@ -438,7 +437,7 @@ class BlobTest {
       InputStream bis = blob.getInputStream();
       assertEquals(0, bis.read());
       assertThrows(IOException.class, () -> bis.skip(Integer.MAX_VALUE));
-      assertEquals(0, bis.read());
+      assertEquals(64, bis.read());
       while (bis.read() != -1) {
         // consume stream
       }


### PR DESCRIPTION
* fix: inconsistent behaviour of BlobInputStream.reset()

  A BlobInputStream will start reading from the current position of the LargeObject used to create it, but the current/marked position does not account for this.
Initialising current position correctly will fix this.

  Closes #3149
* feat: implement efficient skipping in BlobInputStream

  Using seek is more efficient than reading and discarding the bytes. The only behavioural change is it now allows skipping  past the natural end of the stream, but the method contract already allows for this. It should not break anything.

  Closes #3144

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Does `./gradlew styleCheck` pass ?
3. [x] Have you added your new test classes to an existing test suite ~in alphabetical order~?

### Changes to Existing Features:

* [x] Does this break existing behaviour? If so please explain.
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
