### PR TITLE
fixed paragraphs in javadoc comments

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/Driver.java
+++ b/pgjdbc/src/main/java/org/postgresql/Driver.java
@@ -44,8 +44,8 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * <p>The Java SQL framework allows for multiple database drivers. Each driver should supply a class
- * that implements the Driver interface</p>
+ * The Java SQL framework allows for multiple database drivers. Each driver should supply a class
+ * that implements the Driver interface
  *
  * <p>The DriverManager will try to load as many drivers as it can find and then for any given
  * connection request, it will ask each driver in turn to try to connect to the target URL.</p>
@@ -192,10 +192,10 @@ public class Driver implements java.sql.Driver {
   }
 
   /**
-   * <p>Try to make a database connection to the given URL. The driver should return "null" if it
+   * Try to make a database connection to the given URL. The driver should return "null" if it
    * realizes it is the wrong kind of driver to connect to the given URL. This will be common, as
    * when the JDBC driverManager is asked to connect to a given URL, it passes the URL to each
-   * loaded driver in turn.</p>
+   * loaded driver in turn.
    *
    * <p>The driver should raise an SQLException if it is the right driver to connect to the given URL,
    * but has trouble connecting to the database.</p>
@@ -461,8 +461,8 @@ public class Driver implements java.sql.Driver {
   }
 
   /**
-   * <p>The getPropertyInfo method is intended to allow a generic GUI tool to discover what properties
-   * it should prompt a human for in order to get enough information to connect to a database.</p>
+   * The getPropertyInfo method is intended to allow a generic GUI tool to discover what properties
+   * it should prompt a human for in order to get enough information to connect to a database.
    *
    * <p>Note that depending on the values the human has supplied so far, additional values may become
    * necessary, so it may be necessary to iterate through several calls to getPropertyInfo</p>
@@ -512,9 +512,9 @@ public class Driver implements java.sql.Driver {
   }
 
   /**
-   * <p>Report whether the driver is a genuine JDBC compliant driver. A driver may only report "true"
+   * Report whether the driver is a genuine JDBC compliant driver. A driver may only report "true"
    * here if it passes the JDBC compliance tests, otherwise it is required to return false. JDBC
-   * compliance requires full support for the JDBC API and full support for SQL 92 Entry Level.</p>
+   * compliance requires full support for the JDBC API and full support for SQL 92 Entry Level.
    *
    * <p>For PostgreSQL, this is not yet possible, as we are not SQL92 compliant (yet).</p>
    */

--- a/pgjdbc/src/main/java/org/postgresql/PGConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGConnection.java
@@ -122,7 +122,7 @@ public interface PGConnection {
   void addDataType(String type, String className);
 
   /**
-   * <p>This allows client code to add a handler for one of org.postgresql's more unique data types.</p>
+   * This allows client code to add a handler for one of org.postgresql's more unique data types.
    *
    * <p><b>NOTE:</b> This is not part of JDBC, but an extension.</p>
    *
@@ -220,10 +220,11 @@ public interface PGConnection {
   String escapeLiteral(String literal) throws SQLException;
 
   /**
-   * <p>Returns the query mode for this connection.</p>
+   * Returns the query mode for this connection.
    *
    * <p>When running in simple query mode, certain features are not available: callable statements,
    * partial result set fetch, bytea type, etc.</p>
+   *
    * <p>The list of supported features is subject to change.</p>
    *
    * @return the preferred query mode
@@ -294,7 +295,7 @@ public interface PGConnection {
   }
 
   /**
-   * <p>Returns the current values of all parameters reported by the server.</p>
+   * Returns the current values of all parameters reported by the server.
    *
    * <p>PostgreSQL reports values for a subset of parameters (GUCs) to the client
    * at connect-time, then sends update messages whenever the values change

--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -170,8 +170,8 @@ public enum PGProperty {
       new String[]{"true", "false"}),
 
   /**
-   * <p>The timeout value used for socket connect operations. If connecting to the server takes longer
-   * than this value, the connection is broken.</p>
+   * The timeout value used for socket connect operations. If connecting to the server takes longer
+   * than this value, the connection is broken.
    *
    * <p>The timeout is specified in seconds and a value of zero means that it is disabled.</p>
    */
@@ -276,9 +276,9 @@ public enum PGProperty {
       new String[]{"auto", "sspi", "gssapi"}),
 
   /**
-   * <p>After requesting an upgrade to SSL from the server there are reports of the server not responding due to a failover
+   * After requesting an upgrade to SSL from the server there are reports of the server not responding due to a failover
    * without a timeout here, the client can wait forever. The pattern for requesting a GSS encrypted connection is the same so we provide the same
-   * timeout mechanism This timeout will be set before the request and reset after </p>
+   * timeout mechanism This timeout will be set before the request and reset after
    */
   GSS_RESPONSE_TIMEOUT(
       "gssResponseTimeout",
@@ -333,8 +333,8 @@ public enum PGProperty {
       "If disabled hosts are connected in the given order. If enabled hosts are chosen randomly from the set of suitable candidates"),
 
   /**
-   * <p>If this is set then the client side will bind to this address. This is useful if you need
-   * to choose which interface to connect to.</p>
+   * If this is set then the client side will bind to this address. This is useful if you need
+   * to choose which interface to connect to.
    */
   LOCAL_SOCKET_ADDRESS(
       "localSocketAddress",
@@ -451,9 +451,9 @@ public enum PGProperty {
       "Port of the PostgreSQL server (may be specified directly in the JDBC URL)"),
 
   /**
-   * <p>Specifies which mode is used to execute queries to database: simple means ('Q' execute, no parse, no bind, text mode only),
+   * Specifies which mode is used to execute queries to database: simple means ('Q' execute, no parse, no bind, text mode only),
    * extended means always use bind/execute messages, extendedForPrepared means extended for prepared statements only,
-   * extendedCacheEverything means use extended protocol and try cache every statement (including Statement.execute(String sql)) in a query cache.</p>
+   * extendedCacheEverything means use extended protocol and try cache every statement (including Statement.execute(String sql)) in a query cache.
    *
    * <p>This mode is meant for debugging purposes and/or for cases when extended protocol cannot be used (e.g. logical replication protocol)</p>
    */
@@ -547,12 +547,13 @@ public enum PGProperty {
       "Socket read buffer size"),
 
   /**
-   * <p>Connection parameter passed in the startup message. This parameter accepts two values; "true"
+   * Connection parameter passed in the startup message. This parameter accepts two values; "true"
    * and "database". Passing "true" tells the backend to go into walsender mode, wherein a small set
    * of replication commands can be issued instead of SQL statements. Only the simple query protocol
    * can be used in walsender mode. Passing "database" as the value instructs walsender to connect
    * to the database specified in the dbname parameter, which will allow the connection to be used
-   * for logical replication from that database.</p>
+   * for logical replication from that database.
+   *
    * <p>Parameter should be use together with {@link PGProperty#ASSUME_MIN_SERVER_VERSION} with
    * parameter &gt;= 9.4 (backend &gt;= 9.4)</p>
    */
@@ -724,8 +725,8 @@ public enum PGProperty {
       "A class, implementing javax.security.auth.callback.CallbackHandler that can handle PasswordCallback for the ssl password."),
 
   /**
-   * <p>After requesting an upgrade to SSL from the server there are reports of the server not responding due to a failover
-   * without a timeout here, the client can wait forever. This timeout will be set before the request and reset after </p>
+   * After requesting an upgrade to SSL from the server there are reports of the server not responding due to a failover
+   * without a timeout here, the client can wait forever. This timeout will be set before the request and reset after
    */
   SSL_RESPONSE_TIMEOUT(
       "sslResponseTimeout",

--- a/pgjdbc/src/main/java/org/postgresql/PGStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGStatement.java
@@ -55,7 +55,7 @@ public interface PGStatement {
   boolean isUseServerPrepare();
 
   /**
-   * <p>Sets the reuse threshold for using server-prepared statements.</p>
+   * Sets the reuse threshold for using server-prepared statements.
    *
    * <p>If <code>threshold</code> is a non-zero value N, the Nth and subsequent reuses of a
    * PreparedStatement will use server-side prepare.</p>

--- a/pgjdbc/src/main/java/org/postgresql/core/BaseConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/BaseConnection.java
@@ -72,9 +72,9 @@ public interface BaseConnection extends PGConnection, Connection {
   ReplicationProtocol getReplicationProtocol();
 
   /**
-   * <p>Construct and return an appropriate object for the given type and value. This only considers
+   * Construct and return an appropriate object for the given type and value. This only considers
    * the types registered via {@link org.postgresql.PGConnection#addDataType(String, Class)} and
-   * {@link org.postgresql.PGConnection#addDataType(String, String)}.</p>
+   * {@link org.postgresql.PGConnection#addDataType(String, String)}.
    *
    * <p>If no class is registered as handling the given type, then a generic
    * {@link org.postgresql.util.PGobject} instance is returned.</p>
@@ -95,7 +95,7 @@ public interface BaseConnection extends PGConnection, Connection {
   TypeInfo getTypeInfo();
 
   /**
-   * <p>Check if we have at least a particular server version.</p>
+   * Check if we have at least a particular server version.
    *
    * <p>The input version is of the form xxyyzz, matching a PostgreSQL version like xx.yy.zz. So 9.0.12
    * is 90012.</p>
@@ -106,7 +106,7 @@ public interface BaseConnection extends PGConnection, Connection {
   boolean haveMinimumServerVersion(int ver);
 
   /**
-   * <p>Check if we have at least a particular server version.</p>
+   * Check if we have at least a particular server version.
    *
    * <p>The input version is of the form xxyyzz, matching a PostgreSQL version like xx.yy.zz. So 9.0.12
    * is 90012.</p>

--- a/pgjdbc/src/main/java/org/postgresql/core/ConnectionFactory.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/ConnectionFactory.java
@@ -31,7 +31,7 @@ public abstract class ConnectionFactory {
   private static final Logger LOGGER = Logger.getLogger(ConnectionFactory.class.getName());
 
   /**
-   * <p>Establishes and initializes a new connection.</p>
+   * Establishes and initializes a new connection.
    *
    * <p>If the "protocolVersion" property is specified, only that protocol version is tried. Otherwise,
    * all protocols are tried in order, falling back to older protocols as necessary.</p>

--- a/pgjdbc/src/main/java/org/postgresql/core/EncodingPredictor.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/EncodingPredictor.java
@@ -10,7 +10,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import java.io.IOException;
 
 /**
- * <p>Predicts encoding for error messages based on some heuristics.</p>
+ * Predicts encoding for error messages based on some heuristics.
  *
  * <ol>
  * <li>For certain languages, it is known how "FATAL" is translated</li>

--- a/pgjdbc/src/main/java/org/postgresql/core/PGStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/PGStream.java
@@ -39,8 +39,8 @@ import java.sql.SQLException;
 import javax.net.SocketFactory;
 
 /**
- * <p>Wrapper around the raw connection to the server that implements some basic primitives
- * (reading/writing formatted data, doing string encoding, etc).</p>
+ * Wrapper around the raw connection to the server that implements some basic primitives
+ * (reading/writing formatted data, doing string encoding, etc).
  *
  * <p>In general, instances of PGStream are not threadsafe; the caller must ensure that only one thread
  * at a time is accessing a particular PGStream instance.</p>
@@ -338,7 +338,7 @@ public class PGStream implements Closeable, Flushable {
   }
 
   /**
-   * <p>Get a Writer instance that encodes directly onto the underlying stream.</p>
+   * Get a Writer instance that encodes directly onto the underlying stream.
    *
    * <p>The returned Writer should not be closed, as it's a shared object. Writer.flush needs to be
    * called when switching between use of the Writer and use of the PGStream write methods, but it

--- a/pgjdbc/src/main/java/org/postgresql/core/ParameterList.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/ParameterList.java
@@ -16,9 +16,9 @@ import java.io.InputStream;
 import java.sql.SQLException;
 
 /**
- * <p>Abstraction of a list of parameters to be substituted into a Query. The protocol-specific details
+ * Abstraction of a list of parameters to be substituted into a Query. The protocol-specific details
  * of how to efficiently store and stream the parameters is hidden behind implementations of this
- * interface.</p>
+ * interface.
  *
  * <p>In general, instances of ParameterList are associated with a particular Query object (the one
  * that created them) and shouldn't be used against another Query.</p>

--- a/pgjdbc/src/main/java/org/postgresql/core/Parser.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/Parser.java
@@ -420,7 +420,7 @@ public class Parser {
   }
 
   /**
-   * <p>Find the end of the single-quoted string starting at the given offset.</p>
+   * Find the end of the single-quoted string starting at the given offset.
    *
    * <p>Note: for {@code 'single '' quote in string'}, this method currently returns the offset of
    * first {@code '} character after the initial one. The caller must call the method a second time
@@ -467,7 +467,7 @@ public class Parser {
   }
 
   /**
-   * <p>Find the end of the double-quoted string starting at the given offset.</p>
+   * Find the end of the double-quoted string starting at the given offset.
    *
    * <p>Note: for {@code "double "" quote in string"}, this method currently
    * returns the offset of first {@code &quot;} character after the initial one. The caller must
@@ -1259,7 +1259,7 @@ public class Parser {
   }
 
   /**
-   * <p>Filter the SQL string of Java SQL Escape clauses.</p>
+   * Filter the SQL string of Java SQL Escape clauses.
    *
    * <p>Currently implemented Escape clauses are those mentioned in 11.3 in the specification.
    * Basically we look through the sql string for {d xxx}, {t xxx}, {ts xxx}, {oj xxx} or {fn xxx}

--- a/pgjdbc/src/main/java/org/postgresql/core/Query.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/Query.java
@@ -11,8 +11,8 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import java.util.Map;
 
 /**
- * <p>Abstraction of a generic Query, hiding the details of any protocol-version-specific data needed
- * to execute the query efficiently.</p>
+ * Abstraction of a generic Query, hiding the details of any protocol-version-specific data needed
+ * to execute the query efficiently.
  *
  * <p>Query objects should be explicitly closed when no longer needed; if resources are allocated on
  * the server for this query, their cleanup is triggered by closing the Query.</p>
@@ -21,7 +21,7 @@ import java.util.Map;
  */
 public interface Query {
   /**
-   * <p>Create a ParameterList suitable for storing parameters associated with this Query.</p>
+   * Create a ParameterList suitable for storing parameters associated with this Query.
    *
    * <p>If this query has no parameters, a ParameterList will be returned, but it may be a shared
    * immutable object. If this query does have parameters, the returned ParameterList is a new list,
@@ -54,8 +54,8 @@ public interface Query {
   @Nullable SqlCommand getSqlCommand();
 
   /**
-   * <p>Close this query and free any server-side resources associated with it. The resources may not
-   * be immediately deallocated, but closing a Query may make the deallocation more prompt.</p>
+   * Close this query and free any server-side resources associated with it. The resources may not
+   * be immediately deallocated, but closing a Query may make the deallocation more prompt.
    *
    * <p>A closed Query should not be executed.</p>
    */

--- a/pgjdbc/src/main/java/org/postgresql/core/QueryExecutor.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/QueryExecutor.java
@@ -27,7 +27,7 @@ import java.util.Set;
 import java.util.TimeZone;
 
 /**
- * <p>Abstracts the protocol-specific details of executing a query.</p>
+ * Abstracts the protocol-specific details of executing a query.
  *
  * <p>Every connection has a single QueryExecutor implementation associated with it. This object
  * provides:</p>
@@ -345,6 +345,7 @@ public interface QueryExecutor extends TypeTransferModeRegistry {
 
   /**
    * Remove given oid from the list of oids for binary receive encoding.
+   *
    * <p>Note: the binary receive for the oid can be re-activated later.</p>
    *
    * @param oid The oid to request with binary encoding.
@@ -353,6 +354,7 @@ public interface QueryExecutor extends TypeTransferModeRegistry {
 
   /**
    * Gets the oids that should be received using binary encoding.
+   *
    * <p>Note: this returns an unmodifiable set, and its contents might not reflect the current state.</p>
    *
    * @return The oids to request with binary encoding.
@@ -377,6 +379,7 @@ public interface QueryExecutor extends TypeTransferModeRegistry {
 
   /**
    * Remove given oid from the list of oids for binary send encoding.
+   *
    * <p>Note: the binary send for the oid can be re-activated later.</p>
    *
    * @param oid The oid to send with binary encoding.
@@ -385,6 +388,7 @@ public interface QueryExecutor extends TypeTransferModeRegistry {
 
   /**
    * Gets the oids that should be sent using binary encoding.
+   *
    * <p>Note: this returns an unmodifiable set, and its contents might not reflect the current state.</p>
    *
    * @return useBinaryForOids The oids to send with binary encoding.
@@ -463,7 +467,7 @@ public interface QueryExecutor extends TypeTransferModeRegistry {
   boolean isClosed();
 
   /**
-   * <p>Return the server version from the server_version GUC.</p>
+   * Return the server version from the server_version GUC.
    *
    * <p>Note that there's no requirement for this to be numeric or of the form x.y.z. PostgreSQL
    * development releases usually have the format x.ydevel e.g. 9.4devel; betas usually x.ybetan
@@ -493,7 +497,7 @@ public interface QueryExecutor extends TypeTransferModeRegistry {
   @Nullable SQLWarning getWarnings();
 
   /**
-   * <p>Get a machine-readable server version.</p>
+   * Get a machine-readable server version.
    *
    * <p>This returns the value of the server_version_num GUC. If no such GUC exists, it falls back on
    * attempting to parse the text server version for the major version. If there's no minor version

--- a/pgjdbc/src/main/java/org/postgresql/core/QueryWithReturningColumnsKey.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/QueryWithReturningColumnsKey.java
@@ -13,6 +13,7 @@ import java.util.Arrays;
  * Cache key for a query that have some returning columns.
  * {@code columnNames} should contain non-quoted column names.
  * The parser will quote them automatically.
+ *
  * <p>There's a special case of {@code columnNames == new String[]{"*"}} that means all columns
  * should be returned. {@link Parser} is aware of that and does not quote {@code *}</p>
  */

--- a/pgjdbc/src/main/java/org/postgresql/core/ReplicationProtocol.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/ReplicationProtocol.java
@@ -12,7 +12,7 @@ import org.postgresql.replication.fluent.physical.PhysicalReplicationOptions;
 import java.sql.SQLException;
 
 /**
- * <p>Abstracts the protocol-specific details of physic and logic replication.</p>
+ * Abstracts the protocol-specific details of physic and logic replication.
  *
  * <p>With each connection open with replication options associate own instance ReplicationProtocol.</p>
  */

--- a/pgjdbc/src/main/java/org/postgresql/core/ResultHandler.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/ResultHandler.java
@@ -13,8 +13,8 @@ import java.sql.SQLWarning;
 import java.util.List;
 
 /**
- * <p>Callback interface for passing query results from the protocol-specific layer to the
- * protocol-independent JDBC implementation code.</p>
+ * Callback interface for passing query results from the protocol-specific layer to the
+ * protocol-independent JDBC implementation code.
  *
  * <p>In general, a single query execution will consist of a number of calls to handleResultRows,
  * handleCommandStatus, handleWarning, and handleError, followed by a single call to

--- a/pgjdbc/src/main/java/org/postgresql/core/ServerVersion.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/ServerVersion.java
@@ -58,8 +58,8 @@ public enum ServerVersion implements Version {
   }
 
   /**
-   * <p>Attempt to parse the server version string into an XXYYZZ form version number into a
-   * {@link Version}.</p>
+   * Attempt to parse the server version string into an XXYYZZ form version number into a
+   * {@link Version}.
    *
    * <p>If the specified version cannot be parsed, the {@link Version#getVersionNum()} will return 0.</p>
    *
@@ -95,7 +95,7 @@ public enum ServerVersion implements Version {
   }
 
   /**
-   * <p>Attempt to parse the server version string into an XXYYZZ form version number.</p>
+   * Attempt to parse the server version string into an XXYYZZ form version number.
    *
    * <p>Returns 0 if the version could not be parsed.</p>
    *

--- a/pgjdbc/src/main/java/org/postgresql/core/TypeInfo.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/TypeInfo.java
@@ -120,10 +120,10 @@ public interface TypeInfo {
   boolean requiresQuotingSqlType(int sqlType) throws SQLException;
 
   /**
-   * <p>Java Integers are signed 32-bit integers, but oids are unsigned 32-bit integers.
+   * Java Integers are signed 32-bit integers, but oids are unsigned 32-bit integers.
    * We therefore read them as positive long values and then force them into signed integers
    * (wrapping around into negative values when required) or we'd be unable to correctly
-   * handle the upper half of the oid space.</p>
+   * handle the upper half of the oid space.
    *
    * <p>This function handles the mapping of uint32-values in the long to java integers, and
    * throws for values that are out of range.</p>

--- a/pgjdbc/src/main/java/org/postgresql/core/Utils.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/Utils.java
@@ -152,7 +152,7 @@ public class Utils {
   }
 
   /**
-   * <p>Attempt to parse the server version string into an XXYYZZ form version number.</p>
+   * Attempt to parse the server version string into an XXYYZZ form version number.
    *
    * <p>Returns 0 if the version could not be parsed.</p>
    *

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/CopyInImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/CopyInImpl.java
@@ -14,7 +14,7 @@ import org.postgresql.util.PSQLState;
 import java.sql.SQLException;
 
 /**
- * <p>COPY FROM STDIN operation.</p>
+ * COPY FROM STDIN operation.
  *
  * <p>Anticipated flow:
  *

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/CopyOutImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/CopyOutImpl.java
@@ -12,7 +12,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import java.sql.SQLException;
 
 /**
- * <p>Anticipated flow of a COPY TO STDOUT operation:</p>
+ * Anticipated flow of a COPY TO STDOUT operation:
  *
  * <p>CopyManager.copyOut() -&gt;QueryExecutor.startCopy() - sends given query to server
  * -&gt;processCopyResults(): - receives CopyOutResponse from Server - creates new CopyOutImpl

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -182,7 +182,7 @@ public class QueryExecutorImpl extends QueryExecutorBase {
   }
 
   /**
-   * <p>Supplement to synchronization of public methods on current QueryExecutor.</p>
+   * Supplement to synchronization of public methods on current QueryExecutor.
    *
    * <p>Necessary for keeping the connection intact between calls to public methods sharing a state
    * such as COPY subprotocol. waitOnLock() must be called at beginning of each connection access
@@ -3068,8 +3068,8 @@ public class QueryExecutorImpl extends QueryExecutorBase {
   private final boolean cleanupSavePoints;
 
   /**
-   * <p>The estimated server response size since we last consumed the input stream from the server, in
-   * bytes.</p>
+   * The estimated server response size since we last consumed the input stream from the server, in
+   * bytes.
    *
    * <p>Starts at zero, reset by every Sync message. Mainly used for batches.</p>
    *

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/SimpleParameterList.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/SimpleParameterList.java
@@ -182,8 +182,8 @@ class SimpleParameterList implements V3ParameterList {
   }
 
   /**
-   * <p>Escapes a given text value as a literal, wraps it in single quotes, casts it to the
-   * to the given data type, and finally wraps the whole thing in parentheses.</p>
+   * Escapes a given text value as a literal, wraps it in single quotes, casts it to the
+   * to the given data type, and finally wraps the whole thing in parentheses.
    *
    * <p>For example, "123" and "int4" becomes "('123'::int)"</p>
    *

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/SimpleQuery.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/SimpleQuery.java
@@ -74,8 +74,8 @@ class SimpleQuery implements Query {
   }
 
   /**
-   * <p>Return maximum size in bytes that each result row from this query may return. Mainly used for
-   * batches that return results.</p>
+   * Return maximum size in bytes that each result row from this query may return. Mainly used for
+   * batches that return results.
    *
    * <p>Results are cached until/unless the query is re-described.</p>
    *

--- a/pgjdbc/src/main/java/org/postgresql/ds/PGPooledConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/ds/PGPooledConnection.java
@@ -385,10 +385,10 @@ public class PGPooledConnection implements PooledConnection {
   }
 
   /**
-   * <p>Instead of declaring classes implementing Statement, PreparedStatement, and CallableStatement,
+   * Instead of declaring classes implementing Statement, PreparedStatement, and CallableStatement,
    * which would have to be updated for every JDK rev, use a dynamic proxy to handle all calls
    * through the Statement interfaces. This is the part that requires JDK 1.3 or higher, though JDK
-   * 1.2 could be supported with a 3rd-party proxy package.</p>
+   * 1.2 could be supported with a 3rd-party proxy package.
    *
    * <p>The StatementHandler is required in order to return the proper Connection proxy for the
    * getConnection method.</p>

--- a/pgjdbc/src/main/java/org/postgresql/fastpath/Fastpath.java
+++ b/pgjdbc/src/main/java/org/postgresql/fastpath/Fastpath.java
@@ -24,7 +24,7 @@ import java.util.Map;
 import java.util.logging.Level;
 
 /**
- * <p>This class implements the Fastpath api.</p>
+ * This class implements the Fastpath api.
  *
  * <p>This is a means of executing functions embedded in the backend from within a java application.</p>
  *
@@ -131,7 +131,7 @@ public class Fastpath {
   }
 
   /**
-   * <p>Send a function call to the PostgreSQL backend by name.</p>
+   * Send a function call to the PostgreSQL backend by name.
    *
    * <p>Note: the mapping for the procedure name to function id needs to exist, usually to an earlier
    * call to addfunction().</p>
@@ -232,7 +232,7 @@ public class Fastpath {
   }
 
   /**
-   * <p>This adds a function to our lookup table.</p>
+   * This adds a function to our lookup table.
    *
    * <p>User code should use the addFunctions method, which is based upon a query, rather than hard
    * coding the oid. The oid for a function is not guaranteed to remain static, even on different
@@ -246,8 +246,8 @@ public class Fastpath {
   }
 
   /**
-   * <p>This takes a ResultSet containing two columns. Column 1 contains the function name, Column 2
-   * the oid.</p>
+   * This takes a ResultSet containing two columns. Column 1 contains the function name, Column 2
+   * the oid.
    *
    * <p>It reads the entire ResultSet, loading the values into the function table.</p>
    *
@@ -280,7 +280,7 @@ public class Fastpath {
   }
 
   /**
-   * <p>This returns the function id associated by its name.</p>
+   * This returns the function id associated by its name.
    *
    * <p>If addFunction() or addFunctions() have not been called for this name, then an SQLException is
    * thrown.</p>

--- a/pgjdbc/src/main/java/org/postgresql/hostchooser/HostRequirement.java
+++ b/pgjdbc/src/main/java/org/postgresql/hostchooser/HostRequirement.java
@@ -56,10 +56,10 @@ public enum HostRequirement {
   public abstract boolean allowConnectingTo(@Nullable HostStatus status);
 
   /**
-   * <p>The postgreSQL project has decided not to use the term slave to refer to alternate servers.
+   * The postgreSQL project has decided not to use the term slave to refer to alternate servers.
    * secondary or standby is preferred. We have arbitrarily chosen secondary.
    * As of Jan 2018 in order not to break existing code we are going to accept both slave or
-   * secondary for names of alternate servers.</p>
+   * secondary for names of alternate servers.
    *
    * <p>The current policy is to keep accepting this silently but not document slave, or slave preferSlave</p>
    *

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/BooleanTypeUtil.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/BooleanTypeUtil.java
@@ -13,7 +13,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * <p>Helper class to handle boolean type of PostgreSQL.</p>
+ * Helper class to handle boolean type of PostgreSQL.
  *
  * <p>Based on values accepted by the PostgreSQL server:
  * https://www.postgresql.org/docs/current/static/datatype-boolean.html</p>

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/EscapeSyntaxCallMode.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/EscapeSyntaxCallMode.java
@@ -6,9 +6,9 @@
 package org.postgresql.jdbc;
 
 /**
- * <p>Specifies whether a SELECT/CALL statement is used for the underlying SQL for JDBC escape call syntax: 'select' means to
+ * Specifies whether a SELECT/CALL statement is used for the underlying SQL for JDBC escape call syntax: 'select' means to
  * always use SELECT, 'callIfNoReturn' means to use CALL if there is no return parameter (otherwise use SELECT), and 'call' means
- * to always use CALL.</p>
+ * to always use CALL.
  *
  * @see org.postgresql.PGProperty#ESCAPE_SYNTAX_CALL_MODE
  */

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgArray.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgArray.java
@@ -30,7 +30,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * <p>Array is used collect one column of query result data.</p>
+ * Array is used collect one column of query result data.
  *
  * <p>Read a field of type Array into either a natively-typed Java array object or a ResultSet.
  * Accessor methods provide the ability to capture array slices.</p>

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
@@ -635,9 +635,9 @@ public class PgConnection implements BaseConnection {
   }
 
   /**
-   * <p>In SQL, a result table can be retrieved through a cursor that is named. The current row of a
+   * In SQL, a result table can be retrieved through a cursor that is named. The current row of a
    * result can be updated or deleted using a positioned update/delete statement that references the
-   * cursor name.</p>
+   * cursor name.
    *
    * <p>We do not support positioned update/delete, so this is a no-op.</p>
    *
@@ -661,8 +661,8 @@ public class PgConnection implements BaseConnection {
   }
 
   /**
-   * <p>We are required to bring back certain information by the DatabaseMetaData class. These
-   * functions do that.</p>
+   * We are required to bring back certain information by the DatabaseMetaData class. These
+   * functions do that.
    *
    * <p>Method getURL() brings back the URL (good job we saved it)</p>
    *

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnectionCleaningAction.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnectionCleaningAction.java
@@ -20,6 +20,7 @@ import java.util.logging.Logger;
 /**
  * This class segregates the minimal resources required for proper cleanup in case
  * the connection has not been closed by the user code.
+ *
  * <p>For now, it has two actions:</p>
  * <ul>
  *   <li>Print stacktrace when the connection has been created, so users can identify the leak</li>

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
@@ -703,6 +703,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
 
   /**
    * {@inheritDoc}
+   *
    * <p>PostgreSQL doesn't have schemas, but when it does, we'll use the term "schema".</p>
    *
    * @return {@code "schema"}
@@ -913,6 +914,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
 
   /**
    * {@inheritDoc}
+   *
    * <p>Can statements remain open across commits? They may, but this driver cannot guarantee that. In
    * further reflection. we are talking a Statement object here, so the answer is yes, since the
    * Statement is only a vehicle to ExecSQL()</p>
@@ -926,6 +928,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
 
   /**
    * {@inheritDoc}
+   *
    * <p>Can statements remain open across rollbacks? They may, but this driver cannot guarantee that.
    * In further contemplation, we are talking a Statement object here, so the answer is yes, since
    * the Statement is only a vehicle to ExecSQL() in Connection</p>
@@ -1104,6 +1107,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
 
   /**
    * {@inheritDoc}
+   *
    * <p>We only support TRANSACTION_SERIALIZABLE and TRANSACTION_READ_COMMITTED before 8.0; from 8.0
    * READ_UNCOMMITTED and REPEATABLE_READ are accepted aliases for READ_COMMITTED.</p>
    */
@@ -1131,8 +1135,8 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
   }
 
   /**
-   * <p>Does a data definition statement within a transaction force the transaction to commit? It seems
-   * to mean something like:</p>
+   * Does a data definition statement within a transaction force the transaction to commit? It seems
+   * to mean something like:
    *
    * <pre>
    * CREATE TABLE T (A INT);

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
@@ -2445,8 +2445,8 @@ public class PgResultSet implements ResultSet, PGRefCursorResultSet {
   }
 
   /**
-   * <p>Retrieves the value of the designated column in the current row of this <code>ResultSet</code>
-   * object as a <code>boolean</code> in the Java programming language.</p>
+   * Retrieves the value of the designated column in the current row of this <code>ResultSet</code>
+   * object as a <code>boolean</code> in the Java programming language.
    *
    * <p>If the designated column has a Character datatype and is one of the following values: "1",
    * "true", "t", "yes", "y" or "on", a value of <code>true</code> is returned. If the designated
@@ -3157,7 +3157,7 @@ public class PgResultSet implements ResultSet, PGRefCursorResultSet {
   }
 
   /**
-   * <p>This is used to fix get*() methods on Money fields. It should only be used by those methods!</p>
+   * This is used to fix get*() methods on Money fields. It should only be used by those methods!
    *
    * <p>It converts ($##.##) to -##.## and $##.## to ##.##</p>
    *
@@ -3539,7 +3539,7 @@ public class PgResultSet implements ResultSet, PGRefCursorResultSet {
   private static final double LONG_MIN_DOUBLE = StrictMath.nextUp((double) Long.MIN_VALUE);
 
   /**
-   * <p>Converts any numeric binary field to long value.</p>
+   * Converts any numeric binary field to long value.
    *
    * <p>This method is used by getByte,getShort,getInt and getLong. It must support a subset of the
    * following java types that use Binary encoding. (fields that use text encoding use a different

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgStatement.java
@@ -632,7 +632,7 @@ public class PgStatement implements Statement, BaseStatement {
   }
 
   /**
-   * <p>Either initializes new warning wrapper, or adds warning onto the chain.</p>
+   * Either initializes new warning wrapper, or adds warning onto the chain.
    *
    * <p>Although warnings are expected to be added sequentially, the warnings chain may be cleared
    * concurrently at any time via {@link #clearWarnings()}, therefore it is possible that a warning
@@ -675,7 +675,8 @@ public class PgStatement implements Statement, BaseStatement {
   }
 
   /**
-   * <p>Clears the warning chain.</p>
+   * Clears the warning chain.
+   *
    * <p>Note that while it is safe to clear warnings while the query is executing, warnings that are
    * added between calls to {@link #getWarnings()} and #clearWarnings() may be missed.
    * Therefore you should hold a reference to the tail of the previous warning chain

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PreferQueryMode.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PreferQueryMode.java
@@ -6,8 +6,8 @@
 package org.postgresql.jdbc;
 
 /**
- * <p>Specifies which mode is used to execute queries to database: simple means ('Q' execute, no parse, no bind, text mode only),
- * extended means always use bind/execute messages, extendedForPrepared means extended for prepared statements only.</p>
+ * Specifies which mode is used to execute queries to database: simple means ('Q' execute, no parse, no bind, text mode only),
+ * extended means always use bind/execute messages, extendedForPrepared means extended for prepared statements only.
  *
  * <p>Note: this is for debugging purposes only.</p>
  *

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/QueryExecutorTimeZoneProvider.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/QueryExecutorTimeZoneProvider.java
@@ -14,6 +14,7 @@ import java.util.TimeZone;
 /**
  * This class workarounds <a href="https://github.com/wildfly/jandex/issues/93">Exception when
  * indexing guava-30.0-jre</a>.
+ *
  * <p>It looks like {@code jandex} does not support {@code new Interface<..>} with type annotations.
  * </p>
  */

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/TimestampUtils.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/TimestampUtils.java
@@ -1618,8 +1618,8 @@ public class TimestampUtils {
   }
 
   /**
-   * <p>Given a UTC timestamp {@code millis} finds another point in time that is rendered in given time
-   * zone {@code tz} exactly as "millis in UTC".</p>
+   * Given a UTC timestamp {@code millis} finds another point in time that is rendered in given time
+   * zone {@code tz} exactly as "millis in UTC".
    *
    * <p>For instance, given 7 Jan 16:00 UTC and tz=GMT+02:00 it returns 7 Jan 14:00 UTC == 7 Jan 16:00
    * GMT+02:00 Note that is not trivial for timestamps near DST change. For such cases, we rely on

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
@@ -114,6 +114,7 @@ public class TypeInfoCache implements TypeInfo {
   /**
    * PG maps several alias to real type names. When we do queries against pg_catalog, we must use
    * the real type, not an alias, so use this mapping.
+   *
    * <p>
    * Additional values used at runtime (including case variants) will be added to the map.
    * </p>

--- a/pgjdbc/src/main/java/org/postgresql/largeobject/BlobInputStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/largeobject/BlobInputStream.java
@@ -240,7 +240,7 @@ public class BlobInputStream extends InputStream {
   }
 
   /**
-   * <p>Closes this input stream and releases any system resources associated with the stream.</p>
+   * Closes this input stream and releases any system resources associated with the stream.
    *
    * <p>The <code>close</code> method of <code>InputStream</code> does nothing.</p>
    *
@@ -265,9 +265,9 @@ public class BlobInputStream extends InputStream {
   }
 
   /**
-   * <p>Marks the current position in this input stream. A subsequent call to the <code>reset</code>
+   * Marks the current position in this input stream. A subsequent call to the <code>reset</code>
    * method repositions this stream at the last marked position so that subsequent reads re-read the
-   * same bytes.</p>
+   * same bytes.
    *
    * <p>The <code>readlimit</code> arguments tells this input stream to allow that many bytes to be
    * read before the mark position gets invalidated.</p>

--- a/pgjdbc/src/main/java/org/postgresql/largeobject/LargeObject.java
+++ b/pgjdbc/src/main/java/org/postgresql/largeobject/LargeObject.java
@@ -20,8 +20,8 @@ import java.io.OutputStream;
 import java.sql.SQLException;
 
 /**
- * <p>This class provides the basic methods required to run the interface, plus a pair of methods that
- * provide InputStream and OutputStream classes for this object.</p>
+ * This class provides the basic methods required to run the interface, plus a pair of methods that
+ * provide InputStream and OutputStream classes for this object.
  *
  * <p>Normally, client code would use the getAsciiStream, getBinaryStream, or getUnicodeStream methods
  * in ResultSet, or setAsciiStream, setBinaryStream, or setUnicodeStream methods in
@@ -75,7 +75,7 @@ public class LargeObject
   private final boolean commitOnClose; // Only initialized when open a LOB with CommitOnClose
 
   /**
-   * <p>This opens a large object.</p>
+   * This opens a large object.
    *
    * <p>If the object does not exist, then an SQLException is thrown.</p>
    *
@@ -108,7 +108,7 @@ public class LargeObject
   }
 
   /**
-   * <p>This opens a large object.</p>
+   * This opens a large object.
    *
    * <p>If the object does not exist, then an SQLException is thrown.</p>
    *
@@ -266,7 +266,7 @@ public class LargeObject
   }
 
   /**
-   * <p>Sets the current position within the object.</p>
+   * Sets the current position within the object.
    *
    * <p>This is similar to the fseek() call in the standard C library. It allows you to have random
    * access to the large object.</p>
@@ -299,7 +299,7 @@ public class LargeObject
   }
 
   /**
-   * <p>Sets the current position within the object.</p>
+   * Sets the current position within the object.
    *
    * <p>This is similar to the fseek() call in the standard C library. It allows you to have random
    * access to the large object.</p>
@@ -332,8 +332,8 @@ public class LargeObject
   }
 
   /**
-   * <p>This method is inefficient, as the only way to find out the size of the object is to seek to
-   * the end, record the current position, then return to the original position.</p>
+   * This method is inefficient, as the only way to find out the size of the object is to seek to
+   * the end, record the current position, then return to the original position.
    *
    * <p>A better method will be found in the future.</p>
    *
@@ -393,7 +393,7 @@ public class LargeObject
   }
 
   /**
-   * <p>Returns an {@link InputStream} from this object.</p>
+   * Returns an {@link InputStream} from this object.
    *
    * <p>This {@link InputStream} can then be used in any method that requires an InputStream.</p>
    *
@@ -431,7 +431,7 @@ public class LargeObject
   }
 
   /**
-   * <p>Returns an {@link OutputStream} to this object.</p>
+   * Returns an {@link OutputStream} to this object.
    *
    * <p>This OutputStream can then be used in any method that requires an OutputStream.</p>
    *

--- a/pgjdbc/src/main/java/org/postgresql/largeobject/LargeObjectManager.java
+++ b/pgjdbc/src/main/java/org/postgresql/largeobject/LargeObjectManager.java
@@ -78,7 +78,7 @@ public class LargeObjectManager {
   public static final int READWRITE = READ | WRITE;
 
   /**
-   * <p>Constructs the LargeObject API.</p>
+   * Constructs the LargeObject API.
    *
    * <p><b>Important Notice</b> <br>
    * This method should only be called by {@link BaseConnection}</p>
@@ -248,7 +248,7 @@ public class LargeObjectManager {
   }
 
   /**
-   * <p>This creates a large object, returning its OID.</p>
+   * This creates a large object, returning its OID.
    *
    * <p>It defaults to READWRITE for the new object's attributes.</p>
    *
@@ -262,7 +262,7 @@ public class LargeObjectManager {
   }
 
   /**
-   * <p>This creates a large object, returning its OID.</p>
+   * This creates a large object, returning its OID.
    *
    * <p>It defaults to READWRITE for the new object's attributes.</p>
    *
@@ -317,7 +317,7 @@ public class LargeObjectManager {
   }
 
   /**
-   * <p>This deletes a large object.</p>
+   * This deletes a large object.
    *
    * <p>It is identical to the delete method, and is supplied as the C API uses unlink.</p>
    *
@@ -331,7 +331,7 @@ public class LargeObjectManager {
   }
 
   /**
-   * <p>This deletes a large object.</p>
+   * This deletes a large object.
    *
    * <p>It is identical to the delete method, and is supplied as the C API uses unlink.</p>
    *

--- a/pgjdbc/src/main/java/org/postgresql/replication/PGReplicationConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/replication/PGReplicationConnection.java
@@ -27,7 +27,7 @@ public interface PGReplicationConnection {
   ChainedStreamBuilder replicationStream();
 
   /**
-   * <p>Create replication slot, that can be next use in {@link PGReplicationConnection#replicationStream()}</p>
+   * Create replication slot, that can be next use in {@link PGReplicationConnection#replicationStream()}
    *
    * <p>Replication slots provide an automated way to ensure that the master does not remove WAL
    * segments until they have been received by all standbys, and that the master does not remove

--- a/pgjdbc/src/main/java/org/postgresql/replication/PGReplicationStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/replication/PGReplicationStream.java
@@ -24,8 +24,8 @@ public interface PGReplicationStream
     extends AutoCloseable {
 
   /**
-   * <p>Read next wal record from backend. It method can be block until new message will not get
-   * from server.</p>
+   * Read next wal record from backend. It method can be block until new message will not get
+   * from server.
    *
    * <p>A single WAL record is never split across two XLogData messages. When a WAL record crosses a
    * WAL page boundary, and is therefore already split using continuation records, it can be split
@@ -39,10 +39,10 @@ public interface PGReplicationStream
   @Nullable ByteBuffer read() throws SQLException;
 
   /**
-   * <p>Read next WAL record from backend. This method does not block and in contrast to {@link
+   * Read next WAL record from backend. This method does not block and in contrast to {@link
    * PGReplicationStream#read()}. If message from backend absent return null. It allow periodically
    * check message in stream and if they absent sleep some time, but it time should be less than
-   * {@link CommonOptions#getStatusInterval()} to avoid disconnect from the server.</p>
+   * {@link CommonOptions#getStatusInterval()} to avoid disconnect from the server.
    *
    * <p>A single WAL record is never split across two XLogData messages. When a WAL record crosses a
    * WAL page boundary, and is therefore already split using continuation records, it can be split
@@ -57,7 +57,7 @@ public interface PGReplicationStream
   @Nullable ByteBuffer readPending() throws SQLException;
 
   /**
-   * <p>Parameter updates by execute {@link PGReplicationStream#read()} method.</p>
+   * Parameter updates by execute {@link PGReplicationStream#read()} method.
    *
    * <p>It is safe to call this method in a thread different than the main thread. However, usually this
    * method is called in the main thread after a successful {@link PGReplicationStream#read()} or
@@ -69,8 +69,8 @@ public interface PGReplicationStream
   LogSequenceNumber getLastReceiveLSN();
 
   /**
-   * <p>Last flushed LSN sent in update message to backend. Parameter updates only via {@link
-   * PGReplicationStream#setFlushedLSN(LogSequenceNumber)}</p>
+   * Last flushed LSN sent in update message to backend. Parameter updates only via {@link
+   * PGReplicationStream#setFlushedLSN(LogSequenceNumber)}
    *
    * <p>It is safe to call this method in a thread different than the main thread.</p>
    *
@@ -79,8 +79,8 @@ public interface PGReplicationStream
   LogSequenceNumber getLastFlushedLSN();
 
   /**
-   * <p>Last applied lsn sent in update message to backed. Parameter updates only via {@link
-   * PGReplicationStream#setAppliedLSN(LogSequenceNumber)}</p>
+   * Last applied lsn sent in update message to backed. Parameter updates only via {@link
+   * PGReplicationStream#setAppliedLSN(LogSequenceNumber)}
    *
    * <p>It is safe to call this method in a thread different than the main thread.</p>
    *
@@ -89,8 +89,8 @@ public interface PGReplicationStream
   LogSequenceNumber getLastAppliedLSN();
 
   /**
-   * <p>Set flushed LSN. This parameter will be sent to backend on next update status iteration. Flushed
-   * LSN position help backend define which WAL can be recycled.</p>
+   * Set flushed LSN. This parameter will be sent to backend on next update status iteration. Flushed
+   * LSN position help backend define which WAL can be recycled.
    *
    * <p>It is safe to call this method in a thread different than the main thread. The updated value
    * will be sent to the backend in the next status update run.</p>
@@ -101,8 +101,8 @@ public interface PGReplicationStream
   void setFlushedLSN(LogSequenceNumber flushed);
 
   /**
-   * <p>Inform backend which LSN has been applied on standby.
-   * Feedback will send to backend on next update status iteration.</p>
+   * Inform backend which LSN has been applied on standby.
+   * Feedback will send to backend on next update status iteration.
    *
    * <p>It is safe to call this method in a thread different than the main thread. The updated value
    * will be sent to the backend in the next status update run.</p>
@@ -128,8 +128,8 @@ public interface PGReplicationStream
   boolean isClosed();
 
   /**
-   * <p>Stop replication changes from server and free resources. After that connection can be reuse
-   * to another queries. Also after close current stream they cannot be used anymore.</p>
+   * Stop replication changes from server and free resources. After that connection can be reuse
+   * to another queries. Also after close current stream they cannot be used anymore.
    *
    * <p><b>Note:</b> This method can spend much time for logical replication stream on postgresql
    * version 9.6 and lower, because postgresql have bug - during decode big transaction to logical

--- a/pgjdbc/src/main/java/org/postgresql/replication/fluent/ChainedCommonCreateSlotBuilder.java
+++ b/pgjdbc/src/main/java/org/postgresql/replication/fluent/ChainedCommonCreateSlotBuilder.java
@@ -26,8 +26,8 @@ public interface ChainedCommonCreateSlotBuilder<T extends ChainedCommonCreateSlo
   T withSlotName(String slotName);
 
   /**
-   * <p>Temporary slots are not saved to disk and are automatically dropped on error or when
-   * the session has finished.</p>
+   * Temporary slots are not saved to disk and are automatically dropped on error or when
+   * the session has finished.
    *
    * <p>This feature is only supported by PostgreSQL versions &gt;= 10.</p>
    *

--- a/pgjdbc/src/main/java/org/postgresql/replication/fluent/ChainedCreateReplicationSlotBuilder.java
+++ b/pgjdbc/src/main/java/org/postgresql/replication/fluent/ChainedCreateReplicationSlotBuilder.java
@@ -48,7 +48,7 @@ public interface ChainedCreateReplicationSlotBuilder {
   ChainedLogicalCreateSlotBuilder logical();
 
   /**
-   * <p>Create physical replication stream for process wal logs in binary form.</p>
+   * Create physical replication stream for process wal logs in binary form.
    *
    * <p>Example usage:</p>
    * <pre>

--- a/pgjdbc/src/main/java/org/postgresql/replication/fluent/ChainedStreamBuilder.java
+++ b/pgjdbc/src/main/java/org/postgresql/replication/fluent/ChainedStreamBuilder.java
@@ -14,12 +14,11 @@ import org.postgresql.replication.fluent.physical.ChainedPhysicalStreamBuilder;
  */
 public interface ChainedStreamBuilder {
   /**
-   * <p>Create logical replication stream that decode raw wal logs by output plugin to logical form.
+   * Create logical replication stream that decode raw wal logs by output plugin to logical form.
    * Default about logical decoding you can see by following link
    * <a href="http://www.postgresql.org/docs/current/static/logicaldecoding-explanation.html">
    *     Logical Decoding Concepts
    * </a>.
-   * </p>
    *
    * <p>Example usage:</p>
    * <pre>
@@ -48,7 +47,7 @@ public interface ChainedStreamBuilder {
   ChainedLogicalStreamBuilder logical();
 
   /**
-   * <p>Create physical replication stream for process wal logs in binary form.</p>
+   * Create physical replication stream for process wal logs in binary form.
    *
    * <p>Example usage:</p>
    * <pre>

--- a/pgjdbc/src/main/java/org/postgresql/replication/fluent/logical/ChainedLogicalCreateSlotBuilder.java
+++ b/pgjdbc/src/main/java/org/postgresql/replication/fluent/logical/ChainedLogicalCreateSlotBuilder.java
@@ -14,8 +14,8 @@ public interface ChainedLogicalCreateSlotBuilder
     extends ChainedCommonCreateSlotBuilder<ChainedLogicalCreateSlotBuilder> {
 
   /**
-   * <p>Output plugin that should be use for decode physical represent WAL to some logical form.
-   * Output plugin should be installed on server(exists in shared_preload_libraries).</p>
+   * Output plugin that should be use for decode physical represent WAL to some logical form.
+   * Output plugin should be installed on server(exists in shared_preload_libraries).
    *
    * <p>Package postgresql-contrib provides sample output plugin <b>test_decoding</b> that can be
    * use for test logical replication api</p>

--- a/pgjdbc/src/main/java/org/postgresql/ssl/SingleCertValidatingFactory.java
+++ b/pgjdbc/src/main/java/org/postgresql/ssl/SingleCertValidatingFactory.java
@@ -26,10 +26,10 @@ import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509TrustManager;
 
 /**
- * <p>Provides a SSLSocketFactory that authenticates the remote server against an explicit pre-shared
+ * Provides a SSLSocketFactory that authenticates the remote server against an explicit pre-shared
  * SSL certificate. This is more secure than using the NonValidatingFactory as it prevents "man in
  * the middle" attacks. It is also more secure than relying on a central CA signing your server's
- * certificate as it pins the server's certificate.</p>
+ * certificate as it pins the server's certificate.
  *
  * <p>This class requires a single String parameter specified by setting the connection property
  * <code>sslfactoryarg</code>. The value of this property is the PEM-encoded remote server's SSL

--- a/pgjdbc/src/main/java/org/postgresql/sspi/ISSPIClient.java
+++ b/pgjdbc/src/main/java/org/postgresql/sspi/ISSPIClient.java
@@ -10,8 +10,8 @@ import java.io.IOException;
 import java.sql.SQLException;
 
 /**
- * <p>Use Waffle-JNI to support SSPI authentication when PgJDBC is running on a Windows
- * client and talking to a Windows server.</p>
+ * Use Waffle-JNI to support SSPI authentication when PgJDBC is running on a Windows
+ * client and talking to a Windows server.
  *
  * <p>SSPI is not supported on a non-Windows client.</p>
  */

--- a/pgjdbc/src/main/java/org/postgresql/sspi/NTDSAPI.java
+++ b/pgjdbc/src/main/java/org/postgresql/sspi/NTDSAPI.java
@@ -18,7 +18,7 @@ interface NTDSAPI extends StdCallLibrary {
   NTDSAPI instance = (NTDSAPI) Native.loadLibrary("NTDSAPI", NTDSAPI.class);
 
   /**
-   * <p>Wrap DsMakeSpn</p>
+   * Wrap DsMakeSpn
    *
    * <p>To get the String result, call
    *

--- a/pgjdbc/src/main/java/org/postgresql/sspi/SSPIClient.java
+++ b/pgjdbc/src/main/java/org/postgresql/sspi/SSPIClient.java
@@ -31,8 +31,8 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * <p>Use Waffle-JNI to support SSPI authentication when PgJDBC is running on a Windows client and
- * talking to a Windows server.</p>
+ * Use Waffle-JNI to support SSPI authentication when PgJDBC is running on a Windows client and
+ * talking to a Windows server.
  *
  * <p>SSPI is not supported on a non-Windows client.</p>
  *
@@ -70,7 +70,7 @@ public class SSPIClient implements ISSPIClient {
   }
 
   /**
-   * <p>Instantiate an SSPIClient for authentication of a connection.</p>
+   * Instantiate an SSPIClient for authentication of a connection.
    *
    * <p>SSPIClient is not re-usable across connections.</p>
    *

--- a/pgjdbc/src/main/java/org/postgresql/util/ByteStreamWriter.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/ByteStreamWriter.java
@@ -16,16 +16,20 @@ import java.nio.ByteBuffer;
  * <p>The intended use case is wanting to write data to a byte array parameter that is stored off
  * heap in a direct memory pool or in some other form that is inconvenient to assemble into a single
  * heap-allocated buffer.</p>
+ *
  * <p> Users should write their own implementation depending on the
  * original data source. The driver provides a built-in implementation supporting the {@link
  * java.nio.ByteBuffer} class, see {@link ByteBufferByteStreamWriter}.</p>
- * <p> Intended usage is to simply pass in an instance using
+ *
+ * <p>Intended usage is to simply pass in an instance using
  * {@link java.sql.PreparedStatement#setObject(int, Object)}:</p>
  * <pre>
  *     int bufLength = someBufferObject.length();
  *     preparedStatement.setObject(1, new MyByteStreamWriter(bufLength, someBufferObject));
  * </pre>
+ *
  * <p>The length must be known ahead of the stream being written to. </p>
+ *
  * <p>This provides the application more control over memory management than calling
  * {@link java.sql.PreparedStatement#setBinaryStream(int, InputStream)} as with the latter the
  * caller has no control over the buffering strategy. </p>
@@ -35,7 +39,7 @@ public interface ByteStreamWriter {
   /**
    * Returns the length of the stream.
    *
-   * <p> This must be known ahead of calling {@link #writeTo(ByteStreamTarget)}. </p>
+   * <p>This must be known ahead of calling {@link #writeTo(ByteStreamTarget)}. </p>
    *
    * @return the number of bytes in the stream.
    */
@@ -44,7 +48,7 @@ public interface ByteStreamWriter {
   /**
    * Write the data to the provided {@link OutputStream}.
    *
-   * <p> Should not write more than {@link #getLength()} bytes. If attempted, the provided stream
+   * <p>Should not write more than {@link #getLength()} bytes. If attempted, the provided stream
    * will throw an {@link java.io.IOException}. </p>
    *
    * @param target the stream to write the data to

--- a/pgjdbc/src/main/java/org/postgresql/util/ExpressionProperties.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/ExpressionProperties.java
@@ -31,8 +31,8 @@ public class ExpressionProperties extends Properties {
   }
 
   /**
-   * <p>Returns property value with all {@code ${propKey}} like references replaced with the value of
-   * the relevant property with recursive resolution.</p>
+   * Returns property value with all {@code ${propKey}} like references replaced with the value of
+   * the relevant property with recursive resolution.
    *
    * <p>The method returns <code>null</code> if the property is not found.</p>
    *

--- a/pgjdbc/src/main/java/org/postgresql/util/LazyCleaner.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/LazyCleaner.java
@@ -33,6 +33,7 @@ import java.util.logging.Logger;
 
 /**
  * LazyCleaner is a utility class that allows to register objects for deferred cleanup.
+ *
  * <p>Note: this is a driver-internal class</p>
  */
 public class LazyCleaner {
@@ -60,6 +61,7 @@ public class LazyCleaner {
 
   /**
    * Returns a default cleaner instance.
+   *
    * <p>Note: this is driver-internal API.</p>
    * @return the instance of LazyCleaner
    */

--- a/pgjdbc/src/main/java/org/postgresql/util/PGTimestamp.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/PGTimestamp.java
@@ -38,9 +38,9 @@ public class PGTimestamp extends Timestamp {
   }
 
   /**
-   * <p>Constructs a <code>PGTimestamp</code> with the given time zone. The integral seconds are stored
+   * Constructs a <code>PGTimestamp</code> with the given time zone. The integral seconds are stored
    * in the underlying date value; the fractional seconds are stored in the <code>nanos</code> field
-   * of the <code>Timestamp</code> object.</p>
+   * of the <code>Timestamp</code> object.
    *
    * <p>The calendar object is optional. If absent, the driver will treat the timestamp as
    * <code>timestamp without time zone</code>. When present, the driver will treat the timestamp as

--- a/pgjdbc/src/main/java/org/postgresql/util/PGobject.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/PGobject.java
@@ -27,7 +27,7 @@ public class PGobject implements Serializable, Cloneable {
   }
 
   /**
-   * <p>This method sets the type of this object.</p>
+   * This method sets the type of this object.
    *
    * <p>It should not be extended by subclasses, hence it is final</p>
    *

--- a/pgjdbc/src/main/java/org/postgresql/util/PGtokenizer.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/PGtokenizer.java
@@ -41,7 +41,7 @@ public class PGtokenizer {
   protected List<String> tokens = new ArrayList<>();
 
   /**
-   * <p>Create a tokeniser.</p>
+   * Create a tokeniser.
    *
    * <p>We could have used StringTokenizer to do this, however, we needed to handle nesting of '(' ')'
    * '[' ']' '&lt;' and '&gt;' as these are used by the geometric data types.</p>
@@ -145,7 +145,7 @@ public class PGtokenizer {
   }
 
   /**
-   * <p>This returns a new tokenizer based on one of our tokens.</p>
+   * This returns a new tokenizer based on one of our tokens.
    *
    * <p>The geometric datatypes use this to process nested tokens (usually PGpoint).</p>
    *

--- a/pgjdbc/src/main/java/org/postgresql/util/ReaderInputStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/ReaderInputStream.java
@@ -16,8 +16,8 @@ import java.nio.charset.CoderResult;
 import java.nio.charset.StandardCharsets;
 
 /**
- * <p>ReaderInputStream accepts a UTF-16 char stream (Reader) as input and
- * converts it to a UTF-8 byte stream (InputStream) as output.</p>
+ * ReaderInputStream accepts a UTF-16 char stream (Reader) as input and
+ * converts it to a UTF-8 byte stream (InputStream) as output.
  *
  * <p>This is the inverse of java.io.InputStreamReader which converts a
  * binary stream to a character stream.</p>

--- a/pgjdbc/src/main/java/org/postgresql/util/URLCoder.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/URLCoder.java
@@ -10,9 +10,9 @@ import java.net.URLDecoder;
 import java.net.URLEncoder;
 
 /**
- * <p>This class helps with URL encoding and decoding. UTF-8 encoding is used by default to make
+ * This class helps with URL encoding and decoding. UTF-8 encoding is used by default to make
  * encoding consistent across the driver, and encoding might be changed via {@code
- * postgresql.url.encoding} property</p>
+ * postgresql.url.encoding} property
  *
  * <p>Note: this should not be used outside of PostgreSQL source, this is not a public API of the
  * driver.</p>

--- a/pgjdbc/src/main/java/org/postgresql/xa/PGXAConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/xa/PGXAConnection.java
@@ -35,7 +35,7 @@ import javax.transaction.xa.XAResource;
 import javax.transaction.xa.Xid;
 
 /**
- * <p>The PostgreSQL implementation of {@link XAResource}.</p>
+ * The PostgreSQL implementation of {@link XAResource}.
  *
  * <p>This implementation doesn't support transaction interleaving (see JTA specification, section
  * 3.4.4) and suspend/resume.</p>
@@ -158,7 +158,7 @@ public class PGXAConnection extends PGPooledConnection implements XAConnection, 
   }
 
   /**
-   * <p>Preconditions:</p>
+   * Preconditions:
    * <ol>
    *     <li>Flags must be one of TMNOFLAGS, TMRESUME or TMJOIN</li>
    *     <li>xid != null</li>
@@ -247,7 +247,7 @@ public class PGXAConnection extends PGPooledConnection implements XAConnection, 
   }
 
   /**
-   * <p>Preconditions:</p>
+   * Preconditions:
    * <ol>
    *     <li>Flags is one of TMSUCCESS, TMFAIL, TMSUSPEND</li>
    *     <li>xid != null</li>
@@ -299,7 +299,7 @@ public class PGXAConnection extends PGPooledConnection implements XAConnection, 
   }
 
   /**
-   * <p>Prepares transaction. Preconditions:</p>
+   * Prepares transaction. Preconditions:
    * <ol>
    *     <li>xid != null</li>
    *     <li>xid is in ended state</li>
@@ -367,7 +367,7 @@ public class PGXAConnection extends PGPooledConnection implements XAConnection, 
   }
 
   /**
-   * <p>Recovers transaction. Preconditions:</p>
+   * Recovers transaction. Preconditions:
    * <ol>
    *     <li>flag must be one of TMSTARTRSCAN, TMENDRSCAN, TMNOFLAGS or TMSTARTTRSCAN | TMENDRSCAN</li>
    *     <li>If flag isn't TMSTARTRSCAN or TMSTARTRSCAN | TMENDRSCAN, a recovery scan must be in progress</li>
@@ -424,7 +424,7 @@ public class PGXAConnection extends PGPooledConnection implements XAConnection, 
   }
 
   /**
-   * <p>Preconditions:</p>
+   * Preconditions:
    * <ol>
    *     <li>xid is known to the RM or it's in prepared state</li>
    * </ol>
@@ -504,7 +504,7 @@ public class PGXAConnection extends PGPooledConnection implements XAConnection, 
   }
 
   /**
-   * <p>Preconditions:</p>
+   * Preconditions:
    * <ol>
    *     <li>xid must in ended state.</li>
    * </ol>
@@ -555,7 +555,7 @@ public class PGXAConnection extends PGPooledConnection implements XAConnection, 
   }
 
   /**
-   * <p>Commits prepared transaction. Preconditions:</p>
+   * Commits prepared transaction. Preconditions:
    * <ol>
    *     <li>xid must be in prepared state in the server</li>
    * </ol>

--- a/pgjdbc/src/test/java/org/postgresql/replication/LogicalReplicationTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/replication/LogicalReplicationTest.java
@@ -251,9 +251,9 @@ class LogicalReplicationTest {
   }
 
   /**
-   * <p>Bug in postgreSQL that should be fixed in 10 version after code review patch <a
+   * Bug in postgreSQL that should be fixed in 10 version after code review patch <a
    * href="http://www.postgresql.org/message-id/CAFgjRd3hdYOa33m69TbeOfNNer2BZbwa8FFjt2V5VFzTBvUU3w@mail.gmail.com">
-   * Stopping logical replication protocol</a>.</p>
+   * Stopping logical replication protocol</a>.
    *
    * <p>If you try to run it test on version before 10 they fail with time out, because postgresql
    * wait new changes and until waiting messages from client ignores.</p>
@@ -324,9 +324,9 @@ class LogicalReplicationTest {
   }
 
   /**
-   * <p>Bug in postgreSQL that should be fixed in 10 version after code review patch <a
+   * Bug in postgreSQL that should be fixed in 10 version after code review patch <a
    * href="http://www.postgresql.org/message-id/CAFgjRd3hdYOa33m69TbeOfNNer2BZbwa8FFjt2V5VFzTBvUU3w@mail.gmail.com">
-   * Stopping logical replication protocol</a>.</p>
+   * Stopping logical replication protocol</a>.
    *
    * <p>If you try to run it test on version before 10 they fail with time out, because postgresql
    * wait new changes and until waiting messages from client ignores.</p>
@@ -379,9 +379,9 @@ class LogicalReplicationTest {
   }
 
   /**
-   * <p>Bug in postgreSQL that should be fixed in 10 version after code review patch <a
+   * Bug in postgreSQL that should be fixed in 10 version after code review patch <a
    * href="http://www.postgresql.org/message-id/CAFgjRd3hdYOa33m69TbeOfNNer2BZbwa8FFjt2V5VFzTBvUU3w@mail.gmail.com">
-   * Stopping logical replication protocol</a>.</p>
+   * Stopping logical replication protocol</a>.
    *
    * <p>If you try to run it test on version before 10 they fail with time out, because postgresql
    * wait new changes and until waiting messages from client ignores.</p>

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BatchExecuteTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BatchExecuteTest.java
@@ -594,7 +594,7 @@ public class BatchExecuteTest extends BaseTest4 {
   }
 
   /**
-   * <p>This one is reproduced in regular (non-force binary) mode.</p>
+   * This one is reproduced in regular (non-force binary) mode.
    *
    * <p>As of 9.4.1208 the following tests fail:
    * BatchExecuteTest.testBatchWithAlternatingAndUnknownTypes3

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/StatementTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/StatementTest.java
@@ -536,8 +536,8 @@ class StatementTest {
   }
 
   /**
-   * <p>Demonstrates a safe approach to concurrently reading the latest
-   * warnings while periodically clearing them.</p>
+   * Demonstrates a safe approach to concurrently reading the latest
+   * warnings while periodically clearing them.
    *
    * <p>One drawback of this approach is that it requires the reader to make it to the end of the
    * warning chain before clearing it, so long as your warning processing step is not very slow,

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/TimezoneTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/TimezoneTest.java
@@ -32,8 +32,8 @@ import java.util.Properties;
 import java.util.TimeZone;
 
 /**
- * <p>Tests for time and date types with calendars involved. TimestampTest was melting my brain, so I
- * started afresh. -O</p>
+ * Tests for time and date types with calendars involved. TimestampTest was melting my brain, so I
+ * started afresh. -O
  *
  * <p>Conversions that this code tests:</p>
  *

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc4/jdbc41/GetObjectTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc4/jdbc41/GetObjectTest.java
@@ -749,7 +749,7 @@ class GetObjectTest {
   }
 
   /**
-   * <p>Test the behavior getObject for money columns.</p>
+   * Test the behavior getObject for money columns.
    *
    * <p>The test is ignored as it is locale-dependent.</p>
    */

--- a/pgjdbc/src/test/java/org/postgresql/test/ssl/SingleCertValidatingFactoryTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/ssl/SingleCertValidatingFactoryTest.java
@@ -126,9 +126,9 @@ public class SingleCertValidatingFactoryTest {
   }
 
   /**
-   * <p>Connect using SSL and attempt to validate the server's certificate against the wrong pre shared
+   * Connect using SSL and attempt to validate the server's certificate against the wrong pre shared
    * certificate. This test uses a pre generated certificate that will *not* match the test
-   * PostgreSQL server (the certificate is for properssl.example.com).</p>
+   * PostgreSQL server (the certificate is for properssl.example.com).
    *
    * <p>This connection uses a custom SSLSocketFactory using a custom trust manager that validates the
    * remote server's certificate against the pre shared certificate.</p>
@@ -215,8 +215,8 @@ public class SingleCertValidatingFactoryTest {
   }
 
   /**
-   * <p>Connect using SSL and attempt to validate the server's certificate against the proper pre
-   * shared certificate. The certificate is specified as an environment variable.</p>
+   * Connect using SSL and attempt to validate the server's certificate against the proper pre
+   * shared certificate. The certificate is specified as an environment variable.
    *
    * <p>Note: To execute this test successfully you need to set the value of the environment variable
    * DATASOURCE_SSL_CERT prior to running the test.</p>

--- a/pgjdbc/src/test/java/org/postgresql/test/xa/XADataSourceTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/xa/XADataSourceTest.java
@@ -359,7 +359,7 @@ public class XADataSourceTest {
   }
 
   /**
-   * <p>Get the time the current transaction was started from the server.</p>
+   * Get the time the current transaction was started from the server.
    *
    * <p>This can be used to check that transaction doesn't get committed/ rolled back inadvertently, by
    * calling this once before and after the suspected piece of code, and check that they match. It's

--- a/pgjdbc/src/test/java/org/postgresql/util/StubEnvironmentAndProperties.java
+++ b/pgjdbc/src/test/java/org/postgresql/util/StubEnvironmentAndProperties.java
@@ -17,8 +17,10 @@ import java.lang.annotation.Target;
 /**
  * This annotation is used to mark a test method as a test that should be run with stubbing system
  * calls like {@code System#getProperty} and {@code System#getenv}.
+ *
  * <p>The tests should be run in isolation to prevent concurrent modification of properties and
  * the environment.</p>
+ *
  * <p>Note: environment mocking works from a single thread only until
  * <a href="https://github.com/webcompere/system-stubs/pull/46">Fix multi-threaded
  * environment variable mocking</a>, and <a href="https://github.com/mockito/mockito/issues/2142">Mocked


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Hello there, I'm a contributor at @checkstyle, I was working on this issue: https://github.com/checkstyle/checkstyle/issues/15685, my PR: https://github.com/checkstyle/checkstyle/pull/15686

The issue is about fixing [JavadocParagraph](https://checkstyle.org/checks/javadoc/javadocparagraph.html)'s Implementation, currently the check does not work when a paragraph tag have it's corresponding closing tag ( `<p></p>`), it only works when paragraph tag does not have its corresponding closing tag ( `<p>` ). I was trying to fix this problem and during this process I also found some other bugs which I have solved in the same PR.

The PR is almost ready to be merged but our semaphore CI was failing, here its error logs: https://checkstyle.semaphoreci.com/jobs/fa77db90-12db-42f2-b60f-5565630dba95

as I made changes in the JavadocParagraph's implementation and added support to check for `<p></p>`, Semaphore CI started giving error for pgjdbc repository, indicating that it has incorrect paragraph tags' placement. My mentor @romani suggested to send a PR to pgjdbc and fix the incorrect paragraphs' placement ( https://github.com/checkstyle/checkstyle/pull/15686#issuecomment-2395587953 ). 

I have tried to fix it in this PR. I have made changes in javadoc comments and tried to fix the incorrect placements. Our Check was not able to detect these incorrect changes previously but after my PR gets merged, this bug will get fixed and Check's newer version be available in the next release.

I hope my PR gets attention of pgjdbc's maintainers, thank you :)