### PR TITLE
fix: Change "PST" timezone in TimestampTest to "Pacific Standard Time"

### DIFF
--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/TimestampTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/TimestampTest.java
@@ -619,7 +619,7 @@ public class TimestampTest extends BaseTest4 {
   }
 
   private static final Timestamp TS1WTZ =
-      getTimestamp(1950, 2, 7, 15, 0, 0, 100000000, "PST");
+      getTimestamp(1950, 2, 7, 15, 0, 0, 100000000, "Pacific Standard Time");
   private static final String TS1WTZ_PGFORMAT = "1950-02-07 15:00:00.1-08";
 
   private static final Timestamp TS2WTZ =


### PR DESCRIPTION
The timestamp specifier "PST" can be misinterpreted as "Philippine Standard Time" causing the test to fail if Java selects it. Use an unambiguous timezone specifier to ensure desired behaviour.

No breaking changes.

