### PR TITLE
Migrate to Shadow 9

### DIFF
--- a/pgjdbc/build.gradle.kts
+++ b/pgjdbc/build.gradle.kts
@@ -81,11 +81,6 @@ tasks.jar {
     addMultiReleaseContents()
 }
 
-val knows by tasks.existing {
-    group = null // Hide the task from `./gradlew tasks` output
-    description = "This is a dummy task, unfortunately the author refuses to remove it: https://github.com/johnrengelman/shadow/issues/122"
-}
-
 val shaded by configurations.creating
 
 val karafFeatures by configurations.creating {
@@ -269,6 +264,7 @@ tasks.configureEach<Jar> {
 
 tasks.shadowJar {
     configurations = listOf(shaded)
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
     exclude("META-INF/maven/**")
     // ignore module-info.class not used in shaded dependency
     exclude("META-INF/versions/9/module-info.class")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,7 +7,7 @@ pluginManagement {
     plugins {
         id("biz.aQute.bnd.builder") version "7.1.0"
         id("com.github.burrunan.s3-build-cache") version "1.9.4"
-        id("com.gradleup.shadow") version "8.3.9"
+        id("com.gradleup.shadow") version "9.2.2"
         id("com.github.lburgazzoli.karaf") version "0.5.6"
         id("com.github.vlsi.crlf") version "2.0.0"
         id("com.github.vlsi.gettext") version "2.0.0"


### PR DESCRIPTION
```
OLD: old.jar
NEW: new.jar

 JAR   │ old     │ new     │ diff
───────┼─────────┼─────────┼──────────
 class │ 2.1 MiB │ 2.1 MiB │ +1.2 KiB
 other │   473 B │   473 B │      0 B
───────┼─────────┼─────────┼──────────
 total │ 2.1 MiB │ 2.1 MiB │ +1.2 KiB

 CLASSES │ old  │ new  │ diff
─────────┼──────┼──────┼───────────
 classes │  481 │  481 │ 0 (+0 -0)
 methods │ 5873 │ 5873 │ 0 (+0 -0)
  fields │ 1945 │ 1945 │ 0 (+0 -0)

=================
====   JAR   ====
=================

 size     │ diff     │ path
──────────┼──────────┼──────────────────────────────────────────────────────────────────
 19.2 KiB │    +31 B │ ∆ org/postgresql/Driver.class
 24.9 KiB │    +38 B │ ∆ org/postgresql/PGProperty.class
  6.1 KiB │    +10 B │ ∆ org/postgresql/copy/CopyManager.class
  2.3 KiB │    +23 B │ ∆ org/postgresql/core/CachedQuery.class
  7.4 KiB │    -27 B │ ∆ org/postgresql/core/Encoding.class
 16.8 KiB │     -1 B │ ∆ org/postgresql/core/PGStream.class
 22.7 KiB │     -2 B │ ∆ org/postgresql/core/Parser.class
  2.7 KiB │    +39 B │ ∆ org/postgresql/core/QueryExecutorCloseAction.class
 32.4 KiB │    +37 B │ ∆ org/postgresql/core/v3/ConnectionFactoryImpl.class
    708 B │    +29 B │ ∆ org/postgresql/core/v3/QueryExecutorImpl$4.class
 66.9 KiB │    +77 B │ ∆ org/postgresql/core/v3/QueryExecutorImpl.class
 15.8 KiB │    +16 B │ ∆ org/postgresql/core/v3/SimpleParameterList.class
  8.6 KiB │     -2 B │ ∆ org/postgresql/core/v3/replication/V3PGReplicationStream.class
  2.1 KiB │    +36 B │ ∆ org/postgresql/ds/PGConnectionPoolDataSource.class
 10.1 KiB │    +35 B │ ∆ org/postgresql/ds/PGPoolingDataSource.class
  2.1 KiB │    +36 B │ ∆ org/postgresql/ds/PGSimpleDataSource.class
    856 B │    +29 B │ ∆ org/postgresql/ds/common/BaseDataSource$1.class
  7.2 KiB │    +38 B │ ∆ org/postgresql/gss/GssAction.class
  6.2 KiB │     -1 B │ ∆ org/postgresql/gss/GssEncAction.class
  6.8 KiB │     -3 B │ ∆ org/postgresql/gss/MakeGSS.class
  7.4 KiB │     -1 B │ ∆ org/postgresql/jdbc/AbstractBlobClob.class
 12.7 KiB │    +44 B │ ∆ org/postgresql/jdbc/ArrayDecoding.class
  5.4 KiB │    +29 B │ ∆ org/postgresql/jdbc/ArrayEncoding$13.class
  6.2 KiB │    +29 B │ ∆ org/postgresql/jdbc/ArrayEncoding.class
  7.9 KiB │    +24 B │ ∆ org/postgresql/jdbc/BatchResultHandler.class
 14.9 KiB │    -43 B │ ∆ org/postgresql/jdbc/EscapedFunctions.class
 14.9 KiB │    -17 B │ ∆ org/postgresql/jdbc/EscapedFunctions2.class
  1.7 KiB │    +45 B │ ∆ org/postgresql/jdbc/FieldMetadata.class
 13.7 KiB │    +52 B │ ∆ org/postgresql/jdbc/PgArray.class
  2.2 KiB │    +23 B │ ∆ org/postgresql/jdbc/PgBlob.class
 31.8 KiB │    +14 B │ ∆ org/postgresql/jdbc/PgCallableStatement.class
 54.5 KiB │    +78 B │ ∆ org/postgresql/jdbc/PgConnection.class
 86.1 KiB │    +84 B │ ∆ org/postgresql/jdbc/PgDatabaseMetaData.class
 45.9 KiB │    +49 B │ ∆ org/postgresql/jdbc/PgPreparedStatement.class
 96.2 KiB │    +32 B │ ∆ org/postgresql/jdbc/PgResultSet.class
 11.7 KiB │    +20 B │ ∆ org/postgresql/jdbc/PgResultSetMetaData.class
 11.9 KiB │     -5 B │ ∆ org/postgresql/jdbc/PgSQLXML.class
 31.9 KiB │     -3 B │ ∆ org/postgresql/jdbc/PgStatement.class
    1 KiB │    +33 B │ ∆ org/postgresql/jdbc/TimestampUtils$ParsedTimestamp.class
 36.5 KiB │    +75 B │ ∆ org/postgresql/jdbc/TimestampUtils.class
   26 KiB │    +76 B │ ∆ org/postgresql/jdbc/TypeInfoCache.class
  7.2 KiB │     -2 B │ ∆ org/postgresql/jdbcurlresolver/PgPassParser.class
  8.1 KiB │     -4 B │ ∆ org/postgresql/jdbcurlresolver/PgServiceConfParser.class
  2.4 KiB │    +44 B │ ∆ org/postgresql/osgi/PGBundleActivator.class
 10.4 KiB │     -4 B │ ∆ org/postgresql/ssl/LazyKeyManager.class
  9.5 KiB │     -5 B │ ∆ org/postgresql/ssl/LibPQFactory.class
  7.9 KiB │    +38 B │ ∆ org/postgresql/sspi/SSPIClient.class
   39 KiB │    -13 B │ ∆ org/postgresql/translation/messages_bg.class
   13 KiB │    -13 B │ ∆ org/postgresql/translation/messages_cs.class
 23.9 KiB │    -13 B │ ∆ org/postgresql/translation/messages_de.class
 23.8 KiB │    -13 B │ ∆ org/postgresql/translation/messages_fr.class
 22.7 KiB │    -13 B │ ∆ org/postgresql/translation/messages_it.class
 48.8 KiB │    -13 B │ ∆ org/postgresql/translation/messages_ja.class
 11.4 KiB │    -13 B │ ∆ org/postgresql/translation/messages_pl.class
 27.4 KiB │    -14 B │ ∆ org/postgresql/translation/messages_pt_BR.class
   20 KiB │    -14 B │ ∆ org/postgresql/translation/messages_ru.class
 26.7 KiB │    -13 B │ ∆ org/postgresql/translation/messages_sr.class
 26.7 KiB │    -13 B │ ∆ org/postgresql/translation/messages_tr.class
 17.3 KiB │    -13 B │ ∆ org/postgresql/translation/messages_zh_CN.class
 17.3 KiB │    -13 B │ ∆ org/postgresql/translation/messages_zh_TW.class
  8.7 KiB │    +20 B │ ∆ org/postgresql/util/ByteConverter.class
  3.4 KiB │    +36 B │ ∆ org/postgresql/util/LogWriterHandler.class
  1.3 KiB │    +20 B │ ∆ org/postgresql/util/NumberParser.class
 10.1 KiB │    +18 B │ ∆ org/postgresql/util/PGInterval.class
  1.4 KiB │    +36 B │ ∆ org/postgresql/util/PGJDBCMain.class
  6.2 KiB │    -11 B │ ∆ org/postgresql/util/PSQLState.class
  5.7 KiB │    +23 B │ ∆ org/postgresql/util/StreamWrapper.class
 13.4 KiB │    +29 B │ ∆ org/postgresql/xa/PGXAConnection.class
  1.7 KiB │    +36 B │ ∆ org/postgresql/xa/PGXADataSource.class
  5.1 KiB │    +28 B │ ∆ org/postgresql/xml/DefaultPGXmlFactoryFactory.class
──────────┼──────────┼──────────────────────────────────────────────────────────────────
  1.2 MiB │ +1.2 KiB │ (total)
```

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Does `./gradlew styleCheck` pass ?
3. [ ] Have you added your new test classes to an existing test suite in alphabetical order?

### Changes to Existing Features:

* [ ] Does this break existing behaviour? If so please explain.
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
