### PR TITLE
Halln support gss default creds

### DIFF
--- a/docs/content/documentation/use.md
+++ b/docs/content/documentation/use.md
@@ -293,6 +293,11 @@ Specifies whether to perform a JAAS login before authenticating with GSSAPI.
 If set to `true` (the default), the driver will attempt to obtain GSS credentials using the configured JAAS login module(s) (e.g. `Krb5LoginModule` ) before authenticating. 
 To skip the JAAS login, for example if the native GSS implementation is being used to obtain credentials, set this to `false` .
 
+* **`gssUseDefaultCreds (`*boolean*`)`** *Default `false`*\
+Specifies whether to use the default system GSS credentials, rather than using JAAS.
+If set to `false` (the default), the driver will attempt to use GSS credentials matching `user`@DEFAULT_REALM.  If true, the
+driver will use the default system GSS credentials.  This is useful in cases where the default credentials are named differently,
+or CCACHE sources like KCM are used, which JAAS does not support on all platforms.
 * **`gssEncMode (`*String*`)`** *Default `allow`*\
 PostgreSQL® 12 and later now allow GSSAPI encrypted connections. This parameter controls whether to enforce using GSSAPI encryption or not. The options are `disable` , `allow` , `prefer` and `require`
   * `disable` is obvious and disables any attempt to connect using GSS encrypted mode

--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -319,6 +319,20 @@ public enum PGProperty {
       "Login with JAAS before doing GSSAPI authentication"),
 
   /**
+   * Flag to enable/disable the obtaining the default GSS credentials from a pre-existing ccache,
+   * rather than using JAAS.  This also allows GSS to work in environments where the default
+   * kerberos principal a user has is not user@DEFAULT_REALM, but some other user (this is valid,
+   * and often the case in more advanced Kerberos setups).  Finally, this also means that if
+   * the "native" GSS implementation is used (i.e. the local system GSS libraries), all means of
+   * fetching the default credential are supported.  Currently, JAAS is pure java on Linux, and
+   * does not support the use of KCM (and only supports file-based ccaches and keytabs).
+   */
+  GSS_USE_DEFAULT_CREDS(
+      "gssUseDefaultCreds",
+      "false",
+      "Use the default GSS credentials the process already has, rather than a JAAS login"),
+
+  /**
    * The Kerberos service name to use when authenticating with GSSAPI. This is equivalent to libpq's
    * PGKRBSRVNAME environment variable.
    */

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java
@@ -128,6 +128,7 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
     String user = PGProperty.USER.getOrDefault(info);
     String database = PGProperty.PG_DBNAME.getOrDefault(info);
     SslNegotiation sslNegotiation = SslNegotiation.of(Nullness.castNonNull(PGProperty.SSL_NEGOTIATION.getOrDefault(info)));
+
     if (user == null) {
       throw new PSQLException(GT.tr("User cannot be null"), PSQLState.INVALID_NAME);
     }

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java
@@ -128,7 +128,6 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
     String user = PGProperty.USER.getOrDefault(info);
     String database = PGProperty.PG_DBNAME.getOrDefault(info);
     SslNegotiation sslNegotiation = SslNegotiation.of(Nullness.castNonNull(PGProperty.SSL_NEGOTIATION.getOrDefault(info)));
-
     if (user == null) {
       throw new PSQLException(GT.tr("User cannot be null"), PSQLState.INVALID_NAME);
     }
@@ -553,6 +552,7 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
                 PGProperty.JAAS_APPLICATION_NAME.getOrDefault(info),
                 PGProperty.KERBEROS_SERVER_NAME.getOrDefault(info), false, // TODO: fix this
                 PGProperty.JAAS_LOGIN.getBoolean(info),
+                PGProperty.GSS_USE_DEFAULT_CREDS.getBoolean(info),
                 PGProperty.LOG_SERVER_ERROR_DETAIL.getBoolean(info));
             return void.class;
           });
@@ -838,6 +838,7 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
                         PGProperty.JAAS_APPLICATION_NAME.getOrDefault(info),
                         PGProperty.KERBEROS_SERVER_NAME.getOrDefault(info), usespnego,
                         PGProperty.JAAS_LOGIN.getBoolean(info),
+                        PGProperty.GSS_USE_DEFAULT_CREDS.getBoolean(info),
                         PGProperty.LOG_SERVER_ERROR_DETAIL.getBoolean(info));
                     return void.class;
                   });

--- a/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
+++ b/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
@@ -1139,6 +1139,22 @@ public abstract class BaseDataSource implements CommonDataSource, Referenceable 
   }
 
   /**
+   * @return true if using default GSS credentials
+   * @see PGProperty#GSS_USE_DEFAULT_CREDS
+   */
+  public boolean getGssUseDefaultCreds() {
+    return PGProperty.GSS_USE_DEFAULT_CREDS.getBoolean(properties);
+  }
+
+  /**
+   * @param gssUseDefaultCreds true if using default GSS credentials
+   * @see PGProperty#GSS_USE_DEFAULT_CREDS
+   */
+  public void setGssUseDefaultCreds(boolean gssUseDefaultCreds) {
+    PGProperty.GSS_USE_DEFAULT_CREDS.set(properties, gssUseDefaultCreds);
+  }
+
+  /**
    * @return Kerberos server name
    * @see PGProperty#KERBEROS_SERVER_NAME
    */

--- a/pgjdbc/src/main/java/org/postgresql/gss/GssEncAction.java
+++ b/pgjdbc/src/main/java/org/postgresql/gss/GssEncAction.java
@@ -36,18 +36,21 @@ public class GssEncAction implements PrivilegedAction<@Nullable Exception>, Call
   private final String user;
   private final String kerberosServerName;
   private final boolean useSpnego;
+  private final boolean gssUseDefaultCreds;
   private final @Nullable Subject subject;
   private final boolean logServerErrorDetail;
 
   public GssEncAction(PGStream pgStream, @Nullable Subject subject,
       String host, String user,
-      String kerberosServerName, boolean useSpnego, boolean logServerErrorDetail) {
+      String kerberosServerName, boolean useSpnego, boolean gssUseDefaultCreds,
+      boolean logServerErrorDetail) {
     this.pgStream = pgStream;
     this.subject = subject;
     this.host = host;
     this.user = user;
     this.kerberosServerName = kerberosServerName;
     this.useSpnego = useSpnego;
+    this.gssUseDefaultCreds = gssUseDefaultCreds;
     this.logServerErrorDetail = logServerErrorDetail;
   }
 
@@ -100,9 +103,13 @@ public class GssEncAction implements PrivilegedAction<@Nullable Exception>, Call
           }
         }
 
-        GSSName clientName = manager.createName(principalName, GSSName.NT_USER_NAME);
-        clientCreds = manager.createCredential(clientName, 8 * 3600, desiredMechs,
-            GSSCredential.INITIATE_ONLY);
+        if (gssUseDefaultCreds) {
+          clientCreds = manager.createCredential(GSSCredential.INITIATE_ONLY);
+        } else {
+          GSSName clientName = manager.createName(principalName, GSSName.NT_USER_NAME);
+          clientCreds = manager.createCredential(clientName, 8 * 3600, desiredMechs,
+              GSSCredential.INITIATE_ONLY);
+        }
       } else {
         desiredMechs[0] = new Oid("1.2.840.113554.1.2.2");
         clientCreds = gssCredential;

--- a/pgjdbc/src/main/java/org/postgresql/gss/MakeGSS.java
+++ b/pgjdbc/src/main/java/org/postgresql/gss/MakeGSS.java
@@ -118,7 +118,7 @@ public class MakeGSS {
   public static void authenticate(boolean encrypted,
       PGStream pgStream, String host, String user, char @Nullable [] password,
       @Nullable String jaasApplicationName, @Nullable String kerberosServerName,
-      boolean useSpnego, boolean jaasLogin,
+      boolean useSpnego, boolean jaasLogin, boolean gssUseDefaultCreds,
       boolean logServerErrorDetail)
           throws IOException, PSQLException {
     LOGGER.log(Level.FINEST, " <=BE AuthenticationReqGSS");
@@ -151,10 +151,10 @@ public class MakeGSS {
       PrivilegedAction<@Nullable Exception> action;
       if ( encrypted ) {
         action = new GssEncAction(pgStream, sub, host, user,
-            kerberosServerName, useSpnego, logServerErrorDetail);
+            kerberosServerName, useSpnego, gssUseDefaultCreds, logServerErrorDetail);
       } else {
         action = new GssAction(pgStream, sub, host, user,
-            kerberosServerName, useSpnego, logServerErrorDetail);
+            kerberosServerName, useSpnego, gssUseDefaultCreds, logServerErrorDetail);
       }
       //noinspection ConstantConditions
       @SuppressWarnings({"cast.unsafe", "assignment"})


### PR DESCRIPTION
When using the GSSAPI for authentication without JAAS, the postgres Java client library assumes that the GSS (kerberos) principal name is `$user@$REALM`, and hard-codes the username in the call to `GSSManager.createCredential()` before trying to create the credential.  In most kerberos environments, this is a perfectly reasonable assumption, but it breaks when the user running the process does not have a user formatted in that way.

`GSSManager.createCredential()` has a different overload that doesn't take any hints over the principal to use to create a credential, which instead looks in your Kerberos ccache to see what the default credential is and uses that instead.  This continues to assume that you already have a valid Kerberos ccache (which many corporate environments, such as ours, create automatically for you).

This PR allows the user to provide a new option in the postgres connection properties called `gssUseDefaultCreds` which causes the code to call the no-hint version of `createCredential()` to avoid this particular issue.  I'll note that in most cases, getting the default creds is exactly what you want, and it might even be that a better fix is for this to be the default, but I've not done that here.

A reasonable question at this point is: well, why not use JAAS to do that for you?  The answer is nuanced - if you happen to use a file-based ccache, then you can indeed use JAAS for this.  Unfortunately though, JAAS uses the "pure Java" part of the JGSS codebase which (at least on Linux) does not have a "native" implementation, and is limited in the types of ccache supported.  In particular, it does not support KCM, which is a standard way to use a host-based daemon to store the key material for you.  There are several implementations of KCM (Heimdal Kerberos has one, as do RedHat with SSSD), and using KCM requires the use of the system libraries via the JGSS 'native' implementation, which JAAS does not support.

Thus in addition to avoiding the naming assuming, this PR also allows for the use of existing default credentials via the 'native' JGSS implementation on Linux, and hence supports all ccache types that the system libraries do.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?  Yes
2. [x] Does `./gradlew styleCheck` pass ?  Yes
3. [x] Have you added your new test classes to an existing test suite in alphabetical order?  (see below re tests)

### Changes to Existing Features:

* [x] Does this break existing behaviour? If so please explain.

No breaks to existing behaviour, as the option defaults to 'false'.  It only changes one piece of code, introducing a conditional to use default GSS credentials instead of assuming that the non-fully qualified principal name is the same as the postgres 'user'.

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?

Documentation updated, motivation above.

* [x] Have you written new tests for your core changes, as applicable?

I'm happy to write tests, but I can't see how the existing GSS code-paths are tested (and I imagine there isn't a sandbox on github where they can be tested).  If you have pointers, please provide and I'll work within that.

* [x] Have you successfully run tests with your changes locally?

Yes - these changes work in our Kerberos environment, where we have a slightly unusual setup where the principals that people use day-to-day are not strictly user-principals (this is perfectly valid, but unusual), and where the 'short' (no realm) principal name is derived from the username, but does not equal it.

Tested on RHEL8.
