### PR TITLE
fix: remove excessive ReentrantLock.lock usages

### DIFF
--- a/build-logic/jvm/src/main/kotlin/build-logic.without-type-annotations.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/build-logic.without-type-annotations.gradle.kts
@@ -23,6 +23,7 @@ val hiddenAnnotation = Regex(
             "KeyFor|" +
             "Positive|NonNegative|IntRange|" +
             "GuardedBy|UnderInitialization|" +
+            "Holding|" +
             "DefaultQualifier)(?:\\([^)]*\\))?")
 val hiddenImports = Regex("import org.checkerframework")
 

--- a/pgjdbc/src/main/java/org/postgresql/core/QueryExecutorBase.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/QueryExecutorBase.java
@@ -19,6 +19,7 @@ import org.postgresql.util.PSQLException;
 import org.postgresql.util.PSQLState;
 import org.postgresql.util.ServerErrorMessage;
 
+import org.checkerframework.checker.lock.qual.Holding;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -282,10 +283,9 @@ public abstract class QueryExecutorBase implements QueryExecutor {
     this.serverVersionNum = serverVersionNum;
   }
 
+  @Holding("lock")
   public void setTransactionState(TransactionState state) {
-    try (ResourceLock ignore = lock.obtain()) {
-      transactionState = state;
-    }
+    transactionState = state;
   }
 
   public void setStandardConformingStrings(boolean value) {


### PR DESCRIPTION
In some of the cases (private/protected/internal API) we know we already hold the lock, so there's no much sense aquiring it again.

For LruCache, we know we do not perform IO operations, so it is safe to use synchronized as it won't cause Loom virtual thread pinning.

See https://github.com/pgjdbc/pgjdbc/issues/3693

Frankly speaking, I wasn't able to measure any significant difference for before vs after.

On the other hand, removing the excessive try-with-resources and excessive `ReentrantLock.lock/unlock` should be a net positive change.

Note: the results in https://github.com/pgjdbc/pgjdbc/issues/3693 show there's a significant share of locking in `org.postgresql.core.QueryExecutorBase#getTransactionState`, however, the method is used in many places that do not currently aquire the lock (e.g. `PgConnection#commit`), so I did not update `getTransactionState` yet.