### PR TITLE
adds equals implementation for PgArray

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgArray.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgArray.java
@@ -26,8 +26,10 @@ import java.sql.Array;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * <p>Array is used collect one column of query result data.</p>
@@ -504,5 +506,40 @@ public class PgArray implements Array {
     fieldString = null;
     fieldBytes = null;
     arrayList = null;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null || getClass() != obj.getClass()) {
+      return false;
+    }
+
+    PgArray other = (PgArray) obj;
+    if (oid != other.oid) {
+      return false;
+    }
+    if (fieldString == null) {
+      if (other.fieldString != null) {
+        return false;
+      }
+    } else if (!fieldString.equals(other.fieldString)) {
+      return false;
+    }
+    if (fieldBytes == null) {
+      if (other.fieldBytes != null) {
+        return false;
+      }
+    } else if (!java.util.Arrays.equals(fieldBytes, other.fieldBytes)) {
+      return false;
+    }
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(oid, fieldString, Arrays.hashCode(fieldBytes));
   }
 }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ArrayTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ArrayTest.java
@@ -6,6 +6,7 @@
 package org.postgresql.test.jdbc2;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.fail;
 
 import org.postgresql.PGConnection;
@@ -902,6 +903,54 @@ public class ArrayTest extends BaseTest4 {
             ars.getMetaData().getColumnType(1));
       }
     }
+  }
+
+  @Test
+  public void testEqualsWithSameOidSameFieldBytes() throws SQLException {
+    Array arr1 = new PgArray((BaseConnection) conn, Oid.BYTEA_ARRAY, new byte[]{1, 2, 3});
+    Array arr2 = new PgArray((BaseConnection) conn, Oid.BYTEA_ARRAY, new byte[]{1, 2, 3});
+
+    assertEquals(arr1, arr2);
+  }
+
+  @Test
+  public void testEqualsWithDifferentOidSameFieldBytes() throws SQLException {
+    Array arr1 = new PgArray((BaseConnection) conn, Oid.BYTEA_ARRAY, new byte[]{1, 2, 3});
+    Array arr2 = new PgArray((BaseConnection) conn, Oid.BOOL_ARRAY, new byte[]{1, 2, 3});
+
+    assertNotEquals(arr1, arr2);
+  }
+
+  @Test
+  public void testEqualsWithSameOidDifferentFieldBytes() throws SQLException {
+    Array arr1 = new PgArray((BaseConnection) conn, Oid.BYTEA_ARRAY, new byte[]{1, 2, 3});
+    Array arr2 = new PgArray((BaseConnection) conn, Oid.BYTEA_ARRAY, new byte[]{4, 5, 6});
+
+    assertNotEquals(arr1, arr2);
+  }
+
+  @Test
+  public void testEqualsWithSameOidSameFieldString() throws SQLException {
+    Array arr1 = new PgArray((BaseConnection) conn, Oid.VARCHAR_ARRAY, "{\" lead\t\",  unquot\u000B \u2001 \r, \" \fnew \n \"\t, \f\" \" }");
+    Array arr2 = new PgArray((BaseConnection) conn, Oid.VARCHAR_ARRAY, "{\" lead\t\",  unquot\u000B \u2001 \r, \" \fnew \n \"\t, \f\" \" }");
+
+    assertEquals(arr1, arr2);
+  }
+
+  @Test
+  public void testEqualsWithDifferentOidSameFieldString() throws SQLException {
+    Array arr1 = new PgArray((BaseConnection) conn, Oid.VARCHAR_ARRAY, "{\" lead\t\",  unquot\u000B \u2001 \r, \" \fnew \n \"\t, \f\" \" }");
+    Array arr2 = new PgArray((BaseConnection) conn, Oid.VARCHAR, "{\" lead\t\",  unquot\u000B \u2001 \r, \" \fnew \n \"\t, \f\" \" }");
+
+    assertNotEquals(arr1, arr2);
+  }
+
+  @Test
+  public void testEqualsWithSameOidDifferentFieldString() throws SQLException {
+    Array arr1 = new PgArray((BaseConnection) conn, Oid.VARCHAR_ARRAY, "{\" lead1\t\",  unquot\u000B \u2001 \r, \" \fnew1 \n \"\t, \f\" \" }");
+    Array arr2 = new PgArray((BaseConnection) conn, Oid.VARCHAR_ARRAY, "{\" lead2\t\",  unquot\u000B \u2001 \r, \" \fnew2 \n \"\t, \f\" \" }");
+
+    assertNotEquals(arr1, arr2);
   }
 
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?


### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Does `./gradlew styleCheck` pass ?
3. [x] Have you added your new test classes to an existing test suite in alphabetical order?

This PR aims to add implementation of ```equals()``` for PgArray #3170 

For the hashcode() implementation, I've used https://www.baeldung.com/java-objects-hash-vs-objects-hashcode as reference

I have also added a few tests.

@davecramer @vlsi @sehrope suggestions are welcome.
