### PR TITLE
style: fix empty line before javadoc for checkstyle compliance

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -752,7 +752,6 @@ public enum PGProperty {
       null,
       "The password for the client's ssl key (ignored if sslpasswordcallback is set)"),
 
-
   /**
    * The classname instantiating {@link javax.security.auth.callback.CallbackHandler} to use.
    */


### PR DESCRIPTION
Fix #3923 

Remove extra empty line from [PGProperty.java](https://github.com/pgjdbc/pgjdbc/blob/1ac8d99a0042dd8250475aed477bdbfed565a7c1/pgjdbc/src/main/java/org/postgresql/PGProperty.java#L756) to comply with checkstyle `EmptyLineSeparator` rule. This resolves checkstyle CI failure.

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
 - Yes
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
 - Yes

---
Checkstyle https://github.com/checkstyle/checkstyle/pull/18811 is working on a pull request to add `ENUM_CONSTANT_DEF` token in `EmptyLineSeparatorCheck`. The CI job [no-error-pgjdbc](https://app.circleci.com/pipelines/github/checkstyle/checkstyle/41294/workflows/4e884ec5-db58-40c0-b0c1-3fa07e8dea6f/jobs/1297907) failed after pointing extra empty line in the targeted file. Making a simple remove empty line to let CI pass.