### PR TITLE
test: add CI executions with adaptive_fetch=true by default

### DIFF
--- a/.github/workflows/matrix.mjs
+++ b/.github/workflows/matrix.mjs
@@ -197,6 +197,15 @@ matrix.addAxis({
   ]
 });
 
+matrix.addAxis({
+  name: 'adaptive_fetch',
+  title: x => x.value === 'yes' ? 'adaptive_fetch' : '',
+  values: [
+      {value: 'yes', weight: 30},
+      {value: 'no', weight: 70}, // This is the default value, prefer testing it more
+  ]
+});
+
 function lessThan(minVersion) {
     return value => Number(value) < Number(minVersion);
 }
@@ -205,6 +214,7 @@ matrix.setNamePattern([
     'java_version', 'java_distribution', 'pg_version', 'query_mode', 'scram', 'ssl', 'hash', 'os',
     'server_tz', 'tz', 'locale',
     'check_anorm_sbt', 'gss', 'replication', 'slow_tests',
+    'adaptive_fetch'
 ]);
 
 // We take EA builds from Oracle
@@ -302,6 +312,7 @@ include.forEach(v => {
   v.scram = v.scram.value;
   v.check_anorm_sbt = v.check_anorm_sbt.value;
   v.query_mode = v.query_mode.value;
+  v.adaptive_fetch = v.adaptive_fetch.value;
 
   let includeTestTags = [];
   // See https://junit.org/junit5/docs/current/user-guide/#running-tests-tag-expressions
@@ -360,6 +371,9 @@ include.forEach(v => {
   testJvmArgs.push('-Djava.security.egd=file:/dev/./urandom')
   if (v.assumeMinServerVersion) {
       testJvmArgs.push(`-DassumeMinServerVersion=${v.assumeMinServerVersion}`);
+  }
+  if (v.adaptive_fetch === 'yes') {
+      testJvmArgs.push('-DadaptiveFetch=true');
   }
   v.extraJvmArgs = jvmArgs.join(' ');
   v.testExtraJvmArgs = testJvmArgs.join(' ::: ');

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/CursorFetchTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/CursorFetchTest.java
@@ -8,6 +8,7 @@ package org.postgresql.test.jdbc2;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import org.postgresql.PGConnection;
 import org.postgresql.test.TestUtil;
 
 import org.junit.Test;
@@ -78,7 +79,11 @@ public class CursorFetchTest extends BaseTest4 {
       assertEquals(testSize, stmt.getFetchSize());
 
       ResultSet rs = stmt.executeQuery();
-      assertEquals(testSize, rs.getFetchSize());
+      if (!con.unwrap(PGConnection.class).getAdaptiveFetch()) {
+        assertEquals("ResultSet.fetchSize should not change after query execution",
+            testSize,
+            rs.getFetchSize());
+      }
 
       int count = 0;
       while (rs.next()) {
@@ -104,7 +109,11 @@ public class CursorFetchTest extends BaseTest4 {
       assertEquals(testSize, stmt.getFetchSize());
 
       ResultSet rs = stmt.executeQuery();
-      assertEquals(testSize, rs.getFetchSize());
+      if (!con.unwrap(PGConnection.class).getAdaptiveFetch()) {
+        assertEquals("ResultSet.fetchSize should not change after query execution",
+            testSize,
+            rs.getFetchSize());
+      }
 
       for (int j = 0; j <= 50; j++) {
         assertTrue("ran out of rows at position " + j + " with fetch size " + testSize, rs.next());
@@ -147,7 +156,11 @@ public class CursorFetchTest extends BaseTest4 {
       assertEquals(testSize, stmt.getFetchSize());
 
       ResultSet rs = stmt.executeQuery();
-      assertEquals(testSize, rs.getFetchSize());
+      if (!con.unwrap(PGConnection.class).getAdaptiveFetch()) {
+        assertEquals("ResultSet.fetchSize should not change after query execution",
+            testSize,
+            rs.getFetchSize());
+      }
 
       int position = 50;
       assertTrue("ran out of rows doing an absolute fetch at " + position + " with fetch size "

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ResultSetTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ResultSetTest.java
@@ -13,6 +13,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
 
+import org.postgresql.PGConnection;
 import org.postgresql.core.ServerVersion;
 import org.postgresql.jdbc.PreferQueryMode;
 import org.postgresql.test.TestUtil;
@@ -938,7 +939,11 @@ public class ResultSetTest extends BaseTest4 {
 
     assertEquals(ResultSet.CONCUR_UPDATABLE, rs.getConcurrency());
     assertEquals(ResultSet.TYPE_SCROLL_SENSITIVE, rs.getType());
-    assertEquals(100, rs.getFetchSize());
+    if (!con.unwrap(PGConnection.class).getAdaptiveFetch()) {
+      assertEquals("ResultSet.fetchSize should not change after query execution",
+          100,
+          rs.getFetchSize());
+    }
     assertEquals(ResultSet.FETCH_UNKNOWN, rs.getFetchDirection());
 
     rs.close();


### PR DESCRIPTION
It might detect regressions if `adaptiveFetch` interferes with the rest of the features.