### PR TITLE
test: add tests with reWriteBatchedInserts=true

### DIFF
--- a/.github/workflows/matrix.mjs
+++ b/.github/workflows/matrix.mjs
@@ -206,6 +206,15 @@ matrix.addAxis({
   ]
 });
 
+matrix.addAxis({
+  name: 'rewrite_batch_inserts',
+  title: x => x.value === 'yes' ? 'rewrite_batch_inserts' : '',
+  values: [
+      {value: 'yes', weight: 50}, // This is a non-default value; however, it is often used
+      {value: 'no', weight: 50},
+  ]
+});
+
 function lessThan(minVersion) {
     return value => Number(value) < Number(minVersion);
 }
@@ -214,7 +223,7 @@ matrix.setNamePattern([
     'java_version', 'java_distribution', 'pg_version', 'query_mode', 'scram', 'ssl', 'hash', 'os',
     'server_tz', 'tz', 'locale',
     'check_anorm_sbt', 'gss', 'replication', 'slow_tests',
-    'adaptive_fetch'
+    'adaptive_fetch', 'rewrite_batch_inserts'
 ]);
 
 // We take EA builds from Oracle
@@ -313,6 +322,7 @@ include.forEach(v => {
   v.check_anorm_sbt = v.check_anorm_sbt.value;
   v.query_mode = v.query_mode.value;
   v.adaptive_fetch = v.adaptive_fetch.value;
+  v.rewrite_batch_inserts = v.rewrite_batch_inserts.value;
 
   let includeTestTags = [];
   // See https://junit.org/junit5/docs/current/user-guide/#running-tests-tag-expressions
@@ -374,6 +384,9 @@ include.forEach(v => {
   }
   if (v.adaptive_fetch === 'yes') {
       testJvmArgs.push('-DadaptiveFetch=true');
+  }
+  if (v.rewrite_batch_inserts === 'yes') {
+      testJvmArgs.push('-DreWriteBatchedInserts=true');
   }
   v.extraJvmArgs = jvmArgs.join(' ');
   v.testExtraJvmArgs = testJvmArgs.join(' ::: ');

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BaseTest4.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BaseTest4.java
@@ -15,6 +15,7 @@ import org.postgresql.core.Version;
 import org.postgresql.jdbc.PreferQueryMode;
 import org.postgresql.test.TestUtil;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.junit.After;
 import org.junit.Assume;
 import org.junit.Before;
@@ -43,18 +44,19 @@ public class BaseTest4 {
     UNSPECIFIED, VARCHAR
   }
 
-  protected Connection con;
-  protected BinaryMode binaryMode;
-  private ReWriteBatchedInserts reWriteBatchedInserts;
-  protected PreferQueryMode preferQueryMode;
-  private StringType stringType;
+  protected @Nullable Connection con;
+  protected @Nullable BinaryMode binaryMode;
+  private @Nullable ReWriteBatchedInserts reWriteBatchedInserts;
+  protected @Nullable PreferQueryMode preferQueryMode;
+  private @Nullable StringType stringType;
 
   protected void updateProperties(Properties props) {
     if (binaryMode == BinaryMode.FORCE) {
       forceBinary(props);
     }
-    if (reWriteBatchedInserts == ReWriteBatchedInserts.YES) {
-      PGProperty.REWRITE_BATCHED_INSERTS.set(props, true);
+    if (reWriteBatchedInserts != null) {
+      PGProperty.REWRITE_BATCHED_INSERTS.set(props,
+          reWriteBatchedInserts == ReWriteBatchedInserts.YES);
     }
     if (stringType != null) {
       PGProperty.STRING_TYPE.set(props, stringType.name().toLowerCase(Locale.ROOT));

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PreparedStatementTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PreparedStatementTest.java
@@ -14,6 +14,7 @@ import static org.junit.Assert.fail;
 
 import org.postgresql.PGStatement;
 import org.postgresql.core.ServerVersion;
+import org.postgresql.jdbc.PgConnection;
 import org.postgresql.jdbc.PgStatement;
 import org.postgresql.jdbc.PreferQueryMode;
 import org.postgresql.test.TestUtil;
@@ -1477,6 +1478,8 @@ public class PreparedStatementTest extends BaseTest4 {
       pstmt.executeBatch();
     }
     pstmt.close();
+    Assume.assumeFalse("Test assertions below support only non-rewritten insert statements",
+        con.unwrap(PgConnection.class).getQueryExecutor().isReWriteBatchedInsertsEnabled());
     assertTrue("prepareThreshold=5, so the statement should be server-prepared",
         ((PGStatement) pstmt).isUseServerPrepare());
     assertEquals("prepareThreshold=5, so the statement should be server-prepared", 1,


### PR DESCRIPTION
It might detect regressions if `reWriteBatchedInserts` interferes with the rest of the features.