### PR TITLE
fix: ArrayIndexOutOfBounds when write big object into GSS enabled connection, make GSSInputStream robust in face of streams that produce incomplete reads

### DIFF
--- a/benchmarks/src/jmh/java/org/postgresql/benchmark/largeobject/LargeObjectRead.java
+++ b/benchmarks/src/jmh/java/org/postgresql/benchmark/largeobject/LargeObjectRead.java
@@ -131,8 +131,9 @@ public class LargeObjectRead {
   public void readArrayRandom() throws SQLException, IOException {
     readBuffer(
         new StrangeInputStream(
-            getInputStream(),
-            ThreadLocalRandom.current().nextLong()));
+            ThreadLocalRandom.current().nextLong(),
+            getInputStream()
+        ));
   }
 
   private void readBuffer(InputStream is) throws IOException {

--- a/pgjdbc/src/main/java/org/postgresql/gss/GSSInputStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/gss/GSSInputStream.java
@@ -7,6 +7,8 @@ package org.postgresql.gss;
 
 import static org.postgresql.util.internal.Nullness.castNonNull;
 
+import org.postgresql.util.ByteConverter;
+
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.ietf.jgss.GSSContext;
 import org.ietf.jgss.GSSException;
@@ -19,11 +21,19 @@ public class GSSInputStream extends InputStream {
   private final GSSContext gssContext;
   private final MessageProp messageProp;
   private final InputStream wrapped;
-  byte @Nullable [] unencrypted;
-  byte [] encryptedBuffer = new byte[16 * 1024];
-  byte [] int4Buf =  new byte[4];
-  int unencryptedPos;
-  int unencryptedLength;
+  // See https://www.postgresql.org/docs/current/protocol-flow.html#PROTOCOL-FLOW-GSSAPI
+  // The server can be expected to not send encrypted packets of larger than 16kB to the client
+  private byte[] encrypted = new byte[16 * 1024];
+  private int encryptedPos;
+  private int encryptedLength;
+
+  private byte @Nullable [] unencrypted;
+  private int unencryptedPos;
+
+  private final byte[] int4Buf = new byte[4];
+  private int lenPos;
+
+  private final byte[] int1Buf = new byte[1];
 
   public GSSInputStream(InputStream wrapped, GSSContext gssContext, MessageProp messageProp) {
     this.wrapped = wrapped;
@@ -33,44 +43,114 @@ public class GSSInputStream extends InputStream {
 
   @Override
   public int read() throws IOException {
-    return 0;
+    int res = 0;
+    while (res == 0) {
+      res = read(int1Buf);
+    }
+    return res == -1 ? -1 : int1Buf[0] & 0xFF;
   }
 
   @Override
-  public int read(byte [] buffer, int pos, int len) throws IOException {
-    int encryptedLength;
-    int copyLength = 0;
-
-    if ( unencryptedLength > 0 ) {
-      copyLength = Math.min(len, unencryptedLength);
-      System.arraycopy(castNonNull(unencrypted), unencryptedPos, buffer, pos, copyLength);
-      unencryptedLength -= copyLength;
-      unencryptedPos += copyLength;
-    } else {
-      if (wrapped.read(int4Buf, 0, 4) == 4 ) {
-
-        encryptedLength = (int4Buf[0] & 0xFF) << 24 | (int4Buf[1] & 0xFF) << 16 | (int4Buf[2] & 0xFF) << 8
-            | int4Buf[3] & 0xFF;
-
-        wrapped.read(encryptedBuffer, 0, encryptedLength);
-
-        try {
-          byte[] unencrypted = gssContext.unwrap(encryptedBuffer, 0, encryptedLength, messageProp);
-          this.unencrypted = unencrypted;
-          unencryptedLength = unencrypted.length;
-          unencryptedPos = 0;
-
-          copyLength = Math.min(len, unencrypted.length);
-          System.arraycopy(unencrypted, unencryptedPos, buffer, pos, copyLength);
-          unencryptedLength -= copyLength;
-          unencryptedPos += copyLength;
-
-        } catch (GSSException e) {
-          throw new IOException(e);
+  public int read(byte[] buffer, int pos, int len) throws IOException {
+    int n = 0;
+    // Server makes 16KiB frames, so we attempt several reads from the underlying stream
+    // so we don't have to store the unencrypted buffer across GSSInputStream.read calls
+    while (true) {
+      // 1. Reading length from the wrapped stream
+      if (lenPos < 4) {
+        int res = readLength();
+        if (res <= 0) {
+          // Did not read "message length" fully, so we can't read encrypted message yet
+          return n == 0 ? res : n;
         }
-        return copyLength;
+      }
+
+      // 2. Reading encrypted message from the wrapped stream
+      if (encryptedPos < encryptedLength) {
+        int res = readEncryptedBytesAndUnwrap();
+        if (res <= 0) {
+          // Did not read encrypted message fully, so we can't deliver decrypted data yet
+          return n == 0 ? res : n;
+        }
+      }
+
+      // 3. Reading unencrypted message into the user-provided buffer
+      byte[] unencrypted = castNonNull(this.unencrypted);
+      int copyLength = Math.min(len - n, unencrypted.length - unencryptedPos);
+      System.arraycopy(unencrypted, unencryptedPos, buffer, pos + n, copyLength);
+      unencryptedPos += copyLength;
+      n += copyLength;
+      if (unencryptedPos == unencrypted.length) {
+        // Start reading the new message on the next read
+        lenPos = 0;
+        encryptedPos = 0;
+        this.unencrypted = null;
+      }
+      if (n >= len || wrapped.available() <= 0) {
+        return n;
       }
     }
-    return copyLength;
+  }
+
+  /**
+   * Reads the length of the wrapper message.
+   *
+   * @return -1 of end of stream reached, 0 if length is not fully read yet, and 1 if length is
+   *     fully read
+   * @throws IOException if read fails
+   */
+  private int readLength() throws IOException {
+    while (true) {
+      int res = wrapped.read(int4Buf, lenPos, 4 - lenPos);
+      if (res == -1) {
+        return -1;
+      }
+      lenPos += res;
+      if (lenPos == 4) {
+        break;
+      }
+      if (wrapped.available() <= 0) {
+        // Did not read "message length" fully, and there's no more bytes available, so stop trying
+        return 0;
+      }
+    }
+    encryptedLength = ByteConverter.int4(int4Buf, 0);
+    if (encrypted.length < encryptedLength) {
+      // If the buffer is too small, reallocate
+      encrypted = new byte[encryptedLength];
+    }
+    return 1;
+  }
+
+  /**
+   * Reads the encrypted message, and unwraps it.
+   *
+   * @return -1 of end of stream reached, 0 if the message is not fully read yet, and 1 if length is
+   *     fully read
+   * @throws IOException if read fails
+   */
+  private int readEncryptedBytesAndUnwrap() throws IOException {
+    while (true) {
+      int res = wrapped.read(encrypted, encryptedPos, encryptedLength - encryptedPos);
+      if (res == -1) {
+        // Should we raise something like "incomplete GSS message due to end of input stream"?
+        return -1;
+      }
+      encryptedPos += res;
+      if (encryptedPos == encryptedLength) {
+        break;
+      }
+      if (wrapped.available() <= 0) {
+        // The encrypted message is not yet ready, so we can't read user data yet
+        return 0;
+      }
+    }
+    try {
+      this.unencrypted = gssContext.unwrap(encrypted, 0, encryptedLength, messageProp);
+    } catch (GSSException e) {
+      throw new IOException(e);
+    }
+    unencryptedPos = 0;
+    return 1;
   }
 }

--- a/pgjdbc/src/main/java/org/postgresql/gss/GSSOutputStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/gss/GSSOutputStream.java
@@ -49,7 +49,7 @@ public class GSSOutputStream extends PgBufferedOutputStream {
 
   private void writeWrapped(byte[] b, int off, int len) throws IOException {
     try {
-      byte[] token = gssContext.wrap(buf, off, len, messageProp);
+      byte[] token = gssContext.wrap(b, off, len, messageProp);
       pgOut.writeInt4(token.length);
       pgOut.write(token, 0, token.length);
     } catch (GSSException ex) {

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/LargeObjectManagerTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/LargeObjectManagerTest.java
@@ -133,7 +133,7 @@ class LargeObjectManagerTest {
       // Do not use try-with-resources to avoid closing the large object
       InputStream is = lo.getInputStream();
       {
-        try (StrangeInputStream fs = new StrangeInputStream(is, rnd.nextLong())) {
+        try (StrangeInputStream fs = new StrangeInputStream(rnd.nextLong(), is)) {
           while (true) {
             int bufferIndex = rnd.nextInt(buffers.length);
             byte[] buf = buffers[bufferIndex];

--- a/pgjdbc/src/test/java/org/postgresql/test/gss/GSSStreamTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/gss/GSSStreamTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2025, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.test.gss;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+import org.postgresql.gss.GSSInputStream;
+import org.postgresql.gss.GSSOutputStream;
+import org.postgresql.test.util.StrangeInputStream;
+import org.postgresql.test.util.StrangeOutputStream;
+import org.postgresql.util.internal.PgBufferedOutputStream;
+
+import org.ietf.jgss.MessageProp;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.util.Random;
+
+public class GSSStreamTest {
+  static final boolean DEBUG = false;
+  private final MessageProp messageProp = new MessageProp(0, true);
+
+  /**
+   * The test generates a random message, wraps it with {@link GSSOutputStream} and then unwraps
+   * with {@link GSSInputStream}. The output should match the input.
+   *
+   * @throws Exception in case of error
+   */
+  @Test
+  public void testGSSMessageBuffer() throws Exception {
+    ByteArrayOutputStream wrappedContents = new ByteArrayOutputStream();
+    Random rnd = new Random(42);
+    MockGSSContext gssContext = new MockGSSContext(rnd.nextLong(), messageProp);
+    GSSOutputStream gssOutputStream = new GSSOutputStream(
+        new PgBufferedOutputStream(wrappedContents, 20),
+        gssContext, messageProp, 20);
+    byte[] testMessage = new byte[10240];
+    if (DEBUG) {
+      for (int i = 0; i < testMessage.length; i++) {
+        testMessage[i] = (byte) i;
+      }
+    } else {
+      rnd.nextBytes(testMessage);
+    }
+    try (StrangeOutputStream outputStream =
+             new StrangeOutputStream(gssOutputStream, rnd.nextLong(), 0.1);) {
+      outputStream.write(testMessage);
+    }
+
+    // Unwrap the contents
+    // We use StrangeInputStream to test how GSSInputStream would react to the input streams
+    // that produce incomplete reads, and to verify how GSSInputStream would respond to
+    // reads of varying lengths.
+    StrangeInputStream inputStream =
+        new StrangeInputStream(
+            rnd.nextLong(),
+            new GSSInputStream(
+                new StrangeInputStream(
+                    rnd.nextLong(), new ByteArrayInputStream(wrappedContents.toByteArray())),
+                gssContext, messageProp
+            ));
+
+    ByteArrayOutputStream unwrapResults = new ByteArrayOutputStream();
+    int readBytes;
+    byte[] tmpBuf = new byte[testMessage.length];
+    while ((readBytes = inputStream.read(tmpBuf)) != -1) {
+      unwrapResults.write(tmpBuf, 0, readBytes);
+    }
+    byte[] unwrapResult = unwrapResults.toByteArray();
+    assertArrayEquals(testMessage, unwrapResult,
+        "the message should be intact after wrap and unwrap");
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/test/gss/MockGSSContext.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/gss/MockGSSContext.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright (c) 2025, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.test.gss;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.ietf.jgss.ChannelBinding;
+import org.ietf.jgss.GSSContext;
+import org.ietf.jgss.GSSCredential;
+import org.ietf.jgss.GSSException;
+import org.ietf.jgss.GSSName;
+import org.ietf.jgss.MessageProp;
+import org.ietf.jgss.Oid;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Random;
+
+/**
+ * Implements {@link GSSContext} that wraps input packets as follows:
+ * {@code messageLength (message.length + padding.length), message, padding}.
+ */
+public class MockGSSContext implements GSSContext {
+  private final Random rnd;
+
+  public MockGSSContext(long seed, MessageProp messageProp) {
+    rnd = new Random(seed);
+  }
+
+  @Override
+  public byte[] initSecContext(byte[] inputBuf, int offset, int len) throws GSSException {
+    throw new UnsupportedOperationException("not implemented");
+  }
+
+  @Override
+  public int initSecContext(InputStream inStream, OutputStream outStream) throws GSSException {
+    throw new UnsupportedOperationException("not implemented");
+  }
+
+  @Override
+  public byte[] acceptSecContext(byte[] inToken, int offset, int len) throws GSSException {
+    throw new UnsupportedOperationException("not implemented");
+  }
+
+  @Override
+  public void acceptSecContext(InputStream inStream, OutputStream outStream) throws GSSException {
+    throw new UnsupportedOperationException("not implemented");
+  }
+
+  @Override
+  public boolean isEstablished() {
+    throw new UnsupportedOperationException("not implemented");
+  }
+
+  @Override
+  public void dispose() throws GSSException {
+    throw new UnsupportedOperationException("not implemented");
+  }
+
+  @Override
+  public int getWrapSizeLimit(int qop, boolean confReq, int maxTokenSize) throws GSSException {
+    return 100;
+  }
+
+  private static void rangeCheck(byte[] inBuf, int offset, int len) {
+    assertTrue(offset >= 0,
+        () -> "offset should be greater or equal than zero"
+            + ", offset=" + offset + ", len=" + len + ", inBuf.length=" + inBuf.length);
+    assertTrue(offset < inBuf.length,
+        () -> "offset should be less than inBuf.length"
+            + ", offset=" + offset + ", len=" + len + "," + " inBuf.length=" + inBuf.length);
+    assertTrue(len >= 0,
+        () -> "len should be greater or equal than zero"
+            + ", offset=" + offset + ", len=" + len + ", inBuf.length=" + inBuf.length);
+    assertTrue(offset + len <= inBuf.length,
+        () -> "offset + len should not exceed buffer length"
+            + ", offset=" + offset + ", len=" + len + ", inBuf.length=" + inBuf.length);
+  }
+
+  @Override
+  public byte[] wrap(byte[] inBuf, int offset, int len, MessageProp msgProp) throws GSSException {
+    rangeCheck(inBuf, offset, len);
+    byte[] res = new byte[4 + len + rnd.nextInt(inBuf.length)];
+    ByteBuffer.wrap(res).putInt(len).put(inBuf, offset, len);
+    if (GSSStreamTest.DEBUG) {
+      System.out.println("wrapping offset=" + offset + ", len=" + len + " into message of length " + res.length);
+    }
+    return res;
+  }
+
+  @Override
+  public byte[] unwrap(byte[] inBuf, int offset, int len, MessageProp msgProp) throws GSSException {
+    rangeCheck(inBuf, offset, len);
+    ByteBuffer bb = ByteBuffer.wrap(inBuf, offset, len);
+    int msgLen = bb.getInt();
+    if (GSSStreamTest.DEBUG) {
+      System.out.println("unwrapping unwrapping offset=" + offset + ", len=" + len + " into message of length " + msgLen);
+    }
+    return Arrays.copyOfRange(inBuf, offset + 4, offset + 4 + msgLen);
+  }
+
+  @Override
+  public void wrap(InputStream inStream, OutputStream outStream, MessageProp msgProp) throws GSSException {
+    throw new UnsupportedOperationException("not implemented");
+  }
+
+  @Override
+  public void unwrap(InputStream inStream, OutputStream outStream, MessageProp msgProp) throws GSSException {
+    throw new UnsupportedOperationException("not implemented");
+  }
+
+  @Override
+  public byte[] getMIC(byte[] inMsg, int offset, int len, MessageProp msgProp) throws GSSException {
+    throw new UnsupportedOperationException("not implemented");
+  }
+
+  @Override
+  public void getMIC(InputStream inStream, OutputStream outStream, MessageProp msgProp) throws GSSException {
+    throw new UnsupportedOperationException("not implemented");
+  }
+
+  @Override
+  public void verifyMIC(byte[] inToken, int tokOffset, int tokLen, byte[] inMsg, int msgOffset,
+      int msgLen, MessageProp msgProp) throws GSSException {
+    throw new UnsupportedOperationException("not implemented");
+  }
+
+  @Override
+  public void verifyMIC(InputStream tokStream, InputStream msgStream, MessageProp msgProp) throws GSSException {
+    throw new UnsupportedOperationException("not implemented");
+  }
+
+  @Override
+  public byte[] export() throws GSSException {
+    throw new UnsupportedOperationException("not implemented");
+  }
+
+  @Override
+  public void requestMutualAuth(boolean state) throws GSSException {
+    throw new UnsupportedOperationException("not implemented");
+  }
+
+  @Override
+  public void requestReplayDet(boolean state) throws GSSException {
+    throw new UnsupportedOperationException("not implemented");
+  }
+
+  @Override
+  public void requestSequenceDet(boolean state) throws GSSException {
+    throw new UnsupportedOperationException("not implemented");
+  }
+
+  @Override
+  public void requestCredDeleg(boolean state) throws GSSException {
+    throw new UnsupportedOperationException("not implemented");
+  }
+
+  @Override
+  public void requestAnonymity(boolean state) throws GSSException {
+    throw new UnsupportedOperationException("not implemented");
+  }
+
+  @Override
+  public void requestConf(boolean state) throws GSSException {
+    throw new UnsupportedOperationException("not implemented");
+  }
+
+  @Override
+  public void requestInteg(boolean state) throws GSSException {
+    throw new UnsupportedOperationException("not implemented");
+  }
+
+  @Override
+  public void requestLifetime(int lifetime) throws GSSException {
+    throw new UnsupportedOperationException("not implemented");
+  }
+
+  @Override
+  public void setChannelBinding(ChannelBinding cb) throws GSSException {
+    throw new UnsupportedOperationException("not implemented");
+  }
+
+  @Override
+  public boolean getCredDelegState() {
+    throw new UnsupportedOperationException("not implemented");
+  }
+
+  @Override
+  public boolean getMutualAuthState() {
+    throw new UnsupportedOperationException("not implemented");
+  }
+
+  @Override
+  public boolean getReplayDetState() {
+    throw new UnsupportedOperationException("not implemented");
+  }
+
+  @Override
+  public boolean getSequenceDetState() {
+    throw new UnsupportedOperationException("not implemented");
+  }
+
+  @Override
+  public boolean getAnonymityState() {
+    throw new UnsupportedOperationException("not implemented");
+  }
+
+  @Override
+  public boolean isTransferable() throws GSSException {
+    throw new UnsupportedOperationException("not implemented");
+  }
+
+  @Override
+  public boolean isProtReady() {
+    throw new UnsupportedOperationException("not implemented");
+  }
+
+  @Override
+  public boolean getConfState() {
+    throw new UnsupportedOperationException("not implemented");
+  }
+
+  @Override
+  public boolean getIntegState() {
+    throw new UnsupportedOperationException("not implemented");
+  }
+
+  @Override
+  public int getLifetime() {
+    throw new UnsupportedOperationException("not implemented");
+  }
+
+  @Override
+  public GSSName getSrcName() throws GSSException {
+    throw new UnsupportedOperationException("not implemented");
+  }
+
+  @Override
+  public GSSName getTargName() throws GSSException {
+    throw new UnsupportedOperationException("not implemented");
+  }
+
+  @Override
+  public Oid getMech() throws GSSException {
+    throw new UnsupportedOperationException("not implemented");
+  }
+
+  @Override
+  public GSSCredential getDelegCred() throws GSSException {
+    throw new UnsupportedOperationException("not implemented");
+  }
+
+  @Override
+  public boolean isInitiator() throws GSSException {
+    throw new UnsupportedOperationException("not implemented");
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/CopyLargeFileTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/CopyLargeFileTest.java
@@ -95,7 +95,7 @@ class CopyLargeFileTest {
     }
     InputStream in = null;
     try {
-      in = new StrangeInputStream(new FileInputStream("target/buffer.txt"), seed);
+      in = new StrangeInputStream(seed, new FileInputStream("target/buffer.txt"));
       long size = copyAPI.copyIn(
           "COPY pgjdbc_issue366_test_data(data_text_id, glossary_text_id, value) FROM STDIN", in);
       assertEquals(BufferGenerator.ROW_COUNT, size);


### PR DESCRIPTION
This is a re-implementation of https://github.com/pgjdbc/pgjdbc/pull/3492

```
java.lang.ArrayIndexOutOfBoundsException: null
at java.security.jgss/sun.security.jgss.GSSContextImpl.unwrap
at sun.security.jgss.GSSContextImpl.wrap(GSSContextImpl.java:385)
at org.postgresql.gss.GSSOutputStream.writeWrapped(GSSOutputStream.java:52)
at org.postgresql.gss.GSSOutputStream.write(GSSOutputStream.java:76)
at java.io.FilterOutputStream.write(FilterOutputStream.java:97)
at org.postgresql.core.PGStream.send(PGStream.java:398)
```

GSSOutputStream does not handle the buffer switch correctly, when a message is bigger than the GSS buffer due to a wrong buffer variable usage.

GSSInputStream did not handle input streams that produced incomplete reads as it ignored the result of .read(...)
