### PR TITLE
Small simplication of locking patterns in QueryExecutorBase

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/QueryExecutorBase.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/QueryExecutorBase.java
@@ -48,7 +48,7 @@ public abstract class QueryExecutorBase implements QueryExecutor {
   protected final QueryExecutorCloseAction closeAction;
   private @MonotonicNonNull String serverVersion;
   private int serverVersionNum;
-  private TransactionState transactionState = TransactionState.IDLE;
+  private volatile TransactionState transactionState = TransactionState.IDLE;
   private final boolean reWriteBatchedInserts;
   private final boolean columnSanitiserDisabled;
   private final EscapeSyntaxCallMode escapeSyntaxCallMode;
@@ -307,9 +307,7 @@ public abstract class QueryExecutorBase implements QueryExecutor {
 
   @Override
   public TransactionState getTransactionState() {
-    try (ResourceLock ignore = lock.obtain()) {
-      return transactionState;
-    }
+    return transactionState;
   }
 
   public void setEncoding(Encoding encoding) throws IOException {


### PR DESCRIPTION
Shouldn't affect any behavioural aspect, other than being slightly lighter on resources.
As suggested on:
 - https://github.com/pgjdbc/pgjdbc/issues/3835#issuecomment-3460719378

This would probably fix the particular issue reported as #3835 as a side-effect.