### PR TITLE
fix:  incorrect pg_stat_replication.reply_time calculation

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/v3/replication/V3PGReplicationStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/replication/V3PGReplicationStream.java
@@ -207,9 +207,9 @@ public class V3PGReplicationStream implements PGReplicationStream {
       LogSequenceNumber applied, boolean replyRequired) {
     ByteBuffer byteBuffer = ByteBuffer.allocate(1 + 8 + 8 + 8 + 8 + 1);
 
-    long now = System.nanoTime() / NANOS_PER_MILLISECOND;
+    long now = System.currentTimeMillis();
     long systemClock = TimeUnit.MICROSECONDS.convert((now - POSTGRES_EPOCH_2000_01_01),
-        TimeUnit.MICROSECONDS);
+        TimeUnit.MILLISECONDS);
 
     if (LOGGER.isLoggable(Level.FINEST)) {
       @SuppressWarnings("JavaUtilDate")


### PR DESCRIPTION
Hi,

When creating a replication connection using the PostgreSQL JDBC driver,
`pg_stat_replication.reply_time` is reported as a timestamp more than 20 years in the past.

Example:

```
=# select application_name, reply_time from pg_stat_replication;
    application_name    |          reply_time
------------------------+-------------------------------
 PostgreSQL JDBC Driver | 1999-12-21 10:01:58.904961+09
(1 row)
```

I initially noticed this issue while using Debezium, but it can also be reproduced with a minimal replication connection app like [this](https://github.com/user-attachments/files/24557645/LogicaldecodingTest.java).

`reply_time` was calculated using `System.nanoTime()`, which is only suitable for measuring elapsed time and not wall-clock time. Additionally, `TimeUnit.convert()` was used with an incorrect source unit.

This change addresses the issue by:

- Replacing `System.nanoTime()` with `System.currentTimeMillis()` to obtain a proper wall-clock timestamp.
- Correcting the `TimeUnit.convert()` usage so that the source unit matches the actual time value being converted.

What do you think?

### All Submissions:

* [x]  Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x]  Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes to Existing Features:

* [x] Does this break existing behaviour? If so please explain.
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
  * No new tests have been added at this time. I considered adding a test that verifies `reply_time` is not excessively in the past (e.g., more than 24 hours earlier than the current time). However, I'm not sure it's worth adding. 
* [x] Have you successfully run tests with your changes locally?
