### PR TITLE
perf: optimize Set<Integer> which are used for checking if oid should be transferred with binary or text

### DIFF
--- a/benchmarks/build.gradle.kts
+++ b/benchmarks/build.gradle.kts
@@ -13,6 +13,7 @@ dependencies {
     jmhImplementation(project(":postgresql"))
     jmhImplementation(testFixtures(project(":postgresql")))
     jmhImplementation("org.roaringbitmap:RoaringBitmap:1.0.6")
+    jmhImplementation("it.unimi.dsi:fastutil:8.5.13")
     jmhRuntimeOnly("com.ongres.scram:client:2.1")
     jmhImplementation("org.openjdk.jmh:jmh-core:1.37")
     jmhImplementation("org.openjdk.jmh:jmh-generator-annprocess:1.37")

--- a/benchmarks/build.gradle.kts
+++ b/benchmarks/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
     // Make jmhCompileClasspath resolvable
     jmhImplementation(project(":postgresql"))
     jmhImplementation(testFixtures(project(":postgresql")))
+    jmhImplementation("org.roaringbitmap:RoaringBitmap:1.0.6")
     jmhRuntimeOnly("com.ongres.scram:client:2.1")
     jmhImplementation("org.openjdk.jmh:jmh-core:1.37")
     jmhImplementation("org.openjdk.jmh:jmh-generator-annprocess:1.37")

--- a/benchmarks/src/jmh/java/org/postgresql/benchmark/util/IntSetBenchmark.java
+++ b/benchmarks/src/jmh/java/org/postgresql/benchmark/util/IntSetBenchmark.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2024, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.benchmark.util;
+
+import org.postgresql.core.Oid;
+import org.postgresql.util.internal.IntSet;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.roaringbitmap.RoaringBitmap;
+
+import java.util.Arrays;
+import java.util.BitSet;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Tests the performance of hex encoding. The results for OpenJDK 17.0.10 are as follows, so it
+ * looks like {@link Character#forDigit(int, int)} is the way to go.
+ * Here's a result for Apple M1 Max, Java 17.0.10, ARM64.
+ * 23 is present in the set, 73 and 123456 are both absent.
+ * <pre>
+ * Benchmark                          (oid)  Mode  Cnt  Score   Error  Units
+ * IntSetBenchmark.bitset_contains       23  avgt   15  0,990 ± 0,011  ns/op
+ * IntSetBenchmark.bitset_contains       73  avgt   15  1,023 ± 0,049  ns/op
+ * IntSetBenchmark.bitset_contains   123456  avgt   15  0,687 ± 0,008  ns/op
+ * IntSetBenchmark.hashset_contains      23  avgt   15  2,040 ± 0,029  ns/op
+ * IntSetBenchmark.hashset_contains      73  avgt   15  1,993 ± 0,017  ns/op
+ * IntSetBenchmark.hashset_contains  123456  avgt   15  1,959 ± 0,025  ns/op
+ * IntSetBenchmark.intset_contains       23  avgt   15  1,138 ± 0,030  ns/op
+ * IntSetBenchmark.intset_contains       73  avgt   15  1,165 ± 0,013  ns/op
+ * IntSetBenchmark.intset_contains   123456  avgt   15  0,653 ± 0,012  ns/op
+ * IntSetBenchmark.roaring_contains      23  avgt   15  5,008 ± 0,045  ns/op
+ * IntSetBenchmark.roaring_contains      73  avgt   15  5,557 ± 0,056  ns/op
+ * IntSetBenchmark.roaring_contains  123456  avgt   15  1,165 ± 0,010  ns/op
+ * </pre>
+ */
+@Fork(value = 3, jvmArgsPrepend = "-Xmx128m")
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@State(Scope.Thread)
+@Threads(1)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class IntSetBenchmark {
+  /**
+   * See {@code PgConnection#getSupportedBinaryOids()}.
+   */
+  private static final Collection<? extends Integer> SUPPORTED_BINARY_OIDS = Arrays.asList(
+      Oid.BYTEA,
+      Oid.INT2,
+      Oid.INT4,
+      Oid.INT8,
+      Oid.FLOAT4,
+      Oid.FLOAT8,
+      Oid.NUMERIC,
+      Oid.TIME,
+      Oid.DATE,
+      Oid.TIMETZ,
+      Oid.TIMESTAMP,
+      Oid.TIMESTAMPTZ,
+      Oid.BYTEA_ARRAY,
+      Oid.INT2_ARRAY,
+      Oid.INT4_ARRAY,
+      Oid.INT8_ARRAY,
+      Oid.OID_ARRAY,
+      Oid.FLOAT4_ARRAY,
+      Oid.FLOAT8_ARRAY,
+      Oid.VARCHAR_ARRAY,
+      Oid.TEXT_ARRAY,
+      Oid.POINT,
+      Oid.BOX,
+      Oid.UUID);
+
+  IntSet intSet = new IntSet();
+  BitSet bitSet = new BitSet();
+  Set<Integer> hashSet = new HashSet<>();
+  RoaringBitmap roaringBitmap = new RoaringBitmap();
+
+  @Param({"23", "73", "123456"})
+  int oid;
+
+  @Setup
+  public void setup() {
+    intSet.addAll(SUPPORTED_BINARY_OIDS);
+    hashSet.addAll(SUPPORTED_BINARY_OIDS);
+    for (Integer oid : SUPPORTED_BINARY_OIDS) {
+      bitSet.set(oid);
+      roaringBitmap.add(oid);
+    }
+  }
+
+  @Benchmark
+  public boolean intset_contains() {
+    return intSet.contains(oid);
+  }
+
+  @Benchmark
+  public boolean bitset_contains() {
+    return bitSet.get(oid);
+  }
+
+  @Benchmark
+  public boolean hashset_contains() {
+    return hashSet.contains(oid);
+  }
+
+  @Benchmark
+  public boolean roaring_contains() {
+    return roaringBitmap.contains(oid);
+  }
+
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder()
+        .include(IntSetBenchmark.class.getSimpleName())
+        //.addProfiler(GCProfiler.class)
+        .detectJvmArgs()
+        .build();
+
+    new Runner(opt).run();
+  }
+}

--- a/benchmarks/src/jmh/java/org/postgresql/benchmark/util/IntSetBenchmark.java
+++ b/benchmarks/src/jmh/java/org/postgresql/benchmark/util/IntSetBenchmark.java
@@ -8,6 +8,7 @@ package org.postgresql.benchmark.util;
 import org.postgresql.core.Oid;
 import org.postgresql.util.internal.IntSet;
 
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -39,19 +40,22 @@ import java.util.concurrent.TimeUnit;
  * Here's a result for Apple M1 Max, Java 17.0.10, ARM64.
  * 23 is present in the set, 73 and 123456 are both absent.
  * <pre>
- * Benchmark                          (oid)  Mode  Cnt  Score   Error  Units
- * IntSetBenchmark.bitset_contains       23  avgt   15  0,990 ± 0,011  ns/op
- * IntSetBenchmark.bitset_contains       73  avgt   15  1,023 ± 0,049  ns/op
- * IntSetBenchmark.bitset_contains   123456  avgt   15  0,687 ± 0,008  ns/op
- * IntSetBenchmark.hashset_contains      23  avgt   15  2,040 ± 0,029  ns/op
- * IntSetBenchmark.hashset_contains      73  avgt   15  1,993 ± 0,017  ns/op
- * IntSetBenchmark.hashset_contains  123456  avgt   15  1,959 ± 0,025  ns/op
- * IntSetBenchmark.intset_contains       23  avgt   15  1,138 ± 0,030  ns/op
- * IntSetBenchmark.intset_contains       73  avgt   15  1,165 ± 0,013  ns/op
- * IntSetBenchmark.intset_contains   123456  avgt   15  0,653 ± 0,012  ns/op
- * IntSetBenchmark.roaring_contains      23  avgt   15  5,008 ± 0,045  ns/op
- * IntSetBenchmark.roaring_contains      73  avgt   15  5,557 ± 0,056  ns/op
- * IntSetBenchmark.roaring_contains  123456  avgt   15  1,165 ± 0,010  ns/op
+ * Benchmark                             (oid)  Mode  Cnt  Score   Error  Units
+ * IntSetBenchmark.bitSet_contains          23  avgt   15  0,984 ± 0,009  ns/op
+ * IntSetBenchmark.bitSet_contains          73  avgt   15  0,979 ± 0,005  ns/op
+ * IntSetBenchmark.bitSet_contains      123456  avgt   15  0,688 ± 0,015  ns/op
+ * IntSetBenchmark.hashSet_contains         23  avgt   15  2,026 ± 0,013  ns/op
+ * IntSetBenchmark.hashSet_contains         73  avgt   15  1,985 ± 0,004  ns/op
+ * IntSetBenchmark.hashSet_contains     123456  avgt   15  1,968 ± 0,032  ns/op
+ * IntSetBenchmark.intOpenSet_contains      23  avgt   15  1,015 ± 0,011  ns/op
+ * IntSetBenchmark.intOpenSet_contains      73  avgt   15  5,720 ± 0,596  ns/op
+ * IntSetBenchmark.intOpenSet_contains  123456  avgt   15  8,430 ± 0,007  ns/op
+ * IntSetBenchmark.intSet_contains          23  avgt   15  1,101 ± 0,009  ns/op
+ * IntSetBenchmark.intSet_contains          73  avgt   15  1,117 ± 0,005  ns/op
+ * IntSetBenchmark.intSet_contains      123456  avgt   15  0,693 ± 0,010  ns/op
+ * IntSetBenchmark.roaring_contains         23  avgt   15  5,012 ± 0,044  ns/op
+ * IntSetBenchmark.roaring_contains         73  avgt   15  5,561 ± 0,077  ns/op
+ * IntSetBenchmark.roaring_contains     123456  avgt   15  1,163 ± 0,012  ns/op
  * </pre>
  */
 @Fork(value = 3, jvmArgsPrepend = "-Xmx128m")
@@ -95,6 +99,7 @@ public class IntSetBenchmark {
   BitSet bitSet = new BitSet();
   Set<Integer> hashSet = new HashSet<>();
   RoaringBitmap roaringBitmap = new RoaringBitmap();
+  IntOpenHashSet intOpenHashSet = new IntOpenHashSet();
 
   @Param({"23", "73", "123456"})
   int oid;
@@ -106,27 +111,33 @@ public class IntSetBenchmark {
     for (Integer oid : SUPPORTED_BINARY_OIDS) {
       bitSet.set(oid);
       roaringBitmap.add(oid);
+      intOpenHashSet.add((int) oid);
     }
   }
 
   @Benchmark
-  public boolean intset_contains() {
+  public boolean intSet_contains() {
     return intSet.contains(oid);
   }
 
   @Benchmark
-  public boolean bitset_contains() {
+  public boolean bitSet_contains() {
     return bitSet.get(oid);
   }
 
   @Benchmark
-  public boolean hashset_contains() {
+  public boolean hashSet_contains() {
     return hashSet.contains(oid);
   }
 
   @Benchmark
   public boolean roaring_contains() {
     return roaringBitmap.contains(oid);
+  }
+
+  @Benchmark
+  public boolean intOpenSet_contains() {
+    return intOpenHashSet.contains(oid);
   }
 
   public static void main(String[] args) throws RunnerException {

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -48,6 +48,7 @@ import org.postgresql.util.PSQLState;
 import org.postgresql.util.PSQLWarning;
 import org.postgresql.util.ServerErrorMessage;
 import org.postgresql.util.internal.SourceStreamIOException;
+import org.postgresql.util.internal.IntSet;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -123,12 +124,12 @@ public class QueryExecutorImpl extends QueryExecutorBase {
   /**
    * Bit set that has a bit set for each oid which should be received using binary format.
    */
-  private final Set<Integer> useBinaryReceiveForOids = new HashSet<>();
+  private final IntSet useBinaryReceiveForOids = new IntSet();
 
   /**
    * Bit set that has a bit set for each oid which should be sent using binary format.
    */
-  private final Set<Integer> useBinarySendForOids = new HashSet<>();
+  private final IntSet useBinarySendForOids = new IntSet();
 
   /**
    * This is a fake query object so processResults can distinguish "ReadyForQuery" messages
@@ -2990,7 +2991,7 @@ public class QueryExecutorImpl extends QueryExecutorBase {
   public Set<? extends Integer> getBinaryReceiveOids() {
     // copy the values to prevent ConcurrentModificationException when reader accesses the elements
     synchronized (useBinaryReceiveForOids) {
-      return new HashSet<>(useBinaryReceiveForOids);
+      return new HashSet<>(useBinaryReceiveForOids.asSet());
     }
   }
 
@@ -3028,7 +3029,7 @@ public class QueryExecutorImpl extends QueryExecutorBase {
   public Set<? extends Integer> getBinarySendOids() {
     // copy the values to prevent ConcurrentModificationException when reader accesses the elements
     synchronized (useBinarySendForOids) {
-      return new HashSet<>(useBinarySendForOids);
+      return new HashSet<>(useBinarySendForOids.asSet());
     }
   }
 

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -47,8 +47,8 @@ import org.postgresql.util.PSQLException;
 import org.postgresql.util.PSQLState;
 import org.postgresql.util.PSQLWarning;
 import org.postgresql.util.ServerErrorMessage;
-import org.postgresql.util.internal.SourceStreamIOException;
 import org.postgresql.util.internal.IntSet;
+import org.postgresql.util.internal.SourceStreamIOException;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -67,7 +67,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
@@ -2991,7 +2990,7 @@ public class QueryExecutorImpl extends QueryExecutorBase {
   public Set<? extends Integer> getBinaryReceiveOids() {
     // copy the values to prevent ConcurrentModificationException when reader accesses the elements
     synchronized (useBinaryReceiveForOids) {
-      return new HashSet<>(useBinaryReceiveForOids.asSet());
+      return useBinaryReceiveForOids.toMutableSet();
     }
   }
 
@@ -3029,7 +3028,7 @@ public class QueryExecutorImpl extends QueryExecutorBase {
   public Set<? extends Integer> getBinarySendOids() {
     // copy the values to prevent ConcurrentModificationException when reader accesses the elements
     synchronized (useBinarySendForOids) {
-      return new HashSet<>(useBinarySendForOids.asSet());
+      return useBinarySendForOids.toMutableSet();
     }
   }
 

--- a/pgjdbc/src/main/java/org/postgresql/util/internal/IntSet.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/internal/IntSet.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2024, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.util.internal;
+
+import org.postgresql.core.Oid;
+
+import java.util.BitSet;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Read-optimized {@code Set} for storing {@link Oid} values.
+ */
+public class IntSet {
+  /**
+   * Maximal Oid that will bs stored in {@link BitSet}.
+   * If Oid exceeds this value, then it will be stored in {@code Set<Int>} only.
+   * In theory, Oids can be up to 32bit, so we want to limit per-connection memory utilization.
+   * Allow {@code BitSet} to consume up to 8KiB (one for send and one for receive).
+   */
+  private static final int MAX_OID_TO_STORE_IN_BITSET = 8192 * 8;
+
+  /**
+   * Contains all the values.
+   * Note: we could skip storing small values in ths set, however,
+   * it would slow down {@link #asSet()}.
+   */
+  private final Set<Integer> set = new HashSet<>();
+
+  /**
+   * Contains values in range of [0..MAX_OID_TO_STORE_IN_BITSET].
+   */
+  private final BitSet bitSet = new BitSet();
+
+  /**
+   * Is true in case {@link #bitSet} misses some of the values stored in {@link #set}.
+   */
+  private boolean lossy;
+
+  /**
+   * Clears the contents of the set.
+   */
+  public void clear() {
+    set.clear();
+    bitSet.clear();
+    lossy = false;
+  }
+
+  /**
+   * Adds all the values to the set.
+   * @param values set of values to add
+   */
+  public void addAll(Collection<? extends Integer> values) {
+    set.addAll(values);
+    for (Integer value : values) {
+      if (value <= MAX_OID_TO_STORE_IN_BITSET) {
+        bitSet.set(value);
+      } else {
+        lossy = true;
+      }
+    }
+  }
+
+  /**
+   * Adds a single value to the set.
+   *
+   * @param value value to add
+   * @return true if the set did not already contain the specified value
+   */
+  public boolean add(int value) {
+    if (value >= 0 && value <= MAX_OID_TO_STORE_IN_BITSET) {
+      bitSet.set(value);
+    } else {
+      lossy = true;
+    }
+    return set.add(value);
+  }
+
+  /**
+   * Removes a value from the set.
+   * @param value value to remove
+   * @return true if the element was
+   */
+  public boolean remove(int value) {
+    bitSet.clear(value);
+    return set.remove(value);
+  }
+
+  /**
+   * Checks if a given value belongs to the set.
+   * @param value value to check
+   * @return true if the value belons to the set
+   */
+  public boolean contains(int value) {
+    if (value >= 0 && value <= MAX_OID_TO_STORE_IN_BITSET) {
+      return bitSet.get(value);
+    } else if (!lossy) {
+      // We know bitSet contains all the values, so values exceeding its limits are absent
+      return false;
+    }
+    return set.contains(value);
+  }
+
+  /**
+   * Returns {@link Set} view of the current set.
+   * @return Set view
+   */
+  public Set<? extends Integer> asSet() {
+    return set;
+  }
+}

--- a/pgjdbc/src/main/java/org/postgresql/util/internal/IntSet.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/internal/IntSet.java
@@ -17,7 +17,7 @@ import java.util.Set;
 /**
  * Read-optimized {@code Set} for storing {@link Oid} values.
  */
-public class IntSet {
+public final class IntSet {
   /**
    * Maximal Oid that will bs stored in {@link BitSet}.
    * If Oid exceeds this value, then it will be stored in {@code Set<Int>} only.

--- a/pgjdbc/src/main/java/org/postgresql/util/internal/IntSet.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/internal/IntSet.java
@@ -16,6 +16,7 @@ import java.util.Set;
 
 /**
  * Read-optimized {@code Set} for storing {@link Oid} values.
+ * Note: the set does not support nullable values.
  */
 public final class IntSet {
   /**

--- a/pgjdbc/src/test/java/org/postgresql/util/internal/IntSetTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/util/internal/IntSetTest.java
@@ -49,11 +49,22 @@ public class IntSetTest {
   @ParameterizedTest
   @ValueSource(ints = {Oid.UNSPECIFIED, Oid.INT4, Oid.BYTEA, Oid.VARCHAR, Integer.MIN_VALUE,
       Integer.MAX_VALUE})
-  void does_not_contain_other_values(int oid) {
+  void compact_does_not_contain_other_values(int oid) {
     intSet.add(Oid.INT8);
     intSet.add(Oid.BIT);
     assertFalse(intSet.contains(oid),
         () -> "intset contains only INT8 and BIT, so it should not contain oid " + oid);
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {Oid.UNSPECIFIED, Oid.INT4, Oid.BYTEA, Oid.VARCHAR, Integer.MIN_VALUE,
+      Integer.MAX_VALUE})
+  void non_compact_does_not_contain_other_values(int oid) {
+    intSet.add(Oid.INT8);
+    intSet.add(Oid.BIT);
+    intSet.add(23465234);
+    assertFalse(intSet.contains(oid),
+        () -> "intset contains only INT8, BIT, and 23465234, so it should not contain oid " + oid);
   }
 
   @Test
@@ -68,9 +79,22 @@ public class IntSetTest {
 
   @Test
   void addAll_does_not_contains_other_values() {
-    List<Integer> values = Arrays.asList(Oid.UNSPECIFIED, Oid.INT4, Oid.BYTEA, Oid.VARCHAR);
+    List<Integer> values = Arrays.asList(Oid.UNSPECIFIED, Oid.INT4, Oid.BYTEA, Oid.VARCHAR,
+        Integer.MIN_VALUE, Integer.MAX_VALUE);
     intSet.addAll(values);
     assertFalse(intSet.contains(Oid.BIT),
         () -> "intset should not contain BIT after addAll(" + values + ")");
+
+    assertFalse(intSet.contains(2736453),
+        () -> "intset should not contain 2736453 after addAll(" + values + ")");
+
+    assertFalse(intSet.contains(-2736453),
+        () -> "intset should not contain -2736453 after addAll(" + values + ")");
+  }
+
+  @Test
+  void toMutableSet_contains_all_values() {
+    List<Integer> values = Arrays.asList(Oid.UNSPECIFIED, Oid.INT4, Oid.BYTEA, Oid.VARCHAR, 24337);
+    intSet.addAll(values);
   }
 }

--- a/pgjdbc/src/test/java/org/postgresql/util/internal/IntSetTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/util/internal/IntSetTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2024, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.util.internal;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.postgresql.core.Oid;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class IntSetTest {
+  private final IntSet intSet = new IntSet();
+
+  @ParameterizedTest
+  @ValueSource(ints = {Oid.UNSPECIFIED, Oid.INT4, Oid.BYTEA, Oid.VARCHAR, Integer.MIN_VALUE,
+      Integer.MAX_VALUE})
+  void empty_contains_no_values(int oid) {
+    assertFalse(intSet.contains(oid), () -> "empty intset should not contain oid " + oid);
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {Oid.UNSPECIFIED, Oid.INT4, Oid.BYTEA, Oid.VARCHAR, Integer.MIN_VALUE,
+      Integer.MAX_VALUE})
+  void contains_added_value(int oid) {
+    intSet.add(oid);
+    assertTrue(intSet.contains(oid),
+        () -> "intset should contain the oid that was just added: " + oid);
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {Oid.UNSPECIFIED, Oid.INT4, Oid.BYTEA, Oid.VARCHAR, Integer.MIN_VALUE,
+      Integer.MAX_VALUE})
+  void clear_removes_elements(int oid) {
+    intSet.add(oid);
+    intSet.clear();
+    assertFalse(intSet.contains(oid),
+        () -> "intset should contain oid " + oid + " after .clear()");
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {Oid.UNSPECIFIED, Oid.INT4, Oid.BYTEA, Oid.VARCHAR, Integer.MIN_VALUE,
+      Integer.MAX_VALUE})
+  void does_not_contain_other_values(int oid) {
+    intSet.add(Oid.INT8);
+    intSet.add(Oid.BIT);
+    assertFalse(intSet.contains(oid),
+        () -> "intset contains only INT8 and BIT, so it should not contain oid " + oid);
+  }
+
+  @Test
+  void addAll_contains_all_values() {
+    List<Integer> values = Arrays.asList(Oid.UNSPECIFIED, Oid.INT4, Oid.BYTEA, Oid.VARCHAR);
+    intSet.addAll(values);
+    for (Integer value : values) {
+      assertTrue(intSet.contains(value),
+          () -> "intset should contain oid " + value + " after addAdd(" + values + ")");
+    }
+  }
+
+  @Test
+  void addAll_does_not_contains_other_values() {
+    List<Integer> values = Arrays.asList(Oid.UNSPECIFIED, Oid.INT4, Oid.BYTEA, Oid.VARCHAR);
+    intSet.addAll(values);
+    assertFalse(intSet.contains(Oid.BIT),
+        () -> "intset should not contain BIT after addAll(" + values + ")");
+  }
+}


### PR DESCRIPTION
It looks like BitSet is faster than HashSet, so let's use it.

Unfortunately, BitSet would consume memory in case the Oid value is high, and Oids can be up to 32bit, so we limit the max OID stored in a BitSet with 8192*8, so we effectively limit the extra per-connection memory by 16KiB (8KiB for send and 8KiB for receive)

The current maximum id is 2950 (UUID), so the added overhead is about 800 bytes per connection.

Here are benchmark results with Apple M1 Max, Java 17.0.10 ARM64.

The diff is about 1ns per operation (I guess it is negligible), however, the fix makes "useBinaryForSend" disappear from async profiler results, so it might be a net win. It would be great to make an end-to-end measurement somehow (e.g. CPU% for the app)

23 is present in the set, 73 and 123456 are both absent.

```
<pre>
Benchmark                             (oid)  Mode  Cnt  Score   Error  Units
IntSetBenchmark.bitSet_contains          23  avgt   15  0,984 ± 0,009  ns/op
IntSetBenchmark.bitSet_contains          73  avgt   15  0,979 ± 0,005  ns/op
IntSetBenchmark.bitSet_contains      123456  avgt   15  0,688 ± 0,015  ns/op

IntSetBenchmark.hashSet_contains         23  avgt   15  2,026 ± 0,013  ns/op
IntSetBenchmark.hashSet_contains         73  avgt   15  1,985 ± 0,004  ns/op
IntSetBenchmark.hashSet_contains     123456  avgt   15  1,968 ± 0,032  ns/op

IntSetBenchmark.intSet_contains          23  avgt   15  1,101 ± 0,009  ns/op
IntSetBenchmark.intSet_contains          73  avgt   15  1,117 ± 0,005  ns/op
IntSetBenchmark.intSet_contains      123456  avgt   15  0,693 ± 0,010  ns/op

IntSetBenchmark.intOpenSet_contains      23  avgt   15  1,015 ± 0,011  ns/op
IntSetBenchmark.intOpenSet_contains      73  avgt   15  5,720 ± 0,596  ns/op
IntSetBenchmark.intOpenSet_contains  123456  avgt   15  8,430 ± 0,007  ns/op

IntSetBenchmark.roaring_contains         23  avgt   15  5,012 ± 0,044  ns/op
IntSetBenchmark.roaring_contains         73  avgt   15  5,561 ± 0,077  ns/op
IntSetBenchmark.roaring_contains     123456  avgt   15  1,163 ± 0,012  ns/op
```

/cc @plokhotnyuk