### PR TITLE
style: replace @exception with @throws in getBoolean javadoc

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
@@ -2465,8 +2465,8 @@ public class PgResultSet implements ResultSet, PGRefCursorResultSet {
    * @param columnIndex the first column is 1, the second is 2, ...
    * @return the column value; if the value is SQL <code>NULL</code>, the value returned is
    *         <code>false</code>
-   * @exception SQLException if the columnIndex is not valid; if a database access error occurs; if
-   *            this method is called on a closed result set or is an invalid cast to boolean type.
+   * @throws SQLException if the columnIndex is not valid; if a database access error occurs; if
+   *         this method is called on a closed result set or is an invalid cast to boolean type.
    * @see <a href="https://www.postgresql.org/docs/current/static/datatype-boolean.html">PostgreSQL
    *      Boolean Type</a>
    */


### PR DESCRIPTION
Fixes errorprone PreferThrowsTag warning after update to 2.49.0.
