### PR TITLE
Add back application name setting

### DIFF
--- a/docs/content/documentation/use.md
+++ b/docs/content/documentation/use.md
@@ -366,7 +366,9 @@ The default is to sanitise the columns (off).
 
 * **`assumeMinServerVersion (`*String*`)`** *Default `null`*\
 Assume that the server is at least the given version, thus enabling to some optimization at connection time instead of
-trying to be version blind.
+trying to be version blind. 
+  * This allows the application name to be sent on startup instead of as a separate post-connection query.  In addition 
+to optimizing the initial connection, this allows the application name to be logged on the server earlier in the connection process.
 
 * **`currentSchema (`*String*`)`** *Default `null`*\
 Specify the schema (or several schema separated by commas) to be set in the search-path. 

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java
@@ -400,7 +400,7 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
     // application name is important to set as early as possible for connection logging, we set it immediately
     // if we can assume the minimum version supports doing so
     String appName = PGProperty.APPLICATION_NAME.getOrDefault(info);
-    if( appName != null && assumeVersion.getVersionNum() >= ServerVersion.v9_0.getVersionNum() ) {
+    if ( appName != null && assumeVersion.getVersionNum() >= ServerVersion.v9_0.getVersionNum() ) {
       paramList.add(new StartupParam("application_name", appName));
     }
 
@@ -929,26 +929,25 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
     boolean groupStartupParameters = dbVersion >= ServerVersion.v9_0.getVersionNum()
             && PGProperty.GROUP_STARTUP_PARAMETERS.getBoolean(info);
 
-    if( sendApplicationName || sendExtraFloatDigits ) {
+    if ( sendApplicationName || sendExtraFloatDigits ) {
       if (groupStartupParameters) {
         SetupQueryRunner.run(queryExecutor, "BEGIN", false);
       }
 
-      if( sendExtraFloatDigits ) {
+      if ( sendExtraFloatDigits ) {
         if (dbVersion < ServerVersion.v9_0.getVersionNum()) {
           // server version < 9 so 8.x or less
           SetupQueryRunner.run(queryExecutor, "SET extra_float_digits = 2", false);
-        }
-        else {
+        } else {
           // server version < 12 so 9.0 - 11.x
           SetupQueryRunner.run(queryExecutor, "SET extra_float_digits = 3", false);
         }
       }
 
-      if( sendApplicationName ) {
+      if ( sendApplicationName ) {
         StringBuilder sql = new StringBuilder();
         sql.append("SET application_name = '");
-        Utils.escapeLiteral(sql, appName, queryExecutor.getStandardConformingStrings());
+        Utils.escapeLiteral(sql, Nullness.castNonNull(appName), queryExecutor.getStandardConformingStrings());
         sql.append("'");
         SetupQueryRunner.run(queryExecutor, sql.toString(), false);
       }

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java
@@ -394,8 +394,14 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
 
     Version assumeVersion = ServerVersion.from(PGProperty.ASSUME_MIN_SERVER_VERSION.getOrDefault(info));
 
-    // we really don't know the version of the server yet so we can't set application name or extra float digits
+    // we really don't know the version of the server yet so we can't set extra float digits
     // set them in runInitialQueries
+
+    // application name is important to set as early as possible for connection logging
+    String appName = PGProperty.APPLICATION_NAME.getOrDefault(info);
+    if( appName != null && assumeVersion.getVersionNum() >= ServerVersion.v9_0.getVersionNum() ) {
+      paramList.add(new StartupParam("application_name", appName));
+    }
 
     // probably no need to make sure the assumeVersion is 9.4 or greater. The user really wants replication.
     String replication = PGProperty.REPLICATION.getOrDefault(info);

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ParameterStatusTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ParameterStatusTest.java
@@ -8,12 +8,12 @@ package org.postgresql.test.jdbc2;
 import org.postgresql.PGConnection;
 import org.postgresql.core.ServerVersion;
 import org.postgresql.test.TestUtil;
+import org.postgresql.test.annotations.DisabledIfServerVersionBelow;
 
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.StringStartsWith;
 import org.junit.Assert;
 import org.junit.Test;
-import org.postgresql.test.annotations.DisabledIfServerVersionBelow;
 
 import java.sql.Statement;
 import java.util.Map;

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ParameterStatusTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ParameterStatusTest.java
@@ -98,6 +98,19 @@ public class ParameterStatusTest extends BaseTest4 {
   }
 
   @Test
+  @DisabledIfServerVersionBelow("9.0")
+  public void expectedApplicationNameWithNullMinVersion() throws Exception {
+    Properties properties = new Properties();
+    properties.remove("assumeMinServerVersion");
+    con = TestUtil.openDB(properties);
+
+    Map<String,String> params = ((PGConnection) con).getParameterStatuses();
+    Assert.assertEquals("Driver Tests", params.get("application_name"));
+
+    TestUtil.closeDB(con);
+  }
+
+  @Test
   public void reportUpdatedParameters() throws Exception {
     con = TestUtil.openDB();
 

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ParameterStatusTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ParameterStatusTest.java
@@ -13,9 +13,11 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.StringStartsWith;
 import org.junit.Assert;
 import org.junit.Test;
+import org.postgresql.test.annotations.DisabledIfServerVersionBelow;
 
 import java.sql.Statement;
 import java.util.Map;
+import java.util.Properties;
 import java.util.TimeZone;
 import java.util.logging.Logger;
 
@@ -78,6 +80,19 @@ public class ParameterStatusTest extends BaseTest4 {
     // Not reported
     Assert.assertNull(params.get("nonexistent"));
     Assert.assertNull(params.get("enable_hashjoin"));
+
+    TestUtil.closeDB(con);
+  }
+
+  @Test
+  @DisabledIfServerVersionBelow("9.0")
+  public void expectedApplicationNameWithMinVersion() throws Exception {
+    Properties properties = new Properties();
+    properties.put("assumeMinServerVersion", "9.0");
+    con = TestUtil.openDB(properties);
+
+    Map<String,String> params = ((PGConnection) con).getParameterStatuses();
+    Assert.assertEquals("Driver Tests", params.get("application_name"));
 
     TestUtil.closeDB(con);
   }


### PR DESCRIPTION
Fixes #3508, by adding back the application_name startup parameters during the initial connection.