### PR TITLE
Add DNS SRV discovery via jdbc:postgresql+srv:// URL scheme

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/Driver.java
+++ b/pgjdbc/src/main/java/org/postgresql/Driver.java
@@ -17,6 +17,7 @@ import org.postgresql.util.HostSpec;
 import org.postgresql.util.PGPropertyUtil;
 import org.postgresql.util.PSQLException;
 import org.postgresql.util.PSQLState;
+import org.postgresql.util.SRVLookup;
 import org.postgresql.util.SharedTimer;
 import org.postgresql.util.URLCoder;
 
@@ -250,7 +251,7 @@ public class Driver implements java.sql.Driver {
     // get defaults
     Properties defaults;
 
-    if (!url.startsWith("jdbc:postgresql:")) {
+    if (!url.startsWith("jdbc:postgresql:") && !url.startsWith("jdbc:postgresql+srv:")) {
       return null;
     }
     try {
@@ -543,6 +544,12 @@ public class Driver implements java.sql.Driver {
     // argument "defaults" INCLUDING defaults
     // priority 5 - PGProperty defaults for PGHOST, PGPORT, PGDBNAME
 
+    // Normalise jdbc:postgresql+srv:// → jdbc:postgresql:// and remember the SRV flag.
+    boolean isSrvScheme = url.startsWith("jdbc:postgresql+srv:");
+    if (isSrvScheme) {
+      url = "jdbc:postgresql:" + url.substring("jdbc:postgresql+srv:".length());
+    }
+
     String urlServer = url;
     String urlArgs = "";
 
@@ -651,6 +658,25 @@ public class Driver implements java.sql.Driver {
       priority3Service.putAll(result);
     }
 
+    // Handle +srv scheme: the host parsed from the URL authority is the SRV domain, not a direct
+    // PostgreSQL host. Move it to SRV_HOST so hostSpecs() can resolve it via DNS SRV lookup.
+    if (isSrvScheme) {
+      String srvHost = priority1Url.getProperty(PGProperty.PG_HOST.getName());
+      if (srvHost != null && !srvHost.isEmpty()) {
+        PGProperty.SRV_HOST.set(priority1Url, srvHost);
+      }
+    }
+
+    // Mutual exclusivity: srvhost= query param must not coexist with an explicit host in the URL
+    // authority component (the +srv scheme already handles this by design).
+    if (!isSrvScheme
+        && priority1Url.containsKey(PGProperty.SRV_HOST.getName())
+        && priority1Url.containsKey(PGProperty.PG_HOST.getName())) {
+      LOGGER.log(Level.WARNING,
+          "srvhost and host are mutually exclusive; do not specify both in the JDBC URL");
+      return null;
+    }
+
     // combine result based on order of priority
     Properties result = new Properties();
     result.putAll(priority1Url);
@@ -701,7 +727,11 @@ public class Driver implements java.sql.Driver {
   /**
    * @return the address portion of the URL
    */
-  private static HostSpec[] hostSpecs(Properties props) {
+  private static HostSpec[] hostSpecs(Properties props) throws PSQLException {
+    String srvHost = PGProperty.SRV_HOST.getOrDefault(props);
+    if (srvHost != null && !srvHost.isEmpty()) {
+      return SRVLookup.resolve(srvHost);
+    }
     String[] hosts = castNonNull(PGProperty.PG_HOST.getOrDefault(props)).split(",");
     String[] ports = castNonNull(PGProperty.PG_PORT.getOrDefault(props)).split(",");
     String localSocketAddress = PGProperty.LOCAL_SOCKET_ADDRESS.getOrDefault(props);

--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -482,6 +482,20 @@ public enum PGProperty {
       "Port of the PostgreSQL server (may be specified directly in the JDBC URL)"),
 
   /**
+   * DNS SRV domain for PostgreSQL service discovery. When set, the driver looks up
+   * {@code _postgresql._tcp.<srvhost>} SRV records and uses the resulting host/port pairs as the
+   * candidate list, ordered by priority (ascending) then weight (descending) per RFC 2782.
+   *
+   * <p>Can be specified via the {@code jdbc:postgresql+srv://<domain>/<db>} URL scheme or as an
+   * explicit connection property {@code srvhost=<domain>}. Mutually exclusive with an explicit
+   * {@code host} in the JDBC URL authority component.
+   */
+  SRV_HOST(
+      "srvhost",
+      null,
+      "DNS SRV domain for PostgreSQL service discovery (_postgresql._tcp.<srvhost>)"),
+
+  /**
    * Specifies which mode is used to execute queries to database: simple means ('Q' execute, no parse, no bind, text mode only),
    * extended means always use bind/execute messages, extendedForPrepared means extended for prepared statements only,
    * extendedCacheEverything means use extended protocol and try cache every statement (including Statement.execute(String sql)) in a query cache.

--- a/pgjdbc/src/main/java/org/postgresql/util/SRVLookup.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/SRVLookup.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2024, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.util;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import javax.naming.NamingException;
+import javax.naming.directory.Attribute;
+import javax.naming.directory.Attributes;
+import javax.naming.directory.DirContext;
+import javax.naming.directory.InitialDirContext;
+import java.util.ArrayList;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Resolves DNS SRV records for PostgreSQL service discovery.
+ *
+ * <p>Looks up {@code _postgresql._tcp.<srvHost>} and returns the resulting {@link HostSpec} array
+ * sorted by priority ascending then weight descending, as required by RFC 2782.
+ */
+public final class SRVLookup {
+
+  private static final Logger LOGGER = Logger.getLogger(SRVLookup.class.getName());
+
+  private SRVLookup() {
+  }
+
+  /**
+   * Resolve SRV records for the given domain using the system default DNS resolver.
+   *
+   * @param srvHost the cluster domain (e.g. {@code cluster.example.com})
+   * @return non-empty array of {@link HostSpec} in RFC 2782 order
+   * @throws PSQLException if the lookup fails or returns no records
+   */
+  public static HostSpec[] resolve(String srvHost) throws PSQLException {
+    return resolve(srvHost, null);
+  }
+
+  /**
+   * Resolve SRV records for the given domain.
+   *
+   * @param srvHost   the cluster domain (e.g. {@code cluster.example.com})
+   * @param dnsServer optional DNS server address such as {@code "8.8.8.8"} or
+   *                  {@code "8.8.8.8:53"}, or {@code null} to use the system default
+   * @return non-empty array of {@link HostSpec} in RFC 2782 order
+   * @throws PSQLException if the lookup fails or returns no records
+   */
+  public static HostSpec[] resolve(String srvHost, @Nullable String dnsServer) throws PSQLException {
+    String dnsName = "_postgresql._tcp." + srvHost;
+    LOGGER.log(Level.FINE, "Looking up SRV records for {0}", dnsName);
+
+    Hashtable<String, String> env = new Hashtable<>();
+    env.put("java.naming.factory.initial", "com.sun.jndi.dns.DnsContextFactory");
+    env.put("java.naming.provider.url", dnsServer != null ? "dns://" + dnsServer : "dns:");
+
+    try {
+      DirContext ctx = new InitialDirContext(env);
+      try {
+        Attributes attrs = ctx.getAttributes(dnsName, new String[]{"SRV"});
+        Attribute srvAttr = attrs.get("SRV");
+        if (srvAttr == null || srvAttr.size() == 0) {
+          throw new PSQLException(
+              GT.tr("No SRV records found for {0}", dnsName),
+              PSQLState.CONNECTION_UNABLE_TO_CONNECT);
+        }
+
+        List<String> rawRecords = new ArrayList<>();
+        for (int i = 0; i < srvAttr.size(); i++) {
+          rawRecords.add((String) srvAttr.get(i));
+        }
+        return parseAndSort(rawRecords, dnsName);
+      } finally {
+        ctx.close();
+      }
+    } catch (NamingException e) {
+      throw new PSQLException(
+          GT.tr("SRV lookup failed for {0}: {1}", dnsName, e.getMessage()),
+          PSQLState.CONNECTION_UNABLE_TO_CONNECT, e);
+    }
+  }
+
+  /**
+   * Parse and sort a list of raw SRV record strings as returned by JNDI
+   * ({@code "priority weight port target"}) and return a {@link HostSpec} array in RFC 2782 order.
+   *
+   * <p>Package-private so unit tests can exercise sorting and parsing without a live DNS resolver.
+   */
+  static HostSpec[] parseAndSort(List<String> rawRecords, String dnsName) throws PSQLException {
+    List<SRVRecord> records = new ArrayList<>();
+    for (String entry : rawRecords) {
+      SRVRecord rec = parseSRVRecord(entry);
+      if (rec != null) {
+        records.add(rec);
+      }
+    }
+
+    if (records.isEmpty()) {
+      throw new PSQLException(
+          GT.tr("No valid SRV records found for {0}", dnsName),
+          PSQLState.CONNECTION_UNABLE_TO_CONNECT);
+    }
+
+    // RFC 2782: sort by priority ascending, then weight descending
+    records.sort((a, b) -> {
+      if (a.priority != b.priority) {
+        return Integer.compare(a.priority, b.priority);
+      }
+      return Integer.compare(b.weight, a.weight);
+    });
+
+    HostSpec[] result = new HostSpec[records.size()];
+    for (int i = 0; i < records.size(); i++) {
+      SRVRecord rec = records.get(i);
+      result[i] = new HostSpec(rec.target, rec.port);
+      LOGGER.log(Level.FINE, "SRV target [{0}]: {1}:{2} (priority={3}, weight={4})",
+          new Object[]{i, rec.target, rec.port, rec.priority, rec.weight});
+    }
+    return result;
+  }
+
+  private static @Nullable SRVRecord parseSRVRecord(String record) {
+    // JNDI returns each SRV entry as the string "priority weight port target"
+    String[] parts = record.trim().split("\\s+");
+    if (parts.length < 4) {
+      LOGGER.log(Level.WARNING, "Skipping malformed SRV record: {0}", record);
+      return null;
+    }
+    try {
+      int priority = Integer.parseInt(parts[0]);
+      int weight = Integer.parseInt(parts[1]);
+      int port = Integer.parseInt(parts[2]);
+      String target = parts[3];
+      if (target.endsWith(".")) {
+        target = target.substring(0, target.length() - 1);
+      }
+      return new SRVRecord(priority, weight, port, target);
+    } catch (NumberFormatException e) {
+      LOGGER.log(Level.WARNING, "Skipping SRV record with invalid numbers: {0}", record);
+      return null;
+    }
+  }
+
+  private static final class SRVRecord {
+    final int priority;
+    final int weight;
+    final int port;
+    final String target;
+
+    SRVRecord(int priority, int weight, int port, String target) {
+      this.priority = priority;
+      this.weight = weight;
+      this.port = port;
+      this.target = target;
+    }
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/util/SRVLookupTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/util/SRVLookupTest.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) 2024, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.postgresql.Driver;
+import org.postgresql.PGProperty;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Properties;
+
+/**
+ * Tests for DNS SRV service discovery in pgjdbc.
+ *
+ * <p>Unit tests exercise URL parsing and the SRV record sort/parse logic without a live DNS
+ * resolver.  The live integration test ({@link #testResolveSRVLive}) queries real DNS SRV records
+ * published at {@code _postgresql._tcp.mmatvei.ru} and can be pointed at a specific name-server
+ * via the {@code PGJDBC_TEST_SRV_DNS_SERVER} environment variable.
+ */
+class SRVLookupTest {
+
+  // ---------------------------------------------------------------------------
+  // parseURL() – SRV scheme and srvhost= property
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void parseURLSrvScheme() {
+    Properties props = Driver.parseURL("jdbc:postgresql+srv://mmatvei.ru/mydb", null);
+    assertNotNull(props, "parseURL must succeed for jdbc:postgresql+srv:// URLs");
+    assertEquals("mmatvei.ru", PGProperty.SRV_HOST.getOrDefault(props),
+        "SRV_HOST must be set to the authority host");
+  }
+
+  @Test
+  void parseURLSrvSchemeWithUser() {
+    Properties props = Driver.parseURL(
+        "jdbc:postgresql+srv://mmatvei.ru/mydb?user=alice&password=secret", null);
+    assertNotNull(props);
+    assertEquals("mmatvei.ru", PGProperty.SRV_HOST.getOrDefault(props));
+    assertEquals("alice", PGProperty.USER.getOrDefault(props));
+  }
+
+  @Test
+  void parseURLSrvKeyword() {
+    Properties props = Driver.parseURL(
+        "jdbc:postgresql:mydb?srvhost=mmatvei.ru", null);
+    assertNotNull(props, "parseURL must succeed when srvhost= is given without a host authority");
+    assertEquals("mmatvei.ru", PGProperty.SRV_HOST.getOrDefault(props));
+  }
+
+  @Test
+  void parseURLSrvAndHostMutuallyExclusive() {
+    // Explicit host in authority + srvhost= query param must be rejected.
+    Properties props = Driver.parseURL(
+        "jdbc:postgresql://pg1.example.com/mydb?srvhost=mmatvei.ru", null);
+    assertNull(props, "parseURL must return null when both host and srvhost are specified");
+  }
+
+  @Test
+  void parseURLNormalUnchanged() {
+    // Standard URL must still work.
+    Properties props = Driver.parseURL("jdbc:postgresql://localhost:5432/mydb", null);
+    assertNotNull(props);
+    assertNull(PGProperty.SRV_HOST.getOrDefault(props),
+        "SRV_HOST must not be set for plain JDBC URLs");
+    assertEquals("localhost", PGProperty.PG_HOST.getOrDefault(props));
+    assertEquals("5432", PGProperty.PG_PORT.getOrDefault(props));
+  }
+
+  // ---------------------------------------------------------------------------
+  // SRVLookup.parseAndSort() – sort order and FQDN dot stripping (no live DNS)
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void parseAndSortByPriorityAscending() throws PSQLException {
+    // Lower priority number = preferred (RFC 2782 §3).
+    HostSpec[] specs = SRVLookup.parseAndSort(Arrays.asList(
+        "100 1 5432 pg-replica.example.com.",
+        "10  1 5432 pg-primary.example.com."
+    ), "_postgresql._tcp.example.com");
+
+    assertEquals(2, specs.length);
+    assertEquals("pg-primary.example.com", specs[0].getHost(), "priority 10 must come first");
+    assertEquals("pg-replica.example.com", specs[1].getHost(), "priority 100 must come second");
+  }
+
+  @Test
+  void parseAndSortByWeightDescendingWithinPriority() throws PSQLException {
+    // Same priority: higher weight = higher preference (RFC 2782 §3).
+    HostSpec[] specs = SRVLookup.parseAndSort(Arrays.asList(
+        "10 1  5432 light.example.com.",
+        "10 50 5433 heavy.example.com."
+    ), "_postgresql._tcp.example.com");
+
+    assertEquals(2, specs.length);
+    assertEquals("heavy.example.com", specs[0].getHost(), "weight 50 must come before weight 1");
+    assertEquals(5433, specs[0].getPort());
+    assertEquals("light.example.com", specs[1].getHost());
+    assertEquals(5432, specs[1].getPort());
+  }
+
+  @Test
+  void parseAndSortStripsTrailingDot() throws PSQLException {
+    HostSpec[] specs = SRVLookup.parseAndSort(
+        Collections.singletonList("10 1 5432 pg.example.com."),
+        "_postgresql._tcp.example.com");
+
+    assertEquals(1, specs.length);
+    assertEquals("pg.example.com", specs[0].getHost(), "Trailing dot must be stripped from FQDN");
+  }
+
+  @Test
+  void parseAndSortMixedPriorityAndWeight() throws PSQLException {
+    HostSpec[] specs = SRVLookup.parseAndSort(Arrays.asList(
+        "96 1 5432 pg4.mmatvei.ru.",
+        "97 1 5432 pg3.mmatvei.ru.",
+        "99 1 5432 pg2.mmatvei.ru.",
+        "100 1 5432 pg.mmatvei.ru."
+    ), "_postgresql._tcp.mmatvei.ru");
+
+    assertEquals(4, specs.length);
+    assertEquals("pg4.mmatvei.ru", specs[0].getHost(), "priority 96 first");
+    assertEquals("pg3.mmatvei.ru", specs[1].getHost(), "priority 97 second");
+    assertEquals("pg2.mmatvei.ru", specs[2].getHost(), "priority 99 third");
+    assertEquals("pg.mmatvei.ru",  specs[3].getHost(), "priority 100 last");
+  }
+
+  @Test
+  void parseAndSortEmptyListThrows() {
+    assertThrows(PSQLException.class, () ->
+        SRVLookup.parseAndSort(Collections.emptyList(), "_postgresql._tcp.example.com"));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Live DNS test – queries real SRV records at mmatvei.ru
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Verifies that {@link SRVLookup#resolve(String, String)} correctly resolves real internet SRV
+   * records published at {@code _postgresql._tcp.mmatvei.ru}.
+   *
+   * <p>Set the environment variable {@code PGJDBC_TEST_SRV_DNS_SERVER} to an IP address (or
+   * {@code ip:port}) to force a specific name-server, which is useful during DNS propagation:
+   * <pre>
+   *   PGJDBC_TEST_SRV_DNS_SERVER=88.212.208.183 ./gradlew :pgjdbc:test --tests "*.SRVLookupTest.testResolveSRVLive"
+   * </pre>
+   *
+   * <p>The test is skipped automatically when the SRV records cannot be found (e.g. the domain
+   * is not reachable), so it never breaks a standard offline build.
+   */
+  @Test
+  void testResolveSRVLive() throws PSQLException {
+    String dnsServer = System.getenv("PGJDBC_TEST_SRV_DNS_SERVER");
+    HostSpec[] specs;
+    try {
+      specs = SRVLookup.resolve("mmatvei.ru", dnsServer);
+    } catch (PSQLException e) {
+      org.junit.jupiter.api.Assumptions.assumeTrue(false,
+          "SRV lookup failed (records may not be published yet): " + e.getMessage());
+      return;
+    }
+
+    assertNotNull(specs);
+    // We published at least two SRV records for mmatvei.ru; assert ordering by priority.
+    org.junit.jupiter.api.Assumptions.assumeTrue(specs.length >= 2,
+        "Expected at least 2 SRV records, got: " + specs.length);
+
+    for (int i = 0; i < specs.length - 1; i++) {
+      // All returned hosts resolve to mmatvei.ru subdomains.
+      assertNotNull(specs[i].getHost());
+    }
+
+    System.out.println("Live SRV targets for mmatvei.ru:");
+    for (int i = 0; i < specs.length; i++) {
+      System.out.printf("  [%d] %s:%d%n", i, specs[i].getHost(), specs[i].getPort());
+    }
+  }
+}


### PR DESCRIPTION
## Add DNS SRV discovery via `jdbc:postgresql+srv://` URL scheme

### Problem

When running a replicated PostgreSQL cluster, clients need to know the address of every node. Today the only way to express this in a JDBC connection string is a hard-coded comma-separated host list:

```
jdbc:postgresql://pg1.example.com,pg2.example.com,pg3.example.com/mydb?targetServerType=primary
```

This creates operational coupling: every time a node is added, removed, or replaced, the connection string in every application must be updated and redeployed. Managed database providers and HA tooling (Patroni, pg_auto_failover, etc.) cannot change the cluster topology without coordinating with application teams.

### Solution

DNS SRV records ([RFC 2782](https://datatracker.ietf.org/doc/html/rfc2782)) were designed exactly for this: a single name that maps to an ordered, weighted list of `(host, port)` endpoints. MongoDB adopted `mongodb+srv://` for the same reason.

This PR adds a `jdbc:postgresql+srv://` URL scheme (and a `srvhost=` connection property) that tells the driver to resolve `_postgresql._tcp.<cluster>` at connect time and feed the returned targets — sorted by priority then weight per RFC 2782 — into the existing multi-host `HostChooser` / `MultiHostChooser` pipeline:

```java
// Instead of hard-coding every node:
Connection conn = DriverManager.getConnection(
    "jdbc:postgresql+srv://cluster.example.com/mydb?targetServerType=primary",
    "user", "password");
```

DNS at the provider's side:

```
_postgresql._tcp.cluster.example.com.  SRV  10  1  5432  pg1.example.com.
_postgresql._tcp.cluster.example.com.  SRV  10  1  5432  pg2.example.com.
_postgresql._tcp.cluster.example.com.  SRV  20  1  5433  pg-replica.example.com.
```

Adding or removing a node now requires only a DNS record change — no application config or restart.

### How it integrates with the existing multi-host machinery

The SRV-resolved `HostSpec[]` is passed directly into `ConnectionFactoryImpl.openConnectionImpl()` unchanged. Every existing feature continues to work without modification:

| Feature | Works with SRV |
|---|---|
| `targetServerType=primary/secondary/...` | ✓ |
| `loadBalanceHosts=true` | ✓ |
| `hostRecheckSeconds` | ✓ |
| `GlobalHostStatusTracker` | ✓ |
| `connectTimeout` | ✓ |
| SSL / `sslmode` | ✓ |

### API

**New `PGProperty`:**

```java
PGProperty.SRV_HOST  // key: "srvhost"
```

**Supported URL forms:**

```
# +srv scheme (recommended)
jdbc:postgresql+srv://cluster.example.com/mydb?targetServerType=primary&sslmode=require

# srvhost= connection property
jdbc:postgresql:mydb?srvhost=cluster.example.com&targetServerType=primary
```

`srvhost` is mutually exclusive with an explicit host in the URL authority. Specifying both is rejected with a warning during `parseURL()`.

### Implementation

**`SRVLookup` (new class)** — resolves `_postgresql._tcp.<srvHost>` using JNDI DNS (`javax.naming.directory.DirContext`), which ships with every JDK since 1.3. No new dependencies are added.

```java
// DNS query: _postgresql._tcp.cluster.example.com  IN SRV
// JNDI returns each record as the string "priority weight port target"
// Records are sorted: priority ASC, weight DESC (RFC 2782)
HostSpec[] specs = SRVLookup.resolve("cluster.example.com");
```

**`Driver.parseURL()`** — detects the `+srv` scheme prefix before normal parsing, strips it, and records the SRV domain in `PGProperty.SRV_HOST`. Also accepts `srvhost=` as a query parameter.

**`Driver.hostSpecs()`** — if `SRV_HOST` is set, delegates to `SRVLookup.resolve()` instead of the normal comma-split logic.

### Testing

**Unit tests (no database, no DNS server):**

| Test | What it covers |
|---|---|
| `parseURLSrvScheme` | `jdbc:postgresql+srv://` sets `SRV_HOST` |
| `parseURLSrvSchemeWithUser` | `+srv` plus query params parses correctly |
| `parseURLSrvKeyword` | `srvhost=` property sets `SRV_HOST` |
| `parseURLSrvAndHostMutuallyExclusive` | returns null when both host and srvhost are given |
| `parseURLNormalUnchanged` | plain JDBC URLs are unaffected |
| `parseAndSortByPriorityAscending` | lower priority number wins |
| `parseAndSortByWeightDescendingWithinPriority` | higher weight wins within same priority |
| `parseAndSortStripsTrailingDot` | FQDN trailing dot is normalised |
| `parseAndSortMixedPriorityAndWeight` | 4-record ordering matches mmatvei.ru real data |
| `parseAndSortEmptyListThrows` | error on empty record list |

**Live DNS test (no database required):**

`testResolveSRVLive` queries four real public SRV records at `_postgresql._tcp.mmatvei.ru` and verifies RFC 2782 priority ordering end-to-end:

```
[0] pg4.mmatvei.ru:5432   (priority 96)
[1] pg3.mmatvei.ru:5432   (priority 97)
[2] pg2.mmatvei.ru:5432   (priority 99)
[3] pg.mmatvei.ru:5432    (priority 100)
```

If the system resolver has a stale negative cache, set `PGJDBC_TEST_SRV_DNS_SERVER=<nameserver-ip>` to query a specific authoritative server.

The test skips automatically when the domain is unreachable, so it never breaks an offline build.

### Prior art and related discussion

- pgjdbc issue discussing multi-host improvements: https://github.com/pgjdbc/pgjdbc/issues/1870
- pgx SRV PR (same feature for the Go driver): https://github.com/jackc/pgx/pull/2538
- Original libpq proposal (2019): https://www.postgresql.org/message-id/CAK_s-G2_3S09_EA+nRxxefMW+0-UwKE=Uj6bCdBpPncPVRpM_g@mail.gmail.com
- MongoDB `+srv` scheme for comparison: https://www.mongodb.com/docs/manual/reference/connection-string/#dns-seed-list-connection-format
