### PR TITLE
WIP add ability to create holdable cursors at the protocol level

### DIFF
--- a/0001-wip-holdable-portals.patch
+++ b/0001-wip-holdable-portals.patch
@@ -1,0 +1,593 @@
+From 289a9a759683c4f36d5bc6960dd74aa37049d061 Mon Sep 17 00:00:00 2001
+From: Dave Cramer <davecramer@gmail.com>
+Date: Fri, 5 Dec 2025 18:20:23 -0500
+Subject: [PATCH] wip holdable portals
+
+update docs for new protocol message
+
+add function PQsendBindWithCursorOptions to allow cursors with options to be created and fix test to work properly
+---
+ doc/src/sgml/protocol.sgml                    |  40 +++-
+ src/backend/tcop/postgres.c                   |  36 +++
+ src/include/libpq/pqcomm.h                    |   2 +-
+ src/interfaces/libpq/exports.txt              |   2 +
+ src/interfaces/libpq/fe-connect.c             |   5 +
+ src/interfaces/libpq/fe-exec.c                | 222 ++++++++++++++++++
+ src/interfaces/libpq/libpq-fe.h               |   8 +
+ .../modules/libpq_pipeline/libpq_pipeline.c   |  90 +++++++
+ 8 files changed, 399 insertions(+), 6 deletions(-)
+
+diff --git a/doc/src/sgml/protocol.sgml b/doc/src/sgml/protocol.sgml
+index 41c5954a424..3871a8cdf93 100644
+--- a/doc/src/sgml/protocol.sgml
++++ b/doc/src/sgml/protocol.sgml
+@@ -18,7 +18,7 @@
+  </para>
+ 
+  <para>
+-  This document describes version 3.2 of the protocol, introduced in
++  This document describes version 3.3 of the protocol, introduced in
+   <productname>PostgreSQL</productname> version 18. The server and the libpq
+   client library are backwards compatible with protocol version 3.0,
+   implemented in <productname>PostgreSQL</productname> 7.4 and later.
+@@ -192,7 +192,7 @@
+    <title>Protocol Versions</title>
+ 
+    <para>
+-    The current, latest version of the protocol is version 3.2. However, for
++    The current, latest version of the protocol is version 3.3. However, for
+     backwards compatibility with old server versions and middleware that don't
+     support the version negotiation yet, libpq still uses protocol version 3.0
+     by default.
+@@ -206,7 +206,7 @@
+     this would occur if the client requested protocol version 4.0, which does
+     not exist as of this writing).  If the minor version requested by the
+     client is not supported by the server (e.g., the client requests version
+-    3.2, but the server supports only 3.0), the server may either reject the
++    3.3, but the server supports only 3.0), the server may either reject the
+     connection or may respond with a NegotiateProtocolVersion message
+     containing the highest minor protocol version which it supports.  The
+     client may then choose either to continue with the connection using the
+@@ -238,10 +238,18 @@
+      </thead>
+ 
+      <tbody>
++      <row>
++      <entry>3.3</entry>
++      <entry>PostgreSQL 18 and later</entry>
++      <entry>Current latest version. The Bind message now supports an optional
++        cursor options field to control portal behavior, including the ability
++        to create holdable portals that survive transaction commit.
++      </entry>
++      </row>
+       <row>
+       <entry>3.2</entry>
+       <entry>PostgreSQL 18 and later</entry>
+-      <entry>Current latest version. The secret key used in query
++      <entry>The secret key used in query
+         cancellation was enlarged from 4 bytes to a variable length field. The
+         BackendKeyData message was changed to accommodate that, and the CancelRequest
+         message was redefined to have a variable length payload.
+@@ -981,6 +989,9 @@ SELCT 1/0;<!-- this typo is intentional -->
+     pass NULL values for them in the Bind message.)
+     Bind also specifies the format to use for any data returned
+     by the query; the format can be specified overall, or per-column.
++    In protocol 3.3 and later, Bind can optionally specify cursor options
++    to control portal behavior, such as creating a holdable portal that
++    survives transaction commit.
+     The response is either BindComplete or ErrorResponse.
+    </para>
+ 
+@@ -1005,7 +1016,10 @@ SELCT 1/0;<!-- this typo is intentional -->
+ 
+    <para>
+     If successfully created, a named portal object lasts till the end of the
+-    current transaction, unless explicitly destroyed.  An unnamed portal is
++    current transaction, unless explicitly destroyed.  However, a portal
++    created with the CURSOR_OPT_HOLD option (protocol 3.3 and later) is
++    <firstterm>holdable</firstterm> and survives transaction commit, remaining
++    valid until explicitly closed or the session ends.  An unnamed portal is
+     destroyed at the end of the transaction, or as soon as the next Bind
+     statement specifying the unnamed portal as destination is issued.  (Note
+     that a simple Query message also destroys the unnamed portal.)  Named
+@@ -4292,6 +4306,22 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
+         </para>
+        </listitem>
+       </varlistentry>
++
++      <varlistentry>
++       <term>Int32</term>
++       <listitem>
++        <para>
++         Cursor options (protocol 3.3 and later).  A bitmask of options
++         for the portal being created.  Currently defined bits are:
++         <literal>0x0001</literal> (CURSOR_OPT_BINARY, same as setting
++         result format codes to binary),
++         <literal>0x0020</literal> (CURSOR_OPT_HOLD, creates a holdable
++         portal that survives transaction commit).
++         This field is optional; if not present, no cursor options are set.
++         Named portals are required when using CURSOR_OPT_HOLD.
++        </para>
++       </listitem>
++      </varlistentry>
+      </variablelist>
+     </listitem>
+    </varlistentry>
+diff --git a/src/backend/tcop/postgres.c b/src/backend/tcop/postgres.c
+index 7dd75a490aa..7e6a45cc8b9 100644
+--- a/src/backend/tcop/postgres.c
++++ b/src/backend/tcop/postgres.c
+@@ -1636,6 +1636,7 @@ exec_bind_message(StringInfo input_message)
+ 	int			numParams;
+ 	int			numRFormats;
+ 	int16	   *rformats = NULL;
++	int			cursorOptions = 0;
+ 	CachedPlanSource *psrc;
+ 	CachedPlan *cplan;
+ 	Portal		portal;
+@@ -2013,6 +2014,12 @@ exec_bind_message(StringInfo input_message)
+ 			rformats[i] = pq_getmsgint(input_message, 2);
+ 	}
+ 
++	/* Get cursor options if present (protocol 3.3+) */
++	if (input_message->cursor < input_message->len)
++	{
++		cursorOptions = pq_getmsgint(input_message, 4);
++		elog(DEBUG1, "exec_bind_message: read cursorOptions=0x%04x from message", cursorOptions);
++	}
+ 	pq_getmsgend(input_message);
+ 
+ 	/*
+@@ -2061,6 +2068,26 @@ exec_bind_message(StringInfo input_message)
+ 	 */
+ 	PortalSetResultFormat(portal, numRFormats, rformats);
+ 
++	/* Apply cursor options */
++	if (cursorOptions & CURSOR_OPT_HOLD)
++	{
++		elog(DEBUG1, "exec_bind_message: applying CURSOR_OPT_HOLD to portal '%s'", portal_name);
++
++		if (portal_name[0] == '\0')
++			ereport(ERROR,
++					(errcode(ERRCODE_INVALID_CURSOR_NAME),
++					 errmsg("holdable cursors require a named portal")));
++		if (InSecurityRestrictedOperation())
++			ereport(ERROR,
++					(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
++					 errmsg("cannot create cursor WITH HOLD in restricted operation")));
++
++		elog(DEBUG1, "exec_bind_message: CURSOR_OPT_HOLD validation passed for portal '%s'", portal_name);
++	}
++
++	portal->cursorOptions = cursorOptions;
++	elog(DEBUG1, "exec_bind_message: portal '%s' cursorOptions set to 0x%04x", portal_name, cursorOptions);
++
+ 	/*
+ 	 * Done binding; remove the parameters error callback.  Entries emitted
+ 	 * later determine independently whether to log the parameters or not.
+@@ -4908,7 +4935,16 @@ PostgresMain(const char *dbname, const char *username)
+ 
+ 								portal = GetPortalByName(close_target);
+ 								if (PortalIsValid(portal))
++								{
++									elog(DEBUG1, "Close message: closing portal '%s' (cursorOptions=0x%04x)",
++										 close_target, portal->cursorOptions);
+ 									PortalDrop(portal, false);
++									elog(DEBUG1, "Close message: portal '%s' closed successfully", close_target);
++								}
++								else
++								{
++									elog(DEBUG1, "Close message: portal '%s' not found", close_target);
++								}
+ 							}
+ 							break;
+ 						default:
+diff --git a/src/include/libpq/pqcomm.h b/src/include/libpq/pqcomm.h
+index 625f4b43879..dd80da3809a 100644
+--- a/src/include/libpq/pqcomm.h
++++ b/src/include/libpq/pqcomm.h
+@@ -92,7 +92,7 @@ is_unixsock_path(const char *path)
+  * The earliest and latest frontend/backend protocol version supported.
+  */
+ #define PG_PROTOCOL_EARLIEST	PG_PROTOCOL(3,0)
+-#define PG_PROTOCOL_LATEST		PG_PROTOCOL(3,2)
++#define PG_PROTOCOL_LATEST		PG_PROTOCOL(3,3)
+ 
+ /*
+  * Reserved protocol numbers, which have special semantics:
+diff --git a/src/interfaces/libpq/exports.txt b/src/interfaces/libpq/exports.txt
+index dbbae642d76..b01c0948585 100644
+--- a/src/interfaces/libpq/exports.txt
++++ b/src/interfaces/libpq/exports.txt
+@@ -210,3 +210,5 @@ PQgetAuthDataHook         207
+ PQdefaultAuthDataHook     208
+ PQfullProtocolVersion     209
+ appendPQExpBufferVA       210
++PQsendQueryPreparedWithCursorOptions 211
++PQsendBindWithCursorOptions 212
+diff --git a/src/interfaces/libpq/fe-connect.c b/src/interfaces/libpq/fe-connect.c
+index c3a2448dce5..019f62631f2 100644
+--- a/src/interfaces/libpq/fe-connect.c
++++ b/src/interfaces/libpq/fe-connect.c
+@@ -8336,6 +8336,11 @@ pqParseProtocolVersion(const char *value, ProtocolVersion *result, PGconn *conn,
+ 		*result = PG_PROTOCOL(3, 2);
+ 		return true;
+ 	}
++	if (strcmp(value, "3.3") == 0)
++	{
++		*result = PG_PROTOCOL(3, 3);
++		return true;
++	}
+ 
+ 	libpq_append_conn_error(conn, "invalid %s value: \"%s\"",
+ 							context, value);
+diff --git a/src/interfaces/libpq/fe-exec.c b/src/interfaces/libpq/fe-exec.c
+index 7ab33930a39..1804365cd18 100644
+--- a/src/interfaces/libpq/fe-exec.c
++++ b/src/interfaces/libpq/fe-exec.c
+@@ -1682,6 +1682,228 @@ PQsendQueryPrepared(PGconn *conn,
+ 						   resultFormat);
+ }
+ 
++int
++PQsendQueryPreparedWithCursorOptions(PGconn *conn,
++									 const char *stmtName,
++									 int nParams,
++									 const char *const *paramValues,
++									 const int *paramLengths,
++									 const int *paramFormats,
++									 int resultFormat,
++									 const char *portalName,
++									 int cursorOptions)
++{
++	PGcmdQueueEntry *entry;
++
++	if (!PQsendQueryStart(conn, true))
++		return 0;
++
++	if (!stmtName)
++	{
++		libpq_append_conn_error(conn, "statement name is a null pointer");
++		return 0;
++	}
++
++	if ((cursorOptions & 0x0020) && (!portalName || portalName[0] == '\0'))
++	{
++		libpq_append_conn_error(conn, "holdable cursors require a named portal");
++		return 0;
++	}
++
++	entry = pqAllocCmdQueueEntry(conn);
++	if (entry == NULL)
++		return 0;
++
++	if (pqPutMsgStart(PqMsg_Bind, conn) < 0 ||
++		pqPuts(portalName ? portalName : "", conn) < 0 ||
++		pqPuts(stmtName, conn) < 0)
++		goto sendFailed;
++
++	if (nParams > 0 && paramFormats)
++	{
++		if (pqPutInt(nParams, 2, conn) < 0)
++			goto sendFailed;
++		for (int i = 0; i < nParams; i++)
++			if (pqPutInt(paramFormats[i], 2, conn) < 0)
++				goto sendFailed;
++	}
++	else if (pqPutInt(0, 2, conn) < 0)
++		goto sendFailed;
++
++	if (pqPutInt(nParams, 2, conn) < 0)
++		goto sendFailed;
++
++	for (int i = 0; i < nParams; i++)
++	{
++		if (paramValues && paramValues[i])
++		{
++			int len = paramLengths ? paramLengths[i] : strlen(paramValues[i]);
++			if (pqPutInt(len, 4, conn) < 0 ||
++				pqPutnchar(paramValues[i], len, conn) < 0)
++				goto sendFailed;
++		}
++		else if (pqPutInt(-1, 4, conn) < 0)
++			goto sendFailed;
++	}
++
++	if (pqPutInt(1, 2, conn) < 0 ||
++		pqPutInt(resultFormat, 2, conn) < 0)
++		goto sendFailed;
++
++	/* Send cursor options if protocol 3.3+ */
++	if (conn->pversion >= PG_PROTOCOL(3, 3))
++	{
++		if (pqPutInt(cursorOptions, 4, conn) < 0)
++			goto sendFailed;
++	}
++
++	if (pqPutMsgEnd(conn) < 0)
++		goto sendFailed;
++
++	if (pqPutMsgStart(PqMsg_Describe, conn) < 0 ||
++		pqPutc('P', conn) < 0 ||
++		pqPuts(portalName ? portalName : "", conn) < 0 ||
++		pqPutMsgEnd(conn) < 0)
++		goto sendFailed;
++
++	if (pqPutMsgStart(PqMsg_Execute, conn) < 0 ||
++		pqPuts(portalName ? portalName : "", conn) < 0 ||
++		pqPutInt(0, 4, conn) < 0 ||
++		pqPutMsgEnd(conn) < 0)
++		goto sendFailed;
++
++	if (conn->pipelineStatus == PQ_PIPELINE_OFF)
++	{
++		if (pqPutMsgStart(PqMsg_Sync, conn) < 0 ||
++			pqPutMsgEnd(conn) < 0)
++			goto sendFailed;
++	}
++
++	entry->queryclass = PGQUERY_EXTENDED;
++
++	if (pqPipelineFlush(conn) < 0)
++		goto sendFailed;
++
++	conn->asyncStatus = PGASYNC_BUSY;
++	return 1;
++
++sendFailed:
++	pqRecycleCmdQueueEntry(conn, entry);
++	return 0;
++}
++
++/*
++ * PQsendBindWithCursorOptions
++ *	Like PQsendQueryPreparedWithCursorOptions but sends only Bind+Describe,
++ *	not Execute. This allows creating a portal that can be executed later,
++ *	which is necessary for testing holdable portals (execute after commit).
++ */
++int
++PQsendBindWithCursorOptions(PGconn *conn,
++							 const char *stmtName,
++							 int nParams,
++							 const char *const *paramValues,
++							 const int *paramLengths,
++							 const int *paramFormats,
++							 int resultFormat,
++							 const char *portalName,
++							 int cursorOptions)
++{
++	PGcmdQueueEntry *entry;
++
++	if (!PQsendQueryStart(conn, true))
++		return 0;
++
++	if (!stmtName)
++	{
++		libpq_append_conn_error(conn, "statement name is a null pointer");
++		return 0;
++	}
++
++	if ((cursorOptions & 0x0020) && (!portalName || portalName[0] == '\0'))
++	{
++		libpq_append_conn_error(conn, "holdable cursors require a named portal");
++		return 0;
++	}
++
++	entry = pqAllocCmdQueueEntry(conn);
++	if (entry == NULL)
++		return 0;
++
++	if (pqPutMsgStart(PqMsg_Bind, conn) < 0 ||
++		pqPuts(portalName ? portalName : "", conn) < 0 ||
++		pqPuts(stmtName, conn) < 0)
++		goto sendFailed;
++
++	if (nParams > 0 && paramFormats)
++	{
++		if (pqPutInt(nParams, 2, conn) < 0)
++			goto sendFailed;
++		for (int i = 0; i < nParams; i++)
++			if (pqPutInt(paramFormats[i], 2, conn) < 0)
++				goto sendFailed;
++	}
++	else if (pqPutInt(0, 2, conn) < 0)
++		goto sendFailed;
++
++	if (pqPutInt(nParams, 2, conn) < 0)
++		goto sendFailed;
++
++	for (int i = 0; i < nParams; i++)
++	{
++		if (paramValues && paramValues[i])
++		{
++			int len = paramLengths ? paramLengths[i] : strlen(paramValues[i]);
++			if (pqPutInt(len, 4, conn) < 0 ||
++				pqPutnchar(paramValues[i], len, conn) < 0)
++				goto sendFailed;
++		}
++		else if (pqPutInt(-1, 4, conn) < 0)
++			goto sendFailed;
++	}
++
++	if (pqPutInt(1, 2, conn) < 0 ||
++		pqPutInt(resultFormat, 2, conn) < 0)
++		goto sendFailed;
++
++	/* Send cursor options if protocol 3.3+ */
++	if (conn->pversion >= PG_PROTOCOL(3, 3))
++	{
++		if (pqPutInt(cursorOptions, 4, conn) < 0)
++			goto sendFailed;
++	}
++
++	if (pqPutMsgEnd(conn) < 0)
++		goto sendFailed;
++
++	if (pqPutMsgStart(PqMsg_Describe, conn) < 0 ||
++		pqPutc('P', conn) < 0 ||
++		pqPuts(portalName ? portalName : "", conn) < 0 ||
++		pqPutMsgEnd(conn) < 0)
++		goto sendFailed;
++
++	/* No Execute message - portal is created but not executed */
++
++	if (conn->pipelineStatus == PQ_PIPELINE_OFF)
++	{
++		if (pqPutMsgStart(PqMsg_Sync, conn) < 0 ||
++			pqPutMsgEnd(conn) < 0)
++			goto sendFailed;
++	}
++
++	entry->queryclass = PGQUERY_EXTENDED;
++
++	if (pqPipelineFlush(conn) < 0)
++		goto sendFailed;
++
++	conn->asyncStatus = PGASYNC_BUSY;
++	return 1;
++
++sendFailed:
++	pqRecycleCmdQueueEntry(conn, entry);
++	return 0;
++}
++
+ /*
+  * PQsendQueryStart
+  *	Common startup code for PQsendQuery and sibling routines
+diff --git a/src/interfaces/libpq/libpq-fe.h b/src/interfaces/libpq/libpq-fe.h
+index 0852584edae..2311f555137 100644
+--- a/src/interfaces/libpq/libpq-fe.h
++++ b/src/interfaces/libpq/libpq-fe.h
+@@ -525,6 +525,14 @@ extern int	PQsendQueryPrepared(PGconn *conn,
+ 								const int *paramLengths,
+ 								const int *paramFormats,
+ 								int resultFormat);
++extern int	PQsendQueryPreparedWithCursorOptions(PGconn *conn, const char *stmtName,
++								int nParams, const char *const *paramValues,
++								const int *paramLengths, const int *paramFormats,
++								int resultFormat, const char *portalName, int cursorOptions);
++extern int	PQsendBindWithCursorOptions(PGconn *conn, const char *stmtName,
++								int nParams, const char *const *paramValues,
++								const int *paramLengths, const int *paramFormats,
++								int resultFormat, const char *portalName, int cursorOptions);
+ extern int	PQsetSingleRowMode(PGconn *conn);
+ extern int	PQsetChunkedRowsMode(PGconn *conn, int chunkSize);
+ extern PGresult *PQgetResult(PGconn *conn);
+diff --git a/src/test/modules/libpq_pipeline/libpq_pipeline.c b/src/test/modules/libpq_pipeline/libpq_pipeline.c
+index b3af70fa09b..bf97cab88d3 100644
+--- a/src/test/modules/libpq_pipeline/libpq_pipeline.c
++++ b/src/test/modules/libpq_pipeline/libpq_pipeline.c
+@@ -2082,6 +2082,93 @@ process_result(PGconn *conn, PGresult *res, int results, int numsent)
+ 	return got_error;
+ }
+ 
++/*
++ * Test holdable cursors using protocol 3.3 cursor options in Bind message.
++ */
++static void
++test_holdable_cursor(PGconn *conn)
++{
++	PGresult   *res;
++
++	fprintf(stderr, "holdable cursor... ");
++
++	/* Verify protocol 3.3 */
++	if (PQfullProtocolVersion(conn) < 30003)
++		pg_fatal("protocol 3.3 required, got %d", PQfullProtocolVersion(conn));
++
++	/* Start transaction */
++	res = PQexec(conn, "BEGIN");
++	if (PQresultStatus(res) != PGRES_COMMAND_OK)
++		pg_fatal("BEGIN failed: %s", PQerrorMessage(conn));
++	PQclear(res);
++
++	/* Create test table */
++	res = PQexec(conn, "CREATE TEMP TABLE holdable_test(id int)");
++	if (PQresultStatus(res) != PGRES_COMMAND_OK)
++		pg_fatal("CREATE TABLE failed: %s", PQerrorMessage(conn));
++	PQclear(res);
++
++	res = PQexec(conn, "INSERT INTO holdable_test VALUES (1), (2), (3)");
++	if (PQresultStatus(res) != PGRES_COMMAND_OK)
++		pg_fatal("INSERT failed: %s", PQerrorMessage(conn));
++	PQclear(res);
++
++	/* Prepare statement */
++	res = PQprepare(conn, "holdstmt", "SELECT * FROM holdable_test", 0, NULL);
++	if (PQresultStatus(res) != PGRES_COMMAND_OK)
++		pg_fatal("PREPARE failed: %s", PQerrorMessage(conn));
++	PQclear(res);
++
++	/* Enter pipeline mode */
++	if (PQenterPipelineMode(conn) != 1)
++		pg_fatal("failed to enter pipeline mode: %s", PQerrorMessage(conn));
++
++	/* Create holdable portal using Bind with cursor options (no Execute) */
++	if (PQsendBindWithCursorOptions(conn, "holdstmt", 0, NULL, NULL, NULL, 0, "holdportal", 0x0020) != 1)
++		pg_fatal("PQsendBindWithCursorOptions failed: %s", PQerrorMessage(conn));
++
++	/* Commit - portal should survive */
++	if (PQsendQueryParams(conn, "COMMIT", 0, NULL, NULL, NULL, NULL, 0) != 1)
++		pg_fatal("COMMIT failed: %s", PQerrorMessage(conn));
++
++	/* Execute portal after commit using FETCH (portals created via Bind are cursors) */
++	if (PQsendQueryParams(conn, "FETCH ALL FROM holdportal", 0, NULL, NULL, NULL, NULL, 0) != 1)
++		pg_fatal("FETCH failed: %s", PQerrorMessage(conn));
++
++	/* Close portal */
++	if (PQsendQueryParams(conn, "CLOSE holdportal", 0, NULL, NULL, NULL, NULL, 0) != 1)
++		pg_fatal("CLOSE failed: %s", PQerrorMessage(conn));
++
++	if (PQpipelineSync(conn) != 1)
++		pg_fatal("pipeline sync failed: %s", PQerrorMessage(conn));
++
++	/* Get results */
++	res = confirm_result_status(conn, PGRES_TUPLES_OK);	/* RowDescription from Bind+Describe */
++	if (PQnfields(res) != 1)
++		pg_fatal("expected 1 field, got %d", PQnfields(res));
++	PQclear(res);
++	consume_null_result(conn);
++
++	/* COMMIT result seems to be skipped/combined - this is a libpq behavior */
++
++	res = confirm_result_status(conn, PGRES_TUPLES_OK);	/* FETCH after commit */
++	if (PQntuples(res) != 3)
++		pg_fatal("expected 3 rows after commit, got %d", PQntuples(res));
++	PQclear(res);
++	consume_null_result(conn);
++
++	consume_result_status(conn, PGRES_COMMAND_OK);	/* CLOSE */
++	consume_null_result(conn);
++
++	consume_result_status(conn, PGRES_PIPELINE_SYNC);
++	consume_null_result(conn);
++
++	if (PQexitPipelineMode(conn) != 1)
++		pg_fatal("failed to exit pipeline mode: %s", PQerrorMessage(conn));
++
++	fprintf(stderr, "ok\n");
++}
++
+ 
+ static void
+ usage(const char *progname)
+@@ -2100,6 +2187,7 @@ print_test_list(void)
+ {
+ 	printf("cancel\n");
+ 	printf("disallowed_in_pipeline\n");
++	printf("holdable_cursor\n");
+ 	printf("multi_pipelines\n");
+ 	printf("nosync\n");
+ 	printf("pipeline_abort\n");
+@@ -2207,6 +2295,8 @@ main(int argc, char **argv)
+ 		test_cancel(conn);
+ 	else if (strcmp(testname, "disallowed_in_pipeline") == 0)
+ 		test_disallowed_in_pipeline(conn);
++	else if (strcmp(testname, "holdable_cursor") == 0)
++		test_holdable_cursor(conn);
+ 	else if (strcmp(testname, "multi_pipelines") == 0)
+ 		test_multi_pipelines(conn);
+ 	else if (strcmp(testname, "nosync") == 0)
+-- 
+2.50.1 (Apple Git-155)
+

--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -299,6 +299,15 @@ public enum PGProperty {
       "Time in milliseconds we wait for a response from the server after requesting a GSS upgrade"),
 
   /**
+   * Enable support for holdable portals via the _pq_.holdable_portal protocol option.
+   * When enabled, the driver can create portals that survive transaction commits.
+   */
+  HOLDABLE_PORTAL(
+      "holdablePortal",
+      "false",
+      "Enable holdable portal support via protocol option"),
+
+  /**
    * Flag to enable/disable the obtaining the default GSS credentials from a pre-existing ccache,
    * rather than using JAAS.  This also allows GSS to work in environments where the default
    * kerberos principal a user has is not user@DEFAULT_REALM, but some other user (this is valid,

--- a/pgjdbc/src/main/java/org/postgresql/core/ConnectionFactory.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/ConnectionFactory.java
@@ -52,7 +52,8 @@ public abstract class ConnectionFactory {
     if (protoName != null && !protoName.isEmpty()
         && (protoName.equalsIgnoreCase("3")
           || protoName.equalsIgnoreCase("3.0")
-          || protoName.equalsIgnoreCase("3.2"))) {
+          || protoName.equalsIgnoreCase("3.2")
+          || protoName.equalsIgnoreCase("3.3"))) {
       ConnectionFactory connectionFactory = new ConnectionFactoryImpl();
       QueryExecutor queryExecutor = connectionFactory.openConnectionImpl(
           hostSpecs, info);

--- a/pgjdbc/src/main/java/org/postgresql/core/CursorOptions.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/CursorOptions.java
@@ -1,0 +1,42 @@
+package org.postgresql.core;
+
+/**
+ * Cursor options for extended query protocol.
+ * These match the PostgreSQL backend cursor options bitmask.
+ */
+public final class CursorOptions {
+  
+  /** BINARY cursor */
+  public static final int BINARY = 0x0001;
+  
+  /** SCROLL cursor */
+  public static final int SCROLL = 0x0002;
+  
+  /** NO SCROLL cursor */
+  public static final int NO_SCROLL = 0x0004;
+  
+  /** INSENSITIVE cursor */
+  public static final int INSENSITIVE = 0x0008;
+  
+  /** ASENSITIVE cursor */
+  public static final int ASENSITIVE = 0x0010;
+  
+  /** WITH HOLD cursor - survives transaction commit */
+  public static final int HOLD = 0x0020;
+  
+  /** Prefer fast-start plan */
+  public static final int FAST_PLAN = 0x0100;
+  
+  /** Force generic plan */
+  public static final int GENERIC_PLAN = 0x0200;
+  
+  /** Force custom plan */
+  public static final int CUSTOM_PLAN = 0x0400;
+  
+  /** Allow parallel workers */
+  public static final int PARALLEL_OK = 0x0800;
+  
+  private CursorOptions() {
+    // Utility class
+  }
+}

--- a/pgjdbc/src/main/java/org/postgresql/core/HoldablePortal.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/HoldablePortal.java
@@ -1,0 +1,22 @@
+package org.postgresql.core;
+
+import java.sql.SQLException;
+
+/**
+ * Interface for creating holdable portals via the extended query protocol.
+ * Holdable portals survive transaction commits.
+ */
+public interface HoldablePortal {
+  
+  /**
+   * Binds a prepared statement to a named portal with cursor options.
+   * 
+   * @param portalName the portal name (required for holdable cursors)
+   * @param statementName the prepared statement name
+   * @param parameters the parameter values
+   * @param cursorOptions cursor options bitmask (see {@link CursorOptions})
+   * @throws SQLException if binding fails
+   */
+  void bindWithOptions(String portalName, String statementName, 
+                       ParameterList parameters, int cursorOptions) throws SQLException;
+}

--- a/pgjdbc/src/main/java/org/postgresql/core/ProtocolVersion.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/ProtocolVersion.java
@@ -23,7 +23,12 @@ public enum ProtocolVersion {
   /**
    * Protocol version 3.2
    */
-  v3_2(3, 2);
+  v3_2(3, 2),
+
+  /**
+   * Protocol version 3.3 (supports cursor options in Bind message)
+   */
+  v3_3(3, 3);
 
   private final int major;
   private final int minor;

--- a/pgjdbc/src/main/java/org/postgresql/core/QueryExecutor.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/QueryExecutor.java
@@ -98,6 +98,12 @@ public interface QueryExecutor extends TypeTransferModeRegistry {
   int QUERY_BOTH_ROWS_AND_STATUS = 64;
 
   /**
+   * Flag for query execution that indicates a holdable cursor should be used if
+   * possible (survives transaction commit).
+   */
+  int QUERY_HOLDABLE_CURSOR = 128;
+
+  /**
    * Force this query to be described at each execution. This is done in pipelined batches where we
    * might need to detect mismatched result types.
    */

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java
@@ -436,6 +436,12 @@ public class ConnectionFactoryImpl extends ConnectionFactory {
     if (options != null) {
       paramList.add(new StartupParam("options", options));
     }
+
+    // Add _pq_.holdable_portal protocol option if enabled
+    if (PGProperty.HOLDABLE_PORTAL.getBoolean(info)) {
+      paramList.add(new StartupParam("_pq_.holdable_portal", "true"));
+    }
+
     return paramList;
   }
 

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/Portal.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/Portal.java
@@ -52,6 +52,14 @@ class Portal implements ResultCursor {
     this.cleanupRef = cleanupRef;
   }
 
+  int getCursorOptions() {
+    return cursorOptions;
+  }
+
+  void setCursorOptions(int options) {
+    this.cursorOptions = options;
+  }
+
   @Override
   public String toString() {
     return portalName;
@@ -67,4 +75,5 @@ class Portal implements ResultCursor {
   private final String portalName;
   private final byte[] encodedName;
   private @Nullable PhantomReference<?> cleanupRef;
+  private int cursorOptions = 0;
 }

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -230,6 +230,7 @@ public class QueryExecutorImpl extends QueryExecutorBase {
 
     this.allowEncodingChanges = PGProperty.ALLOW_ENCODING_CHANGES.getBoolean(info);
     this.cleanupSavePoints = PGProperty.CLEANUP_SAVEPOINTS.getBoolean(info);
+    this.holdablePortalEnabled = PGProperty.HOLDABLE_PORTAL.getBoolean(info);
     // assignment, argument
     this.replicationProtocol = new V3ReplicationProtocol(this, pgStream);
     readStartupMessages();
@@ -1801,7 +1802,7 @@ public class QueryExecutorImpl extends QueryExecutorBase {
         + 2 + params.getParameterCount() * 2L
         + 2 + encodedSize
         + 2 + numBinaryFields * 2L
-        + (cursorOptions != 0 && protocolVersion.getMinor() >= 3 ? 4 : 0);
+        + (holdablePortalEnabled && cursorOptions != 0 ? 4 : 0);
 
     // backend's MaxAllocSize is the largest message that can
     // be received from a client. If we have a bigger value
@@ -1867,7 +1868,8 @@ public class QueryExecutorImpl extends QueryExecutorBase {
       pgStream.sendInteger2(fields[i].getFormat());
     }
 
-    if (cursorOptions != 0 && protocolVersion.getMinor() >= 3) {
+    // Send cursor options if _pq_.holdable_portal protocol option is enabled
+    if (holdablePortalEnabled && cursorOptions != 0) {
       pgStream.sendInteger4(cursorOptions);
     }
 
@@ -3203,6 +3205,7 @@ public class QueryExecutorImpl extends QueryExecutorBase {
   private long nextUniqueID = 1;
   private final boolean allowEncodingChanges;
   private final boolean cleanupSavePoints;
+  private final boolean holdablePortalEnabled;
 
   /**
    * The estimated server response size since we last consumed the input stream from the server, in

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
@@ -83,10 +83,12 @@ import java.sql.Statement;
 import java.sql.Struct;
 import java.sql.Types;
 import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -198,6 +200,9 @@ public class PgConnection implements BaseConnection {
    * Oids for which binary transfer should be disabled.
    */
   private final Set<? extends Integer> binaryDisabledOids;
+
+  // Track open statements to close non-holdable result sets on commit
+  private final List<java.lang.ref.WeakReference<PgStatement>> openStatements = new ArrayList<>();
 
   private int rsHoldability = ResultSet.CLOSE_CURSORS_AT_COMMIT;
   private int savepointId;
@@ -1016,6 +1021,39 @@ public class PgConnection implements BaseConnection {
 
     if (queryExecutor.getTransactionState() != TransactionState.IDLE) {
       executeTransactionCommand(commitQuery);
+      closeNonHoldableResultSets();
+    }
+  }
+
+  /**
+   * Close all non-holdable result sets after commit.
+   */
+  private void closeNonHoldableResultSets() {
+    lock.lock();
+    try {
+      openStatements.removeIf(ref -> {
+        PgStatement stmt = ref.get();
+        if (stmt == null) {
+          return true; // Remove dead reference
+        }
+        try {
+          stmt.closeNonHoldableResultSets();
+        } catch (SQLException e) {
+          // Ignore errors during cleanup
+        }
+        return false;
+      });
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  /**
+   * Register a statement for tracking.
+   */
+  void registerStatement(PgStatement stmt) {
+    try (ResourceLock ignore = lock.obtain()){
+      openStatements.add(new java.lang.ref.WeakReference<>(stmt));
     }
   }
 
@@ -1441,21 +1479,27 @@ public class PgConnection implements BaseConnection {
   public Statement createStatement(int resultSetType, int resultSetConcurrency,
       int resultSetHoldability) throws SQLException {
     checkClosed();
-    return new PgStatement(this, resultSetType, resultSetConcurrency, resultSetHoldability);
+    PgStatement stmt = new PgStatement(this, resultSetType, resultSetConcurrency, resultSetHoldability);
+    registerStatement(stmt);
+    return stmt;
   }
 
   @Override
   public PreparedStatement prepareStatement(String sql, int resultSetType, int resultSetConcurrency,
       int resultSetHoldability) throws SQLException {
     checkClosed();
-    return new PgPreparedStatement(this, sql, resultSetType, resultSetConcurrency, resultSetHoldability);
+    PgPreparedStatement stmt = new PgPreparedStatement(this, sql, resultSetType, resultSetConcurrency, resultSetHoldability);
+    registerStatement(stmt);
+    return stmt;
   }
 
   @Override
   public CallableStatement prepareCall(String sql, int resultSetType, int resultSetConcurrency,
       int resultSetHoldability) throws SQLException {
     checkClosed();
-    return new PgCallableStatement(this, sql, resultSetType, resultSetConcurrency, resultSetHoldability);
+    PgCallableStatement stmt = new PgCallableStatement(this, sql, resultSetType, resultSetConcurrency, resultSetHoldability);
+    registerStatement(stmt);
+    return stmt;
   }
 
   @Override

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
@@ -882,6 +882,10 @@ public class PgConnection implements BaseConnection {
       // When that happens the connection is still registered in the finalizer queue, so it gets finalized
       return;
     }
+    
+    // Close all open statements
+    closeOpenStatements();
+    
     openStackTrace = null;
     try {
       cleanable.clean();
@@ -889,6 +893,25 @@ public class PgConnection implements BaseConnection {
       throw new PSQLException(
           GT.tr("Unable to close connection properly"),
           PSQLState.UNKNOWN_STATE, e);
+    }
+  }
+
+  /**
+   * Close all open statements.
+   */
+  private void closeOpenStatements() {
+    try (ResourceLock ignore = lock.obtain()) {
+      for (java.lang.ref.WeakReference<PgStatement> ref : openStatements) {
+        PgStatement stmt = ref.get();
+        if (stmt != null) {
+          try {
+            stmt.close();
+          } catch (SQLException e) {
+            // Ignore errors during cleanup
+          }
+        }
+      }
+      openStatements.clear();
     }
   }
 

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
@@ -1052,8 +1052,7 @@ public class PgConnection implements BaseConnection {
    * Close all non-holdable result sets after commit.
    */
   private void closeNonHoldableResultSets() {
-    lock.lock();
-    try {
+    try (ResourceLock ignore = lock.obtain()) {
       openStatements.removeIf(ref -> {
         PgStatement stmt = ref.get();
         if (stmt == null) {
@@ -1066,8 +1065,6 @@ public class PgConnection implements BaseConnection {
         }
         return false;
       });
-    } finally {
-      lock.unlock();
     }
   }
 

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgStatement.java
@@ -454,9 +454,11 @@ public class PgStatement implements Statement, BaseStatement {
     closeForNextExecution();
 
     // Enable cursor-based resultset if possible.
-    if (fetchSize > 0 && !wantsScrollableResultSet() && !connection.getAutoCommit()
-        && !wantsHoldableResultSet()) {
+    if (fetchSize > 0 && !wantsScrollableResultSet() && !connection.getAutoCommit()) {
       flags |= QueryExecutor.QUERY_FORWARD_CURSOR;
+      if (wantsHoldableResultSet()) {
+        flags |= QueryExecutor.QUERY_HOLDABLE_CURSOR;
+      }
     }
 
     if (wantsGeneratedKeysOnce || wantsGeneratedKeysAlways) {

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgStatement.java
@@ -222,6 +222,24 @@ public class PgStatement implements Statement, BaseStatement {
   }
 
   /**
+   * Close all non-holdable result sets.
+   * Called by connection on commit.
+   */
+  void closeNonHoldableResultSets() throws SQLException {
+    synchronized (this) {
+      if (!wantsHoldableResultSet() && firstUnclosedResult != null) {
+        ResultWrapper result = firstUnclosedResult;
+        while (result != null) {
+          if (result.getResultSet() != null) {
+            result.getResultSet().close();
+          }
+          result = result.getNext();
+        }
+      }
+    }
+  }
+
+  /**
    * ResultHandler implementations for updates, queries, and either-or.
    */
   public class StatementResultHandler extends ResultHandlerBase {

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/HoldableCursorTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/HoldableCursorTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2025, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.test.jdbc2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.postgresql.PGProperty;
+import org.postgresql.test.TestUtil;
+
+import org.junit.jupiter.api.Test;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Properties;
+
+/**
+ * Tests for holdable cursors (cursors that survive COMMIT).
+ */
+public class HoldableCursorTest extends BaseTest4 {
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    TestUtil.createTable(con, "test_holdable", "id int, value text");
+    con.setAutoCommit(false);
+  }
+
+  @Override
+  public void tearDown() throws SQLException {
+    if (!con.getAutoCommit()) {
+      con.rollback();
+    }
+    con.setAutoCommit(true);
+    TestUtil.dropTable(con, "test_holdable");
+    super.tearDown();
+  }
+
+  @Test
+  public void testHoldableCursorSurvivesCommit() throws Exception {
+    // Insert test data
+    con.close();
+    Properties props = new Properties();
+    PGProperty.PROTOCOL_VERSION.set(props,"3.3");
+    con = TestUtil.openDB(props);
+    PreparedStatement insert = con.prepareStatement("INSERT INTO test_holdable VALUES (?, ?)");
+    for (int i = 1; i <= 100; i++) {
+      insert.setInt(1, i);
+      insert.setString(2, "value_" + i);
+      insert.addBatch();
+    }
+    insert.executeBatch();
+
+    con.setAutoCommit(false);
+    // Create holdable cursor
+    PreparedStatement stmt = con.prepareStatement(
+        "SELECT id, value FROM test_holdable WHERE id > ? ORDER BY id",
+        ResultSet.TYPE_FORWARD_ONLY,
+        ResultSet.CONCUR_READ_ONLY,
+        ResultSet.HOLD_CURSORS_OVER_COMMIT
+    );
+    stmt.setInt(1, 50);
+    stmt.setFetchSize(10);
+
+    ResultSet rs = stmt.executeQuery();
+
+    // Fetch first 10 rows before commit
+    int count = 0;
+    while (count < 10 && rs.next() ) {
+      assertEquals(51 + count, rs.getInt("id"));
+      assertEquals("value_" + (51 + count), rs.getString("value"));
+      System.out.println("Value: "+ rs.getInt("id"));
+      count++;
+    }
+    assertEquals(10, count);
+
+    // COMMIT - cursor should survive
+    con.commit();
+
+    // Continue fetching after commit
+    count = 0;
+    while (count < 10 && rs.next()) {
+      System.out.println("Value: "+ rs.getInt("id"));
+      assertEquals(61 + count, rs.getInt("id"));
+      assertEquals("value_" + (61 + count), rs.getString("value"));
+      count++;
+    }
+    assertEquals(10, count);
+
+    rs.close();
+    stmt.close();
+  }
+
+  @Test
+  public void testNonHoldableCursorClosesOnCommit() throws Exception {
+    // Insert test data
+    PreparedStatement insert = con.prepareStatement("INSERT INTO test_holdable VALUES (?, ?)");
+    for (int i = 1; i <= 50; i++) {
+      insert.setInt(1, i);
+      insert.setString(2, "value_" + i);
+      insert.addBatch();
+    }
+    insert.executeBatch();
+    con.commit();
+
+    // Create non-holdable cursor (default)
+    PreparedStatement stmt = con.prepareStatement(
+        "SELECT id, value FROM test_holdable ORDER BY id",
+        ResultSet.TYPE_FORWARD_ONLY,
+        ResultSet.CONCUR_READ_ONLY,
+        ResultSet.CLOSE_CURSORS_AT_COMMIT
+    );
+    stmt.setFetchSize(10);
+
+    ResultSet rs = stmt.executeQuery();
+
+    // Fetch some rows
+    assertTrue(rs.next());
+    assertEquals(1, rs.getInt("id"));
+
+    // COMMIT - cursor should close
+    con.commit();
+
+    // Attempting to fetch should fail or return false
+    boolean hasMore = rs.next();
+    // After commit, non-holdable cursor is closed
+    assertTrue(!hasMore || rs.isClosed());
+
+    rs.close();
+    stmt.close();
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/HoldableCursorTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/HoldableCursorTest.java
@@ -45,7 +45,7 @@ public class HoldableCursorTest extends BaseTest4 {
     // Insert test data
     con.close();
     Properties props = new Properties();
-    PGProperty.PROTOCOL_VERSION.set(props,"3.3");
+    PGProperty.HOLDABLE_PORTAL.set(props, "true");
     con = TestUtil.openDB(props);
     PreparedStatement insert = con.prepareStatement("INSERT INTO test_holdable VALUES (?, ?)");
     for (int i = 1; i <= 100; i++) {
@@ -97,6 +97,11 @@ public class HoldableCursorTest extends BaseTest4 {
 
   @Test
   public void testNonHoldableCursorClosesOnCommit() throws Exception {
+    // Use a fresh connection without holdable portal option
+    con.close();
+    con = TestUtil.openDB();
+    con.setAutoCommit(false);
+    
     // Insert test data
     PreparedStatement insert = con.prepareStatement("INSERT INTO test_holdable VALUES (?, ?)");
     for (int i = 1; i <= 50; i++) {
@@ -125,10 +130,15 @@ public class HoldableCursorTest extends BaseTest4 {
     // COMMIT - cursor should close
     con.commit();
 
-    // Attempting to fetch should fail or return false
-    boolean hasMore = rs.next();
-    // After commit, non-holdable cursor is closed
-    assertTrue(!hasMore || rs.isClosed());
+    // Attempting to fetch should fail with exception since result set is closed
+    try {
+      rs.next();
+      // If we get here, check if closed
+      assertTrue(rs.isClosed(), "ResultSet should be closed after commit");
+    } catch (SQLException e) {
+      // Expected: ResultSet is closed
+      assertTrue(e.getMessage().contains("closed"), "Expected 'closed' error, got: " + e.getMessage());
+    }
 
     rs.close();
     stmt.close();


### PR DESCRIPTION
relies on patch to postgres attached 0001-wip-holdable-portals.patch
