### PR TITLE
feat: don't force send extra_float_digits for PostgreSQL >= 12 (#3432)

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java
@@ -392,7 +392,11 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
 
     if (assumeVersion.getVersionNum() >= ServerVersion.v9_0.getVersionNum()) {
       // User is explicitly telling us this is a 9.0+ server so set properties here:
-      paramList.add(new StartupParam("extra_float_digits", "3"));
+      if (assumeVersion.getVersionNum() < ServerVersion.v12.getVersionNum()) {
+        // extra_float_digits is meaningless in this case starting from v12
+        // see note on https://www.postgresql.org/docs/current/runtime-config-client.html#GUC-EXTRA-FLOAT-DIGITS
+        paramList.add(new StartupParam("extra_float_digits", "3"));
+      }
       String appName = PGProperty.APPLICATION_NAME.getOrDefault(info);
       if (appName != null) {
         paramList.add(new StartupParam("application_name", appName));
@@ -921,7 +925,7 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
       SetupQueryRunner.run(queryExecutor, "BEGIN", false);
     }
 
-    if (dbVersion >= ServerVersion.v9_0.getVersionNum()) {
+    if (dbVersion >= ServerVersion.v9_0.getVersionNum() && dbVersion < ServerVersion.v12.getVersionNum()) {
       SetupQueryRunner.run(queryExecutor, "SET extra_float_digits = 3", false);
     }
 


### PR DESCRIPTION
In relation to #3432: since PostgreSQL 12, we do not need to mess with extra_float_digits to get the full precision. Since we already check the server version before setting the parameter, it's just an extra check to avoid sending it for nothing. Free bonus: no more complaints with PgBouncer.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes to Existing Features:

* [X] Does this break existing behaviour? If so please explain.
* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you written new tests for your core changes, as applicable?
* [X] Have you successfully run tests with your changes locally?
