### PR TITLE
feat: Add INFO log when fetchSize is ignored under autocommit=true

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgStatement.java
@@ -42,8 +42,12 @@ import java.util.TimerTask;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import java.util.logging.Level;
 
 public class PgStatement implements Statement, BaseStatement {
+  private static final java.util.logging.Logger LOGGER =
+      java.util.logging.Logger.getLogger(PgStatement.class.getName());
+
   private static final String[] NO_RETURNING_COLUMNS = new String[0];
 
   /**
@@ -457,6 +461,11 @@ public class PgStatement implements Statement, BaseStatement {
     if (fetchSize > 0 && !wantsScrollableResultSet() && !connection.getAutoCommit()
         && !wantsHoldableResultSet()) {
       flags |= QueryExecutor.QUERY_FORWARD_CURSOR;
+    } else if (fetchSize > 0 && connection.getAutoCommit()) {
+      LOGGER.log(Level.INFO,
+          "Server-side cursor is disabled because autocommit=true. "
+              + "fetchSize={0} will not be applied; entire result set will be loaded into memory.",
+          new Object[]{fetchSize});
     }
 
     if (wantsGeneratedKeysOnce || wantsGeneratedKeysAlways) {


### PR DESCRIPTION
First of all, Thank you for maintaining pgjdbc. As someone who relies on PostgreSQL heavily, I really appreciate the effort that goes into this project

If it's not too much trouble, I would like to get feedback on whether adding this log message is acceptable.

### Motivation
While using Spring Batch with JdbcCursorItemReader, our application repeatedly hit OOM because fetchSize was silently ignored when the connection ran with autocommit=true. Although the documentation notes that server-side cursors require autocommit=false, this detail becomes easy to miss when multiple application are involved.
I initially considered implementing a WITH HOLD cursor, but the complexity was non-trivial. So, I am proposing to surface this behavior through an INFO-level log.

### Why INFO
- Users typically set fetchSize because the result set is large.
- Many users expect streaming behavior even when autocommit is true(or may not realize autocommit is enabled).
- This log appears only when fetchSize > 0 and autocommit=true, so it does not introduce noisy logging in unrelated cases.

### What is changed
- Add an INFO-level log in PgStatement.executeInternal when:
  - fetchSize > 0
  - autocommit = true
  - when driver connot use a server-side cursor
- No behavior change
  - cursor flags untouched
- No new test
  - tests passed locally
