### PR TITLE
Use `BufferedInputStream` with `FileInputStream`

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbcurlresolver/PgPassParser.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbcurlresolver/PgPassParser.java
@@ -10,6 +10,7 @@ import org.postgresql.util.OSUtil;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 
+import java.io.BufferedInputStream;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
@@ -96,7 +97,7 @@ public class PgPassParser {
     } catch ( MalformedURLException ex ) {
       // try file
       File file = new File(resourceName);
-      return new FileInputStream(file);
+      return new BufferedInputStream(new FileInputStream(file));
     }
   }
 

--- a/pgjdbc/src/main/java/org/postgresql/jdbcurlresolver/PgServiceConfParser.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbcurlresolver/PgServiceConfParser.java
@@ -12,6 +12,7 @@ import org.postgresql.util.PGPropertyUtil;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 
+import java.io.BufferedInputStream;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
@@ -80,7 +81,7 @@ public class PgServiceConfParser {
     } catch ( MalformedURLException ex ) {
       // try file
       File file = new File(resourceName);
-      return new FileInputStream(file);
+      return new BufferedInputStream(new FileInputStream(file));
     }
   }
 

--- a/pgjdbc/src/main/java/org/postgresql/ssl/LazyKeyManager.java
+++ b/pgjdbc/src/main/java/org/postgresql/ssl/LazyKeyManager.java
@@ -11,9 +11,11 @@ import org.postgresql.util.PSQLState;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 
+import java.io.BufferedInputStream;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.RandomAccessFile;
 import java.net.Socket;
 import java.security.AlgorithmParameters;
@@ -154,9 +156,9 @@ public class LazyKeyManager implements X509KeyManager {
         return null;
       }
       Collection<? extends Certificate> certs;
-      FileInputStream certfileStream = null;
+      InputStream certfileStream = null;
       try {
-        certfileStream = new FileInputStream(certfile);
+        certfileStream = new BufferedInputStream(new FileInputStream(certfile));
         certs = cf.generateCertificates(certfileStream);
       } catch (FileNotFoundException ioex) {
         if (!defaultfile) { // It is not an error if there is no file at the default location

--- a/pgjdbc/src/main/java/org/postgresql/ssl/LibPQFactory.java
+++ b/pgjdbc/src/main/java/org/postgresql/ssl/LibPQFactory.java
@@ -18,10 +18,12 @@ import org.postgresql.util.PSQLState;
 import org.checkerframework.checker.initialization.qual.UnderInitialization;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
+import java.io.BufferedInputStream;
 import java.io.Console;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
 import java.security.GeneralSecurityException;
 import java.security.KeyManagementException;
 import java.security.KeyStore;
@@ -143,9 +145,9 @@ public class LibPQFactory extends WrappedFactory {
         if (sslrootcertfile == null) { // Fall back to default
           sslrootcertfile = defaultdir + "root.crt";
         }
-        FileInputStream fis;
+        InputStream is;
         try {
-          fis = new FileInputStream(sslrootcertfile); // NOSONAR
+          is = new BufferedInputStream(new FileInputStream(sslrootcertfile)); // NOSONAR
         } catch (FileNotFoundException ex) {
           throw new PSQLException(
               GT.tr("Could not open SSL root certificate file {0}.", sslrootcertfile),
@@ -153,9 +155,9 @@ public class LibPQFactory extends WrappedFactory {
         }
         try {
           CertificateFactory cf = CertificateFactory.getInstance("X.509");
-          // Certificate[] certs = cf.generateCertificates(fis).toArray(new Certificate[]{}); //Does
+          // Certificate[] certs = cf.generateCertificates(is).toArray(new Certificate[]{}); //Does
           // not work in java 1.4
-          Object[] certs = cf.generateCertificates(fis).toArray(new Certificate[]{});
+          Object[] certs = cf.generateCertificates(is).toArray(new Certificate[]{});
           ks.load(null, null);
           for (int i = 0; i < certs.length; i++) {
             ks.setCertificateEntry("cert" + i, (Certificate) certs[i]);
@@ -172,7 +174,7 @@ public class LibPQFactory extends WrappedFactory {
               PSQLState.CONNECTION_FAILURE, gsex);
         } finally {
           try {
-            fis.close();
+            is.close();
           } catch (IOException e) {
             /* ignore */
           }

--- a/pgjdbc/src/main/java/org/postgresql/ssl/PKCS12KeyManager.java
+++ b/pgjdbc/src/main/java/org/postgresql/ssl/PKCS12KeyManager.java
@@ -12,6 +12,7 @@ import org.postgresql.util.PSQLState;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 
+import java.io.BufferedInputStream;
 import java.io.FileInputStream;
 import java.net.Socket;
 import java.security.KeyStore;
@@ -190,7 +191,7 @@ public class PKCS12KeyManager implements X509KeyManager {
 
       }
 
-      keyStore.load(new FileInputStream(keyfile), pwdcb.getPassword());
+      keyStore.load(new BufferedInputStream(new FileInputStream(keyfile)), pwdcb.getPassword());
       keystoreLoaded = true;
     }
   }


### PR DESCRIPTION
Some places where `FileInputStream` was being used didn't have `BufferedInputStream`. In many of the use cases, these files were being read 1 byte at a time. This causes excessive IO calls to read the file. By ensuring the `InputStream` is buffered, the IO calls are minimised, improving the performance of the driver.

This performance issue was noticed when a certificate file was on a network drive. It resulted in considerable network traffic.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

