### PR TITLE
docs: add SCRAM authentication test setup section to TESTING.md

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -195,7 +195,7 @@ See [BlobTest.java](https://github.com/pgjdbc/pgjdbc/blob/master/pgjdbc/src/test
 
 ## 9 - SCRAM authentication tests
 
-Some tests (e.g., `ScramTest`) require PostgreSQL to be configured to use SCRAM-SHA-256 authentication for the `testscram` user. Without this setup, the tests will silently pass instead of exercising SCRAM authentication, or fail with unexpected results.
+Some tests (e.g., `ScramTest`) require PostgreSQL to be configured to use SCRAM-SHA-256 authentication for the `testscram` user. Without this setup, the tests will skip instead of exercising SCRAM authentication, or fail with unexpected results.
 
 ### Requirements
 


### PR DESCRIPTION
Fixes #2083

Added a new section 9 to TESTING.md documenting the required setup
for SCRAM authentication tests (ScramTest).

Previously there was no documentation explaining that:
- pg_hba.conf must be configured with scram-sha-256 for the testscram user
- The testscram user password must be set after SCRAM is enabled

Added instructions for both Docker and manual PostgreSQL setup.