### PR TITLE
Revert "fix: make all Calendar instances proleptic Gregorian (#3837)"

### DIFF
--- a/benchmarks/src/jmh/java/org/postgresql/benchmark/statement/BindTimestamp.java
+++ b/benchmarks/src/jmh/java/org/postgresql/benchmark/statement/BindTimestamp.java
@@ -5,8 +5,6 @@
 
 package org.postgresql.benchmark.statement;
 
-import static org.postgresql.jdbc.TimestampUtils.createProlepticGregorianCalendar;
-
 import org.postgresql.benchmark.profilers.FlightRecorderProfiler;
 import org.postgresql.test.TestUtil;
 
@@ -47,7 +45,7 @@ public class BindTimestamp {
   private Connection connection;
   private PreparedStatement ps;
   private Timestamp ts = new Timestamp(System.currentTimeMillis());
-  private Calendar cal = createProlepticGregorianCalendar(TimeZone.getTimeZone("UTC"));
+  private Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
 
   @Setup(Level.Trial)
   public void setUp() throws SQLException {
@@ -83,5 +81,4 @@ public class BindTimestamp {
 
     new Runner(opt).run();
   }
-
 }

--- a/benchmarks/src/jmh/java/org/postgresql/benchmark/time/TimestampToDate.java
+++ b/benchmarks/src/jmh/java/org/postgresql/benchmark/time/TimestampToDate.java
@@ -5,8 +5,6 @@
 
 package org.postgresql.benchmark.time;
 
-import static org.postgresql.jdbc.TimestampUtils.createProlepticGregorianCalendar;
-
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -25,6 +23,7 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 import java.sql.Timestamp;
 import java.util.Calendar;
+import java.util.GregorianCalendar;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 
@@ -42,7 +41,7 @@ public class TimestampToDate {
   TimeZone timeZone;
 
   Timestamp ts = new Timestamp(System.currentTimeMillis());
-  Calendar cachedCalendar = createProlepticGregorianCalendar(TimeZone.getDefault());
+  Calendar cachedCalendar = new GregorianCalendar();
 
   @Setup
   public void init() {

--- a/benchmarks/src/jmh/java/org/postgresql/benchmark/time/TimestampToTime.java
+++ b/benchmarks/src/jmh/java/org/postgresql/benchmark/time/TimestampToTime.java
@@ -5,8 +5,6 @@
 
 package org.postgresql.benchmark.time;
 
-import static org.postgresql.jdbc.TimestampUtils.createProlepticGregorianCalendar;
-
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -43,7 +41,7 @@ public class TimestampToTime {
   TimeZone timeZone;
 
   Timestamp ts = new Timestamp(System.currentTimeMillis());
-  Calendar cachedCalendar = createProlepticGregorianCalendar(TimeZone.getDefault());
+  Calendar cachedCalendar = new GregorianCalendar();
 
   @Setup
   public void init() {

--- a/pgjdbc/src/main/java/org/postgresql/PGStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGStatement.java
@@ -20,9 +20,8 @@ public interface PGStatement {
   // -infinity / infinity representation in Java
   long DATE_POSITIVE_INFINITY = 9223372036825200000L;
   long DATE_NEGATIVE_INFINITY = -9223372036832400000L;
-  // Days (2^31) in ms that can be stored minus the difference between the postgres and java epoch
-  long DATE_POSITIVE_SMALLER_INFINITY = 185541640502400000L;
-  long DATE_NEGATIVE_SMALLER_INFINITY = -185541640502400000L;
+  long DATE_POSITIVE_SMALLER_INFINITY = 185543533774800000L;
+  long DATE_NEGATIVE_SMALLER_INFINITY = -185543533774800000L;
 
   /**
    * Returns the Last inserted/updated oid.

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
@@ -5,7 +5,6 @@
 
 package org.postgresql.jdbc;
 
-import static org.postgresql.jdbc.TimestampUtils.createProlepticGregorianCalendar;
 import static org.postgresql.util.internal.Nullness.castNonNull;
 
 import org.postgresql.Driver;
@@ -3977,7 +3976,7 @@ public class PgResultSet implements ResultSet, PGRefCursorResultSet {
         if (timestampValue == null) {
           return null;
         }
-        Calendar calendar = createProlepticGregorianCalendar(getDefaultCalendar().getTimeZone());
+        Calendar calendar = Calendar.getInstance(getDefaultCalendar().getTimeZone());
         calendar.setTimeInMillis(timestampValue.getTime());
         return type.cast(calendar);
       } else {

--- a/pgjdbc/src/main/java/org/postgresql/util/PGInterval.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/PGInterval.java
@@ -5,8 +5,6 @@
 
 package org.postgresql.util;
 
-import static org.postgresql.jdbc.TimestampUtils.createProlepticGregorianCalendar;
-
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.io.Serializable;
@@ -15,7 +13,6 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
 import java.util.StringTokenizer;
-import java.util.TimeZone;
 
 /**
  * This implements a class that handles the PostgreSQL interval type.
@@ -471,7 +468,7 @@ public class PGInterval extends PGobject implements Serializable, Cloneable {
     if (isNull) {
       return;
     }
-    final Calendar cal = createProlepticGregorianCalendar(TimeZone.getDefault());
+    final Calendar cal = Calendar.getInstance();
     cal.setTime(date);
     add(cal);
     date.setTime(cal.getTime().getTime());

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DateTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DateTest.java
@@ -10,7 +10,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
-import static org.postgresql.jdbc.TimestampUtils.createProlepticGregorianCalendar;
 
 import org.postgresql.test.TestUtil;
 
@@ -24,7 +23,6 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Calendar;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
@@ -320,13 +318,7 @@ public class DateTest extends BaseTest4 {
     st.close();
   }
 
-  private static java.sql.Date makeDate(int year, int month, int day) {
-    Calendar cal = createProlepticGregorianCalendar(TimeZone.getDefault());
-    cal.clear();
-    // Note that Calendar.MONTH is zero based
-    cal.set(year, month - 1, day);
-
-    return new java.sql.Date(cal.getTimeInMillis());
+  private static java.sql.Date makeDate(int y, int m, int d) {
+    return new java.sql.Date(y - 1900, m - 1, d);
   }
-
 }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/GetXXXTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/GetXXXTest.java
@@ -8,7 +8,6 @@ package org.postgresql.test.jdbc2;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.postgresql.jdbc.TimestampUtils.createProlepticGregorianCalendar;
 
 import org.postgresql.test.TestUtil;
 import org.postgresql.util.PGInterval;
@@ -25,7 +24,6 @@ import java.sql.Statement;
 import java.sql.Timestamp;
 import java.util.Calendar;
 import java.util.HashMap;
-import java.util.TimeZone;
 
 /*
 * Test for getObject
@@ -39,7 +37,7 @@ class GetXXXTest {
     TestUtil.createTempTable(con, "test_interval",
         "initial timestamp with time zone, final timestamp with time zone");
     PreparedStatement pstmt = con.prepareStatement("insert into test_interval values (?,?)");
-    Calendar cal = createProlepticGregorianCalendar(TimeZone.getDefault());
+    Calendar cal = Calendar.getInstance();
     cal.add(Calendar.DAY_OF_YEAR, -1);
 
     pstmt.setTimestamp(1, new Timestamp(cal.getTime().getTime()));

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/IntervalTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/IntervalTest.java
@@ -9,7 +9,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.postgresql.jdbc.TimestampUtils.createProlepticGregorianCalendar;
 
 import org.postgresql.test.TestUtil;
 import org.postgresql.util.PGInterval;
@@ -28,8 +27,8 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.GregorianCalendar;
 import java.util.Locale;
-import java.util.TimeZone;
 import java.util.concurrent.ThreadLocalRandom;
 
 @Isolated("Uses Locale.setDefault")
@@ -149,7 +148,7 @@ class IntervalTest {
   @Test
   void addRounding() {
     PGInterval pgi = new PGInterval(0, 0, 0, 0, 0, 0.6006);
-    Calendar cal = createProlepticGregorianCalendar(TimeZone.getDefault());
+    Calendar cal = Calendar.getInstance();
     long origTime = cal.getTime().getTime();
     pgi.add(cal);
     long newTime = cal.getTime().getTime();
@@ -209,7 +208,7 @@ class IntervalTest {
   }
 
   private static Calendar getStartCalendar() {
-    Calendar cal = createProlepticGregorianCalendar(TimeZone.getDefault());
+    Calendar cal = new GregorianCalendar();
     cal.set(Calendar.YEAR, 2005);
     cal.set(Calendar.MONTH, 4);
     cal.set(Calendar.DAY_OF_MONTH, 29);
@@ -285,25 +284,6 @@ class IntervalTest {
     pgi2.add(date);
 
     assertEquals(date2, date);
-  }
-
-  @Test
-  void dateYear1000() throws Exception {
-    final Calendar calYear1000 = createProlepticGregorianCalendar(TimeZone.getDefault());
-    calYear1000.clear();
-    calYear1000.set(1000, Calendar.JANUARY, 1);
-
-    final Calendar calYear2000 = createProlepticGregorianCalendar(TimeZone.getDefault());
-    calYear2000.clear();
-    calYear2000.set(2000, Calendar.JANUARY, 1);
-
-    final Date date = calYear1000.getTime();
-    final Date dateYear2000 = calYear2000.getTime();
-
-    PGInterval pgi = new PGInterval("@ +1000 years");
-    pgi.add(date);
-
-    assertEquals(dateYear2000, date);
   }
 
   @Test
@@ -492,13 +472,7 @@ class IntervalTest {
     assertEquals(1, pgi.getMicroSeconds());
   }
 
-  private static java.sql.Date makeDate(int year, int month, int day) {
-    Calendar cal = createProlepticGregorianCalendar(TimeZone.getDefault());
-    cal.clear();
-    // Note that Calendar.MONTH is zero based
-    cal.set(year, month - 1, day);
-
-    return new java.sql.Date(cal.getTimeInMillis());
+  private static java.sql.Date makeDate(int y, int m, int d) {
+    return new java.sql.Date(y - 1900, m - 1, d);
   }
-
 }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PGTimeTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PGTimeTest.java
@@ -9,7 +9,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
-import static org.postgresql.jdbc.TimestampUtils.createProlepticGregorianCalendar;
 
 import org.postgresql.test.TestUtil;
 import org.postgresql.util.PGInterval;
@@ -58,21 +57,21 @@ public class PGTimeTest extends BaseTest4 {
   public void testTimeWithInterval() throws SQLException {
     assumeTrue(TestUtil.haveIntegerDateTimes(con));
 
-    Calendar cal = createProlepticGregorianCalendar(TimeZone.getDefault());
+    Calendar cal = Calendar.getInstance();
     cal.set(1970, Calendar.JANUARY, 1);
 
     final long now = cal.getTimeInMillis();
     verifyTimeWithInterval(new PGTime(now), new PGInterval(0, 0, 0, 1, 2, 3.14), true);
     verifyTimeWithInterval(new PGTime(now), new PGInterval(0, 0, 0, 1, 2, 3.14), false);
 
-    verifyTimeWithInterval(new PGTime(now, createProlepticGregorianCalendar(TimeZone.getTimeZone("GMT"))),
+    verifyTimeWithInterval(new PGTime(now, Calendar.getInstance(TimeZone.getTimeZone("GMT"))),
         new PGInterval(0, 0, 0, 1, 2, 3.14), true);
-    verifyTimeWithInterval(new PGTime(now, createProlepticGregorianCalendar(TimeZone.getTimeZone("GMT"))),
+    verifyTimeWithInterval(new PGTime(now, Calendar.getInstance(TimeZone.getTimeZone("GMT"))),
         new PGInterval(0, 0, 0, 1, 2, 3.14), false);
 
-    verifyTimeWithInterval(new PGTime(now, createProlepticGregorianCalendar(TimeZone.getTimeZone("GMT+01:00"))),
+    verifyTimeWithInterval(new PGTime(now, Calendar.getInstance(TimeZone.getTimeZone("GMT+01:00"))),
         new PGInterval(0, 0, 0, 1, 2, 3.456), true);
-    verifyTimeWithInterval(new PGTime(now, createProlepticGregorianCalendar(TimeZone.getTimeZone("GMT+01:00"))),
+    verifyTimeWithInterval(new PGTime(now, Calendar.getInstance(TimeZone.getTimeZone("GMT+01:00"))),
         new PGInterval(0, 0, 0, 1, 2, 3.456), false);
   }
 
@@ -136,20 +135,20 @@ public class PGTimeTest extends BaseTest4 {
    */
   @Test
   public void testTimeInsertAndSelect() throws SQLException {
-    Calendar cal = createProlepticGregorianCalendar(TimeZone.getDefault());
+    Calendar cal = Calendar.getInstance();
     cal.set(1970, Calendar.JANUARY, 1);
 
     final long now = cal.getTimeInMillis();
     verifyInsertAndSelect(new PGTime(now), true);
     verifyInsertAndSelect(new PGTime(now), false);
 
-    verifyInsertAndSelect(new PGTime(now, createProlepticGregorianCalendar(TimeZone.getTimeZone("GMT"))), true);
-    verifyInsertAndSelect(new PGTime(now, createProlepticGregorianCalendar(TimeZone.getTimeZone("GMT"))),
+    verifyInsertAndSelect(new PGTime(now, Calendar.getInstance(TimeZone.getTimeZone("GMT"))), true);
+    verifyInsertAndSelect(new PGTime(now, Calendar.getInstance(TimeZone.getTimeZone("GMT"))),
         false);
 
-    verifyInsertAndSelect(new PGTime(now, createProlepticGregorianCalendar(TimeZone.getTimeZone("GMT+01:00"))),
+    verifyInsertAndSelect(new PGTime(now, Calendar.getInstance(TimeZone.getTimeZone("GMT+01:00"))),
         true);
-    verifyInsertAndSelect(new PGTime(now, createProlepticGregorianCalendar(TimeZone.getTimeZone("GMT+01:00"))),
+    verifyInsertAndSelect(new PGTime(now, Calendar.getInstance(TimeZone.getTimeZone("GMT+01:00"))),
         false);
   }
 
@@ -244,5 +243,4 @@ public class PGTimeTest extends BaseTest4 {
     }
     return sdf;
   }
-
 }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PGTimestampTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PGTimestampTest.java
@@ -9,7 +9,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
-import static org.postgresql.jdbc.TimestampUtils.createProlepticGregorianCalendar;
 
 import org.postgresql.test.TestUtil;
 import org.postgresql.util.PGInterval;
@@ -26,6 +25,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
+import java.util.Calendar;
 import java.util.TimeZone;
 
 /**
@@ -66,13 +66,13 @@ class PGTimestampTest {
     verifyTimestampWithInterval(timestamp, interval, false);
 
     timestamp = new PGTimestamp(System.currentTimeMillis(),
-        createProlepticGregorianCalendar(TimeZone.getTimeZone("GMT")));
+        Calendar.getInstance(TimeZone.getTimeZone("GMT")));
     interval = new PGInterval(0, 0, 0, 1, 2, 3.14);
     verifyTimestampWithInterval(timestamp, interval, true);
     verifyTimestampWithInterval(timestamp, interval, false);
 
     timestamp = new PGTimestamp(System.currentTimeMillis(),
-        createProlepticGregorianCalendar(TimeZone.getTimeZone("GMT+01:00")));
+        Calendar.getInstance(TimeZone.getTimeZone("GMT+01:00")));
     interval = new PGInterval(-3, -2, -1, 1, 2, 3.14);
     verifyTimestampWithInterval(timestamp, interval, true);
     verifyTimestampWithInterval(timestamp, interval, false);
@@ -139,15 +139,15 @@ class PGTimestampTest {
     verifyInsertAndSelect(new PGTimestamp(now), true);
     verifyInsertAndSelect(new PGTimestamp(now), false);
 
-    verifyInsertAndSelect(new PGTimestamp(now, createProlepticGregorianCalendar(TimeZone.getTimeZone("GMT"))),
+    verifyInsertAndSelect(new PGTimestamp(now, Calendar.getInstance(TimeZone.getTimeZone("GMT"))),
         true);
-    verifyInsertAndSelect(new PGTimestamp(now, createProlepticGregorianCalendar(TimeZone.getTimeZone("GMT"))),
+    verifyInsertAndSelect(new PGTimestamp(now, Calendar.getInstance(TimeZone.getTimeZone("GMT"))),
         false);
 
     verifyInsertAndSelect(
-        new PGTimestamp(now, createProlepticGregorianCalendar(TimeZone.getTimeZone("GMT+01:00"))), true);
+        new PGTimestamp(now, Calendar.getInstance(TimeZone.getTimeZone("GMT+01:00"))), true);
     verifyInsertAndSelect(
-        new PGTimestamp(now, createProlepticGregorianCalendar(TimeZone.getTimeZone("GMT+01:00"))), false);
+        new PGTimestamp(now, Calendar.getInstance(TimeZone.getTimeZone("GMT+01:00"))), false);
   }
 
   /**
@@ -242,5 +242,4 @@ class PGTimestampTest {
     }
     return sdf;
   }
-
 }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/TimeTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/TimeTest.java
@@ -9,7 +9,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.postgresql.jdbc.TimestampUtils.createProlepticGregorianCalendar;
 
 import org.postgresql.test.TestUtil;
 
@@ -61,9 +60,11 @@ class TimeTest {
   void getTimeZone() throws Exception {
     final Time midnight = new Time(0, 0, 0);
     Statement stmt = con.createStatement();
-    Calendar cal = createProlepticGregorianCalendar(TimeZone.getTimeZone("GMT"));
+    Calendar cal = Calendar.getInstance();
 
-    int localOffset = TimeZone.getDefault().getOffset(midnight.getTime());
+    cal.setTimeZone(TimeZone.getTimeZone("GMT"));
+
+    int localOffset = Calendar.getInstance().getTimeZone().getOffset(midnight.getTime());
 
     // set the time to midnight to make this easy
     assertEquals(1, stmt.executeUpdate(TestUtil.insertSQL("testtime", "'00:00:00','00:00:00'")));
@@ -250,7 +251,7 @@ class TimeTest {
       t = rs.getTime(1);
       assertNotNull(t);
       Time tmpTime = Time.valueOf("5:1:2");
-      int localOffset = TimeZone.getDefault().getOffset(tmpTime.getTime());
+      int localOffset = Calendar.getInstance().getTimeZone().getOffset(tmpTime.getTime());
       int timeOffset = 3 * 60 * 60 * 1000;
       tmpTime.setTime(tmpTime.getTime() + timeOffset + localOffset);
       assertEquals(makeTime(tmpTime.getHours(), tmpTime.getMinutes(), tmpTime.getSeconds()), t);
@@ -259,7 +260,7 @@ class TimeTest {
       t = rs.getTime(1);
       assertNotNull(t);
       tmpTime = Time.valueOf("23:59:59");
-      localOffset = TimeZone.getDefault().getOffset(tmpTime.getTime());
+      localOffset = Calendar.getInstance().getTimeZone().getOffset(tmpTime.getTime());
       timeOffset = -11 * 60 * 60 * 1000;
       tmpTime.setTime(tmpTime.getTime() + timeOffset + localOffset);
       assertEquals(makeTime(tmpTime.getHours(), tmpTime.getMinutes(), tmpTime.getSeconds()), t);
@@ -273,5 +274,4 @@ class TimeTest {
   private static Time makeTime(int h, int m, int s) {
     return Time.valueOf(TestUtil.fix(h, 2) + ":" + TestUtil.fix(m, 2) + ":" + TestUtil.fix(s, 2));
   }
-
 }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/TimestampTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/TimestampTest.java
@@ -10,7 +10,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
-import static org.postgresql.jdbc.TimestampUtils.createProlepticGregorianCalendar;
 
 import org.postgresql.PGStatement;
 import org.postgresql.core.BaseConnection;
@@ -31,11 +30,10 @@ import java.sql.Time;
 import java.sql.Timestamp;
 import java.sql.Types;
 import java.text.SimpleDateFormat;
-import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collection;
+import java.util.GregorianCalendar;
 import java.util.TimeZone;
 
 /*
@@ -84,7 +82,7 @@ public class TimestampTest extends BaseTest4 {
    */
   @Test
   public void testCalendarModification() throws SQLException {
-    Calendar cal = createProlepticGregorianCalendar(TimeZone.getDefault());
+    Calendar cal = Calendar.getInstance();
     Calendar origCal = (Calendar) cal.clone();
     PreparedStatement ps = con.prepareStatement("INSERT INTO " + TSWOTZ_TABLE + " VALUES (?)");
 
@@ -133,9 +131,10 @@ public class TimestampTest extends BaseTest4 {
   }
 
   private void runInfinityTests(String table, long value) throws SQLException {
+    GregorianCalendar cal = new GregorianCalendar();
     // Pick some random timezone that is hopefully different than ours
     // and exists in this JVM.
-    Calendar cal = createProlepticGregorianCalendar(TimeZone.getTimeZone("Europe/Warsaw"));
+    cal.setTimeZone(TimeZone.getTimeZone("Europe/Warsaw"));
 
     String strValue;
     if (value == PGStatement.DATE_POSITIVE_INFINITY) {
@@ -219,38 +218,9 @@ public class TimestampTest extends BaseTest4 {
   }
 
   /*
-   * Tests the timestamp methods in ResultSet on timestamp with time zone we insert a known string
-   * value fpr the year 1000 (don't use setTimestamp) then see that we get back the same value from
-   * getTimestamp
-   */
-  @Test
-  public void testGetTimestampYear1000WTZ() throws SQLException {
-    assumeTrue(TestUtil.haveIntegerDateTimes(con));
-
-    Statement stmt = con.createStatement();
-
-    assertEquals(1, stmt.executeUpdate(TestUtil.insertSQL(TSWTZ_TABLE, "'" + TS_YEAR1000_WTZ_PGFORMAT + "'")));
-
-    ResultSet rs = stmt.executeQuery("select ts from " + TSWTZ_TABLE);
-    assertNotNull(rs);
-
-    assertTrue(rs.next());
-    Timestamp t = rs.getTimestamp(1);
-    assertNotNull(t);
-    // Be aware that Timestamp.toString() formats with the Julian calendar for such old dates
-    assertEquals(TS_YEAR1000_WTZ, t);
-
-    rs.close();
-
-    assertEquals(1, stmt.executeUpdate("DELETE FROM " + TSWTZ_TABLE));
-
-    stmt.close();
-  }
-
-  /*
    * Tests the timestamp methods in PreparedStatement on timestamp with time zone we insert a value
    * using setTimestamp then see that we get back the same value from getTimestamp (which we know
-   * works as it was tested independently of setTimestamp)
+   * works as it was tested independently of setTimestamp
    */
   @Test
   public void testSetTimestampWTZ() throws SQLException {
@@ -314,34 +284,6 @@ public class TimestampTest extends BaseTest4 {
     timestampTestWTZ();
 
     assertEquals(20, stmt.executeUpdate("DELETE FROM " + TSWTZ_TABLE));
-
-    pstmt.close();
-    stmt.close();
-  }
-
-  /*
-   * Tests the timestamp methods in PreparedStatement on timestamp with time zone we insert the
-   * year 1000 value using setTimestamp then see that we get back the same value from getTimestamp
-   * (which we know works as it was tested independently of setTimestamp)
-   */
-  @Test
-  public void testSetTimestampYear1000WTZ() throws SQLException {
-    assumeTrue(TestUtil.haveIntegerDateTimes(con));
-
-    Statement stmt = con.createStatement();
-    PreparedStatement pstmt = con.prepareStatement(TestUtil.insertSQL(TSWTZ_TABLE, "?"));
-
-    pstmt.setTimestamp(1, TS_YEAR1000_WTZ);
-    assertEquals(1, pstmt.executeUpdate());
-
-    ResultSet rs = stmt.executeQuery("select ts from " + TSWTZ_TABLE);
-    assertNotNull(rs);
-    assertTrue(rs.next());
-    assertEquals(ODT_YEAR1000, rs.getObject(1, OffsetDateTime.class));
-
-    rs.close();
-
-    assertEquals(1, stmt.executeUpdate("DELETE FROM " + TSWTZ_TABLE));
 
     pstmt.close();
     stmt.close();
@@ -667,8 +609,6 @@ public class TimestampTest extends BaseTest4 {
         ts = ts + tz;
         dateFormat = new SimpleDateFormat("y-M-d H:m:s z");
       }
-      dateFormat.setCalendar(createProlepticGregorianCalendar(TimeZone.getDefault()));
-
       java.util.Date date = dateFormat.parse(ts);
       result = new Timestamp(date.getTime());
       result.setNanos(f);
@@ -693,12 +633,6 @@ public class TimestampTest extends BaseTest4 {
   private static final Timestamp TS4WTZ =
       getTimestamp(2000, 7, 7, 15, 0, 0, 123456000, "GMT");
   private static final String TS4WTZ_PGFORMAT = "2000-07-07 15:00:00.123456+00";
-
-  private static final Timestamp TS_YEAR1000_WTZ =
-      getTimestamp(1000, 1, 1, 0, 0, 0, 0, "UTC");
-  private static final String TS_YEAR1000_WTZ_PGFORMAT = "1000-01-01 00:00:00.0+00";
-  private static final OffsetDateTime ODT_YEAR1000 =
-      OffsetDateTime.of(1000, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
 
   private static final Timestamp TS1WOTZ =
       getTimestamp(1950, 2, 7, 15, 0, 0, 100000000, null);

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/TimezoneCachingTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/TimezoneCachingTest.java
@@ -8,7 +8,6 @@ package org.postgresql.test.jdbc2;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
-import static org.postgresql.jdbc.TimestampUtils.createProlepticGregorianCalendar;
 
 import org.postgresql.core.BaseConnection;
 import org.postgresql.jdbc.TimestampUtils;
@@ -26,6 +25,7 @@ import java.sql.Statement;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.util.Calendar;
+import java.util.GregorianCalendar;
 import java.util.TimeZone;
 
 public class TimezoneCachingTest extends BaseTest4 {
@@ -105,8 +105,8 @@ public class TimezoneCachingTest extends BaseTest4 {
     TimeZone tz2 = TimeZone.getTimeZone("GMT-2:00");
     TimeZone tz3 = TimeZone.getTimeZone("UTC+2");
     TimeZone tz4 = TimeZone.getTimeZone("UTC+3");
-    Calendar c3 = createProlepticGregorianCalendar(tz3);
-    Calendar c4 = createProlepticGregorianCalendar(tz4);
+    Calendar c3 = new GregorianCalendar(tz3);
+    Calendar c4 = new GregorianCalendar(tz4);
     try {
       stmt = con.createStatement();
       TimeZone.setDefault(tz1);
@@ -254,8 +254,8 @@ public class TimezoneCachingTest extends BaseTest4 {
     TimeZone tz2 = TimeZone.getTimeZone("GMT-2:00"); // 10 hour difference
     Timestamp ts1 = new Timestamp(2016 - 1900, 0, 31, 3, 0, 0, 0);
     Timestamp ts2 = new Timestamp(2016 - 1900, 0, 31, 13, 0, 0, 0); // 10 hour difference
-    Calendar c1 = createProlepticGregorianCalendar(tz1);
-    Calendar c2 = createProlepticGregorianCalendar(tz2);
+    Calendar c1 = new GregorianCalendar(tz1);
+    Calendar c2 = new GregorianCalendar(tz2);
     try {
       TimeZone.setDefault(tz1);
       pstmt = con.prepareStatement("INSERT INTO testtz VALUES (?,?)");

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/TimezoneTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/TimezoneTest.java
@@ -8,7 +8,6 @@ package org.postgresql.test.jdbc2;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.postgresql.jdbc.TimestampUtils.createProlepticGregorianCalendar;
 
 import org.postgresql.PGProperty;
 import org.postgresql.test.TestUtil;
@@ -77,10 +76,10 @@ public class TimezoneTest {
     TimeZone tzGMT05 = TimeZone.getTimeZone("GMT-05"); // -0500 always
     TimeZone tzGMT13 = TimeZone.getTimeZone("GMT+13"); // +1000 always
 
-    cUTC = createProlepticGregorianCalendar(tzUTC);
-    cGMT03 = createProlepticGregorianCalendar(tzGMT03);
-    cGMT05 = createProlepticGregorianCalendar(tzGMT05);
-    cGMT13 = createProlepticGregorianCalendar(tzGMT13);
+    cUTC = Calendar.getInstance(tzUTC);
+    cGMT03 = Calendar.getInstance(tzGMT03);
+    cGMT05 = Calendar.getInstance(tzGMT05);
+    cGMT13 = Calendar.getInstance(tzGMT13);
   }
 
   @BeforeEach
@@ -860,10 +859,9 @@ public class TimezoneTest {
     PreparedStatement pstmt =
         con.prepareStatement("SELECT ts, d FROM testtimezone order by seq /*" + timeZone + "*/");
 
-    Calendar expectedTimestamp = createProlepticGregorianCalendar(TimeZone.getDefault());
+    Calendar expectedTimestamp = Calendar.getInstance();
 
     SimpleDateFormat sdf = new SimpleDateFormat(testDateFormat);
-    sdf.setCalendar(expectedTimestamp);
 
     for (int i = 0; i < PREPARE_THRESHOLD; i++) {
       ResultSet rs = pstmt.executeQuery();
@@ -973,5 +971,4 @@ public class TimezoneTest {
     }
     return millis;
   }
-
 }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc4/jdbc41/GetObjectTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc4/jdbc41/GetObjectTest.java
@@ -9,7 +9,6 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.postgresql.jdbc.TimestampUtils.createProlepticGregorianCalendar;
 
 import org.postgresql.core.BaseConnection;
 import org.postgresql.core.ServerVersion;
@@ -48,6 +47,7 @@ import java.sql.Time;
 import java.sql.Timestamp;
 import java.sql.Types;
 import java.util.Calendar;
+import java.util.GregorianCalendar;
 import java.util.TimeZone;
 import java.util.UUID;
 
@@ -198,9 +198,14 @@ class GetObjectTest {
     ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("table1", "timestamp_without_time_zone_column"));
     try {
       assertTrue(rs.next());
-      Calendar calendar = createProlepticGregorianCalendar(TimeZone.getDefault());
+      Calendar calendar = GregorianCalendar.getInstance();
       calendar.clear();
-      calendar.set(2004, Calendar.OCTOBER, 19, 10, 23, 54);
+      calendar.set(Calendar.YEAR, 2004);
+      calendar.set(Calendar.MONTH, Calendar.OCTOBER);
+      calendar.set(Calendar.DAY_OF_MONTH, 19);
+      calendar.set(Calendar.HOUR_OF_DAY, 10);
+      calendar.set(Calendar.MINUTE, 23);
+      calendar.set(Calendar.SECOND, 54);
       Timestamp expectedNoZone = new Timestamp(calendar.getTimeInMillis());
       assertEquals(expectedNoZone, rs.getObject("timestamp_without_time_zone_column", Timestamp.class));
       assertEquals(expectedNoZone, rs.getObject(1, Timestamp.class));
@@ -219,9 +224,14 @@ class GetObjectTest {
         + ", null::timestamp as null_timestamp");
     try {
       assertTrue(rs.next());
-      Calendar calendar = createProlepticGregorianCalendar(TimeZone.getDefault());
+      Calendar calendar = GregorianCalendar.getInstance();
       calendar.clear();
-      calendar.set(2004,  Calendar.OCTOBER, 19, 10, 23, 54);
+      calendar.set(Calendar.YEAR, 2004);
+      calendar.set(Calendar.MONTH, Calendar.OCTOBER);
+      calendar.set(Calendar.DAY_OF_MONTH, 19);
+      calendar.set(Calendar.HOUR_OF_DAY, 10);
+      calendar.set(Calendar.MINUTE, 23);
+      calendar.set(Calendar.SECOND, 54);
       java.util.Date expected = new java.util.Date(calendar.getTimeInMillis());
       assertEquals(expected, rs.getObject("timestamp_without_time_zone_column", java.util.Date.class));
       assertEquals(expected, rs.getObject(1, java.util.Date.class));
@@ -251,9 +261,14 @@ class GetObjectTest {
       try {
         assertTrue(rs.next());
 
-        Calendar calendar = createProlepticGregorianCalendar(timeZone);
+        Calendar calendar = GregorianCalendar.getInstance(timeZone);
         calendar.clear();
-        calendar.set(2004, Calendar.OCTOBER, 19, 10, 23, 54);
+        calendar.set(Calendar.YEAR, 2004);
+        calendar.set(Calendar.MONTH, Calendar.OCTOBER);
+        calendar.set(Calendar.DAY_OF_MONTH, 19);
+        calendar.set(Calendar.HOUR_OF_DAY, 10);
+        calendar.set(Calendar.MINUTE, 23);
+        calendar.set(Calendar.SECOND, 54);
         Timestamp expectedWithZone = new Timestamp(calendar.getTimeInMillis());
         assertEquals(expectedWithZone, rs.getObject("timestamp_with_time_zone_column", Timestamp.class));
         assertEquals(expectedWithZone, rs.getObject(1, Timestamp.class));
@@ -277,9 +292,14 @@ class GetObjectTest {
         + ", TIMESTAMP '2004-10-19 10:23:54+02'::timestamp as timestamp_with_time_zone_column, null::timestamp as null_timestamp");
     try {
       assertTrue(rs.next());
-      Calendar calendar = createProlepticGregorianCalendar(TimeZone.getDefault());
+      Calendar calendar = GregorianCalendar.getInstance();
       calendar.clear();
-      calendar.set(2004,  Calendar.OCTOBER, 19, 10, 23, 54);
+      calendar.set(Calendar.YEAR, 2004);
+      calendar.set(Calendar.MONTH, Calendar.OCTOBER);
+      calendar.set(Calendar.DAY_OF_MONTH, 19);
+      calendar.set(Calendar.HOUR_OF_DAY, 10);
+      calendar.set(Calendar.MINUTE, 23);
+      calendar.set(Calendar.SECOND, 54);
       long expected = calendar.getTimeInMillis();
       assertEquals(expected, rs.getObject("timestamp_without_time_zone_column", Calendar.class).getTimeInMillis());
       assertEquals(expected, rs.getObject(1, Calendar.class).getTimeInMillis());
@@ -289,29 +309,6 @@ class GetObjectTest {
       assertEquals(expected, rs.getObject("timestamp_with_time_zone_column", Calendar.class).getTimeInMillis());
       assertEquals(expected, rs.getObject(2, Calendar.class).getTimeInMillis());
       assertNull(rs.getObject(3, Calendar.class));
-    } finally {
-      rs.close();
-    }
-  }
-
-  /**
-   * Test the behavior getObject for timestamp columns using the year 1000.
-   */
-  @Test
-  void getCalendarYear1000() throws SQLException {
-    Statement stmt = conn.createStatement();
-
-    ResultSet rs = stmt.executeQuery("select TIMESTAMP '1000-10-19 10:23:54'::timestamp as timestamp_without_time_zone_column"
-        + ", TIMESTAMP '1000-10-19 10:23:54+02'::timestamp as timestamp_with_time_zone_column, null::timestamp as null_timestamp");
-    try {
-      assertTrue(rs.next());
-      Calendar expectedCal = createProlepticGregorianCalendar(TimeZone.getDefault());
-      expectedCal.clear();
-      expectedCal.set(1000, Calendar.OCTOBER, 19, 10, 23, 54);
-
-      assertEquals(expectedCal.getTimeInMillis(), rs.getObject("timestamp_without_time_zone_column", Calendar.class).getTimeInMillis());
-      expectedCal.setTimeZone(TimeZone.getTimeZone("GMT+2:00"));
-      assertEquals(expectedCal.getTimeInMillis(), rs.getObject("timestamp_with_time_zone_column", Calendar.class).getTimeInMillis());
     } finally {
       rs.close();
     }
@@ -328,9 +325,11 @@ class GetObjectTest {
     ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("table1", "date_column"));
     try {
       assertTrue(rs.next());
-      Calendar calendar = createProlepticGregorianCalendar(TimeZone.getDefault());
+      Calendar calendar = GregorianCalendar.getInstance();
       calendar.clear();
-      calendar.set(1999, Calendar.JANUARY, 8);
+      calendar.set(Calendar.YEAR, 1999);
+      calendar.set(Calendar.MONTH, Calendar.JANUARY);
+      calendar.set(Calendar.DAY_OF_MONTH, 8);
       Date expectedNoZone = new Date(calendar.getTimeInMillis());
       assertEquals(expectedNoZone, rs.getObject("date_column", Date.class));
       assertEquals(expectedNoZone, rs.getObject(1, Date.class));
@@ -380,9 +379,14 @@ class GetObjectTest {
     ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("table1", "time_without_time_zone_column"));
     try {
       assertTrue(rs.next());
-      Calendar calendar = createProlepticGregorianCalendar(TimeZone.getDefault());
+      Calendar calendar = GregorianCalendar.getInstance();
       calendar.clear();
-      calendar.set(1970,  Calendar.JANUARY, 1, 4, 5, 6);
+      calendar.set(Calendar.YEAR, 1970);
+      calendar.set(Calendar.MONTH, Calendar.JANUARY);
+      calendar.set(Calendar.DAY_OF_MONTH, 1);
+      calendar.set(Calendar.HOUR, 4);
+      calendar.set(Calendar.MINUTE, 5);
+      calendar.set(Calendar.SECOND, 6);
       Time expectedNoZone = new Time(calendar.getTimeInMillis());
       assertEquals(expectedNoZone, rs.getObject("time_without_time_zone_column", Time.class));
       assertEquals(expectedNoZone, rs.getObject(1, Time.class));

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc42/TimestampUtilsTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc42/TimestampUtilsTest.java
@@ -6,7 +6,6 @@
 package org.postgresql.test.jdbc42;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 import org.postgresql.jdbc.TimestampUtils;
 import org.postgresql.util.ByteConverter;
@@ -15,14 +14,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.sql.SQLException;
-import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.OffsetTime;
-import java.time.ZoneOffset;
-import java.time.temporal.ChronoUnit;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.GregorianCalendar;
 import java.util.TimeZone;
 
 class TimestampUtilsTest {
@@ -178,142 +171,4 @@ class TimestampUtilsTest {
         timestampUtils.toOffsetTime(inputTime),
         "timestampUtils.toOffsetTime(" + inputTime + ")");
   }
-
-  @Test
-  void getSharedCalendar() {
-    Calendar calendar = timestampUtils.getSharedCalendar(null);
-    // The default time zone should be applied
-    assertEquals(TimeZone.getDefault(), calendar.getTimeZone());
-    assertInstanceOf(GregorianCalendar.class, calendar);
-    GregorianCalendar gregorianCalendar = (GregorianCalendar) calendar;
-    // The returned calendar should be pure (proleptic) Gregorian
-    assertEquals(new Date(Long.MIN_VALUE), gregorianCalendar.getGregorianChange());
-  }
-
-  @Test
-  void createProlepticGregorianCalendar() {
-    Calendar calendar = TimestampUtils.createProlepticGregorianCalendar(TimeZone.getTimeZone(ZoneOffset.UTC));
-    // The supplied time zone should be applied
-    assertEquals(TimeZone.getTimeZone(ZoneOffset.UTC), calendar.getTimeZone());
-    assertInstanceOf(GregorianCalendar.class, calendar);
-    GregorianCalendar gregorianCalendar = (GregorianCalendar) calendar;
-    // The returned calendar should be pure (proleptic) Gregorian
-    assertEquals(new Date(Long.MIN_VALUE), gregorianCalendar.getGregorianChange());
-    // Perform a date calculation close to the default switch from Julian to Gregorian dates
-    gregorianCalendar.clear();
-    gregorianCalendar.set(1582, Calendar.OCTOBER, 5);
-    gregorianCalendar.add(Calendar.DAY_OF_MONTH, 15);
-    assertEquals(1582, gregorianCalendar.get(Calendar.YEAR));
-    assertEquals(Calendar.OCTOBER, gregorianCalendar.get(Calendar.MONTH));
-    // Would be 30 if the calendar had the default Julian to Gregorian change date
-    assertEquals(20, gregorianCalendar.get(Calendar.DAY_OF_MONTH));
-  }
-
-  @Test
-  void toDate() throws SQLException {
-    Calendar expectedCal = TimestampUtils.createProlepticGregorianCalendar(TimeZone.getDefault());
-    expectedCal.clear();
-    expectedCal.set(2025, Calendar.NOVEMBER, 25);
-
-    assertEquals(expectedCal.getTime(), timestampUtils.toDate(TimestampUtils.createProlepticGregorianCalendar(TimeZone.getDefault()), "2025-11-25"));
-    assertEquals(expectedCal.getTime(), timestampUtils.toDate(null, "2025-11-25 00:00:00"));
-  }
-
-  @Test
-  void toDateYear1000() throws SQLException {
-    Calendar expectedCal = TimestampUtils.createProlepticGregorianCalendar(TimeZone.getDefault());
-    expectedCal.clear();
-    expectedCal.set(1000, Calendar.JANUARY, 1);
-    // Be aware that Date.toString() formats with the Julian calendar for such old dates
-    assertEquals(expectedCal.getTime(), timestampUtils.toDate(TimestampUtils.createProlepticGregorianCalendar(TimeZone.getDefault()), "1000-01-01"));
-    assertEquals(expectedCal.getTime(), timestampUtils.toDate(null, "1000-01-01 00:00:00"));
-  }
-
-  @Test
-  void toDateBin() throws SQLException {
-    final int days = 10;
-    final byte[] bytes = new byte[4];
-    ByteConverter.int4(bytes, 0, days);
-
-    Calendar expectedCal = TimestampUtils.createProlepticGregorianCalendar(TimeZone.getDefault());
-    expectedCal.clear();
-    // Postgres epoch (but in default time zone) + days
-    expectedCal.set(2000, Calendar.JANUARY, 1 + days);
-
-    assertEquals(expectedCal.getTime(), timestampUtils.toDateBin(null, bytes));
-  }
-
-  @Test
-  void toDateBinYear1000() throws SQLException {
-    // java.time is based on ISO-8601, that means the proleptic Gregorian calendar is used
-    final int days = Math.toIntExact(ChronoUnit.DAYS.between(LocalDate.of(2000, 1, 1), LocalDate.of(1000, 1, 1)));
-    final byte[] bytes = new byte[4];
-    ByteConverter.int4(bytes, 0, days);
-
-    Calendar expectedCal = TimestampUtils.createProlepticGregorianCalendar(TimeZone.getDefault());
-    expectedCal.clear();
-    expectedCal.set(1000, Calendar.JANUARY, 1);
-
-    // Be aware that Date.toString() formats with the Julian calendar for such old dates
-    assertEquals(expectedCal.getTime(), timestampUtils.toDateBin(null, bytes));
-  }
-
-  @Test
-  void toTimestamp() throws SQLException {
-    Calendar expectedCal = TimestampUtils.createProlepticGregorianCalendar(TimeZone.getDefault());
-    expectedCal.clear();
-    expectedCal.set(2025, Calendar.NOVEMBER, 25, 16, 34, 45);
-
-    assertEquals(expectedCal.getTime().getTime(), timestampUtils.toTimestamp(TimestampUtils.createProlepticGregorianCalendar(TimeZone.getDefault()), "2025-11-25 16:34:45").getTime());
-    assertEquals(expectedCal.getTime().getTime(), timestampUtils.toTimestamp(null, "2025-11-25 16:34:45").getTime());
-  }
-
-  @Test
-  void toTimestampYear1000() throws SQLException {
-    Calendar expectedCal = TimestampUtils.createProlepticGregorianCalendar(TimeZone.getDefault());
-    expectedCal.clear();
-    expectedCal.set(1000, Calendar.NOVEMBER, 25, 16, 34, 45);
-
-    assertEquals(expectedCal.getTime().getTime(), timestampUtils.toTimestamp(TimestampUtils.createProlepticGregorianCalendar(TimeZone.getDefault()), "1000-11-25 16:34:45").getTime());
-    assertEquals(expectedCal.getTime().getTime(), timestampUtils.toTimestamp(null, "1000-11-25 16:34:45").getTime());
-  }
-
-  @Test
-  void toTimestampBin() throws SQLException {
-    final int days = 10;
-    final int hours = 14;
-    final int minutes = 16;
-    final long daysInMicros = days * 24L * 60L * 60L * 1000_000L;
-    final long hoursInMicros = hours * 60L * 60L * 1000_000L;
-    final long minutesInMicros = minutes * 60L * 1000_000L;
-    final byte[] bytes = new byte[8];
-    ByteConverter.int8(bytes, 0, daysInMicros + hoursInMicros + minutesInMicros);
-
-    Calendar expectedCal = TimestampUtils.createProlepticGregorianCalendar(TimeZone.getDefault());
-    expectedCal.clear();
-    // Postgres epoch (but in default time zone) + days
-    expectedCal.set(2000, Calendar.JANUARY, 1 + days, hours, minutes);
-
-    assertEquals(expectedCal.getTime().getTime(), timestampUtils.toTimestampBin(null, bytes, false).getTime());
-  }
-
-  @Test
-  void toTimestampBinYear1000() throws SQLException {
-    // java.time is based on ISO-8601, that means the proleptic Gregorian calendar is used
-    final int days = Math.toIntExact(ChronoUnit.DAYS.between(LocalDate.of(2000, 1, 1), LocalDate.of(1000, 1, 1)));
-    final int hours = 14;
-    final int minutes = 16;
-    final long daysInMicros = days * 24L * 60L * 60L * 1000_000L;
-    final long hoursInMicros = hours * 60L * 60L * 1000_000L;
-    final long minutesInMicros = minutes * 60L * 1000_000L;
-    final byte[] bytes = new byte[8];
-    ByteConverter.int8(bytes, 0, daysInMicros + hoursInMicros + minutesInMicros);
-
-    Calendar expectedCal = TimestampUtils.createProlepticGregorianCalendar(TimeZone.getDefault());
-    expectedCal.clear();
-    expectedCal.set(1000, Calendar.JANUARY, 1, hours, minutes);
-
-    assertEquals(expectedCal.getTime().getTime(), timestampUtils.toTimestampBin(null, bytes, false).getTime());
-  }
-
 }


### PR DESCRIPTION
Reverts pgjdbc/pgjdbc#3887

Due to https://github.com/pgjdbc/pgjdbc/issues/3930 we will revert this change and release a new version.
If we want to move forward with this it will have to be in a new major version as it is a breaking change.