### PR TITLE
fix: ArrayIndexOutOfBounds when write big object into GSS enabled connection

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/gss/GSSOutputStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/gss/GSSOutputStream.java
@@ -77,7 +77,6 @@ public class GSSOutputStream extends PgBufferedOutputStream {
       off += buf.length;
       len -= buf.length;
     }
-    // Put the rest into buffer
     if (len == 0) {
       return;
     }

--- a/pgjdbc/src/main/java/org/postgresql/gss/GSSOutputStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/gss/GSSOutputStream.java
@@ -50,8 +50,8 @@ public class GSSOutputStream extends PgBufferedOutputStream {
   private void writeWrapped(byte[] b, int off, int len) throws IOException {
     try {
       byte[] token = gssContext.wrap(b, off, len, messageProp);
-      pgOut.writeInt4(len);
-      pgOut.write(token, 0, len);
+      pgOut.writeInt4(token.length);
+      pgOut.write(token, 0, token.length);
     } catch (GSSException ex) {
       throw new IOException(ex);
     }

--- a/pgjdbc/src/main/java/org/postgresql/gss/GSSOutputStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/gss/GSSOutputStream.java
@@ -50,8 +50,8 @@ public class GSSOutputStream extends PgBufferedOutputStream {
   private void writeWrapped(byte[] b, int off, int len) throws IOException {
     try {
       byte[] token = gssContext.wrap(b, off, len, messageProp);
-      pgOut.writeInt4(token.length);
-      pgOut.write(token, 0, token.length);
+      pgOut.writeInt4(len);
+      pgOut.write(token, 0, len);
     } catch (GSSException ex) {
       throw new IOException(ex);
     }
@@ -73,10 +73,9 @@ public class GSSOutputStream extends PgBufferedOutputStream {
     }
     // Write out the rest, chunk the writes, so we do not exceed the maximum encrypted message size
     while (len >= buf.length) {
-      int writeSize = Math.min(buf.length - count, len);
-      writeWrapped(b, off, writeSize);
-      off += writeSize;
-      len -= writeSize;
+      writeWrapped(b, off, buf.length);
+      off += buf.length;
+      len -= buf.length;
     }
     // Put the rest into buffer
     if (len == 0) {

--- a/pgjdbc/src/test/java/org/postgresql/test/gss/GSSOutputStreamTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/gss/GSSOutputStreamTest.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright (c) 2020, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.test.gss;
+
+import org.postgresql.gss.GSSOutputStream;
+import org.postgresql.util.NullOutputStream;
+import org.postgresql.util.internal.PgBufferedOutputStream;
+
+import org.ietf.jgss.ChannelBinding;
+import org.ietf.jgss.GSSContext;
+import org.ietf.jgss.GSSCredential;
+import org.ietf.jgss.GSSException;
+import org.ietf.jgss.GSSName;
+import org.ietf.jgss.MessageProp;
+import org.ietf.jgss.Oid;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+
+public class GSSOutputStreamTest {
+  private final MessageProp messageProp = new MessageProp(0, true);
+  private final GSSContext gssContext = new FakeGSSContext();
+  private final PgBufferedOutputStream nullOutputStream =
+      new PgBufferedOutputStream(new NullOutputStream(), 10);
+
+  @Test
+  public void testGSSMessageBuffer() throws Exception {
+    GSSOutputStream gssOutputStream = new GSSOutputStream(nullOutputStream, gssContext,
+        messageProp, 10);
+
+    gssOutputStream.write(new byte[0]);
+    gssOutputStream.write(new byte[1]);
+    gssOutputStream.write(new byte[9]);
+    gssOutputStream.write(new byte[1]);
+    gssOutputStream.write(new byte[100]);
+  }
+
+  public static class FakeGSSContext implements GSSContext {
+    @Override
+    public byte[] initSecContext(byte[] bytes, int i, int i1) throws GSSException {
+      return bytes;
+    }
+
+    @Override
+    public int initSecContext(InputStream inputStream, OutputStream outputStream) throws GSSException {
+      return 0;
+    }
+
+    @Override
+    public byte[] acceptSecContext(byte[] bytes, int i, int i1) throws GSSException {
+      return bytes;
+    }
+
+    @Override
+    public void acceptSecContext(InputStream inputStream, OutputStream outputStream) throws GSSException {
+
+    }
+
+    @Override
+    public boolean isEstablished() {
+      return true;
+    }
+
+    @Override
+    public void dispose() throws GSSException {
+
+    }
+
+    @Override
+    public int getWrapSizeLimit(int i, boolean b, int maxTokenSize) throws GSSException {
+      return maxTokenSize;
+    }
+
+    @Override
+    public byte[] wrap(byte[] bytes, int i, int i1, MessageProp messageProp) throws GSSException {
+      Assert.assertTrue("ArrayIndexOutOfBoundsException", bytes.length >= i + i1);
+      return bytes;
+    }
+
+    @Override
+    public void wrap(InputStream inputStream, OutputStream outputStream, MessageProp messageProp) throws GSSException {
+
+    }
+
+    @Override
+    public byte[] unwrap(byte[] bytes, int i, int i1, MessageProp messageProp) throws GSSException {
+      Assert.assertTrue("ArrayIndexOutOfBoundsException", bytes.length >= i + i1);
+      return bytes;
+    }
+
+    @Override
+    public void unwrap(InputStream inputStream, OutputStream outputStream, MessageProp messageProp) throws GSSException {
+
+    }
+
+    @Override
+    public byte[] getMIC(byte[] bytes, int i, int i1, MessageProp messageProp) throws GSSException {
+      return bytes;
+    }
+
+    @Override
+    public void getMIC(InputStream inputStream, OutputStream outputStream, MessageProp messageProp) throws GSSException {
+
+    }
+
+    @Override
+    public void verifyMIC(byte[] bytes, int i, int i1, byte[] bytes1, int i2, int i3, MessageProp messageProp) throws GSSException {
+
+    }
+
+    @Override
+    public void verifyMIC(InputStream inputStream, InputStream inputStream1, MessageProp messageProp) throws GSSException {
+
+    }
+
+    @Override
+    public byte[] export() throws GSSException {
+      return null;
+    }
+
+    @Override
+    public void requestMutualAuth(boolean b) throws GSSException {
+
+    }
+
+    @Override
+    public void requestReplayDet(boolean b) throws GSSException {
+
+    }
+
+    @Override
+    public void requestSequenceDet(boolean b) throws GSSException {
+
+    }
+
+    @Override
+    public void requestCredDeleg(boolean b) throws GSSException {
+
+    }
+
+    @Override
+    public void requestAnonymity(boolean b) throws GSSException {
+
+    }
+
+    @Override
+    public void requestConf(boolean b) throws GSSException {
+
+    }
+
+    @Override
+    public void requestInteg(boolean b) throws GSSException {
+
+    }
+
+    @Override
+    public void requestLifetime(int i) throws GSSException {
+
+    }
+
+    @Override
+    public void setChannelBinding(ChannelBinding channelBinding) throws GSSException {
+
+    }
+
+    @Override
+    public boolean getCredDelegState() {
+      return false;
+    }
+
+    @Override
+    public boolean getMutualAuthState() {
+      return false;
+    }
+
+    @Override
+    public boolean getReplayDetState() {
+      return false;
+    }
+
+    @Override
+    public boolean getSequenceDetState() {
+      return false;
+    }
+
+    @Override
+    public boolean getAnonymityState() {
+      return false;
+    }
+
+    @Override
+    public boolean isTransferable() throws GSSException {
+      return false;
+    }
+
+    @Override
+    public boolean isProtReady() {
+      return false;
+    }
+
+    @Override
+    public boolean getConfState() {
+      return false;
+    }
+
+    @Override
+    public boolean getIntegState() {
+      return false;
+    }
+
+    @Override
+    public int getLifetime() {
+      return 0;
+    }
+
+    @Override
+    public GSSName getSrcName() throws GSSException {
+      return null;
+    }
+
+    @Override
+    public GSSName getTargName() throws GSSException {
+      return null;
+    }
+
+    @Override
+    public Oid getMech() throws GSSException {
+      return null;
+    }
+
+    @Override
+    public GSSCredential getDelegCred() throws GSSException {
+      return null;
+    }
+
+    @Override
+    public boolean isInitiator() throws GSSException {
+      return false;
+    }
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/test/gss/GSSOutputStreamTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/gss/GSSOutputStreamTest.java
@@ -78,7 +78,7 @@ public class GSSOutputStreamTest {
 
     @Override
     public byte[] wrap(byte[] bytes, int i, int i1, MessageProp messageProp) throws GSSException {
-      Assert.assertTrue("ArrayIndexOutOfBoundsException", bytes.length >= i + i1);
+      Assert.assertTrue("ArrayIndexOutOfBoundsException offset " + i + " length " + i1 + " buffer capacity " + bytes.length, bytes.length >= i + i1);
       return bytes;
     }
 
@@ -89,7 +89,7 @@ public class GSSOutputStreamTest {
 
     @Override
     public byte[] unwrap(byte[] bytes, int i, int i1, MessageProp messageProp) throws GSSException {
-      Assert.assertTrue("ArrayIndexOutOfBoundsException", bytes.length >= i + i1);
+      Assert.assertTrue("ArrayIndexOutOfBoundsException offset " + i + " length " + i1 + " buffer capacity " + bytes.length, bytes.length >= i + i1);
       return bytes;
     }
 

--- a/pgjdbc/src/test/java/org/postgresql/test/gss/GSSOutputStreamTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/gss/GSSOutputStreamTest.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Arrays;
 
 public class GSSOutputStreamTest {
   private final MessageProp messageProp = new MessageProp(0, true);
@@ -97,7 +98,7 @@ public class GSSOutputStreamTest {
     @Override
     public byte[] wrap(byte[] bytes, int i, int i1, MessageProp messageProp) throws GSSException {
       Assert.assertTrue("ArrayIndexOutOfBoundsException offset " + i + " length " + i1 + " buffer capacity " + bytes.length, bytes.length >= i + i1);
-      return bytes;
+      return Arrays.copyOfRange(bytes, i, i + i1);
     }
 
     @Override
@@ -108,7 +109,7 @@ public class GSSOutputStreamTest {
     @Override
     public byte[] unwrap(byte[] bytes, int i, int i1, MessageProp messageProp) throws GSSException {
       Assert.assertTrue("ArrayIndexOutOfBoundsException offset " + i + " length " + i1 + " buffer capacity " + bytes.length, bytes.length >= i + i1);
-      return bytes;
+      return Arrays.copyOfRange(bytes, i, i + i1);
     }
 
     @Override
@@ -118,7 +119,7 @@ public class GSSOutputStreamTest {
 
     @Override
     public byte[] getMIC(byte[] bytes, int i, int i1, MessageProp messageProp) throws GSSException {
-      return bytes;
+      throw new GSSException(GSSException.UNAVAILABLE);
     }
 
     @Override

--- a/pgjdbc/src/test/java/org/postgresql/test/gss/GSSOutputStreamTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/gss/GSSOutputStreamTest.java
@@ -6,7 +6,6 @@
 package org.postgresql.test.gss;
 
 import org.postgresql.gss.GSSOutputStream;
-import org.postgresql.util.NullOutputStream;
 import org.postgresql.util.internal.PgBufferedOutputStream;
 
 import org.ietf.jgss.ChannelBinding;

--- a/pgjdbc/src/test/java/org/postgresql/test/gss/GSSOutputStreamTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/gss/GSSOutputStreamTest.java
@@ -27,12 +27,10 @@ public class GSSOutputStreamTest {
   private final MessageProp messageProp = new MessageProp(0, true);
   private final GSSContext gssContext = new FakeGSSContext();
 
-
   @Test
   public void testGSSMessageBuffer() throws Exception {
     ByteArrayOutputStream outputBuffer = new ByteArrayOutputStream();
-    GSSOutputStream gssOutputStream = new GSSOutputStream(new PgBufferedOutputStream(outputBuffer
-        , 10), gssContext, messageProp, 10);
+    GSSOutputStream gssOutputStream = new GSSOutputStream(new PgBufferedOutputStream(outputBuffer, 10), gssContext, messageProp, 10);
 
     gssOutputStream.write(new byte[0]);
     gssOutputStream.write(new byte[1]);
@@ -45,8 +43,7 @@ public class GSSOutputStreamTest {
   @Test
   public void testGSSMessageBigWrite() throws Exception {
     ByteArrayOutputStream outputBuffer = new ByteArrayOutputStream();
-    GSSOutputStream gssOutputStream = new GSSOutputStream(new PgBufferedOutputStream(outputBuffer
-        , 10), gssContext, messageProp, 10);
+    GSSOutputStream gssOutputStream = new GSSOutputStream(new PgBufferedOutputStream(outputBuffer, 10), gssContext, messageProp, 10);
     gssOutputStream.write(new byte[1]);
     gssOutputStream.write(new byte[20]);
     gssOutputStream.flush();

--- a/pgjdbc/src/test/java/org/postgresql/util/NullOutputStream.java
+++ b/pgjdbc/src/test/java/org/postgresql/util/NullOutputStream.java
@@ -5,7 +5,6 @@
 
 package org.postgresql.util;
 
-import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
 
@@ -13,15 +12,6 @@ import java.io.PrintStream;
  * Created by davec on 3/14/17.
  */
 public class NullOutputStream extends PrintStream {
-  private static class BlackHole extends OutputStream {
-    @Override
-    public void write(int b) throws IOException {
-    }
-  }
-
-  public NullOutputStream() {
-    super(new BlackHole());
-  }
 
   public NullOutputStream(OutputStream out) {
     super(out);

--- a/pgjdbc/src/test/java/org/postgresql/util/NullOutputStream.java
+++ b/pgjdbc/src/test/java/org/postgresql/util/NullOutputStream.java
@@ -5,6 +5,7 @@
 
 package org.postgresql.util;
 
+import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
 
@@ -12,6 +13,15 @@ import java.io.PrintStream;
  * Created by davec on 3/14/17.
  */
 public class NullOutputStream extends PrintStream {
+  private static class BlackHole extends OutputStream {
+    @Override
+    public void write(int b) throws IOException {
+    }
+  }
+
+  public NullOutputStream() {
+    super(new BlackHole());
+  }
 
   public NullOutputStream(OutputStream out) {
     super(out);


### PR DESCRIPTION
fix this error stack

```
java.lang.ArrayIndexOutOfBoundsException: null
        at java.security.jgss/sun.security.jgss.GSSContextImpl.unwrap
        at sun.security.jgss.GSSContextImpl.wrap(GSSContextImpl.java:385)
        at org.postgresql.gss.GSSOutputStream.writeWrapped(GSSOutputStream.java:52)
        at org.postgresql.gss.GSSOutputStream.write(GSSOutputStream.java:76)
        at java.io.FilterOutputStream.write(FilterOutputStream.java:97)
        at org.postgresql.core.PGStream.send(PGStream.java:398)
```

`GSSOutputStream` does not handle the buffer switch correctly, when a message is bigger than the GSS buffer, GSSOutputStream will pass the input buffer offset as the GSS buffer offset into GSSContext. The offset is much bigger than the GSS buffer, so will cause ArrayIndexOutOfBounds.

Fix this by adding the buffer switch logic into `GSSOutputStream.write()` and also adding a test to demo how to reproduce this bug.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Does `./gradlew styleCheck` pass ?
3. [x] Have you added your new test classes to an existing test suite in alphabetical order?

### Changes to Existing Features:

* [x] Not breaking existing behaviour
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
