### PR TITLE
Do not assume "test" database in DatabaseMetaDataTransactionIsolationTest

### DIFF
--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseMetaDataTransactionIsolationTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseMetaDataTransactionIsolationTest.java
@@ -39,7 +39,7 @@ class DatabaseMetaDataTransactionIsolationTest {
     // Restore to defaults
     con.setAutoCommit(true);
     try (Statement st = con.createStatement()) {
-      st.execute("alter database test set default_transaction_isolation to DEFAULT");
+      st.execute("alter database " + TestUtil.getDatabase() + " set default_transaction_isolation to DEFAULT");
     }
   }
 
@@ -68,7 +68,7 @@ class DatabaseMetaDataTransactionIsolationTest {
   void alterDatabaseDefaultTransactionIsolation(String isolationLevel) throws SQLException {
     try (Statement st = con.createStatement()) {
       st.execute(
-          "alter database test set default_transaction_isolation to '" + isolationLevel + "'");
+          "alter database " + TestUtil.getDatabase() + " set default_transaction_isolation to '" + isolationLevel + "'");
     }
 
     assertIsolationEquals(


### PR DESCRIPTION
This commit updates the `DatabaseMetaDataTransactionIsolationTest` suite to not assume that the unit tests are running in the "test" database. Instead, we now use `TestUtil.getDatabase()` to retrieve the current database name.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes to Existing Features:

* [x] Does this break existing behaviour? If so please explain.
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
