### PR TITLE
Add configurable boolean-to-numeric conversion for ResultSet getters

### DIFF
--- a/docs/content/documentation/use.md
+++ b/docs/content/documentation/use.md
@@ -191,6 +191,10 @@ or 'statement XXX is not valid' so JDBC driver rolls back and retries
 * **`cleanupSavepoints (`*boolean*`)`** *Default `false`*\
 Determines if the SAVEPOINT created in autosave mode is released prior to the statement. This is done to avoid running out of shared buffers on the server in the case where 1000's of queries are performed.
 
+* **`convertBooleanToNumeric (`*boolean*`)`** *Default `false`*\
+Enable automatic conversion of PostgreSQL boolean values ('t'/'f') to numeric types (1/0) when using numeric getters (`getByte`, `getInt`, `getLong`, `getShort`) on ResultSet.
+When enabled, boolean columns containing 't' will return 1, and 'f' will return 0 instead of throwing a conversion exception.
+
 * **`channelBinding (`*String*`)`** *Default `prefer`*\
 This option controls the client's use of channel binding. A setting of `require` means that the connection must employ channel binding, `prefer` means that the client will choose channel binding if available, and `disable` prevents the use of channel binding. The default is `prefer` if PostgreSQL is compiled with SSL support; otherwise the default is `disable`.
 

--- a/docs/content/documentation/use.md
+++ b/docs/content/documentation/use.md
@@ -192,7 +192,7 @@ or 'statement XXX is not valid' so JDBC driver rolls back and retries
 Determines if the SAVEPOINT created in autosave mode is released prior to the statement. This is done to avoid running out of shared buffers on the server in the case where 1000's of queries are performed.
 
 * **`convertBooleanToNumeric (`*boolean*`)`** *Default `false`*\
-Enable automatic conversion of PostgreSQL boolean values ('t'/'f') to numeric types (1/0) when using numeric getters (`getByte`, `getInt`, `getLong`, `getShort`) on ResultSet.
+Enable automatic conversion of PostgreSQL boolean values ('t'/'f') to numeric types (1/0) when using numeric getters (`getByte`, `getShort`, `getInt`, `getLong`, `getFloat`, `getDouble`, `getBigDecimal`) on ResultSet.
 When enabled, boolean columns containing 't' will return 1, and 'f' will return 0 instead of throwing a conversion exception.
 
 * **`channelBinding (`*String*`)`** *Default `prefer`*\

--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -832,6 +832,17 @@ public enum PGProperty {
       "",
       "Factory class to instantiate factories for XML processing"),
 
+  /**
+   * Enable automatic conversion of PostgreSQL boolean values ('t'/'f') to numeric types (1/0).
+   * When enabled, calling numeric getters (getByte, getInt, getLong, getShort) on boolean columns
+   * will convert 't' to 1 and 'f' to 0 instead of throwing a conversion exception.
+   * Default is false to maintain backward compatibility.
+   */
+  CONVERT_BOOLEAN_TO_NUMERIC(
+      "convertBooleanToNumeric",
+      "false",
+      "Enable automatic conversion of PostgreSQL boolean values ('t'/'f') to numeric types (1/0)"),
+
   ;
 
   private final String name;

--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -181,6 +181,17 @@ public enum PGProperty {
       "The timeout value in seconds used for socket connect operations."),
 
   /**
+   * Enable automatic conversion of PostgreSQL boolean values ('t'/'f') to numeric types (1/0).
+   * When enabled, calling numeric getters (getByte, getShort, getInt, getLong, getFloat, getDouble, getBigDecimal) on boolean columns
+   * will convert 't' to 1 and 'f' to 0 instead of throwing a conversion exception.
+   * Default is false to maintain backward compatibility.
+   */
+  CONVERT_BOOLEAN_TO_NUMERIC(
+      "convertBooleanToNumeric",
+      "false",
+      "Enable automatic conversion of PostgreSQL boolean values ('t'/'f') to numeric types (1/0)"),
+
+  /**
    * Specify the schema (or several schema separated by commas) to be set in the search-path. This schema will be used to resolve
    * unqualified object names used in statements over this connection.
    */
@@ -831,17 +842,6 @@ public enum PGProperty {
       "xmlFactoryFactory",
       "",
       "Factory class to instantiate factories for XML processing"),
-
-  /**
-   * Enable automatic conversion of PostgreSQL boolean values ('t'/'f') to numeric types (1/0).
-   * When enabled, calling numeric getters (getByte, getInt, getLong, getShort) on boolean columns
-   * will convert 't' to 1 and 'f' to 0 instead of throwing a conversion exception.
-   * Default is false to maintain backward compatibility.
-   */
-  CONVERT_BOOLEAN_TO_NUMERIC(
-      "convertBooleanToNumeric",
-      "false",
-      "Enable automatic conversion of PostgreSQL boolean values ('t'/'f') to numeric types (1/0)"),
 
   ;
 

--- a/pgjdbc/src/main/java/org/postgresql/core/BaseConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/BaseConnection.java
@@ -238,4 +238,10 @@ public interface BaseConnection extends PGConnection, Connection {
    * @return true if should be included and passed on to other exceptions
    */
   boolean getLogServerErrorDetail();
+
+  /**
+   * Returns true if boolean values should be converted to numeric types (1/0).
+   * @return true if boolean to numeric conversion is enabled
+   */
+  boolean getConvertBooleanToNumeric();
 }

--- a/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
+++ b/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
@@ -991,6 +991,22 @@ public abstract class BaseDataSource implements CommonDataSource, Referenceable 
   }
 
   /**
+   * @return convertBooleanToNumeric
+   * @see PGProperty#CONVERT_BOOLEAN_TO_NUMERIC
+   */
+  public boolean getConvertBooleanToNumeric() {
+    return PGProperty.CONVERT_BOOLEAN_TO_NUMERIC.getBoolean(properties);
+  }
+
+  /**
+   * @param convertBooleanToNumeric convertBooleanToNumeric
+   * @see PGProperty#CONVERT_BOOLEAN_TO_NUMERIC
+   */
+  public void setConvertBooleanToNumeric(boolean convertBooleanToNumeric) {
+    PGProperty.CONVERT_BOOLEAN_TO_NUMERIC.set(properties, convertBooleanToNumeric);
+  }
+
+  /**
    * @return current schema
    * @see PGProperty#CURRENT_SCHEMA
    */

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
@@ -204,6 +204,8 @@ public class PgConnection implements BaseConnection {
   private final boolean logServerErrorDetail;
   // Bind String to UNSPECIFIED or VARCHAR?
   private final boolean bindStringAsVarchar;
+  // Convert boolean values to numeric types?
+  private final boolean convertBooleanToNumeric;
 
   // Current warnings; there might be more on queryExecutor too.
   private @Nullable SQLWarning firstWarning;
@@ -363,6 +365,7 @@ public class PgConnection implements BaseConnection {
     finalizeAction = new PgConnectionCleaningAction(lock, openStackTrace, queryExecutor.getCloseAction());
     this.logServerErrorDetail = PGProperty.LOG_SERVER_ERROR_DETAIL.getBoolean(info);
     this.disableColumnSanitiser = PGProperty.DISABLE_COLUMN_SANITISER.getBoolean(info);
+    this.convertBooleanToNumeric = PGProperty.CONVERT_BOOLEAN_TO_NUMERIC.getBoolean(info);
 
     if (haveMinimumServerVersion(ServerVersion.v8_3)) {
       typeCache.addCoreType("uuid", Oid.UUID, Types.OTHER, "java.util.UUID", Oid.UUID_ARRAY);
@@ -1661,6 +1664,11 @@ public class PgConnection implements BaseConnection {
   @Override
   public boolean getLogServerErrorDetail() {
     return logServerErrorDetail;
+  }
+
+  @Override
+  public boolean getConvertBooleanToNumeric() {
+    return convertBooleanToNumeric;
   }
 
   @Override

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
@@ -37,6 +37,7 @@ import org.postgresql.util.PSQLState;
 import org.checkerframework.checker.index.qual.NonNegative;
 import org.checkerframework.checker.index.qual.Positive;
 import org.checkerframework.checker.nullness.qual.EnsuresNonNull;
+import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.checker.nullness.qual.PolyNull;
 import org.checkerframework.checker.nullness.qual.RequiresNonNull;
@@ -2493,7 +2494,7 @@ public class PgResultSet implements ResultSet, PGRefCursorResultSet {
   private static final BigInteger BYTEMIN = new BigInteger(Byte.toString(Byte.MIN_VALUE));
 
   // Cache for the boolean conversion property to avoid repeated property lookups
-  private Boolean convertBooleanToNumericCache;
+  private @MonotonicNonNull Boolean convertBooleanToNumericCache;
 
   /**
    * Helper method to check if boolean-to-numeric conversion should be attempted.
@@ -2519,28 +2520,23 @@ public class PgResultSet implements ResultSet, PGRefCursorResultSet {
       return -1;
     }
 
-    // Safety check for column bounds
-    int col = columnIndex - 1;
-    if (col < 0 || col >= fields.length) {
-      return -1;
-    }
-
     String trimmed = stringValue.trim();
     if (trimmed.isEmpty()) {
       return -1;
     }
 
     // Check if the column is actually a boolean type for better accuracy
+    int col = columnIndex - 1;
     boolean isBooleanColumn = fields[col].getOID() == Oid.BOOL;
 
     if (isBooleanColumn) {
       // This is definitely a boolean column, so be more permissive with conversion
       if (trimmed.length() == 1) {
         char c = trimmed.charAt(0);
-        if (c == 't' || c == 'T') {
+        if (c == 't') {
           return 1;
         }
-        if (c == 'f' || c == 'F') {
+        if (c == 'f') {
           return 0;
         }
       }
@@ -2556,10 +2552,10 @@ public class PgResultSet implements ResultSet, PGRefCursorResultSet {
       // Not a boolean column, only convert obvious boolean values to avoid false positives
       if (trimmed.length() == 1) {
         char c = trimmed.charAt(0);
-        if (c == 't' || c == 'T') {
+        if (c == 't') {
           return 1;
         }
-        if (c == 'f' || c == 'F') {
+        if (c == 'f') {
           return 0;
         }
       }

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
@@ -2498,8 +2498,8 @@ public class PgResultSet implements ResultSet, PGRefCursorResultSet {
 
   /**
    * Helper method to check if boolean-to-numeric conversion should be attempted.
-   * If convertBooleanToNumeric property is enabled and the string value is a PostgreSQL
-   * boolean ('t', 'f', 'true', 'false' etc), converts to appropriate numeric value.
+   * If convertBooleanToNumeric property is enabled and the column is a boolean type,
+   * converts PostgreSQL boolean values ('t' or 'f') to numeric values (1 or 0).
    *
    * @param stringValue the string value from the database
    * @param columnIndex the column index to check if it's a boolean column
@@ -2529,35 +2529,14 @@ public class PgResultSet implements ResultSet, PGRefCursorResultSet {
     int col = columnIndex - 1;
     boolean isBooleanColumn = fields[col].getOID() == Oid.BOOL;
 
-    if (isBooleanColumn) {
-      // This is definitely a boolean column, so be more permissive with conversion
-      if (trimmed.length() == 1) {
-        char c = trimmed.charAt(0);
-        if (c == 't') {
-          return 1;
-        }
-        if (c == 'f') {
-          return 0;
-        }
-      }
-
-      // Handle full boolean strings for boolean columns
-      if ("true".equalsIgnoreCase(trimmed)) {
+    // Only check for boolean values if it's actually a boolean column to avoid false positives
+    if (isBooleanColumn && trimmed.length() == 1) {
+      char c = trimmed.charAt(0);
+      if (c == 't') {
         return 1;
       }
-      if ("false".equalsIgnoreCase(trimmed)) {
+      if (c == 'f') {
         return 0;
-      }
-    } else {
-      // Not a boolean column, only convert obvious boolean values to avoid false positives
-      if (trimmed.length() == 1) {
-        char c = trimmed.charAt(0);
-        if (c == 't') {
-          return 1;
-        }
-        if (c == 'f') {
-          return 0;
-        }
       }
     }
 

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
@@ -2814,7 +2814,15 @@ public class PgResultSet implements ResultSet, PGRefCursorResultSet {
       return (float) readDoubleValue(value, oid, "float");
     }
 
-    return toFloat(getFixedString(columnIndex));
+    String s = getFixedString(columnIndex);
+
+    // Check if this might be a boolean value that should be converted to numeric
+    int booleanValue = tryConvertBooleanToNumeric(s, columnIndex);
+    if (booleanValue != -1) {
+      return (float) booleanValue;
+    }
+
+    return toFloat(s);
   }
 
   @Pure
@@ -2835,7 +2843,15 @@ public class PgResultSet implements ResultSet, PGRefCursorResultSet {
       return readDoubleValue(value, oid, "double");
     }
 
-    return toDouble(getFixedString(columnIndex));
+    String s = getFixedString(columnIndex);
+
+    // Check if this might be a boolean value that should be converted to numeric
+    int booleanValue = tryConvertBooleanToNumeric(s, columnIndex);
+    if (booleanValue != -1) {
+      return (double) booleanValue;
+    }
+
+    return toDouble(s);
   }
 
   @Override
@@ -2891,6 +2907,14 @@ public class PgResultSet implements ResultSet, PGRefCursorResultSet {
     }
 
     String stringValue = getFixedString(columnIndex);
+
+    // Check if this might be a boolean value that should be converted to numeric
+    int booleanValue = tryConvertBooleanToNumeric(stringValue, columnIndex);
+    if (booleanValue != -1) {
+      BigDecimal res = BigDecimal.valueOf(booleanValue);
+      return scaleBigDecimal(res, scale);
+    }
+
     if (allowSpecial) {
       if ("NaN".equalsIgnoreCase(stringValue)) {
         return Double.NaN;

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
@@ -2505,7 +2505,7 @@ public class PgResultSet implements ResultSet, PGRefCursorResultSet {
    * @param columnIndex the column index to check if it's a boolean column
    * @return numeric value (0 or 1) if conversion applied, -1 if no conversion needed
    */
-  private int tryConvertBooleanToNumeric(String stringValue, int columnIndex) {
+  private int tryConvertBooleanToNumeric(@Nullable String stringValue, int columnIndex) {
     if (stringValue == null || stringValue.isEmpty()) {
       return -1;
     }

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/AbstractArraysTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/AbstractArraysTest.java
@@ -1114,5 +1114,10 @@ public abstract class AbstractArraysTest<A> {
     public boolean getLogServerErrorDetail() {
       return false;
     }
+
+    @Override
+    public boolean getConvertBooleanToNumeric() {
+      return false;
+    }
   }
 }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ResultSetTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ResultSetTest.java
@@ -1490,15 +1490,15 @@ public class ResultSetTest extends BaseTest4 {
         assertFalse(rs.getBoolean("bool_col"));
       }
 
-      // Test text column with 't'/'f' values
+      // Test text column with 't'/'f' values - should NOT be converted (not boolean column)
       try (ResultSet rs = stmt.executeQuery("SELECT 't'::text AS text_col")) {
         assertTrue(rs.next());
-        assertEquals(1, rs.getInt("text_col"));
+        assertThrows(PSQLException.class, () -> rs.getInt("text_col"));
       }
 
       try (ResultSet rs = stmt.executeQuery("SELECT 'f'::text AS text_col")) {
         assertTrue(rs.next());
-        assertEquals(0, rs.getInt("text_col"));
+        assertThrows(PSQLException.class, () -> rs.getInt("text_col"));
       }
     }
   }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ResultSetTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ResultSetTest.java
@@ -1455,6 +1455,9 @@ public class ResultSetTest extends BaseTest4 {
       assertThrows(PSQLException.class, () -> rs.getInt("bool_col"));
       assertThrows(PSQLException.class, () -> rs.getLong("bool_col"));
       assertThrows(PSQLException.class, () -> rs.getShort("bool_col"));
+      assertThrows(PSQLException.class, () -> rs.getFloat("bool_col"));
+      assertThrows(PSQLException.class, () -> rs.getDouble("bool_col"));
+      assertThrows(PSQLException.class, () -> rs.getBigDecimal("bool_col"));
 
       // getBoolean should still work
       assertTrue(rs.getBoolean("bool_col"));
@@ -1477,6 +1480,9 @@ public class ResultSetTest extends BaseTest4 {
         assertEquals(1, rs.getInt("bool_col"));
         assertEquals(1L, rs.getLong("bool_col"));
         assertEquals((short) 1, rs.getShort("bool_col"));
+        assertEquals(1.0f, rs.getFloat("bool_col"));
+        assertEquals(1.0, rs.getDouble("bool_col"));
+        assertEquals(new BigDecimal("1"), rs.getBigDecimal("bool_col"));
         assertTrue(rs.getBoolean("bool_col"));
       }
 
@@ -1487,6 +1493,9 @@ public class ResultSetTest extends BaseTest4 {
         assertEquals(0, rs.getInt("bool_col"));
         assertEquals(0L, rs.getLong("bool_col"));
         assertEquals((short) 0, rs.getShort("bool_col"));
+        assertEquals(0.0f, rs.getFloat("bool_col"));
+        assertEquals(0.0, rs.getDouble("bool_col"));
+        assertEquals(new BigDecimal("0"), rs.getBigDecimal("bool_col"));
         assertFalse(rs.getBoolean("bool_col"));
       }
 


### PR DESCRIPTION
Addresses: https://github.com/pgjdbc/pgjdbc/issues/367

### Problem:
  When calling numeric getters (getByte(), getInt(), getLong(), getShort(), getFloat(), getDouble(), getBigDecimal()) on PostgreSQL boolean columns, the driver
  throws PSQLException: Bad value for type byte : f. 

  ### Solution:
  Added a new connection property `convertBooleanToNumeric` that enables automatic conversion of PostgreSQL boolean values to numeric types:
  - 't' → 1
  - 'f' → 0
  - Works with boolean columns
  - Property cached per connection for optimal performance
  - Boolean column type detection prevents false positive conversions

  ### Usage:
  // JDBC URL
  jdbc:postgresql://host:5432/db?convertBooleanToNumeric=true

  // HikariCP
  config.addDataSourceProperty("convertBooleanToNumeric", "true");

  // Spring Boot
  spring.datasource.hikari.data-source-properties.convertBooleanToNumeric=true

  ### Backward Compatibility:
  - Default: false (maintains existing behavior)
  - getBoolean() continues working regardless of property setting
  - No changes to existing application behavior unless explicitly enabled


### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Does `./gradlew styleCheck` pass ?
3. [x] Have you added your new test classes to an existing test suite in alphabetical order?

### Changes to Existing Features:

* [x] Does this break existing behaviour? If so please explain.
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
