### PR TITLE
validates resultset parameters

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
@@ -1397,27 +1397,48 @@ public class PgConnection implements BaseConnection {
     return Integer.parseInt(dirtyString.substring(start, end));
   }
 
+  // Validation check for integer values that need to be positive
+  // mainly added to check resultSetType, resultSetConcurrency and resultSetHoldability
+  private static boolean isPositive(int value) {
+    if (value < 0) {
+      return false;
+    }
+    return true;
+  }
+
   @Override
   public Statement createStatement(int resultSetType, int resultSetConcurrency,
       int resultSetHoldability) throws SQLException {
     checkClosed();
-    return new PgStatement(this, resultSetType, resultSetConcurrency, resultSetHoldability);
+    if (isPositive(resultSetType) && isPositive(resultSetConcurrency) && isPositive(resultSetHoldability)) {
+      return new PgStatement(this, resultSetType, resultSetConcurrency, resultSetHoldability);
+    } else {
+      throw new IllegalArgumentException("Value must be positive");
+    }
   }
 
   @Override
   public PreparedStatement prepareStatement(String sql, int resultSetType, int resultSetConcurrency,
       int resultSetHoldability) throws SQLException {
     checkClosed();
-    return new PgPreparedStatement(this, sql, resultSetType, resultSetConcurrency,
-        resultSetHoldability);
+    if (isPositive(resultSetType) && isPositive(resultSetConcurrency) && isPositive(resultSetHoldability)) {
+      return new PgPreparedStatement(this, sql, resultSetType, resultSetConcurrency,
+          resultSetHoldability);
+    } else {
+      throw new IllegalArgumentException("Value must be positive");
+    }
   }
 
   @Override
   public CallableStatement prepareCall(String sql, int resultSetType, int resultSetConcurrency,
       int resultSetHoldability) throws SQLException {
     checkClosed();
-    return new PgCallableStatement(this, sql, resultSetType, resultSetConcurrency,
-        resultSetHoldability);
+    if (isPositive(resultSetType) && isPositive(resultSetConcurrency) && isPositive(resultSetHoldability)) {
+      return new PgCallableStatement(this, sql, resultSetType, resultSetConcurrency,
+          resultSetHoldability);
+    } else {
+      throw new IllegalArgumentException("Value must be positive");
+    }
   }
 
   @Override

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ResultSetTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ResultSetTest.java
@@ -944,6 +944,96 @@ public class ResultSetTest extends BaseTest4 {
   }
 
   @Test
+  public void testCreateStatementWithInvalidResultSetParams() throws SQLException {
+    try {
+      con.createStatement(-1, -1,-1);
+      fail("Should have thrown an IllegalArgumentException");
+    } catch (IllegalArgumentException e) {
+      // Ok
+    }
+  }
+
+  @Test
+  public void testCreateStatementWithInvalidResultSetConcurrency() throws SQLException {
+    try {
+      con.createStatement( ResultSet.TYPE_SCROLL_INSENSITIVE, -1) ;
+      fail("Should have thrown an IllegalArgumentException");
+    } catch (IllegalArgumentException e) {
+      // Ok
+    }
+  }
+
+  @Test
+  public void testCreateStatementWithInvalidResultSetHoldability() throws SQLException {
+    try {
+      con.createStatement( ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet.CONCUR_UPDATABLE, -1) ;
+      fail("Should have thrown an IllegalArgumentException");
+    } catch (IllegalArgumentException e) {
+      // Ok
+    }
+  }
+
+  @Test
+  public void testPrepareStatementWithInvalidResultSetParams() throws SQLException {
+    try {
+      con.prepareStatement("SELECT id FROM testrs", -1,-1 ,-1);
+      fail("Should have thrown an IllegalArgumentException");
+    } catch (IllegalArgumentException e) {
+      // Ok
+    }
+  }
+
+  @Test
+  public void testPrepareStatementWithInvalidResultSetConcurrency() throws SQLException {
+    try {
+      con.prepareStatement("SELECT id FROM testrs", ResultSet.TYPE_SCROLL_INSENSITIVE,-1 );
+      fail("Should have thrown an IllegalArgumentException");
+    } catch (IllegalArgumentException e) {
+      // Ok
+    }
+  }
+
+  @Test
+  public void testPrepareStatementWithInvalidResultSetHoldability() throws SQLException {
+    try {
+      con.prepareStatement("SELECT id FROM testrs", ResultSet.TYPE_SCROLL_INSENSITIVE,ResultSet.CONCUR_UPDATABLE ,-1);
+      fail("Should have thrown an IllegalArgumentException");
+    } catch (IllegalArgumentException e) {
+      // Ok
+    }
+  }
+
+  @Test
+  public void testPrepareCallWithInvalidResultSetParams() throws SQLException {
+    try {
+      con.prepareCall("SELECT id FROM testrs", -1,-1 ,-1);
+      fail("Should have thrown an IllegalArgumentException");
+    } catch (IllegalArgumentException e) {
+      // Ok
+    }
+  }
+
+  @Test
+  public void testPrepareCallWithInvalidResultSetConcurrency() throws SQLException {
+    try {
+      con.prepareCall("SELECT id FROM testrs", ResultSet.TYPE_SCROLL_INSENSITIVE,-1 );
+      fail("Should have thrown an IllegalArgumentException");
+    } catch (IllegalArgumentException e) {
+      // Ok
+    }
+  }
+
+  @Test
+  public void testPrepareCallWithInvalidResultSetHoldability() throws SQLException {
+    try {
+      con.prepareCall("SELECT id FROM testrs", ResultSet.TYPE_SCROLL_INSENSITIVE,ResultSet.CONCUR_UPDATABLE ,-1);
+      fail("Should have thrown an IllegalArgumentException");
+    } catch (IllegalArgumentException e) {
+      // Ok
+    }
+  }
+
+  @Test
   public void testZeroRowResultPositioning() throws SQLException {
     Statement stmt =
         con.createStatement(ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet.CONCUR_UPDATABLE);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Does `./gradlew styleCheck` pass ?
3. [x] Have you added your new test classes to an existing test suite in alphabetical order?

This PR aims to fix issue #3061 
currently resultSet paramters can accept negative values. I have added a validation that ensures the resultset parameters are always > 0

The parameters being validated are
- resultSetType
- resultSetConcurrency
- resultSetHoldability

The methods where this validation is applied are:
- prepareCall
- prepareStatement
- createStatement

Within pgjdbc/src/test/java/org/postgresql/jdbc & pgjdbc/src/test/java/org/postgresql/core I couldn't find a test file for PGConnection.

I wanted to know if I should add additional tests pertaining to this issue?