### PR TITLE
Fixed issue #2538: parsing comment in callable statement

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/Parser.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/Parser.java
@@ -1065,6 +1065,16 @@ public class Parser {
           ch = jdbcSql.charAt(i);
         }
       }
+      if (ch == '-') { // possibly -- style comment
+        i = Parser.parseLineComment(jdbcSql.toCharArray(), i);
+        if (i < len) {
+          ch = jdbcSql.charAt(i);
+        }
+
+        if (i == len - 1) {
+          i++; // end of line comment
+        }
+      }
 
       switch (state) {
         case 1:  // Looking for { at start of query
@@ -1167,10 +1177,12 @@ public class Parser {
           }
           break;
 
-        case 8:  // At trailing end of query, eating closing comment or whitespace
+        case 8:  // At trailing end of query, eating closing block comment or whitespace
           if (ch == '/' || Character.isWhitespace(ch)) {
             ++i;
-          } else if (i < len) {
+          } else if (ch == '-' && jdbcSql.charAt(i + 1) == '-') {
+            i = len; // found start of the line comment, ignoring rest of the query
+          } else if (i < len - 1) {
             syntaxError = true;
           }
           break;

--- a/pgjdbc/src/main/java/org/postgresql/core/Parser.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/Parser.java
@@ -1040,6 +1040,7 @@ public class Parser {
     // TODO: Merge with escape processing (and parameter parsing?) so we only parse each query once.
     // RE: frequently used statements are cached (see {@link org.postgresql.jdbc.PgConnection#borrowQuery}), so this "merge" is not that important.
     String sql = jdbcSql;
+    char[] sqlCharArray = jdbcSql.toCharArray();
     boolean isFunction = false;
     boolean outParamBeforeFunc = false;
 
@@ -1057,7 +1058,7 @@ public class Parser {
 
       if (ch == '/') { // possibly /* */ style comment
         int prevI = i;
-        i = Parser.parseBlockComment(jdbcSql.toCharArray(), i);
+        i = Parser.parseBlockComment(sqlCharArray, i);
         if (i > prevI) {
           ++i; // found comment block, advance index to skip closing comment char /
         }
@@ -1066,7 +1067,7 @@ public class Parser {
         }
       }
       if (ch == '-') { // possibly -- style comment
-        i = Parser.parseLineComment(jdbcSql.toCharArray(), i);
+        i = Parser.parseLineComment(sqlCharArray, i);
         if (i < len) {
           ch = jdbcSql.charAt(i);
         }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/CallableStmtTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/CallableStmtTest.java
@@ -13,14 +13,12 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import org.junit.jupiter.params.ParameterizedTest;
-
-import org.junit.jupiter.params.provider.CsvSource;
-
 import org.postgresql.test.TestUtil;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import java.math.BigDecimal;
 import java.sql.Array;

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/CallableStmtTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/CallableStmtTest.java
@@ -13,13 +13,12 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import org.junit.jupiter.params.provider.ValueSource;
-
 import org.postgresql.test.TestUtil;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.math.BigDecimal;
 import java.sql.Array;
@@ -332,6 +331,19 @@ public class CallableStmtTest extends BaseTest4 {
       "{ ? = call testspg__insertInt(?)}/* test comment */",
       "{ ? = call testspg__insertInt(?)} /* test comment */",
       "{ ? = call testspg__insertInt(?)} /* test comment */ ",
+      "{ ? = call testspg__insertInt(?)} -- test comment",
+      "{ -- test comment\n? = call testspg__insertInt(?)}",
+      "{ -- test comment\n ? = call testspg__insertInt(?)}",
+      "-- test comment\n {? = call testspg__insertInt(?)}",
+      "{? = call testspg__insertInt(?)}-- test comment",
+      "{? -- test comment \n = call testspg__insertInt(?)}",
+      "{? = -- test comment \n call testspg__insertInt(?)}",
+      "{? = call -- test comment \n testspg__insertInt(?)}",
+      "{? = call testspg__insertInt(?)-- test comment \n }",
+      "{? = call testspg__insertInt(-- test comment \n ?)}",
+      "{? = call testspg__insertInt(?-- test comment \n)}",
+      "{? = call testspg__insertInt(?)-- test comment \n}",
+      "{? = call testspg__insertInt-- test comment \n(?)}",
   })
   public void testCallableStatementWithComment(String sqlCall) throws SQLException {
     CallableStatement call = con.prepareCall(sqlCall);

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/CallableStmtTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/CallableStmtTest.java
@@ -13,6 +13,10 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import org.junit.jupiter.params.ParameterizedTest;
+
+import org.junit.jupiter.params.provider.CsvSource;
+
 import org.postgresql.test.TestUtil;
 
 import org.junit.jupiter.api.BeforeAll;
@@ -306,4 +310,36 @@ public class CallableStmtTest extends BaseTest4 {
     assertFalse(rs.next());
   }
 
+  @ParameterizedTest
+  @CsvSource(value = {
+      "{? = call testspg__insertInt(?)}",
+      "/* test comment */ {? = call testspg__insertInt(?)}",
+      "{/* test comment */ ? = call testspg__insertInt(?)}",
+      "{/* test comment */? = call testspg__insertInt(?)}",
+      "{ /* test comment */ ? = call testspg__insertInt(?)}",
+      "{ /* test comment */? = call testspg__insertInt(?)}",
+      "{ ? /* test comment */ = call testspg__insertInt(?)}",
+      "{ ? /* test comment */= call testspg__insertInt(?)}",
+      "{ ?/* test comment */ = call testspg__insertInt(?)}",
+      "{ ?/* test comment */= call testspg__insertInt(?)}",
+      "{ ? = /* test comment */ call testspg__insertInt(?)}",
+      "{ ? =/* test comment */ call testspg__insertInt(?)}",
+      "{ ? =/* test comment */call testspg__insertInt(?)}",
+      "{ ? = call /* test comment */ testspg__insertInt(?)}",
+      "{ ? = call/* test comment */ testspg__insertInt(?)}",
+      "{ ? = call /* test comment */testspg__insertInt(?)}",
+      "{ ? = call testspg__insertInt(?) /* test comment */}",
+      "{ ? = call testspg__insertInt(?)/* test comment */}",
+      "{ ? = call testspg__insertInt(?)}/* test comment */",
+      "{ ? = call testspg__insertInt(?)} /* test comment */",
+      "{ ? = call testspg__insertInt(?)} /* test comment */ ",
+  }, delimiter = '#')
+  public void testCallableStatementWithComment(String sqlCall) throws SQLException {
+    CallableStatement call = con.prepareCall(sqlCall);
+    call.setInt(2, 100);
+    call.registerOutParameter(1, java.sql.Types.INTEGER);//this will fail for statement with preceding comment
+    call.executeUpdate();
+    int result = call.getInt(1);
+    assertEquals(1, result);
+  }
 }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/CallableStmtTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/CallableStmtTest.java
@@ -337,7 +337,8 @@ public class CallableStmtTest extends BaseTest4 {
   public void testCallableStatementWithComment(String sqlCall) throws SQLException {
     CallableStatement call = con.prepareCall(sqlCall);
     call.setInt(2, 100);
-    call.registerOutParameter(1, java.sql.Types.INTEGER);//this will fail for statement with preceding comment
+    //this should not fail for statement with comment in various positions
+    call.registerOutParameter(1, java.sql.Types.INTEGER);
     call.executeUpdate();
     int result = call.getInt(1);
     assertEquals(1, result);

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/CallableStmtTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/CallableStmtTest.java
@@ -13,12 +13,13 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import org.junit.jupiter.params.provider.ValueSource;
+
 import org.postgresql.test.TestUtil;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
 
 import java.math.BigDecimal;
 import java.sql.Array;
@@ -309,7 +310,7 @@ public class CallableStmtTest extends BaseTest4 {
   }
 
   @ParameterizedTest
-  @CsvSource(value = {
+  @ValueSource(strings = {
       "{? = call testspg__insertInt(?)}",
       "/* test comment */ {? = call testspg__insertInt(?)}",
       "{/* test comment */ ? = call testspg__insertInt(?)}",
@@ -331,7 +332,7 @@ public class CallableStmtTest extends BaseTest4 {
       "{ ? = call testspg__insertInt(?)}/* test comment */",
       "{ ? = call testspg__insertInt(?)} /* test comment */",
       "{ ? = call testspg__insertInt(?)} /* test comment */ ",
-  }, delimiter = '#')
+  })
   public void testCallableStatementWithComment(String sqlCall) throws SQLException {
     CallableStatement call = con.prepareCall(sqlCall);
     call.setInt(2, 100);


### PR DESCRIPTION
Fixed parsing comment in callable statement causing syntax issue and preventing registration of out param

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Does `./gradlew styleCheck` pass ?
3. [x] Have you added your new test classes to an existing test suite in alphabetical order?

### Changes to Existing Features:

* [ ] Does this break existing behaviour? If so please explain.
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
