### PR TITLE
fix: SQLWarnings returned on successful SQL statements issue #3300

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgStatement.java
@@ -255,7 +255,10 @@ public class PgStatement implements Statement, BaseStatement {
 
     @Override
     public void handleWarning(SQLWarning warning) {
-      PgStatement.this.addWarning(warning);
+      // if it starts with 00 it means successful completion and not a warning
+      if (!warning.getSQLState().startsWith("00")) {
+        PgStatement.this.addWarning(warning);
+      }
     }
 
   }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/StatementTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/StatementTest.java
@@ -107,6 +107,15 @@ class StatementTest {
   }
 
   @Test
+  void testNoWarningOnSQLState00() throws SQLException {
+    try (Statement stmt = con.createStatement()) {
+      stmt.execute("drop table if exists nonexistent");
+      SQLWarning warning = stmt.getWarnings();
+      assertNull(warning);
+    }
+  }
+
+  @Test
   void resultSetClosed() throws SQLException {
     Statement stmt = con.createStatement();
     ResultSet rs = stmt.executeQuery("select 1");


### PR DESCRIPTION
The server sends a notice response for successful SQL statements. Previously we have been generating SQLWarnings on this. 
There is no reason to and doing so causes useless warnings to be logged.
see https://hibernate.atlassian.net/browse/HHH-18296