### PR TITLE
issue #3153: return XAER_NOTA on rollback

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/xa/PGXAConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/xa/PGXAConnection.java
@@ -650,6 +650,7 @@ public class PGXAConnection extends PGPooledConnection implements XAConnection, 
 
   private int mapSQLStateToXAErrorCode(SQLException sqlException) {
     if (isPostgreSQLIntegrityConstraintViolation(sqlException)) {
+      committedOrRolledBack = true;
       return XAException.XA_RBINTEGRITY;
     }
 

--- a/pgjdbc/src/test/java/org/postgresql/test/xa/XADataSourceTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/xa/XADataSourceTest.java
@@ -775,7 +775,8 @@ public class XADataSourceTest {
 
   /**
    * When using deferred constraints a constraint violation can occur on prepare. This has to be
-   * mapped to the correct XA Error Code
+   * mapped to the correct XA Error Code. As a consequence, the transaction is rolled back.
+   * A subsequent rollback invocation should return XAER_NOTA.
    */
   @Test
   void mappingOfConstraintViolations() throws Exception {
@@ -791,6 +792,14 @@ public class XADataSourceTest {
       fail("Prepare is expected to fail as an integrity violation occurred");
     } catch (XAException xae) {
       assertEquals(XAException.XA_RBINTEGRITY, xae.errorCode, "Prepare call with deferred constraints violations expects XA_RBINTEGRITY");
+
+      try {
+        xaRes.rollback(xid);
+
+        fail("Rollback is expected to fail as the transaction should have been already rolled back during prepare");
+      } catch (XAException xaex) {
+        assertEquals(XAException.XAER_NOTA, xaex.errorCode, "Rollback call on the already rolled back xid " + xid + " expects XAER_NOTA");
+      }
     }
   }
 


### PR DESCRIPTION
### Changes to Existing Features:

* Does this break existing behaviour? If so please explain.
  * It does not break existing behaviour
* Have you added an explanation of what your changes do and why you'd like us to include them?
  * Yep, I wrote an explanation in the related issue (#3153)
* Have you written new tests for your core changes, as applicable?
  * I modified a test of  `XADataSourceTest`
* Have you successfully run tests with your changes locally?
  * Yes, I have tested my changes using `./gradlew test`
