### PR TITLE
fix: support bytea in preferQueryMode=simple

### DIFF
--- a/benchmarks/src/jmh/java/org/postgresql/benchmark/encoding/HexEncodingBenchmark.java
+++ b/benchmarks/src/jmh/java/org/postgresql/benchmark/encoding/HexEncodingBenchmark.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2024, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.benchmark.encoding;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Tests the performance of hex encoding.
+ * The results for OpenJDK 17.0.10 are as follows, so it looks like
+ * {@link Character#forDigit(int, int)} is the way to go.
+ * <pre>
+ * Benchmark                        (length)  Mode  Cnt    Score   Error  Units
+ * HexEncoding.character_fordigit        100  avgt   15  251,683 ± 0,292  ns/op
+ * HexEncoding.digit1_array_lookup       100  avgt   15  264,285 ± 0,215  ns/op
+ * HexEncoding.digit1_branchless         100  avgt   15  304,102 ± 0,361  ns/op
+ * HexEncoding.digit1_conditional        100  avgt   15  252,811 ± 1,458  ns/op
+ * HexEncoding.digit2_char_array         100  avgt   15  291,056 ± 2,524  ns/op
+ * HexEncoding.digit2_string_array       100  avgt   15  453,326 ± 5,742  ns/op
+ * HexEncoding.digit2_subarray           100  avgt   15  330,701 ± 2,523  ns/op
+ * </pre>
+ */
+@Fork(value = 3, jvmArgsPrepend = "-Xmx128m")
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@State(Scope.Thread)
+@Threads(1)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class HexEncodingBenchmark {
+
+  @Param({"100"})//{"1", "5", "10", "50", "100"})
+  public int length;
+
+  byte[] data;
+  StringBuilder sb = new StringBuilder();
+
+  private static final char[] HEX_DIGITS = "01234567890abcdef".toCharArray();
+  private static final String[] HEX_PAIRS = new String[256];
+  private static final char[][] HEX_CHAR_PAIRS = new char[256][];
+  private static final char[] HEX_CHAR_BIG_ARRAY;
+
+  static {
+    for (int i = 0; i < HEX_PAIRS.length; i++) {
+      HEX_PAIRS[i] = String.format("%02x", i);
+      HEX_CHAR_PAIRS[i] = HEX_PAIRS[i].toCharArray();
+    }
+    HEX_CHAR_BIG_ARRAY = String.join("", HEX_PAIRS).toCharArray();
+  }
+
+  @Setup
+  public void setup() {
+    data = new byte[length];
+    sb.ensureCapacity(length * 2);
+    ThreadLocalRandom.current().nextBytes(data);
+  }
+
+  @Setup(Level.Invocation)
+  public void clearBuffer() {
+    sb.setLength(0);
+  }
+
+  @Benchmark
+  public StringBuilder digit1_array_lookup() {
+    StringBuilder sb = this.sb;
+    char[] hexDigits = HEX_DIGITS;
+    for (byte b : data) {
+      sb.append(hexDigits[(b >> 4) & 0xF]);
+      sb.append(hexDigits[b & 0xF]);
+    }
+    return sb;
+  }
+
+  @Benchmark
+  public StringBuilder character_fordigit() {
+    StringBuilder sb = this.sb;
+    for (byte b : data) {
+      sb.append(Character.forDigit((b >> 4) & 0xF, 16));
+      sb.append(Character.forDigit(b & 0xF, 16));
+    }
+    return sb;
+  }
+
+  private static char digit_branchless(int digit) {
+    return (char) (87 + digit + (((digit - 10) >> 31) & -39));
+  }
+
+  @Benchmark
+  public StringBuilder digit1_branchless() {
+    StringBuilder sb = this.sb;
+    for (byte b : data) {
+      sb.append(digit_branchless((b >> 4) & 0xF));
+      sb.append(digit_branchless(b & 0xF));
+    }
+    return sb;
+  }
+
+  private static char digit_conditional(int digit) {
+    if (digit < 10) {
+      return (char) ('0' + digit);
+    }
+    return (char) ('a' - 10 + digit);
+  }
+
+  @Benchmark
+  public StringBuilder digit1_conditional() {
+    StringBuilder sb = this.sb;
+    for (byte b : data) {
+      sb.append(digit_conditional((b >> 4) & 0xF));
+      sb.append(digit_conditional(b & 0xF));
+    }
+    return sb;
+  }
+
+  @Benchmark
+  public StringBuilder digit2_string_array() {
+    StringBuilder sb = this.sb;
+    for (byte b : data) {
+      sb.append(HEX_PAIRS[b & 0xff]);
+    }
+    return sb;
+  }
+
+  @Benchmark
+  public StringBuilder digit2_char_array() {
+    StringBuilder sb = this.sb;
+    for (byte b : data) {
+      sb.append(HEX_CHAR_PAIRS[b & 0xff]);
+    }
+    return sb;
+  }
+
+  @Benchmark
+  public StringBuilder digit2_subarray() {
+    StringBuilder sb = this.sb;
+    for (byte b : data) {
+      int idx = (b & 0xff) * 2;
+      sb.append(HEX_CHAR_BIG_ARRAY, idx, 2);
+    }
+    return sb;
+  }
+
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder()
+        .include(HexEncodingBenchmark.class.getSimpleName())
+        //.addProfiler(GCProfiler.class)
+        .detectJvmArgs()
+        .build();
+
+    new Runner(opt).run();
+  }
+}

--- a/pgjdbc/src/main/java/org/postgresql/core/Utils.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/Utils.java
@@ -7,6 +7,7 @@
 package org.postgresql.core;
 
 import org.postgresql.util.GT;
+import org.postgresql.util.PGbytea;
 import org.postgresql.util.PSQLException;
 import org.postgresql.util.PSQLState;
 
@@ -27,10 +28,7 @@ public class Utils {
    */
   public static String toHexString(byte[] data) {
     StringBuilder sb = new StringBuilder(data.length * 2);
-    for (byte element : data) {
-      sb.append(Integer.toHexString((element >> 4) & 15));
-      sb.append(Integer.toHexString(element & 15));
-    }
+    PGbytea.appendHexString(sb, data, 0, data.length);
     return sb.toString();
   }
 

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/ArrayEncoding.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/ArrayEncoding.java
@@ -10,6 +10,7 @@ import org.postgresql.core.Encoding;
 import org.postgresql.core.Oid;
 import org.postgresql.util.ByteConverter;
 import org.postgresql.util.GT;
+import org.postgresql.util.PGbytea;
 import org.postgresql.util.PSQLException;
 import org.postgresql.util.PSQLState;
 
@@ -925,12 +926,6 @@ final class ArrayEncoding {
       Oid.BYTEA_ARRAY) {
 
     /**
-     * The possible characters to use for representing hex binary data.
-     */
-    private final char[] hexDigits = new char[]{'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd',
-        'e', 'f'};
-
-    /**
      * {@inheritDoc}
      */
     @Override
@@ -1025,14 +1020,7 @@ final class ArrayEncoding {
 
         if (array[i] != null) {
           sb.append("\"\\\\x");
-          for (int j = 0; j < array[i].length; j++) {
-            byte b = array[i][j];
-
-            // get the value for the left 4 bits (drop sign)
-            sb.append(hexDigits[(b & 0xF0) >>> 4]);
-            // get the value for the right 4 bits
-            sb.append(hexDigits[b & 0x0F]);
-          }
+          PGbytea.appendHexString(sb, array[i], 0, array[i].length);
           sb.append('"');
         } else {
           sb.append("NULL");

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BaseTest4.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BaseTest4.java
@@ -97,11 +97,6 @@ public class BaseTest4 {
     TestUtil.closeDB(con);
   }
 
-  public void assumeByteaSupported() {
-    Assume.assumeTrue("bytea is not supported in simple protocol execution mode",
-        preferQueryMode != PreferQueryMode.SIMPLE);
-  }
-
   public static void assumeCallableStatementsSupported(Connection con) throws SQLException {
     PreferQueryMode preferQueryMode = con.unwrap(PGConnection.class).getPreferQueryMode();
     Assume.assumeTrue("callable statements are not fully supported in simple protocol execution mode",

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ServerCursorTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ServerCursorTest.java
@@ -48,7 +48,6 @@ public class ServerCursorTest extends BaseTest4 {
   // Test regular cursor fetching
   @Test
   public void testBasicFetch() throws Exception {
-    assumeByteaSupported();
     createRows(1);
 
     PreparedStatement stmt =
@@ -69,7 +68,6 @@ public class ServerCursorTest extends BaseTest4 {
   // Test binary cursor fetching
   @Test
   public void testBinaryFetch() throws Exception {
-    assumeByteaSupported();
     createRows(1);
 
     PreparedStatement stmt =

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/UpdateableResultTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/UpdateableResultTest.java
@@ -308,7 +308,6 @@ public class UpdateableResultTest extends BaseTest4 {
 
   @Test
   public void testUpdateStreams() throws SQLException, UnsupportedEncodingException {
-    assumeByteaSupported();
     String string = "Hello";
     byte[] bytes = new byte[]{0, '\\', (byte) 128, (byte) 255};
 

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc3/Jdbc3CallableStatementTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc3/Jdbc3CallableStatementTest.java
@@ -492,7 +492,6 @@ public class Jdbc3CallableStatementTest extends BaseTest4 {
 
   @Test
   public void testGetBytes01() throws Throwable {
-    assumeByteaSupported();
     byte[] testdata = "TestData".getBytes();
     try {
       Statement stmt = con.createStatement();
@@ -663,7 +662,6 @@ public class Jdbc3CallableStatementTest extends BaseTest4 {
 
   @Test
   public void testGetBytes02() throws Throwable {
-    assumeByteaSupported();
     byte[] testdata = "TestData".getBytes();
     try {
       Statement stmt = con.createStatement();

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc4/BinaryStreamTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc4/BinaryStreamTest.java
@@ -25,7 +25,6 @@ public class BinaryStreamTest extends BaseTest4 {
   @Override
   public void setUp() throws Exception {
     super.setUp();
-    assumeByteaSupported();
     TestUtil.createTable(con, "images", "img bytea");
 
     Random random = new Random(31459);

--- a/pgjdbc/src/test/java/org/postgresql/test/util/BrokenInputStream.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/util/BrokenInputStream.java
@@ -28,4 +28,9 @@ public class BrokenInputStream extends InputStream {
 
     return is.read();
   }
+
+  @Override
+  public int available() throws IOException {
+    return is.available();
+  }
 }

--- a/pgjdbc/src/test/java/org/postgresql/test/util/ByteStreamWriterTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/util/ByteStreamWriterTest.java
@@ -29,7 +29,6 @@ public class ByteStreamWriterTest extends BaseTest4 {
   @Override
   public void setUp() throws Exception {
     super.setUp();
-    assumeByteaSupported();
     TestUtil.createTempTable(con, "images", "img bytea");
   }
 


### PR DESCRIPTION
This adds text encoding for `bytea`.

Interestingly, the tricks with `private final char[] hexDigits` do not improve performance, and we probably should stick with `Character.forDigit(...)` for `int -> hex` conversions.

----

Unfortunately, we have two different handling of "stream underflow" with `StreamWrapper` and `ByteStreamWriter`.

Both of them might report their lengths, and both of them might happen to underflow or overflow.

`PGStream` handles `StreamWrapper` as follows (see org.postgresql.core.PGStream#sendStream):
* If there's not enough data in the stream => raise "Premature end of input stream"
* If there's too much data => just ignore it

`PGStream` handles `ByteStreamWriter` as follows (see org.postgresql.core.PGStream#send(ByteStreamWriter)):
* If there's not enough data in the stream => append zeros
* If there's too much data => throw an error

Note: `ByteStreamWriter` works in a push manner, so we can't easily stop it, so "throwing an error" on overflow might be ok.

However, it is unfortunate we have different behaviours regarding "pad with zeros" vs "throw on underflow". I think we should raise an error on underflow in both cases.