### PR TITLE
fix: Issue #3757 PreparedStatement.toString fails for hex encoded bytea parameter

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/util/PGbytea.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/PGbytea.java
@@ -237,7 +237,7 @@ public class PGbytea {
           throw new IllegalArgumentException(GT.tr("Invalid bytea hex format character {0}", c2));
         }
 
-        sb.append(str,i,i + 1);
+        sb.append(str,i,i + 2);
         i += 2;
       }
 

--- a/pgjdbc/src/main/java/org/postgresql/util/PGbytea.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/PGbytea.java
@@ -22,15 +22,21 @@ import java.sql.SQLException;
 public class PGbytea {
   private static final int MAX_3_BUFF_SIZE = 2 * 1024 * 1024;
 
-  // Lookup table for hex validation - similar to Netty's approach
-  // Using byte[] instead of int[] as we only need 1 bit per entry
   static final byte[] HEX_LOOKUP = new byte[256];
+
   static {
     // Initialize lookup table for hex characters
-    for (char c = '0'; c <= '9'; c++) HEX_LOOKUP[c] = 1;
-    for (char c = 'a'; c <= 'f'; c++) HEX_LOOKUP[c] = 1;
-    for (char c = 'A'; c <= 'F'; c++) HEX_LOOKUP[c] = 1;
+    for (char c = '0'; c <= '9'; c++) {
+      HEX_LOOKUP[c] = 1;
+    }
+    for (char c = 'a'; c <= 'f'; c++) {
+      HEX_LOOKUP[c] = 1;
+    }
+    for (char c = 'A'; c <= 'F'; c++) {
+      HEX_LOOKUP[c] = 1;
+    }
   }
+
   /**
    * Lookup table for each of the valid ascii code points (offset by {@code '0'})
    * to the 4 bit numeric value.
@@ -209,7 +215,6 @@ public class PGbytea {
         char c = str.charAt(i);
 
         // Skip whitespace using bitwise operation
-        // Based on Netty's implementation
         if ((c <= ' ' && ((1L << c) & ((1L << ' ') | (1L << '\t') | (1L << '\r') | (1L << '\n'))) != 0)) {
           i++;
           continue;
@@ -232,8 +237,7 @@ public class PGbytea {
           throw new IllegalArgumentException(GT.tr("Invalid bytea hex format character {0}", c2));
         }
 
-        sb.append(c1);
-        sb.append(c2);
+        sb.append(str,i,i + 1);
         i += 2;
       }
 

--- a/pgjdbc/src/main/java/org/postgresql/util/PGbytea.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/PGbytea.java
@@ -22,6 +22,15 @@ import java.sql.SQLException;
 public class PGbytea {
   private static final int MAX_3_BUFF_SIZE = 2 * 1024 * 1024;
 
+  // Lookup table for hex validation - similar to Netty's approach
+  // Using byte[] instead of int[] as we only need 1 bit per entry
+  static final byte[] HEX_LOOKUP = new byte[256];
+  static {
+    // Initialize lookup table for hex characters
+    for (char c = '0'; c <= '9'; c++) HEX_LOOKUP[c] = 1;
+    for (char c = 'a'; c <= 'f'; c++) HEX_LOOKUP[c] = 1;
+    for (char c = 'A'; c <= 'F'; c++) HEX_LOOKUP[c] = 1;
+  }
   /**
    * Lookup table for each of the valid ascii code points (offset by {@code '0'})
    * to the 4 bit numeric value.
@@ -182,6 +191,55 @@ public class PGbytea {
    * @throws IOException in case there's underflow in the input value
    */
   public static String toPGLiteral(Object value, SqlSerializationContext context) throws IOException {
+    if (value instanceof String) {
+      final String str = (String) value;
+      final int length = str.length();
+
+      // Fast fail if string is too short
+      if (length < 2 || str.charAt(0) != '\\' || str.charAt(1) != 'x') {
+        throw new IllegalArgumentException(GT.tr("bytea string parameters must be hex format"));
+      }
+
+      // Pre-calculate capacity: prefix('\x') + actual hex digits + suffix('::bytea')
+      final StringBuilder sb = new StringBuilder(length + 7);  // Conservative estimate
+      sb.append("'\\x");
+
+      int i = 2;
+      while (i < length) {
+        char c = str.charAt(i);
+
+        // Skip whitespace using bitwise operation
+        // Based on Netty's implementation
+        if ((c <= ' ' && ((1L << c) & ((1L << ' ') | (1L << '\t') | (1L << '\r') | (1L << '\n'))) != 0)) {
+          i++;
+          continue;
+        }
+
+        // Check if we have enough characters left
+        if (i + 2 > length) {
+          throw new IllegalArgumentException(GT.tr("Truncated bytea hex format"));
+        }
+
+        // Get hex digits
+        final char c1 = c;
+        final char c2 = str.charAt(i + 1);
+
+        // Validate hex digits using lookup table
+        if (c1 >= HEX_LOOKUP.length || HEX_LOOKUP[c1] == 0) {
+          throw new IllegalArgumentException(GT.tr("Invalid bytea hex format character {0}", c1));
+        }
+        if (c2 >= HEX_LOOKUP.length || HEX_LOOKUP[c2] == 0) {
+          throw new IllegalArgumentException(GT.tr("Invalid bytea hex format character {0}", c2));
+        }
+
+        sb.append(c1);
+        sb.append(c2);
+        i += 2;
+      }
+
+      sb.append("'::bytea");
+      return sb.toString();
+    }
     if (value instanceof byte[]) {
       byte[] bytes = (byte[]) value;
       StringBuilder sb = new StringBuilder(bytes.length * 2 + 11);
@@ -253,6 +311,6 @@ public class PGbytea {
     }
 
     throw new IllegalArgumentException(
-        GT.tr("Can't convert {0} to {1} literal", value.getClass(), "bytea"));
+        GT.tr("Cannot convert {0} to {1} literal", value.getClass(), "bytea"));
   }
 }

--- a/pgjdbc/src/test/java/org/postgresql/util/PGbyteaTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/util/PGbyteaTest.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.postgresql.core.v3.SqlSerializationContext;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;

--- a/pgjdbc/src/test/java/org/postgresql/util/PGbyteaTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/util/PGbyteaTest.java
@@ -6,9 +6,13 @@
 package org.postgresql.util;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import org.postgresql.core.v3.SqlSerializationContext;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
 import java.sql.SQLException;
 import java.util.Random;
 
@@ -51,5 +55,201 @@ class PGbyteaTest {
       encoded[idx + 1] = hexDigits[b & 0x0F];
     }
     return encoded;
+  }
+
+  @Test
+  void toPGLiteral_validHexString_lowercase() throws IOException {
+    String input = "\\xcafebabe";
+    String expected = "'\\xcafebabe'::bytea";
+    String result = PGbytea.toPGLiteral(input, SqlSerializationContext.of(true, true));
+    assertEquals(expected, result);
+  }
+
+  @Test
+  void toPGLiteral_validHexString_uppercase() throws IOException {
+    String input = "\\xCAFEBABE";
+    String expected = "'\\xCAFEBABE'::bytea";
+    String result = PGbytea.toPGLiteral(input, SqlSerializationContext.of(true, true));
+    assertEquals(expected, result);
+  }
+
+  @Test
+  void toPGLiteral_validHexString_mixed() throws IOException {
+    String input = "\\xCaFeBaBe";
+    String expected = "'\\xCaFeBaBe'::bytea";
+    String result = PGbytea.toPGLiteral(input, SqlSerializationContext.of(true, true));
+    assertEquals(expected, result);
+  }
+
+  @Test
+  void toPGLiteral_validHexString_empty() throws IOException {
+    String input = "\\x";
+    String expected = "'\\x'::bytea";
+    String result = PGbytea.toPGLiteral(input, SqlSerializationContext.of(true, true));
+    assertEquals(expected, result);
+  }
+
+  @Test
+  void toPGLiteral_validHexString_withWhitespace() throws IOException {
+    String input = "\\xca fe ba be";
+    String expected = "'\\xcafebabe'::bytea";
+    String result = PGbytea.toPGLiteral(input, SqlSerializationContext.of(true, true));
+    assertEquals(expected, result);
+  }
+
+  @Test
+  void toPGLiteral_validHexString_withTabs() throws IOException {
+    String input = "\\xca\tfe\tba\tbe";
+    String expected = "'\\xcafebabe'::bytea";
+    String result = PGbytea.toPGLiteral(input, SqlSerializationContext.of(true, true));
+    assertEquals(expected, result);
+  }
+
+  @Test
+  void toPGLiteral_validHexString_withNewlines() throws IOException {
+    String input = "\\xca\nfe\nba\nbe";
+    String expected = "'\\xcafebabe'::bytea";
+    String result = PGbytea.toPGLiteral(input, SqlSerializationContext.of(true, true));
+    assertEquals(expected, result);
+  }
+
+  @Test
+  void toPGLiteral_validHexString_withCarriageReturns() throws IOException {
+    String input = "\\xca\rfe\rba\rbe";
+    String expected = "'\\xcafebabe'::bytea";
+    String result = PGbytea.toPGLiteral(input, SqlSerializationContext.of(true, true));
+    assertEquals(expected, result);
+  }
+
+  @Test
+  void toPGLiteral_validHexString_longValue() throws IOException {
+    String input = "\\x0123456789abcdefABCDEF";
+    String expected = "'\\x0123456789abcdefABCDEF'::bytea";
+    String result = PGbytea.toPGLiteral(input, SqlSerializationContext.of(true, true));
+    assertEquals(expected, result);
+  }
+
+  @Test
+  void toPGLiteral_invalidString_noHexPrefix() {
+    String input = "cafebabe";
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+      PGbytea.toPGLiteral(input, SqlSerializationContext.of(true, true));
+    });
+    assertEquals("bytea string parameters must be hex format", exception.getMessage());
+  }
+
+  @Test
+  void toPGLiteral_invalidString_wrongPrefix() {
+    String input = "\\ycafebabe";
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+      PGbytea.toPGLiteral(input, SqlSerializationContext.of(true, true));
+    });
+    assertEquals("bytea string parameters must be hex format", exception.getMessage());
+  }
+
+  @Test
+  void toPGLiteral_invalidString_tooShort() {
+    String input = "\\";
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+      PGbytea.toPGLiteral(input, SqlSerializationContext.of(true, true));
+    });
+    assertEquals("bytea string parameters must be hex format", exception.getMessage());
+  }
+
+  @Test
+  void toPGLiteral_invalidString_emptyString() {
+    String input = "";
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+      PGbytea.toPGLiteral(input, SqlSerializationContext.of(true, true));
+    });
+    assertEquals("bytea string parameters must be hex format", exception.getMessage());
+  }
+
+  @Test
+  void toPGLiteral_invalidString_invalidHexCharacter() {
+    String input = "\\xcafegabe";
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+      PGbytea.toPGLiteral(input, SqlSerializationContext.of(true, true));
+    });
+    assertEquals("Invalid bytea hex format character g", exception.getMessage());
+  }
+
+  @Test
+  void toPGLiteral_invalidString_invalidHexCharacterSymbol() {
+    String input = "\\xcafe@abe";
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+      PGbytea.toPGLiteral(input, SqlSerializationContext.of(true, true));
+    });
+    assertEquals("Invalid bytea hex format character @", exception.getMessage());
+  }
+
+  @Test
+  void toPGLiteral_invalidString_oddNumberOfHexDigits() {
+    String input = "\\xcafebab";
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+      PGbytea.toPGLiteral(input, SqlSerializationContext.of(true, true));
+    });
+    assertEquals("Truncated bytea hex format", exception.getMessage());
+  }
+
+  @Test
+  void toPGLiteral_validHexString_withWhitespaceAtEnd() throws IOException {
+    // This case works because whitespace is skipped and "cafeba" is valid hex
+    String input = "\\xcafe ba";
+    String expected = "'\\xcafeba'::bytea";
+    String result = PGbytea.toPGLiteral(input, SqlSerializationContext.of(true, true));
+    assertEquals(expected, result);
+  }
+
+  @Test
+  void toPGLiteral_invalidString_truncatedAfterWhitespace() {
+    // This case fails because after skipping whitespace, there's only one hex character left
+    String input = "\\xcafe b";
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+      PGbytea.toPGLiteral(input, SqlSerializationContext.of(true, true));
+    });
+    assertEquals("Truncated bytea hex format", exception.getMessage());
+  }
+
+  @Test
+  void toPGLiteral_invalidString_highUnicodeCharacter() {
+    String input = "\\xcafe\u1234abe";
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+      PGbytea.toPGLiteral(input, SqlSerializationContext.of(true, true));
+    });
+    assertEquals("Invalid bytea hex format character \u1234", exception.getMessage());
+  }
+
+  @Test
+  void toPGLiteral_validString_allHexDigits() throws IOException {
+    String input = "\\x0123456789abcdefABCDEF";
+    String expected = "'\\x0123456789abcdefABCDEF'::bytea";
+    String result = PGbytea.toPGLiteral(input, SqlSerializationContext.of(true, true));
+    assertEquals(expected, result);
+  }
+
+  @Test
+  void toPGLiteral_validString_singleByte() throws IOException {
+    String input = "\\xff";
+    String expected = "'\\xff'::bytea";
+    String result = PGbytea.toPGLiteral(input, SqlSerializationContext.of(true, true));
+    assertEquals(expected, result);
+  }
+
+  @Test
+  void toPGLiteral_validString_zeroByte() throws IOException {
+    String input = "\\x00";
+    String expected = "'\\x00'::bytea";
+    String result = PGbytea.toPGLiteral(input, SqlSerializationContext.of(true, true));
+    assertEquals(expected, result);
+  }
+
+  @Test
+  void toPGLiteral_deprecatedMethod_validString() throws IOException {
+    String input = "\\xcafebabe";
+    String expected = "'\\xcafebabe'::bytea";
+    @SuppressWarnings("deprecation")
+    String result = PGbytea.toPGLiteral(input);
+    assertEquals(expected, result);
   }
 }

--- a/pgjdbc/src/test/java/org/postgresql/util/PGbyteaTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/util/PGbyteaTest.java
@@ -95,8 +95,7 @@ class PGbyteaTest {
         Arguments.of("\\xcafegabe", "Invalid bytea hex format character g", "invalid hex character"),
         Arguments.of("\\xcafe@abe", "Invalid bytea hex format character @", "invalid hex character symbol"),
         Arguments.of("\\xcafebab", "Truncated bytea hex format", "odd number of hex digits"),
-        Arguments.of("\\xcafe b", "Truncated bytea hex format", "truncated after whitespace"),
-        Arguments.of("\\xcafe\u1234abe", "Invalid bytea hex format character \u1234", "high unicode character")
+        Arguments.of("\\xcafe b", "Truncated bytea hex format", "truncated after whitespace")
     );
   }
 


### PR DESCRIPTION
One thing.

Do we really want to allow whitespace in the hex encoded parameter?

Also fixed the error message which had an `'` in it which stopped MessageFormat from formatting the message properly