### PR TITLE
Using `synchronized(this)` instead of `InternalLock` when writing to sockets

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/PGStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/PGStream.java
@@ -276,7 +276,7 @@ public class PGStream implements Closeable, Flushable {
 
     // Buffer sizes submitted by Sverre H Huseby <sverrehu@online.no>
     pgInput = new VisibleBufferedInputStream(connection.getInputStream(), 8192);
-    pgOutput = new BufferedOutputStream(connection.getOutputStream(), 8192);
+    pgOutput = new BufferedOutputStream(connection.getOutputStream(), 8192) {};
 
     if (encoding != null) {
       setEncoding(encoding);


### PR DESCRIPTION
Currently when inserting with rewritten batches a lot of CPU is spent on `lock()`/`unlock()` calls of `BufferedOutputStream` on writing of each _value_.

Proposed changes switch internal implementation of `BufferedOutputStream` to use `syncronized(this)` instead of `InternalLock`

If synchronization is not needed then a better approach would be using of custom implementation.