### PR TITLE
Deprecate all PostgreSQL versions older than 9.1

### DIFF
--- a/.github/workflows/matrix.js
+++ b/.github/workflows/matrix.js
@@ -55,8 +55,6 @@ matrix.addAxis({
   title: x => 'PG ' + x,
   // Strings allow versions like 18-ea
   values: [
-    '8.4',
-    '9.0',
     '9.1',
     '9.2',
     '9.3',
@@ -70,7 +68,7 @@ matrix.addAxis({
     '14',
     '15',
     '16',
-    '17beta1'
+    '17beta2'
   ]
 });
 
@@ -159,7 +157,7 @@ matrix.addAxis({
   title: x => (x.value === 'yes' ? '' : 'no_') + 'scram',
   values: [
     {value: 'yes', weight: 10},
-    {value: 'no', weight: 10},
+    {value: 'no', weight: 5},
   ]
 });
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ The purpose of the *Guidelines for Contributing* is to create a collaboration ba
 **Do NOT** blindly obey these guidelines, use them (after understanding) where they make sense.
 
 Currently the PgJDBC driver supports the Oracle and OpenJDK Java implementations of
-versions **8** and **higher**; and PostgreSQL server versions from **8.4** and higher.
+versions **8** and **higher**; and PostgreSQL server versions from **9.1** and higher.
 
 Some PostgreSQL forks *might* work but are not officially supported, we support vendors of forks
 that want to improve this driver by sending us pull requests that are not disruptive to the

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ The current version of the driver should be compatible with **PostgreSQL 8.4 and
 
 PgJDBC regression tests are run against all PostgreSQL versions since 9.1, including "build PostgreSQL from git master" version. There are other derived forks of PostgreSQL but they have not been certified to run with PgJDBC. If you find a bug or regression on supported versions, please file an [Issue](https://github.com/pgjdbc/pgjdbc/issues).
 
+> **Note:** PgJDBC versions since 42.8.0 are not guaranteed to work with PostgreSQL older than 9.1.
+
 ## Get the Driver
 Most people do not need to compile PgJDBC. You can download the precompiled driver (jar) from the [PostgreSQL JDBC site](https://jdbc.postgresql.org/download/) or using your chosen dependency management tool:
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -53,7 +53,7 @@ If you have Docker, you can use `docker-compose` to launch test database (see [d
     to reproduce CI errors locally. It respects all the same environment variables
     used by the CI matrix:
 
-    PGV   = "8.4" | "9.0" | ... "13" ...   - PostgreSQL server version (defaults to latest)
+    PGV   = "9.2" | "9.6" | ... "13" ...   - PostgreSQL server version (defaults to latest)
     SSL   = "yes" | "no"                   - Whether to enable SSL
     XA    = "yes" | "no"                   - Whether to enable XA for prepared transactions
     SCRAM = "yes" | "no"                   - Whether to enable SCRAM authentication
@@ -67,9 +67,9 @@ If you have Docker, you can use `docker-compose` to launch test database (see [d
 
     docker/bin/postgres-server
 
-    To start a v8.4 server without SSL:
+    To start a v9.2 server without SSL:
 
-    PGV=8.4 SSL=off docker/bin/postgres-server
+    PGV=9.2 SSL=off docker/bin/postgres-server
 
     To start a v10 server with SCRAM disabled:
 

--- a/docker/bin/postgres-server
+++ b/docker/bin/postgres-server
@@ -7,7 +7,7 @@ set -euo pipefail
 # to reproduce CI errors locally. It respects all the same environment variables
 # used by the CI matrix:
 #
-#    PGV   = "8.4" | "9.0" | ... "13" ...   - PostgreSQL server version (defaults to latest)
+#    PGV   = "9.2" | "9.6" | ... "13" ...   - PostgreSQL server version (defaults to latest)
 #    SSL   = "yes" | "no"                   - Whether to enable SSL
 #    XA    = "yes" | "no"                   - Whether to enable XA for prepared transactions
 #    SCRAM = "yes" | "no"                   - Whether to enable SCRAM authentication
@@ -21,9 +21,9 @@ set -euo pipefail
 #
 #     docker/bin/postgres-server
 #
-# To start a v8.4 server without SSL:
+# To start a v9.2 server without SSL:
 #
-#     PGV=8.4 SSL=off docker/bin/postgres-server
+#     PGV=9.2 SSL=off docker/bin/postgres-server
 #
 # To start a v10 server with SCRAM disabled:
 #

--- a/docs/content/download/_index.md
+++ b/docs/content/download/_index.md
@@ -8,7 +8,11 @@ Binary JAR file downloads of the JDBC driver are available here and the current 
 
 ## Latest Versions
 
-This is the current version of the driver. Unless you have unusual requirements (running old applications or JVMs), this is the driver you should be using. It supports PostgreSQL 8.2 or newer and requires Java 6 or newer. It contains support for SSL and the javax.sql package.
+This is the current version of the driver. Unless you have unusual requirements (running old applications or JVMs), this is the driver you should be using. It supports PostgreSQL 8.4 or newer and requires Java 6 or newer. It contains support for SSL and the javax.sql package.
+
+> **Note:**
+>
+> Testing of PostgreSQL versions is currently limited to versions 9.1 and newer. PgJDBC versions since 42.8.0 are not guaranteed to work with PostgreSQL older than 9.1.
 
 {{< recent-versions >}}
 

--- a/docs/data/versions.toml
+++ b/docs/data/versions.toml
@@ -8,13 +8,6 @@ description= "If you are using Java 8 or newer then you should use the JDBC 4.2 
 url= "/download/postgresql-42.7.3.jar"
 
 [[recent]]
-j_name= "Java 8"
-version= "42.6.2"
-suffix=""
-description= "If you are using Java 8 or newer then you should use the JDBC 4.2 version."
-url= "/download/postgresql-42.6.2.jar"
-
-[[recent]]
 j_name= "Java 7"
 version= "42.2.29"
 suffix="jre7"
@@ -38,10 +31,10 @@ url= "/download/postgresql-42.7.2.jar"
 
 [[past]]
 j_name= "Java 8"
-version= "42.6.1"
+version= "42.6.2"
 suffix=""
 description= "If you are using Java 8 or newer then you should use the JDBC 4.2 version."
-url= "/download/postgresql-42.6.1.jar"
+url= "/download/postgresql-42.6.2.jar"
 
 [[past]]
 j_name= "Java 8"

--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -79,7 +79,7 @@ public enum PGProperty {
    */
   ASSUME_MIN_SERVER_VERSION(
       "assumeMinServerVersion",
-      null,
+      "9.1",
       "Assume the server is at least that version"),
 
   /**

--- a/pgjdbc/src/main/java/org/postgresql/core/ServerVersion.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/ServerVersion.java
@@ -16,9 +16,13 @@ import java.text.ParsePosition;
 public enum ServerVersion implements Version {
 
   INVALID("0.0.0"),
+  @Deprecated
   v8_2("8.2.0"),
+  @Deprecated
   v8_3("8.3.0"),
+  @Deprecated
   v8_4("8.4.0"),
+  @Deprecated
   v9_0("9.0.0"),
   v9_1("9.1.0"),
   v9_2("9.2.0"),

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
@@ -272,8 +272,8 @@ public class PgConnection implements BaseConnection {
     // Now make the initial connection and set up local state
     this.queryExecutor = ConnectionFactory.openConnection(hostSpecs, info);
 
-    // WARNING for unsupported servers (8.1 and lower are not supported)
-    if (LOGGER.isLoggable(Level.WARNING) && !haveMinimumServerVersion(ServerVersion.v8_2)) {
+    // WARNING for unsupported servers (9.0 and lower are not supported)
+    if (LOGGER.isLoggable(Level.WARNING) && !haveMinimumServerVersion(ServerVersion.v9_1)) {
       LOGGER.log(Level.WARNING, "Unsupported Server Version: {0}", queryExecutor.getServerVersion());
     }
 


### PR DESCRIPTION
Older versions of postgres containers (8.4 and 9.0)  use a Docker Image Format v1 that is no longer supported:

[DEPRECATION NOTICE] Docker Image Format v1 and Docker Image manifest version 2, schema 1 support is disabled by default and will be removed in an upcoming release. Suggest the author of docker.io/library/postgres:8.4 to upgrade the image to the OCI Format or Docker Image manifest v2, schema 2. More information at https://docs.docker.com/go/deprecated-image-specs/

Removing them from the matrix.