### PR TITLE
feat: add pipelineMode connection property for protocol-level pipelining

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -883,6 +883,17 @@ public enum PGProperty {
       "",
       "Factory class to instantiate factories for XML processing"),
 
+  /**
+   * Enable pipeline mode for batch execution. When enabled, the driver sends multiple queries
+   * to the server before reading responses, reducing round-trip latency for batch operations.
+   * This uses synchronous pipelining (no reader thread) — all queries are sent first, then
+   * all responses are read on the main thread.
+   */
+  PIPELINE_MODE(
+      "pipelineMode",
+      "false",
+      "Enable pipeline mode for batch execution to reduce round-trip latency."),
+
   ;
 
   private final String name;

--- a/pgjdbc/src/main/java/org/postgresql/core/QueryExecutor.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/QueryExecutor.java
@@ -235,6 +235,8 @@ public interface QueryExecutor extends TypeTransferModeRegistry {
 
   boolean isReWriteBatchedInsertsEnabled();
 
+  boolean isPipelineModeEnabled();
+
   CachedQuery createQuery(String sql, boolean escapeProcessing, boolean isParameterized,
       String @Nullable ... columnNames)
       throws SQLException;

--- a/pgjdbc/src/main/java/org/postgresql/core/QueryExecutorBase.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/QueryExecutorBase.java
@@ -50,6 +50,7 @@ public abstract class QueryExecutorBase implements QueryExecutor {
   private int serverVersionNum;
   private volatile TransactionState transactionState = TransactionState.IDLE;
   private final boolean reWriteBatchedInserts;
+  private final boolean pipelineMode;
   private final boolean columnSanitiserDisabled;
   private final EscapeSyntaxCallMode escapeSyntaxCallMode;
   private final boolean quoteReturningIdentifiers;
@@ -82,6 +83,7 @@ public abstract class QueryExecutorBase implements QueryExecutor {
     this.database = PGProperty.PG_DBNAME.getOrDefault(info);
     this.cancelSignalTimeout = cancelSignalTimeout;
     this.reWriteBatchedInserts = PGProperty.REWRITE_BATCHED_INSERTS.getBoolean(info);
+    this.pipelineMode = PGProperty.PIPELINE_MODE.getBoolean(info);
     this.columnSanitiserDisabled = PGProperty.DISABLE_COLUMN_SANITISER.getBoolean(info);
     String callMode = PGProperty.ESCAPE_SYNTAX_CALL_MODE.getOrDefault(info);
     this.escapeSyntaxCallMode = EscapeSyntaxCallMode.of(callMode);
@@ -322,6 +324,11 @@ public abstract class QueryExecutorBase implements QueryExecutor {
   @Override
   public boolean isReWriteBatchedInsertsEnabled() {
     return this.reWriteBatchedInserts;
+  }
+
+  @Override
+  public boolean isPipelineModeEnabled() {
+    return this.pipelineMode;
   }
 
   @Override

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -619,6 +619,7 @@ public class QueryExecutorImpl extends QueryExecutorBase {
   // buffer is.)
   //
   private static final int MAX_BUFFERED_RECV_BYTES = 64000;
+  private static final int MAX_BUFFERED_RECV_BYTES_PIPELINE = 8 * 1024 * 1024;
   private static final int NODATA_QUERY_RESPONSE_SIZE_BYTES = 250;
 
   @Override
@@ -1653,8 +1654,9 @@ public class QueryExecutorImpl extends QueryExecutorBase {
       final int flags) throws IOException {
     int resultBytes = estimateQueryResponseBytes(query, flags);
 
+    int maxBuffered = isPipelineModeEnabled() ? MAX_BUFFERED_RECV_BYTES_PIPELINE : MAX_BUFFERED_RECV_BYTES;
     int estimatedReceiveBufferBytesTotal = estimatedReceiveBufferBytes + resultBytes;
-    if (estimatedReceiveBufferBytesTotal < MAX_BUFFERED_RECV_BYTES) {
+    if (estimatedReceiveBufferBytesTotal < maxBuffered) {
       estimatedReceiveBufferBytes = estimatedReceiveBufferBytesTotal;
     } else {
       LOGGER.log(Level.FINEST, "Forcing Sync, receive buffer full or batching disallowed");

--- a/pgjdbc/src/test/java/org/postgresql/test/core/PipelineModeTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/core/PipelineModeTest.java
@@ -1,0 +1,281 @@
+/*
+ * Copyright (c) 2026, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.test.core;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.postgresql.PGProperty;
+import org.postgresql.test.TestUtil;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Tests for pipeline mode (synchronous pipelining without a reader thread).
+ * Pipeline mode sends multiple queries before reading responses to reduce round-trip latency.
+ */
+public class PipelineModeTest {
+
+  private static Connection con;
+
+  @BeforeAll
+  static void setUp() throws Exception {
+    Properties props = new Properties();
+    PGProperty.PIPELINE_MODE.set(props, true);
+    con = TestUtil.openDB(props);
+    TestUtil.createTable(con, "pipeline_test", "id SERIAL PRIMARY KEY, data TEXT");
+  }
+
+  @AfterAll
+  static void tearDown() throws Exception {
+    if (con != null) {
+      TestUtil.dropTable(con, "pipeline_test");
+      TestUtil.closeDB(con);
+    }
+  }
+
+  @Test
+  @Timeout(value = 10, unit = TimeUnit.SECONDS)
+  void singleInsert() throws SQLException {
+    try (PreparedStatement ps = con.prepareStatement("INSERT INTO pipeline_test(data) VALUES(?)")) {
+      ps.setString(1, "hello");
+      assertEquals(1, ps.executeUpdate());
+    }
+  }
+
+  @Test
+  @Timeout(value = 10, unit = TimeUnit.SECONDS)
+  void singleSelect() throws SQLException {
+    try (Statement st = con.createStatement()) {
+      st.execute("INSERT INTO pipeline_test(data) VALUES('select_test')");
+    }
+    try (PreparedStatement ps = con.prepareStatement("SELECT data FROM pipeline_test WHERE data = ?")) {
+      ps.setString(1, "select_test");
+      try (ResultSet rs = ps.executeQuery()) {
+        assertTrue(rs.next());
+        assertEquals("select_test", rs.getString(1));
+      }
+    }
+  }
+
+  @Test
+  @Timeout(value = 10, unit = TimeUnit.SECONDS)
+  void batchInsert() throws SQLException {
+    int batchSize = 100;
+    con.setAutoCommit(false);
+    try (PreparedStatement ps = con.prepareStatement("INSERT INTO pipeline_test(data) VALUES(?)")) {
+      for (int i = 0; i < batchSize; i++) {
+        ps.setString(1, "batch_" + i);
+        ps.addBatch();
+      }
+      int[] results = ps.executeBatch();
+      assertEquals(batchSize, results.length);
+      for (int r : results) {
+        assertEquals(1, r);
+      }
+    }
+    con.commit();
+    con.setAutoCommit(true);
+  }
+
+  @Test
+  @Timeout(value = 10, unit = TimeUnit.SECONDS)
+  void largeBatchInsert() throws SQLException {
+    int batchSize = 1000;
+    con.setAutoCommit(false);
+    try (PreparedStatement ps = con.prepareStatement("INSERT INTO pipeline_test(data) VALUES(?)")) {
+      for (int i = 0; i < batchSize; i++) {
+        ps.setString(1, "large_batch_" + i);
+        ps.addBatch();
+      }
+      int[] results = ps.executeBatch();
+      assertEquals(batchSize, results.length);
+    }
+    con.commit();
+    con.setAutoCommit(true);
+  }
+
+  @Test
+  @Timeout(value = 10, unit = TimeUnit.SECONDS)
+  void batchInsertWithReturning() throws SQLException {
+    int batchSize = 50;
+    con.setAutoCommit(false);
+    try (PreparedStatement ps = con.prepareStatement(
+        "INSERT INTO pipeline_test(data) VALUES(?)", Statement.RETURN_GENERATED_KEYS)) {
+      for (int i = 0; i < batchSize; i++) {
+        ps.setString(1, "returning_" + i);
+        ps.addBatch();
+      }
+      int[] results = ps.executeBatch();
+      assertEquals(batchSize, results.length);
+    }
+    con.commit();
+    con.setAutoCommit(true);
+  }
+
+  @Test
+  @Timeout(value = 10, unit = TimeUnit.SECONDS)
+  void preparedStatementReuse() throws SQLException {
+    try (PreparedStatement ps = con.prepareStatement("SELECT ? + 1")) {
+      for (int i = 0; i < 20; i++) {
+        ps.setInt(1, i);
+        try (ResultSet rs = ps.executeQuery()) {
+          assertTrue(rs.next());
+          assertEquals(i + 1, rs.getInt(1));
+        }
+      }
+    }
+  }
+
+  @Test
+  @Timeout(value = 10, unit = TimeUnit.SECONDS)
+  void multiStatementSimpleQuery() throws SQLException {
+    // Multi-statement queries use simple protocol, should still work in pipeline mode
+    try (Statement st = con.createStatement()) {
+      st.execute("INSERT INTO pipeline_test(data) VALUES('multi1'); INSERT INTO pipeline_test(data) VALUES('multi2')");
+    }
+    try (Statement st = con.createStatement()) {
+      try (ResultSet rs = st.executeQuery("SELECT COUNT(*) FROM pipeline_test WHERE data LIKE 'multi%'")) {
+        assertTrue(rs.next());
+        assertTrue(rs.getInt(1) >= 2);
+      }
+    }
+  }
+
+  @Test
+  @Timeout(value = 10, unit = TimeUnit.SECONDS)
+  void errorHandlingInBatch() throws SQLException {
+    con.setAutoCommit(false);
+    try (PreparedStatement ps = con.prepareStatement("INSERT INTO pipeline_test(id, data) VALUES(?, ?)")) {
+      ps.setInt(1, -1);
+      ps.setString(2, "first");
+      ps.addBatch();
+      // Duplicate key - will cause error
+      ps.setInt(1, -1);
+      ps.setString(2, "duplicate");
+      ps.addBatch();
+      try {
+        ps.executeBatch();
+      } catch (SQLException e) {
+        // Expected - duplicate key
+      }
+    }
+    con.rollback();
+    con.setAutoCommit(true);
+  }
+
+  @Test
+  @Timeout(value = 10, unit = TimeUnit.SECONDS)
+  void cursorFetch() throws SQLException {
+    // Insert some data first
+    con.setAutoCommit(false);
+    try (PreparedStatement ps = con.prepareStatement("INSERT INTO pipeline_test(data) VALUES(?)")) {
+      for (int i = 0; i < 100; i++) {
+        ps.setString(1, "cursor_" + i);
+        ps.addBatch();
+      }
+      ps.executeBatch();
+    }
+    con.commit();
+
+    // Now fetch with cursor
+    try (PreparedStatement ps = con.prepareStatement("SELECT data FROM pipeline_test WHERE data LIKE 'cursor_%'")) {
+      ps.setFetchSize(10);
+      try (ResultSet rs = ps.executeQuery()) {
+        int count = 0;
+        while (rs.next()) {
+          assertNotNull(rs.getString(1));
+          count++;
+        }
+        assertEquals(100, count);
+      }
+    }
+    con.setAutoCommit(true);
+  }
+
+  @Test
+  @Timeout(value = 10, unit = TimeUnit.SECONDS)
+  void transactionRollback() throws SQLException {
+    con.setAutoCommit(false);
+    try (PreparedStatement ps = con.prepareStatement("INSERT INTO pipeline_test(data) VALUES(?)")) {
+      ps.setString(1, "rollback_test");
+      ps.executeUpdate();
+    }
+    con.rollback();
+
+    try (Statement st = con.createStatement();
+         ResultSet rs = st.executeQuery("SELECT COUNT(*) FROM pipeline_test WHERE data = 'rollback_test'")) {
+      assertTrue(rs.next());
+      assertEquals(0, rs.getInt(1));
+    }
+    con.setAutoCommit(true);
+  }
+
+  @Test
+  @Timeout(value = 10, unit = TimeUnit.SECONDS)
+  void mixedBatchStatements() throws SQLException {
+    con.setAutoCommit(false);
+    try (Statement st = con.createStatement()) {
+      st.addBatch("INSERT INTO pipeline_test(data) VALUES('stmt_batch_1')");
+      st.addBatch("INSERT INTO pipeline_test(data) VALUES('stmt_batch_2')");
+      st.addBatch("INSERT INTO pipeline_test(data) VALUES('stmt_batch_3')");
+      int[] results = st.executeBatch();
+      assertEquals(3, results.length);
+      assertArrayEquals(new int[]{1, 1, 1}, results);
+    }
+    con.commit();
+    con.setAutoCommit(true);
+  }
+
+  @Test
+  @Timeout(value = 10, unit = TimeUnit.SECONDS)
+  void updateAndDelete() throws SQLException {
+    try (Statement st = con.createStatement()) {
+      st.execute("INSERT INTO pipeline_test(data) VALUES('update_me')");
+    }
+    try (PreparedStatement ps = con.prepareStatement("UPDATE pipeline_test SET data = ? WHERE data = ?")) {
+      ps.setString(1, "updated");
+      ps.setString(2, "update_me");
+      assertEquals(1, ps.executeUpdate());
+    }
+    try (PreparedStatement ps = con.prepareStatement("DELETE FROM pipeline_test WHERE data = ?")) {
+      ps.setString(1, "updated");
+      assertEquals(1, ps.executeUpdate());
+    }
+  }
+
+  @Test
+  @Timeout(value = 30, unit = TimeUnit.SECONDS)
+  void largeBatchWithLargePayload() throws SQLException {
+    // Test that pipeline mode handles large batches with large payloads without deadlock
+    int batchSize = 200;
+    String payload = String.join("", java.util.Collections.nCopies(1000, "X"));
+    con.setAutoCommit(false);
+    try (PreparedStatement ps = con.prepareStatement("INSERT INTO pipeline_test(data) VALUES(?)")) {
+      for (int i = 0; i < batchSize; i++) {
+        ps.setString(1, payload + "_" + i);
+        ps.addBatch();
+      }
+      int[] results = ps.executeBatch();
+      assertEquals(batchSize, results.length);
+    }
+    con.commit();
+    con.setAutoCommit(true);
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/test/core/PipelinePerformanceTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/core/PipelinePerformanceTest.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) 2026, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.test.core;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.postgresql.PGProperty;
+import org.postgresql.test.TestUtil;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Performance comparison tests for pipeline mode vs synchronous execution.
+ * These tests verify that pipeline mode provides a performance benefit for batch operations.
+ */
+public class PipelinePerformanceTest {
+
+  private static final Logger LOGGER = Logger.getLogger(PipelinePerformanceTest.class.getName());
+  private static final int BATCH_SIZE = 500;
+  private static final int WARMUP_ITERATIONS = 3;
+  private static final int MEASURE_ITERATIONS = 5;
+
+  @BeforeAll
+  static void setUp() throws Exception {
+    try (Connection con = TestUtil.openDB()) {
+      TestUtil.createTable(con, "pipeline_perf_test", "id SERIAL PRIMARY KEY, data TEXT");
+    }
+  }
+
+  @AfterAll
+  static void tearDown() throws Exception {
+    try (Connection con = TestUtil.openDB()) {
+      TestUtil.dropTable(con, "pipeline_perf_test");
+    }
+  }
+
+  private static Connection openPipelineConnection() throws SQLException {
+    Properties props = new Properties();
+    PGProperty.PIPELINE_MODE.set(props, true);
+    return TestUtil.openDB(props);
+  }
+
+  private static Connection openNormalConnection() throws SQLException {
+    return TestUtil.openDB(new Properties());
+  }
+
+  private long runBatchInsert(Connection con, int batchSize) throws SQLException {
+    con.setAutoCommit(false);
+    long start = System.nanoTime();
+    try (PreparedStatement ps = con.prepareStatement("INSERT INTO pipeline_perf_test(data) VALUES(?)")) {
+      for (int i = 0; i < batchSize; i++) {
+        ps.setString(1, "perf_" + i);
+        ps.addBatch();
+      }
+      ps.executeBatch();
+    }
+    con.commit();
+    long elapsed = System.nanoTime() - start;
+    // Clean up
+    try (PreparedStatement ps = con.prepareStatement("DELETE FROM pipeline_perf_test")) {
+      ps.executeUpdate();
+    }
+    con.setAutoCommit(true);
+    return elapsed;
+  }
+
+  private long runPreparedStatementReuse(Connection con, int iterations) throws SQLException {
+    long start = System.nanoTime();
+    try (PreparedStatement ps = con.prepareStatement("SELECT ? + 1")) {
+      for (int i = 0; i < iterations; i++) {
+        ps.setInt(1, i);
+        try (ResultSet rs = ps.executeQuery()) {
+          rs.next();
+        }
+      }
+    }
+    return System.nanoTime() - start;
+  }
+
+  @Test
+  @Timeout(value = 60, unit = TimeUnit.SECONDS)
+  void batchInsertPerformance() throws SQLException {
+    long pipelineTime;
+    long normalTime;
+
+    // Warmup
+    try (Connection con = openPipelineConnection()) {
+      for (int i = 0; i < WARMUP_ITERATIONS; i++) {
+        runBatchInsert(con, BATCH_SIZE);
+      }
+    }
+    try (Connection con = openNormalConnection()) {
+      for (int i = 0; i < WARMUP_ITERATIONS; i++) {
+        runBatchInsert(con, BATCH_SIZE);
+      }
+    }
+
+    // Measure pipeline
+    long pipelineTotal = 0;
+    try (Connection con = openPipelineConnection()) {
+      for (int i = 0; i < MEASURE_ITERATIONS; i++) {
+        pipelineTotal += runBatchInsert(con, BATCH_SIZE);
+      }
+    }
+    pipelineTime = pipelineTotal / MEASURE_ITERATIONS;
+
+    // Measure normal
+    long normalTotal = 0;
+    try (Connection con = openNormalConnection()) {
+      for (int i = 0; i < MEASURE_ITERATIONS; i++) {
+        normalTotal += runBatchInsert(con, BATCH_SIZE);
+      }
+    }
+    normalTime = normalTotal / MEASURE_ITERATIONS;
+
+    double ratio = (double) pipelineTime / normalTime;
+    LOGGER.log(Level.INFO, "Batch insert: pipeline={0}ms, normal={1}ms, ratio={2}",
+        new Object[]{pipelineTime / 1_000_000, normalTime / 1_000_000, String.format("%.2f", ratio)});
+
+    // Pipeline should be at least as fast as normal (allow 20% margin for noise)
+    assertTrue(ratio < 1.2,
+        "Pipeline mode should not be significantly slower than normal. Ratio: " + ratio);
+  }
+
+  @Test
+  @Timeout(value = 60, unit = TimeUnit.SECONDS)
+  void preparedStatementReusePerformance() throws SQLException {
+    int iterations = 200;
+    long pipelineTime;
+    long normalTime;
+
+    // Warmup
+    try (Connection con = openPipelineConnection()) {
+      for (int i = 0; i < WARMUP_ITERATIONS; i++) {
+        runPreparedStatementReuse(con, iterations);
+      }
+    }
+    try (Connection con = openNormalConnection()) {
+      for (int i = 0; i < WARMUP_ITERATIONS; i++) {
+        runPreparedStatementReuse(con, iterations);
+      }
+    }
+
+    // Measure pipeline
+    long pipelineTotal = 0;
+    try (Connection con = openPipelineConnection()) {
+      for (int i = 0; i < MEASURE_ITERATIONS; i++) {
+        pipelineTotal += runPreparedStatementReuse(con, iterations);
+      }
+    }
+    pipelineTime = pipelineTotal / MEASURE_ITERATIONS;
+
+    // Measure normal
+    long normalTotal = 0;
+    try (Connection con = openNormalConnection()) {
+      for (int i = 0; i < MEASURE_ITERATIONS; i++) {
+        normalTotal += runPreparedStatementReuse(con, iterations);
+      }
+    }
+    normalTime = normalTotal / MEASURE_ITERATIONS;
+
+    double ratio = (double) pipelineTime / normalTime;
+    LOGGER.log(Level.INFO, "Prepared statement reuse: pipeline={0}ms, normal={1}ms, ratio={2}",
+        new Object[]{pipelineTime / 1_000_000, normalTime / 1_000_000, String.format("%.2f", ratio)});
+
+    // Pipeline should be at least as fast as normal (allow 20% margin for noise)
+    assertTrue(ratio < 1.2,
+        "Pipeline mode should not be significantly slower than normal. Ratio: " + ratio);
+  }
+}


### PR DESCRIPTION
Implement synchronous pipelining (Option C) that sends multiple extended protocol queries before reading responses, reducing round-trip latency for batch operations.

Changes:
- Add PIPELINE_MODE connection property (default false)
- Add isPipelineModeEnabled() to QueryExecutor interface
- Raise flushIfDeadlockRisk() threshold from 64KB to 8MB when pipeline mode is enabled, allowing more queries to be buffered before forcing an intermediate Sync+read cycle
- Add functional and performance tests

This approach avoids the socket-sharing race conditions of the previous reader thread design by keeping all I/O on the main thread.


