### PR TITLE
chore: bump Gradle to 9.0

### DIFF
--- a/build-logic/jvm/src/main/java/org/gradle/util/ConfigureUtil.java
+++ b/build-logic/jvm/src/main/java/org/gradle/util/ConfigureUtil.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.util;
+
+import groovy.lang.Closure;
+import org.codehaus.groovy.runtime.GeneratedClosure;
+import org.gradle.api.Action;
+import org.gradle.internal.Actions;
+import org.gradle.internal.metaobject.ConfigureDelegate;
+import org.gradle.internal.metaobject.DynamicInvokeResult;
+import org.gradle.internal.metaobject.DynamicObject;
+import org.gradle.internal.metaobject.DynamicObjectUtil;
+import org.gradle.util.internal.ClosureBackedAction;
+
+import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.Map;
+
+import static org.gradle.util.internal.CollectionUtils.toStringList;
+
+/**
+ * Contains utility methods to configure objects with Groovy Closures.
+ * <p>
+ * Plugins should avoid using this class and methods that use {@link groovy.lang.Closure} as this makes the plugin harder to use in other languages. Instead, plugins should create methods that use {@link Action}.
+ * Here's an example pseudocode:
+ * <pre class='autoTested'>
+ *     interface MyOptions {
+ *         RegularFileProperty getOptionsFile()
+ *     }
+ *     abstract class MyExtension {
+ *         private final MyOptions options
+ *
+ *         {@literal @}Inject abstract ObjectFactory getObjectFactory()
+ *
+ *         public MyExtension() {
+ *             this.options = getObjectFactory().newInstance(MyOptions)
+ *         }
+ *
+ *         public void options(Action{@literal <?} extends MyOptions{@literal >}  action) {
+ *              action.execute(options)
+ *         }
+ *     }
+ *     extensions.create("myExtension", MyExtension)
+ *     myExtension {
+ *         options {
+ *             optionsFile = layout.projectDirectory.file("options.properties")
+ *         }
+ *     }
+ * </pre>
+ * <p>
+ * Gradle automatically generates a Closure-taking method at runtime for each method with an {@link Action} as a single argument as long as the object is created with {@link org.gradle.api.model.ObjectFactory#newInstance(Class, Object...)}.
+ * <p>
+ * As a last resort, to apply some configuration represented by a Groovy Closure, a plugin can use {@link org.gradle.api.Project#configure(Object, Closure)}.
+ *
+ * @deprecated Will be removed in Gradle 9.0.
+ * @see <a href="https://github.com/gradle/gradle/blob/v8.14.3/platforms/core-configuration/model-core/src/main/java/org/gradle/util/ConfigureUtil.java">ConfigureUtil.java</a>
+ */
+@Deprecated
+public class ConfigureUtil {
+
+  public static <T> T configureByMap(Map<?, ?> properties, T delegate) {
+    logDeprecation();
+    return configureByMapInternal(properties, delegate);
+  }
+
+  private static <T> T configureByMapInternal(Map<?, ?> properties, T delegate) {
+    if (properties.isEmpty()) {
+      return delegate;
+    }
+    DynamicObject dynamicObject = DynamicObjectUtil.asDynamicObject(delegate);
+
+    for (Map.Entry<?, ?> entry : properties.entrySet()) {
+      String name = entry.getKey().toString();
+      Object value = entry.getValue();
+
+      DynamicInvokeResult result = dynamicObject.trySetProperty(name, value);
+      if (result.isFound()) {
+        continue;
+      }
+
+      result = dynamicObject.tryInvokeMethod(name, value);
+      if (!result.isFound()) {
+        throw dynamicObject.setMissingProperty(name);
+      }
+    }
+
+    return delegate;
+  }
+
+  public static <T> T configureByMap(Map<?, ?> properties, T delegate, Collection<?> mandatoryKeys) {
+    logDeprecation();
+    if (!mandatoryKeys.isEmpty()) {
+      Collection<String> missingKeys = toStringList(mandatoryKeys);
+      missingKeys.removeAll(toStringList(properties.keySet()));
+      if (!missingKeys.isEmpty()) {
+        throw new IncompleteInputException("Input configuration map does not contain following mandatory keys: " + missingKeys, missingKeys);
+      }
+    }
+    return configureByMapInternal(properties, delegate);
+  }
+
+  /**
+   * Incomplete input exception.
+   */
+  @Deprecated
+  public static class IncompleteInputException extends RuntimeException {
+    private final Collection missingKeys;
+
+    public IncompleteInputException(String message, Collection missingKeys) {
+      super(message);
+      this.missingKeys = missingKeys;
+      logDeprecation();
+    }
+
+    public Collection getMissingKeys() {
+      return missingKeys;
+    }
+  }
+
+  /**
+   * <p>Configures {@code target} with {@code configureClosure}, via the {@link Configurable} interface if necessary.</p>
+   *
+   * <p>If {@code target} does not implement {@link Configurable} interface, it is set as the delegate of a clone of
+   * {@code configureClosure} with a resolve strategy of {@code DELEGATE_FIRST}.</p>
+   *
+   * <p>If {@code target} does implement the {@link Configurable} interface, the {@code configureClosure} will be passed to
+   * {@code delegate}'s {@link Configurable#configure(Closure)} method.</p>
+   *
+   * @param configureClosure The configuration closure
+   * @param target The object to be configured
+   * @return The delegate param
+   */
+  public static <T> T configure(@Nullable Closure configureClosure, T target) {
+    logDeprecation();
+    if (configureClosure == null) {
+      return target;
+    }
+
+    if (target instanceof Configurable) {
+      ((Configurable) target).configure(configureClosure);
+    } else {
+      configureTarget(configureClosure, target, new ConfigureDelegate(configureClosure, target));
+    }
+
+    return target;
+  }
+
+  /**
+   * Creates an action that uses the given closure to configure objects of type T.
+   */
+  public static <T> Action<T> configureUsing(@Nullable final Closure configureClosure) {
+    logDeprecation();
+    if (configureClosure == null) {
+      return Actions.doNothing();
+    }
+
+    return new WrappedConfigureAction<T>(configureClosure);
+  }
+
+  /**
+   * Called from an object's {@link Configurable#configure} method.
+   */
+  public static <T> T configureSelf(@Nullable Closure configureClosure, T target) {
+    logDeprecation();
+    if (configureClosure == null) {
+      return target;
+    }
+
+    configureTarget(configureClosure, target, new ConfigureDelegate(configureClosure, target));
+    return target;
+  }
+
+  /**
+   * Called from an object's {@link Configurable#configure} method.
+   */
+  public static <T> T configureSelf(@Nullable Closure configureClosure, T target, ConfigureDelegate closureDelegate) {
+    logDeprecation();
+    if (configureClosure == null) {
+      return target;
+    }
+
+    configureTarget(configureClosure, target, closureDelegate);
+    return target;
+  }
+
+  private static <T> void configureTarget(Closure configureClosure, T target, ConfigureDelegate closureDelegate) {
+    if (!(configureClosure instanceof GeneratedClosure)) {
+      new ClosureBackedAction<T>(configureClosure, Closure.DELEGATE_FIRST, false).execute(target);
+      return;
+    }
+
+    // Hackery to make closure execution faster, by short-circuiting the expensive property and method lookup on Closure
+    Closure withNewOwner = configureClosure.rehydrate(target, closureDelegate, configureClosure.getThisObject());
+    new ClosureBackedAction<T>(withNewOwner, Closure.OWNER_ONLY, false).execute(target);
+  }
+
+  private static void logDeprecation() {
+  }
+
+  /**
+   * Wrapper configure action.
+   *
+   * @param <T> the action type.
+   */
+  @Deprecated
+  public static class WrappedConfigureAction<T> implements Action<T> {
+    private final Closure configureClosure;
+
+    WrappedConfigureAction(Closure configureClosure) {
+      this.configureClosure = configureClosure;
+    }
+
+    @Override
+    public void execute(T t) {
+      configure(configureClosure, t);
+    }
+
+    public Closure getConfigureClosure() {
+      return configureClosure;
+    }
+  }
+}

--- a/build-logic/jvm/src/main/java/org/gradle/util/VersionNumber.java
+++ b/build-logic/jvm/src/main/java/org/gradle/util/VersionNumber.java
@@ -1,0 +1,294 @@
+/*
+ * Copyright 2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.util;
+
+import javax.annotation.Nullable;
+
+import java.util.Comparator;
+import java.util.Locale;
+import java.util.Objects;
+
+/**
+ * This class is only here to maintain binary compatibility with existing plugins.
+ *
+ * @deprecated Will be removed in Gradle 9.0.
+ * @see <a href="https://github.com/gradle/gradle/blob/v8.14.3/subprojects/core/src/main/java/org/gradle/util/VersionNumber.java">VersionNumber.java</a>
+ */
+@Deprecated
+public class VersionNumber implements Comparable<VersionNumber> {
+  private final static Comparator<VersionNumber> QUALIFIER_COMPARATOR =
+      Comparator.comparing(
+          VersionNumber::getQualifier,
+          Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER));
+
+  private static final DefaultScheme DEFAULT_SCHEME = new DefaultScheme();
+  private static final SchemeWithPatchVersion PATCH_SCHEME = new SchemeWithPatchVersion();
+  public static final VersionNumber UNKNOWN = version(0);
+
+  private final int major;
+  private final int minor;
+  private final int micro;
+  private final int patch;
+  private final String qualifier;
+  private final AbstractScheme scheme;
+
+  public VersionNumber(int major, int minor, int micro, @Nullable String qualifier) {
+    this(major, minor, micro, 0, qualifier, DEFAULT_SCHEME, true);
+  }
+
+  public VersionNumber(int major, int minor, int micro, int patch, @Nullable String qualifier) {
+    this(major, minor, micro, patch, qualifier, PATCH_SCHEME, true);
+  }
+
+  private VersionNumber(int major, int minor, int micro, int patch, @Nullable String qualifier, AbstractScheme scheme, boolean logDeprecation) {
+    this.major = major;
+    this.minor = minor;
+    this.micro = micro;
+    this.patch = patch;
+    this.qualifier = qualifier;
+    this.scheme = scheme;
+  }
+
+  public int getMajor() {
+    return major;
+  }
+
+  public int getMinor() {
+    return minor;
+  }
+
+  public int getMicro() {
+    return micro;
+  }
+
+  public int getPatch() {
+    return patch;
+  }
+
+  @Nullable
+  public String getQualifier() {
+    return qualifier;
+  }
+
+  public VersionNumber getBaseVersion() {
+    return new VersionNumber(major, minor, micro, patch, null, scheme, false);
+  }
+
+  @Override
+  public int compareTo(VersionNumber other) {
+    if (major != other.major) {
+      return major - other.major;
+    }
+    if (minor != other.minor) {
+      return minor - other.minor;
+    }
+    if (micro != other.micro) {
+      return micro - other.micro;
+    }
+    if (patch != other.patch) {
+      return patch - other.patch;
+    }
+    return QUALIFIER_COMPARATOR.compare(this, other);
+  }
+
+  @Override
+  public boolean equals(@Nullable Object other) {
+    return other instanceof VersionNumber && compareTo((VersionNumber) other) == 0;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = major;
+    result = 31 * result + minor;
+    result = 31 * result + micro;
+    result = 31 * result + patch;
+    result = 31 * result + Objects.hashCode(qualifier);
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return scheme.format(this);
+  }
+
+  public static VersionNumber version(int major) {
+    return version(major, 0);
+  }
+
+  public static VersionNumber version(int major, int minor) {
+    return new VersionNumber(major, minor, 0, 0, null, DEFAULT_SCHEME, false);
+  }
+
+  /**
+   * Returns the default MAJOR.MINOR.MICRO-QUALIFIER scheme.
+   */
+  public static Scheme scheme() {
+    return DEFAULT_SCHEME;
+  }
+
+  /**
+   * Returns the MAJOR.MINOR.MICRO.PATCH-QUALIFIER scheme.
+   */
+  public static Scheme withPatchNumber() {
+    return PATCH_SCHEME;
+  }
+
+  public static VersionNumber parse(String versionString) {
+    return DEFAULT_SCHEME.parse(versionString);
+  }
+
+  @Nullable
+  private static String toLowerCase(@Nullable String string) {
+    return string == null ? null : string.toLowerCase(Locale.ROOT);
+  }
+
+  /**
+   * Returns the version number scheme.
+   */
+  @Deprecated
+  public interface Scheme {
+    VersionNumber parse(String value);
+    String format(VersionNumber versionNumber);
+  }
+
+  private abstract static class AbstractScheme implements Scheme {
+    final int depth;
+
+    protected AbstractScheme(int depth) {
+      this.depth = depth;
+    }
+
+    @Override
+    public VersionNumber parse(@Nullable String versionString) {
+      if (versionString == null || versionString.isEmpty()) {
+        return UNKNOWN;
+      }
+      Scanner scanner = new Scanner(versionString);
+
+
+      if (!scanner.hasDigit()) {
+        return UNKNOWN;
+      }
+      int minor = 0;
+      int micro = 0;
+      int patch = 0;
+      int major = scanner.scanDigit();
+      if (scanner.isSeparatorAndDigit('.')) {
+        scanner.skipSeparator();
+        minor = scanner.scanDigit();
+        if (scanner.isSeparatorAndDigit('.')) {
+          scanner.skipSeparator();
+          micro = scanner.scanDigit();
+          if (depth > 3 && scanner.isSeparatorAndDigit('.', '_')) {
+            scanner.skipSeparator();
+            patch = scanner.scanDigit();
+          }
+        }
+      }
+
+      if (scanner.isEnd()) {
+        return new VersionNumber(major, minor, micro, patch, null, this, false);
+      }
+
+      if (scanner.isQualifier()) {
+        scanner.skipSeparator();
+        return new VersionNumber(major, minor, micro, patch, scanner.remainder(), this, false);
+      }
+
+      return UNKNOWN;
+    }
+
+    private static class Scanner {
+      int pos;
+      final String str;
+
+      private Scanner(String string) {
+        this.str = string;
+      }
+
+      boolean hasDigit() {
+        return pos < str.length() && Character.isDigit(str.charAt(pos));
+      }
+
+      boolean isSeparatorAndDigit(char... separators) {
+        return pos < str.length() - 1 && oneOf(separators) && Character.isDigit(str.charAt(pos + 1));
+      }
+
+      private boolean oneOf(char... separators) {
+        char current = str.charAt(pos);
+        for (char separator : separators) {
+          if (current == separator) {
+            return true;
+          }
+        }
+        return false;
+      }
+
+      boolean isQualifier() {
+        return pos < str.length() - 1 && oneOf('.', '-');
+      }
+
+      int scanDigit() {
+        int start = pos;
+        while (hasDigit()) {
+          pos++;
+        }
+        return Integer.parseInt(str.substring(start, pos));
+      }
+
+      public boolean isEnd() {
+        return pos == str.length();
+      }
+
+      public void skipSeparator() {
+        pos++;
+      }
+
+      @Nullable
+      public String remainder() {
+        return pos == str.length() ? null : str.substring(pos);
+      }
+    }
+  }
+
+  private static class DefaultScheme extends AbstractScheme {
+    private static final String VERSION_TEMPLATE = "%d.%d.%d%s";
+
+    public DefaultScheme() {
+      super(3);
+    }
+
+    @Override
+    public String format(VersionNumber versionNumber) {
+      return String.format(VERSION_TEMPLATE, versionNumber.major, versionNumber.minor, versionNumber.micro, versionNumber.qualifier == null ? "" : "-" + versionNumber.qualifier);
+    }
+  }
+
+  private static class SchemeWithPatchVersion extends AbstractScheme {
+    private static final String VERSION_TEMPLATE = "%d.%d.%d.%d%s";
+
+    private SchemeWithPatchVersion() {
+      super(4);
+    }
+
+    @Override
+    public String format(VersionNumber versionNumber) {
+      return String.format(VERSION_TEMPLATE, versionNumber.major, versionNumber.minor, versionNumber.micro, versionNumber.patch, versionNumber.qualifier == null ? "" : "-" + versionNumber.qualifier);
+    }
+  }
+
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=bd71102213493060956ec229d946beee57158dbd89d0e62b91bca0fa2c5f3531
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
+distributionSha256Sum=8fad3d78296ca518113f3d29016617c7f9367dc005f932bd9d93bf45ba46072b
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/test-gss/gradle/wrapper/gradle-wrapper.properties
+++ b/test-gss/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=bd71102213493060956ec229d946beee57158dbd89d0e62b91bca0fa2c5f3531
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
+distributionSha256Sum=8fad3d78296ca518113f3d29016617c7f9367dc005f932bd9d93bf45ba46072b
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Gradle 9 did drop ConfigureUtil and VersionNumber classes that are still used by some of the plugins (e.g. gradle-karaf-plugin).
Let's ressurect the classes until the plugins no longer use them.
