### PR TITLE
fix: resolve isolation level's query being called in a subtransaction when using **autosave=always** 

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -602,7 +602,7 @@ public class QueryExecutorImpl extends QueryExecutorBase {
   }
 
   private boolean possibleIsolationLevelQuery(Query query) {
-    return query.getNativeSql().contains("isolation");
+    return query.getNativeSql().toLowerCase().contains("isolation");
   }
 
   private ResultHandler sendQueryPreamble(final ResultHandler delegateHandler, int flags)

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -602,7 +602,7 @@ public class QueryExecutorImpl extends QueryExecutorBase {
   }
 
   private boolean possibleIsolationLevelQuery(Query query) {
-    return query.getNativeSql().toLowerCase().contains("isolation");
+    return query.getNativeSql().toLowerCase(Locale.ROOT).contains("isolation");
   }
 
   private ResultHandler sendQueryPreamble(final ResultHandler delegateHandler, int flags)

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -360,7 +360,10 @@ public class QueryExecutorImpl extends QueryExecutorBase {
       try {
         try {
           handler = sendQueryPreamble(handler, flags);
-          autosave = sendAutomaticSavepoint(query, flags);
+          //if it's an isolation level query then it should be the first thing set after a BEGIN not autosave
+          if (!possibleIsolationLevelQuery(query)) {
+            autosave = sendAutomaticSavepoint(query, flags);
+          }
           sendQuery(query, (V3ParameterList) parameters, maxRows, fetchSize, flags,
               handler, null, adaptiveFetch);
           if ((flags & QueryExecutor.QUERY_EXECUTE_AS_SIMPLE) != 0) {
@@ -596,6 +599,10 @@ public class QueryExecutorImpl extends QueryExecutorBase {
         rollbackIfRequired(autosave, e);
       }
     }
+  }
+
+  private boolean possibleIsolationLevelQuery(Query query) {
+    return query.getNativeSql().contains("isolation");
   }
 
   private ResultHandler sendQueryPreamble(final ResultHandler delegateHandler, int flags)

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/AutoSaveIsolationTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/AutoSaveIsolationTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2004, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.test.jdbc2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.postgresql.PGProperty;
+import org.postgresql.test.TestUtil;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Properties;
+
+public class AutoSaveIsolationTest {
+  private Connection con;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    Properties props = new Properties();
+    con = TestUtil.openDB(props);
+  }
+
+  @AfterEach
+  void tearDown() throws Exception {
+    con = TestUtil.openDB();
+    TestUtil.closeDB(con);
+  }
+
+  @Test
+  public void testAlwaysAutoSaveBetweenBeginAndSetIsolationLevel() throws SQLException {
+    Properties props = new Properties();
+    PGProperty.AUTOSAVE.set(props,"always");
+    con = TestUtil.openDB();
+    int initialIsolationLevel = con.getTransactionIsolation();
+
+    con.setAutoCommit(false);
+
+    Statement stmt = con.createStatement();
+
+    try {
+      stmt.executeUpdate("set local transaction isolation level serializable read only deferrable");
+    } catch (Exception e) {
+      fail("Isolation level should have been set before sending a SAVEPOINT PGJDBC_AUTOSAVE");
+    }
+
+    int newIsolationLevel = con.getTransactionIsolation();
+
+    assertEquals(Connection.TRANSACTION_SERIALIZABLE, newIsolationLevel);
+
+    con.commit();
+
+    int afterCommitIsolationLevel = con.getTransactionIsolation();
+
+    assertEquals(initialIsolationLevel,afterCommitIsolationLevel);
+
+    stmt.close();
+  }
+
+  @Test
+  public void testNeverAutoSaveBetweenBeginAndSetIsolationLevel() throws SQLException {
+    Properties props = new Properties();
+    PGProperty.AUTOSAVE.set(props,"never");//default
+    con = TestUtil.openDB();
+    int initialIsolationLevel = con.getTransactionIsolation();
+
+    con.setAutoCommit(false);
+
+    Statement stmt = con.createStatement();
+
+    try {
+      stmt.executeUpdate("set local transaction isolation level serializable read only deferrable");
+    } catch (Exception e) {
+      fail("Isolation level should have been set successfully");
+    }
+
+    int newIsolationLevel = con.getTransactionIsolation();
+
+    assertEquals(Connection.TRANSACTION_SERIALIZABLE, newIsolationLevel);
+
+    con.commit();
+
+    int afterCommitIsolationLevel = con.getTransactionIsolation();
+
+    assertEquals(initialIsolationLevel,afterCommitIsolationLevel);
+
+    stmt.close();
+  }
+
+}

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/AutoSaveIsolationTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/AutoSaveIsolationTest.java
@@ -39,7 +39,7 @@ public class AutoSaveIsolationTest {
   public void testAlwaysAutoSaveBetweenBeginAndSetIsolationLevel() throws SQLException {
     Properties props = new Properties();
     PGProperty.AUTOSAVE.set(props,"always");
-    con = TestUtil.openDB();
+    con = TestUtil.openDB(props);
     int initialIsolationLevel = con.getTransactionIsolation();
 
     con.setAutoCommit(false);
@@ -69,7 +69,7 @@ public class AutoSaveIsolationTest {
   public void testNeverAutoSaveBetweenBeginAndSetIsolationLevel() throws SQLException {
     Properties props = new Properties();
     PGProperty.AUTOSAVE.set(props,"never");//default
-    con = TestUtil.openDB();
+    con = TestUtil.openDB(props);
     int initialIsolationLevel = con.getTransactionIsolation();
 
     con.setAutoCommit(false);


### PR DESCRIPTION
- This PR resolves #3307 by basically checking if there is a possible isolation level query while having ``autosave=always`` then we most likely don't need to have a `savepoint` before it so we just skip sending a ``SAVEPOINT PGJDBC_AUTOSAVE`` as it wont be necessary for this kind of query since PostgreSQL docs does specify that setting the isolation level should be immediately after ``BEGIN`` https://www.postgresql.org/docs/current/sql-begin.html

- TBH I think the parsing could be done better by specifying ``set`` and ``isolation`` keywords but I don't really think there would be a case that would crash not sending a ``SAVEPOINT`` if there is a ``transaction`` keyword only in a query. For now though it does fix the ``SAVEPOINT`` issue between ``BEGIN`` and ``SET ISOLATION LEVEL``

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Does `./gradlew styleCheck` pass ?
3. [x] Have you added your new test classes to an existing test suite in alphabetical order?

### Changes to Existing Features:

* [ ] Does this break existing behaviour? If so please explain.
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
