### PR TITLE
Restrict test with scram_iterations to v16+ and release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [42.7.10] (2026-02-11)
 
+### Security
+* fix: Limit SCRAM PBKDF2 iterations accepted from the server
+pgjdbc was vulnerable to a client-side denial of service in SCRAM-SHA-256 authentication, where a malicious or compromised PostgreSQL server could specify an extremely large PBKDF2 iteration count, causing the client to consume unbounded CPU and potentially exhaust connection pools. The fix introduces a new scramMaxIterations connection property (defaulting to 100,000) to cap iteration counts before computation begins.
+See the [Security Advisory](https://github.com/pgjdbc/pgjdbc/security/advisories/GHSA-98qh-xjc8-98pq) for more detail.
+The following [CVE-2026-42198](https://nvd.nist.gov/vuln/detail/CVE-2026-42198) has been issued.
+
 ### Changed
 * chore: Migrate to Shadow 9 [PR 3931](https://github.com/pgjdbc/pgjdbc/pull/3931)
 * style: fix empty line before javadoc for checkstyle compliance [PR #3925](https://github.com/pgjdbc/pgjdbc/pull/3925)

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/ScramTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/ScramTest.java
@@ -14,6 +14,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import org.postgresql.PGProperty;
 import org.postgresql.core.ServerVersion;
 import org.postgresql.test.TestUtil;
+import org.postgresql.test.annotations.EnabledForServerVersionRange;
 import org.postgresql.util.PSQLException;
 import org.postgresql.util.PSQLState;
 
@@ -179,6 +180,7 @@ class ScramTest {
   }
 
   @Test
+  @EnabledForServerVersionRange(gte = "16")
   void acceptsValidCredentialsBelowCustomCap() throws SQLException {
     int serverScramIterations = Integer.parseInt(TestUtil.queryForString(con, "SHOW scram_iterations"));
     String password = "t0pSecret";


### PR DESCRIPTION
One of the new scram max iterations tests uses the `scram_iterations` GUC but that's only available in v16+. So we restrict that one test accordingly via `@EnabledForServerVersionRange("16")`.

Also updates the CHANGELOG with the fix itself.