### PR TITLE
Fix getNotifications() documentation

### DIFF
--- a/docs/content/documentation/server-prepare.md
+++ b/docs/content/documentation/server-prepare.md
@@ -163,9 +163,8 @@ class Listener extends Thread {
                 // receive notifications immediately:
                 // org.postgresql.PGNotification notifications[] = pgconn.getNotifications(10000);
 
-                if (notifications != null) {
-                    for (int i = 0; i < notifications.length; i++)
-                        System.out.println("Got notification: " + notifications[i].getName());
+                for (int i = 0; i < notifications.length; i++) {
+                    System.out.println("Got notification: " + notifications[i].getName());
                 }
 
                 // wait a while before checking again for new

--- a/pgjdbc/src/main/java/org/postgresql/PGConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGConnection.java
@@ -53,7 +53,7 @@ public interface PGConnection {
 
   /**
    * This method returns any notifications that have been received since the last call to this
-   * method. Returns null if there have been no notifications.
+   * method. Returns an empty array if there have been no notifications.
    *
    * @return notifications that have been received
    * @throws SQLException if something wrong happens
@@ -63,8 +63,8 @@ public interface PGConnection {
 
   /**
    * This method returns any notifications that have been received since the last call to this
-   * method. Returns null if there have been no notifications. A timeout can be specified so the
-   * driver waits for notifications.
+   * method. Returns an empty array if there have been no notifications. A timeout can be specified
+   * so the driver waits for notifications.
    *
    * @param timeoutMillis when 0, blocks forever. when &gt; 0, blocks up to the specified number of millis
    *        or until at least one notification has been received. If more than one notification is

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/NotifyTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/NotifyTest.java
@@ -40,6 +40,14 @@ class NotifyTest {
 
   @Test
   @Timeout(60)
+  void testNoNotifications() throws SQLException {
+    PGNotification[] notifications = conn.unwrap(PGConnection.class).getNotifications();
+    assertNotNull(notifications);
+    assertEquals(0, notifications.length);
+  }
+
+  @Test
+  @Timeout(60)
   void testNotify() throws SQLException {
     Statement stmt = conn.createStatement();
     stmt.executeUpdate("LISTEN mynotification");


### PR DESCRIPTION
These methods return an empty array if there have been no notifications, not null. Update the documentation and add a test. Fixes #3798

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
