### PR TITLE
refactor: factor out duplicated .getBytes() when converting date/time to Date/Time/Timestamp

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/ArrayDecoding.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/ArrayDecoding.java
@@ -336,7 +336,7 @@ final class ArrayDecoding {
 
     @Override
     Object parseValue(String stringVal, BaseConnection connection) throws SQLException {
-      return connection.getTimestampUtils().toDate(null, stringVal.getBytes());
+      return connection.getTimestampUtils().toDate(null, stringVal);
     }
   };
 
@@ -345,7 +345,7 @@ final class ArrayDecoding {
 
     @Override
     Object parseValue(String stringVal, BaseConnection connection) throws SQLException {
-      return connection.getTimestampUtils().toTime(null, stringVal.getBytes());
+      return connection.getTimestampUtils().toTime(null, stringVal);
     }
   };
 
@@ -354,7 +354,7 @@ final class ArrayDecoding {
 
     @Override
     Object parseValue(String stringVal, BaseConnection connection) throws SQLException {
-      return connection.getTimestampUtils().toTimestamp(null, stringVal.getBytes());
+      return connection.getTimestampUtils().toTimestamp(null, stringVal);
     }
   };
 

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgCallableStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgCallableStatement.java
@@ -478,8 +478,7 @@ class PgCallableStatement extends PgPreparedStatement implements CallableStateme
       return null;
     }
 
-    String value = result.toString();
-    return getTimestampUtils().toDate(cal, value.getBytes());
+    return getTimestampUtils().toDate(cal, result.toString());
   }
 
   @Override
@@ -490,8 +489,7 @@ class PgCallableStatement extends PgPreparedStatement implements CallableStateme
       return null;
     }
 
-    String value = result.toString();
-    return getTimestampUtils().toTime(cal, value.getBytes());
+    return getTimestampUtils().toTime(cal, result.toString());
   }
 
   @Override
@@ -502,8 +500,7 @@ class PgCallableStatement extends PgPreparedStatement implements CallableStateme
       return null;
     }
 
-    String value = result.toString();
-    return getTimestampUtils().toTimestamp(cal, value.getBytes());
+    return getTimestampUtils().toTimestamp(cal, result.toString());
   }
 
   @Override

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
@@ -634,7 +634,7 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
             setDate(parameterIndex, (LocalDate) in);
             break;
           } else {
-            tmpd = getTimestampUtils().toDate(getDefaultCalendar(), in.toString().getBytes());
+            tmpd = getTimestampUtils().toDate(getDefaultCalendar(), in.toString());
           }
           setDate(parameterIndex, tmpd);
         }
@@ -653,7 +653,7 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
             setTime(parameterIndex, (OffsetTime) in);
             break;
           } else {
-            tmpt = getTimestampUtils().toTime(getDefaultCalendar(), in.toString().getBytes());
+            tmpt = getTimestampUtils().toTime(getDefaultCalendar(), in.toString());
           }
           setTime(parameterIndex, tmpt);
         }

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
@@ -546,7 +546,7 @@ public class PgResultSet implements ResultSet, PGRefCursorResultSet {
       }
     }
 
-    return getTimestampUtils().toDate(cal, castNonNull(value));
+    return getTimestampUtils().toDate(cal, value);
   }
 
   @Override

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/TimestampUtils.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/TimestampUtils.java
@@ -416,17 +416,14 @@ public class TimestampUtils {
    * @param s The ISO formatted date string to parse.
    * @return null if s is null or a timestamp of the parsed string s.
    * @throws SQLException if there is a problem parsing s.
-   * @deprecated use {@link #toTimestamp(Calendar, byte[])}
    */
-  @Deprecated
   public @PolyNull Timestamp toTimestamp(@Nullable Calendar cal,
       @PolyNull String s) throws SQLException {
-    try (ResourceLock ignore = lock.obtain()) {
-      if (s == null) {
-        return null;
-      }
-      return toTimestamp(cal, s.getBytes(StandardCharsets.UTF_8));
+    // TODO: replace all internal usages so they do not need to create intermediate strings
+    if (s == null) {
+      return null;
     }
+    return toTimestamp(cal, s.getBytes(StandardCharsets.UTF_8));
   }
 
   /**
@@ -699,16 +696,13 @@ public class TimestampUtils {
     return OffsetDateTime.ofInstant(instant, ZoneOffset.UTC);
   }
 
-  @Deprecated
   public @PolyNull Time toTime(
       @Nullable Calendar cal, @PolyNull String s) throws SQLException {
-    try (ResourceLock ignore = lock.obtain()) {
-      // 1) Parse backend string
-      if (s == null) {
-        return null;
-      }
-      return toTime(cal, s.getBytes(StandardCharsets.UTF_8));
+    // TODO: replace all internal usages so they do not need to create intermediate strings
+    if (s == null) {
+      return null;
     }
+    return toTime(cal, s.getBytes(StandardCharsets.UTF_8));
   }
 
   public @PolyNull Time toTime(
@@ -758,15 +752,13 @@ public class TimestampUtils {
     }
   }
 
-  @Deprecated
   public @PolyNull Date toDate(@Nullable Calendar cal,
       @PolyNull String s) throws SQLException {
-    try (ResourceLock ignore = lock.obtain()) {
-      if (s == null) {
-        return null;
-      }
-      return toDate(cal, s.getBytes(StandardCharsets.UTF_8));
+    // TODO: replace all internal usages so they do not need to create intermediate strings
+    if (s == null) {
+      return null;
     }
+    return toDate(cal, s.getBytes(StandardCharsets.UTF_8));
   }
 
   public @PolyNull Date toDate(@Nullable Calendar cal,


### PR DESCRIPTION
At best, we should avoid `byte[] -> String -> byte[]` conversions when dealing with datetime, however, currently PgCallableStatement uses getObject eagerly, so we lose the underlying wire format byte[] early.

That is why we have to use .toString() when converting to date. Ideally, we should keep the source byte[] data and convert it on request.

---

The change avoids `getBytes()` with the default encoding. I believe, date-time use limited alphabet, so the encoding should not matter much. However, the use of the default encoding was not the best choice.