### PR TITLE
fix: attach the released jar and signature to the GitHub release

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -20,9 +20,6 @@ jobs:
     permissions:
       # write permission is required to create a github release
       contents: write
-    env:
-      # Publish pre-release files to a draft release
-      PUBLISH_SNAPSHOT: true
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
       - name: Get the current version
@@ -53,53 +50,3 @@ jobs:
            version: ${{ steps.current_version.outputs.result }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Checkout sources
-        if: ${{ env.PUBLISH_SNAPSHOT == 'true' }}
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - name: Set up JDK 17
-        if: ${{ env.PUBLISH_SNAPSHOT == 'true' }}
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
-        with:
-          java-version: 17
-          distribution: liberica
-      - name: Build
-        if: ${{ env.PUBLISH_SNAPSHOT == 'true' }}
-        uses: burrunan/gradle-cache-action@4b67497abd37a511d6c1dc6299bdd84ff39f7bf5 # v3.0.2
-        with:
-          job-id: jdk17
-          arguments: --scan --no-parallel --no-daemon :postgresql:osgiJar
-      - name: Attach files to release
-        if: ${{ env.PUBLISH_SNAPSHOT == 'true' }}
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
-        env:
-          # https://github.com/release-drafter/release-drafter#action-outputs
-          RELEASE_ID: ${{ steps.prepare_release.outputs.id }}
-        with:
-          # language=JavaScript
-          script: |
-            const fs = require('fs');
-            const {RELEASE_ID} = process.env;
-            // remove old jar files from the release
-            const assets = await github.rest.repos.listReleaseAssets({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                release_id: RELEASE_ID
-            });
-            for (const asset of assets.data) {
-                if (asset.name.endsWith('.jar')) {
-                    await github.rest.repos.deleteReleaseAsset({
-                        owner: context.repo.owner,
-                        repo: context.repo.repo,
-                        asset_id: asset.id
-                    });
-                }
-            }
-            const globber = await glob.create('pgjdbc/build/libs/postgresql-*-osgi.jar');
-            const files = await globber.glob();
-            await github.rest.repos.uploadReleaseAsset({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                name: files[0].replace(/^(.*build\/libs\/postgresql-)/, "postgresql-").replace("-osgi", ""),
-                release_id: RELEASE_ID,
-                data: fs.readFileSync(files[0])
-            })

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,10 +105,13 @@ jobs:
 
       # Publish to Central before generating a tag, so we don't need to drop the tag if
       # Central deployment fails.
+      # publishAllPublicationsToTmp-mavenRepository stages the signed artifacts under
+      # pgjdbc/build/local-maven-repo in the same Gradle run, so the jar and signature attached to
+      # the GitHub release below are byte-for-byte the ones uploaded to Central.
       - name: Publish to Central Portal
         uses: burrunan/gradle-cache-action@4b67497abd37a511d6c1dc6299bdd84ff39f7bf5 # v3.0.2
         with:
-          arguments: publishAggregationToCentralPortal
+          arguments: publishAggregationToCentralPortal :postgresql:publishAllPublicationsToTmp-mavenRepository
           # language=properties
           properties: |
             release=true
@@ -129,6 +132,62 @@ jobs:
           version: ${{ steps.release_version.outputs.version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Must run after "Publish GitHub release" (the release has to exist) and before the version
+      # bump below, whose push triggers release-drafter for the next version's draft.
+      - name: Attach files to the release
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        env:
+          # https://github.com/release-drafter/release-drafter#action-outputs
+          RELEASE_ID: ${{ steps.publish_release.outputs.id }}
+          VERSION: ${{ steps.release_version.outputs.version }}
+        with:
+          # language=JavaScript
+          script: |
+            const fs = require('fs');
+            const {RELEASE_ID, VERSION} = process.env;
+            // The jar and its detached PGP signature staged by the publish step. Paths are fixed,
+            // so a missing file means the publish step failed to produce it.
+            const artifactDir = `pgjdbc/build/local-maven-repo/org/postgresql/postgresql/${VERSION}`;
+            const artifactName = `postgresql-${VERSION}.jar`;
+            const uploadFiles = [
+                [artifactName, `${artifactDir}/${artifactName}`],
+                [`${artifactName}.asc`, `${artifactDir}/${artifactName}.asc`],
+            ];
+            for (const [name, filePath] of uploadFiles) {
+                if (!fs.existsSync(filePath)) {
+                    core.setFailed(`Release artifact ${name} not found at ${filePath}. Check that the publish step ran publishAllPublicationsToTmp-mavenRepository.`);
+                    return;
+                }
+            }
+            // Drop any stale jar/signature assets (e.g. a SNAPSHOT jar carried over on an older
+            // draft) before re-uploading. This assumes the release ships exactly uploadFiles; widen
+            // the filter if more jars are ever attached.
+            const assets = await github.rest.repos.listReleaseAssets({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                release_id: RELEASE_ID
+            });
+            for (const asset of assets.data) {
+                if (asset.name.endsWith('.jar') || asset.name.endsWith('.jar.asc')) {
+                    core.info(`Deleting stale release asset ${asset.name}`);
+                    await github.rest.repos.deleteReleaseAsset({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        asset_id: asset.id
+                    });
+                }
+            }
+            for (const [name, filePath] of uploadFiles) {
+                core.info(`Uploading ${name} from ${filePath}`);
+                await github.rest.repos.uploadReleaseAsset({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    name,
+                    release_id: RELEASE_ID,
+                    data: fs.readFileSync(filePath)
+                });
+            }
 
       - name: Compute the next patch version
         id: next_version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 * chore: `commitPrepared` / `rollback`-of-prepared now return `XAER_RMFAIL` instead of `XAER_RMERR` when the underlying connection is left in a non-idle `TransactionState`. Transaction managers (Geronimo, Narayana, Atomikos) treat `XAER_RMFAIL` as retryable on a fresh `XAResource`; the prepared transaction is no longer abandoned.
 
 ### Fixed
+* fix: the published GitHub release now ships the released `postgresql-<version>.jar` and its detached PGP signature, taken from the same signed build that is uploaded to Maven Central, instead of a leftover SNAPSHOT jar [Issue #3812](https://github.com/pgjdbc/pgjdbc/issues/3812) [PR #3814](https://github.com/pgjdbc/pgjdbc/pull/3814)
 * fix: simplify the `Statement#cancel` state machine by dropping the redundant `CANCELLED` state. `killTimerTask` now waits for the state to return to `IDLE` directly, which removes a spin-forever case when more than one thread observes the cancel completing [PR #1827](https://github.com/pgjdbc/pgjdbc/pull/1827).
 * fix: the driver no longer nulls the `contextClassLoader` of shared `ForkJoinPool.commonPool()` worker threads, which previously left unrelated tasks on those threads running with a `null` classloader [Issue #4155](https://github.com/pgjdbc/pgjdbc/issues/4155)
 * fix: getCharacterStream wraps String in StringReader [PR #4063](https://github.com/pgjdbc/pgjdbc/pull/4063)


### PR DESCRIPTION
## Why

Fixes #3812. The published GitHub release shipped a SNAPSHOT jar. The attach lived in the per-push draft path (`release-drafter.yml`), which refreshed the draft with a SNAPSHOT `osgi` jar on every push to `master`; that asset then carried over when the draft was published.

## What

- Move the release-asset attach into `release.yml`, after `Publish GitHub release`. The published release now carries the actual `postgresql-<version>.jar` and its `.asc` signature.
- The publish step also runs `:postgresql:publishAllPublicationsToTmp-mavenRepository`, staging the signed artifacts under `pgjdbc/build/local-maven-repo` in the same Gradle run that uploads to Central, so the attached files are byte-for-byte the ones published to Maven Central. (`createReleaseBundle` keeps the `-osgi` classifier in the on-disk jar name; the local Maven repo gives the flat `postgresql-<version>.jar` with no rename.)
- Remove the per-push SNAPSHOT build and attach from `release-drafter.yml`. Draft releases no longer carry a jar between releases — this behaviour change is noted in the CHANGELOG.

## How to verify

Locally, with a throwaway signing key:

```
./gradlew :postgresql:publishAllPublicationsToTmp-mavenRepository -Prelease
```

Confirm `pgjdbc/build/local-maven-repo/org/postgresql/postgresql/<version>/` contains `postgresql-<version>.jar` and `postgresql-<version>.jar.asc`, and that `gpg --verify postgresql-<version>.jar.asc postgresql-<version>.jar` passes. The attach step reads exactly those two paths.