### PR TITLE
Changed docker-compose version and renamed script file in instructions to match the real file name

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -252,15 +252,15 @@ You also need to test your changes with older JDKs. PgJDBC must support JDK8
 
 You can get old JDK versions from the [Oracle Java Archive](http://www.oracle.com/technetwork/java/archive-139210.html).
 
-If you have Docker, you can use `docker-compose` to launch test database (see [docker](docker)):
+If you have Docker, you can use `docker compose` to launch test database (see [docker](docker)):
 
     cd docker/postgres-server
 
     # Launch the most recent PostgreSQL database with SSL, XA, and SCRAM
-    docker-compose down && docker-compose up
+    docker compose down && docker compose up
 
     # Launch PostgreSQL 9.6, with XA, without SSL
-    docker-compose down && SSL=no XA=yes docker-compose up
+    docker compose down && SSL=no XA=yes docker compose up
 
 Alternatively, to run the test server with Docker in the foreground:
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -43,7 +43,7 @@ customized values of the properties `database`, `username` and
 The test suite requires that you have the `contrib/lo` and `contrib/test_decoding` modules
 installed.
 
-If you have Docker, you can use `docker-compose` to launch test database (see [docker](docker)):
+If you have Docker, you can use `docker compose` to launch test database (see [docker](docker)):
 
     cd docker && bin/postgres-server
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -45,7 +45,7 @@ installed.
 
 If you have Docker, you can use `docker-compose` to launch test database (see [docker](docker)):
 
-    cd docker && bin/postgresql-server
+    cd docker && bin/postgres-server
 
     Helper script to start a postgres container for testing the PGJDBC driver.
 

--- a/docker/bin/postgres-server
+++ b/docker/bin/postgres-server
@@ -55,7 +55,7 @@ main () {
     cd "${script_dir}/../postgres-server"
 
     log "Starting Postgres server and mapping to local port ${publish_port}"
-    exec docker-compose run \
+    exec docker compose run \
         --rm \
         --publish="${publish_port}:5432" \
         --publish="${replica_one_port}:5433" \

--- a/docker/postgres-server/README.md
+++ b/docker/postgres-server/README.md
@@ -3,14 +3,14 @@ Docker Compose script helps to start a PostgreSQL instance for tests
 Typical usage
 =============
 
-    docker-compose up # starts the database
+    docker compose up # starts the database
 
     ...
     Ctrl+C
 
-    docker-compose up -d # launch the container in background
+    docker compose up -d # launch the container in background
 
-    docker-compose rm # removes the container (e.g. to recreate the db)
+    docker compose rm # removes the container (e.g. to recreate the db)
 
 Environment variables
 =====================
@@ -23,9 +23,9 @@ Environment variables
 Example usages
 ==============
 
-    docker-compose down && PGV=10 SSL=no XA=yes SCRAM=yes docker-compose up
+    docker compose down && PGV=10 SSL=no XA=yes SCRAM=yes docker compose up
 
-    docker-compose down && PGV=latest docker-compose up
+    docker compose down && PGV=latest docker compose up
 
 Alternative Foreground Helper
 =============================


### PR DESCRIPTION
The name postgresql-server is not the real file name inside docker directory. Should instead be postgres-server

Docker compose v2 migration https://docs.docker.com/compose/migrate/ 

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?