### PR TITLE
Add module-info support

### DIFF
--- a/build-logic/verification/src/main/kotlin/build-logic.autostyle.gradle.kts
+++ b/build-logic/verification/src/main/kotlin/build-logic.autostyle.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 autostyle {
     kotlinGradle {
-        ktlint()
+        ktlint("0.37.2")
         trimTrailingWhitespace()
         endWithNewline()
     }

--- a/pgjdbc-module-test/build.gradle.kts
+++ b/pgjdbc-module-test/build.gradle.kts
@@ -1,0 +1,22 @@
+import com.github.vlsi.gradle.dsl.configureEach
+
+plugins {
+    id("build-logic.java-library")
+    `jvm-test-suite`
+}
+
+tasks.configureEach<JavaCompile> {
+    options.release = 11
+}
+
+testing {
+    suites {
+        val test by getting(JvmTestSuite::class) {
+            useJUnitJupiter("5.10.2")
+            dependencies {
+                implementation(platform("org.junit:junit-bom:5.10.2"))
+                implementation(project(":postgresql"))
+            }
+        }
+    }
+}

--- a/pgjdbc-module-test/src/test/java/module-info.java
+++ b/pgjdbc-module-test/src/test/java/module-info.java
@@ -1,0 +1,5 @@
+open module org.postgresql.test.module {
+  requires org.junit.jupiter.api;
+  requires org.postgresql.jdbc;
+  requires java.sql;
+}

--- a/pgjdbc-module-test/src/test/java/org/postgresql/test/module/PlainModuleTest.java
+++ b/pgjdbc-module-test/src/test/java/org/postgresql/test/module/PlainModuleTest.java
@@ -1,11 +1,11 @@
 package org.postgresql.test.module;
 
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.postgresql.Driver;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.api.Test;
 
 public class PlainModuleTest {
   @Test

--- a/pgjdbc-module-test/src/test/java/org/postgresql/test/module/PlainModuleTest.java
+++ b/pgjdbc-module-test/src/test/java/org/postgresql/test/module/PlainModuleTest.java
@@ -1,0 +1,35 @@
+package org.postgresql.test.module;
+
+import org.junit.jupiter.api.Test;
+
+import org.postgresql.Driver;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class PlainModuleTest {
+  @Test
+  public void moduleShouldNotBeAutomatic() {
+    var module = Driver.class.getModule().getDescriptor();
+    assertFalse(module.isAutomatic());
+  }
+
+  @Test
+  public void driverVersionShouldBePositive() throws Exception {
+    Class<?> driverClass = Class.forName("org.postgresql.Driver");
+    java.sql.Driver driver = (java.sql.Driver) driverClass.getConstructor().newInstance();
+
+    // We use regular assert instead of hamcrest since
+    // org.hamcrest.Matchers not found by org.ops4j.pax.tipi.hamcrest.core
+
+    assertPositive("driver.getMajorVersion()", driver.getMajorVersion());
+    assertPositive("driver.getMinorVersion()", driver.getMinorVersion());
+  }
+
+  private void assertPositive(String message, int value) {
+    if (value > 0) {
+      return;
+    }
+    fail(message + " should be positive, actual value is " + value);
+  }
+}

--- a/pgjdbc-osgi-test/build.gradle.kts
+++ b/pgjdbc-osgi-test/build.gradle.kts
@@ -74,12 +74,14 @@ tasks.test {
     dependsOn(pgjdbcRepository)
     systemProperty("logback.configurationFile", file("src/test/resources/logback-test.xml"))
     // Regular systemProperty can't be used here as we need lazy evaluation of pgjdbcRepository
-    jvmArgumentProviders.add(CommandLineArgumentProvider {
-        listOf(
-            "-Dpgjdbc.org.ops4j.pax.url.mvn.repositories=" +
+    jvmArgumentProviders.add(
+        CommandLineArgumentProvider {
+            listOf(
+                "-Dpgjdbc.org.ops4j.pax.url.mvn.repositories=" +
                     "file:${pgjdbcRepository.singleFile.absolutePath}@snapshots@id=pgjdbc-current" +
                     ",${project.findProperty("osgi.test.mavencentral.url")}@id=central",
-            "-Dpgjdbc.org.ops4j.pax.url.mvn.localRepository=file:${paxLocalCacheRepository.get().asFile.absolutePath}@id=pax-repo"
-        )
-    })
+                "-Dpgjdbc.org.ops4j.pax.url.mvn.localRepository=file:${paxLocalCacheRepository.get().asFile.absolutePath}@id=pax-repo"
+            )
+        }
+    )
 }

--- a/pgjdbc/build.gradle.kts
+++ b/pgjdbc/build.gradle.kts
@@ -113,11 +113,13 @@ tasks.named<JavaCompile>("compileJava11Java") {
     val compileJavaDestinationDirectory = tasks.compileJava.flatMap { it.destinationDirectory }
     // sets execution order and cache relationship
     inputs.dir(compileJavaDestinationDirectory)
-    options.compilerArgumentProviders.add(CommandLineArgumentProvider {
-        listOf(
-            "--patch-module", "org.postgresql.jdbc=${compileJavaDestinationDirectory.get().asFile.absolutePath}",
-        )
-    })
+    options.compilerArgumentProviders.add(
+        CommandLineArgumentProvider {
+            listOf(
+                "--patch-module", "org.postgresql.jdbc=${compileJavaDestinationDirectory.get().asFile.absolutePath}",
+            )
+        }
+    )
 }
 
 tasks.jar {
@@ -259,7 +261,7 @@ tasks.shadowJar {
     // shadow excludes module-info.class files by default, see https://github.com/johnrengelman/shadow/issues/710#issuecomment-1553178619
     excludes.remove("module-info.class")
     listOf(
-            "com.ongres"
+        "com.ongres"
     ).forEach {
         relocate(it, "${project.group}.shaded.$it")
     }
@@ -291,21 +293,24 @@ val osgiJar by tasks.registering(Bundle::class) {
 karaf {
     features.apply {
         xsdVersion = "1.5.0"
-        feature(closureOf<com.github.lburgazzoli.gradle.plugin.karaf.features.model.FeatureDescriptor> {
-            name = "postgresql"
-            description = "PostgreSQL JDBC driver karaf feature"
-            version = project.version.toString()
-            details = "Java JDBC 4.2 (JRE 8+) driver for PostgreSQL database"
-            feature("transaction-api")
-            includeProject = true
-            bundle(
-                project.group.toString(),
-                closureOf<com.github.lburgazzoli.gradle.plugin.karaf.features.model.BundleDescriptor> {
-                    wrap = false
-                })
-            // List argument clears the "default" configurations
-            configurations(listOf(karafFeatures))
-        })
+        feature(
+            closureOf<com.github.lburgazzoli.gradle.plugin.karaf.features.model.FeatureDescriptor> {
+                name = "postgresql"
+                description = "PostgreSQL JDBC driver karaf feature"
+                version = project.version.toString()
+                details = "Java JDBC 4.2 (JRE 8+) driver for PostgreSQL database"
+                feature("transaction-api")
+                includeProject = true
+                bundle(
+                    project.group.toString(),
+                    closureOf<com.github.lburgazzoli.gradle.plugin.karaf.features.model.BundleDescriptor> {
+                        wrap = false
+                    }
+                )
+                // List argument clears the "default" configurations
+                configurations(listOf(karafFeatures))
+            }
+        )
     }
 }
 
@@ -319,12 +324,13 @@ val sourceWithoutCheckerAnnotations by configurations.creating {
 
 val hiddenAnnotation = Regex(
     "@(?:Nullable|NonNull|PolyNull|MonotonicNonNull|RequiresNonNull|EnsuresNonNull|" +
-            "Regex|" +
-            "Pure|" +
-            "KeyFor|" +
-            "Positive|NonNegative|IntRange|" +
-            "GuardedBy|UnderInitialization|" +
-            "DefaultQualifier)(?:\\([^)]*\\))?")
+        "Regex|" +
+        "Pure|" +
+        "KeyFor|" +
+        "Positive|NonNegative|IntRange|" +
+        "GuardedBy|UnderInitialization|" +
+        "DefaultQualifier)(?:\\([^)]*\\))?"
+)
 val hiddenImports = Regex("import org.checkerframework")
 
 val removeTypeAnnotations by tasks.registering(Sync::class) {
@@ -385,11 +391,13 @@ val sourceDistribution by tasks.registering(Tar::class) {
     }
     dependsOn(tasks.generateKar)
     into("src/main/resources") {
-        from(tasks.jar.map {
-            zipTree(it.archiveFile).matching {
-                include("META-INF/MANIFEST.MF")
+        from(
+            tasks.jar.map {
+                zipTree(it.archiveFile).matching {
+                    include("META-INF/MANIFEST.MF")
+                }
             }
-        })
+        )
         into("META-INF") {
             dependencyLicenses(shadedLicenseFiles)
         }

--- a/pgjdbc/build.gradle.kts
+++ b/pgjdbc/build.gradle.kts
@@ -71,15 +71,15 @@ val String.v: String get() = rootProject.extra["$this.version"] as String
 
 dependencies {
     constraints {
-        api("com.github.waffle:waffle-jna:1.9.1")
-        api("org.osgi:org.osgi.core:6.0.0")
-        api("org.osgi:org.osgi.service.jdbc:1.0.0")
+        api("com.github.waffle:waffle-jna:3.3.0")
+        api("org.osgi:osgi.core:8.0.0")
+        api("org.osgi:org.osgi.service.jdbc:1.1.0")
     }
 
     "sspiImplementation"("com.github.waffle:waffle-jna")
     // The dependencies are provided by OSGi container,
     // so they should not be exposed as transitive dependencies
-    "osgiCompileOnly"("org.osgi:org.osgi.core")
+    "osgiCompileOnly"("org.osgi:osgi.core")
     "osgiCompileOnly"("org.osgi:org.osgi.service.jdbc")
     "testImplementation"("org.osgi:org.osgi.service.jdbc") {
         because("DataSourceFactory is needed for PGDataSourceFactoryTest")
@@ -100,6 +100,29 @@ if (skipReplicationTests) {
     tasks.configureEach<Test> {
         exclude("org/postgresql/replication/**")
         exclude("org/postgresql/test/jdbc2/CopyBothResponseTest*")
+    }
+}
+
+val java11 by sourceSets.creating {
+    java.srcDir("src/main/java11")
+    compileClasspath = sourceSets["main"].compileClasspath
+}
+
+tasks.named<JavaCompile>("compileJava11Java") {
+    options.release = 11
+    val compileJavaDestinationDirectory = tasks.compileJava.flatMap { it.destinationDirectory }
+    // sets execution order and cache relationship
+    inputs.dir(compileJavaDestinationDirectory)
+    options.compilerArgumentProviders.add(CommandLineArgumentProvider {
+        listOf(
+            "--patch-module", "org.postgresql.jdbc=${compileJavaDestinationDirectory.get().asFile.absolutePath}",
+        )
+    })
+}
+
+tasks.jar {
+    into("META-INF/versions/11") {
+        from(sourceSets["java11"].output)
     }
 }
 
@@ -218,6 +241,7 @@ tasks.configureEach<Jar> {
     manifest {
         attributes["Main-Class"] = "org.postgresql.util.PGJDBCMain"
         attributes["Automatic-Module-Name"] = "org.postgresql.jdbc"
+        attributes["Multi-Release"] = "true"
     }
 }
 
@@ -228,7 +252,12 @@ tasks.shadowJar {
     exclude("META-INF/NOTICE*")
     into("META-INF") {
         dependencyLicenses(shadedLicenseFiles)
+        into("versions/11") {
+            from(sourceSets["java11"].output)
+        }
     }
+    // shadow excludes module-info.class files by default, see https://github.com/johnrengelman/shadow/issues/710#issuecomment-1553178619
+    excludes.remove("module-info.class")
     listOf(
             "com.ongres"
     ).forEach {
@@ -418,5 +447,12 @@ val extraMavenPublications by configurations.getting
     extraMavenPublications(karaf.features.outputFile) {
         builtBy(tasks.named("generateFeatures"))
         classifier = "features"
+    }
+}
+
+sourceSets {
+    main {
+        // todo: fix how preprocessVersion srcSets
+        java.setSrcDirs(listOf("src/main/java", preprocessVersion))
     }
 }

--- a/pgjdbc/build.gradle.kts
+++ b/pgjdbc/build.gradle.kts
@@ -73,7 +73,7 @@ dependencies {
     constraints {
         api("com.github.waffle:waffle-jna:3.3.0")
         api("org.osgi:osgi.core:8.0.0")
-        api("org.osgi:org.osgi.service.jdbc:1.1.0")
+        api("org.osgi:org.osgi.service.jdbc:1.0.1")
     }
 
     "sspiImplementation"("com.github.waffle:waffle-jna")

--- a/pgjdbc/src/main/java/org/postgresql/sspi/SSPIClient.java
+++ b/pgjdbc/src/main/java/org/postgresql/sspi/SSPIClient.java
@@ -229,7 +229,10 @@ public class SSPIClient implements ISSPIClient {
           SEC_BUFFER_DESC_FACTORY.newInstance(Sspi.SECBUFFER_TOKEN, receivedToken);
     } catch (ReflectiveOperationException ex) {
       // A fallback just in case
-      continueToken = new SecBufferDesc(Sspi.SECBUFFER_TOKEN, receivedToken);
+      Sspi.SecBuffer[] secBuffers = new Sspi.SecBuffer[]{new Sspi.SecBuffer(Sspi.SECBUFFER_TOKEN, receivedToken)};
+      continueToken = new SecBufferDesc();
+      continueToken.pBuffers = secBuffers[0].getPointer();
+      continueToken.cBuffers = secBuffers.length;
     }
 
     sspiContext.initialize(sspiContext.getHandle(), continueToken, castNonNull(targetName));

--- a/pgjdbc/src/main/java11/module-info.java
+++ b/pgjdbc/src/main/java11/module-info.java
@@ -1,9 +1,3 @@
-
-/*
-attributes["Main-Class"] = "org.postgresql.util.PGJDBCMain"
-        attributes["Automatic-Module-Name"] = "org.postgresql.jdbc"
- */
-
 module org.postgresql.jdbc {
   requires static java.desktop;
   requires java.logging;

--- a/pgjdbc/src/main/java11/module-info.java
+++ b/pgjdbc/src/main/java11/module-info.java
@@ -1,0 +1,24 @@
+
+/*
+attributes["Main-Class"] = "org.postgresql.util.PGJDBCMain"
+        attributes["Automatic-Module-Name"] = "org.postgresql.jdbc"
+ */
+
+module org.postgresql.jdbc {
+  requires static java.desktop;
+  requires java.logging;
+  requires java.management;
+  requires java.naming;
+  requires java.security.jgss;
+  requires java.sql;
+  requires java.transaction.xa;
+  requires static org.checkerframework.checker.qual;
+  requires static com.sun.jna;
+  requires static com.sun.jna.platform;
+  requires static waffle.jna;
+  requires static org.osgi.service.jdbc;
+  requires static osgi.core;
+
+  exports org.postgresql;
+  provides java.sql.Driver with org.postgresql.Driver;
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -38,6 +38,7 @@ includeBuild("build-logic")
 
 // Renovate treats names as dependency coordinates when vararg include(...) is used, so we have separate include calls here
 include("benchmarks")
+include("pgjdbc-module-test")
 include("pgjdbc-osgi-test")
 include("postgresql")
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Does `./gradlew styleCheck` pass ?
3. [ ] Have you added your new test classes to an existing test suite in alphabetical order?

Fixes https://github.com/pgjdbc/pgjdbc/issues/1979, https://github.com/pgjdbc/pgjdbc/issues/2657

* Adds module-info.java file.
* Adds new black-box test suite to verify the jar we created is modular.
* Bumped a few dependencies to get updated automatic-module-names or modular jars (waffle, osgi).
* Didn't upgrade scram version, as it's shaded in the released jar.
* Added a new sourceSet that compiled the module-info.java file.

