### PR TITLE
Client default timezone no longer sent to the server

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/PGConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGConnection.java
@@ -336,10 +336,6 @@ public interface PGConnection {
    *  </li>
    *  <li><code>DateStyle</code> - PgJDBC requires this to always be set to <code>ISO</code></li>
    *  <li><code>standard_conforming_strings</code> - indirectly via {@link #escapeLiteral(String)}</li>
-   *  <li>
-   *    <code>TimeZone</code> - set from JDK timezone see {@link java.util.TimeZone#getDefault()}
-   *    and {@link java.util.TimeZone#setDefault(TimeZone)}
-   *  </li>
    *  <li><code>integer_datetimes</code></li>
    *  <li><code>IntervalStyle</code></li>
    *  <li><code>server_encoding</code></li>

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java
@@ -52,7 +52,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.TimeZone;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
@@ -390,7 +389,6 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
     paramList.add(new StartupParam("database", database));
     paramList.add(new StartupParam("client_encoding", "UTF8"));
     paramList.add(new StartupParam("DateStyle", "ISO"));
-    paramList.add(new StartupParam("TimeZone", createPostgresTimeZone()));
 
     Version assumeVersion = ServerVersion.from(PGProperty.ASSUME_MIN_SERVER_VERSION.getOrDefault(info));
 
@@ -426,37 +424,6 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
     rec.setParameters(params);
     rec.setThrown(thrown);
     LOGGER.log(rec);
-  }
-
-  /**
-   * Convert Java time zone to postgres time zone. All others stay the same except that GMT+nn
-   * changes to GMT-nn and vise versa.
-   * If you provide GMT+/-nn postgres uses POSIX rules which has a positive sign for west of Greenwich
-   * JAVA uses ISO rules which the positive sign is east of Greenwich
-   * To make matters more interesting postgres will always report in ISO
-   *
-   * @return The current JVM time zone in postgresql format.
-   */
-  private static String createPostgresTimeZone() {
-    String tz = TimeZone.getDefault().getID();
-    if (tz.length() <= 3 || !tz.startsWith("GMT")) {
-      return tz;
-    }
-    char sign = tz.charAt(3);
-    String start;
-    switch (sign) {
-      case '+':
-        start = "GMT-";
-        break;
-      case '-':
-        start = "GMT+";
-        break;
-      default:
-        // unknown type
-        return tz;
-    }
-
-    return start + tz.substring(4);
   }
 
   private static PGStream enableGSSEncrypted(PGStream pgStream, GSSEncMode gssEncMode, String host, Properties info,

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/TimeZoneTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/TimeZoneTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2018, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.jdbc;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.postgresql.test.SlowTests;
+import org.postgresql.test.TestUtil;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.Optional;
+import java.util.Random;
+import java.util.Set;
+import java.util.TimeZone;
+import java.util.stream.Stream;
+
+/**
+ * TimeZone is a global parameter affecting all APIs used by an application. User must be able
+ * to choose any available TimeZone or use system default. In any case application must
+ * connect to database successfully and must not misinterpret time-related data. This test
+ * is unlikely to catch an error when executed in local environment, where both sides,
+ * client and server, share the same OS and locale-related software components. But it highlights
+ * perfectly the problem when software relies on similarity of independently managed clients and server.
+ */
+class TimeZoneTest {
+  @Nullable
+  private static TimeZone savedTimeZone = null;
+
+  @BeforeAll
+  static void setup() {
+    savedTimeZone = TimeZone.getDefault();
+  }
+
+  @AfterAll
+  static void close() {
+    TimeZone.setDefault(savedTimeZone);
+  }
+
+  /**
+   * When server uses client timezone, we can run into 2 kind of bugs:
+   * <ol>
+   *   <li>Client sets a just created new timezone Mars/Muskbase. It sends it to the server but server rejects to connect, since it doesn't aware of a new timezone.</li>
+   *   <li>The government of a country changed daylight savings rules of local timezone. Client sends its timezone id to the server,
+   *   connects successfully, but server has old daylight savings rules for that timezone. If server and client rely on client's zone info, the data will be corrupted 6 months a year.
+   *   This is what we have in Mexico. If server has timezone info created before 2023, it most likely misinterpret time in Mexico timezone, because it had changed.
+   *   </li>
+   * </ol>
+   * Here we try to detect both risks, but we have no garantee, that we are going to make it. The only way we can garantee
+   * the integrity of time-related data is to learn basics and use time API properly.
+   *
+   * @param zoneId zone ID
+   * @throws SQLException Occurs, when connection can not be established
+   */
+  @ParameterizedTest
+  @MethodSource("provideZoneIds")
+  @Category(SlowTests.class)
+  void testTimeZone(String zoneId) throws SQLException {
+    TimeZone.setDefault(TimeZone.getTimeZone(zoneId));
+    try (Connection connection = TestUtil.openDB()) {
+      try (Statement stmt = connection.createStatement()) {
+        long clientTime = System.currentTimeMillis();
+        try (ResultSet rs = stmt.executeQuery("select now()")) {
+          rs.next();
+          Timestamp ts = rs.getTimestamp(1);
+          Instant instant = ts.toInstant();
+          long serverTime = instant.toEpochMilli();
+          assertTrue(Math.abs(serverTime - clientTime) <= 10_000L, "Client and server time are close enough");
+        }
+      }
+    }
+  }
+
+  @Test
+  @Disabled("Use more reliable testTimeZone")
+  void testRandomTimeZone() throws SQLException {
+    Set<String> set = ZoneId.getAvailableZoneIds();
+    Random random = new Random();
+    int pos = random.nextInt(set.size());
+    Optional<String> value = set.stream().skip(pos).findFirst();
+    if (value.isPresent()) {
+      String zone = value.get();
+      testTimeZone(zone);
+    }
+  }
+
+  static Stream<Arguments> provideZoneIds() {
+    Set<String> zoneIds = ZoneId.getAvailableZoneIds();
+    return zoneIds.stream()
+        .sorted()
+        .map(Arguments::of);
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ParameterStatusTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ParameterStatusTest.java
@@ -48,10 +48,6 @@ public class ParameterStatusTest extends BaseTest4 {
     Assert.assertNotNull(params.get("DateStyle"));
     MatcherAssert.assertThat(params.get("DateStyle"), StringStartsWith.startsWith("ISO"));
 
-    // PgJDBC sets TimeZone via Java's TimeZone.getDefault()
-    // Pg reports POSIX timezones which are negated, so:
-    Assert.assertEquals("GMT-08:00", params.get("TimeZone"));
-
     // Must be reported. All these exist in 8.2 or above, and we don't bother
     // with test coverage older than that.
     Assert.assertNotNull(params.get("integer_datetimes"));


### PR DESCRIPTION
Fixes issue #2311

We no longer need to configure timezone startup parameter, because we just don't use it.


### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Does `./gradlew styleCheck` pass ?
3. [x] Have you added your new test classes to an existing test suite in alphabetical order?

### Changes to Existing Features:

* [ ] Does this break existing behaviour? If so please explain.
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully run tests with your changes locally? - Only first 2000 tests. I didn't wait for all the tests to finish because they took too long.
