### PR TITLE
fix: drain CopyOut messages after cancel to restore connection usability

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -1161,6 +1161,27 @@ public class QueryExecutorImpl extends QueryExecutorBase {
         }
       } else if (op instanceof CopyOut) {
         sendQueryCancel();
+        // Drain remaining CopyData messages and wait for ReadyForQuery so the
+        // connection is clean for the next query. Without this drain the stale
+        // server messages corrupt subsequent operations (issue #1290).
+        try (ResourceLock ignore = lock.obtain()) {
+          do {
+            try {
+              processCopyResults(op, true);
+            } catch (SQLException se) {
+              errors++;
+              if (error != null) {
+                SQLException e = se;
+                SQLException next;
+                while ((next = e.getNextException()) != null) {
+                  e = next;
+                }
+                e.setNextException(error);
+              }
+              error = se;
+            }
+          } while (hasLock(op));
+        }
       }
 
     } catch (IOException ioe) {

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc4/PGCopyInputStreamTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc4/PGCopyInputStreamTest.java
@@ -97,6 +97,28 @@ class PGCopyInputStreamTest {
     }
   }
 
+  @Test
+  void connectionIsUsableAfterPartialRead() throws SQLException, IOException {
+    // Regression test for https://github.com/pgjdbc/pgjdbc/issues/1290:
+    // closing a PGCopyInputStream before EOF must drain remaining server messages
+    // so the connection can be reused for a subsequent COPY operation.
+    PGConnection pgConn = conn.unwrap(PGConnection.class);
+
+    // Partial read: consume fewer bytes than the full COPY output, then close.
+    try (PGCopyInputStream in = new PGCopyInputStream(pgConn, COPY_SQL)) {
+      byte[] partial = new byte[COPY_ROW_SIZE];
+      assertEquals(COPY_ROW_SIZE, in.read(partial), "Should read one row");
+      // close() calls cancelCopy() which must drain remaining CopyData + ReadyForQuery
+    }
+
+    // The connection must be usable for a fresh COPY after the partial read + close.
+    try (PGCopyInputStream in2 = new PGCopyInputStream(pgConn, COPY_SQL)) {
+      List<byte[]> chunks = readFully(in2, COPY_ROW_SIZE);
+      assertEquals(NUM_TEST_ROWS, chunks.size(), "Second COPY must return all rows");
+      assertEquals("0\n1\n2\n3\n", chunksToString(chunks), "Second COPY must return correct data");
+    }
+  }
+
   private static List<byte[]> readFully(PGCopyInputStream in, int size) throws SQLException, IOException {
     List<byte[]> chunks = new ArrayList<>();
     do {


### PR DESCRIPTION
## Problem

When `PGCopyInputStream` is closed before EOF, `close()` calls `cancelCopy()` on the underlying `CopyOut` operation. The `CopyIn` branch in `QueryExecutorImpl.cancelCopy()` correctly sends `CopyFail` and then **drains remaining server messages** (`CopyData`, `CommandComplete`, `ReadyForQuery`) in a loop until the connection lock is released.

The `CopyOut` branch only called `sendQueryCancel()` — an out-of-band cancel signal sent on a **separate socket** — but never drained the remaining `CopyData` and `ReadyForQuery` messages from the **main connection buffer**. This left stale server messages on the wire that corrupted subsequent queries, making the connection unusable.

Reproducer (from the issue):
```java
try (PGCopyInputStream in = new PGCopyInputStream(conn, COPY_SQL)) {
    byte[] partial = new byte[5];
    in.read(partial); // read less than full output
    // close() → cancelCopy() → stale messages left on wire
}
// Next query or COPY fails because connection is in broken state
```

## Fix

After `sendQueryCancel()`, add the same `processCopyResults` drain loop used by the `CopyIn` path. This ensures all remaining `CopyData` messages and the final `ReadyForQuery` are consumed, fully resetting the connection before the lock is released.

## Test

Added `connectionIsUsableAfterPartialRead()` in `PGCopyInputStreamTest`: performs a partial read, closes the stream, then opens a second `PGCopyInputStream` on the same connection and verifies all rows are returned correctly.

Fixes #1290