### PR TITLE
test: test both binaryMode=true,false when creating connections in DatabaseMetaDataTest

### DIFF
--- a/build-logic/jvm/src/main/kotlin/build-logic.test-junit5.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/build-logic.test-junit5.gradle.kts
@@ -38,6 +38,7 @@ tasks.configureEach<Test> {
         value?.let { systemProperty(name, it) }
     }
     passProperty("junit.jupiter.execution.parallel.enabled", "true")
+    passProperty("junit.jupiter.extensions.autodetection.enabled", "true")
     // TODO: remove when upgrade to JUnit 5.9+
     // See https://github.com/junit-team/junit5/commit/347e3119d36a5c226cddd7981452f11335fad422
     passProperty("junit.jupiter.execution.parallel.config.strategy", "DYNAMIC")

--- a/pgjdbc/build.gradle.kts
+++ b/pgjdbc/build.gradle.kts
@@ -90,6 +90,9 @@ dependencies {
     testImplementation("se.jiderhamn:classloader-leak-test-framework:1.1.2")
     testFixturesImplementation("junit:junit:4.13.2")
     testFixturesImplementation("org.junit.jupiter:junit-jupiter-api:5.10.2")
+    testFixturesImplementation("org.junit.jupiter:junit-jupiter-engine:5.10.2") {
+        because("We use BeforeEachMethodAdapter to add parameters to beforeeach and aftereach methods")
+    }
     testFixturesImplementation("org.checkerframework:checker-qual:3.42.0")
 }
 

--- a/pgjdbc/reduced-pom.xml
+++ b/pgjdbc/reduced-pom.xml
@@ -105,6 +105,12 @@
                     <systemPropertyVariables>
                         <build.properties.relative.path>.</build.properties.relative.path>
                     </systemPropertyVariables>
+                    <properties>
+                        <configurationParameters>
+                            junit.jupiter.extensions.autodetection.enabled=true
+                            junit.jupiter.execution.timeout.default=5 m
+                        </configurationParameters>
+                    </properties>
                 </configuration>
             </plugin>
             <plugin>

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseMetaDataTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseMetaDataTest.java
@@ -49,11 +49,6 @@ import java.util.Set;
  */
 public class DatabaseMetaDataTest {
   private Connection con;
-  private BinaryMode binaryMode;
-
-  public void initDatabaseMetaDataTest(BinaryMode binaryMode) {
-    this.binaryMode = binaryMode;
-  }
 
   public static Iterable<Object[]> data() {
     Collection<Object[]> ids = new ArrayList<>();
@@ -64,7 +59,7 @@ public class DatabaseMetaDataTest {
   }
 
   @BeforeEach
-  void setUp() throws Exception {
+  void setUp(BinaryMode binaryMode) throws Exception {
     if (binaryMode == BinaryMode.FORCE) {
       final Properties props = new Properties();
       PGProperty.PREPARE_THRESHOLD.set(props, -1);
@@ -182,7 +177,6 @@ public class DatabaseMetaDataTest {
   @MethodSource("data")
   @ParameterizedTest(name = "binary = {0}")
   void arrayTypeInfo(BinaryMode binaryMode) throws SQLException {
-    initDatabaseMetaDataTest(binaryMode);
     DatabaseMetaData dbmd = con.getMetaData();
     ResultSet rs = dbmd.getColumns(null, null, "intarraytable", "a");
     assertTrue(rs.next());
@@ -198,7 +192,6 @@ public class DatabaseMetaDataTest {
   @MethodSource("data")
   @ParameterizedTest(name = "binary = {0}")
   void arrayInt4DoubleDim(BinaryMode binaryMode) throws SQLException {
-    initDatabaseMetaDataTest(binaryMode);
     DatabaseMetaData dbmd = con.getMetaData();
     ResultSet rs = dbmd.getColumns(null, null, "intarraytable", "b");
     assertTrue(rs.next());
@@ -212,7 +205,6 @@ public class DatabaseMetaDataTest {
   @MethodSource("data")
   @ParameterizedTest(name = "binary = {0}")
   void customArrayTypeInfo(BinaryMode binaryMode) throws SQLException {
-    initDatabaseMetaDataTest(binaryMode);
     DatabaseMetaData dbmd = con.getMetaData();
     ResultSet res = dbmd.getColumns(null, null, "customtable", null);
     assertTrue(res.next());
@@ -250,7 +242,6 @@ public class DatabaseMetaDataTest {
   @MethodSource("data")
   @ParameterizedTest(name = "binary = {0}")
   void tables(BinaryMode binaryMode) throws Exception {
-    initDatabaseMetaDataTest(binaryMode);
     DatabaseMetaData dbmd = con.getMetaData();
     assertNotNull(dbmd);
 
@@ -292,7 +283,6 @@ public class DatabaseMetaDataTest {
   @MethodSource("data")
   @ParameterizedTest(name = "binary = {0}")
   void crossReference(BinaryMode binaryMode) throws Exception {
-    initDatabaseMetaDataTest(binaryMode);
     Connection con1 = TestUtil.openDB();
 
     TestUtil.createTable(con1, "vv", "a int not null, b int not null, constraint vv_pkey primary key ( a, b )");
@@ -342,7 +332,6 @@ public class DatabaseMetaDataTest {
   @MethodSource("data")
   @ParameterizedTest(name = "binary = {0}")
   void foreignKeyActions(BinaryMode binaryMode) throws Exception {
-    initDatabaseMetaDataTest(binaryMode);
     Connection conn = TestUtil.openDB();
     TestUtil.createTable(conn, "pkt", "id int primary key");
     TestUtil.createTable(conn, "fkt1",
@@ -372,7 +361,6 @@ public class DatabaseMetaDataTest {
   @MethodSource("data")
   @ParameterizedTest(name = "binary = {0}")
   void foreignKeysToUniqueIndexes(BinaryMode binaryMode) throws Exception {
-    initDatabaseMetaDataTest(binaryMode);
     Connection con1 = TestUtil.openDB();
     TestUtil.createTable(con1, "pkt",
         "a int not null, b int not null, CONSTRAINT pkt_pk_a PRIMARY KEY (a), CONSTRAINT pkt_un_b UNIQUE (b)");
@@ -398,7 +386,6 @@ public class DatabaseMetaDataTest {
   @MethodSource("data")
   @ParameterizedTest(name = "binary = {0}")
   void multiColumnForeignKeys(BinaryMode binaryMode) throws Exception {
-    initDatabaseMetaDataTest(binaryMode);
     Connection con1 = TestUtil.openDB();
     TestUtil.createTable(con1, "pkt",
         "a int not null, b int not null, CONSTRAINT pkt_pk PRIMARY KEY (a,b)");
@@ -430,7 +417,6 @@ public class DatabaseMetaDataTest {
   @MethodSource("data")
   @ParameterizedTest(name = "binary = {0}")
   void sameTableForeignKeys(BinaryMode binaryMode) throws Exception {
-    initDatabaseMetaDataTest(binaryMode);
     Connection con1 = TestUtil.openDB();
 
     TestUtil.createTable(con1, "person",
@@ -495,7 +481,6 @@ public class DatabaseMetaDataTest {
   @MethodSource("data")
   @ParameterizedTest(name = "binary = {0}")
   void foreignKeys(BinaryMode binaryMode) throws Exception {
-    initDatabaseMetaDataTest(binaryMode);
     Connection con1 = TestUtil.openDB();
     TestUtil.createTable(con1, "people", "id int4 primary key, name text");
     TestUtil.createTable(con1, "policy", "id int4 primary key, name text");
@@ -556,7 +541,6 @@ public class DatabaseMetaDataTest {
   @MethodSource("data")
   @ParameterizedTest(name = "binary = {0}")
   void numericPrecision(BinaryMode binaryMode) throws SQLException {
-    initDatabaseMetaDataTest(binaryMode);
     DatabaseMetaData dbmd = con.getMetaData();
     assertNotNull(dbmd);
     ResultSet rs = dbmd.getColumns(null, "public", "precision_test", "%");
@@ -568,7 +552,6 @@ public class DatabaseMetaDataTest {
   @MethodSource("data")
   @ParameterizedTest(name = "binary = {0}")
   void columns(BinaryMode binaryMode) throws SQLException {
-    initDatabaseMetaDataTest(binaryMode);
     // At the moment just test that no exceptions are thrown KJ
     String [] metadataColumns = {"TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "COLUMN_NAME",
                                  "DATA_TYPE", "TYPE_NAME", "COLUMN_SIZE", "BUFFER_LENGTH",
@@ -591,7 +574,6 @@ public class DatabaseMetaDataTest {
   @MethodSource("data")
   @ParameterizedTest(name = "binary = {0}")
   void droppedColumns(BinaryMode binaryMode) throws SQLException {
-    initDatabaseMetaDataTest(binaryMode);
     if (!TestUtil.haveMinimumServerVersion(con, ServerVersion.v8_4)) {
       return;
     }
@@ -643,7 +625,6 @@ public class DatabaseMetaDataTest {
   @MethodSource("data")
   @ParameterizedTest(name = "binary = {0}")
   void serialColumns(BinaryMode binaryMode) throws SQLException {
-    initDatabaseMetaDataTest(binaryMode);
     DatabaseMetaData dbmd = con.getMetaData();
     ResultSet rs = dbmd.getColumns(null, null, "sercoltest", null);
     int rownum = 0;
@@ -670,7 +651,6 @@ public class DatabaseMetaDataTest {
   @MethodSource("data")
   @ParameterizedTest(name = "binary = {0}")
   void columnPrivileges(BinaryMode binaryMode) throws SQLException {
-    initDatabaseMetaDataTest(binaryMode);
     // At the moment just test that no exceptions are thrown KJ
     DatabaseMetaData dbmd = con.getMetaData();
     assertNotNull(dbmd);
@@ -706,21 +686,18 @@ public class DatabaseMetaDataTest {
   @MethodSource("data")
   @ParameterizedTest(name = "binary = {0}")
   void tablePrivileges(BinaryMode binaryMode) throws SQLException {
-    initDatabaseMetaDataTest(binaryMode);
     relationPrivilegesHelper("metadatatest");
   }
 
   @MethodSource("data")
   @ParameterizedTest(name = "binary = {0}")
   void viewPrivileges(BinaryMode binaryMode) throws SQLException {
-    initDatabaseMetaDataTest(binaryMode);
     relationPrivilegesHelper("viewtest");
   }
 
   @MethodSource("data")
   @ParameterizedTest(name = "binary = {0}")
   void materializedViewPrivileges(BinaryMode binaryMode) throws SQLException {
-    initDatabaseMetaDataTest(binaryMode);
     Assumptions.assumeTrue(TestUtil.haveMinimumServerVersion(con, ServerVersion.v9_3));
     TestUtil.createMaterializedView(con, "matviewtest", "SELECT id, quest FROM metadatatest");
     try {
@@ -733,7 +710,6 @@ public class DatabaseMetaDataTest {
   @MethodSource("data")
   @ParameterizedTest(name = "binary = {0}")
   void noTablePrivileges(BinaryMode binaryMode) throws SQLException {
-    initDatabaseMetaDataTest(binaryMode);
     Statement stmt = con.createStatement();
     stmt.execute("REVOKE ALL ON metadatatest FROM PUBLIC");
     stmt.execute("REVOKE ALL ON metadatatest FROM " + TestUtil.getUser());
@@ -745,7 +721,6 @@ public class DatabaseMetaDataTest {
   @MethodSource("data")
   @ParameterizedTest(name = "binary = {0}")
   void primaryKeys(BinaryMode binaryMode) throws SQLException {
-    initDatabaseMetaDataTest(binaryMode);
     // At the moment just test that no exceptions are thrown KJ
     DatabaseMetaData dbmd = con.getMetaData();
     assertNotNull(dbmd);
@@ -756,7 +731,6 @@ public class DatabaseMetaDataTest {
   @MethodSource("data")
   @ParameterizedTest(name = "binary = {0}")
   void indexInfo(BinaryMode binaryMode) throws SQLException {
-    initDatabaseMetaDataTest(binaryMode);
     Statement stmt = con.createStatement();
     stmt.execute("create index idx_id on metadatatest (id)");
     stmt.execute("create index idx_func_single on metadatatest (upper(colour))");
@@ -817,7 +791,6 @@ public class DatabaseMetaDataTest {
   @MethodSource("data")
   @ParameterizedTest(name = "binary = {0}")
   void indexInfoColumnOrder(BinaryMode binaryMode) throws SQLException {
-    initDatabaseMetaDataTest(binaryMode);
     DatabaseMetaData dbmd = con.getMetaData();
     assertNotNull(dbmd);
     ResultSet rs = dbmd.getIndexInfo(null, null, "metadatatest", false, false);
@@ -841,7 +814,6 @@ public class DatabaseMetaDataTest {
   @MethodSource("data")
   @ParameterizedTest(name = "binary = {0}")
   void indexInfoColumnCase(BinaryMode binaryMode) throws SQLException {
-    initDatabaseMetaDataTest(binaryMode);
     DatabaseMetaData dbmd = con.getMetaData();
     assertNotNull(dbmd);
 
@@ -861,7 +833,6 @@ public class DatabaseMetaDataTest {
   @MethodSource("data")
   @ParameterizedTest(name = "binary = {0}")
   void notNullDomainColumn(BinaryMode binaryMode) throws SQLException {
-    initDatabaseMetaDataTest(binaryMode);
     DatabaseMetaData dbmd = con.getMetaData();
     ResultSet rs = dbmd.getColumns("", "", "domaintable", "");
     assertTrue(rs.next());
@@ -875,7 +846,6 @@ public class DatabaseMetaDataTest {
   @MethodSource("data")
   @ParameterizedTest(name = "binary = {0}")
   void domainColumnSize(BinaryMode binaryMode) throws SQLException {
-    initDatabaseMetaDataTest(binaryMode);
     DatabaseMetaData dbmd = con.getMetaData();
     ResultSet rs = dbmd.getColumns("", "", "domaintable", "");
     assertTrue(rs.next());
@@ -894,7 +864,6 @@ public class DatabaseMetaDataTest {
   @MethodSource("data")
   @ParameterizedTest(name = "binary = {0}")
   void ascDescIndexInfo(BinaryMode binaryMode) throws SQLException {
-    initDatabaseMetaDataTest(binaryMode);
     if (!TestUtil.haveMinimumServerVersion(con, ServerVersion.v8_3)) {
       return;
     }
@@ -920,7 +889,6 @@ public class DatabaseMetaDataTest {
   @MethodSource("data")
   @ParameterizedTest(name = "binary = {0}")
   void partialIndexInfo(BinaryMode binaryMode) throws SQLException {
-    initDatabaseMetaDataTest(binaryMode);
     Statement stmt = con.createStatement();
     stmt.execute("create index idx_p_name_id on metadatatest (name) where id > 5");
     stmt.close();
@@ -941,7 +909,6 @@ public class DatabaseMetaDataTest {
   @MethodSource("data")
   @ParameterizedTest(name = "binary = {0}")
   void tableTypes(BinaryMode binaryMode) throws SQLException {
-    initDatabaseMetaDataTest(binaryMode);
     final List<String> expectedTableTypes = new ArrayList<>(Arrays.asList("FOREIGN TABLE", "INDEX", "PARTITIONED INDEX",
         "MATERIALIZED VIEW", "PARTITIONED TABLE", "SEQUENCE", "SYSTEM INDEX", "SYSTEM TABLE", "SYSTEM TOAST INDEX",
         "SYSTEM TOAST TABLE", "SYSTEM VIEW", "TABLE", "TEMPORARY INDEX", "TEMPORARY SEQUENCE", "TEMPORARY TABLE",
@@ -967,7 +934,6 @@ public class DatabaseMetaDataTest {
   @MethodSource("data")
   @ParameterizedTest(name = "binary = {0}")
   void funcWithoutNames(BinaryMode binaryMode) throws SQLException {
-    initDatabaseMetaDataTest(binaryMode);
     DatabaseMetaData dbmd = con.getMetaData();
     assertNotNull(dbmd);
     ResultSet rs = dbmd.getProcedureColumns(null, null, "f1", null);
@@ -994,7 +960,6 @@ public class DatabaseMetaDataTest {
   @MethodSource("data")
   @ParameterizedTest(name = "binary = {0}")
   void funcWithNames(BinaryMode binaryMode) throws SQLException {
-    initDatabaseMetaDataTest(binaryMode);
     DatabaseMetaData dbmd = con.getMetaData();
     ResultSet rs = dbmd.getProcedureColumns(null, null, "f2", null);
 
@@ -1014,7 +979,6 @@ public class DatabaseMetaDataTest {
   @MethodSource("data")
   @ParameterizedTest(name = "binary = {0}")
   void funcWithDirection(BinaryMode binaryMode) throws SQLException {
-    initDatabaseMetaDataTest(binaryMode);
     DatabaseMetaData dbmd = con.getMetaData();
     ResultSet rs = dbmd.getProcedureColumns(null, null, "f3", null);
 
@@ -1039,7 +1003,6 @@ public class DatabaseMetaDataTest {
   @MethodSource("data")
   @ParameterizedTest(name = "binary = {0}")
   void funcReturningComposite(BinaryMode binaryMode) throws SQLException {
-    initDatabaseMetaDataTest(binaryMode);
     DatabaseMetaData dbmd = con.getMetaData();
     ResultSet rs = dbmd.getProcedureColumns(null, null, "f4", null);
 
@@ -1080,7 +1043,6 @@ public class DatabaseMetaDataTest {
   @MethodSource("data")
   @ParameterizedTest(name = "binary = {0}")
   void funcReturningTable(BinaryMode binaryMode) throws Exception {
-    initDatabaseMetaDataTest(binaryMode);
     if (!TestUtil.haveMinimumServerVersion(con, ServerVersion.v8_4)) {
       return;
     }
@@ -1101,7 +1063,6 @@ public class DatabaseMetaDataTest {
   @MethodSource("data")
   @ParameterizedTest(name = "binary = {0}")
   void versionColumns(BinaryMode binaryMode) throws SQLException {
-    initDatabaseMetaDataTest(binaryMode);
     // At the moment just test that no exceptions are thrown KJ
     DatabaseMetaData dbmd = con.getMetaData();
     assertNotNull(dbmd);
@@ -1112,7 +1073,6 @@ public class DatabaseMetaDataTest {
   @MethodSource("data")
   @ParameterizedTest(name = "binary = {0}")
   void bestRowIdentifier(BinaryMode binaryMode) throws SQLException {
-    initDatabaseMetaDataTest(binaryMode);
     // At the moment just test that no exceptions are thrown KJ
     DatabaseMetaData dbmd = con.getMetaData();
     assertNotNull(dbmd);
@@ -1124,7 +1084,6 @@ public class DatabaseMetaDataTest {
   @MethodSource("data")
   @ParameterizedTest(name = "binary = {0}")
   void procedures(BinaryMode binaryMode) throws SQLException {
-    initDatabaseMetaDataTest(binaryMode);
     // At the moment just test that no exceptions are thrown KJ
     DatabaseMetaData dbmd = con.getMetaData();
     assertNotNull(dbmd);
@@ -1135,7 +1094,6 @@ public class DatabaseMetaDataTest {
   @MethodSource("data")
   @ParameterizedTest(name = "binary = {0}")
   void catalogs(BinaryMode binaryMode) throws SQLException {
-    initDatabaseMetaDataTest(binaryMode);
     DatabaseMetaData dbmd = con.getMetaData();
     try (ResultSet rs = dbmd.getCatalogs()) {
       List<String> catalogs = new ArrayList<>();
@@ -1159,7 +1117,6 @@ public class DatabaseMetaDataTest {
   @MethodSource("data")
   @ParameterizedTest(name = "binary = {0}")
   void schemas(BinaryMode binaryMode) throws Exception {
-    initDatabaseMetaDataTest(binaryMode);
     DatabaseMetaData dbmd = con.getMetaData();
     assertNotNull(dbmd);
 
@@ -1189,7 +1146,6 @@ public class DatabaseMetaDataTest {
   @MethodSource("data")
   @ParameterizedTest(name = "binary = {0}")
   void escaping(BinaryMode binaryMode) throws SQLException {
-    initDatabaseMetaDataTest(binaryMode);
     DatabaseMetaData dbmd = con.getMetaData();
     ResultSet rs = dbmd.getTables(null, null, "a'", new String[]{"TABLE"});
     assertTrue(rs.next());
@@ -1202,7 +1158,6 @@ public class DatabaseMetaDataTest {
   @MethodSource("data")
   @ParameterizedTest(name = "binary = {0}")
   void searchStringEscape(BinaryMode binaryMode) throws Exception {
-    initDatabaseMetaDataTest(binaryMode);
     DatabaseMetaData dbmd = con.getMetaData();
     String pattern = dbmd.getSearchStringEscape() + "_";
     PreparedStatement pstmt = con.prepareStatement("SELECT 'a' LIKE ?, '_' LIKE ?");
@@ -1219,7 +1174,6 @@ public class DatabaseMetaDataTest {
   @MethodSource("data")
   @ParameterizedTest(name = "binary = {0}")
   void getUDTQualified(BinaryMode binaryMode) throws Exception {
-    initDatabaseMetaDataTest(binaryMode);
     Statement stmt = null;
     try {
       stmt = con.createStatement();
@@ -1275,7 +1229,6 @@ public class DatabaseMetaDataTest {
   @MethodSource("data")
   @ParameterizedTest(name = "binary = {0}")
   void getUDT1(BinaryMode binaryMode) throws Exception {
-    initDatabaseMetaDataTest(binaryMode);
     try {
       Statement stmt = con.createStatement();
       stmt.execute("create domain testint8 as int8");
@@ -1308,7 +1261,6 @@ public class DatabaseMetaDataTest {
   @MethodSource("data")
   @ParameterizedTest(name = "binary = {0}")
   void getUDT2(BinaryMode binaryMode) throws Exception {
-    initDatabaseMetaDataTest(binaryMode);
     try {
       Statement stmt = con.createStatement();
       stmt.execute("create domain testint8 as int8");
@@ -1342,7 +1294,6 @@ public class DatabaseMetaDataTest {
   @MethodSource("data")
   @ParameterizedTest(name = "binary = {0}")
   void getUDT3(BinaryMode binaryMode) throws Exception {
-    initDatabaseMetaDataTest(binaryMode);
     try {
       Statement stmt = con.createStatement();
       stmt.execute("create domain testint8 as int8");
@@ -1375,7 +1326,6 @@ public class DatabaseMetaDataTest {
   @MethodSource("data")
   @ParameterizedTest(name = "binary = {0}")
   void getUDT4(BinaryMode binaryMode) throws Exception {
-    initDatabaseMetaDataTest(binaryMode);
     try {
       Statement stmt = con.createStatement();
       stmt.execute("create type testint8 as (i int8)");
@@ -1406,7 +1356,6 @@ public class DatabaseMetaDataTest {
   @MethodSource("data")
   @ParameterizedTest(name = "binary = {0}")
   void types(BinaryMode binaryMode) throws SQLException {
-    initDatabaseMetaDataTest(binaryMode);
     // https://www.postgresql.org/docs/8.2/static/datatype.html
     List<String> stringTypeList = new ArrayList<>();
     stringTypeList.addAll(Arrays.asList("bit",
@@ -1469,7 +1418,6 @@ public class DatabaseMetaDataTest {
   @MethodSource("data")
   @ParameterizedTest(name = "binary = {0}")
   void typeInfoSigned(BinaryMode binaryMode) throws SQLException {
-    initDatabaseMetaDataTest(binaryMode);
     DatabaseMetaData dbmd = con.getMetaData();
     ResultSet rs = dbmd.getTypeInfo();
     while (rs.next()) {
@@ -1486,7 +1434,6 @@ public class DatabaseMetaDataTest {
   @MethodSource("data")
   @ParameterizedTest(name = "binary = {0}")
   void typeInfoQuoting(BinaryMode binaryMode) throws SQLException {
-    initDatabaseMetaDataTest(binaryMode);
     DatabaseMetaData dbmd = con.getMetaData();
     ResultSet rs = dbmd.getTypeInfo();
     while (rs.next()) {
@@ -1502,7 +1449,6 @@ public class DatabaseMetaDataTest {
   @MethodSource("data")
   @ParameterizedTest(name = "binary = {0}")
   void informationAboutArrayTypes(BinaryMode binaryMode) throws SQLException {
-    initDatabaseMetaDataTest(binaryMode);
     DatabaseMetaData dbmd = con.getMetaData();
     ResultSet rs = dbmd.getColumns("", "", "arraytable", "");
     assertTrue(rs.next());
@@ -1518,7 +1464,6 @@ public class DatabaseMetaDataTest {
   @MethodSource("data")
   @ParameterizedTest(name = "binary = {0}")
   void partitionedTablesIndex(BinaryMode binaryMode) throws SQLException {
-    initDatabaseMetaDataTest(binaryMode);
     if (TestUtil.haveMinimumServerVersion(con, ServerVersion.v11)) {
       Statement stmt = null;
       try {
@@ -1543,7 +1488,6 @@ public class DatabaseMetaDataTest {
   @MethodSource("data")
   @ParameterizedTest(name = "binary = {0}")
   void partitionedTables(BinaryMode binaryMode) throws SQLException {
-    initDatabaseMetaDataTest(binaryMode);
     if (TestUtil.haveMinimumServerVersion(con, ServerVersion.v11)) {
       Statement stmt = null;
       try {
@@ -1571,7 +1515,6 @@ public class DatabaseMetaDataTest {
   @MethodSource("data")
   @ParameterizedTest(name = "binary = {0}")
   void identityColumns(BinaryMode binaryMode) throws SQLException {
-    initDatabaseMetaDataTest(binaryMode);
     if ( TestUtil.haveMinimumServerVersion(con, ServerVersion.v10) ) {
       Statement stmt = null;
       try {
@@ -1597,7 +1540,6 @@ public class DatabaseMetaDataTest {
   @MethodSource("data")
   @ParameterizedTest(name = "binary = {0}")
   void generatedColumns(BinaryMode binaryMode) throws SQLException {
-    initDatabaseMetaDataTest(binaryMode);
     if ( TestUtil.haveMinimumServerVersion(con, ServerVersion.v12) ) {
       DatabaseMetaData dbmd = con.getMetaData();
       ResultSet rs = dbmd.getColumns("", "", "employee", "gross_pay");
@@ -1610,7 +1552,6 @@ public class DatabaseMetaDataTest {
   @MethodSource("data")
   @ParameterizedTest(name = "binary = {0}")
   void getSQLKeywords(BinaryMode binaryMode) throws SQLException {
-    initDatabaseMetaDataTest(binaryMode);
     DatabaseMetaData dbmd = con.getMetaData();
     String keywords = dbmd.getSQLKeywords();
 
@@ -1682,7 +1623,6 @@ public class DatabaseMetaDataTest {
   @MethodSource("data")
   @ParameterizedTest(name = "binary = {0}")
   void functionColumns(BinaryMode binaryMode) throws SQLException {
-    initDatabaseMetaDataTest(binaryMode);
     if (!TestUtil.haveMinimumServerVersion(con, ServerVersion.v8_4)) {
       return;
     }
@@ -1748,7 +1688,6 @@ public class DatabaseMetaDataTest {
   @MethodSource("data")
   @ParameterizedTest(name = "binary = {0}")
   void smallSerialColumns(BinaryMode binaryMode) throws SQLException {
-    initDatabaseMetaDataTest(binaryMode);
     Assumptions.assumeTrue(TestUtil.haveMinimumServerVersion(con, ServerVersion.v9_2));
     TestUtil.createTable(con, "smallserial_test", "a smallserial");
 
@@ -1770,7 +1709,6 @@ public class DatabaseMetaDataTest {
   @MethodSource("data")
   @ParameterizedTest(name = "binary = {0}")
   void smallSerialSequenceLikeColumns(BinaryMode binaryMode) throws SQLException {
-    initDatabaseMetaDataTest(binaryMode);
     Statement stmt = con.createStatement();
     // This is the equivalent of the smallserial, not the actual smallserial
     stmt.execute("CREATE SEQUENCE smallserial_test_a_seq;\n"
@@ -1803,7 +1741,6 @@ public class DatabaseMetaDataTest {
   @MethodSource("data")
   @ParameterizedTest(name = "binary = {0}")
   void upperCaseMetaDataLabels(BinaryMode binaryMode) throws SQLException {
-    initDatabaseMetaDataTest(binaryMode);
     ResultSet rs = con.getMetaData().getTables(null, null, null, null);
     ResultSetMetaData rsmd = rs.getMetaData();
 

--- a/pgjdbc/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/pgjdbc/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,1 @@
+org.postgresql.test.impl.AfterBeforeParameterResolver

--- a/pgjdbc/src/testFixtures/java/org/postgresql/test/impl/AfterBeforeParameterResolver.java
+++ b/pgjdbc/src/testFixtures/java/org/postgresql/test/impl/AfterBeforeParameterResolver.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2024, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.test.impl;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+import org.junit.jupiter.engine.execution.BeforeEachMethodAdapter;
+import org.junit.jupiter.engine.extension.ExtensionRegistry;
+
+import java.lang.annotation.Annotation;
+import java.util.Optional;
+
+/**
+ * Passes JUnit5's {@code ParameterizedTest} parameters to {@code @BeforeEach} and {@code AfterEach}
+ * methods.
+ *
+ * @see <a href="https://github.com/junit-team/junit5/issues/3157">Parameterized BeforeEach or
+ * AfterEach only</a>
+ */
+public class AfterBeforeParameterResolver implements BeforeEachMethodAdapter, ParameterResolver {
+  private @Nullable ParameterResolver parameterisedTestParameterResolver;
+
+  @Override
+  public void invokeBeforeEachMethod(ExtensionContext context, ExtensionRegistry registry) {
+    Optional<ParameterResolver> resolverOptional = registry.getExtensions(ParameterResolver.class)
+        .stream()
+        .filter(parameterResolver -> parameterResolver.getClass().getName().contains(
+            "ParameterizedTestParameterResolver"))
+        .findFirst();
+    parameterisedTestParameterResolver = resolverOptional.orElse(null);
+  }
+
+  @Override
+  public boolean supportsParameter(ParameterContext parameterContext,
+      ExtensionContext extensionContext) throws ParameterResolutionException {
+    // JUnit asks us to resolve a parameter for "BeforeEach" method,
+    // and we delegate to the "parameterized test" implementation,
+    // however it expects to resolve a parameter on a "test method".
+    if (parameterisedTestParameterResolver != null
+        && isExecutedOnAfterOrBeforeMethod(parameterContext)) {
+      // pContext refers to a parameter on a test method
+      ParameterContext pContext = getTestMethodParameterContext(parameterContext, extensionContext);
+      return parameterisedTestParameterResolver.supportsParameter(pContext, extensionContext);
+    }
+    return false;
+  }
+
+  private DefaultParameterContext getTestMethodParameterContext(ParameterContext parameterContext,
+      ExtensionContext extensionContext) {
+    return new DefaultParameterContext(
+        parameterContext.getIndex(),
+        extensionContext.getRequiredTestMethod().getParameters()[parameterContext.getIndex()],
+        parameterContext.getTarget());
+  }
+
+  private boolean isExecutedOnAfterOrBeforeMethod(ParameterContext parameterContext) {
+    for (Annotation annotation : parameterContext.getDeclaringExecutable().getDeclaredAnnotations()) {
+      if (isAfterEachOrBeforeEachAnnotation(annotation)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private boolean isAfterEachOrBeforeEachAnnotation(Annotation annotation) {
+    return annotation.annotationType() == BeforeEach.class || annotation.annotationType() == AfterEach.class;
+  }
+
+  @Override
+  public Object resolveParameter(ParameterContext parameterContext,
+      ExtensionContext extensionContext) throws ParameterResolutionException {
+    return parameterisedTestParameterResolver.resolveParameter(
+        getTestMethodParameterContext(parameterContext, extensionContext),
+        extensionContext);
+  }
+}

--- a/pgjdbc/src/testFixtures/java/org/postgresql/test/impl/DefaultParameterContext.java
+++ b/pgjdbc/src/testFixtures/java/org/postgresql/test/impl/DefaultParameterContext.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2024, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.test.impl;
+
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.platform.commons.util.AnnotationUtils;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Parameter;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Implements {@link ParameterContext} as JUnit does not provide default implementation.
+ */
+public class DefaultParameterContext implements ParameterContext {
+  private final int index;
+  private final Parameter parameter;
+  private final Optional<Object> target;
+
+  public DefaultParameterContext(int index, Parameter parameter,
+      Optional<Object> target) {
+    this.index = index;
+    this.parameter = parameter;
+    this.target = target;
+  }
+
+  @Override
+  public int getIndex() {
+    return index;
+  }
+
+  @Override
+  public Parameter getParameter() {
+    return parameter;
+  }
+
+  @Override
+  public Optional<Object> getTarget() {
+    return target;
+  }
+
+  @Override
+  public boolean isAnnotated(Class<? extends Annotation> annotationType) {
+    return AnnotationUtils.isAnnotated(parameter, index, annotationType);
+  }
+
+  @Override
+  public <A extends Annotation> Optional<A> findAnnotation(Class<A> annotationType) {
+    return AnnotationUtils.findAnnotation(parameter, index, annotationType);
+  }
+
+  @Override
+  public <A extends Annotation> List<A> findRepeatableAnnotations(Class<A> annotationType) {
+    return AnnotationUtils.findRepeatableAnnotations(parameter, index, annotationType);
+  }
+
+  @Override
+  public String toString() {
+    return "DefaultParameterContext[parameter=" + parameter + ", index=" + index + ", target=" + target + "]";
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/pgjdbc/pgjdbc/issues/3229

It looks like jdbc2.DatabaseMetaDataTest was the only impacted test.