### PR TITLE
fix: initialize maxBufferedRecvBytes from actual socket receive buffe…

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -56,7 +56,7 @@
   * 7. DEADLOCK PREVENTION STATE MACHINE
   *    Prevents client/server deadlock via buffer management:
   *    - Tracks estimatedReceiveBufferBytes (accumulated response size)
-  *    - When exceeds MAX_BUFFERED_RECV_BYTES (64KB), forces Sync and processes results
+  *    - When exceeds maxBufferedRecvBytes (socket recv buffer size), forces Sync and processes results
   *    - Resets counter after consuming server responses
   *    - Ensures server doesn't block on write while client blocks on write
   */
@@ -234,6 +234,20 @@ public class QueryExecutorImpl extends QueryExecutorBase {
     this.cleanupSavePoints = PGProperty.CLEANUP_SAVEPOINTS.getBoolean(info);
     // assignment, argument
     this.replicationProtocol = new V3ReplicationProtocol(this, pgStream);
+
+    // Initialize maxBufferedRecvBytes from actual socket receive buffer size.
+    // This is used by flushIfDeadlockRisk() to avoid client/server deadlocks in batch execution.
+    int recvBufSize = DEFAULT_MAX_BUFFERED_RECV_BYTES;
+    try {
+      int socketRecvBuf = pgStream.getSocket().getReceiveBufferSize();
+      if (socketRecvBuf > 0) {
+        recvBufSize = socketRecvBuf;
+      }
+    } catch (SocketException e) {
+      // ignore, use the default
+    }
+    this.maxBufferedRecvBytes = recvBufSize;
+
     readStartupMessages();
   }
 
@@ -585,7 +599,7 @@ public class QueryExecutorImpl extends QueryExecutorBase {
   // waiting for the driver to read some more data.
   //
   // To avoid this, we guess at how much response data we can request from the
-  // server before the server -> driver stream's buffer is full (MAX_BUFFERED_RECV_BYTES).
+  // server before the server -> driver stream's buffer is full (maxBufferedRecvBytes).
   // This is the point where the server blocks on write and stops reading data. If we
   // reach this point, we force a Sync message and read pending data from the server
   // until ReadyForQuery, then go back to writing more queries unless we saw an error.
@@ -604,15 +618,28 @@ public class QueryExecutorImpl extends QueryExecutorBase {
   //
   // See github issue #194 and #195 .
   //
-  // Assume 64k server->client buffering, which is extremely conservative. A typical
-  // system will have 200kb or more of buffers for its receive buffers, and the sending
-  // system will typically have the same on the send side, giving us 400kb or to work
-  // with. (We could check Java's receive buffer size, but prefer to assume a very
-  // conservative buffer instead, and we don't know how big the server's send
-  // buffer is.)
+  // Use the actual socket receive buffer size as the maximum amount of data we'll
+  // allow to accumulate before forcing a Sync and reading results. This is more
+  // accurate than a hardcoded value, as it reflects the actual OS-level buffering
+  // available on the client side. We still don't know the server's send buffer size,
+  // but using the actual receive buffer size (rather than assuming a very conservative
+  // 64KB) significantly reduces the number of unnecessary forced Syncs in batch
+  // execution, especially on systems with larger socket buffers (commonly 256KB+).
   //
-  private static final int MAX_BUFFERED_RECV_BYTES = 64000;
+  // If we cannot determine the socket receive buffer size (e.g. due to a SocketException),
+  // we fall back to the conservative 64KB default.
+  //
+  private static final int DEFAULT_MAX_BUFFERED_RECV_BYTES = 64000;
   private static final int NODATA_QUERY_RESPONSE_SIZE_BYTES = 250;
+
+  /**
+   * The maximum number of bytes we'll allow to accumulate in the estimated receive buffer
+   * before forcing a Sync and reading results. Initialized from the actual socket receive
+   * buffer size, or falls back to DEFAULT_MAX_BUFFERED_RECV_BYTES if unavailable.
+   *
+   * <p>Not {@code final} to allow override in tests via reflection.</p>
+   */
+  private int maxBufferedRecvBytes;
 
   @Override
   public void execute(Query[] queries, @Nullable ParameterList[] parameterLists,
@@ -1586,7 +1613,7 @@ public class QueryExecutorImpl extends QueryExecutorBase {
    * To prevent client/server protocol deadlocks, we try to manage the estimated recv buffer size
    * and force a sync +flush and process results if we think it might be getting too full.
    *
-   * See the comments above MAX_BUFFERED_RECV_BYTES's declaration for details.
+   * See the comments above DEFAULT_MAX_BUFFERED_RECV_BYTES and maxBufferedRecvBytes for details.
    */
   private void flushIfDeadlockRisk(Query query, boolean disallowBatching,
       ResultHandler resultHandler,
@@ -1622,7 +1649,7 @@ public class QueryExecutorImpl extends QueryExecutorBase {
        */
     }
 
-    if (disallowBatching || estimatedReceiveBufferBytes >= MAX_BUFFERED_RECV_BYTES) {
+    if (disallowBatching || estimatedReceiveBufferBytes >= maxBufferedRecvBytes) {
       LOGGER.log(Level.FINEST, "Forcing Sync, receive buffer full or batching disallowed");
       sendSync();
       processResults(resultHandler, flags);
@@ -3257,7 +3284,7 @@ public class QueryExecutorImpl extends QueryExecutorBase {
    *
    * <p>Starts at zero, reset by every Sync message. Mainly used for batches.</p>
    *
-   * <p>Used to avoid deadlocks, see MAX_BUFFERED_RECV_BYTES.</p>
+   * <p>Used to avoid deadlocks, see DEFAULT_MAX_BUFFERED_RECV_BYTES and maxBufferedRecvBytes.</p>
    */
   private int estimatedReceiveBufferBytes;
 

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BatchDeadlockTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BatchDeadlockTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+
 import org.postgresql.core.QueryExecutor;
 import org.postgresql.core.v3.QueryExecutorImpl;
 import org.postgresql.jdbc.PgConnection;
@@ -144,61 +145,6 @@ public class BatchDeadlockTest {
     assertTimeoutPreemptively(BATCH_TIMEOUT, () -> executeLargeInsertBatch(con),
         "Large batch should complete without deadlock within "
             + BATCH_TIMEOUT.getSeconds() + "s after the fix");
-  }
-
-  /**
-   * Verifies that a large batch deadlocks when {@code maxBufferedRecvBytes} is overridden to the
-   * old hardcoded value (64,000 bytes) while the actual socket buffer is small (8KB).
-   *
-   * <p>This reproduces the pre-fix behaviour described in GitHub issue #194: the driver
-   * pipelines up to 64KB of estimated responses before flushing, but the actual OS TCP buffers
-   * can only hold ~8KB, causing both sides to block waiting for the other to read.
-   *
-   * <p>A separate connection is used so that the deadlock does not corrupt the connection
-   * used by the other tests and tearDown.
-   *
-   * <p>Note: this test is best-effort. It will skip gracefully when the OS enforces a minimum
-   * socket buffer size >= 64KB (e.g. on some Linux systems with large TCP buffer auto-tuning),
-   * since in that case the deadlock would not occur even with the old code. The other three
-   * tests in this class are reliable on all systems and provide the primary verification.
-   */
-  @Test
-  void largeBatchDeadlocksBeforeFix() throws Exception {
-    int actualSocketRecvBuf = getSocketReceiveBufferSize(con);
-    if (actualSocketRecvBuf >= OLD_HARDCODED_MAX_BUFFERED_RECV_BYTES) {
-      // OS enforced a minimum socket buffer >= old constant; deadlock cannot be triggered.
-      return;
-    }
-
-    // Open a dedicated connection for the deadlock test so tearDown is not affected.
-    Properties props = new Properties();
-    props.setProperty("receiveBufferSize", String.valueOf(SMALL_RECV_BUF_BYTES));
-    Connection deadlockCon = TestUtil.openDB(props);
-
-    // Simulate pre-fix behaviour: override maxBufferedRecvBytes to the old hardcoded value.
-    setMaxBufferedRecvBytes(deadlockCon, OLD_HARDCODED_MAX_BUFFERED_RECV_BYTES);
-
-    boolean[] timedOut = {false};
-    try {
-      assertTimeoutPreemptively(DEADLOCK_TIMEOUT,
-          () -> executeLargeInsertBatch(deadlockCon));
-    } catch (AssertionError e) {
-      // assertTimeoutPreemptively throws AssertionError on timeout, confirming deadlock.
-      timedOut[0] = true;
-    } finally {
-      // Close forcibly; the connection may be in a broken state after the deadlock.
-      try {
-        deadlockCon.close();
-      } catch (Exception ignored) {
-        // expected when the connection was aborted by the timeout
-      }
-    }
-
-    assertTrue(timedOut[0],
-        "With old hardcoded maxBufferedRecvBytes=" + OLD_HARDCODED_MAX_BUFFERED_RECV_BYTES
-            + " and actual socket recv buf=" + actualSocketRecvBuf
-            + ", the batch should deadlock (time out within "
-            + DEADLOCK_TIMEOUT.getSeconds() + "s)");
   }
 
   // ---------------------------------------------------------------------------

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BatchDeadlockTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BatchDeadlockTest.java
@@ -79,7 +79,7 @@ public class BatchDeadlockTest {
     Properties props = new Properties();
     props.setProperty("receiveBufferSize", String.valueOf(SMALL_RECV_BUF_BYTES));
     con = TestUtil.openDB(props);
-    TestUtil.createTempTable(con, "batch_deadlock_test", "id INTEGER, data TEXT");
+    TestUtil.createTable(con, "batch_deadlock_test", "id INTEGER, data TEXT");
   }
 
   @AfterEach

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BatchDeadlockTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BatchDeadlockTest.java
@@ -1,0 +1,258 @@
+/*
+ * Copyright (c) 2004, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.test.jdbc2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.postgresql.core.QueryExecutor;
+import org.postgresql.core.v3.QueryExecutorImpl;
+import org.postgresql.jdbc.PgConnection;
+import org.postgresql.test.TestUtil;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.net.Socket;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.time.Duration;
+import java.util.Properties;
+
+/**
+ * Tests to verify that batch execution does not deadlock when the socket receive buffer is
+ * smaller than the old hardcoded {@code MAX_BUFFERED_RECV_BYTES} constant (64,000 bytes).
+ *
+ * <p>See GitHub issue #194: PgJDBC can experience client/server deadlocks during batch execution.
+ *
+ * <p>The deadlock occurs when the driver pipelines too many queries without flushing and reading
+ * the server's responses. Both sides block waiting for the other to read, causing deadlock.
+ * The fix initialises {@code maxBufferedRecvBytes} from the actual socket receive buffer size
+ * rather than using a hardcoded 64KB constant, so the driver flushes at the right point.
+ */
+public class BatchDeadlockTest {
+
+  /** Field name in QueryExecutorImpl used to track the flush threshold. */
+  private static final String MAX_BUFFERED_RECV_BYTES_FIELD = "maxBufferedRecvBytes";
+
+  /** Field name in QueryExecutorBase for the underlying stream. */
+  private static final String PG_STREAM_FIELD = "pgStream";
+
+  /** Field name in PGStream for the underlying socket. */
+  private static final String SOCKET_FIELD = "connection";
+
+  /** The old hardcoded value that caused the deadlock (see issue #194). */
+  private static final int OLD_HARDCODED_MAX_BUFFERED_RECV_BYTES = 64000;
+
+  /**
+   * A small socket receive buffer, much smaller than the old 64KB constant.
+   * Large enough to sustain the connection, small enough to expose the bug.
+   */
+  private static final int SMALL_RECV_BUF_BYTES = 8192;
+
+  /**
+   * Number of rows in the batch. Each row generates a response of ~250 bytes
+   * (CommandComplete + ReadyForQuery), so 2000 rows ≈ 500KB total response,
+   * far exceeding both the old 64KB threshold and the small socket buffer.
+   */
+  private static final int LARGE_BATCH_SIZE = 2000;
+
+  /** Maximum time the fixed batch is allowed to run before we consider it hung. */
+  private static final Duration BATCH_TIMEOUT = Duration.ofSeconds(30);
+
+  /**
+   * Maximum time to wait for the pre-fix simulation to deadlock.
+   * Short enough to keep CI fast; long enough to be reliable.
+   */
+  private static final Duration DEADLOCK_TIMEOUT = Duration.ofSeconds(10);
+
+  private Connection con;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    Properties props = new Properties();
+    props.setProperty("receiveBufferSize", String.valueOf(SMALL_RECV_BUF_BYTES));
+    con = TestUtil.openDB(props);
+    TestUtil.createTempTable(con, "batch_deadlock_test", "id INTEGER, data TEXT");
+  }
+
+  @AfterEach
+  void tearDown() throws Exception {
+    try {
+      TestUtil.dropTable(con, "batch_deadlock_test");
+    } finally {
+      TestUtil.closeDB(con);
+    }
+  }
+
+  /**
+   * Verifies that after the fix, {@code maxBufferedRecvBytes} is initialised from the actual
+   * socket receive buffer size rather than the old hardcoded 64,000 byte constant.
+   *
+   * <p>When a small receive buffer is requested via {@code receiveBufferSize}, the OS may round
+   * up the value but it should still be smaller than 64,000. The field must reflect this smaller
+   * value so that the driver flushes frequently enough to avoid deadlock.
+   */
+  @Test
+  void maxBufferedRecvBytesIsInitialisedFromSocketReceiveBufferSize() throws Exception {
+    int maxBufferedRecvBytes = getMaxBufferedRecvBytes(con);
+    int actualSocketRecvBuf = getSocketReceiveBufferSize(con);
+
+    assertEquals(actualSocketRecvBuf, maxBufferedRecvBytes,
+        "maxBufferedRecvBytes should equal the actual socket receive buffer size, "
+            + "not the old hardcoded value of " + OLD_HARDCODED_MAX_BUFFERED_RECV_BYTES);
+  }
+
+  /**
+   * Verifies that when a small receive buffer is requested, {@code maxBufferedRecvBytes} is
+   * smaller than the old hardcoded 64,000 byte constant that caused the deadlock.
+   *
+   * <p>This test is skipped on systems where the OS enforces a minimum socket buffer size
+   * larger than the old constant (uncommon but possible).
+   */
+  @Test
+  void maxBufferedRecvBytesIsSmallerThanOldHardcodedValueWhenSmallBufferRequested()
+      throws Exception {
+    int actualSocketRecvBuf = getSocketReceiveBufferSize(con);
+    if (actualSocketRecvBuf >= OLD_HARDCODED_MAX_BUFFERED_RECV_BYTES) {
+      // OS enforced a minimum larger than the old constant; cannot demonstrate difference.
+      return;
+    }
+
+    int maxBufferedRecvBytes = getMaxBufferedRecvBytes(con);
+    assertTrue(maxBufferedRecvBytes < OLD_HARDCODED_MAX_BUFFERED_RECV_BYTES,
+        "With a small socket receive buffer (" + actualSocketRecvBuf + " bytes), "
+            + "maxBufferedRecvBytes (" + maxBufferedRecvBytes + ") should be less than "
+            + "the old hardcoded value of " + OLD_HARDCODED_MAX_BUFFERED_RECV_BYTES + " bytes");
+  }
+
+  /**
+   * Verifies that a large batch completes successfully with the fix in place.
+   *
+   * <p>With a small socket receive buffer and {@code maxBufferedRecvBytes} set from the actual
+   * buffer size, the driver flushes and reads server responses frequently enough to keep both
+   * sides' buffers from filling, preventing deadlock.
+   */
+  @Test
+  void largeBatchCompletesWithoutDeadlockAfterFix() {
+    assertTimeoutPreemptively(BATCH_TIMEOUT, () -> executeLargeInsertBatch(con),
+        "Large batch should complete without deadlock within "
+            + BATCH_TIMEOUT.getSeconds() + "s after the fix");
+  }
+
+  /**
+   * Verifies that a large batch deadlocks when {@code maxBufferedRecvBytes} is overridden to the
+   * old hardcoded value (64,000 bytes) while the actual socket buffer is small (8KB).
+   *
+   * <p>This reproduces the pre-fix behaviour described in GitHub issue #194: the driver
+   * pipelines up to 64KB of estimated responses before flushing, but the actual OS TCP buffers
+   * can only hold ~8KB, causing both sides to block waiting for the other to read.
+   *
+   * <p>A separate connection is used so that the deadlock does not corrupt the connection
+   * used by the other tests and tearDown.
+   *
+   * <p>Note: this test is best-effort. It will skip gracefully when the OS enforces a minimum
+   * socket buffer size >= 64KB (e.g. on some Linux systems with large TCP buffer auto-tuning),
+   * since in that case the deadlock would not occur even with the old code. The other three
+   * tests in this class are reliable on all systems and provide the primary verification.
+   */
+  @Test
+  void largeBatchDeadlocksBeforeFix() throws Exception {
+    int actualSocketRecvBuf = getSocketReceiveBufferSize(con);
+    if (actualSocketRecvBuf >= OLD_HARDCODED_MAX_BUFFERED_RECV_BYTES) {
+      // OS enforced a minimum socket buffer >= old constant; deadlock cannot be triggered.
+      return;
+    }
+
+    // Open a dedicated connection for the deadlock test so tearDown is not affected.
+    Properties props = new Properties();
+    props.setProperty("receiveBufferSize", String.valueOf(SMALL_RECV_BUF_BYTES));
+    Connection deadlockCon = TestUtil.openDB(props);
+
+    // Simulate pre-fix behaviour: override maxBufferedRecvBytes to the old hardcoded value.
+    setMaxBufferedRecvBytes(deadlockCon, OLD_HARDCODED_MAX_BUFFERED_RECV_BYTES);
+
+    boolean[] timedOut = {false};
+    try {
+      assertTimeoutPreemptively(DEADLOCK_TIMEOUT,
+          () -> executeLargeInsertBatch(deadlockCon));
+    } catch (AssertionError e) {
+      // assertTimeoutPreemptively throws AssertionError on timeout, confirming deadlock.
+      timedOut[0] = true;
+    } finally {
+      // Close forcibly; the connection may be in a broken state after the deadlock.
+      try {
+        deadlockCon.close();
+      } catch (Exception ignored) {
+        // expected when the connection was aborted by the timeout
+      }
+    }
+
+    assertTrue(timedOut[0],
+        "With old hardcoded maxBufferedRecvBytes=" + OLD_HARDCODED_MAX_BUFFERED_RECV_BYTES
+            + " and actual socket recv buf=" + actualSocketRecvBuf
+            + ", the batch should deadlock (time out within "
+            + DEADLOCK_TIMEOUT.getSeconds() + "s)");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Inserts {@link #LARGE_BATCH_SIZE} rows as a single JDBC batch.
+   * Total response data is approximately LARGE_BATCH_SIZE * 250 bytes.
+   */
+  private static void executeLargeInsertBatch(Connection con) throws Exception {
+    con.setAutoCommit(false);
+    try (PreparedStatement ps = con.prepareStatement(
+        "INSERT INTO batch_deadlock_test VALUES (?, ?)")) {
+      StringBuilder sb = new StringBuilder(200);
+      for (int j = 0; j < 200; j++) {
+        sb.append('x');
+      }
+      String payload = sb.toString();
+      for (int i = 0; i < LARGE_BATCH_SIZE; i++) {
+        ps.setInt(1, i);
+        ps.setString(2, payload);
+        ps.addBatch();
+      }
+      ps.executeBatch();
+    }
+    con.commit();
+  }
+
+  private static int getMaxBufferedRecvBytes(Connection con)
+      throws Exception {
+    QueryExecutor qe = con.unwrap(PgConnection.class).getQueryExecutor();
+    Field field = QueryExecutorImpl.class.getDeclaredField(MAX_BUFFERED_RECV_BYTES_FIELD);
+    field.setAccessible(true);
+    return (int) field.get(qe);
+  }
+
+  private static void setMaxBufferedRecvBytes(Connection con, int value)
+      throws Exception {
+    QueryExecutor qe = con.unwrap(PgConnection.class).getQueryExecutor();
+    Field field = QueryExecutorImpl.class.getDeclaredField(MAX_BUFFERED_RECV_BYTES_FIELD);
+    field.setAccessible(true);
+    field.set(qe, value);
+  }
+
+  private static int getSocketReceiveBufferSize(Connection con)
+      throws Exception {
+    QueryExecutor qe = con.unwrap(PgConnection.class).getQueryExecutor();
+    Field pgStreamField = qe.getClass().getSuperclass().getDeclaredField(PG_STREAM_FIELD);
+    pgStreamField.setAccessible(true);
+    Object pgStream = pgStreamField.get(qe);
+    Field socketField = pgStream.getClass().getDeclaredField(SOCKET_FIELD);
+    socketField.setAccessible(true);
+    Socket socket = (Socket) socketField.get(pgStream);
+    return socket.getReceiveBufferSize();
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BatchDeadlockTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BatchDeadlockTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, PostgreSQL Global Development Group
+ * Copyright (c) 2026, PostgreSQL Global Development Group
  * See the LICENSE file in the project root for more information.
  */
 

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BatchDeadlockTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BatchDeadlockTest.java
@@ -67,12 +67,6 @@ public class BatchDeadlockTest {
   /** Maximum time the fixed batch is allowed to run before we consider it hung. */
   private static final Duration BATCH_TIMEOUT = Duration.ofSeconds(30);
 
-  /**
-   * Maximum time to wait for the pre-fix simulation to deadlock.
-   * Short enough to keep CI fast; long enough to be reliable.
-   */
-  private static final Duration DEADLOCK_TIMEOUT = Duration.ofSeconds(10);
-
   private Connection con;
 
   @BeforeEach


### PR DESCRIPTION
(first open source contribution to this repo just fixing a bug that was really bothering me - any feedback is appreciated ) 

Trying to fix this bug http://github.com/pgjdbc/pgjdbc/issues/194 
The driver has a hardcoded 64KB threshold (`MAX_BUFFERED_RECV_BYTES`) for deciding when to flush during batch execution. The idea is to avoid a deadlock where both sides block waiting for the other to drain their buffers. But if the actual OS socket receive buffer is smaller than 64KB, the driver pipelines too many queries before flushing and you still get the deadlock.

This reads the real socket receive buffer size at connection time and uses that as the threshold instead. If it can't be read, it falls back to the old 64KB default.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Does `./gradlew styleCheck` pass ?
3. [x] Have you added your new test classes to an existing test suite in alphabetical order?

### Changes to Existing Features:

* [x] Does this break existing behaviour? If so please explain.
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
