### PR TITLE
chore: add gradle/actions/dependency-submission so GitHub shows all dependencies used when building pgjdbc

### DIFF
--- a/.github/workflows/gradle-dependency-submit.yaml
+++ b/.github/workflows/gradle-dependency-submit.yaml
@@ -1,0 +1,26 @@
+name: Dependency Submission
+
+# See https://github.com/gradle/actions/blob/768a17f3488dc3fe0155ff431553e1f53d57e22e/dependency-submission/README.md#the-dependency-submission-action
+# The action allows GitHub to alert about reported vulnerabilities in the project
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  dependency-submission:
+    name: Submit dependencies
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout sources
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+    - name: Set up JDK 21
+      uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4
+      with:
+        distribution: zulu
+        java-version: 21
+    - name: Generate and submit dependency graph
+      uses: gradle/actions/dependency-submission@8379f6a1328ee0e06e2bb424dadb7b159856a326 # v4


### PR DESCRIPTION
See https://github.com/gradle/actions/blob/768a17f3488dc3fe0155ff431553e1f53d57e22e/dependency-submission/README.md#the-dependency-submission-action
