### PR TITLE
chore: fix published project name

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,7 +40,7 @@ dependencies {
     // nmcpAggregation declares the list of projects should be published to Central Portal
     // Currently we publish a single project only, however, if we add more, we need to add them here
     // as well.
-    nmcpAggregation(projects.pgjdbc)
+    nmcpAggregation(projects.postgresql)
 }
 
 jacoco {


### PR DESCRIPTION
`projects.pgjdbc` is the root project (it makes no sense publishing it)
`projects.postgresql` is the dirver jar (it should be published)
