### PR TITLE
fix: support java.time values in updatable ResultSet updateRow()/insertRow()

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
@@ -2110,25 +2110,46 @@ public class PgResultSet implements ResultSet, PGRefCursorResultSet {
         // toString() isn't enough for date and time types; we must format it correctly
         // or we won't be able to re-parse it.
         //
-        case Types.DATE:
-          rowBuffer.set(columnIndex, connection
-              .encodeString(
-                  getTimestampUtils().toString(
-                      getDefaultCalendar(), (Date) valueObject)));
+        case Types.DATE: {
+          // getObject(int, LocalDate.class) returns LocalDate, so updating the row buffer with
+          // such a value must not assume it is always a java.sql.Date.
+          String stringValue = valueObject instanceof LocalDate
+              ? getTimestampUtils().toString((LocalDate) valueObject)
+              : getTimestampUtils().toString(getDefaultCalendar(), (Date) valueObject);
+          rowBuffer.set(columnIndex, connection.encodeString(stringValue));
           break;
+        }
 
-        case Types.TIME:
-          rowBuffer.set(columnIndex, connection
-              .encodeString(
-                  getTimestampUtils().toString(
-                      getDefaultCalendar(), (Time) valueObject)));
+        case Types.TIME: {
+          // time and timetz both map to Types.TIME, so the value can be java.sql.Time,
+          // java.time.LocalTime (time) or java.time.OffsetTime (timetz).
+          String stringValue;
+          if (valueObject instanceof OffsetTime) {
+            stringValue = getTimestampUtils().toString((OffsetTime) valueObject);
+          } else if (valueObject instanceof LocalTime) {
+            stringValue = getTimestampUtils().toString((LocalTime) valueObject);
+          } else {
+            stringValue = getTimestampUtils().toString(getDefaultCalendar(), (Time) valueObject);
+          }
+          rowBuffer.set(columnIndex, connection.encodeString(stringValue));
           break;
+        }
 
-        case Types.TIMESTAMP:
-          rowBuffer.set(columnIndex, connection.encodeString(
-              getTimestampUtils().toString(
-                  getDefaultCalendar(), (Timestamp) valueObject)));
+        case Types.TIMESTAMP: {
+          // timestamp and timestamptz both map to Types.TIMESTAMP, so the value can be
+          // java.sql.Timestamp, java.time.LocalDateTime (timestamp)
+          // or java.time.OffsetDateTime (timestamptz).
+          String stringValue;
+          if (valueObject instanceof OffsetDateTime) {
+            stringValue = getTimestampUtils().toString((OffsetDateTime) valueObject);
+          } else if (valueObject instanceof LocalDateTime) {
+            stringValue = getTimestampUtils().toString((LocalDateTime) valueObject);
+          } else {
+            stringValue = getTimestampUtils().toString(getDefaultCalendar(), (Timestamp) valueObject);
+          }
+          rowBuffer.set(columnIndex, connection.encodeString(stringValue));
           break;
+        }
 
         case Types.NULL:
           // Should never happen?

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/UpdateableResultTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/UpdateableResultTest.java
@@ -35,6 +35,12 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Timestamp;
 import java.sql.Types;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.ZoneOffset;
 import java.util.TimeZone;
 
 @Isolated("Uses TimeZone.setDefault")
@@ -61,6 +67,8 @@ public class UpdateableResultTest extends BaseTest4 {
       TestUtil.execute(con, "ALTER TABLE multicol ADD CONSTRAINT multicol_pk PRIMARY KEY (id1, id2)");
       TestUtil.createTable(con, "nopkmulticol", "id1 int not null, id2 int not null, val text");
       TestUtil.createTable(con, "booltable", "id int not null primary key, b boolean default false");
+      TestUtil.createTable(con, "datetimetable", "id int not null primary key, "
+          + "ttz timetz, tstz timestamptz, ts timestamp, d date, t time");
     }
   }
 
@@ -75,6 +83,7 @@ public class UpdateableResultTest extends BaseTest4 {
       TestUtil.dropTable(con, "multicol");
       TestUtil.dropTable(con, "nopkmulticol");
       TestUtil.dropTable(con, "booltable");
+      TestUtil.dropTable(con, "datetimetable");
       TestUtil.dropTable(con, "unique_null_constraint");
       TestUtil.dropTable(con, "hasdate");
       TestUtil.dropTable(con, "uniquekeys");
@@ -101,9 +110,11 @@ public class UpdateableResultTest extends BaseTest4 {
     TestUtil.execute(con, "TRUNCATE multicol CASCADE");
     TestUtil.execute(con, "TRUNCATE nopkmulticol");
     TestUtil.execute(con, "TRUNCATE booltable CASCADE");
+    TestUtil.execute(con, "TRUNCATE datetimetable");
     TestUtil.execute(con, "ALTER SEQUENCE serialtable_gen_id_seq RESTART WITH 1");
 
     TestUtil.execute(con, "insert into booltable (id) values (1)");
+    TestUtil.execute(con, "insert into datetimetable (id) values (1)");
     TestUtil.execute(con, "insert into uniquekeys(id, id2, dt) values (1, 2, now())");
     TestUtil.execute(con, "insert into second values (1,'anyvalue' )");
     TestUtil.execute(con, "insert into unique_null_constraint values (1, 'dave')");
@@ -921,5 +932,112 @@ public class UpdateableResultTest extends BaseTest4 {
     }
     rs.close();
     st.close();
+  }
+
+  /*
+   * Updating an updatable ResultSet with java.time values used to throw a ClassCastException while
+   * refreshing the in-memory row buffer, even though the UPDATE itself succeeded.
+   * See https://github.com/pgjdbc/pgjdbc/issues/3464
+   */
+
+  @Test
+  public void testUpdateRowWithOffsetTime() throws SQLException {
+    OffsetTime value = OffsetTime.of(LocalTime.of(12, 34, 56, 123_456_000), ZoneOffset.ofHours(-8));
+    OffsetTime fromDb = updateRowAndReselect("ttz", value, OffsetTime.class);
+    // timetz keeps the offset, but a binary fetch may re-express it in the session time zone,
+    // so compare the instant rather than the textual offset
+    assertTrue(value.isEqual(fromDb), "expected " + value + " to equal " + fromDb);
+  }
+
+  @Test
+  public void testUpdateRowWithOffsetDateTime() throws SQLException {
+    OffsetDateTime value =
+        OffsetDateTime.of(LocalDateTime.of(2024, 1, 31, 12, 34, 56, 123_456_000), ZoneOffset.ofHours(5));
+    OffsetDateTime fromDb = updateRowAndReselect("tstz", value, OffsetDateTime.class);
+    // timestamptz is stored as an instant and returned in the session time zone
+    assertTrue(value.isEqual(fromDb), "expected " + value + " to equal " + fromDb);
+  }
+
+  @Test
+  public void testUpdateRowWithLocalDateTime() throws SQLException {
+    LocalDateTime value = LocalDateTime.of(2024, 1, 31, 12, 34, 56, 123_456_000);
+    assertEquals(value, updateRowAndReselect("ts", value, LocalDateTime.class));
+  }
+
+  @Test
+  public void testUpdateRowWithLocalDate() throws SQLException {
+    LocalDate value = LocalDate.of(2024, 1, 31);
+    assertEquals(value, updateRowAndReselect("d", value, LocalDate.class));
+  }
+
+  @Test
+  public void testUpdateRowWithLocalTime() throws SQLException {
+    LocalTime value = LocalTime.of(12, 34, 56, 123_456_000);
+    assertEquals(value, updateRowAndReselect("t", value, LocalTime.class));
+  }
+
+  @Test
+  public void testInsertRowWithJavaTimeValues() throws SQLException {
+    OffsetTime ttz = OffsetTime.of(LocalTime.of(1, 2, 3, 456_000_000), ZoneOffset.ofHours(-8));
+    OffsetDateTime tstz =
+        OffsetDateTime.of(LocalDateTime.of(2024, 6, 1, 1, 2, 3, 456_000_000), ZoneOffset.ofHours(5));
+    LocalDateTime ts = LocalDateTime.of(2024, 6, 1, 1, 2, 3, 456_000_000);
+    LocalDate d = LocalDate.of(2024, 6, 1);
+    LocalTime t = LocalTime.of(1, 2, 3, 456_000_000);
+
+    try (Statement st = con.createStatement(ResultSet.TYPE_SCROLL_INSENSITIVE,
+        ResultSet.CONCUR_UPDATABLE);
+        ResultSet rs = st.executeQuery("SELECT id, ttz, tstz, ts, d, t FROM datetimetable")) {
+      rs.moveToInsertRow();
+      rs.updateInt("id", 2);
+      rs.updateObject("ttz", ttz);
+      rs.updateObject("tstz", tstz);
+      rs.updateObject("ts", ts);
+      rs.updateObject("d", d);
+      rs.updateObject("t", t);
+      // insertRow() refreshes the same row buffer as updateRow(), so it shared the bug
+      rs.insertRow();
+    }
+
+    try (Statement st = con.createStatement();
+        ResultSet rs = st.executeQuery("SELECT ttz, tstz, ts, d, t FROM datetimetable WHERE id = 2")) {
+      assertTrue(rs.next());
+      OffsetTime ttzFromDb = rs.getObject(1, OffsetTime.class);
+      OffsetDateTime tstzFromDb = rs.getObject(2, OffsetDateTime.class);
+      assertNotNull(ttzFromDb);
+      assertNotNull(tstzFromDb);
+      assertTrue(ttz.isEqual(ttzFromDb), "expected " + ttz + " to equal " + ttzFromDb);
+      assertTrue(tstz.isEqual(tstzFromDb), "expected " + tstz + " to equal " + tstzFromDb);
+      assertEquals(ts, rs.getObject(3, LocalDateTime.class));
+      assertEquals(d, rs.getObject(4, LocalDate.class));
+      assertEquals(t, rs.getObject(5, LocalTime.class));
+    }
+  }
+
+  /**
+   * Updates {@code column} of the seeded {@code datetimetable} row through an updatable
+   * {@link ResultSet} and reads the value back with a fresh query to confirm it reached the
+   * database.
+   */
+  private <T> T updateRowAndReselect(String column, T value, Class<T> type) throws SQLException {
+    try (Statement st = con.createStatement(ResultSet.TYPE_SCROLL_INSENSITIVE,
+        ResultSet.CONCUR_UPDATABLE);
+        ResultSet rs =
+            st.executeQuery("SELECT id, " + column + " FROM datetimetable WHERE id = 1")) {
+      assertTrue(rs.next(), "datetimetable must contain the seeded row with id = 1");
+      rs.updateObject(column, value);
+      // Before the fix this threw ClassCastException while refreshing the row buffer
+      rs.updateRow();
+      // The freshly written row buffer must be parseable back into the same type
+      assertNotNull(rs.getObject(column, type), "row buffer value must not be null after updateRow()");
+    }
+    try (Statement st = con.createStatement();
+        ResultSet rs =
+            st.executeQuery("SELECT " + column + " FROM datetimetable WHERE id = 1")) {
+      assertTrue(rs.next());
+      T fromDb = rs.getObject(1, type);
+      assertNotNull(fromDb);
+      return fromDb;
+    }
   }
 }


### PR DESCRIPTION
### Why

Reading a date/time column with `getObject(int, <java.time type>.class)` and writing the value straight back through an updatable `ResultSet` failed with a `ClassCastException`. The `UPDATE`/`INSERT` itself reached the database, but `updateRow()`/`insertRow()` then refreshed the in-memory row buffer in `setRowBufferColumn()`, which cast every value to `java.sql.Date`/`Time`/`Timestamp`.

Fixes #3464

### What

Handle the JSR-310 types that `getObject` can return when refreshing the row buffer:

- `date` → `LocalDate`
- `time` / `timetz` → `LocalTime` / `OffsetTime`
- `timestamp` / `timestamptz` → `LocalDateTime` / `OffsetDateTime`

The legacy `java.sql.*` path is unchanged, so existing callers see no behaviour change.

### How to verify

`UpdateableResultTest` covers `updateRow()` for each type plus an `insertRow()` case. Reverting only the production change makes every new test fail with the original `ClassCastException`.

    ./gradlew :postgresql:test --tests "org.postgresql.test.jdbc2.UpdateableResultTest"

### Checklist

- [x] `./gradlew styleCheck` passes
- [x] Tests pass locally (PostgreSQL 16)
- [x] New tests added for the change
- [ ] Breaking change — none
