### PR TITLE
fix: return only the transactions accessible by the current_user in XAResource.recover

### DIFF
--- a/pgjdbc/src/test/java/org/postgresql/test/xa/XADataSourceTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/xa/XADataSourceTest.java
@@ -95,7 +95,7 @@ public class XADataSourceTest {
   }
 
   @AfterEach
-  void tearDown() throws SQLException {
+  void tearDown() throws SQLException, XAException {
     try {
       xaconn.close();
     } catch (Exception ignored) {
@@ -109,24 +109,22 @@ public class XADataSourceTest {
 
   }
 
-  private void clearAllPrepared() throws SQLException {
-    Statement st = dbConn.createStatement();
+  private void clearAllPrepared() throws SQLException, XAException {
+    XAConnection con = xaDs.getXAConnection();
+    XAResource xaResource = con.getXAResource();
     try {
-      ResultSet rs = st.executeQuery(
-          "SELECT x.gid, x.owner = current_user "
-              + "FROM pg_prepared_xacts x "
-              + "WHERE x.database = current_database()");
-
-      Statement st2 = dbConn.createStatement();
-      while (rs.next()) {
-        // TODO: This should really use org.junit.Assume once we move to JUnit 4
-        assertTrue(rs.getBoolean(2),
-            "Only prepared xacts owned by current user may be present in db");
-        st2.executeUpdate("ROLLBACK PREPARED '" + rs.getString(1) + "'");
+      // Get the first batch of the xids
+      Xid[] xids = xaResource.recover(XAResource.TMSTARTRSCAN);
+      while (xids.length != 0) {
+        for (Xid xid : xids) {
+          xaResource.rollback(xid);
+        }
+        // Get the next batch of the xids
+        xids = xaResource.recover(XAResource.TMNOFLAGS);
       }
-      st2.close();
     } finally {
-      st.close();
+      xaResource.recover(XAResource.TMENDRSCAN);
+      con.close();
     }
   }
 


### PR DESCRIPTION
Fixes https://github.com/pgjdbc/pgjdbc/issues/3445

See also
* https://github.com/pgjdbc/pgjdbc/pull/178
* https://www.postgresql.org/message-id/CAB%3DJe-FN4u6Xb8D3eY7qWAbfhEvM-8fpWb-cLKJuxVC%3D5tMFtA%40mail.gmail.com
