### PR TITLE
fix: make PgConnection#abort compatible with Java 24

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
@@ -1712,7 +1712,7 @@ public class PgConnection implements BaseConnection {
       return;
     }
 
-    SQL_PERMISSION_ABORT.checkGuard(this);
+    checkPermission(SQL_PERMISSION_ABORT);
 
     AbortCommand command = new AbortCommand();
     executor.execute(command);


### PR DESCRIPTION
Previously, #abort was using SQLPermission("callAbort").checkGuard(this) to test abort permission, however, Java 24 permanently removes Security Manager, so checkGuard always throws an exception.

The fix is to verify if the security manager is installed before checking the permission.

Fixes https://github.com/pgjdbc/pgjdbc/issues/3581
