### PR TITLE
docs: Relabel 42.7.4 as past version as it is no longer the latest

### DIFF
--- a/docs/data/versions.toml
+++ b/docs/data/versions.toml
@@ -7,13 +7,6 @@ description= "If you are using Java 8 or newer then you should use the JDBC 4.2 
 url= "/download/postgresql-42.7.5.jar"
 
 [[recent]]
-j_name= "Java 8"
-version= "42.7.4"
-suffix=""
-description= "If you are using Java 8 or newer then you should use the JDBC 4.2 version."
-url= "/download/postgresql-42.7.4.jar"
-
-[[recent]]
 j_name= "Java 7"
 version= "42.2.29"
 suffix="jre7"
@@ -28,6 +21,13 @@ description= "If you are using Java 6  then you should use the  JDBC 4.0 version
 url= "/download/postgresql-42.2.27.jre6.jar"
 
 # Past Versions
+[[past]]
+j_name= "Java 8"
+version= "42.7.4"
+suffix=""
+description= "If you are using Java 8 or newer then you should use the JDBC 4.2 version."
+url= "/download/postgresql-42.7.4.jar"
+
 [[past]]
 j_name= "Java 8"
 version= "42.7.3"


### PR DESCRIPTION
I'm not particularly familiar with how the website gets generated but looks like it's all data driven so hoping this is that's required.

Fixes #3585