### PR TITLE
Undeprecate sslfactoryarg connection property

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -664,9 +664,7 @@ public enum PGProperty {
 
   /**
    * The String argument to give to the constructor of the SSL Factory.
-   * @deprecated use {@code ..Factory(Properties)} constructor.
    */
-  @Deprecated
   SSL_FACTORY_ARG(
       "sslfactoryarg",
       null,


### PR DESCRIPTION
Undeprecates the `sslfactoryarg` connection property. Similar to the `socketfactoyarg`, it can be used to customize the injected factory class. As there are no plans to remove it in the future, we are undeprecating it to silence the deprecation warning in user code that references it.

See https://github.com/pgjdbc/pgjdbc/issues/2725 and https://github.com/pgjdbc/pgjdbc/pull/2923 for related discussion.