### PR TITLE
Add support for Infinity::numeric values in ResultSet.getObject

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/util/ByteConverter.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/ByteConverter.java
@@ -135,7 +135,7 @@ public class ByteConverter {
     //0 based number of 4 decimal digits (i.e. 2-byte shorts) before the decimal
     //a value <= 0 indicates an absolute value < 1.
     short weight = ByteConverter.int2(bytes, pos + 2);
-    //indicates positive, negative or NaN
+    //indicates positive, negative, NaN, Infinity or -Infinity
     short sign = ByteConverter.int2(bytes, pos + 4);
     //number of digits after the decimal. This must be >= 0.
     //a value of 0 indicates a whole number (integer).

--- a/pgjdbc/src/main/java/org/postgresql/util/ByteConverter.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/ByteConverter.java
@@ -59,6 +59,8 @@ public class ByteConverter {
   private static final short NUMERIC_POS = 0x0000;
   private static final short NUMERIC_NEG = 0x4000;
   private static final short NUMERIC_NAN = (short) 0xC000;
+  private static final short NUMERIC_PINF = (short) 0xD000;
+  private static final short NUMERIC_NINF = (short) 0xF000;
   private static final int SHORT_BYTES = 2;
   private static final int LONG_BYTES = 4;
   private static final int[] INT_TEN_POWERS = new int[6];
@@ -113,13 +115,14 @@ public class ByteConverter {
 
   /**
    * Convert a variable length array of bytes to a {@link Number}. The result will
-   * always be a {@link BigDecimal} or {@link Double#NaN}.
+   * always be a {@link BigDecimal} or a special {@link Double} value.
    *
    * @param bytes array of bytes to be decoded from binary numeric representation.
    * @param pos index of the start position of the bytes array for number
    * @param numBytes number of bytes to use, length is already encoded
    *                in the binary format but this is used for double checking
-   * @return BigDecimal representation of numeric or {@link Double#NaN}.
+   * @return BigDecimal representation of numeric or one of the special double values
+   *     {@link Double#NaN}, {@link Double#NEGATIVE_INFINITY} and {@link Double#POSITIVE_INFINITY}.
    */
   public static Number numeric(byte [] bytes, int pos, int numBytes) {
 
@@ -157,14 +160,18 @@ public class ByteConverter {
       throw new IllegalArgumentException("invalid length of bytes \"numeric\" value");
     }
 
-    if (!(sign == NUMERIC_POS
-        || sign == NUMERIC_NEG
-        || sign == NUMERIC_NAN)) {
-      throw new IllegalArgumentException("invalid sign in \"numeric\" value");
-    }
-
-    if (sign == NUMERIC_NAN) {
-      return Double.NaN;
+    switch (sign) {
+      case NUMERIC_POS:
+      case NUMERIC_NEG:
+        break;
+      case NUMERIC_NAN:
+        return Double.NaN;
+      case NUMERIC_PINF:
+        return Double.POSITIVE_INFINITY;
+      case NUMERIC_NINF:
+        return Double.NEGATIVE_INFINITY;
+      default:
+        throw new IllegalArgumentException("invalid sign in \"numeric\" value");
     }
 
     if ((scale & NUMERIC_DSCALE_MASK) != scale) {

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PreparedStatementTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PreparedStatementTest.java
@@ -18,6 +18,7 @@ import org.postgresql.jdbc.PgStatement;
 import org.postgresql.jdbc.PreferQueryMode;
 import org.postgresql.test.TestUtil;
 import org.postgresql.test.util.BrokenInputStream;
+import org.postgresql.util.GT;
 import org.postgresql.util.PSQLState;
 
 import org.junit.Assert;
@@ -648,7 +649,7 @@ public class PreparedStatementTest extends BaseTest4 {
       fail("NaN::numeric rs.getBigDecimal");
     } catch (SQLException e) {
       assertEquals(PSQLState.NUMERIC_VALUE_OUT_OF_RANGE.getState(), e.getSQLState());
-      assertEquals("Bad value for type BigDecimal : NaN", e.getMessage());
+      assertEquals(GT.tr("Bad value for type {0} : {1}", "BigDecimal", "NaN"), e.getMessage());
     }
 
     rs.close();
@@ -700,7 +701,7 @@ public class PreparedStatementTest extends BaseTest4 {
       fail("inf numeric rs.getBigDecimal");
     } catch (SQLException e) {
       assertEquals(PSQLState.NUMERIC_VALUE_OUT_OF_RANGE.getState(), e.getSQLState());
-      assertEquals("Bad value for type BigDecimal : Infinity", e.getMessage());
+      assertEquals(GT.tr("Bad value for type {0} : {1}", "BigDecimal", "Infinity"), e.getMessage());
     }
 
     try {
@@ -708,7 +709,7 @@ public class PreparedStatementTest extends BaseTest4 {
       fail("-inf numeric rs.getBigDecimal");
     } catch (SQLException e) {
       assertEquals(PSQLState.NUMERIC_VALUE_OUT_OF_RANGE.getState(), e.getSQLState());
-      assertEquals("Bad value for type BigDecimal : -Infinity", e.getMessage());
+      assertEquals(GT.tr("Bad value for type {0} : {1}", "BigDecimal", "-Infinity"), e.getMessage());
     }
   }
 

--- a/pgjdbc/src/test/java/org/postgresql/util/BigDecimalByteConverterTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/util/BigDecimalByteConverterTest.java
@@ -93,4 +93,14 @@ public class BigDecimalByteConverterTest {
       assertEquals(number.toPlainString(), actual.toPlainString());
     }
   }
+
+  @Test
+  void testSpecialNumericValues() {
+    Number nan = ByteConverter.numeric(new byte[]{0, 0, 0, 0, (byte) 0xC0, 0, 0, 0});
+    assertEquals(Double.NaN, nan);
+    Number pinf = ByteConverter.numeric(new byte[]{0, 0, 0, 0, (byte) 0xD0, 0, 0, 0});
+    assertEquals(Double.POSITIVE_INFINITY, pinf);
+    Number ninf = ByteConverter.numeric(new byte[]{0, 0, 0, 0, (byte) 0xF0, 0, 0, 0});
+    assertEquals(Double.NEGATIVE_INFINITY, ninf);
+  }
 }


### PR DESCRIPTION
Since version 14, PostgreSQL supports `Infinity` and `-Infinity` special values for `numeric` type. This PR adds support for getting them via the `ResultSet.getObject(int)` and `ResultSet.getObject(String)` methods. These methods return values of type `Object` and usually they return `BigDecimal` values for normal `numeric` values. Since `BigDecimal` in Java does not support special values `NaN`, `Infinity` and `-Infinity` the `getObject` methods return them as `Double` values. Prior to this PR only `NaN` was supported and this PR extends the support to `Infinity` and `-Infinity`.

Fixes #3286 

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes to Existing Features:

* [x] Does this break existing behaviour? If so please explain.
  In a way. The `ResultSet.getObject(int)` and `ResultSet.getObject(String)` used to throw an exception when they encountered `Infinity::numeric` or `-Infinity::numeric` value. This PR makes the behaviour consistent with the `NaN` values.
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
