### PR TITLE
feat: support java.time.Instant  and java.time.ZonedDateTime for ResultSet.getObject(..., Class) and PreparedStatement.set(..., Object)

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
@@ -74,6 +74,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.OffsetTime;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
@@ -692,6 +693,8 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
       case Types.TIMESTAMP_WITH_TIMEZONE:
         if (in instanceof OffsetDateTime) {
           setTimestamp(parameterIndex, (OffsetDateTime) in);
+        } else if (in instanceof ZonedDateTime) {
+          setTimestamp(parameterIndex, ((ZonedDateTime) in).toOffsetDateTime());
         } else if (in instanceof Instant) {
           setTimestamp(parameterIndex, (Instant) in);
         } else if (in instanceof PGTimestamp) {
@@ -1074,6 +1077,8 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
       setTimestamp(parameterIndex, (LocalDateTime) x);
     } else if (x instanceof OffsetDateTime) {
       setTimestamp(parameterIndex, (OffsetDateTime) x);
+    } else if (x instanceof ZonedDateTime) {
+      setTimestamp(parameterIndex, ((ZonedDateTime) x).toOffsetDateTime());
     } else if (x instanceof Instant) {
       setTimestamp(parameterIndex, (Instant) x);
     } else if (x instanceof Map) {

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
@@ -68,6 +68,7 @@ import java.sql.SQLXML;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.sql.Types;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -691,6 +692,8 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
       case Types.TIMESTAMP_WITH_TIMEZONE:
         if (in instanceof OffsetDateTime) {
           setTimestamp(parameterIndex, (OffsetDateTime) in);
+        } else if (in instanceof Instant) {
+          setTimestamp(parameterIndex, (Instant) in);
         } else if (in instanceof PGTimestamp) {
           setObject(parameterIndex, in);
         } else {
@@ -1071,6 +1074,8 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
       setTimestamp(parameterIndex, (LocalDateTime) x);
     } else if (x instanceof OffsetDateTime) {
       setTimestamp(parameterIndex, (OffsetDateTime) x);
+    } else if (x instanceof Instant) {
+      setTimestamp(parameterIndex, (Instant) x);
     } else if (x instanceof Map) {
       setMap(parameterIndex, (Map<?, ?>) x);
     } else if (x instanceof Number) {
@@ -1561,6 +1566,12 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
       throws SQLException {
     int oid = Oid.TIMESTAMPTZ;
     bindString(i, getTimestampUtils().toString(offsetDateTime), oid);
+  }
+
+  private void setTimestamp(@Positive int i, Instant instant)
+      throws SQLException {
+    int oid = Oid.TIMESTAMPTZ;
+    bindString(i, getTimestampUtils().toString(instant), oid);
   }
 
   public ParameterMetaData createParameterMetaData(BaseConnection conn, int[] oids)

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc42/GetObject310InfinityTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc42/GetObject310InfinityTest.java
@@ -20,6 +20,7 @@ import java.lang.reflect.Field;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
@@ -58,19 +59,26 @@ public class GetObject310InfinityTest extends BaseTest4 {
       for (String expression : Arrays.asList("-infinity", "infinity")) {
         for (String pgType : Arrays.asList("date", "timestamp",
             "timestamp with time zone")) {
-          for (Class<?> klass : Arrays.asList(LocalDate.class, LocalDateTime.class,
-              OffsetDateTime.class)) {
+          for (Class<?> klass : Arrays.asList(
+              LocalDate.class, LocalDateTime.class,
+              OffsetDateTime.class, Instant.class)) {
             if (klass.equals(LocalDate.class) && !"date".equals(pgType)) {
               continue;
             }
             if (klass.equals(LocalDateTime.class) && !pgType.startsWith("timestamp")) {
               continue;
             }
+            if (klass.equals(LocalDateTime.class) && "timestamp with time zone".equals(pgType)) {
+              // org.postgresql.util.PSQLException: Cannot convert the column of type TIMESTAMPTZ to requested type timestamp.
+              continue;
+            }
             if (klass.equals(OffsetDateTime.class) && !pgType.startsWith("timestamp")) {
               continue;
             }
-            if (klass.equals(LocalDateTime.class) && "timestamp with time zone".equals(pgType)) {
-              // org.postgresql.util.PSQLException: Cannot convert the column of type TIMESTAMPTZ to requested type timestamp.
+            if (klass.equals(Instant.class) && !pgType.equals("timestamp with time zone")) {
+              continue;
+            }
+            if (!klass.equals(Instant.class) || binaryMode != BinaryMode.REGULAR) {
               continue;
             }
             Field field = null;

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc42/GetObject310Test.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc42/GetObject310Test.java
@@ -35,6 +35,7 @@ import java.time.OffsetDateTime;
 import java.time.OffsetTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.time.chrono.IsoChronology;
 import java.time.chrono.IsoEra;
 import java.time.temporal.Temporal;
@@ -198,6 +199,10 @@ public class GetObject310Test extends BaseTest4 {
     Instant expectedInstant = offsetDT.toInstant();
     assertEquals(expectedInstant, rs.getObject(columnName, Instant.class), () -> "getObject(" + columnName + ", Instant.class)");
     assertEquals(expectedInstant, rs.getObject(1, Instant.class), "getObject(int, Instant.class)");
+
+    ZonedDateTime expectedZonedDateTime = offsetDT.toZonedDateTime();
+    assertEquals(expectedZonedDateTime, rs.getObject(columnName, ZonedDateTime.class), () -> "getObject(" + columnName + ", ZonedDateTime.class)");
+    assertEquals(expectedZonedDateTime, rs.getObject(1, ZonedDateTime.class), "getObject(int, ZonedDateTime.class)");
   }
 
   /**
@@ -215,6 +220,7 @@ public class GetObject310Test extends BaseTest4 {
         assertEquals(localTime, rs.getObject(1, LocalTime.class));
 
         assertDataTypeMismatch(rs, "time_without_time_zone_column", Instant.class);
+        assertDataTypeMismatch(rs, "time_without_time_zone_column", ZonedDateTime.class);
         assertDataTypeMismatch(rs, "time_without_time_zone_column", OffsetTime.class);
         assertDataTypeMismatch(rs, "time_without_time_zone_column", OffsetDateTime.class);
         assertDataTypeMismatch(rs, "time_without_time_zone_column", LocalDate.class);
@@ -346,6 +352,7 @@ public class GetObject310Test extends BaseTest4 {
         // TODO: this should also not work, but that's an open discussion (see https://github.com/pgjdbc/pgjdbc/pull/2467):
         // assertDataTypeMismatch(rs, "timestamp_without_time_zone_column", OffsetDateTime.class);
         assertDataTypeMismatch(rs, "timestamp_without_time_zone_column", Instant.class);
+        assertDataTypeMismatch(rs, "timestamp_without_time_zone_column", ZonedDateTime.class);
       }
       stmt.executeUpdate("DELETE FROM table1");
     }
@@ -356,13 +363,13 @@ public class GetObject310Test extends BaseTest4 {
    */
   @Test
   public void testGetTimestampWithTimeZone() throws SQLException {
-    runGetOffsetDateTimeAndInstant(UTC);
-    runGetOffsetDateTimeAndInstant(GMT03);
-    runGetOffsetDateTimeAndInstant(GMT05);
-    runGetOffsetDateTimeAndInstant(GMT13);
+    runGetOffsetDateTime(UTC);
+    runGetOffsetDateTime(GMT03);
+    runGetOffsetDateTime(GMT05);
+    runGetOffsetDateTime(GMT13);
   }
 
-  private void runGetOffsetDateTimeAndInstant(ZoneOffset offset) throws SQLException {
+  private void runGetOffsetDateTime(ZoneOffset offset) throws SQLException {
     try (Statement stmt = con.createStatement()) {
       stmt.executeUpdate(TestUtil.insertSQL("table1", "timestamp_with_time_zone_column", "TIMESTAMP WITH TIME ZONE '2004-10-19 10:23:54.123456" + offset.toString() + "'"));
 
@@ -446,6 +453,10 @@ public class GetObject310Test extends BaseTest4 {
         Instant.class,
         "'1582-09-30 00:00:00 Z'::timestamptz, '1582-10-16 00:00:00 Z'::timestamptz",
         range.stream().map(OffsetDateTime::toInstant).collect(Collectors.toList()));
+    runProlepticTests(
+        ZonedDateTime.class,
+        "'1582-09-30 00:00:00 Z'::timestamptz, '1582-10-16 00:00:00 Z'::timestamptz",
+        range.stream().map(OffsetDateTime::toZonedDateTime).collect(Collectors.toList()));
   }
 
   private <T extends Temporal> void runProlepticTests(Class<T> clazz, String selectRange, List<T> expectedTemporals) throws SQLException {

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc42/SetObject310InfinityTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc42/SetObject310InfinityTest.java
@@ -22,6 +22,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
@@ -64,6 +65,7 @@ public class SetObject310InfinityTest extends BaseTest4 {
   @Test
   public void testTimestamptz() throws SQLException {
     runTestforType(OffsetDateTime.MAX, OffsetDateTime.MIN, "timestamp_without_time_zone_column", null);
+    runTestforType(Instant.MAX, Instant.MIN, "timestamp_without_time_zone_column", null);
   }
 
   @Test

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc42/SetObject310Test.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc42/SetObject310Test.java
@@ -339,6 +339,19 @@ public class SetObject310Test extends BaseTest4 {
         setInstantValueAndReadItBack(ps, data.toInstant(), data.toInstant(),
             () -> "(with ZoneId=" + dataZone + "), with TimeZone"
                 + ".default=" + storeZone);
+        setInstantValueAndReadItBack(
+            ps,
+            data.toZonedDateTime(),
+            data.toInstant(),
+            () -> "(with ZoneId=" + dataZone + "), with TimeZone"
+                + ".default=" + storeZone);
+        //
+        setInstantValueAndReadItBack(
+            ps,
+            data.toZonedDateTime().withZoneSameInstant(ZoneId.of("America/New_York")),
+            data.toInstant(),
+            () -> "(with ZoneId=" + dataZone + "), with TimeZone"
+                + ".default=" + storeZone + ", ZonedDateTime.zoneId=America/New_York");
       }
     }
   }


### PR DESCRIPTION
Previously, the users had to round-trip to OffsetDateTime.class which had several drawbacks: 1) It was not convenient when the application already had Instant at hand 2) Instant has a closer mapping to the underlying PostgreSQL timestamptz type (== seconds from epoch),
  so it is a bit faster if the user does not need date/time components.

Only timestamptz and timetz are supported for Instant. timestamp in the database does not properly represent a moment in time, so we fail fast so the application developer could either alter the type of the column or use a different type in Java (e.g. LocalDateTime)

Fixes https://github.com/pgjdbc/pgjdbc/issues/1325

Depends on:
* https://github.com/pgjdbc/pgjdbc/pull/4228
