### PR TITLE
chore: add top-level read-only permissions for GitHub Actions when missing

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,6 +19,9 @@ on:
   schedule:
     - cron: '22 13 * * 6'
 
+# Declare default permissions as read-only.
+permissions: read-all
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})

--- a/.github/workflows/gradle-dependency-submit.yaml
+++ b/.github/workflows/gradle-dependency-submit.yaml
@@ -7,13 +7,15 @@ on:
     branches:
       - master
 
-permissions:
-  contents: write
+# Declare default permissions as read-only.
+permissions: read-all
 
 jobs:
   dependency-submission:
     name: Submit dependencies
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
     - name: Checkout sources
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/.github/workflows/ossf-scorecard.yaml
+++ b/.github/workflows/ossf-scorecard.yaml
@@ -15,7 +15,7 @@ on:
   push:
     branches: [ "main" ]
 
-# Declare default permissions as read only.
+# Declare default permissions as read-only.
 permissions: read-all
 
 jobs:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -8,12 +8,18 @@ on:
       - 'release/**'
   # pull_request_target allows PR from forks to access secrets, so please NEVER add pull_request_target
 
+# Declare default permissions as read-only.
+permissions: read-all
+
 jobs:
   update_release_draft:
     # Skip release drafts in forks
     if: github.repository_owner == 'pgjdbc'
     name: Update Release Draft
     runs-on: ubuntu-latest
+    permissions:
+      # write permission is required to create a github release
+      contents: write
     env:
       # Publish pre-release files to a draft release
       PUBLISH_SNAPSHOT: true


### PR DESCRIPTION
The top-level permissions configure the defaults, so we'd better have a default read-only configuration so the newly added jobs would not accidentally get write permissions.
