### PR TITLE
fix: ensure Connection.isValid() returns true even if prepared statements deallocate

### DIFF
--- a/docs/content/documentation/server-prepare.md
+++ b/docs/content/documentation/server-prepare.md
@@ -424,7 +424,7 @@ following might be helpful to debug the case.
 
 1. Client logging. If you add `loggerLevel=TRACE&loggerFile=pgjdbc-trace.log`, you would get trace
 of the messages send between the driver and the backend
-1. You might check `org.postgresql.test.jdbc2.AutoRollbackTestSuite` as it verifies lots of combinations
+1. You might check `org.postgresql.test.jdbc2.AutoRollbackTest` as it verifies lots of combinations
 
 ##### Client Logging
 Logging is now configured using `java.util.logging`. Create a logging.properties file in resources similar to:

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -318,8 +318,6 @@ public class QueryExecutorImpl extends QueryExecutorBase {
     switch (getPreferQueryMode()) {
       case SIMPLE:
         return flags | QUERY_EXECUTE_AS_SIMPLE;
-      case EXTENDED:
-        return flags & ~QUERY_EXECUTE_AS_SIMPLE;
       default:
         return flags;
     }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/AutoRollbackTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/AutoRollbackTest.java
@@ -34,7 +34,7 @@ import java.util.Properties;
 import java.util.concurrent.atomic.AtomicInteger;
 
 @RunWith(Parameterized.class)
-public class AutoRollbackTestSuite extends BaseTest4 {
+public class AutoRollbackTest extends BaseTest4 {
   private static final AtomicInteger counter = new AtomicInteger();
 
   private enum CleanSavePoint {
@@ -125,7 +125,7 @@ public class AutoRollbackTestSuite extends BaseTest4 {
   private final TestStatement testSql;
   private final ReturnColumns cols;
 
-  public AutoRollbackTestSuite(AutoSave autoSave, CleanSavePoint cleanSavePoint, AutoCommit autoCommit,
+  public AutoRollbackTest(AutoSave autoSave, CleanSavePoint cleanSavePoint, AutoCommit autoCommit,
       FailMode failMode, ContinueMode continueMode, boolean flushCacheOnDeallocate,
       boolean trans, TestStatement testSql, ReturnColumns cols) {
     this.autoSave = autoSave;
@@ -307,16 +307,8 @@ public class AutoRollbackTestSuite extends BaseTest4 {
         }
         return;
       case IS_VALID:
-        if (!flushCacheOnDeallocate && autoSave == AutoSave.NEVER
-            && DEALLOCATES.contains(failMode) && autoCommit == AutoCommit.NO
-            && con.unwrap(PGConnection.class).getPreferQueryMode() != PreferQueryMode.SIMPLE) {
-          Assert.assertFalse("Connection.isValid should return false since failMode=" + failMode
-              + ", flushCacheOnDeallocate=false, and autosave=NEVER",
-              con.isValid(4));
-        } else {
-          Assert.assertTrue("Connection.isValid should return true unless the connection is closed",
-              con.isValid(4));
-        }
+        Assert.assertTrue("Connection.isValid should return true unless the connection is closed",
+            con.isValid(4));
         return;
       default:
         break;


### PR DESCRIPTION
Previously, the code for `.isValid()` was using `executeWithFlags("", QueryExecutor.QUERY_EXECUTE_AS_SIMPLE)`

However, the execution still went with extended query protocol since `QueryExecutorImpl#updateQueryMode` trimmed the flag in `preferQueryMode=extended` (default) mode.

It does not feel right to trim the flag there since the intention of the option was to "prefer" query mode unless specified explicitly.

The case is identified and tested in `AutoRollbackTest`: isValid should return true after statements like DEALLOCATE, `DISCARD`, and so on.

See https://github.com/pgjdbc/pgjdbc/pull/3631
Fixes https://github.com/pgjdbc/pgjdbc/issues/3630
