### PR TITLE
chore: use Java 21 for building pgjdbc by default

### DIFF
--- a/.github/workflows/buildcache.yml
+++ b/.github/workflows/buildcache.yml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu, macos, windows]
-        jdk: [17]
+        jdk: [21]
 
     name: '${{ matrix.os }}, ${{ matrix.jdk }} seed build cache'
     runs-on: ${{ matrix.os }}-latest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -57,11 +57,11 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
-      
+
     - uses: actions/setup-java@v4
       with:
         distribution: zulu
-        java-version: 17
+        java-version: 21
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/debezium.yml
+++ b/.github/workflows/debezium.yml
@@ -19,11 +19,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 50
-      - name: 'Set up JDK 17'
+      - name: 'Set up JDK 21'
         uses: actions/setup-java@v4
         with:
           distribution: zulu
-          java-version: 17
+          java-version: 21
       - uses: burrunan/gradle-cache-action@v2
         name: Publish Snapshot
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,18 +45,18 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 50
-    - name: 'Set up JDK 17'
+    - name: 'Set up JDK 21'
       uses: actions/setup-java@v4
       with:
         distribution: zulu
-        java-version: 17
+        java-version: 21
     - uses: burrunan/gradle-cache-action@v2
       name: Verify code style
       env:
         S3_BUILD_CACHE_ACCESS_KEY_ID: ${{ secrets.S3_BUILD_CACHE_ACCESS_KEY_ID }}
         S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.S3_BUILD_CACHE_SECRET_KEY }}
       with:
-        job-id: jdk17
+        job-id: jdk21
         arguments: styleCheck jandex -PenableErrorprone classes
 
   linux-checkerframework:
@@ -66,11 +66,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 50
-      - name: 'Set up JDK 17'
+      - name: 'Set up JDK 21'
         uses: actions/setup-java@v4
         with:
           distribution: zulu
-          java-version: 17
+          java-version: 21
       - uses: burrunan/gradle-cache-action@v2
         name: Run CheckerFramework
         env:
@@ -78,11 +78,11 @@ jobs:
           S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.S3_BUILD_CACHE_SECRET_KEY }}
         with:
           read-only: false
-          job-id: checker-jdk17
+          job-id: checker-jdk21
           arguments: --scan --no-parallel --no-daemon -PenableCheckerframework classes
 
   source-distribution-check:
-    name: 'Source distribution (JDK 17)'
+    name: 'Source distribution (JDK 21)'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -91,18 +91,18 @@ jobs:
       - name: Start PostgreSQL
         working-directory: docker/postgres-server
         run: docker compose up -d && docker compose logs
-      - name: 'Set up JDK 17'
+      - name: 'Set up JDK 21'
         uses: actions/setup-java@v4
         with:
           distribution: zulu
-          java-version: 17
+          java-version: 21
       - uses: burrunan/gradle-cache-action@v2
         name: Prepare source distribution
         env:
           S3_BUILD_CACHE_ACCESS_KEY_ID: ${{ secrets.S3_BUILD_CACHE_ACCESS_KEY_ID }}
           S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.S3_BUILD_CACHE_SECRET_KEY }}
         with:
-          job-id: source-release-jdk17
+          job-id: source-release-jdk21
           arguments: --scan --no-parallel --no-daemon sourceDistribution -Ppgjdbc.version=1.0 -Prelease
       - name: Verify source distribution
         working-directory: pgjdbc/build/distributions
@@ -166,14 +166,14 @@ jobs:
         sed -i -r '/- (543[3-4]):\1/d' docker-compose.yml
         docker compose up -d
         docker compose logs
-    - name: Set up Java 17 and ${{ matrix.non_ea_java_version }}, ${{ matrix.java_distribution }}, ${{ runner.arch }}
+    - name: Set up Java 21 and ${{ matrix.non_ea_java_version }}, ${{ matrix.java_distribution }}, ${{ runner.arch }}
       uses: actions/setup-java@v4
       with:
-        # The latest one will be the default, so we use Java 17 for launching Gradle
-        # oracle-actions/setup-java below requires Java 17, so we must install Java 17 before calling oracle-actions/setup-java
+        # The latest one will be the default, so we use Java 21 for launching Gradle
+        # oracle-actions/setup-java below requires Java 21, so we must install Java 21 before calling oracle-actions/setup-java
         java-version: |
           ${{ matrix.non_ea_java_version }}
-          17
+          21
         distribution: ${{ matrix.java_distribution }}
         # Architecture is explicit to workaround https://github.com/actions/setup-java/issues/559
         architecture: ${{ runner.arch == 'ARM64' && 'aarch64' || 'x64' }}
@@ -182,16 +182,17 @@ jobs:
       if: ${{ matrix.oracle_java_website != '' }}
       uses: oracle-actions/setup-java@8fb9d7717810ccde9f8d4bef1e6f43d180f506b5 # v1.4.1
       env:
-        JAVA_HOME_17_X64: ${{ env.JAVA_HOME_17_AARCH64 || env.JAVA_HOME_17_X64 }}
+        # Java 21 is needed for executing oracle-actions/setup-java, so we pass it here
+        JAVA_HOME_21_X64: ${{ env.JAVA_HOME_21_AARCH64 || env.JAVA_HOME_21_X64 }}
       with:
         website: ${{ matrix.oracle_java_website }}
         release: ${{ matrix.java_version }}
-    - name: Set up Java 17 ${{ matrix.java_distribution }} as default
-      # oracle-actions/setup-java above installs EA java by default, so we need to reinstall Java 17 as the default
+    - name: Set up Java 21 ${{ matrix.java_distribution }} as default
+      # oracle-actions/setup-java above installs EA java by default, so we need to reinstall Java 21 as the default
       if: ${{ matrix.oracle_java_website != '' }}
       uses: actions/setup-java@v4
       with:
-        java-version: 17
+        java-version: 21
         distribution: ${{ matrix.java_distribution }}
         # Architecture is explicit to workaround https://github.com/actions/setup-java/issues/559
         architecture: ${{ runner.arch == 'ARM64' && 'aarch64' || 'x64' }}
@@ -218,7 +219,7 @@ jobs:
         properties: |
           includeTestTags=${{ matrix.includeTestTags }}
           testExtraJvmArgs=${{ matrix.testExtraJvmArgs }}
-          jdkBuildVersion=17
+          jdkBuildVersion=21
           jdkTestVersion=${{ matrix.java_version == 'EA' && steps.setup_ea_java.outputs.version || matrix.java_version }}
           jdkTestVendor=${{ matrix.java_vendor }}
           # We provision JDKs with GitHub Actions for caching purposes, so Gradle should rather fail in case JDK is not found

--- a/.github/workflows/nightlysnapshot.yml
+++ b/.github/workflows/nightlysnapshot.yml
@@ -40,11 +40,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 50
-      - name: 'Set up JDK 17'
+      - name: 'Set up JDK 21'
         uses: actions/setup-java@v4
         with:
           distribution: zulu
-          java-version: 17
+          java-version: 21
       - uses: burrunan/gradle-cache-action@v2
         name: Publish Snapshot
         env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,7 @@ Here are a few important things you should know about contributing code:
 In order to build the source code for PgJDBC you will need the following tools:
 
   - A Git client
-  - A JDK for the JDBC version you'd like to build (Java 17 for pgjdbc 42.7.1, Java 8 for older pgjdbc releases)
+  - A JDK for the JDBC version you'd like to build (Java 21 for pgjdbc 42.7.1, Java 8 for older pgjdbc releases)
   - A running PostgreSQL instance (optional for unit/integration tests)
 
 We use [Gradle's Toolchains for JVM projects](https://docs.gradle.org/current/userguide/toolchains.html)
@@ -84,7 +84,7 @@ to separate JDK version used for building and running tests.
 This means Gradle will automatically find the required JDK version or download it for you.
 
 You could control JDK versions with the following Gradle properties:
-* `jdkBuildVersion`. Defaults to 17. [JDK version](https://docs.gradle.org/8.4/userguide/toolchains.html#sec:consuming) to use for building $projectName. If the value is 0, then the current Java is used.
+* `jdkBuildVersion`. Defaults to 21. [JDK version](https://docs.gradle.org/8.4/userguide/toolchains.html#sec:consuming) to use for building $projectName. If the value is 0, then the current Java is used.
 * `jdkBuildVendor`. [JDK vendor](https://docs.gradle.org/8.4/userguide/toolchains.html#sec:vendors) to use building
 * `jdkBuildImplementation`. Vendor-specific [virtual machine implementation](https://docs.gradle.org/8.4/userguide/toolchains.html#selecting_toolchains_by_virtual_machine_implementation) to use building
 * `jdkTestVersion`. Defaults to `jdkBuildVersion`. [JDK version](https://docs.gradle.org/8.4/userguide/toolchains.html#sec:consuming) to use for testing.
@@ -157,7 +157,7 @@ is used for releasing artifacts.
 ## Releasing a new version
 
 Prerequisites:
-- Java 17
+- Java 21
 - a PostgreSQL instance for running tests; it must have a user named `test` as well as a database named `test`
 - ensure that the RPM packaging CI isn't failing at
   [copr web page](https://copr.fedorainfracloud.org/coprs/g/pgjdbc/pgjdbc-travis/builds/)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,19 +4,12 @@ configuration: Release
 
 clone_depth: 1
 environment:
-  JAVA_HOME: 'C:\Program Files\Java\jdk17'
+  JAVA_HOME: 'C:\Program Files\Java\jdk21'
   matrix:
-  - pg: 9.6.11-1
-    PlatformToolset: v120
-matrix:
-  allow_failures:
-    - pg: master
-  exclude:
-    - platform: x86
-      pg: 11.1-1
-      PlatformToolset: v140
-    - platform: x86
-      pg: master
+  - pg: 16
+  # AppVeyor takes ~20 min for running the tests, so testing two PG versions results in slow PR feedback
+  # It might be worth uncommenting if the tests get faster somehow
+  # - pg: 11
 
 skip_commits:
   files:
@@ -48,22 +41,47 @@ install:
 
 before_build:
 - ps: Add-Content -PATH "$env:pgroot\data\postgresql.conf" "wal_level=logical"
-- ps: Add-Content -PATH "$env:pgroot\data\postgresql.conf" "wal_level=logical"
 - ps: Add-Content -PATH "$env:pgroot\data\postgresql.conf" "max_wal_senders=3"
-- ps: Add-Content -PATH "$env:pgroot\data\postgresql.conf" "wal_keep_segments=10"
 - ps: Add-Content -PATH "$env:pgroot\data\postgresql.conf" "wal_sender_timeout=5s"
 - ps: Add-Content -PATH "$env:pgroot\data\postgresql.conf" "max_replication_slots=10"
-- ps: Add-Content -PATH "$env:pgroot\data\pg_hba.conf" "host    replication     all             127.0.0.1/32            trust"
-- net start postgresql%x64%-%pgversion%
+- ps: |
+    Copy-Item -Path .\certdir\server\pg_hba.conf -Destination "$env:pgroot\data\pg_hba.conf" -Force
+    (Get-Content -Raw "$env:pgroot\data\pg_hba.conf") -replace '(?m)^local\b', '#local' | Set-Content "$env:pgroot\data\pg_hba.conf"
+    # PostgreSQL 11 can't start if ssl=off and pg_hba.conf includes hostssl, so we comment it out as we don't configure ssl yet
+    (Get-Content -Raw "$env:pgroot\data\pg_hba.conf") -replace '(?m)^hostssl\b', '#hostssl' | Set-Content "$env:pgroot\data\pg_hba.conf"
+    Write-Host "Here's the contents of pg_hba.conf:"
+    Get-Content "$env:pgroot\data\pg_hba.conf" | Where-Object { $_ -notmatch '^\s*#' -and $_.Trim() -ne '' }
+- ps: |
+    net start "postgresql$env:x64-$env:pgversion"
+    if ($LASTEXITCODE -ne 0) {
+      Select-String -Path "$env:pgroot\data\postgresql.conf" -Pattern "log_directory|logging_collector"
+      $pgLogDir = "$env:pgroot\data\log"
+      if (-not (Test-Path $pgLogDir)) {
+        Write-Host "Log directory does not exist: $pgLogDir"
+      } else {
+        $latestLog = Get-ChildItem -Path $pgLogDir -File |
+                     Sort-Object LastWriteTime -Descending |
+                     Select-Object -First 1
+        if ($latestLog) {
+          Write-Host "=== Showing latest PostgreSQL log: $($latestLog.Name) ==="
+          Get-Content -Path $latestLog.FullName -Tail 100
+        } else {
+          Write-Host "No PostgreSQL log files found."
+        }
+      }
+      throw "PostgreSQL did not start, so there's no reason to continue with the tests"
+    }
 - path %pgroot%\bin;%PATH%
 - mkdir %APPDATA%\postgresql
 - echo *:*:*:postgres:Password12!> %APPDATA%\postgresql\pgpass.conf
 - createuser -U postgres test
 - psql -U postgres -c "alter user test with password 'test'" postgres
 - psql -U postgres -c "alter user test with replication" postgres
+- psql -U postgres -c "CREATE EXTENSION sslinfo" postgres
 - createuser -U postgres testsspi
 - createdb -U postgres -O test test
 - createdb -U postgres -O test test_2
+- psql -U postgres -c "CREATE EXTENSION hstore" test
 - del %APPDATA%\postgresql\pgpass.conf
 
 build_script:
@@ -72,7 +90,7 @@ build_script:
 test_script:
   - echo redirect escape ^> foo.bar
   - echo privilegedPassword=Password12!>c:\projects\pgjdbc\build.local.properties
-  - gradlew test
+  - gradlew test -PskipReplicationTests
 
 cache:
   - C:\Users\appveyor\.m2

--- a/build-logic/build-parameters/build.gradle.kts
+++ b/build-logic/build-parameters/build.gradle.kts
@@ -23,7 +23,7 @@ buildParameters {
     }
     val projectName = "pgjdbc"
     integer("jdkBuildVersion") {
-        defaultValue.set(17)
+        defaultValue.set(21)
         mandatory.set(true)
         description.set("JDK version to use for building $projectName. If the value is 0, then the current Java is used. (see https://docs.gradle.org/8.4/userguide/toolchains.html#sec:consuming)")
     }

--- a/certdir/server/pg_hba.conf
+++ b/certdir/server/pg_hba.conf
@@ -73,10 +73,10 @@
 # "local" is for Unix domain socket connections only
 local   all         postgres                          trust
 # IPv4 local connections:
-host    all         postgres    127.0.0.1/32          trust
-host    test	all         127.0.0.1/32          md5
-host    hostdb         all         127.0.0.1/32          md5
-hostnossl    hostnossldb         all         127.0.0.1/32          md5
-hostssl    hostssldb         all         127.0.0.1/32          md5    
-hostssl    hostsslcertdb         all         127.0.0.1/32          md5    clientcert=verify-full
-hostssl    certdb         all         127.0.0.1/32          cert
+host    all         postgres    all          trust
+host    test	all         all          md5
+host    hostdb         all         all          md5
+hostnossl    hostnossldb         all         all          md5
+hostssl    hostssldb         all         all          md5
+hostssl    hostsslcertdb         all         all          md5    clientcert=verify-full
+hostssl    certdb         all         all          cert

--- a/docker/postgres-server/scripts/entrypoint.sh
+++ b/docker/postgres-server/scripts/entrypoint.sh
@@ -36,7 +36,6 @@ main () {
 
     # Customize pg_hba.conf
     local pg_hba="/home/certdir/pg_hba.conf"
-    sed -i 's/127.0.0.1\/32/0.0.0.0\/0/g' "${pg_hba}"
     add_pg_opt "-c hba_file=${pg_hba}"
 
     if is_option_enabled "${SSL}"; then


### PR DESCRIPTION
Note: the resulting binaries still target Java 8, so the change should not be use-visible.

However, we would use a newer toolset which should result in fewer bugs in the generated binaries.
