### PR TITLE
use docker v2 which changes docker-compose to docker compose 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,7 +94,7 @@ jobs:
           fetch-depth: 50
       - name: Start PostgreSQL
         working-directory: docker/postgres-server
-        run: docker-compose up -d && docker-compose logs
+        run: docker compose up -d && docker compose logs
       - name: 'Set up JDK 17'
         uses: actions/setup-java@v4
         with:
@@ -164,12 +164,12 @@ jobs:
         CREATE_REPLICAS: ${{ matrix.replication }}
       # The below run command is long, however, it is intentional, and it makes the output nicer in GitHub UI
       run: |
-        echo 'Starting PostgreSQL via docker-compose down; PGV=${{ matrix.pg_version }} TZ=${{ matrix.server_tz }} XA=${{ matrix.xa }} SSL=${{ matrix.ssl }} SCRAM=${{ matrix.scram }} CREATE_REPLICAS=${{ matrix.replication }} docker-compose up'
+        echo 'Starting PostgreSQL via docker compose down; PGV=${{ matrix.pg_version }} TZ=${{ matrix.server_tz }} XA=${{ matrix.xa }} SSL=${{ matrix.ssl }} SCRAM=${{ matrix.scram }} CREATE_REPLICAS=${{ matrix.replication }} docker compose up'
 
-        docker-compose down -v --rmi local || true
-        sed -i -r '/- (543[3-4]):\1/d' docker-compose.yml
-        docker-compose up -d
-        docker-compose logs
+        docker compose down -v --rmi local || true
+        sed -i -r '/- (543[3-4]):\1/d' docker compose.yml
+        docker compose up -d
+        docker compose logs
     - name: Set up Java 17 and ${{ matrix.non_ea_java_version }}, ${{ matrix.java_distribution }}, ${{ runner.arch }}
       uses: actions/setup-java@v4
       with:
@@ -274,5 +274,5 @@ jobs:
       if: ${{ always() }}
       working-directory: docker/postgres-server
       run: |
-        docker-compose ps
-        docker-compose down -v --rmi local
+        docker compose ps
+        docker compose down -v --rmi local

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -167,7 +167,7 @@ jobs:
         echo 'Starting PostgreSQL via docker compose down; PGV=${{ matrix.pg_version }} TZ=${{ matrix.server_tz }} XA=${{ matrix.xa }} SSL=${{ matrix.ssl }} SCRAM=${{ matrix.scram }} CREATE_REPLICAS=${{ matrix.replication }} docker compose up'
 
         docker compose down -v --rmi local || true
-        sed -i -r '/- (543[3-4]):\1/d' docker compose.yml
+        sed -i -r '/- (543[3-4]):\1/d' docker-compose.yml
         docker compose up -d
         docker compose logs
     - name: Set up Java 17 and ${{ matrix.non_ea_java_version }}, ${{ matrix.java_distribution }}, ${{ runner.arch }}

--- a/.github/workflows/omni.yml
+++ b/.github/workflows/omni.yml
@@ -299,7 +299,7 @@ jobs:
 
     - name: Start PostgreSQL
       working-directory: docker/postgres-server
-      run: docker-compose up -d && docker-compose logs
+      run: docker compose up -d && docker compose logs
       env:
         PGV: ${{ matrix.pg_version }}
 
@@ -340,7 +340,7 @@ jobs:
             # Server is not online so dump some logs for debugging
             docker ps
             cd docker/postgres-server
-            docker-compose logs
+            docker compose logs
         fi
         psql -c 'SELECT version()'
 
@@ -378,7 +378,7 @@ jobs:
         fetch-depth: 50
     - name: Compile and start PostgreSQL
       working-directory: docker/postgres-head
-      run: docker-compose up -d && docker-compose logs
+      run: docker compose up -d && docker compose logs
     - name: Set up JDK
       uses: actions/setup-java@v4
       with:
@@ -398,7 +398,7 @@ jobs:
             # Server is not online so dump some logs for debugging
             docker ps
             cd docker/postgres-head
-            docker-compose logs
+            docker compose logs
         fi
         psql -c 'SELECT version()'
     - name: Prepare local properties

--- a/docker/postgres-head/docker-compose.yml
+++ b/docker/postgres-head/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   pgdb:
     build:

--- a/docker/postgres-server/docker-compose.yml
+++ b/docker/postgres-server/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   pgdb:
     image: postgres:${PGV:-latest}


### PR DESCRIPTION
note, the missing `-`
see https://github.blog/changelog/2024-04-10-github-hosted-runner-images-deprecation-notice-docker-compose-v1/ for details