### PR TITLE
chore: appply the latest byte-buddy version for tests so we support the latest Java versions

### DIFF
--- a/build-logic/jvm/src/main/kotlin/build-logic.test-junit5.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/build-logic.test-junit5.gradle.kts
@@ -13,6 +13,9 @@ dependencies {
     if (buildParameters.testJdkVersion >= 11) {
         // system-stubs 2.0+ requires Java 11+
         testImplementation("uk.org.webcompere:system-stubs-jupiter:2.1.7")
+        // system-stubs-jupiter might come with an outdated byte-buddy version, so we mention
+        // the latest one so it would be updated by the bots even if system-stubs-jupiter does not update
+        testImplementation(platform("net.bytebuddy:byte-buddy-parent:1.17.4"))
     } else {
         testImplementation("uk.org.webcompere:system-stubs-jupiter:1.2.1") // renovate:ignore
     }


### PR DESCRIPTION
See https://github.com/webcompere/system-stubs/issues/93
