### PR TITLE
bug report: PgInterval ignores case for represented interval string

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/util/PGInterval.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/PGInterval.java
@@ -165,6 +165,7 @@ public class PGInterval extends PGobject implements Serializable, Cloneable {
       String valueToken = null;
 
       value = value.replace('+', ' ').replace('@', ' ');
+      value = value.toLowerCase(Locale.ROOT);
       final StringTokenizer st = new StringTokenizer(value);
       for (int i = 1; st.hasMoreTokens(); i++) {
         String token = st.nextToken();

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/IntervalTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/IntervalTest.java
@@ -112,6 +112,22 @@ class IntervalTest {
   }
 
   @Test
+  void checkCapitalization() throws Exception {
+    PGInterval pgi = new PGInterval("1 year 3 months 4 days 5 hours 6 minutes");
+    PGInterval yCapital = new PGInterval("1 Year 3 months 4 days 5 hours 6 minutes");
+    PGInterval mCapital = new PGInterval("1 year 3 Months 4 days 5 hours 6 minutes");
+    PGInterval dCapital = new PGInterval("1 year 3 months 4 Days 5 hours 6 minutes");
+    PGInterval hCapital = new PGInterval("1 year 3 months 4 days 5 Hours 6 minutes");
+    PGInterval minCapital = new PGInterval("1 year 3 months 4 days 5 hours 6 Minutes");
+
+    assertEquals(pgi, yCapital);
+    assertEquals(pgi, mCapital);
+    assertEquals(pgi, dCapital);
+    assertEquals(pgi, hCapital);
+    assertEquals(pgi, minCapital);
+  }
+
+  @Test
   void daysHours() throws SQLException {
     Statement stmt = conn.createStatement();
     ResultSet rs = stmt.executeQuery("SELECT '101:12:00'::interval");


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes to Existing Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?

As reported in #3297, PGInteval should be able to ignore case when taking a string interval.

* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
