### PR TITLE
perf: cache composite and simple subqueries

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/NativeQuery.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/NativeQuery.java
@@ -19,6 +19,7 @@ public class NativeQuery {
   private static final int[] NO_BINDS = new int[0];
 
   public final String nativeSql;
+  public final String originalSql;
   public final int[] bindPositions;
   public final SqlCommand command;
   public final boolean multiStatement;
@@ -30,11 +31,16 @@ public class NativeQuery {
   }
 
   public NativeQuery(String nativeSql, SqlCommand dml) {
-    this(nativeSql, NO_BINDS, true, dml);
+    this(nativeSql, nativeSql, NO_BINDS, true, dml);
   }
 
   public NativeQuery(String nativeSql, int @Nullable [] bindPositions, boolean multiStatement, SqlCommand dml) {
+    this(nativeSql, nativeSql, bindPositions, multiStatement, dml);
+  }
+
+  public NativeQuery(String nativeSql, String originalSql, int @Nullable [] bindPositions, boolean multiStatement, SqlCommand dml) {
     this.nativeSql = nativeSql;
+    this.originalSql = originalSql;
     this.bindPositions =
         bindPositions == null || bindPositions.length == 0 ? NO_BINDS : bindPositions;
     this.multiStatement = multiStatement;

--- a/pgjdbc/src/main/java/org/postgresql/core/QueryExecutorBase.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/QueryExecutorBase.java
@@ -332,6 +332,10 @@ public abstract class QueryExecutorBase implements QueryExecutor {
     return statementCache.borrow(sql);
   }
 
+  protected final @Nullable CachedQuery getQuery(String sql) {
+    return statementCache.get(sql);
+  }
+
   @Override
   public final CachedQuery borrowCallableQuery(String sql) throws SQLException {
     return statementCache.borrow(new CallableQueryKey(sql));

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PreparedStatementTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PreparedStatementTest.java
@@ -46,7 +46,9 @@ import java.sql.Statement;
 import java.sql.Timestamp;
 import java.sql.Types;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -1851,5 +1853,69 @@ public class PreparedStatementTest extends BaseTest4 {
     } catch (SQLException ex) {
       // ignore
     }
+  }
+
+  @Test
+  public void testBatchSelect() throws SQLException {
+    PreparedStatement pstmt = null;
+    PreparedStatement batchSelect = null;
+    ResultSet rs = null;
+    try {
+      pstmt = con.prepareStatement("INSERT INTO inttable (a) VALUES (?);"
+              + "INSERT INTO inttable (a) VALUES (?);"
+              + "INSERT INTO inttable (a) VALUES (?);"
+              + "INSERT INTO inttable (a) VALUES (?);");
+      ((PgStatement) pstmt).setPrepareThreshold(0);
+      for (int i = 0; i < 4; i++) {
+        pstmt.setInt(i + 1, i + 1);
+      }
+      pstmt.execute();
+      batchSelect =  con.prepareStatement("select * from inttable where a = ?;"
+          + "select * from inttable where a = ?;"
+          + "select * from inttable where a = ?;");
+      for (int i = 0; i < 3; i++) {
+        batchSelect.setInt(i + 1, i + 1);
+      }
+
+      List<Integer> results = new ArrayList<>();
+      boolean hasResults = batchSelect.execute();
+      while (hasResults) {
+        rs = batchSelect.getResultSet();
+        while (rs.next()) {
+          results.add(rs.getInt(1));
+        }
+        hasResults = batchSelect.getMoreResults();
+      }
+      assertEquals(Arrays.asList(1, 2, 3), results);
+    } catch (SQLException e) {
+      throw new RuntimeException(e);
+    } finally {
+      TestUtil.closeQuietly(rs);
+      TestUtil.closeQuietly(pstmt);
+      TestUtil.closeQuietly(batchSelect);
+    }
+  }
+
+  @Test
+  public void testBatchSelectWithPrepareThreshold1() throws SQLException {
+    assumeBinaryModeRegular();
+    Assume.assumeTrue("simple protocol only does not support prepared statement requests",
+        preferQueryMode != PreferQueryMode.SIMPLE);
+
+    PreparedStatement pstmt =  con.prepareStatement("select * from inttable where a = ?;"
+        + "select * from inttable where a = ?;"
+        + "select * from inttable where a = ?;");
+    ((PgStatement) pstmt).setPrepareThreshold(1);
+    for (int i = 0; i < 3; i++) {
+      pstmt.setInt(i + 1, i + 1);
+    }
+    pstmt.execute();
+    pstmt.close();
+    Assume.assumeFalse("Test assertions below support only non-rewritten insert statements",
+        con.unwrap(PgConnection.class).getQueryExecutor().isReWriteBatchedInsertsEnabled());
+    assertTrue("prepareThreshold=1, so the statement should be server-prepared",
+        ((PGStatement) pstmt).isUseServerPrepare());
+    assertEquals("prepareThreshold=1, so the one statement should be server-prepared", 1,
+        getNumberOfServerPreparedStatements("select * from inttable where a = $1"));
   }
 }


### PR DESCRIPTION
The driver now supports composite queries, which theoretically should execute far more efficiently. However, the current implementation treats every simple statement within a composite query as distinct, even when they’re identical. For example, in SQL like:  "select * from table where col = ?;  select * from table where col = ?; " the driver considers these two subqueries completely separate and rebuilds an execution plan for each.  

Queries are cached in a map called statementCache, where the key is the full SQL string. When a composite query runs, only the entire statement is cached—not its individual components. As a result, if a later composite query contains any of the same simple subqueries, their plans cannot be reused because they aren’t stored in statementCache; instead, they are regenerated from scratch. Since plan generation can be very time-consuming, this behavior significantly degrades performance in workloads with frequently repeated subqueries.  

In my optimization, I cache both composite queries and their constituent simple queries. Identical subqueries are now recognized by their SQL string, and their existing plans are reused, improving execution speed.  

### All Submissions:

* [ ] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Does `./gradlew styleCheck` pass ?
3. [ ] Have you added your new test classes to an existing test suite in alphabetical order?

### Changes to Existing Features:

* [ ] Does this break existing behaviour? If so please explain.
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
