### PR TITLE
Bugfix: Wrong updatable classification of result sets

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
@@ -1879,6 +1879,14 @@ public class PgResultSet implements ResultSet, PGRefCursorResultSet {
     @Nullable String[] s = quotelessTableName(castNonNull(tableName));
     String quotelessTableName = castNonNull(s[0]);
     @Nullable String quotelessSchemaName = s[1];
+    
+    if (quotelessSchemaName == null || quotelessSchemaName.isEmpty()) {
+        // Note: When a query with an unqualified table name is fired, only primary keys of the connection's schema must be inspected.
+        // Otherwise, if you have multiple schemas with the same table and primary key names but different primary key columns, a result 
+        // set may be wrongly classified as updatable.
+        quotelessSchemaName = connection.getSchema();
+    }
+    
     ResultSet rs = ((PgDatabaseMetaData) connection.getMetaData()).getPrimaryUniqueKeys("",
         quotelessSchemaName, quotelessTableName);
 


### PR DESCRIPTION
The problem occurs, if 

 * there are multipe schemas
 * Same table names with same unique constraint names but different column names

In this case, the union of all those columns is assumed to be the set of columns of the unique key.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

There is another unfortunately outdated PR from the ancient times: https://github.com/pgjdbc/pgjdbc/pull/923

