### PR TITLE
fix: add support for multiple schemas via PgConnection.setSchema

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
@@ -1681,7 +1681,8 @@ public class PgConnection implements BaseConnection {
   public @Nullable String getSchema() throws SQLException {
     checkClosed();
     try (Statement stmt = createStatement()) {
-      try (ResultSet rs = stmt.executeQuery("select current_schema()")) {
+      // current_schema() only returns the first schema, SHOW search_path returns all schemas on the search path
+      try (ResultSet rs = stmt.executeQuery("SHOW search_path")) {
         if (!rs.next()) {
           return null; // Is it ever possible?
         }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc4/jdbc41/SchemaTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc4/jdbc41/SchemaTest.java
@@ -148,28 +148,22 @@ class SchemaTest {
   @Test
   void multipleSearchPath() throws SQLException {
     execute("SET search_path TO schema1,schema2");
-    assertEquals("schema1", conn.getSchema());
+    assertEquals("schema1, schema2", conn.getSchema());
 
     execute("SET search_path TO \"schema ,6\",schema2");
-    assertEquals("schema ,6", conn.getSchema());
+    assertEquals("\"schema ,6\", schema2", conn.getSchema());
   }
 
   @Test
-  void setSchemaList() throws SQLException {
+  void setAndGetSchemaList() throws SQLException {
     conn.setSchema("schema1,schema2");
-    assertEquals("schema1", conn.getSchema());
-    ResultSet searchPath = conn.prepareStatement("SHOW search_path").executeQuery();
-    searchPath.next();
-    assertEquals("schema1, schema2", searchPath.getString(1));
+    assertEquals("schema1, schema2", conn.getSchema());
   }
 
   @Test
   void setSchemaListWithSpecialChars() throws SQLException {
     conn.setSchema("schema \"4, schema '5, UpperCase");
-    assertEquals("schema \"4", conn.getSchema());
-    ResultSet searchPath = conn.prepareStatement("SHOW search_path").executeQuery();
-    searchPath.next();
-    assertEquals("\"schema \"\"4\", \"schema '5\", \"UpperCase\"", searchPath.getString(1));
+    assertEquals("\"schema \"\"4\", \"schema '5\", \"UpperCase\"", conn.getSchema());
   }
 
   @Test
@@ -195,9 +189,10 @@ class SchemaTest {
   }
 
   @Test
-  public void schemaPath$User() throws Exception {
+  void schemaPath$User() throws Exception {
     execute("SET search_path TO \"$user\",public,schema2");
-    assertEquals(TestUtil.getUser(), conn.getSchema());
+    // SHOW search_path does not resolve $user
+    assertEquals("\"$user\", public, schema2", conn.getSchema());
   }
 
   private void execute(String sql) throws SQLException {


### PR DESCRIPTION
The JDBC connection string already supports multiple schemas, now programmatically setting multiple schemas also works.

Closes issue 3605.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests? -> Only partially, I get authentication errors sometimes, although I set the credentials correctly. Seems like some tests are flaky.
2. [x] Does `./gradlew styleCheck` pass ?

### Changes to Existing Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
