### PR TITLE
fix: restore pre-describe for generated-key batches

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/Field.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/Field.java
@@ -17,7 +17,7 @@ public class Field {
   public static final int TEXT_FORMAT = 0;
   public static final int BINARY_FORMAT = 1;
 
-  private final int length; // Internal Length of this field
+  private final short length; // Internal Length of this field
   private final int oid; // OID of the type
   private final int mod; // type modifier of this field
   private String columnLabel; // Column label
@@ -49,7 +49,7 @@ public class Field {
    * @param length the length of the field
    * @param mod modifier
    */
-  public Field(String name, int oid, int length, int mod) {
+  public Field(String name, int oid, short length, int mod) {
     this(name, oid, length, mod, 0, 0);
   }
 
@@ -60,7 +60,7 @@ public class Field {
    * @param oid the OID of the field
    */
   public Field(String name, int oid) {
-    this(name, oid, 0, -1);
+    this(name, oid, (short) 0, -1);
   }
 
   /**
@@ -72,7 +72,7 @@ public class Field {
    * @param tableOid the OID of the columns' table
    * @param positionInTable the position of column in the table (first column is 1, second column is 2, etc...)
    */
-  public Field(String columnLabel, int oid, int length, int mod, int tableOid,
+  public Field(String columnLabel, int oid, short length, int mod, int tableOid,
       int positionInTable) {
     this.columnLabel = columnLabel;
     this.oid = oid;
@@ -112,7 +112,7 @@ public class Field {
    * Returns the length of this Field's data type.
    * @return the length of this Field's data type
    */
-  public int getLength() {
+  public short getLength() {
     return length;
   }
 

--- a/pgjdbc/src/main/java/org/postgresql/core/ResultHandler.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/ResultHandler.java
@@ -88,10 +88,4 @@ public interface ResultHandler {
    * @return the first encountered exception
    */
   @Nullable SQLException getException();
-
-  /**
-   * Returns the first encountered warning. The rest are chained via {@link SQLException#setNextException(SQLException)}
-   * @return the first encountered warning
-   */
-  @Nullable SQLWarning getWarning();
 }

--- a/pgjdbc/src/main/java/org/postgresql/core/ResultHandlerBase.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/ResultHandlerBase.java
@@ -11,7 +11,6 @@ import static org.postgresql.util.internal.Nullness.castNonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.sql.SQLException;
-import java.sql.SQLWarning;
 import java.util.List;
 
 /**
@@ -19,14 +18,11 @@ import java.util.List;
  * {@link SQLException#setNextException(SQLException)} has {@code O(N)} complexity,
  * so this class tracks the last exception object to speedup {@code setNextException}.
  */
-public class ResultHandlerBase implements ResultHandler {
+public abstract class ResultHandlerBase implements ResultHandler {
   // Last exception is tracked to avoid O(N) SQLException#setNextException just in case there
   // will be lots of exceptions (e.g. all batch rows fail with constraint violation or so)
   private @Nullable SQLException firstException;
   private @Nullable SQLException lastException;
-
-  private @Nullable SQLWarning firstWarning;
-  private @Nullable SQLWarning lastWarning;
 
   @Override
   public void handleResultRows(Query fromQuery, Field[] fields, List<Tuple> tuples,
@@ -39,17 +35,6 @@ public class ResultHandlerBase implements ResultHandler {
 
   @Override
   public void secureProgress() {
-  }
-
-  @Override
-  public void handleWarning(SQLWarning warning) {
-    if (firstWarning == null) {
-      firstWarning = lastWarning = warning;
-      return;
-    }
-    SQLWarning lastWarning = castNonNull(this.lastWarning);
-    lastWarning.setNextException(warning);
-    this.lastWarning = warning;
   }
 
   @Override
@@ -73,10 +58,5 @@ public class ResultHandlerBase implements ResultHandler {
   @Override
   public @Nullable SQLException getException() {
     return firstException;
-  }
-
-  @Override
-  public @Nullable SQLWarning getWarning() {
-    return firstWarning;
   }
 }

--- a/pgjdbc/src/main/java/org/postgresql/core/ResultHandlerDelegate.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/ResultHandlerDelegate.java
@@ -74,12 +74,4 @@ public class ResultHandlerDelegate implements ResultHandler {
     }
     return null;
   }
-
-  @Override
-  public @Nullable SQLWarning getWarning() {
-    if (delegate != null) {
-      return delegate.getWarning();
-    }
-    return null;
-  }
 }

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -658,7 +658,13 @@ public class QueryExecutorImpl extends QueryExecutorBase {
         estimatedReceiveBufferBytes = 0;
 
         for (int i = 0; i < queries.length; i++) {
-          Query query = queries[i];
+          SimpleQuery query = (SimpleQuery) queries[i];
+          if (i == 0) {
+            estimatedReceiveBufferBytes += estimateQueryResponseBytes(query, flags);
+          } else {
+            flushIfDeadlockRisk(query, handler, batchHandler, flags);
+          }
+
           V3ParameterList parameters = (V3ParameterList) parameterLists[i];
           if (parameters == null) {
             parameters = SimpleQuery.NO_PARAMETERS;
@@ -672,10 +678,9 @@ public class QueryExecutorImpl extends QueryExecutorBase {
         }
 
         if (handler.getException() == null) {
-          if ((flags & QueryExecutor.QUERY_EXECUTE_AS_SIMPLE) != 0) {
-            // Sync message is not required for 'Q' execution as 'Q' ends with ReadyForQuery message
-            // on its own
-          } else {
+          // Sync message is not required for 'Q' execution as 'Q' ends with ReadyForQuery message
+          // on its own
+          if ((flags & QueryExecutor.QUERY_EXECUTE_AS_SIMPLE) == 0) {
             sendSync();
           }
           processResults(handler, flags, adaptiveFetch);
@@ -1589,22 +1594,27 @@ public class QueryExecutorImpl extends QueryExecutorBase {
     }
   }
 
-  /*
-   * To prevent client/server protocol deadlocks, we try to manage the estimated recv buffer size
-   * and force a sync +flush and process results if we think it might be getting too full.
-   *
-   * See the comments above MAX_BUFFERED_RECV_BYTES's declaration for details.
+  /**
+   * Returns estimated number of bytes produced by a single query execution, or
+   * {@link #MAX_BUFFERED_RECV_BYTES} if no estimation can be made.
+   * @param query input query
+   * @param flags query execution flags
+   * @return estimated number of bytes produced by a single query execution or MAX_BUFFERED_RECV_BYTES
    */
-  private void flushIfDeadlockRisk(Query query, boolean disallowBatching,
-      ResultHandler resultHandler,
-      @Nullable BatchResultHandler batchHandler,
-      final int flags) throws IOException {
+  private int estimateQueryResponseBytes(SimpleQuery query, int flags) {
     // Assume all statements need at least this much reply buffer space,
     // plus params
-    estimatedReceiveBufferBytes += NODATA_QUERY_RESPONSE_SIZE_BYTES;
+    int resultBytes = NODATA_QUERY_RESPONSE_SIZE_BYTES;
 
-    SimpleQuery sq = (SimpleQuery) query;
-    if (sq.isStatementDescribed()) {
+    // We know this is deprecated, but still respect it in case anyone's using it.
+    // PgJDBC its self no longer does.
+    @SuppressWarnings("deprecation")
+    boolean disallowBatching = (flags & QueryExecutor.QUERY_DISALLOW_BATCHING) != 0;
+    if (disallowBatching) {
+      return MAX_BUFFERED_RECV_BYTES;
+    }
+
+    if (query.isStatementDescribed()) {
       /*
        * Estimate the response size of the fields and add it to the expected response size.
        *
@@ -1612,13 +1622,13 @@ public class QueryExecutorImpl extends QueryExecutorBase {
        * case for batches and we're leaving plenty of breathing room in this approach. It's still
        * not deadlock-proof though; see pgjdbc github issues #194 and #195.
        */
-      int maxResultRowSize = sq.getMaxResultRowSize();
+      int maxResultRowSize = query.getMaxResultRowSize();
       if (maxResultRowSize >= 0) {
-        estimatedReceiveBufferBytes += maxResultRowSize;
+        resultBytes += maxResultRowSize;
       } else {
         LOGGER.log(Level.FINEST, "Couldn''t estimate result size or result size unbounded, "
             + "disabling batching for this query.");
-        disallowBatching = true;
+        return MAX_BUFFERED_RECV_BYTES;
       }
     } else {
       /*
@@ -1628,17 +1638,34 @@ public class QueryExecutorImpl extends QueryExecutorBase {
        * NODATA_QUERY_RESPONSE_SIZE_BYTES is enough to cover it.
        */
     }
+    return resultBytes;
+  }
 
-    if (disallowBatching || estimatedReceiveBufferBytes >= MAX_BUFFERED_RECV_BYTES) {
+  /*
+   * To prevent client/server protocol deadlocks, we try to manage the estimated recv buffer size
+   * and force a sync +flush and process results if we think it might be getting too full.
+   *
+   * See the comments above MAX_BUFFERED_RECV_BYTES's declaration for details.
+   */
+  private void flushIfDeadlockRisk(SimpleQuery query,
+      ResultHandler resultHandler,
+      @Nullable BatchResultHandler batchHandler,
+      final int flags) throws IOException {
+    int resultBytes = estimateQueryResponseBytes(query, flags);
+
+    int estimatedReceiveBufferBytesTotal = estimatedReceiveBufferBytes + resultBytes;
+    if (estimatedReceiveBufferBytesTotal < MAX_BUFFERED_RECV_BYTES) {
+      estimatedReceiveBufferBytes = estimatedReceiveBufferBytesTotal;
+    } else {
       LOGGER.log(Level.FINEST, "Forcing Sync, receive buffer full or batching disallowed");
       sendSync();
       processResults(resultHandler, flags);
-      estimatedReceiveBufferBytes = 0;
+      // We've processed incoming bytes, and the query to be executed would consume receive buffer
+      estimatedReceiveBufferBytes = resultBytes;
       if (batchHandler != null) {
         batchHandler.secureProgress();
       }
     }
-
   }
 
   /*
@@ -1651,14 +1678,7 @@ public class QueryExecutorImpl extends QueryExecutorBase {
     Query[] subqueries = query.getSubqueries();
     SimpleParameterList[] subparams = parameters.getSubparams();
 
-    // We know this is deprecated, but still respect it in case anyone's using it.
-    // PgJDBC its self no longer does.
-    @SuppressWarnings("deprecation")
-    boolean disallowBatching = (flags & QueryExecutor.QUERY_DISALLOW_BATCHING) != 0;
-
     if (subqueries == null) {
-      flushIfDeadlockRisk(query, disallowBatching, resultHandler, batchHandler, flags);
-
       // If we saw errors, don't send anything more.
       if (resultHandler.getException() == null) {
         if (fetchSize != 0) {
@@ -1669,12 +1689,15 @@ public class QueryExecutorImpl extends QueryExecutorBase {
       }
     } else {
       for (int i = 0; i < subqueries.length; i++) {
-        final Query subquery = subqueries[i];
-        flushIfDeadlockRisk(subquery, disallowBatching, resultHandler, batchHandler, flags);
-
-        // If we saw errors, don't send anything more.
-        if (resultHandler.getException() != null) {
-          break;
+        final SimpleQuery subquery = (SimpleQuery) subqueries[i];
+        if (i == 0) {
+          estimatedReceiveBufferBytes += estimateQueryResponseBytes(subquery, flags);
+        } else {
+          flushIfDeadlockRisk(subquery, resultHandler, batchHandler, flags);
+          // If we saw errors, don't send anything more.
+          if (resultHandler.getException() != null) {
+            break;
+          }
         }
 
         // In the situation where parameters is already

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -658,7 +658,13 @@ public class QueryExecutorImpl extends QueryExecutorBase {
         estimatedReceiveBufferBytes = 0;
 
         for (int i = 0; i < queries.length; i++) {
-          Query query = queries[i];
+          SimpleQuery query = (SimpleQuery) queries[i];
+          if (i == 0) {
+            estimatedReceiveBufferBytes += estimateQueryResponseBytes(query, flags);
+          } else {
+            flushIfDeadlockRisk(query, handler, batchHandler, flags);
+          }
+
           V3ParameterList parameters = (V3ParameterList) parameterLists[i];
           if (parameters == null) {
             parameters = SimpleQuery.NO_PARAMETERS;
@@ -672,10 +678,9 @@ public class QueryExecutorImpl extends QueryExecutorBase {
         }
 
         if (handler.getException() == null) {
-          if ((flags & QueryExecutor.QUERY_EXECUTE_AS_SIMPLE) != 0) {
-            // Sync message is not required for 'Q' execution as 'Q' ends with ReadyForQuery message
-            // on its own
-          } else {
+          // Sync message is not required for 'Q' execution as 'Q' ends with ReadyForQuery message
+          // on its own
+          if ((flags & QueryExecutor.QUERY_EXECUTE_AS_SIMPLE) == 0) {
             sendSync();
           }
           processResults(handler, flags, adaptiveFetch);
@@ -1589,22 +1594,27 @@ public class QueryExecutorImpl extends QueryExecutorBase {
     }
   }
 
-  /*
-   * To prevent client/server protocol deadlocks, we try to manage the estimated recv buffer size
-   * and force a sync +flush and process results if we think it might be getting too full.
-   *
-   * See the comments above MAX_BUFFERED_RECV_BYTES's declaration for details.
+  /**
+   * Returns estimated number of bytes produced by a single query execution, or
+   * {@link #MAX_BUFFERED_RECV_BYTES} if no estimation can be made.
+   * @param query input query
+   * @param flags query execution flags
+   * @return estimated number of bytes produced by a single query execution or MAX_BUFFERED_RECV_BYTES
    */
-  private void flushIfDeadlockRisk(Query query, boolean disallowBatching,
-      ResultHandler resultHandler,
-      @Nullable BatchResultHandler batchHandler,
-      final int flags) throws IOException {
+  private static int estimateQueryResponseBytes(SimpleQuery query, int flags) {
     // Assume all statements need at least this much reply buffer space,
     // plus params
-    estimatedReceiveBufferBytes += NODATA_QUERY_RESPONSE_SIZE_BYTES;
+    int resultBytes = NODATA_QUERY_RESPONSE_SIZE_BYTES;
 
-    SimpleQuery sq = (SimpleQuery) query;
-    if (sq.isStatementDescribed()) {
+    // We know this is deprecated, but still respect it in case anyone's using it.
+    // PgJDBC its self no longer does.
+    @SuppressWarnings("deprecation")
+    boolean disallowBatching = (flags & QueryExecutor.QUERY_DISALLOW_BATCHING) != 0;
+    if (disallowBatching) {
+      return MAX_BUFFERED_RECV_BYTES;
+    }
+
+    if (query.isStatementDescribed()) {
       /*
        * Estimate the response size of the fields and add it to the expected response size.
        *
@@ -1612,13 +1622,13 @@ public class QueryExecutorImpl extends QueryExecutorBase {
        * case for batches and we're leaving plenty of breathing room in this approach. It's still
        * not deadlock-proof though; see pgjdbc github issues #194 and #195.
        */
-      int maxResultRowSize = sq.getMaxResultRowSize();
+      int maxResultRowSize = query.getMaxResultRowSize();
       if (maxResultRowSize >= 0) {
-        estimatedReceiveBufferBytes += maxResultRowSize;
+        resultBytes += maxResultRowSize;
       } else {
         LOGGER.log(Level.FINEST, "Couldn''t estimate result size or result size unbounded, "
             + "disabling batching for this query.");
-        disallowBatching = true;
+        return MAX_BUFFERED_RECV_BYTES;
       }
     } else {
       /*
@@ -1628,17 +1638,34 @@ public class QueryExecutorImpl extends QueryExecutorBase {
        * NODATA_QUERY_RESPONSE_SIZE_BYTES is enough to cover it.
        */
     }
+    return resultBytes;
+  }
 
-    if (disallowBatching || estimatedReceiveBufferBytes >= MAX_BUFFERED_RECV_BYTES) {
+  /*
+   * To prevent client/server protocol deadlocks, we try to manage the estimated recv buffer size
+   * and force a sync +flush and process results if we think it might be getting too full.
+   *
+   * See the comments above MAX_BUFFERED_RECV_BYTES's declaration for details.
+   */
+  private void flushIfDeadlockRisk(SimpleQuery query,
+      ResultHandler resultHandler,
+      @Nullable BatchResultHandler batchHandler,
+      final int flags) throws IOException {
+    int resultBytes = estimateQueryResponseBytes(query, flags);
+
+    int estimatedReceiveBufferBytesTotal = estimatedReceiveBufferBytes + resultBytes;
+    if (estimatedReceiveBufferBytesTotal < MAX_BUFFERED_RECV_BYTES) {
+      estimatedReceiveBufferBytes = estimatedReceiveBufferBytesTotal;
+    } else {
       LOGGER.log(Level.FINEST, "Forcing Sync, receive buffer full or batching disallowed");
       sendSync();
       processResults(resultHandler, flags);
-      estimatedReceiveBufferBytes = 0;
+      // We've processed incoming bytes, and the query to be executed would consume receive buffer
+      estimatedReceiveBufferBytes = resultBytes;
       if (batchHandler != null) {
         batchHandler.secureProgress();
       }
     }
-
   }
 
   /*
@@ -1651,14 +1678,7 @@ public class QueryExecutorImpl extends QueryExecutorBase {
     Query[] subqueries = query.getSubqueries();
     SimpleParameterList[] subparams = parameters.getSubparams();
 
-    // We know this is deprecated, but still respect it in case anyone's using it.
-    // PgJDBC its self no longer does.
-    @SuppressWarnings("deprecation")
-    boolean disallowBatching = (flags & QueryExecutor.QUERY_DISALLOW_BATCHING) != 0;
-
     if (subqueries == null) {
-      flushIfDeadlockRisk(query, disallowBatching, resultHandler, batchHandler, flags);
-
       // If we saw errors, don't send anything more.
       if (resultHandler.getException() == null) {
         if (fetchSize != 0) {
@@ -1669,12 +1689,15 @@ public class QueryExecutorImpl extends QueryExecutorBase {
       }
     } else {
       for (int i = 0; i < subqueries.length; i++) {
-        final Query subquery = subqueries[i];
-        flushIfDeadlockRisk(subquery, disallowBatching, resultHandler, batchHandler, flags);
-
-        // If we saw errors, don't send anything more.
-        if (resultHandler.getException() != null) {
-          break;
+        final SimpleQuery subquery = (SimpleQuery) subqueries[i];
+        if (i == 0) {
+          estimatedReceiveBufferBytes += estimateQueryResponseBytes(subquery, flags);
+        } else {
+          flushIfDeadlockRisk(subquery, resultHandler, batchHandler, flags);
+          // If we saw errors, don't send anything more.
+          if (resultHandler.getException() != null) {
+            break;
+          }
         }
 
         // In the situation where parameters is already

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -164,6 +164,13 @@ public class QueryExecutorImpl extends QueryExecutorBase {
     Encoding.canonicalize("in_hot_standby");
   }
 
+  class DiscardResultsHandler extends ResultHandlerBase {
+    @Override
+    public void handleWarning(SQLWarning warning) {
+      addWarning(warning);
+    }
+  }
+
   /**
    * TimeZone of the current connection (TimeZone backend parameter).
    */
@@ -763,7 +770,7 @@ public class QueryExecutorImpl extends QueryExecutorBase {
         // from cleanupSavepoints). These responses would otherwise be misinterpreted
         // by receiveFastpathResult(). See https://github.com/pgjdbc/pgjdbc/issues/3910
         if (!pendingExecuteQueue.isEmpty()) {
-          processResults(new ResultHandlerBase(), 0);
+          processResults(new DiscardResultsHandler(), 0);
         }
         sendFastpathCall(fnid, (SimpleParameterList) parameters);
         return receiveFastpathResult();
@@ -1074,7 +1081,7 @@ public class QueryExecutorImpl extends QueryExecutorBase {
         // from cleanupSavepoints). These responses would otherwise be misinterpreted
         // by processCopyResults(). See https://github.com/pgjdbc/pgjdbc/issues/3910
         if (!pendingExecuteQueue.isEmpty()) {
-          processResults(new ResultHandlerBase(), 0);
+          processResults(new DiscardResultsHandler(), 0);
         }
         LOGGER.log(Level.FINEST, " FE=> Query(CopyStart)");
 

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -2865,7 +2865,7 @@ public class QueryExecutorImpl extends QueryExecutorBase {
       int tableOid = pgStream.receiveInteger4();
       short positionInTable = (short) pgStream.receiveInteger2();
       int typeOid = pgStream.receiveInteger4();
-      int typeLength = pgStream.receiveInteger2();
+      short typeLength = (short) pgStream.receiveInteger2();
       int typeModifier = pgStream.receiveInteger4();
       int formatType = pgStream.receiveInteger2();
       fields[i] = new Field(columnLabel,

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -164,6 +164,13 @@ public class QueryExecutorImpl extends QueryExecutorBase {
     Encoding.canonicalize("in_hot_standby");
   }
 
+  class DiscardResultHandler extends ResultHandlerBase {
+    @Override
+    public void handleWarning(SQLWarning warning) {
+      addWarning(warning);
+    }
+  }
+
   /**
    * TimeZone of the current connection (TimeZone backend parameter).
    */
@@ -763,7 +770,7 @@ public class QueryExecutorImpl extends QueryExecutorBase {
         // from cleanupSavepoints). These responses would otherwise be misinterpreted
         // by receiveFastpathResult(). See https://github.com/pgjdbc/pgjdbc/issues/3910
         if (!pendingExecuteQueue.isEmpty()) {
-          processResults(new ResultHandlerBase(), 0);
+          processResults(new DiscardResultHandler(), 0);
         }
         sendFastpathCall(fnid, (SimpleParameterList) parameters);
         return receiveFastpathResult();
@@ -1074,7 +1081,7 @@ public class QueryExecutorImpl extends QueryExecutorBase {
         // from cleanupSavepoints). These responses would otherwise be misinterpreted
         // by processCopyResults(). See https://github.com/pgjdbc/pgjdbc/issues/3910
         if (!pendingExecuteQueue.isEmpty()) {
-          processResults(new ResultHandlerBase(), 0);
+          processResults(new DiscardResultHandler(), 0);
         }
         LOGGER.log(Level.FINEST, " FE=> Query(CopyStart)");
 

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/SimpleQuery.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/SimpleQuery.java
@@ -13,6 +13,7 @@ import org.postgresql.core.ParameterList;
 import org.postgresql.core.Query;
 import org.postgresql.core.SqlCommand;
 import org.postgresql.jdbc.PgResultSet;
+import org.postgresql.jdbc.TypeInfoCache;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -99,8 +100,8 @@ class SimpleQuery implements Query {
     int maxResultRowSize = 0;
     if (fields != null) {
       for (Field f : fields) {
-        final int fieldLength = f.getLength();
-        if (fieldLength < 1 || fieldLength >= 65535) {
+        final int fieldLength = TypeInfoCache.estimateMaxLength(f.getOID(), f.getLength(), f.getMod());
+        if (fieldLength < 0) {
           /*
            * Field length unknown or large; we can't make any safe estimates about the result size,
            * so we have to fall back to sending queries individually.

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
@@ -1253,12 +1253,8 @@ public class PgConnection implements BaseConnection {
    */
   private class TransactionCommandHandler extends ResultHandlerBase {
     @Override
-    public void handleCompletion() throws SQLException {
-      SQLWarning warning = getWarning();
-      if (warning != null) {
-        PgConnection.this.addWarning(warning);
-      }
-      super.handleCompletion();
+    public void handleWarning(SQLWarning warning) {
+      PgConnection.this.addWarning(warning);
     }
   }
 

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
@@ -14,6 +14,7 @@ import org.postgresql.core.Oid;
 import org.postgresql.core.ParameterList;
 import org.postgresql.core.Query;
 import org.postgresql.core.QueryExecutor;
+import org.postgresql.core.ResultHandler;
 import org.postgresql.core.ServerVersion;
 import org.postgresql.core.TypeInfo;
 import org.postgresql.core.v3.BatchedQuery;
@@ -1796,7 +1797,7 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
   public ParameterMetaData getParameterMetaData() throws SQLException {
     int flags = QueryExecutor.QUERY_ONESHOT | QueryExecutor.QUERY_DESCRIBE_ONLY
         | QueryExecutor.QUERY_SUPPRESS_BEGIN;
-    StatementResultHandler handler = new StatementResultHandler();
+    ResultHandler handler = new DiscardResultHandler();
     connection.getQueryExecutor().execute(preparedQuery.query, preparedParameters, handler, 0, 0,
         flags);
 

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
@@ -2206,12 +2206,8 @@ public class PgResultSet implements ResultSet, PGRefCursorResultSet {
     }
 
     @Override
-    public void handleCompletion() throws SQLException {
-      SQLWarning warning = getWarning();
-      if (warning != null) {
-        PgResultSet.this.addWarning(warning);
-      }
-      super.handleCompletion();
+    public void handleWarning(SQLWarning warning) {
+      PgResultSet.this.addWarning(warning);
     }
   }
 

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgStatement.java
@@ -223,6 +223,16 @@ public class PgStatement implements Statement, BaseStatement {
   }
 
   /**
+   * ResultHandler that discards all results.
+   */
+  public class DiscardResultHandler extends ResultHandlerBase {
+    @Override
+    public void handleWarning(SQLWarning warning) {
+      PgStatement.this.addWarning(warning);
+    }
+  }
+
+  /**
    * ResultHandler implementations for updates, queries, and either-or.
    */
   public class StatementResultHandler extends ResultHandlerBase {
@@ -510,21 +520,8 @@ public class PgStatement implements Statement, BaseStatement {
       // When binaryTransfer is forced, then we need to know resulting parameter and column types,
       // thus sending a describe request.
       int flags2 = flags | QueryExecutor.QUERY_DESCRIBE_ONLY;
-      StatementResultHandler handler2 = new StatementResultHandler();
-      connection.getQueryExecutor().execute(queryToExecute, queryParameters, handler2, 0, 0,
+      connection.getQueryExecutor().execute(queryToExecute, queryParameters, new DiscardResultHandler(), 0, 0,
           flags2);
-      // We should not create temporary ResultSet when processing "describe row" command;
-      // however, it is the way PgPreparedStatement#getMetaData() works now
-      ResultWrapper result2 = handler2.getResults();
-      if (result2 != null) {
-        // Note: if the user requested "statement.closeOnCompletion()" then we should not
-        // let the driver's internal resultset to close the user statement
-        // At best we should stop creating the intermediate ResultSet objects
-        boolean prevCloseOnCompletion = closeOnCompletion;
-        closeOnCompletion = false;
-        castNonNull(result2.getResultSet(), "result2.getResultSet()").close();
-        closeOnCompletion = prevCloseOnCompletion;
-      }
     }
 
     StatementResultHandler handler = new StatementResultHandler();
@@ -900,17 +897,12 @@ public class PgStatement implements Statement, BaseStatement {
         && !queries[0].isStatementDescribed()
         && (flags & QueryExecutor.QUERY_EXECUTE_AS_SIMPLE) == 0) {
       int describeFlags = flags | QueryExecutor.QUERY_DESCRIBE_ONLY;
-      StatementResultHandler describeHandler = new StatementResultHandler();
       try {
         connection.getQueryExecutor().execute(
-            queries[0], parameterLists[0], describeHandler, 0, 0, describeFlags);
+            queries[0], parameterLists[0], new DiscardResultHandler(), 0, 0, describeFlags);
       } catch (SQLException e) {
         handler.handleError(e);
         handler.handleCompletion();
-      }
-      ResultWrapper describeResult = describeHandler.getResults();
-      if (describeResult != null) {
-        castNonNull(describeResult.getResultSet(), "describeResult.getResultSet()").close();
       }
     }
 

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgStatement.java
@@ -223,6 +223,16 @@ public class PgStatement implements Statement, BaseStatement {
   }
 
   /**
+   * ResultHandler that discards all results.
+   */
+  class DiscardResultHandler extends ResultHandlerBase {
+    @Override
+    public void handleWarning(SQLWarning warning) {
+      PgStatement.this.addWarning(warning);
+    }
+  }
+
+  /**
    * ResultHandler implementations for updates, queries, and either-or.
    */
   public class StatementResultHandler extends ResultHandlerBase {
@@ -510,21 +520,8 @@ public class PgStatement implements Statement, BaseStatement {
       // When binaryTransfer is forced, then we need to know resulting parameter and column types,
       // thus sending a describe request.
       int flags2 = flags | QueryExecutor.QUERY_DESCRIBE_ONLY;
-      StatementResultHandler handler2 = new StatementResultHandler();
-      connection.getQueryExecutor().execute(queryToExecute, queryParameters, handler2, 0, 0,
+      connection.getQueryExecutor().execute(queryToExecute, queryParameters, new DiscardResultHandler(), 0, 0,
           flags2);
-      // We should not create temporary ResultSet when processing "describe row" command;
-      // however, it is the way PgPreparedStatement#getMetaData() works now
-      ResultWrapper result2 = handler2.getResults();
-      if (result2 != null) {
-        // Note: if the user requested "statement.closeOnCompletion()" then we should not
-        // let the driver's internal resultset to close the user statement
-        // At best we should stop creating the intermediate ResultSet objects
-        boolean prevCloseOnCompletion = closeOnCompletion;
-        closeOnCompletion = false;
-        castNonNull(result2.getResultSet(), "result2.getResultSet()").close();
-        closeOnCompletion = prevCloseOnCompletion;
-      }
     }
 
     StatementResultHandler handler = new StatementResultHandler();
@@ -900,17 +897,12 @@ public class PgStatement implements Statement, BaseStatement {
         && !queries[0].isStatementDescribed()
         && (flags & QueryExecutor.QUERY_EXECUTE_AS_SIMPLE) == 0) {
       int describeFlags = flags | QueryExecutor.QUERY_DESCRIBE_ONLY;
-      StatementResultHandler describeHandler = new StatementResultHandler();
       try {
         connection.getQueryExecutor().execute(
-            queries[0], parameterLists[0], describeHandler, 0, 0, describeFlags);
+            queries[0], parameterLists[0], new DiscardResultHandler(), 0, 0, describeFlags);
       } catch (SQLException e) {
         handler.handleError(e);
         handler.handleCompletion();
-      }
-      ResultWrapper describeResult = describeHandler.getResults();
-      if (describeResult != null) {
-        castNonNull(describeResult.getResultSet(), "describeResult.getResultSet()").close();
       }
     }
 

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgStatement.java
@@ -12,7 +12,9 @@ import org.postgresql.core.BaseConnection;
 import org.postgresql.core.BaseStatement;
 import org.postgresql.core.CachedQuery;
 import org.postgresql.core.Field;
+import org.postgresql.core.NativeQuery;
 import org.postgresql.core.ParameterList;
+import org.postgresql.core.Parser;
 import org.postgresql.core.Provider;
 import org.postgresql.core.Query;
 import org.postgresql.core.QueryExecutor;
@@ -809,6 +811,29 @@ public class PgStatement implements Statement, BaseStatement {
     // Simple statements should not replace ?, ? with $1, $2
     boolean shouldUseParameterized = false;
     CachedQuery cachedQuery = connection.createQuery(sql, replaceProcessingEnabled, shouldUseParameterized);
+    // BatchResultHandler allocates one update-count slot per batch entry, but
+    // multi-statement SQL emits one CommandComplete per statement, so it fails
+    // with "Too many update results" or ClassCastException deep in the protocol.
+    // Reject at the JDBC boundary. Note: CachedQueryCreateAction only splits when
+    // isParameterized=true or preferQueryMode >= EXTENDED. Statement.addBatch(sql)
+    // always passes isParameterized=false, so SIMPLE and EXTENDED_FOR_PREPARED
+    // produce a single SimpleQuery wrapping the raw multi-statement SQL (with
+    // getSubqueries()==null). Re-parse with splitStatements=true in those modes.
+    boolean isMultiStatement = cachedQuery.query.getSubqueries() != null;
+    if (!isMultiStatement
+        && connection.getPreferQueryMode().compareTo(PreferQueryMode.EXTENDED) < 0) {
+      List<NativeQuery> parsed = Parser.parseJdbcSql(sql,
+          connection.getStandardConformingStrings(),
+          false /* withParameters */, true /* splitStatements */,
+          false /* isBatchedReWriteConfigured */, false /* quoteReturningIdentifiers */);
+      isMultiStatement = parsed.size() > 1;
+    }
+    if (isMultiStatement) {
+      throw new PSQLException(
+          GT.tr("Multi-statement SQL is not supported in Statement.addBatch(); "
+              + "call addBatch() once per statement instead."),
+          PSQLState.NOT_IMPLEMENTED);
+    }
     batchStatements.add(cachedQuery.query);
     batchParameters.add(null);
   }

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgStatement.java
@@ -891,6 +891,29 @@ public class PgStatement implements Statement, BaseStatement {
     BatchResultHandler handler;
     handler = createBatchHandler(queries, parameterLists);
 
+    // Describe the query before batching so flushIfDeadlockRisk can estimate
+    // response sizes accurately and avoid client/server TCP deadlock. See #194.
+    SqlCommand sqlCommand = queries[0].getSqlCommand();
+    boolean queryReturnsRows = wantsGeneratedKeysAlways
+        || (sqlCommand != null && sqlCommand.isReturningKeywordPresent());
+    if (queryReturnsRows
+        && !queries[0].isStatementDescribed()
+        && (flags & QueryExecutor.QUERY_EXECUTE_AS_SIMPLE) == 0) {
+      int describeFlags = flags | QueryExecutor.QUERY_DESCRIBE_ONLY;
+      StatementResultHandler describeHandler = new StatementResultHandler();
+      try {
+        connection.getQueryExecutor().execute(
+            queries[0], parameterLists[0], describeHandler, 0, 0, describeFlags);
+      } catch (SQLException e) {
+        handler.handleError(e);
+        handler.handleCompletion();
+      }
+      ResultWrapper describeResult = describeHandler.getResults();
+      if (describeResult != null) {
+        castNonNull(describeResult.getResultSet(), "describeResult.getResultSet()").close();
+      }
+    }
+
     try (ResourceLock ignore = lock.obtain()) {
       result = null;
     }

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
@@ -793,6 +793,34 @@ public class TypeInfoCache implements TypeInfo {
     return type;
   }
 
+  public static int estimateMaxLength(int oid, short typlen, int typmod) {
+    if (typlen >= 0) {
+      return typlen;
+    }
+    switch (oid) {
+      case Oid.BPCHAR:
+      case Oid.VARCHAR:
+      case Oid.VARBIT:
+        if (typmod == -1) {
+          return -1;
+        }
+        return typmod - 4;
+      case Oid.NUMERIC:
+        if (typmod == -1) {
+          return -1;
+        }
+        int precision = (typmod - 4 >> 16) & 0xffff;
+        // The actual storage requirement is two bytes for each group of four decimal digits,
+        // plus three to eight bytes overhead.
+        return 8 + precision / 2;
+      case Oid.BIT:
+      case Oid.CHAR:
+        return typmod;
+      default:
+        return -1;
+    }
+  }
+
   @Override
   public int getPrecision(int oid, int typmod) {
     oid = convertArrayToBaseOid(oid);

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
@@ -793,6 +793,31 @@ public class TypeInfoCache implements TypeInfo {
     return type;
   }
 
+  public static int estimateMaxLength(int oid, short typlen, int typmod) {
+    if (typlen >= 0) {
+      return typlen;
+    }
+    switch (oid) {
+      case Oid.BPCHAR:
+      case Oid.VARCHAR:
+      case Oid.VARBIT:
+        if (typmod == -1) {
+          return -1;
+        }
+        return typmod - 4;
+      case Oid.NUMERIC:
+        int precision = (typmod - 4 >> 16) & 0xffff;
+        // The actual storage requirement is two bytes for each group of four decimal digits,
+        // plus three to eight bytes overhead.
+        return 8 + precision / 2;
+      case Oid.BIT:
+      case Oid.CHAR:
+        return typmod;
+      default:
+        return -1;
+    }
+  }
+
   @Override
   public int getPrecision(int oid, int typmod) {
     oid = convertArrayToBaseOid(oid);

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BatchDeadlockTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BatchDeadlockTest.java
@@ -65,8 +65,10 @@ public class BatchDeadlockTest extends BaseTest4 {
 
   /**
    * Size of the text payload per row in characters.
+   * Query executor tries to keep receiving buffer under 64000 bytes,
+   * so if we have payloads greater than 32K, then it would effectively be a "one-by-one" processing.
    */
-  private static final int PAYLOAD_SIZE = 100_000;
+  private static final int PAYLOAD_SIZE = 30_000;
 
   private final String payload = String.join("", Collections.nCopies(PAYLOAD_SIZE, "X"));
 
@@ -90,7 +92,7 @@ public class BatchDeadlockTest extends BaseTest4 {
   @BeforeAll
   static void createTables() throws Exception {
     try (Connection con = TestUtil.openDB()) {
-      TestUtil.createTable(con, "batch_deadlock_test", "id SERIAL PRIMARY KEY, data TEXT");
+      TestUtil.createTable(con, "batch_deadlock_test", "id SERIAL PRIMARY KEY, data varchar(" + PAYLOAD_SIZE + ")");
     }
   }
 

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BatchDeadlockTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BatchDeadlockTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2026, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.test.jdbc2;
+
+import org.postgresql.test.TestUtil;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Tests for client/server deadlock prevention during batch execution.
+ *
+ * <p>See <a href="https://github.com/pgjdbc/pgjdbc/issues/194">issue #194</a>.
+ *
+ * <h2>Background</h2>
+ *
+ * <p>When pipelining a large batch, the driver sends queries while the server sends back results.
+ * If the driver does not periodically flush and read results, both sides can block on their
+ * respective TCP send buffers, causing a deadlock.
+ *
+ * <p>The driver avoids this via {@code flushIfDeadlockRisk()} in {@code QueryExecutorImpl}, which
+ * estimates the amount of buffered response data and forces a Sync+flush when it nears the TCP
+ * buffer limit. To estimate accurately, it needs the query to be described first (via a Parse +
+ * Describe round-trip), so it can call {@code getMaxResultRowSize()} on the query's result fields.
+ */
+@ParameterizedClass
+@MethodSource("data")
+public class BatchDeadlockTest extends BaseTest4 {
+  public enum ReturningInQuery {
+    ID_DATA("id", "data"),
+    STAR("*"),
+    NO();
+
+    final String[] columns;
+
+    ReturningInQuery(String... columns) {
+      this.columns = columns;
+    }
+
+  }
+
+  /**
+   * Number of rows in the batch. Combined with {@link #PAYLOAD_SIZE}, the total RETURNING data
+   * must exceed the TCP buffer capacity (~128KB on most systems) to trigger the deadlock without
+   * the fix. 500 rows × 100KB = 50MB, well above any realistic buffer size.
+   */
+  private static final int BATCH_SIZE = 500;
+
+  /**
+   * Size of the text payload per row in characters.
+   */
+  private static final int PAYLOAD_SIZE = 100_000;
+
+  private final String payload = String.join("", Collections.nCopies(PAYLOAD_SIZE, "X"));
+
+  private final ReturningInQuery returningInQuery;
+
+  public BatchDeadlockTest(ReturningInQuery returningInQuery, BinaryMode binaryMode) {
+    this.returningInQuery = returningInQuery;
+    setBinaryMode(binaryMode);
+  }
+
+  public static Iterable<Object[]> data() {
+    Collection<Object[]> ids = new ArrayList<>();
+    for (ReturningInQuery returningInQuery : ReturningInQuery.values()) {
+      for (BinaryMode binaryMode : BinaryMode.values()) {
+        ids.add(new Object[]{returningInQuery, binaryMode});
+      }
+    }
+    return ids;
+  }
+
+  @BeforeAll
+  static void createTables() throws Exception {
+    try (Connection con = TestUtil.openDB()) {
+      TestUtil.createTable(con, "batch_deadlock_test", "id SERIAL PRIMARY KEY, data TEXT");
+    }
+  }
+
+  @AfterAll
+  static void dropTables() throws Exception {
+    try (Connection con = TestUtil.openDB()) {
+      TestUtil.dropTable(con, "batch_deadlock_test");
+    }
+  }
+
+  @Override
+  protected void setUp() throws Exception {
+    super.setUp();
+    TestUtil.execute(con, "TRUNCATE batch_deadlock_test");
+    con.setAutoCommit(false);
+  }
+
+  /**
+   * Verifies that a large batch using {@code prepareStatement(sql, String[])} with a large
+   * {@code TEXT} column completes without deadlock.
+   */
+  @Test
+  @Timeout(value = 10, unit = TimeUnit.SECONDS, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
+  void largePreparedBatchWithGeneratedKeysDoesNotDeadlock() throws Exception {
+    assumeNotSimpleQueryMode();
+    try (PreparedStatement ps = preparedStatement()) {
+      for (int i = 0; i < BATCH_SIZE; i++) {
+        ps.setString(1, payload);
+        ps.addBatch();
+      }
+      ps.executeBatch();
+    }
+  }
+
+  private PreparedStatement preparedStatement() throws SQLException {
+    switch (returningInQuery) {
+      case STAR:
+        return con.prepareStatement(
+            "INSERT INTO batch_deadlock_test(data) VALUES (?) RETURNING *");
+      case NO:
+        return con.prepareStatement(
+            "INSERT INTO batch_deadlock_test(data) VALUES (?)",
+            Statement.RETURN_GENERATED_KEYS);
+      default:
+        return con.prepareStatement(
+            "INSERT INTO batch_deadlock_test(data) VALUES (?)",
+            returningInQuery.columns);
+    }
+  }
+
+  /**
+   * Verifies that a large batch using {@code createStatement(sql, String[])} with a large
+   * {@code TEXT} column completes without deadlock.
+   */
+  @Test
+  @Disabled("Deadlock with simple (non-prepared) addBatch(sql) is a known issue")
+  @Timeout(value = 10, unit = TimeUnit.SECONDS, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
+  void largeSimpleBatchWithGeneratedKeysDoesNotDeadlock() throws Exception {
+    String sql;
+    switch (returningInQuery) {
+      case STAR:
+        sql = "INSERT INTO batch_deadlock_test(data) VALUES ('" + payload + "') RETURNING *";
+        break;
+      case NO:
+        sql = "INSERT INTO batch_deadlock_test(data) VALUES ('" + payload + "')";
+        break;
+      default:
+        sql =
+            "INSERT INTO batch_deadlock_test(data) VALUES ('" + payload + "') RETURNING " + String.join(",", returningInQuery.columns);
+        break;
+    }
+    try (Statement ps = con.createStatement()) {
+      for (int i = 0; i < BATCH_SIZE; i++) {
+        ps.addBatch(sql);
+      }
+      ps.executeBatch();
+    }
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BatchDeadlockTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BatchDeadlockTest.java
@@ -5,13 +5,19 @@
 
 package org.postgresql.test.jdbc2;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.postgresql.PGProperty;
 import org.postgresql.test.TestUtil;
+import org.postgresql.test.util.CountingSocketFactory;
+import org.postgresql.util.TestLogHandler;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.parallel.Isolated;
 import org.junit.jupiter.params.ParameterizedClass;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -22,7 +28,12 @@ import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Properties;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.LogManager;
+import java.util.logging.Logger;
+import java.util.regex.Pattern;
 
 /**
  * Tests for client/server deadlock prevention during batch execution.
@@ -42,10 +53,13 @@ import java.util.concurrent.TimeUnit;
  */
 @ParameterizedClass
 @MethodSource("data")
+@Isolated("Captures org.postgresql logs, so it needs to work in isolation from the other tests")
 public class BatchDeadlockTest extends BaseTest4 {
   public enum ReturningInQuery {
     ID_DATA("id", "data"),
     STAR("*"),
+    ID("id"),
+    // Note: Statement.RETURN_GENERATED_KEYS causes pgjdbc to add `RETURNING *` which is bad for performance
     NO();
 
     final String[] columns;
@@ -54,12 +68,21 @@ public class BatchDeadlockTest extends BaseTest4 {
       this.columns = columns;
     }
 
+    /**
+     * Whether the RETURNING list brings back the large {@code data} varchar. If false, the
+     * per-row response is a handful of bytes and the whole batch fits in the receive buffer
+     * with a single flush.
+     */
+    boolean returnsLargeData() {
+      return this == ID_DATA || this == STAR || this == NO;
+    }
+
   }
 
   /**
    * Number of rows in the batch. Combined with {@link #PAYLOAD_SIZE}, the total RETURNING data
    * must exceed the TCP buffer capacity (~128KB on most systems) to trigger the deadlock without
-   * the fix. 500 rows × 100KB = 50MB, well above any realistic buffer size.
+   * the fix. 500 rows × 30KB = 15MB, well above any realistic buffer size.
    */
   private static final int BATCH_SIZE = 500;
 
@@ -72,11 +95,31 @@ public class BatchDeadlockTest extends BaseTest4 {
 
   private final String payload = String.join("", Collections.nCopies(PAYLOAD_SIZE, "X"));
 
+  private static final Pattern FE_DESCRIBE_STATEMENT = Pattern.compile("FE=> Describe\\(statement");
+  private static final Pattern FE_DESCRIBE_PORTAL = Pattern.compile("FE=> Describe\\(portal");
+  private static final Pattern FE_EXECUTE = Pattern.compile("FE=> Execute");
+  private static final Pattern FE_SYNC = Pattern.compile("FE=> Sync");
+
   private final ReturningInQuery returningInQuery;
+
+  private TestLogHandler logHandler;
+  private Logger driverLogger;
+  private Level previousDriverLogLevel;
+  private CountingSocketFactory.Counters socketCounters;
 
   public BatchDeadlockTest(ReturningInQuery returningInQuery, BinaryMode binaryMode) {
     this.returningInQuery = returningInQuery;
     setBinaryMode(binaryMode);
+  }
+
+  @Override
+  protected void updateProperties(Properties props) {
+    super.updateProperties(props);
+    if (socketCounters == null) {
+      socketCounters = CountingSocketFactory.register();
+    }
+    PGProperty.SOCKET_FACTORY.set(props, CountingSocketFactory.class.getName());
+    PGProperty.SOCKET_FACTORY_ARG.set(props, socketCounters.key());
   }
 
   public static Iterable<Object[]> data() {
@@ -108,6 +151,29 @@ public class BatchDeadlockTest extends BaseTest4 {
     super.setUp();
     TestUtil.execute(con, "TRUNCATE batch_deadlock_test");
     con.setAutoCommit(false);
+    driverLogger = LogManager.getLogManager().getLogger("org.postgresql");
+    previousDriverLogLevel = driverLogger.getLevel();
+    driverLogger.setLevel(Level.ALL);
+    logHandler = new TestLogHandler();
+    driverLogger.addHandler(logHandler);
+  }
+
+  @Override
+  protected void tearDown() throws SQLException {
+    if (driverLogger != null) {
+      if (logHandler != null) {
+        driverLogger.removeHandler(logHandler);
+      }
+      driverLogger.setLevel(previousDriverLogLevel);
+    }
+    try {
+      super.tearDown();
+    } finally {
+      if (socketCounters != null) {
+        CountingSocketFactory.unregister(socketCounters);
+        socketCounters = null;
+      }
+    }
   }
 
   /**
@@ -118,12 +184,54 @@ public class BatchDeadlockTest extends BaseTest4 {
   @Timeout(value = 10, unit = TimeUnit.SECONDS, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
   void largePreparedBatchWithGeneratedKeysDoesNotDeadlock() throws Exception {
     assumeNotSimpleQueryMode();
+    long roundtripsBefore = socketCounters.roundtrips.get();
+    int describeStatementBefore = logHandler.getRecordsMatching(FE_DESCRIBE_STATEMENT).size();
+    int describePortalBefore = logHandler.getRecordsMatching(FE_DESCRIBE_PORTAL).size();
+    int executeBefore = logHandler.getRecordsMatching(FE_EXECUTE).size();
+    int syncBefore = logHandler.getRecordsMatching(FE_SYNC).size();
     try (PreparedStatement ps = preparedStatement()) {
       for (int i = 0; i < BATCH_SIZE; i++) {
         ps.setString(1, payload);
         ps.addBatch();
       }
       ps.executeBatch();
+    }
+    long roundtrips = socketCounters.roundtrips.get() - roundtripsBefore;
+    int describeStatement =
+        logHandler.getRecordsMatching(FE_DESCRIBE_STATEMENT).size() - describeStatementBefore;
+    int describePortal =
+        logHandler.getRecordsMatching(FE_DESCRIBE_PORTAL).size() - describePortalBefore;
+    int executes = logHandler.getRecordsMatching(FE_EXECUTE).size() - executeBefore;
+    int syncs = logHandler.getRecordsMatching(FE_SYNC).size() - syncBefore;
+
+    String metrics = String.format(
+        "BATCH_SIZE=%d, roundtrips=%d, Describe(statement)=%d, Describe(portal)=%d, "
+            + "Execute=%d, Sync=%d",
+        BATCH_SIZE, roundtrips, describeStatement, describePortal, executes, syncs);
+
+    // Pre-describe should happen about once (for the statement), not per row.
+    assertTrue(describeStatement <= 3,
+        () -> "Describe(statement) should fire ~once (pre-describe), got " + metrics);
+    // Describe(portal) fires per Bind when the query returns rows (RETURNING / generated keys),
+    // so ~BATCH_SIZE is expected. Catch regressions that send extras (2x per row etc.).
+    assertTrue(describePortal <= BATCH_SIZE + 5,
+        () -> "Describe(portal) should be ~BATCH_SIZE, got " + metrics);
+    assertTrue(executes <= BATCH_SIZE + 2,
+        () -> "Execute count should be ~BATCH_SIZE, got " + metrics);
+    // Sync / roundtrip upper bounds depend on whether the RETURNING clause brings back the
+    // large varchar. With large data, many forced flushes happen; without, the whole batch
+    // fits in the receive buffer and only the terminating Sync fires.
+    if (returningInQuery.returnsLargeData()) {
+      assertTrue(syncs < BATCH_SIZE, () -> "Sync should not fire per row, got " + metrics);
+      assertTrue(roundtrips < BATCH_SIZE, () -> "batch should pipeline, got " + metrics);
+    } else {
+      int expectedRoundtrips = BATCH_SIZE * 250 /* bytes per row */ * 2 / 64000;
+      assertTrue(syncs <= expectedRoundtrips,
+          () -> "small RETURNING fits in receive buffer — expected a few terminating Syncs, "
+              + "got " + metrics);
+      assertTrue(roundtrips <= expectedRoundtrips,
+          () -> "small RETURNING fits in receive buffer — expected a few write→read cycles, "
+              + "got " + metrics);
     }
   }
 

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BatchExecuteTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BatchExecuteTest.java
@@ -9,12 +9,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import org.postgresql.PGProperty;
 import org.postgresql.PGStatement;
 import org.postgresql.test.TestUtil;
+import org.postgresql.util.PSQLState;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedClass;
@@ -279,6 +281,24 @@ public class BatchExecuteTest extends BaseTest4 {
 
     } finally {
       TestUtil.closeQuietly(stmt);
+    }
+  }
+
+  @Test
+  public void testMultiStatementSqlInAddBatch() throws Exception {
+    // Multi-statement SQL in a single addBatch() entry has never worked in pgjdbc:
+    // BatchResultHandler allocates one update-count slot per batch entry, but
+    // CompositeQuery emits one CommandComplete per sub-statement, so it used to fail
+    // deep inside the protocol layer with "Too many update results were returned"
+    // or ClassCastException. Reject it at the JDBC boundary with a clear message.
+    try (Statement stmt = con.createStatement()) {
+      String sql = "UPDATE testbatch SET col1 = col1 + 1 WHERE pk = 1;"
+          + " UPDATE testbatch SET col1 = col1 + 2 WHERE pk = 1";
+      SQLException sqle = assertThrows(SQLException.class, () -> stmt.addBatch(sql));
+      assertEquals(PSQLState.NOT_IMPLEMENTED.getState(), sqle.getSQLState(),
+          "Multi-statement addBatch() should fail with NOT_IMPLEMENTED SQLState");
+      assertEquals(0, getCol1Value(),
+          "Rejected addBatch() must not execute either UPDATE.");
     }
   }
 

--- a/testkit/src/main/java/org/postgresql/test/jdbc2/BaseTest4.java
+++ b/testkit/src/main/java/org/postgresql/test/jdbc2/BaseTest4.java
@@ -62,6 +62,9 @@ public class BaseTest4 {
     if (stringType != null) {
       PGProperty.STRING_TYPE.set(props, stringType.name().toLowerCase(Locale.ROOT));
     }
+    if (preferQueryMode != null) {
+      PGProperty.PREFER_QUERY_MODE.set(props, preferQueryMode.value());
+    }
   }
 
   protected static void forceBinary(Properties props) {
@@ -71,6 +74,10 @@ public class BaseTest4 {
 
   public final void setBinaryMode(BinaryMode binaryMode) {
     this.binaryMode = binaryMode;
+  }
+
+  public final void setPreferQueryMode(PreferQueryMode preferQueryMode) {
+    this.preferQueryMode = preferQueryMode;
   }
 
   public @Nullable StringType getStringType() {

--- a/testkit/src/main/java/org/postgresql/test/util/CountingSocketFactory.java
+++ b/testkit/src/main/java/org/postgresql/test/util/CountingSocketFactory.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright (c) 2026, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.test.util;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import javax.net.SocketFactory;
+
+/**
+ * A {@link SocketFactory} that wraps sockets to count "roundtrips" as write→read direction
+ * transitions on the underlying socket. One or more writes followed by one or more reads is
+ * one roundtrip: the client stopped writing and waited for the server. Ten consecutive Sync
+ * messages with no intervening read count as zero roundtrips.
+ *
+ * <p>Counters are <em>per-connection</em>, not static. A test allocates a {@link Counters}
+ * instance via {@link #register()}, passes its {@link Counters#key()} via
+ * {@code PGProperty.SOCKET_FACTORY_ARG}, and reads cumulative values back through that
+ * instance. Two tests running in parallel each get their own {@code Counters}.
+ *
+ * <p>All counters are cumulative. Tests read deltas: snapshot values before an operation,
+ * run it, snapshot after, and assert on the difference.
+ *
+ * <p>Under SSL, roundtrip counts still reflect real wire direction changes (SSLSocket uses
+ * the underlying plain socket's streams), but handshake traffic contributes to the counters —
+ * snapshot after the connection is established.
+ */
+public class CountingSocketFactory extends SocketFactory {
+
+  /**
+   * Per-connection counters. Owned by the test; the factory looks it up by {@link #key} and
+   * writes into it.
+   */
+  public static final class Counters {
+    public final AtomicLong roundtrips = new AtomicLong();
+    public final AtomicLong bytesOut = new AtomicLong();
+    public final AtomicLong bytesIn = new AtomicLong();
+
+    private final String key;
+
+    private Counters(String key) {
+      this.key = key;
+    }
+
+    public String key() {
+      return key;
+    }
+  }
+
+  private static final ConcurrentMap<String, Counters> REGISTRY = new ConcurrentHashMap<>();
+
+  /**
+   * Allocates a fresh {@link Counters} and registers it so a factory instantiated with its
+   * key can find it. The caller should {@link #unregister(Counters)} at the end of the test
+   * to release the registry slot.
+   */
+  public static Counters register() {
+    String key = UUID.randomUUID().toString();
+    Counters c = new Counters(key);
+    REGISTRY.put(key, c);
+    return c;
+  }
+
+  public static void unregister(Counters counters) {
+    REGISTRY.remove(counters.key);
+  }
+
+  private final Counters counters;
+
+  public CountingSocketFactory(String key) {
+    Counters c = key == null ? null : REGISTRY.get(key);
+    if (c == null) {
+      throw new IllegalArgumentException(
+          "No CountingSocketFactory.Counters registered for key=" + key
+              + ". Call CountingSocketFactory.register() and pass its key() via "
+              + "PGProperty.SOCKET_FACTORY_ARG.");
+    }
+    this.counters = c;
+  }
+
+  @Override
+  public Socket createSocket() {
+    return new CountingSocket(counters);
+  }
+
+  @Override
+  public Socket createSocket(String host, int port) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Socket createSocket(String host, int port, InetAddress localHost, int localPort) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Socket createSocket(InetAddress host, int port) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Socket createSocket(InetAddress address, int port, InetAddress localAddress,
+      int localPort) {
+    throw new UnsupportedOperationException();
+  }
+
+  private enum Dir { NONE, WRITE, READ }
+
+  private static final class CountingSocket extends Socket {
+    private final Counters counters;
+    private final AtomicReference<Dir> lastDir = new AtomicReference<>(Dir.NONE);
+    private @Nullable InputStream countingIn;
+    private @Nullable OutputStream countingOut;
+
+    CountingSocket(Counters counters) {
+      this.counters = counters;
+    }
+
+    @Override
+    public synchronized InputStream getInputStream() throws IOException {
+      InputStream countingIn = this.countingIn;
+      if (countingIn == null) {
+        this.countingIn = countingIn = new CountingInputStream(super.getInputStream(), this);
+      }
+      return countingIn;
+    }
+
+    @Override
+    public synchronized OutputStream getOutputStream() throws IOException {
+      OutputStream countingOut = this.countingOut;
+      if (countingOut == null) {
+        this.countingOut = countingOut = new CountingOutputStream(super.getOutputStream(), this);
+      }
+      return countingOut;
+    }
+
+    void onWrite(int n) {
+      if (n <= 0) {
+        return;
+      }
+      counters.bytesOut.addAndGet(n);
+      lastDir.set(Dir.WRITE);
+    }
+
+    void onRead(int n) {
+      if (n <= 0) {
+        return;
+      }
+      counters.bytesIn.addAndGet(n);
+      if (lastDir.getAndSet(Dir.READ) == Dir.WRITE) {
+        counters.roundtrips.incrementAndGet();
+      }
+    }
+  }
+
+  private static final class CountingInputStream extends FilterInputStream {
+    private final CountingSocket socket;
+
+    CountingInputStream(InputStream in, CountingSocket socket) {
+      super(in);
+      this.socket = socket;
+    }
+
+    @Override
+    public int read() throws IOException {
+      int b = in.read();
+      socket.onRead(b == -1 ? 0 : 1);
+      return b;
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+      int n = in.read(b, off, len);
+      socket.onRead(n);
+      return n;
+    }
+  }
+
+  private static final class CountingOutputStream extends OutputStream {
+    private final OutputStream out;
+    private final CountingSocket socket;
+
+    CountingOutputStream(OutputStream out, CountingSocket socket) {
+      this.out = out;
+      this.socket = socket;
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+      out.write(b);
+      socket.onWrite(1);
+    }
+
+    @Override
+    public void write(byte[] b, int off, int len) throws IOException {
+      out.write(b, off, len);
+      socket.onWrite(len);
+    }
+
+    @Override
+    public void flush() throws IOException {
+      out.flush();
+    }
+
+    @Override
+    public void close() throws IOException {
+      out.close();
+    }
+  }
+}


### PR DESCRIPTION

Commit [d232e605](https://github.com/pgjdbc/pgjdbc/commit/d232e605de960f3a8ca2dfef4974dbe546b860bb) removed the pre-describe step from internalExecuteBatch for queries with wantsGeneratedKeysAlways. Without it the driver cannot estimate result row sizes before pipelining, so flushIfDeadlockRisk falls back to 250 bytes per query. For INSERT ... RETURNING with large columns the actual response is orders of magnitude larger, overflowing TCP buffers and causing client/server deadlock.


### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Does `./gradlew styleCheck` pass ?
3. [x] Have you added your new test classes to an existing test suite in alphabetical order?

### Changes to Existing Features:

* [x] Does this break existing behaviour? If so please explain.
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
