### PR TITLE
validates resultsetParams in PGStatement constructor. uses assertThro…

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
@@ -1397,48 +1397,25 @@ public class PgConnection implements BaseConnection {
     return Integer.parseInt(dirtyString.substring(start, end));
   }
 
-  // Validation check for integer values that need to be positive
-  // mainly added to check resultSetType, resultSetConcurrency and resultSetHoldability
-  private static boolean isPositive(int value) {
-    if (value < 0) {
-      return false;
-    }
-    return true;
-  }
-
   @Override
   public Statement createStatement(int resultSetType, int resultSetConcurrency,
       int resultSetHoldability) throws SQLException {
     checkClosed();
-    if (isPositive(resultSetType) && isPositive(resultSetConcurrency) && isPositive(resultSetHoldability)) {
-      return new PgStatement(this, resultSetType, resultSetConcurrency, resultSetHoldability);
-    } else {
-      throw new IllegalArgumentException("Value must be positive");
-    }
+    return new PgStatement(this, resultSetType, resultSetConcurrency, resultSetHoldability);
   }
 
   @Override
   public PreparedStatement prepareStatement(String sql, int resultSetType, int resultSetConcurrency,
       int resultSetHoldability) throws SQLException {
     checkClosed();
-    if (isPositive(resultSetType) && isPositive(resultSetConcurrency) && isPositive(resultSetHoldability)) {
-      return new PgPreparedStatement(this, sql, resultSetType, resultSetConcurrency,
-          resultSetHoldability);
-    } else {
-      throw new IllegalArgumentException("Value must be positive");
-    }
+    return new PgPreparedStatement(this, sql, resultSetType, resultSetConcurrency, resultSetHoldability);
   }
 
   @Override
   public CallableStatement prepareCall(String sql, int resultSetType, int resultSetConcurrency,
       int resultSetHoldability) throws SQLException {
     checkClosed();
-    if (isPositive(resultSetType) && isPositive(resultSetConcurrency) && isPositive(resultSetHoldability)) {
-      return new PgCallableStatement(this, sql, resultSetType, resultSetConcurrency,
-          resultSetHoldability);
-    } else {
-      throw new IllegalArgumentException("Value must be positive");
-    }
+    return new PgCallableStatement(this, sql, resultSetType, resultSetConcurrency, resultSetHoldability);
   }
 
   @Override

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgStatement.java
@@ -161,11 +161,26 @@ public class PgStatement implements Statement, BaseStatement {
       throws SQLException {
     this.connection = c;
     forceBinaryTransfers |= c.getForceBinary();
+    // validation check for allowed values of resultset type
+    if (rsType != ResultSet.TYPE_FORWARD_ONLY && rsType != ResultSet.TYPE_SCROLL_INSENSITIVE && rsType != ResultSet.TYPE_SCROLL_SENSITIVE) {
+      throw new PSQLException(GT.tr("Unknown value for ResultSet type"),
+          PSQLState.INVALID_PARAMETER_VALUE);
+    }
     resultsettype = rsType;
+    // validation check for allowed values of resultset concurrency
+    if (rsConcurrency != ResultSet.CONCUR_READ_ONLY && rsConcurrency != ResultSet.CONCUR_UPDATABLE) {
+      throw new PSQLException(GT.tr("Unknown value for ResultSet concurrency"),
+          PSQLState.INVALID_PARAMETER_VALUE);
+    }
     concurrency = rsConcurrency;
     setFetchSize(c.getDefaultFetchSize());
     setPrepareThreshold(c.getPrepareThreshold());
     setAdaptiveFetch(c.getAdaptiveFetch());
+    // validation check for allowed values of resultset holdability
+    if (rsHoldability != ResultSet.HOLD_CURSORS_OVER_COMMIT && rsHoldability != ResultSet.CLOSE_CURSORS_AT_COMMIT) {
+      throw new PSQLException(GT.tr("Unknown value for ResultSet holdability"),
+          PSQLState.INVALID_PARAMETER_VALUE);
+    }
     this.rsHoldability = rsHoldability;
   }
 

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ResultSetTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ResultSetTest.java
@@ -8,6 +8,7 @@ package org.postgresql.test.jdbc2;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
@@ -16,6 +17,7 @@ import org.postgresql.core.ServerVersion;
 import org.postgresql.jdbc.PreferQueryMode;
 import org.postgresql.test.TestUtil;
 import org.postgresql.util.PGobject;
+import org.postgresql.util.PSQLException;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -945,92 +947,47 @@ public class ResultSetTest extends BaseTest4 {
 
   @Test
   public void testCreateStatementWithInvalidResultSetParams() throws SQLException {
-    try {
-      con.createStatement(-1, -1,-1);
-      fail("Should have thrown an IllegalArgumentException");
-    } catch (IllegalArgumentException e) {
-      // Ok
-    }
+    assertThrows(PSQLException.class, () -> con.createStatement(-1, -1,-1));
   }
 
   @Test
   public void testCreateStatementWithInvalidResultSetConcurrency() throws SQLException {
-    try {
-      con.createStatement( ResultSet.TYPE_SCROLL_INSENSITIVE, -1) ;
-      fail("Should have thrown an IllegalArgumentException");
-    } catch (IllegalArgumentException e) {
-      // Ok
-    }
+    assertThrows(PSQLException.class, () -> con.createStatement( ResultSet.TYPE_SCROLL_INSENSITIVE, -1) );
   }
 
   @Test
   public void testCreateStatementWithInvalidResultSetHoldability() throws SQLException {
-    try {
-      con.createStatement( ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet.CONCUR_UPDATABLE, -1) ;
-      fail("Should have thrown an IllegalArgumentException");
-    } catch (IllegalArgumentException e) {
-      // Ok
-    }
+    assertThrows(PSQLException.class, () -> con.createStatement( ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet.CONCUR_UPDATABLE, -1) );
   }
 
   @Test
   public void testPrepareStatementWithInvalidResultSetParams() throws SQLException {
-    try {
-      con.prepareStatement("SELECT id FROM testrs", -1,-1 ,-1);
-      fail("Should have thrown an IllegalArgumentException");
-    } catch (IllegalArgumentException e) {
-      // Ok
-    }
+    assertThrows(PSQLException.class, () -> con.prepareStatement("SELECT id FROM testrs", -1, -1,-1));
   }
 
   @Test
   public void testPrepareStatementWithInvalidResultSetConcurrency() throws SQLException {
-    try {
-      con.prepareStatement("SELECT id FROM testrs", ResultSet.TYPE_SCROLL_INSENSITIVE,-1 );
-      fail("Should have thrown an IllegalArgumentException");
-    } catch (IllegalArgumentException e) {
-      // Ok
-    }
+    assertThrows(PSQLException.class, () -> con.prepareStatement("SELECT id FROM testrs", ResultSet.TYPE_SCROLL_INSENSITIVE, -1) );
   }
 
   @Test
   public void testPrepareStatementWithInvalidResultSetHoldability() throws SQLException {
-    try {
-      con.prepareStatement("SELECT id FROM testrs", ResultSet.TYPE_SCROLL_INSENSITIVE,ResultSet.CONCUR_UPDATABLE ,-1);
-      fail("Should have thrown an IllegalArgumentException");
-    } catch (IllegalArgumentException e) {
-      // Ok
-    }
+    assertThrows(PSQLException.class, () -> con.prepareStatement("SELECT id FROM testrs", ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet.CONCUR_UPDATABLE, -1) );
   }
 
   @Test
   public void testPrepareCallWithInvalidResultSetParams() throws SQLException {
-    try {
-      con.prepareCall("SELECT id FROM testrs", -1,-1 ,-1);
-      fail("Should have thrown an IllegalArgumentException");
-    } catch (IllegalArgumentException e) {
-      // Ok
-    }
+    assertThrows(PSQLException.class, () -> con.prepareCall("SELECT id FROM testrs", -1, -1,-1));
   }
 
   @Test
   public void testPrepareCallWithInvalidResultSetConcurrency() throws SQLException {
-    try {
-      con.prepareCall("SELECT id FROM testrs", ResultSet.TYPE_SCROLL_INSENSITIVE,-1 );
-      fail("Should have thrown an IllegalArgumentException");
-    } catch (IllegalArgumentException e) {
-      // Ok
-    }
+    assertThrows(PSQLException.class, () -> con.prepareCall("SELECT id FROM testrs", ResultSet.TYPE_SCROLL_INSENSITIVE, -1) );
   }
 
   @Test
   public void testPrepareCallWithInvalidResultSetHoldability() throws SQLException {
-    try {
-      con.prepareCall("SELECT id FROM testrs", ResultSet.TYPE_SCROLL_INSENSITIVE,ResultSet.CONCUR_UPDATABLE ,-1);
-      fail("Should have thrown an IllegalArgumentException");
-    } catch (IllegalArgumentException e) {
-      // Ok
-    }
+    assertThrows(PSQLException.class, () -> con.prepareCall("SELECT id FROM testrs", ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet.CONCUR_UPDATABLE, -1) );
   }
 
   @Test


### PR DESCRIPTION
@vlsi @davecramer @sehrope 

This PR adheres to review comments provided in #3167 

- Validation of resultset params is done at the PgStatement constructor as PgPreparedStatement and PgCallableStatement inherit from there and the validation holds true at the base level
- localized messages are provided. Instead of SQL Exception, using PSQLException with invalid param errorcode
- tests now use assertThrows instead of fail

```./gradlew test```, ```./gradlew build```, and  ```./gradlew styleCheck``` are all passing