### PR TITLE
feat: Add access for global host status tracker

### DIFF
--- a/pgjdbc/src/test/java/org/postgresql/test/hostchooser/MultiHostsConnectionTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/hostchooser/MultiHostsConnectionTest.java
@@ -25,6 +25,7 @@ import static org.postgresql.test.TestUtil.closeDB;
 import org.postgresql.PGProperty;
 import org.postgresql.hostchooser.GlobalHostStatusTracker;
 import org.postgresql.hostchooser.HostRequirement;
+import org.postgresql.hostchooser.HostStatus;
 import org.postgresql.test.TestUtil;
 import org.postgresql.util.HostSpec;
 import org.postgresql.util.PSQLException;
@@ -274,9 +275,9 @@ public class MultiHostsConnectionTest {
       con = TestUtil.openPrivilegedDB();
       con.createStatement().execute(
           "BEGIN;"
-          + "SET TRANSACTION READ WRITE;"
-          + "ALTER DATABASE " + TestUtil.getDatabase() + " SET default_transaction_read_only=off;"
-          + "COMMIT;"
+              + "SET TRANSACTION READ WRITE;"
+              + "ALTER DATABASE " + TestUtil.getDatabase() + " SET default_transaction_read_only=off;"
+              + "COMMIT;"
       );
       TestUtil.closeDB(con);
     }
@@ -489,5 +490,19 @@ public class MultiHostsConnectionTest {
 
     getConnection(primary, false, secondary1, fake1, primary1);
     assertRemote(primaryIp);
+  }
+
+  @Test
+  void connectToAnyAndGetReadOnlyMap() throws SQLException {
+    getConnection(any, fake1, primary1);
+    assertGlobalState(primary1, "ConnectOK");
+    assertGlobalState(fake1, "ConnectFail");
+
+    Map<HostSpec, HostStatus> statusMap = GlobalHostStatusTracker.getHostStatusMap();
+
+    assertTrue(statusMap.containsKey(hostSpec(primary1)));
+    assertTrue(statusMap.containsKey(hostSpec(fake1)));
+    assertEquals(statusMap.get(hostSpec(primary1)),  HostStatus.valueOf("ConnectOK"));
+    assertEquals(statusMap.get(hostSpec(fake1)),  HostStatus.valueOf("ConnectFail"));
   }
 }


### PR DESCRIPTION
### All Submissions:

* [V] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [V] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [V] Does your submission pass tests?
2. [V] Does `./gradlew styleCheck` pass ?
3. [V] Have you added your new test classes to an existing test suite in alphabetical order?

### Changes to Existing Features:

* [X] Does this break existing behaviour? If so please explain.
* [V] Have you added an explanation of what your changes do and why you'd like us to include them?
* [V] Have you written new tests for your core changes, as applicable?
* [V] Have you successfully run tests with your changes locally?


### Explain feature:
When connecting, the driver receives information about hosts in ascending order of delay. If one of the three available servers goes down for maintenance, connections are switched to other free hosts. However, when the first server comes back online, the driver does not notice this and does not reconnect to it.

Our goal is to understand how the driver sees available hosts, and force connections to be closed so that the driver can reconnect to the first \ host.
