### PR TITLE
updated SimpleParameterList to fix the byte-array - Addresses a bug that caused syntax errors when executing SELECT statements with parameterized byte arrays

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/v3/SimpleParameterList.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/SimpleParameterList.java
@@ -26,6 +26,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.util.Arrays;
@@ -75,8 +76,17 @@ class SimpleParameterList implements V3ParameterList {
     --index;
 
     encoded[index] = null;
-    paramValues[index] = value;
     flags[index] = (byte) (direction(index) | IN | binary);
+    
+    if (value instanceof byte[]) {
+      byte[] byteArray = (byte[]) value;
+      String hexString = new BigInteger(1, byteArray).toString(16);
+      paramValues[index] = hexString; // Store hex string representation
+    } else {
+      paramValues[index] = value; // Store original value for other data types
+    }
+
+
 
     // If we are setting something to an UNSPECIFIED NULL, don't overwrite
     // our existing type for it. We don't need the correct type info to

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/SimpleParameterList.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/SimpleParameterList.java
@@ -26,7 +26,6 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.util.Arrays;
@@ -77,16 +76,13 @@ class SimpleParameterList implements V3ParameterList {
 
     encoded[index] = null;
     flags[index] = (byte) (direction(index) | IN | binary);
-    
+
     if (value instanceof byte[]) {
       byte[] byteArray = (byte[]) value;
-      String hexString = new BigInteger(1, byteArray).toString(16);
-      paramValues[index] = hexString; // Store hex string representation
+      paramValues[index] = byteArray;
     } else {
       paramValues[index] = value; // Store original value for other data types
     }
-
-
 
     // If we are setting something to an UNSPECIFIED NULL, don't overwrite
     // our existing type for it. We don't need the correct type info to


### PR DESCRIPTION
### All Submissions:
This Pr Addresses a bug that caused syntax errors when executing SELECT statements with parameterized byte arrays, specifically in cases like SELECT FROM bytea_test WHERE b = ? in pgjdbc#3169. https://github.com/pgjdbc/pgjdbc/issues/3169
* [ Y] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [ Y] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ Y] Does your submission pass tests?
2. [ Y] Does `./gradlew styleCheck` pass ? 
3. [ Y] Have you added your new test classes to an existing test suite in alphabetical order?

### Changes to Existing Features:

* [ N] Does this break existing behaviour? If so please explain.
* [ Y] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ N] Have you written new tests for your core changes, as applicable?
* [ Y] Have you successfully run tests with your changes locally?
