### PR TITLE
Fix #3224 - conversion for TIME '24:00' to LocalTime breaks in binary-mode 

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/TimestampUtils.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/TimestampUtils.java
@@ -60,6 +60,7 @@ public class TimestampUtils {
   // LocalTime.MAX is 23:59:59.999_999_999, and it wraps to 24:00:00 when nanos exceed 999_999_499
   // since PostgreSQL has microsecond resolution only
   private static final LocalTime MAX_TIME = LocalTime.MAX.minus(Duration.ofNanos(500));
+  private static final long MAX_TIME_NANOS = MAX_TIME.toNanoOfDay();
   private static final OffsetDateTime MAX_OFFSET_DATETIME = OffsetDateTime.MAX.minus(Duration.ofMillis(500));
   private static final LocalDateTime MAX_LOCAL_DATETIME = LocalDateTime.MAX.minus(Duration.ofMillis(500));
   // low value for dates is   4713 BC
@@ -1437,7 +1438,13 @@ public class TimestampUtils {
       micros = ByteConverter.int8(bytes, 0);
     }
 
-    return LocalTime.ofNanoOfDay(Math.multiplyExact(micros, 1000L));
+    long nanos = Math.multiplyExact(micros, 1000L);
+
+    if (nanos > MAX_TIME_NANOS) {
+      return LocalTime.MAX;
+    } else {
+      return LocalTime.ofNanoOfDay(nanos);
+    }
   }
 
   /**

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc42/GetObject310Test.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc42/GetObject310Test.java
@@ -210,7 +210,6 @@ public class GetObject310Test extends BaseTest4 {
         assertDataTypeMismatch(rs, "time_without_time_zone_column", LocalDate.class);
         assertDataTypeMismatch(rs, "time_without_time_zone_column", LocalDateTime.class);
       }
-      stmt.executeUpdate("DELETE FROM table1");
     }
   }
 
@@ -229,7 +228,6 @@ public class GetObject310Test extends BaseTest4 {
         assertEquals(localTime, rs.getObject("time_without_time_zone_column", LocalTime.class));
         assertEquals(localTime, rs.getObject(1, LocalTime.class));
       }
-      stmt.executeUpdate("DELETE FROM table1");
     }
   }
 
@@ -246,7 +244,6 @@ public class GetObject310Test extends BaseTest4 {
         assertNull(rs.getObject("time_without_time_zone_column", LocalTime.class));
         assertNull(rs.getObject(1, LocalTime.class));
       }
-      stmt.executeUpdate("DELETE FROM table1");
     }
   }
 
@@ -264,7 +261,6 @@ public class GetObject310Test extends BaseTest4 {
         assertDataTypeMismatch(rs, "time_with_time_zone_column", LocalDateTime.class);
         assertDataTypeMismatch(rs, "time_with_time_zone_column", LocalDate.class);
       }
-      stmt.executeUpdate("DELETE FROM table1");
     }
   }
 

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc42/GetObject310Test.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc42/GetObject310Test.java
@@ -215,6 +215,25 @@ public class GetObject310Test extends BaseTest4 {
   }
 
   /**
+   * Test the behavior getObject for time columns with value "24:00", which isn't supported by
+   * {@link LocalTime}, and thus gets converted to {@link LocalTime#MAX}
+   */
+  @Test
+  public void testGetLocalTimeMax() throws SQLException {
+    try (Statement stmt = con.createStatement() ) {
+      stmt.executeUpdate(TestUtil.insertSQL("table1", "time_without_time_zone_column", "TIME '24:00'"));
+
+      try (ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("table1", "time_without_time_zone_column"))) {
+        assertTrue(rs.next());
+        LocalTime localTime = LocalTime.MAX;
+        assertEquals(localTime, rs.getObject("time_without_time_zone_column", LocalTime.class));
+        assertEquals(localTime, rs.getObject(1, LocalTime.class));
+      }
+      stmt.executeUpdate("DELETE FROM table1");
+    }
+  }
+
+  /**
    * Test the behavior getObject for time columns with null.
    */
   @Test


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes to Existing Features:

* [ ] Does this break existing behaviour? If so please explain.
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Description

Fixes the bug described in #3224

Conversion of binary-values of `TIME` has been adapted to interpret `24:00` as `LocalTime.MAX` - as does conversion from text-values.
As PostgreSQL only supports microsecond-precision, all values larger than `23:59:59.999_999_499` are converted to `LocalTime.MAX` - as is done in other places in TimestampUtils.java

Binary test-values for [TimestampUtilsTest.java](https://github.com/pgjdbc/pgjdbc/compare/master...pmenke-de:pgjdbc:fix-localtime-max?expand=1#diff-97a2717f6b8899b272ea539e9b1dcd0baa5b8e0555172772076cc2ca92f4ce21) are guessed, as I couldn't find a documentation / source, of how they're actually computed.
