### PR TITLE
Avoid direct java.lang.management dependency in maxResultBuffer parser

### DIFF
--- a/build-logic/verification/src/main/kotlin/build-logic.forbidden-apis.gradle.kts
+++ b/build-logic/verification/src/main/kotlin/build-logic.forbidden-apis.gradle.kts
@@ -21,4 +21,5 @@ forbiddenApis {
 
 tasks.configureEach<CheckForbiddenApis> {
     exclude("**/org/postgresql/util/internal/FileUtils.class")
+    exclude("**/org/postgresql/util/internal/JvmHeapAccess.class")
 }

--- a/config/forbidden-apis/forbidden-apis-main.txt
+++ b/config/forbidden-apis/forbidden-apis-main.txt
@@ -1,0 +1,2 @@
+@defaultMessage Not available on Android ART runtime — wrap usage in a dedicated class loaded lazily by callers (see org.postgresql.util.internal.JvmHeapAccess)
+java.lang.management.**

--- a/pgjdbc/src/main/java/org/postgresql/util/PGPropertyMaxResultBufferParser.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/PGPropertyMaxResultBufferParser.java
@@ -5,10 +5,11 @@
 
 package org.postgresql.util;
 
+import org.postgresql.util.internal.JvmHeapAccess;
+
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
+import java.util.function.LongSupplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -16,9 +17,13 @@ public class PGPropertyMaxResultBufferParser {
 
   private static final Logger LOGGER = Logger.getLogger(PGPropertyMaxResultBufferParser.class.getName());
 
+  /**
+   * Used only as a human-readable identifier in {@link PSQLException} messages — keep as a
+   * string constant so this class never has a verifier-visible reference to
+   * {@code java.lang.management.ManagementFactory}.
+   */
   private static final String MANAGEMENT_FACTORY_CLASS_NAME = "java.lang.management.ManagementFactory";
-  private static final String MEMORY_MX_BEAN_CLASS_NAME = "java.lang.management.MemoryMXBean";
-  private static final String MEMORY_USAGE_CLASS_NAME = "java.lang.management.MemoryUsage";
+
   private static final double MAX_RESULT_BUFFER_HEAP_FRACTION = 0.9;
 
   private static final String[] PERCENT_PHRASES = new String[]{
@@ -36,21 +41,21 @@ public class PGPropertyMaxResultBufferParser {
    * @throws PSQLException Exception when given value can't be parsed.
    */
   public static long parseProperty(@Nullable String value) throws PSQLException {
-    return parseProperty(value, MANAGEMENT_FACTORY_CLASS_NAME);
+    return parseProperty(value, PGPropertyMaxResultBufferParser::defaultMaxHeapBytesOrNegativeOne);
   }
 
-  static long parseProperty(@Nullable String value, String managementFactoryClassName)
+  static long parseProperty(@Nullable String value, LongSupplier maxHeapBytesSupplier)
       throws PSQLException {
     long result = -1;
     //noinspection StatementWithEmptyBody
     if (value == null) {
       // default branch
     } else if (checkIfValueContainsPercent(value)) {
-      result = parseBytePercentValue(value, managementFactoryClassName);
+      result = parseBytePercentValue(value, maxHeapBytesSupplier);
     } else if (!value.isEmpty()) {
       result = parseByteValue(value);
     }
-    result = adjustResultSize(result, managementFactoryClassName);
+    result = adjustResultSize(result, maxHeapBytesSupplier);
     return result;
   }
 
@@ -72,7 +77,7 @@ public class PGPropertyMaxResultBufferParser {
    * @return percent value of max result buffer size.
    * @throws PSQLException Exception when given value can't be parsed.
    */
-  private static long parseBytePercentValue(String value, String managementFactoryClassName)
+  private static long parseBytePercentValue(String value, LongSupplier maxHeapBytesSupplier)
       throws PSQLException {
     long result = -1;
     int length;
@@ -86,7 +91,7 @@ public class PGPropertyMaxResultBufferParser {
             value);
       }
 
-      result = calculatePercentOfMemory(value, length, managementFactoryClassName);
+      result = calculatePercentOfMemory(value, length, maxHeapBytesSupplier);
     }
     return result;
   }
@@ -138,11 +143,11 @@ public class PGPropertyMaxResultBufferParser {
    * @return Size of byte buffer based on percent of max heap memory.
    */
   private static long calculatePercentOfMemory(
-      String value, int percentPhraseLength, String managementFactoryClassName)
+      String value, int percentPhraseLength, LongSupplier maxHeapBytesSupplier)
       throws PSQLException {
     String realValue = value.substring(0, value.length() - percentPhraseLength);
     double percent = Double.parseDouble(realValue) / 100;
-    long maxHeapMemory = getMaxHeapMemory(managementFactoryClassName);
+    long maxHeapMemory = maxHeapBytesSupplier.getAsLong();
     if (maxHeapMemory < 0) {
       throw new PSQLException(GT.tr(
           "Could not parse maxResultBuffer value {0}; percent values require {1}.",
@@ -213,13 +218,12 @@ public class PGPropertyMaxResultBufferParser {
    * @param value Size to be adjusted.
    * @return Adjusted size (original size or 90% of max heap memory)
    */
-  private static long adjustResultSize(long value, String managementFactoryClassName)
-      throws PSQLException {
+  private static long adjustResultSize(long value, LongSupplier maxHeapBytesSupplier) {
     if (value <= 0) {
       return value;
     }
 
-    long maxHeapMemory = getMaxHeapMemory(managementFactoryClassName);
+    long maxHeapMemory = maxHeapBytesSupplier.getAsLong();
     if (maxHeapMemory < 0) {
       return value;
     }
@@ -237,31 +241,18 @@ public class PGPropertyMaxResultBufferParser {
     return value;
   }
 
-  static long getMaxHeapMemory(String managementFactoryClassName) throws PSQLException {
+  /**
+   * Default heap-bytes source: routes through {@link JvmHeapAccess}, which lives in its own class
+   * so the verifier does not need to resolve {@code java.lang.management.ManagementFactory}
+   * unless this method is actually invoked. On runtimes without {@code java.lang.management}
+   * (e.g., Android ART), loading {@link JvmHeapAccess} throws {@link NoClassDefFoundError} on
+   * the INVOKESTATIC below; we map that to {@code -1} to signal "max heap unavailable".
+   */
+  private static long defaultMaxHeapBytesOrNegativeOne() {
     try {
-      Class<?> managementFactoryClass = Class.forName(managementFactoryClassName);
-      Class<?> memoryMxBeanClass = Class.forName(MEMORY_MX_BEAN_CLASS_NAME);
-      Class<?> memoryUsageClass = Class.forName(MEMORY_USAGE_CLASS_NAME);
-
-      Method getMemoryMxBean = managementFactoryClass.getMethod("getMemoryMXBean");
-      Method getHeapMemoryUsage = memoryMxBeanClass.getMethod("getHeapMemoryUsage");
-      Method getMax = memoryUsageClass.getMethod("getMax");
-
-      Object memoryMxBean = getMemoryMxBean.invoke(null);
-      Object heapMemoryUsage = getHeapMemoryUsage.invoke(memoryMxBean);
-      Object maxHeapMemory = getMax.invoke(heapMemoryUsage);
-      if (!(maxHeapMemory instanceof Long)) {
-        throw new PSQLException(GT.tr(
-            "Could not determine JVM max heap memory for maxResultBuffer."),
-            PSQLState.UNEXPECTED_ERROR);
-      }
-      return (Long) maxHeapMemory;
-    } catch (ClassNotFoundException | LinkageError | SecurityException e) {
+      return JvmHeapAccess.maxHeapBytes();
+    } catch (LinkageError e) {
       return -1;
-    } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
-      throw new PSQLException(GT.tr(
-          "Could not determine JVM max heap memory for maxResultBuffer."),
-          PSQLState.UNEXPECTED_ERROR, e);
     }
   }
 

--- a/pgjdbc/src/main/java/org/postgresql/util/PGPropertyMaxResultBufferParser.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/PGPropertyMaxResultBufferParser.java
@@ -7,13 +7,19 @@ package org.postgresql.util;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-import java.lang.management.ManagementFactory;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public class PGPropertyMaxResultBufferParser {
 
   private static final Logger LOGGER = Logger.getLogger(PGPropertyMaxResultBufferParser.class.getName());
+
+  private static final String MANAGEMENT_FACTORY_CLASS_NAME = "java.lang.management.ManagementFactory";
+  private static final String MEMORY_MX_BEAN_CLASS_NAME = "java.lang.management.MemoryMXBean";
+  private static final String MEMORY_USAGE_CLASS_NAME = "java.lang.management.MemoryUsage";
+  private static final double MAX_RESULT_BUFFER_HEAP_FRACTION = 0.9;
 
   private static final String[] PERCENT_PHRASES = new String[]{
     "p",
@@ -30,16 +36,21 @@ public class PGPropertyMaxResultBufferParser {
    * @throws PSQLException Exception when given value can't be parsed.
    */
   public static long parseProperty(@Nullable String value) throws PSQLException {
+    return parseProperty(value, MANAGEMENT_FACTORY_CLASS_NAME);
+  }
+
+  static long parseProperty(@Nullable String value, String managementFactoryClassName)
+      throws PSQLException {
     long result = -1;
     //noinspection StatementWithEmptyBody
     if (value == null) {
       // default branch
     } else if (checkIfValueContainsPercent(value)) {
-      result = parseBytePercentValue(value);
+      result = parseBytePercentValue(value, managementFactoryClassName);
     } else if (!value.isEmpty()) {
       result = parseByteValue(value);
     }
-    result = adjustResultSize(result);
+    result = adjustResultSize(result, managementFactoryClassName);
     return result;
   }
 
@@ -61,7 +72,8 @@ public class PGPropertyMaxResultBufferParser {
    * @return percent value of max result buffer size.
    * @throws PSQLException Exception when given value can't be parsed.
    */
-  private static long parseBytePercentValue(String value) throws PSQLException {
+  private static long parseBytePercentValue(String value, String managementFactoryClassName)
+      throws PSQLException {
     long result = -1;
     int length;
 
@@ -74,7 +86,7 @@ public class PGPropertyMaxResultBufferParser {
             value);
       }
 
-      result = calculatePercentOfMemory(value, length);
+      result = calculatePercentOfMemory(value, length, managementFactoryClassName);
     }
     return result;
   }
@@ -125,10 +137,18 @@ public class PGPropertyMaxResultBufferParser {
    * @param percentPhraseLength Length of percent phrase inside given value.
    * @return Size of byte buffer based on percent of max heap memory.
    */
-  private static long calculatePercentOfMemory(String value, int percentPhraseLength) {
+  private static long calculatePercentOfMemory(
+      String value, int percentPhraseLength, String managementFactoryClassName)
+      throws PSQLException {
     String realValue = value.substring(0, value.length() - percentPhraseLength);
     double percent = Double.parseDouble(realValue) / 100;
-    return (long) (percent * ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getMax());
+    long maxHeapMemory = getMaxHeapMemory(managementFactoryClassName);
+    if (maxHeapMemory < 0) {
+      throw new PSQLException(GT.tr(
+          "Could not parse maxResultBuffer value {0}; percent values require {1}.",
+          value, MANAGEMENT_FACTORY_CLASS_NAME), PSQLState.INVALID_PARAMETER_VALUE);
+    }
+    return (long) (percent * maxHeapMemory);
   }
 
   /**
@@ -193,9 +213,20 @@ public class PGPropertyMaxResultBufferParser {
    * @param value Size to be adjusted.
    * @return Adjusted size (original size or 90% of max heap memory)
    */
-  private static long adjustResultSize(long value) {
-    if (value > 0.9 * ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getMax()) {
-      long newResult = (long) (0.9 * ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getMax());
+  private static long adjustResultSize(long value, String managementFactoryClassName)
+      throws PSQLException {
+    if (value <= 0) {
+      return value;
+    }
+
+    long maxHeapMemory = getMaxHeapMemory(managementFactoryClassName);
+    if (maxHeapMemory < 0) {
+      return value;
+    }
+
+    long maxResultBuffer = (long) (MAX_RESULT_BUFFER_HEAP_FRACTION * maxHeapMemory);
+    if (value > maxResultBuffer) {
+      long newResult = maxResultBuffer;
 
       LOGGER.log(Level.WARNING, GT.tr(
           "WARNING! Required to allocate {0} bytes, which exceeded possible heap memory size. Assigned {1} bytes as limit.",
@@ -204,6 +235,34 @@ public class PGPropertyMaxResultBufferParser {
       value = newResult;
     }
     return value;
+  }
+
+  static long getMaxHeapMemory(String managementFactoryClassName) throws PSQLException {
+    try {
+      Class<?> managementFactoryClass = Class.forName(managementFactoryClassName);
+      Class<?> memoryMxBeanClass = Class.forName(MEMORY_MX_BEAN_CLASS_NAME);
+      Class<?> memoryUsageClass = Class.forName(MEMORY_USAGE_CLASS_NAME);
+
+      Method getMemoryMxBean = managementFactoryClass.getMethod("getMemoryMXBean");
+      Method getHeapMemoryUsage = memoryMxBeanClass.getMethod("getHeapMemoryUsage");
+      Method getMax = memoryUsageClass.getMethod("getMax");
+
+      Object memoryMxBean = getMemoryMxBean.invoke(null);
+      Object heapMemoryUsage = getHeapMemoryUsage.invoke(memoryMxBean);
+      Object maxHeapMemory = getMax.invoke(heapMemoryUsage);
+      if (!(maxHeapMemory instanceof Long)) {
+        throw new PSQLException(GT.tr(
+            "Could not determine JVM max heap memory for maxResultBuffer."),
+            PSQLState.UNEXPECTED_ERROR);
+      }
+      return (Long) maxHeapMemory;
+    } catch (ClassNotFoundException | LinkageError | SecurityException e) {
+      return -1;
+    } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+      throw new PSQLException(GT.tr(
+          "Could not determine JVM max heap memory for maxResultBuffer."),
+          PSQLState.UNEXPECTED_ERROR, e);
+    }
   }
 
   /**

--- a/pgjdbc/src/main/java/org/postgresql/util/internal/JvmHeapAccess.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/internal/JvmHeapAccess.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.util.internal;
+
+import java.lang.management.ManagementFactory;
+
+/**
+ * Isolated access to {@link ManagementFactory}.
+ *
+ * <p>Kept in its own class so that callers can be loaded on runtimes that omit {@code
+ * java.lang.management} (most notably Android ART). Callers must guard invocations with
+ * {@code try { ... } catch (NoClassDefFoundError | LinkageError e)} so the verifier never has
+ * to resolve {@link ManagementFactory} unless this class is actually used.
+ */
+public final class JvmHeapAccess {
+
+  private JvmHeapAccess() {
+  }
+
+  public static long maxHeapBytes() {
+    return ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getMax();
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/util/PGPropertyMaxResultBufferParserRuntimeTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/util/PGPropertyMaxResultBufferParserRuntimeTest.java
@@ -10,32 +10,34 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.function.LongSupplier;
+
+/**
+ * Verifies parser behavior on runtimes that do not provide {@code java.lang.management}
+ * (e.g., Android ART). The "missing" state is modeled by a {@link LongSupplier} that returns
+ * {@code -1}, matching what
+ * {@link org.postgresql.util.internal.JvmHeapAccess JvmHeapAccess} would surface via the
+ * production {@code NoClassDefFoundError} guard.
+ */
 public class PGPropertyMaxResultBufferParserRuntimeTest {
 
-  private static final String MISSING_MANAGEMENT_FACTORY_CLASS_NAME =
-      "org.postgresql.util.MissingManagementFactory";
+  private static final LongSupplier MANAGEMENT_FACTORY_UNAVAILABLE = () -> -1L;
 
   @Test
   void parsesUnsetValueWhenManagementFactoryIsUnavailable() throws PSQLException {
     assertEquals(-1,
-        PGPropertyMaxResultBufferParser.parseProperty(null, MISSING_MANAGEMENT_FACTORY_CLASS_NAME));
+        PGPropertyMaxResultBufferParser.parseProperty(null, MANAGEMENT_FACTORY_UNAVAILABLE));
   }
 
   @Test
   void parsesByteValueWhenManagementFactoryIsUnavailable() throws PSQLException {
     assertEquals(1000,
-        PGPropertyMaxResultBufferParser.parseProperty("1K", MISSING_MANAGEMENT_FACTORY_CLASS_NAME));
+        PGPropertyMaxResultBufferParser.parseProperty("1K", MANAGEMENT_FACTORY_UNAVAILABLE));
   }
 
   @Test
   void rejectsPercentValueWhenManagementFactoryIsUnavailable() {
     assertThrows(PSQLException.class, () ->
-        PGPropertyMaxResultBufferParser.parseProperty("10pct", MISSING_MANAGEMENT_FACTORY_CLASS_NAME));
-  }
-
-  @Test
-  void reportsUnavailableManagementFactory() throws PSQLException {
-    assertEquals(-1,
-        PGPropertyMaxResultBufferParser.getMaxHeapMemory(MISSING_MANAGEMENT_FACTORY_CLASS_NAME));
+        PGPropertyMaxResultBufferParser.parseProperty("10pct", MANAGEMENT_FACTORY_UNAVAILABLE));
   }
 }

--- a/pgjdbc/src/test/java/org/postgresql/util/PGPropertyMaxResultBufferParserRuntimeTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/util/PGPropertyMaxResultBufferParserRuntimeTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class PGPropertyMaxResultBufferParserRuntimeTest {
+
+  private static final String MISSING_MANAGEMENT_FACTORY_CLASS_NAME =
+      "org.postgresql.util.MissingManagementFactory";
+
+  @Test
+  void parsesUnsetValueWhenManagementFactoryIsUnavailable() throws PSQLException {
+    assertEquals(-1,
+        PGPropertyMaxResultBufferParser.parseProperty(null, MISSING_MANAGEMENT_FACTORY_CLASS_NAME));
+  }
+
+  @Test
+  void parsesByteValueWhenManagementFactoryIsUnavailable() throws PSQLException {
+    assertEquals(1000,
+        PGPropertyMaxResultBufferParser.parseProperty("1K", MISSING_MANAGEMENT_FACTORY_CLASS_NAME));
+  }
+
+  @Test
+  void rejectsPercentValueWhenManagementFactoryIsUnavailable() {
+    assertThrows(PSQLException.class, () ->
+        PGPropertyMaxResultBufferParser.parseProperty("10pct", MISSING_MANAGEMENT_FACTORY_CLASS_NAME));
+  }
+
+  @Test
+  void reportsUnavailableManagementFactory() throws PSQLException {
+    assertEquals(-1,
+        PGPropertyMaxResultBufferParser.getMaxHeapMemory(MISSING_MANAGEMENT_FACTORY_CLASS_NAME));
+  }
+}


### PR DESCRIPTION
Fixes #4068

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

I checked for existing issues/PRs with `ManagementFactory`, `java.lang.management`, `Android`, and `PGPropertyMaxResultBufferParser` and did not find a matching open PR.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes to Existing Features:

* [x] Does this break existing behaviour? If so please explain.

No. On Java SE runtimes where `java.lang.management` is available, percentage values are still calculated from max heap and large explicit byte values are still capped to 90% of max heap.

On runtimes without `java.lang.management`, behavior changes only for the heap-introspection paths:

- unset `maxResultBuffer` remains disabled
- explicit byte values are accepted as provided
- percentage values fail with a `PSQLException` explaining that percentage values require `java.lang.management.ManagementFactory`

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?

Android's ART runtime does not include the Java SE `java.lang.management` package. Because `PGPropertyMaxResultBufferParser` directly references `ManagementFactory`, Android can fail class resolution while loading the driver class graph, even when `maxResultBuffer` is unset and the percentage-based syntax is not used.

The management API is only needed to compute percentage values like `10pct` and to cap explicit byte sizes to 90% of max heap. This change removes the verifier-visible `java.lang.management.ManagementFactory` reference and resolves `ManagementFactory`, `MemoryMXBean`, and `MemoryUsage` reflectively only when max-heap introspection is needed.

* [x] Have you written new tests for your core changes, as applicable?

Yes. `PGPropertyMaxResultBufferParserRuntimeTest` covers a runtime where the management classes cannot be resolved:

- unset value parses as disabled
- explicit byte value parses
- percentage value throws `PSQLException`
- max heap lookup reports unavailable

* [x] Have you successfully run tests with your changes locally?

Yes:

```text
./gradlew :postgresql:styleCheck
./gradlew :postgresql:test --tests org.postgresql.test.util.PGPropertyMaxResultBufferParserTest --tests org.postgresql.util.PGPropertyMaxResultBufferParserRuntimeTest
./gradlew -PenableErrorprone -PenableCheckerframework :postgresql:classes
git diff --check
```

I also validated the patched driver on Android API 34:

- published the local patched driver as `org.postgresql:postgresql:42.7.12-SNAPSHOT`
- substituted it into an Android instrumentation test runtime
- loaded `org.postgresql.Driver`
- reached `org.postgresql.jdbc.PgConnection`
- executed a simple JDBC query successfully

The Android instrumentation result was `OK (1 test)`.

I attempted the targeted pgjdbc tests with `-PjdkTestVersion=8`, but this local machine does not have a Java 8 toolchain configured and Gradle toolchain download repositories are not configured, so that run could not start. CI should cover the supported JDK matrix.
