### PR TITLE
chore: use bump org.apache.bcel:bcel test dependency in testCompileClasspath as well

### DIFF
--- a/pgjdbc-osgi-test/build.gradle.kts
+++ b/pgjdbc-osgi-test/build.gradle.kts
@@ -14,6 +14,11 @@ val pgjdbcRepository by configurations.creating {
 }
 
 dependencies {
+    constraints {
+        testImplementation("org.apache.bcel:bcel:6.10.0") {
+            because("classloader-leak-test-framework uses bcel, and we want addressing CVEs")
+        }
+    }
     pgjdbcRepository(projects.postgresql)
 
     testImplementation(projects.postgresql) {
@@ -38,9 +43,6 @@ dependencies {
     testRuntimeOnly(platform("org.ow2.asm:asm-bom:9.8"))
     testRuntimeOnly("org.apache.aries.spifly:org.apache.aries.spifly.dynamic.bundle:1.3.7")
     testImplementation("se.jiderhamn:classloader-leak-test-framework:1.1.2")
-    testRuntimeOnly("org.apache.bcel:bcel:6.10.0") {
-        because("classloader-leak-test-framework uses bcel, and we want addressing CVEs")
-    }
 }
 
 // <editor-fold defaultstate="collapsed" desc="Pass dependency versions to pax-exam container">


### PR DESCRIPTION
Previously, bcel was updated only in testRuntimeClasspath, so it triggered alarms like "old BCEL used in compilation".

Now we use an updated bcel for both compile and the runtime, and we use constraints rather than direct dependency, so bcel no longer participates in the classpath if third-party libraries move away from bcel.
