### PR TITLE
style: fix lambda argument indentation for checkstyle compliance

### DIFF
--- a/testkit/src/main/java/org/postgresql/test/impl/ServerVersionCondition.java
+++ b/testkit/src/main/java/org/postgresql/test/impl/ServerVersionCondition.java
@@ -29,7 +29,7 @@ public class ServerVersionCondition implements ExecutionCondition {
   public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
     return context.getElement()
             .flatMap(element ->
-                    AnnotationUtils.findAnnotation(element, DisabledIfServerVersionBelow.class)
+                AnnotationUtils.findAnnotation(element, DisabledIfServerVersionBelow.class)
                             .map(annotation -> ServerVersionCondition.toResult(element, annotation))
             ).orElse(ENABLED);
   }


### PR DESCRIPTION
Correct indentation of lambda arguments from level 20 to level 16 in ServerVersionCondition to comply with checkstyle Indentation rules. This resolves CI checkstyle failures.

Related to #18784

* [X] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
- Yes. I checked the commit rules and made it follow CONTRIBUTING.md's styles
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
- Yes

---

Checkstyle https://github.com/checkstyle/checkstyle/pull/18784 is working on a pull request to fix false negatives in indentation for lambda arguments. The CI job [no-error-pgjdbc](https://app.circleci.com/pipelines/github/checkstyle/checkstyle/41134/workflows/98b89a52-c66b-43d2-9a07-267d36663cda/jobs/1290276) failed after pointing indentation error in the targeted file. Making a simple fix in indentation to let CI pass. 