### PR TITLE
perf: avoid extra copies when receiving int4 and int2 in PGStream

### DIFF
--- a/benchmarks/src/jmh/java/org/postgresql/benchmark/stream/StreamReceiveInteger.java
+++ b/benchmarks/src/jmh/java/org/postgresql/benchmark/stream/StreamReceiveInteger.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2023, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.benchmark.stream;
+
+import org.postgresql.core.VisibleBufferedInputStream;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.io.ByteArrayInputStream;
+import java.util.concurrent.TimeUnit;
+
+@Fork(value = 5, jvmArgsPrepend = "-Xmx128m")
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class StreamReceiveInteger {
+
+  private byte[] integerData;
+
+  @Setup
+  public void setUp() throws Exception {
+    // we only use a fixed buffer size of 8192 (8 KB)
+    integerData = new byte[8192];
+
+    for (int i = 0; i < integerData.length; i += 2) {
+      int value = i / 2;
+      integerData[i] = (byte) (value >> 8);
+      integerData[i + 1] = (byte) (value & 0xFF);
+    }
+  }
+
+  @Benchmark
+  public void readInt4Benchmark(Blackhole bh) throws Exception {
+    // We can't reuse the stream, so we need to create it in a benchmark method
+    VisibleBufferedInputStream bufferedInputStream =
+        new VisibleBufferedInputStream(
+            new ByteArrayInputStream(integerData), integerData.length);
+    for (int i = 0; i < integerData.length / 4; i++) {
+      int value = bufferedInputStream.readInt4();
+      bh.consume(value);
+    }
+  }
+
+  @Benchmark
+  public void readInt2Benchmark(Blackhole bh) throws Exception {
+    // We can't reuse the stream, so we need to create it in a benchmark method
+    VisibleBufferedInputStream bufferedInputStream =
+        new VisibleBufferedInputStream(
+            new ByteArrayInputStream(integerData), integerData.length);
+    for (int i = 0; i < integerData.length / 2; i++) {
+      int value = bufferedInputStream.readInt2();
+      bh.consume(value);
+    }
+  }
+
+  @Benchmark
+  public void readInt1Benchmark(Blackhole bh) throws Exception {
+    // We can't reuse the stream, so we need to create it in a benchmark method
+    VisibleBufferedInputStream bufferedInputStream =
+        new VisibleBufferedInputStream(
+            new ByteArrayInputStream(integerData), integerData.length);
+    for (int i = 0; i < integerData.length; i++) {
+      int value = bufferedInputStream.read();
+      bh.consume(value);
+    }
+  }
+
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder()
+        .include(StreamReceiveInteger.class.getSimpleName())
+        .detectJvmArgs()
+        .build();
+
+    new Runner(opt).run();
+  }
+}

--- a/pgjdbc/src/main/java/org/postgresql/core/PGStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/PGStream.java
@@ -49,10 +49,6 @@ public class PGStream implements Closeable, Flushable {
   private final SocketFactory socketFactory;
   private final HostSpec hostSpec;
   private final int maxSendBufferSize;
-
-  private final byte[] int4Buf;
-  private final byte[] int2Buf;
-
   private Socket connection;
   private VisibleBufferedInputStream pgInput;
   private PgBufferedOutputStream pgOutput;
@@ -125,9 +121,6 @@ public class PGStream implements Closeable, Flushable {
     Socket socket = createSocket(timeout);
     changeSocket(socket);
     setEncoding(Encoding.getJVMEncoding("UTF-8"));
-
-    int2Buf = new byte[2];
-    int4Buf = new byte[4];
   }
 
   @SuppressWarnings({"method.invocation", "initialization.fields.uninitialized"})
@@ -171,10 +164,6 @@ public class PGStream implements Closeable, Flushable {
     setNetworkTimeout(soTimeout);
     socket.setKeepAlive(keepAlive);
     socket.setTcpNoDelay(tcpNoDelay);
-
-    int2Buf = new byte[2];
-    int4Buf = new byte[4];
-
   }
 
   /**
@@ -498,26 +487,17 @@ public class PGStream implements Closeable, Flushable {
    * @throws IOException if an I/O error occurs
    */
   public int receiveInteger4() throws IOException {
-    if (pgInput.read(int4Buf) != 4) {
-      throw new EOFException();
-    }
-
-    return (int4Buf[0] & 0xFF) << 24 | (int4Buf[1] & 0xFF) << 16 | (int4Buf[2] & 0xFF) << 8
-        | int4Buf[3] & 0xFF;
+    return pgInput.readInt4();
   }
 
   /**
-   * Receives a two byte integer from the backend.
+   * Receives a two byte integer from the backend as an unsigned integer (0..65535).
    *
    * @return the integer received from the backend
    * @throws IOException if an I/O error occurs
    */
   public int receiveInteger2() throws IOException {
-    if (pgInput.read(int2Buf) != 2) {
-      throw new EOFException();
-    }
-
-    return (int2Buf[0] & 0xFF) << 8 | int2Buf[1] & 0xFF;
+    return pgInput.readInt2();
   }
 
   /**

--- a/pgjdbc/src/main/java/org/postgresql/core/VisibleBufferedInputStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/VisibleBufferedInputStream.java
@@ -5,6 +5,8 @@
 
 package org.postgresql.core;
 
+import org.postgresql.util.ByteConverter;
+
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -75,6 +77,34 @@ public class VisibleBufferedInputStream extends InputStream {
       return buffer[index++] & 0xFF;
     }
     return -1;
+  }
+
+  /**
+   * Reads an int2 value from the underlying stream as an unsigned integer (0..65535).
+   * @return int2 in the range of 0..65535
+   * @throws IOException if an I/ O error occurs.
+   */
+  public int readInt2() throws IOException {
+    if (ensureBytes(2)) {
+      int res = ByteConverter.int2(buffer, index) & 0xffff;
+      index += 2;
+      return res;
+    }
+    throw new EOFException("End of stream reached while trying to read integer2");
+  }
+
+  /**
+   * Reads an int4 value from the underlying stream.
+   * @return int4 value from the underlying stream
+   * @throws IOException if an I/ O error occurs.
+   */
+  public int readInt4() throws IOException {
+    if (ensureBytes(4)) {
+      int res = ByteConverter.int4(buffer, index);
+      index += 4;
+      return res;
+    }
+    throw new EOFException("End of stream reached while trying to read integer4");
   }
 
   /**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes to Existing Features:

This PR is for #3250 
I have moved receiveInteger2 and receiveInteger4 to VisibleBufferedInputStream. 
Within PGStream, I have also removed dependency on int4buf and int2buf by directly writing value to OutputStream inside sendInteger2 and sendInteger4
* [x] Have you successfully run tests with your changes locally?


Based on reviews, can further add tests and documentation for the new methods