### PR TITLE
chore: make the build fail in case the tests are not declared properly

### DIFF
--- a/build-logic/jvm/src/main/kotlin/build-logic.test-junit5.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/build-logic.test-junit5.gradle.kts
@@ -44,6 +44,7 @@ tasks.configureEach<Test> {
     }
     passProperty("junit.jupiter.execution.parallel.enabled", "true")
     passProperty("junit.jupiter.extensions.autodetection.enabled", "true")
+    passProperty("junit.platform.discovery.issue.severity.critical", "warn")
     // TODO: remove when upgrade to JUnit 5.9+
     // See https://github.com/junit-team/junit5/commit/347e3119d36a5c226cddd7981452f11335fad422
     passProperty("junit.jupiter.execution.parallel.config.strategy", "DYNAMIC")


### PR DESCRIPTION
JUnit 5.13 can detect misplaced @Test annotations which were previously ignored. For instance, if the method returns Object rather than void, JUnit ignores the test.

After the change, such issues should result in a build failure.

The new property requires JUnit 5.13, so I'll move the change to https://github.com/pgjdbc/pgjdbc/pull/3652

Here's a sample failure:

```
> Task :postgresql:test FAILED
FAILURE   0,0sec, UnknownClass > initializationError
    org.junit.platform.launcher.core.DiscoveryIssueException: TestEngine with ID 'junit-jupiter' encountered 2 critical issues during test discovery:

    (1) [WARNING] @Test method 'private int org.postgresql.test.jdbc42.SetObject310InfinityTest.abc()' must not be private. It will not be executed.
        Source: MethodSource [className = 'org.postgresql.test.jdbc42.SetObject310InfinityTest', methodName = 'abc', methodParameterTypes = '']
                at org.postgresql.test.jdbc42.SetObject310InfinityTest.abc(SourceFile:0)

    (2) [WARNING] @Test method 'private int org.postgresql.test.jdbc42.SetObject310InfinityTest.abc()' must not return a value. It will not be executed.
        Source: MethodSource [className = 'org.postgresql.test.jdbc42.SetObject310InfinityTest', methodName = 'abc', methodParameterTypes = '']
                at org.postgresql.test.jdbc42.SetObject310InfinityTest.abc(SourceFile:0)
```
