### PR TITLE
Add PEMKeyManager to handle PEM based certs and keys.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,7 +116,7 @@ on a command line (the outputs are located in the relevant:
     ./gradlew check # verify code style, execute tests
     ./gradlew style # update code formatting (for auto-correctable cases) and verify style (e.g. CheckStyle, ErrorProne, tab vs spaces, and so on)
     ./gradlew styleCheck # report code style violations
-    ./gradlew -PenableErrorprone classes # verify code with Error Prone tool
+    ./gradlew -PenableErrorprone  -PenableCheckerframework classes # verify code with Error Prone tool and Checkerframework
 
     ./gradlew test # execute tests
     ./gradlew test --tests org.postgresql.test.ssl.SslTest # execute test by class

--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -440,6 +440,11 @@ public enum PGProperty {
       false),
 
   /**
+   * Algorithm for the PEM key.
+   */
+  PEM_KEY_ALGORITHM("pemKeyAlgorithm", "RSA", "Algorithm of the PEM key"),
+
+  /**
    * Database name to connect to (may be specified directly in the JDBC URL).
    */
   PG_DBNAME(

--- a/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
+++ b/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
@@ -1801,6 +1801,14 @@ public abstract class BaseDataSource implements CommonDataSource, Referenceable 
     PGProperty.XML_FACTORY_FACTORY.set(properties, xmlFactoryFactory);
   }
 
+  public @Nullable String getPemKeyAlgorithm() {
+    return PGProperty.PEM_KEY_ALGORITHM.getOrDefault(properties);
+  }
+
+  public void setPemKeyAlgorithm(String algorithm) {
+    PGProperty.PEM_KEY_ALGORITHM.set(properties, algorithm);
+  }
+
   /*
    * Alias methods below, these are to help with ease-of-use with other database tools / frameworks
    * which expect normal java bean getters / setters to exist for the property names.
@@ -1917,4 +1925,13 @@ public abstract class BaseDataSource implements CommonDataSource, Referenceable 
   public boolean isReWriteBatchedInserts() {
     return getReWriteBatchedInserts();
   }
+
+  public void setPemKeyAlgo(String algorithm) {
+    setPemKeyAlgorithm(algorithm);
+  }
+
+  public @Nullable String getPemKeyAlgo() {
+    return getPemKeyAlgorithm();
+  }
+
 }

--- a/pgjdbc/src/main/java/org/postgresql/ssl/BaseX509KeyManager.java
+++ b/pgjdbc/src/main/java/org/postgresql/ssl/BaseX509KeyManager.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright (c) 2025, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.ssl;
+
+import org.postgresql.util.GT;
+import org.postgresql.util.PSQLException;
+import org.postgresql.util.PSQLState;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.io.IOException;
+import java.net.Socket;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.AclEntry;
+import java.nio.file.attribute.AclEntryPermission;
+import java.nio.file.attribute.AclFileAttributeView;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.nio.file.attribute.UserPrincipal;
+import java.security.Principal;
+import java.security.cert.X509Certificate;
+import java.util.List;
+import java.util.Set;
+
+import javax.net.ssl.X509KeyManager;
+import javax.security.auth.x500.X500Principal;
+
+public abstract class BaseX509KeyManager implements X509KeyManager {
+
+  protected @Nullable PSQLException error;
+
+  /**
+   * getCertificateChain and getPrivateKey cannot throw exceptions, therefore any exception is stored
+   * in {@link #error} and can be raised by this method.
+   *
+   * @throws PSQLException if any exception is stored in {@link #error} and can be raised
+   */
+  public void throwKeyManagerException() throws PSQLException {
+    if (error != null) {
+      throw error;
+    }
+  }
+
+  @Override
+  public String @Nullable [] getClientAliases(String keyType, Principal @Nullable [] principals) {
+    String alias = chooseClientAlias(new String[]{keyType}, principals, (Socket) null);
+    return alias == null ? null : new String[]{alias};
+  }
+
+  @Override
+  public @Nullable String chooseClientAlias(String[] keyType, Principal @Nullable [] principals,
+                                            @Nullable Socket socket) {
+    if (principals == null || principals.length == 0) {
+      // Postgres 8.4 and earlier do not send the list of accepted certificate authorities
+      // to the client. See BUG #5468. We only hope, that our certificate will be accepted.
+      return "user";
+    } else {
+      // Sending a wrong certificate makes the connection rejected, even, if clientcert=0 in
+      // pg_hba.conf.
+      // therefore we only send our certificate, if the issuer is listed in issuers
+      X509Certificate[] certchain = getCertificateChain("user");
+      if (certchain == null) {
+        return null;
+      } else {
+        X509Certificate cert = certchain[certchain.length - 1];
+        X500Principal ourissuer = cert.getIssuerX500Principal();
+        String certKeyType = cert.getPublicKey().getAlgorithm();
+        boolean keyTypeFound = false;
+        boolean found = false;
+        if (keyType != null && keyType.length > 0) {
+          for (String kt : keyType) {
+            if (kt.equalsIgnoreCase(certKeyType)) {
+              keyTypeFound = true;
+            }
+          }
+        } else {
+          // If no key types were passed in, assume we don't care
+          // about checking that the cert uses a particular key type.
+          keyTypeFound = true;
+        }
+        if (keyTypeFound) {
+          for (Principal issuer : principals) {
+            if (ourissuer.equals(issuer)) {
+              found = keyTypeFound;
+            }
+          }
+        }
+        return found ? "user" : null;
+      }
+    }
+  }
+
+  @Override
+  public String @Nullable [] getServerAliases(String s, Principal @Nullable [] principals) {
+    return new String[]{};
+  }
+
+  @Override
+  public @Nullable String chooseServerAlias(String s, Principal @Nullable [] principals,
+                                            @Nullable Socket socket) {
+    // we are not a server
+    return null;
+  }
+
+  /**
+   * Validates that the private key file has secure permissions (owner-only readable).
+   * On POSIX systems, ensures no group or other permissions are set.
+   * On Windows systems, checks ACLs to ensure only the owner and trusted system accounts have access.
+   *
+   * @param keyPath the path to the private key file
+   * @throws PSQLException if the file has insecure permissions
+   */
+  public static void validateKeyFilePermissions(Path keyPath) throws PSQLException {
+    // Try POSIX permissions first (Linux, macOS, Unix)
+    if (validatePosixPermissions(keyPath)) {
+      return;
+    }
+
+    // If POSIX is not supported, try Windows ACL permissions
+    if (validateWindowsAclPermissions(keyPath)) {
+      return;
+    }
+    throw new PSQLException(
+            GT.tr("Unable to retrieve the permissions of the private key file \"{0}\"",
+                  keyPath.toString()),
+            PSQLState.CONNECTION_FAILURE);
+  }
+
+  /**
+   * Validates POSIX file permissions of key.
+   *
+   * @param keyPath the path to the private key file
+   * @return true if validation succeeded (permissions are secure), false if POSIX is not supported
+   * @throws PSQLException if the file has insecure permissions
+   */
+  private static boolean validatePosixPermissions(Path keyPath) throws PSQLException {
+    try {
+      Set<PosixFilePermission> permissions = Files.getPosixFilePermissions(keyPath);
+
+      boolean hasGroupPerms = permissions.contains(PosixFilePermission.GROUP_READ)
+                              || permissions.contains(PosixFilePermission.GROUP_WRITE)
+                              || permissions.contains(PosixFilePermission.GROUP_EXECUTE);
+
+      boolean hasOtherPerms = permissions.contains(PosixFilePermission.OTHERS_READ)
+                              || permissions.contains(PosixFilePermission.OTHERS_WRITE)
+                              || permissions.contains(PosixFilePermission.OTHERS_EXECUTE);
+
+      if (hasGroupPerms || hasOtherPerms) {
+        throw new PSQLException(
+                GT.tr("Private key file \"{0}\" has insecure permissions. "
+                      + "Permissions for group and other must be revoked. "
+                      + "Current permissions: {1}",
+                      keyPath.toString(),
+                      PosixFilePermissions.toString(permissions)),
+                PSQLState.CONNECTION_FAILURE);
+      }
+      return true;
+    } catch (UnsupportedOperationException e) {
+      return false;
+    } catch (IOException e) {
+      throw new PSQLException(
+              GT.tr("Could not read permissions for private key file \"{0}\"", keyPath.toString()),
+              PSQLState.CONNECTION_FAILURE, e);
+    }
+  }
+
+  /**
+   * Validates Windows ACL permissions of the key file.
+   *
+   * @param keyPath the path to the private key file
+   * @return true if validation succeeded (permissions are secure), false if ACL is not supported
+   * @throws PSQLException if the file has insecure permissions
+   */
+  private static boolean validateWindowsAclPermissions(Path keyPath) throws PSQLException {
+    try {
+      AclFileAttributeView aclView = Files.getFileAttributeView(keyPath, AclFileAttributeView.class);
+      if (aclView == null) {
+        return false;
+      }
+
+      UserPrincipal owner = aclView.getOwner();
+      List<AclEntry> aclEntries = aclView.getAcl();
+
+      for (AclEntry entry : aclEntries) {
+        UserPrincipal principal = entry.principal();
+        String principalName = principal.getName();
+
+        // Allow owner, SYSTEM, and Administrators (these are trusted on Windows)
+        boolean isTrustedPrincipal = principal.equals(owner)
+                                     || principalName.equals("NT AUTHORITY\\SYSTEM")
+                                     || principalName.equals("BUILTIN\\Administrators")
+                                     || principalName.endsWith("\\Administrators");
+
+        if (!isTrustedPrincipal) {
+          // Check if this non-owner principal has READ permission
+          Set<AclEntryPermission> permissions = entry.permissions();
+          if (permissions.contains(AclEntryPermission.READ_DATA)
+              || permissions.contains(AclEntryPermission.READ_ATTRIBUTES)
+              || permissions.contains(AclEntryPermission.READ_NAMED_ATTRS)) {
+            throw new PSQLException(
+                    GT.tr("Private key file \"{0}\" has insecure permissions. "
+                          + "Non-owner principal \"{1}\" has read access.",
+                          keyPath.toString(),
+                          principalName),
+                    PSQLState.CONNECTION_FAILURE);
+          }
+        }
+      }
+      return true;
+    } catch (UnsupportedOperationException e) {
+      return false;
+    } catch (IOException e) {
+      throw new PSQLException(
+              GT.tr("Could not read ACL permissions for private key file \"{0}\"", keyPath.toString()),
+              PSQLState.CONNECTION_FAILURE, e);
+    }
+  }
+}

--- a/pgjdbc/src/main/java/org/postgresql/ssl/PEMKeyManager.java
+++ b/pgjdbc/src/main/java/org/postgresql/ssl/PEMKeyManager.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2025, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.ssl;
+
+import org.postgresql.util.GT;
+import org.postgresql.util.PSQLException;
+import org.postgresql.util.PSQLState;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.security.KeyFactory;
+import java.security.PrivateKey;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.List;
+
+public class PEMKeyManager extends BaseX509KeyManager {
+
+  private final String keyFilePath;
+  private final String certFilePath;
+  private final String keyAlgorithm;
+
+  public PEMKeyManager(String pemKeyPath, String pemCertsPath, String keyAlgorithm) {
+    this.keyFilePath = pemKeyPath;
+    this.certFilePath = pemCertsPath;
+    this.keyAlgorithm = keyAlgorithm;
+  }
+
+  @Override
+  public @Nullable PrivateKey getPrivateKey(String s) {
+    try {
+      Path keyPath = Paths.get(keyFilePath);
+
+      // Validate file permissions before reading
+      validateKeyFilePermissions(keyPath);
+
+      List<String> lines = Files.readAllLines(keyPath);
+      StringBuilder keyContent = new StringBuilder();
+      for (String line : lines) {
+        // as we are using PKCS#8 format, we just expect "BEGIN PRIVATE KEY" as the start of the key
+        // ref: https://datatracker.ietf.org/doc/html/rfc5208#section-5
+        if (line.contains("BEGIN PRIVATE KEY"))  {
+          // ignore the start of the key
+          continue;
+        }
+        // as we are using PKCS#8 format, we just expect "END PRIVATE KEY" as the end of the key
+        // ref: https://datatracker.ietf.org/doc/html/rfc5208#section-5
+        if (line.contains("END PRIVATE KEY")) {
+          // stop reading after we encounter end of the key
+          break;
+        }
+        keyContent.append(line.trim());
+      }
+
+      byte[] privateKeyDERBytes = Base64.getDecoder().decode(keyContent.toString());
+      PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(privateKeyDERBytes);
+      KeyFactory kf = KeyFactory.getInstance(this.keyAlgorithm);
+
+      // to prevent security attacks, lets wipe out the contents of variables holding sensitive data
+      Arrays.fill(privateKeyDERBytes, (byte) 0);
+      for (int i = 0; i < keyContent.length(); i++) {
+        keyContent.setCharAt(i, '\0');
+      }
+
+      return kf.generatePrivate(keySpec);
+    } catch (Exception e) {
+      error = new PSQLException(GT.tr("Could not load the private key"), PSQLState.CONNECTION_FAILURE, e);
+    }
+    return null;
+  }
+
+  @Override
+  public X509Certificate @Nullable [] getCertificateChain(String alias) {
+    try (InputStream inStream = Files.newInputStream(Paths.get(this.certFilePath))) {
+      CertificateFactory cf = CertificateFactory.getInstance("X.509");
+
+      Collection<? extends Certificate> certs = cf.generateCertificates(inStream);
+      List<X509Certificate> certChain = new ArrayList<>();
+
+      for (Certificate cert : certs) {
+        if (cert instanceof X509Certificate) {
+          certChain.add((X509Certificate) cert);
+        }
+      }
+
+      return certChain.toArray(new X509Certificate[0]);
+    } catch (Exception e) {
+      error = new PSQLException(GT.tr("Could not load cert chain"), PSQLState.CONNECTION_FAILURE, e);
+    }
+    return null;
+  }
+
+}

--- a/pgjdbc/src/main/java/org/postgresql/ssl/PKCS12KeyManager.java
+++ b/pgjdbc/src/main/java/org/postgresql/ssl/PKCS12KeyManager.java
@@ -13,25 +13,20 @@ import org.postgresql.util.internal.FileUtils;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-import java.net.Socket;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
-import java.security.Principal;
 import java.security.PrivateKey;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
 
-import javax.net.ssl.X509KeyManager;
 import javax.security.auth.callback.Callback;
 import javax.security.auth.callback.CallbackHandler;
 import javax.security.auth.callback.PasswordCallback;
 import javax.security.auth.callback.UnsupportedCallbackException;
-import javax.security.auth.x500.X500Principal;
 
-public class PKCS12KeyManager implements X509KeyManager {
+public class PKCS12KeyManager extends BaseX509KeyManager {
 
   private final CallbackHandler cbh;
-  private @Nullable PSQLException error;
   private final String keyfile;
   private final KeyStore keyStore;
   boolean keystoreLoaded;
@@ -47,79 +42,6 @@ public class PKCS12KeyManager implements X509KeyManager {
         "Unable to find pkcs12 keystore."),
         PSQLState.CONNECTION_FAILURE, kse);
     }
-  }
-
-  /**
-   * getCertificateChain and getPrivateKey cannot throw exceptions, therefore any exception is stored
-   * in {@link #error} and can be raised by this method.
-   *
-   * @throws PSQLException if any exception is stored in {@link #error} and can be raised
-   */
-  public void throwKeyManagerException() throws PSQLException {
-    if (error != null) {
-      throw error;
-    }
-  }
-
-  @Override
-  public String @Nullable [] getClientAliases(String keyType, Principal @Nullable [] principals) {
-    String alias = chooseClientAlias(new String[]{keyType}, principals, (Socket) null);
-    return alias == null ? null : new String[]{alias};
-  }
-
-  @Override
-  public @Nullable String chooseClientAlias(String[] keyType, Principal @Nullable [] principals,
-      @Nullable Socket socket) {
-    if (principals == null || principals.length == 0) {
-      // Postgres 8.4 and earlier do not send the list of accepted certificate authorities
-      // to the client. See BUG #5468. We only hope, that our certificate will be accepted.
-      return "user";
-    } else {
-      // Sending a wrong certificate makes the connection rejected, even, if clientcert=0 in
-      // pg_hba.conf.
-      // therefore we only send our certificate, if the issuer is listed in issuers
-      X509Certificate[] certchain = getCertificateChain("user");
-      if (certchain == null) {
-        return null;
-      } else {
-        X509Certificate cert = certchain[certchain.length - 1];
-        X500Principal ourissuer = cert.getIssuerX500Principal();
-        String certKeyType = cert.getPublicKey().getAlgorithm();
-        boolean keyTypeFound = false;
-        boolean found = false;
-        if (keyType != null && keyType.length > 0) {
-          for (String kt : keyType) {
-            if (kt.equalsIgnoreCase(certKeyType)) {
-              keyTypeFound = true;
-            }
-          }
-        } else {
-          // If no key types were passed in, assume we don't care
-          // about checking that the cert uses a particular key type.
-          keyTypeFound = true;
-        }
-        if (keyTypeFound) {
-          for (Principal issuer : principals) {
-            if (ourissuer.equals(issuer)) {
-              found = keyTypeFound;
-            }
-          }
-        }
-        return found ? "user" : null;
-      }
-    }
-  }
-
-  @Override
-  public String @Nullable [] getServerAliases(String s, Principal @Nullable [] principals) {
-    return new String[]{};
-  }
-
-  @Override
-  public @Nullable String chooseServerAlias(String s, Principal @Nullable [] principals,
-      @Nullable Socket socket) {
-    // we are not a server
-    return null;
   }
 
   @Override

--- a/pgjdbc/src/test/java/org/postgresql/test/ssl/PEMKeyManagerTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/ssl/PEMKeyManagerTest.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) 2025, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.test.ssl;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.postgresql.PGProperty;
+import org.postgresql.ssl.PEMKeyManager;
+import org.postgresql.test.TestUtil;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.AclEntry;
+import java.nio.file.attribute.AclEntryPermission;
+import java.nio.file.attribute.AclEntryType;
+import java.nio.file.attribute.AclFileAttributeView;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.UserPrincipal;
+import java.sql.Connection;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+import java.util.logging.Logger;
+
+import javax.security.auth.x500.X500Principal;
+
+public class PEMKeyManagerTest {
+
+  private static final Logger LOGGER = Logger.getLogger(PEMKeyManagerTest.class.getName());
+
+  private Set<PosixFilePermission> originalPosixPermissions;
+  private List<AclEntry> originalAclPermissions;
+  private Path keyFilePath;
+
+  /**
+   * Let's attempt to make the goodclient.key file to have correct permissions (owner read-only permissions).
+   * If it's not possible, lets not fail, and go ahead with the tests.
+   */
+  @BeforeEach
+  void setKeyFilePermissions() {
+    try {
+      String keyFilePathStr = TestUtil.getSslTestCertPath("goodclient.key");
+      File keyFile = new File(keyFilePathStr);
+
+      if (keyFile.exists()) {
+        keyFilePath = keyFile.toPath();
+
+        // Check if the file system supports POSIX permissions
+        if (Files.getFileAttributeView(keyFilePath, java.nio.file.attribute.PosixFileAttributeView.class) != null) {
+          // Save original POSIX permissions
+          originalPosixPermissions = Files.getPosixFilePermissions(keyFilePath);
+          LOGGER.info("Saved original POSIX permissions for " + keyFilePathStr);
+
+          // Set POSIX permissions to 400 (read-only for owner)
+          Set<PosixFilePermission> perms = new HashSet<>();
+          perms.add(PosixFilePermission.OWNER_READ);
+          Files.setPosixFilePermissions(keyFilePath, perms);
+          LOGGER.info("Set POSIX permissions to 400 for " + keyFilePathStr);
+        } else {
+          // Windows: Save original ACL and set owner-only read permissions
+          AclFileAttributeView aclView = Files.getFileAttributeView(keyFilePath, AclFileAttributeView.class);
+          if (aclView != null) {
+            originalAclPermissions = aclView.getAcl();
+            LOGGER.info("Saved original ACL permissions for " + keyFilePathStr);
+          }
+          setWindowsOwnerOnlyPermissions(keyFilePath);
+          LOGGER.info("Set Windows ACL permissions to owner read-only for " + keyFilePathStr);
+        }
+      }
+    } catch (Exception e) {
+      // Log and ignore permission setting errors - tests may still pass
+      LOGGER.warning("Failed to set file permissions for goodclient.key: " + e.getMessage());
+    }
+  }
+
+  /**
+   * Restores the original file permissions that were saved in setKeyFilePermissions.
+   */
+  @AfterEach
+  void restoreKeyFilePermissions() {
+    try {
+      if (keyFilePath != null && Files.exists(keyFilePath)) {
+        // Restore POSIX permissions if they were saved
+        if (originalPosixPermissions != null) {
+          Files.setPosixFilePermissions(keyFilePath, originalPosixPermissions);
+          LOGGER.info("Restored original POSIX permissions for " + keyFilePath);
+          originalPosixPermissions = null;
+        }
+
+        // Restore ACL permissions if they were saved
+        if (originalAclPermissions != null) {
+          AclFileAttributeView aclView = Files.getFileAttributeView(keyFilePath, AclFileAttributeView.class);
+          if (aclView != null) {
+            aclView.setAcl(originalAclPermissions);
+            LOGGER.info("Restored original ACL permissions for " + keyFilePath);
+          }
+          originalAclPermissions = null;
+        }
+
+        keyFilePath = null;
+      }
+    } catch (Exception e) {
+      // Log and ignore permission restoration errors
+      LOGGER.warning("Failed to restore file permissions for goodclient.key: " + e.getMessage());
+    }
+  }
+
+  /**
+   * Sets Windows ACL permissions to allow only the owner to read the file.
+   * This is equivalent to chmod 400 on Unix systems.
+   */
+  private void setWindowsOwnerOnlyPermissions(Path path) throws Exception {
+    AclFileAttributeView aclView = Files.getFileAttributeView(path, AclFileAttributeView.class);
+    if (aclView == null) {
+      return; // ACL not supported
+    }
+
+    UserPrincipal owner = Files.getOwner(path);
+
+    // Create ACL entry that grants only read permissions to the owner
+    AclEntry entry = AclEntry.newBuilder()
+        .setType(AclEntryType.ALLOW)
+        .setPrincipal(owner)
+        .setPermissions(
+            EnumSet.of(
+                AclEntryPermission.READ_DATA,
+                AclEntryPermission.READ_ATTRIBUTES,
+                AclEntryPermission.READ_NAMED_ATTRS,
+                AclEntryPermission.SYNCHRONIZE
+            )
+        )
+        .build();
+
+    // Set the ACL with only the owner's read permissions
+    List<AclEntry> acl = new ArrayList<>();
+    acl.add(entry);
+    aclView.setAcl(acl);
+  }
+
+  @Test
+  void TestChooseClientAlias() {
+    String sslKeyFile = TestUtil.getSslTestCertPath("goodclient.key");
+    String sslCertFile = TestUtil.getSslTestCertPath("goodclient.crt");
+    PEMKeyManager pemKeyManager = new PEMKeyManager(sslKeyFile, sslCertFile, "RSA");
+
+    X500Principal testPrincipal = new X500Principal("CN=root certificate, O=PgJdbc test, ST=CA, C=US");
+    X500Principal[] issuers = new X500Principal[]{testPrincipal};
+
+    String validKeyType = pemKeyManager.chooseClientAlias(new String[]{"RSA"}, issuers, null);
+    assertNotNull(validKeyType);
+
+    String ignoresCase = pemKeyManager.chooseClientAlias(new String[]{"rsa"}, issuers, null);
+    assertNotNull(ignoresCase);
+
+    String invalidKeyType = pemKeyManager.chooseClientAlias(new String[]{"EC"}, issuers, null);
+    assertNull(invalidKeyType);
+
+    String containsValidKeyType = pemKeyManager.chooseClientAlias(new String[]{"EC", "RSA"}, issuers, null);
+    assertNotNull(containsValidKeyType);
+
+    String ignoresBlank = pemKeyManager.chooseClientAlias(new String[]{}, issuers, null);
+    assertNotNull(ignoresBlank);
+  }
+
+  @Test
+  void TestGoodClientPEM() throws Exception {
+    TestUtil.assumeSslTestsEnabled();
+
+    Properties props = new Properties();
+    PGProperty.SSL_MODE.set(props, "prefer");
+    PGProperty.SSL_KEY.set(props, TestUtil.getSslTestCertPath("goodclient.key"));
+    PGProperty.SSL_CERT.set(props, TestUtil.getSslTestCertPath("goodclient.crt"));
+    PGProperty.PEM_KEY_ALGORITHM.set(props, "RSA");
+
+    try (Connection conn = TestUtil.openDB(props)) {
+      boolean sslUsed = TestUtil.queryForBoolean(conn, "SELECT ssl FROM pg_stat_ssl WHERE pid = pg_backend_pid()");
+      assertTrue(sslUsed, "SSL should be in use");
+    }
+  }
+}


### PR DESCRIPTION
### Context

I found that PGJDBC currently lacks support for PEM based certs and keys.

We have a use case where PEM files are auto renewed on disk and
converting them to DER format requires running something that watches
files on disk and auto-converts to DER.

Hence I would like to propose a patch for supporting PEM based certs, keys.

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Does `./gradlew styleCheck` pass ?
3. [x] Have you added your new test classes to an existing test suite in alphabetical order?

### Changes to Existing Features:

- Adding support for PEM based certs will not affect the existing behavior.
- Added new tests for PEMKeyManager

