### PR TITLE
fix: handle java.sql.Array encoding

### DIFF
--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc4/ArrayTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc4/ArrayTest.java
@@ -11,6 +11,7 @@ import static org.junit.Assert.assertTrue;
 
 import org.postgresql.core.ServerVersion;
 import org.postgresql.geometric.PGbox;
+import org.postgresql.geometric.PGpoint;
 import org.postgresql.jdbc.PgConnection;
 import org.postgresql.jdbc.PreferQueryMode;
 import org.postgresql.test.TestUtil;
@@ -701,6 +702,23 @@ public class ArrayTest extends BaseTest4 {
         Array jsonArray = rs.getArray(1);
         assertNotNull(jsonArray);
         assertEquals("jsonb", jsonArray.getBaseTypeName());
+      }
+    }
+  }
+
+  @Test
+  public void testJavaSqlArrayInArray() throws SQLException {
+    Array a1 = con.createArrayOf("point", new Object[] {new PGpoint(1, 1), new PGpoint(2, 2)});
+    Array a2 = con.createArrayOf("point", new Object[] {new PGpoint(3, 3), new PGpoint(4, 4)});
+    Array a = con.createArrayOf("point", new Object[]{ a1, a2 });
+    Object[][] arr = (Object[][]) a.getArray();
+
+    assertEquals(2, arr.length);
+    assertEquals(2, arr[0].length);
+    for (int i = 0, c = 1; i < arr.length; i++) {
+      for (int j = 0; j < arr[0].length; j++, c++) {
+        PGpoint p = (PGpoint) arr[i][j];
+        assertEquals(p, new PGpoint(c, c));
       }
     }
   }


### PR DESCRIPTION
- objects that implement java.sql.Array should not be escaped

The current behavior of OBJECT_ARRAY encoder is that it will try to escape every non-null object that isn't an array.
This has the side effect that objects that implement java.sql.Array gets escaped as well resulting in incorrectly formatted array literals in case of nested arrays which also came up in https://github.com/pgjdbc/pgjdbc/pull/3306

The proposed solution is to extract the underlying object array by calling java.sql.Array#getArray() and then let the existing logic take care of the encoding.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Does `./gradlew styleCheck` pass ?
3. [x] Have you added your new test classes to an existing test suite in alphabetical order?

### Changes to Existing Features:

* [x] Does this break existing behaviour? If so please explain.
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
