### PR TITLE
chore: replace com.github.johnrengelman.shadow 8.1.1 with com.gradleup.shadow 8.3.7

### DIFF
--- a/pgjdbc/build.gradle.kts
+++ b/pgjdbc/build.gradle.kts
@@ -21,7 +21,7 @@ plugins {
     id("build-logic.java-comment-preprocessor")
     id("build-logic.without-type-annotations")
     id("biz.aQute.bnd.builder") apply false
-    id("com.github.johnrengelman.shadow")
+    id("com.gradleup.shadow")
     id("com.github.lburgazzoli.karaf")
     id("com.github.vlsi.gettext")
     id("com.github.vlsi.gradle-extensions")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,7 +7,7 @@ pluginManagement {
     plugins {
         id("biz.aQute.bnd.builder") version "7.1.0"
         id("com.github.burrunan.s3-build-cache") version "1.9.2"
-        id("com.github.johnrengelman.shadow") version "8.1.1"
+        id("com.gradleup.shadow") version "8.3.7"
         id("com.github.lburgazzoli.karaf") version "0.5.6"
         id("com.github.vlsi.crlf") version "2.0.0"
         id("com.github.vlsi.gettext") version "2.0.0"


### PR DESCRIPTION
The plugin changed its coordinates, thus we did not receive version updates.

See https://github.com/GradleUp/shadow/pull/1492#issuecomment-3018598936
