### PR TITLE
Add "SELF_REFERENCING_COL_NAME" field to getTables' ResultSetMetaData to fix NullPointerException

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
@@ -1463,7 +1463,8 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
       f[5] = new Field("TYPE_CAT", Oid.VARCHAR);
       f[6] = new Field("TYPE_SCHEM", Oid.VARCHAR);
       f[7] = new Field("TYPE_NAME", Oid.VARCHAR);
-      f[8] = new Field("REF_GENERATION", Oid.VARCHAR);
+      f[8] = new Field("SELF_REFERENCING_COL_NAME", Oid.VARCHAR);
+      f[9] = new Field("REF_GENERATION", Oid.VARCHAR);
       return ((BaseStatement) createMetaDataStatement()).createDriverResultSet(f, v);
     }
 

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseMetaDataTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseMetaDataTest.java
@@ -274,6 +274,23 @@ public class DatabaseMetaDataTest {
 
   @MethodSource("data")
   @ParameterizedTest(name = "binary = {0}")
+  void tables_whenWrongCatalogGetMetaData_expectNoException(BinaryMode binaryMode) throws Exception {
+    DatabaseMetaData dbmd = con.getMetaData();
+    assertNotNull(dbmd);
+
+    ResultSet rs = dbmd.getTables("FakeCatalog", "", null, new String[]{"TABLE"});
+    assertFalse(rs.next());
+
+    ResultSetMetaData resultSetMetaData = rs.getMetaData();
+    for (int col = 1; col <= resultSetMetaData.getColumnCount(); col++) {
+      resultSetMetaData.getColumnLabel(col);
+    }
+
+    rs.close();
+  }
+
+  @MethodSource("data")
+  @ParameterizedTest(name = "binary = {0}")
   void tables(BinaryMode binaryMode) throws Exception {
     DatabaseMetaData dbmd = con.getMetaData();
     assertNotNull(dbmd);


### PR DESCRIPTION
Fixes https://github.com/pgjdbc/pgjdbc/issues/3659

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


