### PR TITLE
Pipeline option b

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -394,6 +394,23 @@ jobs:
       with:
         name: ${{ steps.artifact_name.outputs.name }}
         path: ${{ runner.temp }}/pg-server-logs.txt
+    - name: Sanitize test results artifact name
+      if: ${{ always() }}
+      id: test_artifact_name
+      shell: bash
+      env:
+        MATRIX_NAME: ${{ matrix.name }}
+      run: |
+        name="test-results-${MATRIX_NAME}"
+        name="${name//[\":<>|*?\\\/]/}"
+        echo "name=$name" >> "$GITHUB_OUTPUT"
+    - name: Upload test results
+      if: ${{ always() }}
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: ${{ steps.test_artifact_name.outputs.name }}
+        path: pgjdbc/build/test-results/test/
+        retention-days: 7
     - name: Test GSS
       if: ${{ matrix.gss == 'yes' }}
       # language=bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -307,7 +307,7 @@ jobs:
         arguments: --scan --no-parallel --no-daemon jandex test ${{ matrix.extraGradleArgs }}
         properties: |
           includeTestTags=${{ matrix.includeTestTags }}
-          testExtraJvmArgs=${{ matrix.testExtraJvmArgs }} ::: -Djava.util.logging.config.file=logging.properties
+          testExtraJvmArgs=${{ matrix.testExtraJvmArgs }}
           jdkBuildVersion=21
           jdkTestVersion=${{ matrix.java_version == 'EA' && steps.setup_ea_java.outputs.version || matrix.java_version }}
           jdkTestVendor=${{ matrix.java_vendor }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -142,7 +142,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     needs: matrix_prep
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix: ${{fromJson(needs.matrix_prep.outputs.matrix)}}
     env:
       ACTIONS_STEP_DEBUG: true
@@ -307,7 +307,7 @@ jobs:
         arguments: --scan --no-parallel --no-daemon jandex test ${{ matrix.extraGradleArgs }}
         properties: |
           includeTestTags=${{ matrix.includeTestTags }}
-          testExtraJvmArgs=${{ matrix.testExtraJvmArgs }}
+          testExtraJvmArgs=${{ matrix.testExtraJvmArgs }} ::: -Djava.util.logging.config.file=logging.properties
           jdkBuildVersion=21
           jdkTestVersion=${{ matrix.java_version == 'EA' && steps.setup_ea_java.outputs.version || matrix.java_version }}
           jdkTestVendor=${{ matrix.java_vendor }}
@@ -409,7 +409,9 @@ jobs:
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ${{ steps.test_artifact_name.outputs.name }}
-        path: pgjdbc/build/test-results/test/
+        path: |
+          pgjdbc/build/test-results/test/
+          pgjdbc-*.log
         retention-days: 7
     - name: Test GSS
       if: ${{ matrix.gss == 'yes' }}

--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -482,6 +482,16 @@ public enum PGProperty {
       "Port of the PostgreSQL server (may be specified directly in the JDBC URL)"),
 
   /**
+   * Enable pipeline mode with a dedicated reader thread. When true, the driver uses a separate
+   * thread to read responses from the server, allowing send and receive to be decoupled.
+   * This enables true protocol-level pipelining for batch operations.
+   */
+  PIPELINE_MODE(
+      "pipelineMode",
+      "false",
+      "Enable pipeline mode with a dedicated reader thread for decoupled send/receive."),
+
+  /**
    * Specifies which mode is used to execute queries to database: simple means ('Q' execute, no parse, no bind, text mode only),
    * extended means always use bind/execute messages, extendedForPrepared means extended for prepared statements only,
    * extendedCacheEverything means use extended protocol and try cache every statement (including Statement.execute(String sql)) in a query cache.

--- a/pgjdbc/src/main/java/org/postgresql/core/QueryExecutor.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/QueryExecutor.java
@@ -446,6 +446,12 @@ public interface QueryExecutor extends TypeTransferModeRegistry {
   void abort();
 
   /**
+   * Start the pipeline reader thread. Called after connection setup is complete.
+   */
+  default void startPipelineReaderThread() {
+  }
+
+  /**
    * Close this connection cleanly.
    */
   void close();

--- a/pgjdbc/src/main/java/org/postgresql/core/QueryExecutorBase.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/QueryExecutorBase.java
@@ -74,6 +74,12 @@ public abstract class QueryExecutorBase implements QueryExecutor {
   protected final ResourceLock lock = new ResourceLock();
   protected final Condition lockCondition = lock.newCondition();
 
+  /**
+   * Lock used in pipeline mode to serialize access to the send path (pgOutput).
+   * In non-pipeline mode this is unused — the main {@link #lock} covers everything.
+   */
+  protected final ResourceLock sendLock = new ResourceLock();
+
   @SuppressWarnings({"assignment", "argument", "method.invocation"})
   protected QueryExecutorBase(PGStream pgStream, int cancelSignalTimeout, Properties info) throws SQLException {
     this.pgStream = pgStream;
@@ -109,6 +115,13 @@ public abstract class QueryExecutorBase implements QueryExecutor {
 
   protected QueryExecutorCloseAction createCloseAction() {
     return new QueryExecutorCloseAction(pgStream);
+  }
+
+  /**
+   * Returns whether server error detail should be included in error messages.
+   */
+  public boolean getLogServerErrorDetail() {
+    return logServerErrorDetail;
   }
 
   /**

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/PipelineReaderThread.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/PipelineReaderThread.java
@@ -190,7 +190,7 @@ class PipelineReaderThread extends Thread {
     for (int i = 0; i < fields.length; i++) {
       String columnLabel = pgStream.receiveCanonicalString();
       int tableOid = pgStream.receiveInteger4();
-      short positionInTable = (short) pgStream.receiveInteger2();
+      int positionInTable = pgStream.receiveInteger2();
       int typeOid = pgStream.receiveInteger4();
       int typeLength = pgStream.receiveInteger2();
       int typeModifier = pgStream.receiveInteger4();

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/PipelineReaderThread.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/PipelineReaderThread.java
@@ -246,21 +246,22 @@ class PipelineReaderThread extends Thread {
 
     advanceSlot();
     if (currentSlot != null) {
-      currentSlot.commandStatus = status;
+      ResponseSlot slot = currentSlot;
+      slot.commandStatus = status;
       try {
         commandCompleteParser.parse(status);
-        currentSlot.updateCount = commandCompleteParser.getRows();
-        currentSlot.insertOID = commandCompleteParser.getOid();
+        slot.updateCount = commandCompleteParser.getRows();
+        slot.insertOID = commandCompleteParser.getOid();
       } catch (SQLException e) {
-        currentSlot.completeExceptionally(e);
+        slot.completeExceptionally(e);
         currentSlot = null;
         return;
       }
       // For non-simple queries, CommandComplete ends this slot's data
       // (ReadyForQuery will finalize it)
       // For simple queries, more results may follow before ReadyForQuery
-      if (!currentSlot.asSimple) {
-        currentSlot.complete();
+      if (!slot.asSimple) {
+        slot.complete();
         currentSlot = null;
       }
     }

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/PipelineReaderThread.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/PipelineReaderThread.java
@@ -29,8 +29,9 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Dedicated reader thread for pipeline mode. Owns pgInput exclusively after startup.
- * Reads protocol messages and dispatches results to ResponseSlots.
+ * Dedicated reader thread for pipeline mode. Owns ALL socket reads exclusively.
+ * No other thread may read from pgStream while this thread is running.
+ * Handles both extended protocol and simple query protocol responses.
  */
 class PipelineReaderThread extends Thread {
 
@@ -41,8 +42,6 @@ class PipelineReaderThread extends Thread {
   private final ConcurrentLinkedDeque<ResponseSlot> pendingSlots;
   private final AtomicBoolean running = new AtomicBoolean(true);
   private final CommandCompleteParser commandCompleteParser = new CommandCompleteParser();
-  private volatile boolean paused;
-  private final Object pauseLock = new Object();
 
   private @Nullable ResponseSlot currentSlot;
 
@@ -60,61 +59,15 @@ class PipelineReaderThread extends Thread {
     this.interrupt();
   }
 
-  /**
-   * Pause the reader thread so the synchronous path can read from the socket.
-   * Blocks until the reader thread is actually paused.
-   */
-  void pause() {
-    synchronized (pauseLock) {
-      paused = true;
-      try {
-        // Reader checks paused flag after each SocketTimeoutException or message.
-        // Wait for it to enter the paused state.
-        pauseLock.wait(2000);
-      } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
-      }
-    }
-  }
-
-  /**
-   * Resume the reader thread after synchronous execution completes.
-   */
-  void unpause() {
-    synchronized (pauseLock) {
-      paused = false;
-      pauseLock.notifyAll();
-    }
-  }
-
   @Override
   public void run() {
     try {
-      // Set a short socket timeout so we can check the paused flag periodically
       pgStream.setNetworkTimeout(100);
       while (running.get()) {
-        // Check if we should pause for synchronous execution
-        if (paused) {
-          synchronized (pauseLock) {
-            pauseLock.notifyAll(); // signal that we're paused
-            while (paused && running.get()) {
-              try {
-                pauseLock.wait();
-              } catch (InterruptedException e) {
-                if (!running.get()) {
-                  return;
-                }
-              }
-            }
-          }
-          // Restore socket timeout after pause (synchronous path may have changed it)
-          pgStream.setNetworkTimeout(100);
-        }
         try {
           processOneMessage();
         } catch (SocketTimeoutException e) {
-          // This is the 100ms poll timeout — just continue the loop
-          // to check the paused flag and try again.
+          // Poll timeout — loop back to check running flag
         }
       }
     } catch (IOException e) {
@@ -234,11 +187,11 @@ class PipelineReaderThread extends Thread {
     for (int i = 0; i < fields.length; i++) {
       String columnLabel = pgStream.receiveCanonicalString();
       int tableOid = pgStream.receiveInteger4();
-      short positionInTable = (short)pgStream.receiveInteger2();
+      short positionInTable = (short) pgStream.receiveInteger2();
       int typeOid = pgStream.receiveInteger4();
-      short typeLength = (short)pgStream.receiveInteger2();
+      short typeLength = (short) pgStream.receiveInteger2();
       int typeModifier = pgStream.receiveInteger4();
-      short formatType = (short)pgStream.receiveInteger2();
+      short formatType = (short) pgStream.receiveInteger2();
       fields[i] = new Field(columnLabel, typeOid, typeLength, typeModifier, tableOid, positionInTable);
       fields[i].setFormat(formatType);
     }
@@ -246,9 +199,11 @@ class PipelineReaderThread extends Thread {
     LOGGER.log(Level.FINEST, " <=BE RowDescription({0})", size);
 
     advanceSlot();
-    if (currentSlot != null && currentSlot.query != null) {
+    if (currentSlot != null) {
       currentSlot.fields = fields;
-      currentSlot.query.setFields(fields);
+      if (currentSlot.query != null) {
+        currentSlot.query.setFields(fields);
+      }
     }
   }
 
@@ -256,7 +211,7 @@ class PipelineReaderThread extends Thread {
     pgStream.receiveInteger4(); // message size
     int numParams = pgStream.receiveInteger2();
     for (int i = 0; i < numParams; i++) {
-      pgStream.receiveInteger4(); // type OID — consumed but not used in pipeline mode
+      pgStream.receiveInteger4(); // type OID
     }
     LOGGER.log(Level.FINEST, " <=BE ParameterDescription({0})", numParams);
   }
@@ -301,9 +256,8 @@ class PipelineReaderThread extends Thread {
         currentSlot = null;
         return;
       }
-      // For non-simple queries, CommandComplete ends this slot's data
-      // (ReadyForQuery will finalize it)
-      // For simple queries, more results may follow before ReadyForQuery
+      // For simple queries, more CommandComplete messages may follow before ReadyForQuery
+      // For extended protocol, CommandComplete ends this slot
       if (!slot.asSimple) {
         slot.complete();
         currentSlot = null;
@@ -345,8 +299,9 @@ class PipelineReaderThread extends Thread {
     try {
       executor.receiveParameterStatus();
     } catch (SQLException e) {
-      // Fatal parameter status change (encoding, datestyle)
-      failAllPending(e);
+      failAllPending(new PSQLException(
+          "Fatal parameter status change",
+          PSQLState.CONNECTION_FAILURE, e));
     }
   }
 
@@ -382,7 +337,7 @@ class PipelineReaderThread extends Thread {
         throw new IOException("unexpected transaction state: " + (int) tStatus);
     }
 
-    // Complete current slot if still active (simple query case)
+    // Complete current slot if still active (simple query case — ReadyForQuery ends it)
     if (currentSlot != null) {
       currentSlot.complete();
       currentSlot = null;
@@ -403,7 +358,7 @@ class PipelineReaderThread extends Thread {
     }
   }
 
-  private void failAllPending(SQLException ex) {
+  private void failAllPending(PSQLException ex) {
     if (currentSlot != null) {
       currentSlot.completeExceptionally(ex);
       currentSlot = null;
@@ -414,10 +369,5 @@ class PipelineReaderThread extends Thread {
         slot.completeExceptionally(ex);
       }
     }
-  }
-
-  // Overload for IOException
-  private void failAllPending(PSQLException ex) {
-    failAllPending((SQLException) ex);
   }
 }

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/PipelineReaderThread.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/PipelineReaderThread.java
@@ -1,0 +1,378 @@
+/*
+ * Copyright (c) 2026, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.core.v3;
+
+import org.postgresql.core.CommandCompleteParser;
+import org.postgresql.core.Field;
+import org.postgresql.core.Notification;
+import org.postgresql.core.PGStream;
+import org.postgresql.core.PgMessageType;
+import org.postgresql.core.TransactionState;
+import org.postgresql.core.Tuple;
+import org.postgresql.util.PSQLException;
+import org.postgresql.util.PSQLState;
+import org.postgresql.util.PSQLWarning;
+import org.postgresql.util.ServerErrorMessage;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.io.IOException;
+import java.net.SocketTimeoutException;
+import java.sql.SQLException;
+import java.sql.SQLWarning;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Dedicated reader thread for pipeline mode. Owns pgInput exclusively after startup.
+ * Reads protocol messages and dispatches results to ResponseSlots.
+ */
+class PipelineReaderThread extends Thread {
+
+  private static final Logger LOGGER = Logger.getLogger(PipelineReaderThread.class.getName());
+
+  private final PGStream pgStream;
+  private final QueryExecutorImpl executor;
+  private final ConcurrentLinkedDeque<ResponseSlot> pendingSlots;
+  private final AtomicBoolean running = new AtomicBoolean(true);
+  private final CommandCompleteParser commandCompleteParser = new CommandCompleteParser();
+
+  private @Nullable ResponseSlot currentSlot;
+
+  PipelineReaderThread(PGStream pgStream, QueryExecutorImpl executor,
+                       ConcurrentLinkedDeque<ResponseSlot> pendingSlots) {
+    super("pgjdbc-reader-" + pgStream.getHostSpec());
+    setDaemon(true);
+    this.pgStream = pgStream;
+    this.executor = executor;
+    this.pendingSlots = pendingSlots;
+  }
+
+  void shutdown() {
+    running.set(false);
+    this.interrupt();
+  }
+
+  @Override
+  public void run() {
+    try {
+      while (running.get()) {
+        try {
+          processOneMessage();
+        } catch (SocketTimeoutException e) {
+          // Network timeout — fail current slot but don't kill the thread
+          if (currentSlot != null) {
+            currentSlot.completeExceptionally(new PSQLException(
+                "Query timed out", PSQLState.QUERY_CANCELED, e));
+            currentSlot = null;
+          }
+        }
+      }
+    } catch (IOException e) {
+      if (running.get()) {
+        failAllPending(new PSQLException(
+            "An I/O error occurred while reading from the backend.",
+            PSQLState.CONNECTION_FAILURE, e));
+      }
+    }
+  }
+
+  private void processOneMessage() throws IOException {
+    int c = pgStream.receiveChar();
+
+    switch (c) {
+      case PgMessageType.ASYNCHRONOUS_NOTICE: // 'A'
+        receiveAsyncNotify();
+        break;
+
+      case PgMessageType.PARSE_COMPLETE_RESPONSE: // '1'
+        pgStream.receiveInteger4();
+        LOGGER.log(Level.FINEST, " <=BE ParseComplete");
+        break;
+
+      case PgMessageType.BIND_COMPLETE_RESPONSE: // '2'
+        pgStream.receiveInteger4();
+        LOGGER.log(Level.FINEST, " <=BE BindComplete");
+        break;
+
+      case PgMessageType.CLOSE_COMPLETE_RESPONSE: // '3'
+        pgStream.receiveInteger4();
+        LOGGER.log(Level.FINEST, " <=BE CloseComplete");
+        break;
+
+      case PgMessageType.NO_DATA_RESPONSE: // 'n'
+        pgStream.receiveInteger4();
+        LOGGER.log(Level.FINEST, " <=BE NoData");
+        break;
+
+      case PgMessageType.PARAMETER_DESCRIPTION_RESPONSE: // 't'
+        receiveParameterDescription();
+        break;
+
+      case PgMessageType.ROW_DESCRIPTION_RESPONSE: // 'T'
+        receiveRowDescription();
+        break;
+
+      case PgMessageType.DATA_ROW_RESPONSE: // 'D'
+        receiveDataRow();
+        break;
+
+      case PgMessageType.COMMAND_COMPLETE_RESPONSE: // 'C'
+        receiveCommandComplete();
+        break;
+
+      case PgMessageType.EMPTY_QUERY_RESPONSE: // 'I'
+        pgStream.receiveInteger4();
+        LOGGER.log(Level.FINEST, " <=BE EmptyQuery");
+        advanceSlot();
+        if (currentSlot != null) {
+          currentSlot.commandStatus = "EMPTY";
+        }
+        break;
+
+      case PgMessageType.PORTAL_SUSPENDED_RESPONSE: // 's'
+        pgStream.receiveInteger4();
+        LOGGER.log(Level.FINEST, " <=BE PortalSuspended");
+        if (currentSlot != null) {
+          currentSlot.portalSuspended = true;
+          currentSlot.complete();
+          currentSlot = null;
+        }
+        break;
+
+      case PgMessageType.ERROR_RESPONSE: // 'E'
+        receiveError();
+        break;
+
+      case PgMessageType.NOTICE_RESPONSE: // 'N'
+        receiveNotice();
+        break;
+
+      case PgMessageType.PARAMETER_STATUS_RESPONSE: // 'S'
+        receiveParameterStatus();
+        break;
+
+      case PgMessageType.READY_FOR_QUERY_RESPONSE: // 'Z'
+        receiveReadyForQuery();
+        break;
+
+      default:
+        // Skip unknown messages
+        int len = pgStream.receiveInteger4();
+        if (len > 4) {
+          pgStream.receive(len - 4);
+        }
+        LOGGER.log(Level.WARNING, " <=BE Unknown message type: {0}", (char) c);
+        break;
+    }
+  }
+
+  private void advanceSlot() {
+    if (currentSlot == null) {
+      currentSlot = pendingSlots.poll();
+      // Skip SYNC_MARKERs — they're consumed in receiveReadyForQuery
+      while (currentSlot == ResponseSlot.SYNC_MARKER) {
+        currentSlot = pendingSlots.poll();
+      }
+    }
+  }
+
+  private void receiveRowDescription() throws IOException {
+    pgStream.receiveInteger4(); // message size
+    int size = pgStream.receiveInteger2();
+    Field[] fields = new Field[size];
+
+    for (int i = 0; i < fields.length; i++) {
+      String columnLabel = pgStream.receiveCanonicalString();
+      int tableOid = pgStream.receiveInteger4();
+      short positionInTable = (short) pgStream.receiveInteger2();
+      int typeOid = pgStream.receiveInteger4();
+      int typeLength = pgStream.receiveInteger2();
+      int typeModifier = pgStream.receiveInteger4();
+      int formatType = pgStream.receiveInteger2();
+      fields[i] = new Field(columnLabel, typeOid, typeLength, typeModifier, tableOid, positionInTable);
+      fields[i].setFormat(formatType);
+    }
+
+    LOGGER.log(Level.FINEST, " <=BE RowDescription({0})", size);
+
+    advanceSlot();
+    if (currentSlot != null && currentSlot.query != null) {
+      currentSlot.fields = fields;
+      currentSlot.query.setFields(fields);
+    }
+  }
+
+  private void receiveParameterDescription() throws IOException {
+    pgStream.receiveInteger4(); // message size
+    int numParams = pgStream.receiveInteger2();
+    for (int i = 0; i < numParams; i++) {
+      pgStream.receiveInteger4(); // type OID — consumed but not used in pipeline mode
+    }
+    LOGGER.log(Level.FINEST, " <=BE ParameterDescription({0})", numParams);
+  }
+
+  private void receiveDataRow() throws IOException {
+    Tuple tuple;
+    try {
+      tuple = pgStream.receiveTupleV3();
+    } catch (OutOfMemoryError oome) {
+      throw new IOException("Ran out of memory retrieving query results", oome);
+    } catch (SQLException e) {
+      throw new IOException("Error receiving data row", e);
+    }
+
+    advanceSlot();
+    if (currentSlot != null) {
+      currentSlot.addTuple(tuple);
+    }
+
+    if (LOGGER.isLoggable(Level.FINEST)) {
+      LOGGER.log(Level.FINEST, " <=BE DataRow(len={0})", tuple.length());
+    }
+  }
+
+  private void receiveCommandComplete() throws IOException {
+    int len = pgStream.receiveInteger4();
+    String status = pgStream.receiveString(len - 5);
+    pgStream.receiveChar(); // trailing \0
+
+    LOGGER.log(Level.FINEST, " <=BE CommandStatus({0})", status);
+
+    advanceSlot();
+    if (currentSlot != null) {
+      currentSlot.commandStatus = status;
+      try {
+        commandCompleteParser.parse(status);
+        currentSlot.updateCount = commandCompleteParser.getRows();
+        currentSlot.insertOID = commandCompleteParser.getOid();
+      } catch (SQLException e) {
+        currentSlot.completeExceptionally(e);
+        currentSlot = null;
+        return;
+      }
+      // For non-simple queries, CommandComplete ends this slot's data
+      // (ReadyForQuery will finalize it)
+      // For simple queries, more results may follow before ReadyForQuery
+      if (!currentSlot.asSimple) {
+        currentSlot.complete();
+        currentSlot = null;
+      }
+    }
+  }
+
+  private void receiveError() throws IOException {
+    int elen = pgStream.receiveInteger4();
+    ServerErrorMessage errorMsg = new ServerErrorMessage(
+        pgStream.receiveErrorString(elen - 4));
+
+    LOGGER.log(Level.FINEST, " <=BE ErrorMessage({0})", errorMsg.toString());
+
+    PSQLException error = new PSQLException(errorMsg, executor.getLogServerErrorDetail());
+
+    advanceSlot();
+    if (currentSlot != null) {
+      currentSlot.completeExceptionally(error);
+      currentSlot = null;
+    }
+  }
+
+  private void receiveNotice() throws IOException {
+    int nlen = pgStream.receiveInteger4();
+    ServerErrorMessage warnMsg = new ServerErrorMessage(pgStream.receiveErrorString(nlen - 4));
+    SQLWarning warning = new PSQLWarning(warnMsg);
+
+    LOGGER.log(Level.FINEST, " <=BE NoticeResponse({0})", warnMsg.toString());
+
+    if (currentSlot != null) {
+      currentSlot.addWarning(warning);
+    } else {
+      executor.addWarning(warning);
+    }
+  }
+
+  private void receiveParameterStatus() throws IOException {
+    try {
+      executor.receiveParameterStatus();
+    } catch (SQLException e) {
+      // Fatal parameter status change (encoding, datestyle)
+      failAllPending(e);
+    }
+  }
+
+  private void receiveAsyncNotify() throws IOException {
+    pgStream.receiveInteger4(); // message length
+    int pid = pgStream.receiveInteger4();
+    String msg = pgStream.receiveCanonicalString();
+    String param = pgStream.receiveString();
+    executor.addNotification(new Notification(msg, pid, param));
+
+    LOGGER.log(Level.FINEST, " <=BE AsyncNotify({0},{1},{2})", new Object[]{pid, msg, param});
+  }
+
+  private void receiveReadyForQuery() throws IOException {
+    if (pgStream.receiveInteger4() != 5) {
+      throw new IOException("unexpected length of ReadyForQuery message");
+    }
+
+    char tStatus = (char) pgStream.receiveChar();
+    LOGGER.log(Level.FINEST, " <=BE ReadyForQuery({0})", tStatus);
+
+    switch (tStatus) {
+      case 'I':
+        executor.setTransactionState(TransactionState.IDLE);
+        break;
+      case 'T':
+        executor.setTransactionState(TransactionState.OPEN);
+        break;
+      case 'E':
+        executor.setTransactionState(TransactionState.FAILED);
+        break;
+      default:
+        throw new IOException("unexpected transaction state: " + (int) tStatus);
+    }
+
+    // Complete current slot if still active (simple query case)
+    if (currentSlot != null) {
+      currentSlot.complete();
+      currentSlot = null;
+    }
+
+    // Drain any remaining slots up to the SYNC_MARKER — these were
+    // discarded by the server after an error
+    ResponseSlot slot;
+    while ((slot = pendingSlots.peek()) != null) {
+      if (slot == ResponseSlot.SYNC_MARKER) {
+        pendingSlots.poll(); // consume the marker
+        break;
+      }
+      pendingSlots.poll();
+      slot.completeExceptionally(new PSQLException(
+          "Query discarded due to prior error in pipeline batch",
+          PSQLState.IN_FAILED_SQL_TRANSACTION));
+    }
+  }
+
+  private void failAllPending(SQLException ex) {
+    if (currentSlot != null) {
+      currentSlot.completeExceptionally(ex);
+      currentSlot = null;
+    }
+    ResponseSlot slot;
+    while ((slot = pendingSlots.poll()) != null) {
+      if (slot != ResponseSlot.SYNC_MARKER) {
+        slot.completeExceptionally(ex);
+      }
+    }
+  }
+
+  // Overload for IOException
+  private void failAllPending(PSQLException ex) {
+    failAllPending((SQLException) ex);
+  }
+}

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/PipelineReaderThread.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/PipelineReaderThread.java
@@ -41,6 +41,8 @@ class PipelineReaderThread extends Thread {
   private final ConcurrentLinkedDeque<ResponseSlot> pendingSlots;
   private final AtomicBoolean running = new AtomicBoolean(true);
   private final CommandCompleteParser commandCompleteParser = new CommandCompleteParser();
+  private volatile boolean paused;
+  private final Object pauseLock = new Object();
 
   private @Nullable ResponseSlot currentSlot;
 
@@ -58,19 +60,61 @@ class PipelineReaderThread extends Thread {
     this.interrupt();
   }
 
+  /**
+   * Pause the reader thread so the synchronous path can read from the socket.
+   * Blocks until the reader thread is actually paused.
+   */
+  void pause() {
+    synchronized (pauseLock) {
+      paused = true;
+      try {
+        // Reader checks paused flag after each SocketTimeoutException or message.
+        // Wait for it to enter the paused state.
+        pauseLock.wait(2000);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+    }
+  }
+
+  /**
+   * Resume the reader thread after synchronous execution completes.
+   */
+  void unpause() {
+    synchronized (pauseLock) {
+      paused = false;
+      pauseLock.notifyAll();
+    }
+  }
+
   @Override
   public void run() {
     try {
+      // Set a short socket timeout so we can check the paused flag periodically
+      pgStream.setNetworkTimeout(100);
       while (running.get()) {
+        // Check if we should pause for synchronous execution
+        if (paused) {
+          synchronized (pauseLock) {
+            pauseLock.notifyAll(); // signal that we're paused
+            while (paused && running.get()) {
+              try {
+                pauseLock.wait();
+              } catch (InterruptedException e) {
+                if (!running.get()) {
+                  return;
+                }
+              }
+            }
+          }
+          // Restore socket timeout after pause (synchronous path may have changed it)
+          pgStream.setNetworkTimeout(100);
+        }
         try {
           processOneMessage();
         } catch (SocketTimeoutException e) {
-          // Network timeout — fail current slot but don't kill the thread
-          if (currentSlot != null) {
-            currentSlot.completeExceptionally(new PSQLException(
-                "Query timed out", PSQLState.QUERY_CANCELED, e));
-            currentSlot = null;
-          }
+          // This is the 100ms poll timeout — just continue the loop
+          // to check the paused flag and try again.
         }
       }
     } catch (IOException e) {

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/PipelineReaderThread.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/PipelineReaderThread.java
@@ -190,11 +190,11 @@ class PipelineReaderThread extends Thread {
     for (int i = 0; i < fields.length; i++) {
       String columnLabel = pgStream.receiveCanonicalString();
       int tableOid = pgStream.receiveInteger4();
-      int positionInTable = pgStream.receiveInteger2();
+      short positionInTable = (short)pgStream.receiveInteger2();
       int typeOid = pgStream.receiveInteger4();
-      int typeLength = pgStream.receiveInteger2();
+      short typeLength = (short)pgStream.receiveInteger2();
       int typeModifier = pgStream.receiveInteger4();
-      int formatType = pgStream.receiveInteger2();
+      short formatType = (short)pgStream.receiveInteger2();
       fields[i] = new Field(columnLabel, typeOid, typeLength, typeModifier, tableOid, positionInTable);
       fields[i].setFormat(formatType);
     }

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -411,7 +411,7 @@ public class QueryExecutorImpl extends QueryExecutorBase {
   public void execute(Query query, @Nullable ParameterList parameters,
       ResultHandler handler,
       int maxRows, int fetchSize, int flags, boolean adaptiveFetch) throws SQLException {
-    if (pipelineMode) {
+    if (pipelineMode && (flags & QueryExecutor.QUERY_EXECUTE_AS_SIMPLE) == 0) {
       executePipeline(query, parameters, handler, maxRows, fetchSize, flags);
       return;
     }
@@ -646,7 +646,7 @@ public class QueryExecutorImpl extends QueryExecutorBase {
   public void execute(Query[] queries, @Nullable ParameterList[] parameterLists,
       BatchResultHandler batchHandler, int maxRows, int fetchSize, int flags, boolean adaptiveFetch)
       throws SQLException {
-    if (pipelineMode) {
+    if (pipelineMode && (flags & QueryExecutor.QUERY_EXECUTE_AS_SIMPLE) == 0) {
       executeBatchPipeline(queries, parameterLists, batchHandler, maxRows, flags);
       return;
     }

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -3423,9 +3423,9 @@ public class QueryExecutorImpl extends QueryExecutorBase {
 
       sendParse(sq, params, oneShot);
       sendBind(sq, params, portal, noBinaryTransfer);
-      if (!noMeta && !sq.isPortalDescribed()) {
+      if (!noMeta && (!sq.isPortalDescribed() || sq.getFields() == null)) {
         sendDescribePortal(sq, portal);
-      } else {
+      } else if (sq.getFields() != null) {
         // Describe skipped — pre-populate slot fields from cached query metadata
         slot.fields = sq.getFields();
       }
@@ -3522,13 +3522,13 @@ public class QueryExecutorImpl extends QueryExecutorBase {
 
         sendParse(sq, params, oneShot);
         sendBind(sq, params, null, noBinaryTransfer);
-        if (!noMeta && !sq.isPortalDescribed()) {
+        if (!noMeta && (!sq.isPortalDescribed() || sq.getFields() == null)) {
           sendDescribePortal(sq, null);
         }
         sendExecute(sq, null, rows);
 
         slots[i] = new ResponseSlot(sq, null, false, flags);
-        if (noMeta || sq.isPortalDescribed()) {
+        if ((noMeta || sq.isPortalDescribed()) && sq.getFields() != null) {
           slots[i].fields = sq.getFields();
         }
         pending.add(slots[i]);

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -3433,9 +3433,9 @@ public class QueryExecutorImpl extends QueryExecutorBase {
         // Describe skipped — pre-populate slot fields from cached query metadata
         if (LOGGER.isLoggable(Level.FINEST)) {
           LOGGER.log(Level.FINEST, " FE=> pipeline skip Describe, using cached fields={0}, portalDescribed={1}, query={2}",
-              new Object[]{sq.getFields().length, sq.isPortalDescribed(), sq});
+              new Object[]{castNonNull(sq.getFields()).length, sq.isPortalDescribed(), sq});
         }
-        slot.fields = sq.getFields();
+        slot.fields = castNonNull(sq.getFields());
       } else {
         if (LOGGER.isLoggable(Level.FINEST)) {
           LOGGER.log(Level.FINEST, " FE=> pipeline skip Describe, noMeta={0}, portalDescribed={1}, fields=null, query={2}",
@@ -3548,9 +3548,9 @@ public class QueryExecutorImpl extends QueryExecutorBase {
         if ((noMeta || sq.isPortalDescribed()) && sq.getFields() != null) {
           if (LOGGER.isLoggable(Level.FINEST)) {
             LOGGER.log(Level.FINEST, " FE=> pipeline batch[{0}] pre-populate slot.fields from cache, fields={1}",
-                new Object[]{i, sq.getFields().length});
+                new Object[]{i, castNonNull(sq.getFields()).length});
           }
-          slots[i].fields = sq.getFields();
+          slots[i].fields = castNonNull(sq.getFields());
         }
         pending.add(slots[i]);
       }
@@ -3653,12 +3653,14 @@ public class QueryExecutorImpl extends QueryExecutorBase {
     if (slot.warnings != null) {
       handler.handleWarning(slot.warnings);
     }
-    Field[] fields = slot.fields != null ? slot.fields : query.getFields();
+    @SuppressWarnings("nullness")
+    Field @Nullable [] fields = slot.fields != null ? slot.fields : query.getFields();
     if (LOGGER.isLoggable(Level.FINEST)) {
+      Field @Nullable [] qf = query.getFields();
       LOGGER.log(Level.FINEST, " pipeline deliverSlotResults: slot.fields={0}, query.getFields()={1}, tuples={2}, commandStatus={3}, query={4}",
           new Object[]{
               slot.fields != null ? slot.fields.length : null,
-              query.getFields() != null ? query.getFields().length : null,
+              qf != null ? qf.length : null,
               slot.tuples != null ? slot.tuples.size() : null,
               slot.commandStatus,
               query});

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -3485,10 +3485,11 @@ public class QueryExecutorImpl extends QueryExecutorBase {
       }
       sendExecute(sq, portal, rows);
       sendSync();
-      pgStream.flush();
 
       slots.add(slot);
       slots.add(ResponseSlot.SYNC_MARKER);
+
+      pgStream.flush();
     } catch (IOException e) {
       abort();
       handler.handleError(new PSQLException(
@@ -3597,8 +3598,8 @@ public class QueryExecutorImpl extends QueryExecutorBase {
       }
 
       sendSync();
-      pgStream.flush();
       pending.add(ResponseSlot.SYNC_MARKER);
+      pgStream.flush();
     } catch (IOException e) {
       abort();
       handler.handleError(new PSQLException(
@@ -3641,10 +3642,11 @@ public class QueryExecutorImpl extends QueryExecutorBase {
     try (ResourceLock ignore = sendLock.obtain()) {
       sendExecute(query, portal, fetchSize);
       sendSync();
-      pgStream.flush();
 
       slots.add(slot);
       slots.add(ResponseSlot.SYNC_MARKER);
+
+      pgStream.flush();
     } catch (IOException e) {
       abort();
       handler.handleError(new PSQLException(

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -3425,6 +3425,9 @@ public class QueryExecutorImpl extends QueryExecutorBase {
       sendBind(sq, params, portal, noBinaryTransfer);
       if (!noMeta && !sq.isPortalDescribed()) {
         sendDescribePortal(sq, portal);
+      } else {
+        // Describe skipped — pre-populate slot fields from cached query metadata
+        slot.fields = sq.getFields();
       }
       sendExecute(sq, portal, rows);
       sendSync();
@@ -3525,6 +3528,9 @@ public class QueryExecutorImpl extends QueryExecutorBase {
         sendExecute(sq, null, rows);
 
         slots[i] = new ResponseSlot(sq, null, false, flags);
+        if (noMeta || sq.isPortalDescribed()) {
+          slots[i].fields = sq.getFields();
+        }
         pending.add(slots[i]);
       }
 

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -2881,9 +2881,9 @@ public class QueryExecutorImpl extends QueryExecutorBase {
       int tableOid = pgStream.receiveInteger4();
       short positionInTable = (short) pgStream.receiveInteger2();
       int typeOid = pgStream.receiveInteger4();
-      int typeLength = pgStream.receiveInteger2();
+      short typeLength = (short)pgStream.receiveInteger2();
       int typeModifier = pgStream.receiveInteger4();
-      int formatType = pgStream.receiveInteger2();
+      short formatType = (short)pgStream.receiveInteger2();
       fields[i] = new Field(columnLabel,
           typeOid, typeLength, typeModifier, tableOid, positionInTable);
       fields[i].setFormat(formatType);

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -3423,7 +3423,7 @@ public class QueryExecutorImpl extends QueryExecutorBase {
 
       sendParse(sq, params, oneShot);
       sendBind(sq, params, portal, noBinaryTransfer);
-      if (!noMeta && (!sq.isPortalDescribed() || sq.getFields() == null)) {
+      if (!noMeta && !noResults && (!sq.isPortalDescribed() || sq.getFields() == null)) {
         if (LOGGER.isLoggable(Level.FINEST)) {
           LOGGER.log(Level.FINEST, " FE=> pipeline sendDescribePortal, portalDescribed={0}, fields={1}, query={2}",
               new Object[]{sq.isPortalDescribed(), sq.getFields() != null, sq});
@@ -3535,7 +3535,7 @@ public class QueryExecutorImpl extends QueryExecutorBase {
 
         sendParse(sq, params, oneShot);
         sendBind(sq, params, null, noBinaryTransfer);
-        if (!noMeta && (!sq.isPortalDescribed() || sq.getFields() == null)) {
+        if (!noMeta && !noResults && (!sq.isPortalDescribed() || sq.getFields() == null)) {
           if (LOGGER.isLoggable(Level.FINEST)) {
             LOGGER.log(Level.FINEST, " FE=> pipeline batch[{0}] sendDescribePortal, portalDescribed={1}, fields={2}",
                 new Object[]{i, sq.isPortalDescribed(), sq.getFields() != null});

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -3424,10 +3424,23 @@ public class QueryExecutorImpl extends QueryExecutorBase {
       sendParse(sq, params, oneShot);
       sendBind(sq, params, portal, noBinaryTransfer);
       if (!noMeta && (!sq.isPortalDescribed() || sq.getFields() == null)) {
+        if (LOGGER.isLoggable(Level.FINEST)) {
+          LOGGER.log(Level.FINEST, " FE=> pipeline sendDescribePortal, portalDescribed={0}, fields={1}, query={2}",
+              new Object[]{sq.isPortalDescribed(), sq.getFields() != null, sq});
+        }
         sendDescribePortal(sq, portal);
       } else if (sq.getFields() != null) {
         // Describe skipped — pre-populate slot fields from cached query metadata
+        if (LOGGER.isLoggable(Level.FINEST)) {
+          LOGGER.log(Level.FINEST, " FE=> pipeline skip Describe, using cached fields={0}, portalDescribed={1}, query={2}",
+              new Object[]{sq.getFields().length, sq.isPortalDescribed(), sq});
+        }
         slot.fields = sq.getFields();
+      } else {
+        if (LOGGER.isLoggable(Level.FINEST)) {
+          LOGGER.log(Level.FINEST, " FE=> pipeline skip Describe, noMeta={0}, portalDescribed={1}, fields=null, query={2}",
+              new Object[]{noMeta, sq.isPortalDescribed(), sq});
+        }
       }
       sendExecute(sq, portal, rows);
       sendSync();
@@ -3523,12 +3536,20 @@ public class QueryExecutorImpl extends QueryExecutorBase {
         sendParse(sq, params, oneShot);
         sendBind(sq, params, null, noBinaryTransfer);
         if (!noMeta && (!sq.isPortalDescribed() || sq.getFields() == null)) {
+          if (LOGGER.isLoggable(Level.FINEST)) {
+            LOGGER.log(Level.FINEST, " FE=> pipeline batch[{0}] sendDescribePortal, portalDescribed={1}, fields={2}",
+                new Object[]{i, sq.isPortalDescribed(), sq.getFields() != null});
+          }
           sendDescribePortal(sq, null);
         }
         sendExecute(sq, null, rows);
 
         slots[i] = new ResponseSlot(sq, null, false, flags);
         if ((noMeta || sq.isPortalDescribed()) && sq.getFields() != null) {
+          if (LOGGER.isLoggable(Level.FINEST)) {
+            LOGGER.log(Level.FINEST, " FE=> pipeline batch[{0}] pre-populate slot.fields from cache, fields={1}",
+                new Object[]{i, sq.getFields().length});
+          }
           slots[i].fields = sq.getFields();
         }
         pending.add(slots[i]);
@@ -3633,6 +3654,15 @@ public class QueryExecutorImpl extends QueryExecutorBase {
       handler.handleWarning(slot.warnings);
     }
     Field[] fields = slot.fields != null ? slot.fields : query.getFields();
+    if (LOGGER.isLoggable(Level.FINEST)) {
+      LOGGER.log(Level.FINEST, " pipeline deliverSlotResults: slot.fields={0}, query.getFields()={1}, tuples={2}, commandStatus={3}, query={4}",
+          new Object[]{
+              slot.fields != null ? slot.fields.length : null,
+              query.getFields() != null ? query.getFields().length : null,
+              slot.tuples != null ? slot.tuples.size() : null,
+              slot.commandStatus,
+              query});
+    }
     if (fields != null && slot.tuples != null) {
       // SELECT-like query that returned rows
       ResultCursor cursor = slot.portalSuspended ? slot.portal : null;
@@ -3640,6 +3670,11 @@ public class QueryExecutorImpl extends QueryExecutorBase {
     } else if (slot.commandStatus != null) {
       // DML or DDL — no result rows
       handler.handleCommandStatus(slot.commandStatus, slot.updateCount, slot.insertOID);
+    } else {
+      if (LOGGER.isLoggable(Level.FINEST)) {
+        LOGGER.log(Level.FINEST, " pipeline deliverSlotResults: NO RESULT DELIVERED, fields={0}, tuples={1}, commandStatus={2}",
+            new Object[]{fields != null, slot.tuples != null, slot.commandStatus});
+      }
     }
   }
 }

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -411,10 +411,28 @@ public class QueryExecutorImpl extends QueryExecutorBase {
   public void execute(Query query, @Nullable ParameterList parameters,
       ResultHandler handler,
       int maxRows, int fetchSize, int flags, boolean adaptiveFetch) throws SQLException {
-    if (pipelineMode && (flags & QueryExecutor.QUERY_EXECUTE_AS_SIMPLE) == 0) {
-      executePipeline(query, parameters, handler, maxRows, fetchSize, flags);
+    if (pipelineMode) {
+      if ((flags & QueryExecutor.QUERY_EXECUTE_AS_SIMPLE) == 0) {
+        executePipeline(query, parameters, handler, maxRows, fetchSize, flags);
+        return;
+      }
+      // Simple queries can't use pipeline protocol — pause reader thread
+      // so it doesn't consume responses meant for the synchronous path.
+      PipelineReaderThread reader = castNonNull(pipelineReaderThread);
+      reader.pause();
+      try {
+        executeSynchronous(query, parameters, handler, maxRows, fetchSize, flags, adaptiveFetch);
+      } finally {
+        reader.unpause();
+      }
       return;
     }
+    executeSynchronous(query, parameters, handler, maxRows, fetchSize, flags, adaptiveFetch);
+  }
+
+  private void executeSynchronous(Query query, @Nullable ParameterList parameters,
+      ResultHandler handler,
+      int maxRows, int fetchSize, int flags, boolean adaptiveFetch) throws SQLException {
     try (ResourceLock ignore = lock.obtain()) {
       waitOnLock();
       if (LOGGER.isLoggable(Level.FINEST)) {
@@ -646,10 +664,26 @@ public class QueryExecutorImpl extends QueryExecutorBase {
   public void execute(Query[] queries, @Nullable ParameterList[] parameterLists,
       BatchResultHandler batchHandler, int maxRows, int fetchSize, int flags, boolean adaptiveFetch)
       throws SQLException {
-    if (pipelineMode && (flags & QueryExecutor.QUERY_EXECUTE_AS_SIMPLE) == 0) {
+    if (pipelineMode) {
+      if ((flags & QueryExecutor.QUERY_EXECUTE_AS_SIMPLE) != 0) {
+        PipelineReaderThread reader = castNonNull(pipelineReaderThread);
+        reader.pause();
+        try {
+          executeBatchSynchronous(queries, parameterLists, batchHandler, maxRows, fetchSize, flags, adaptiveFetch);
+        } finally {
+          reader.unpause();
+        }
+        return;
+      }
       executeBatchPipeline(queries, parameterLists, batchHandler, maxRows, flags);
       return;
     }
+    executeBatchSynchronous(queries, parameterLists, batchHandler, maxRows, fetchSize, flags, adaptiveFetch);
+  }
+
+  private void executeBatchSynchronous(Query[] queries, @Nullable ParameterList[] parameterLists,
+      BatchResultHandler batchHandler, int maxRows, int fetchSize, int flags, boolean adaptiveFetch)
+      throws SQLException {
     try (ResourceLock ignore = lock.obtain()) {
       waitOnLock();
       if (LOGGER.isLoggable(Level.FINEST)) {

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -414,16 +414,11 @@ public class QueryExecutorImpl extends QueryExecutorBase {
     if (pipelineMode) {
       if ((flags & QueryExecutor.QUERY_EXECUTE_AS_SIMPLE) == 0) {
         executePipeline(query, parameters, handler, maxRows, fetchSize, flags);
-        return;
-      }
-      // Simple queries can't use pipeline protocol — pause reader thread
-      // so it doesn't consume responses meant for the synchronous path.
-      PipelineReaderThread reader = castNonNull(pipelineReaderThread);
-      reader.pause();
-      try {
+      } else if (pipelineReaderThread != null && pipelineReaderThread.isAlive()) {
+        executeSimplePipeline(query, parameters, handler, flags);
+      } else {
+        // Reader thread not started yet (connection setup phase) — use synchronous path
         executeSynchronous(query, parameters, handler, maxRows, fetchSize, flags, adaptiveFetch);
-      } finally {
-        reader.unpause();
       }
       return;
     }
@@ -666,12 +661,10 @@ public class QueryExecutorImpl extends QueryExecutorBase {
       throws SQLException {
     if (pipelineMode) {
       if ((flags & QueryExecutor.QUERY_EXECUTE_AS_SIMPLE) != 0) {
-        PipelineReaderThread reader = castNonNull(pipelineReaderThread);
-        reader.pause();
-        try {
+        if (pipelineReaderThread != null && pipelineReaderThread.isAlive()) {
+          executeBatchSimplePipeline(queries, parameterLists, batchHandler, flags);
+        } else {
           executeBatchSynchronous(queries, parameterLists, batchHandler, maxRows, fetchSize, flags, adaptiveFetch);
-        } finally {
-          reader.unpause();
         }
         return;
       }
@@ -3518,12 +3511,11 @@ public class QueryExecutorImpl extends QueryExecutorBase {
         }
       }
       sendExecute(sq, portal, rows);
-      sendSync();
 
       slots.add(slot);
       slots.add(ResponseSlot.SYNC_MARKER);
 
-      pgStream.flush();
+      sendSync();
     } catch (IOException e) {
       abort();
       handler.handleError(new PSQLException(
@@ -3557,6 +3549,98 @@ public class QueryExecutorImpl extends QueryExecutorBase {
     // Deliver results to handler
     deliverSlotResults(slot, handler, sq);
     handler.handleCompletion();
+  }
+
+  /**
+   * Execute a simple query in pipeline mode. Sends the query using the simple protocol ('Q' message)
+   * and waits for the reader thread to complete the ResponseSlot.
+   */
+  private void executeSimplePipeline(Query query, @Nullable ParameterList parameters,
+      ResultHandler handler, int flags) throws SQLException {
+
+    // Handle CompositeQuery (multi-statement SQL) by executing each subquery
+    Query[] subqueries = query.getSubqueries();
+    if (subqueries != null) {
+      SimpleParameterList[] subparams = parameters != null
+          ? ((SimpleParameterList) parameters).getSubparams() : null;
+      for (int i = 0; i < subqueries.length; i++) {
+        ParameterList subparam = subparams != null ? subparams[i] : null;
+        executeSimplePipeline(subqueries[i], subparam, handler, flags);
+        if (handler.getException() != null) {
+          break;
+        }
+      }
+      return;
+    }
+
+    if (parameters == null) {
+      parameters = SimpleQuery.NO_PARAMETERS;
+    }
+
+    SimpleQuery sq = (SimpleQuery) query;
+    SimpleParameterList params = (SimpleParameterList) parameters;
+
+    ResponseSlot slot = new ResponseSlot(sq, null, true, flags);
+    ConcurrentLinkedDeque<ResponseSlot> slots = pipelineSlots();
+
+    try (ResourceLock ignore = sendLock.obtain()) {
+      // Send the simple query message
+      String nativeSql = sq.toString(
+          params,
+          SqlSerializationContext.of(getStandardConformingStrings(), false));
+
+      LOGGER.log(Level.FINEST, " FE=> PipelineSimpleQuery(query=\"{0}\")", nativeSql);
+      Encoding encoding = pgStream.getEncoding();
+      byte[] encoded = encoding.encode(nativeSql);
+      pgStream.sendChar(PgMessageType.QUERY_REQUEST);
+      pgStream.sendInteger4(encoded.length + 4 + 1);
+      pgStream.send(encoded);
+      pgStream.sendChar(0);
+
+      // Add slot before flush so reader can find it
+      slots.add(slot);
+      slots.add(ResponseSlot.SYNC_MARKER);
+
+      pgStream.flush();
+    } catch (IOException e) {
+      abort();
+      handler.handleError(new PSQLException(
+          GT.tr("An I/O error occurred while sending to the backend."),
+          PSQLState.CONNECTION_FAILURE, e));
+      handler.handleCompletion();
+      return;
+    }
+
+    // Wait for reader thread to complete the slot
+    try {
+      slot.await(castNonNull(pipelineReaderThread));
+    } catch (Exception e) {
+      handler.handleError(new PSQLException(
+          "Interrupted waiting for simple query response",
+          PSQLState.CONNECTION_FAILURE, e));
+      handler.handleCompletion();
+      return;
+    }
+
+    // Deliver results to handler
+    deliverSlotResults(slot, handler, sq);
+    handler.handleCompletion();
+  }
+
+  /**
+   * Execute a batch of simple queries in pipeline mode.
+   * Sends each query individually and waits for each response.
+   */
+  private void executeBatchSimplePipeline(Query[] queries, @Nullable ParameterList[] parameterLists,
+      BatchResultHandler batchHandler, int flags) throws SQLException {
+    for (int i = 0; i < queries.length; i++) {
+      executeSimplePipeline(queries[i], parameterLists[i], batchHandler, flags);
+      if (batchHandler.getException() != null) {
+        break;
+      }
+      batchHandler.secureProgress();
+    }
+    batchHandler.handleCompletion();
   }
 
   /**
@@ -3631,7 +3715,7 @@ public class QueryExecutorImpl extends QueryExecutorBase {
         pending.add(slots[i]);
       }
 
-      sendSync();
+      sendSync(false);
       pending.add(ResponseSlot.SYNC_MARKER);
       pgStream.flush();
     } catch (IOException e) {
@@ -3675,12 +3759,11 @@ public class QueryExecutorImpl extends QueryExecutorBase {
 
     try (ResourceLock ignore = sendLock.obtain()) {
       sendExecute(query, portal, fetchSize);
-      sendSync();
 
       slots.add(slot);
       slots.add(ResponseSlot.SYNC_MARKER);
 
-      pgStream.flush();
+      sendSync();
     } catch (IOException e) {
       abort();
       handler.handleError(new PSQLException(

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -248,7 +248,7 @@ public class QueryExecutorImpl extends QueryExecutorBase {
     if (pipelineMode) {
       this.pipelinePendingSlots = new ConcurrentLinkedDeque<>();
       this.pipelineReaderThread = new PipelineReaderThread(pgStream, this, pipelinePendingSlots);
-      this.pipelineReaderThread.start();
+      // Reader thread is started later via startPipelineReaderThread() after connection setup
     } else {
       this.pipelinePendingSlots = null;
       this.pipelineReaderThread = null;
@@ -3371,6 +3371,17 @@ public class QueryExecutorImpl extends QueryExecutorBase {
   private final boolean pipelineMode;
   private final @Nullable ConcurrentLinkedDeque<ResponseSlot> pipelinePendingSlots;
   private final @Nullable PipelineReaderThread pipelineReaderThread;
+
+  /**
+   * Start the pipeline reader thread. Must be called after connection setup is complete
+   * to avoid the reader thread consuming responses meant for synchronous setup queries.
+   */
+  @Override
+  public void startPipelineReaderThread() {
+    if (pipelineReaderThread != null) {
+      pipelineReaderThread.start();
+    }
+  }
 
   private ConcurrentLinkedDeque<ResponseSlot> pipelineSlots() {
     return castNonNull(pipelinePendingSlots);

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -132,6 +132,7 @@ import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
 import java.util.TimeZone;
+import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
@@ -232,9 +233,19 @@ public class QueryExecutorImpl extends QueryExecutorBase {
 
     this.allowEncodingChanges = PGProperty.ALLOW_ENCODING_CHANGES.getBoolean(info);
     this.cleanupSavePoints = PGProperty.CLEANUP_SAVEPOINTS.getBoolean(info);
+    this.pipelineMode = PGProperty.PIPELINE_MODE.getBoolean(info);
     // assignment, argument
     this.replicationProtocol = new V3ReplicationProtocol(this, pgStream);
     readStartupMessages();
+
+    if (pipelineMode) {
+      this.pipelinePendingSlots = new ConcurrentLinkedDeque<>();
+      this.pipelineReaderThread = new PipelineReaderThread(pgStream, this, pipelinePendingSlots);
+      this.pipelineReaderThread.start();
+    } else {
+      this.pipelinePendingSlots = null;
+      this.pipelineReaderThread = null;
+    }
   }
 
   @Override
@@ -393,6 +404,10 @@ public class QueryExecutorImpl extends QueryExecutorBase {
   public void execute(Query query, @Nullable ParameterList parameters,
       ResultHandler handler,
       int maxRows, int fetchSize, int flags, boolean adaptiveFetch) throws SQLException {
+    if (pipelineMode) {
+      executePipeline(query, parameters, handler, maxRows, fetchSize, flags);
+      return;
+    }
     try (ResourceLock ignore = lock.obtain()) {
       waitOnLock();
       if (LOGGER.isLoggable(Level.FINEST)) {
@@ -624,6 +639,10 @@ public class QueryExecutorImpl extends QueryExecutorBase {
   public void execute(Query[] queries, @Nullable ParameterList[] parameterLists,
       BatchResultHandler batchHandler, int maxRows, int fetchSize, int flags, boolean adaptiveFetch)
       throws SQLException {
+    if (pipelineMode) {
+      executeBatchPipeline(queries, parameterLists, batchHandler, maxRows, flags);
+      return;
+    }
     try (ResourceLock ignore = lock.obtain()) {
       waitOnLock();
       if (LOGGER.isLoggable(Level.FINEST)) {
@@ -2762,6 +2781,10 @@ public class QueryExecutorImpl extends QueryExecutorBase {
   @Override
   public void fetch(ResultCursor cursor, ResultHandler handler, int fetchSize,
       boolean adaptiveFetch) throws SQLException {
+    if (pipelineMode) {
+      fetchPipeline(cursor, handler, fetchSize);
+      return;
+    }
     try (ResourceLock ignore = lock.obtain()) {
       waitOnLock();
       final Portal portal = (Portal) cursor;
@@ -3294,4 +3317,323 @@ public class QueryExecutorImpl extends QueryExecutorBase {
       new SimpleQuery(
           new NativeQuery("ROLLBACK TO SAVEPOINT PGJDBC_AUTOSAVE", null, false, SqlCommand.BLANK),
           null, false);
+
+  @Override
+  public void close() {
+    shutdownPipelineReader();
+    super.close();
+  }
+
+  @Override
+  public void abort() {
+    shutdownPipelineReader();
+    super.abort();
+  }
+
+  private void shutdownPipelineReader() {
+    PipelineReaderThread reader = pipelineReaderThread;
+    if (reader != null) {
+      reader.shutdown();
+    }
+  }
+
+  // --- Pipeline mode fields ---
+  private final boolean pipelineMode;
+  private final @Nullable ConcurrentLinkedDeque<ResponseSlot> pipelinePendingSlots;
+  private final @Nullable PipelineReaderThread pipelineReaderThread;
+
+  private ConcurrentLinkedDeque<ResponseSlot> pipelineSlots() {
+    return castNonNull(pipelinePendingSlots);
+  }
+
+  /**
+   * Execute a single query in pipeline mode. Sends messages under sendLock,
+   * then waits for the reader thread to complete the ResponseSlot.
+   */
+  private void executePipeline(Query query, @Nullable ParameterList parameters,
+      ResultHandler handler, int maxRows, int fetchSize, int flags) throws SQLException {
+
+    // Handle CompositeQuery (multi-statement SQL) by executing each subquery
+    Query[] subqueries = query.getSubqueries();
+    if (subqueries != null) {
+      SimpleParameterList[] subparams = parameters != null
+          ? ((SimpleParameterList) parameters).getSubparams() : null;
+      for (int i = 0; i < subqueries.length; i++) {
+        ParameterList subparam = subparams != null ? subparams[i] : null;
+        executePipeline(subqueries[i], subparam, handler, maxRows, fetchSize, flags);
+        if (handler.getException() != null) {
+          break;
+        }
+      }
+      return;
+    }
+
+    if (parameters == null) {
+      parameters = SimpleQuery.NO_PARAMETERS;
+    }
+
+    flags = updateQueryMode(flags);
+    boolean noMeta = (flags & QueryExecutor.QUERY_NO_METADATA) != 0;
+    boolean oneShot = (flags & QueryExecutor.QUERY_ONESHOT) != 0;
+    boolean noBinaryTransfer = (flags & QUERY_NO_BINARY_TRANSFER) != 0;
+    boolean noResults = (flags & QueryExecutor.QUERY_NO_RESULTS) != 0;
+    boolean usePortal = (flags & QueryExecutor.QUERY_FORWARD_CURSOR) != 0 && !noResults && !noMeta
+        && fetchSize > 0;
+
+    SimpleQuery sq = (SimpleQuery) query;
+    SimpleParameterList params = (SimpleParameterList) parameters;
+    params.checkAllParametersSet();
+
+    int rows;
+    if (noResults) {
+      rows = 1;
+    } else if (usePortal) {
+      rows = fetchSize;
+    } else if (maxRows != 0) {
+      rows = maxRows;
+    } else {
+      rows = 0;
+    }
+
+    Portal portal = null;
+    if (usePortal) {
+      portal = new Portal(sq, "C_" + (nextUniqueID++));
+    }
+
+    ResponseSlot slot = new ResponseSlot(sq, portal, false, flags);
+
+    ConcurrentLinkedDeque<ResponseSlot> slots = pipelineSlots();
+    ResponseSlot beginSlot = null;
+
+    try (ResourceLock ignore = sendLock.obtain()) {
+      processDeadParsedQueries();
+      processDeadPortals();
+
+      // Send BEGIN if needed — as extended protocol so it shares our Sync
+      boolean needsBegin = (flags & QueryExecutor.QUERY_SUPPRESS_BEGIN) == 0
+          && getTransactionState() == TransactionState.IDLE;
+      if (needsBegin) {
+        SimpleQuery beginQuery = (flags & QueryExecutor.QUERY_READ_ONLY_HINT) == 0
+            ? beginTransactionQuery : beginReadOnlyTransactionQuery;
+        sendOneQuery(beginQuery, SimpleQuery.NO_PARAMETERS, 0, 0,
+            QueryExecutor.QUERY_NO_METADATA | QueryExecutor.QUERY_ONESHOT);
+        beginSlot = new ResponseSlot(beginQuery, null, false, 0);
+        slots.add(beginSlot);
+      }
+
+      sendParse(sq, params, oneShot);
+      sendBind(sq, params, portal, noBinaryTransfer);
+      if (!noMeta && !sq.isPortalDescribed()) {
+        sendDescribePortal(sq, portal);
+      }
+      sendExecute(sq, portal, rows);
+      sendSync();
+      pgStream.flush();
+
+      slots.add(slot);
+      slots.add(ResponseSlot.SYNC_MARKER);
+    } catch (IOException e) {
+      abort();
+      handler.handleError(new PSQLException(
+          GT.tr("An I/O error occurred while sending to the backend."),
+          PSQLState.CONNECTION_FAILURE, e));
+      handler.handleCompletion();
+      return;
+    }
+
+    // If we sent BEGIN, await it and propagate any error
+    if (beginSlot != null) {
+      beginSlot.await(castNonNull(pipelineReaderThread));
+      if (beginSlot.error != null) {
+        handler.handleError(beginSlot.error);
+        handler.handleCompletion();
+        return;
+      }
+    }
+
+    // Wait for reader thread to complete the slot
+    try {
+      slot.await(castNonNull(pipelineReaderThread));
+    } catch (Exception e) {
+      handler.handleError(new PSQLException(
+          "Interrupted waiting for query response",
+          PSQLState.CONNECTION_FAILURE, e));
+      handler.handleCompletion();
+      return;
+    }
+
+    // Deliver results to handler
+    deliverSlotResults(slot, handler, sq);
+    handler.handleCompletion();
+  }
+
+  /**
+   * Execute a batch of queries in pipeline mode. Sends all queries under a single
+   * sendLock acquisition with one Sync at the end, then waits for all slots.
+   */
+  private void executeBatchPipeline(Query[] queries, @Nullable ParameterList[] parameterLists,
+      BatchResultHandler batchHandler, int maxRows, int flags) throws SQLException {
+
+    flags = updateQueryMode(flags);
+    boolean oneShot = (flags & QueryExecutor.QUERY_ONESHOT) != 0;
+    boolean noBinaryTransfer = (flags & QUERY_NO_BINARY_TRANSFER) != 0;
+    boolean noResults = (flags & QueryExecutor.QUERY_NO_RESULTS) != 0;
+    boolean noMeta = (flags & QueryExecutor.QUERY_NO_METADATA) != 0;
+
+    int rows;
+    if (noResults) {
+      rows = 1;
+    } else if (maxRows != 0) {
+      rows = maxRows;
+    } else {
+      rows = 0;
+    }
+
+    ResponseSlot[] slots = new ResponseSlot[queries.length];
+    ConcurrentLinkedDeque<ResponseSlot> pending = pipelineSlots();
+
+    ResultHandler handler = batchHandler;
+    try (ResourceLock ignore = sendLock.obtain()) {
+      processDeadParsedQueries();
+      processDeadPortals();
+
+      // Send BEGIN if needed — as extended protocol
+      boolean needsBegin = (flags & QueryExecutor.QUERY_SUPPRESS_BEGIN) == 0
+          && getTransactionState() == TransactionState.IDLE;
+      if (needsBegin) {
+        SimpleQuery beginQuery = (flags & QueryExecutor.QUERY_READ_ONLY_HINT) == 0
+            ? beginTransactionQuery : beginReadOnlyTransactionQuery;
+        sendOneQuery(beginQuery, SimpleQuery.NO_PARAMETERS, 0, 0,
+            QueryExecutor.QUERY_NO_METADATA | QueryExecutor.QUERY_ONESHOT);
+        ResponseSlot beginSlot = new ResponseSlot(beginQuery, null, false, 0);
+        pending.add(beginSlot);
+      }
+
+      for (int i = 0; i < queries.length; i++) {
+        SimpleQuery sq = (SimpleQuery) queries[i];
+        SimpleParameterList params = (SimpleParameterList) parameterLists[i];
+        if (params == null) {
+          params = SimpleQuery.NO_PARAMETERS;
+        }
+        params.checkAllParametersSet();
+
+        sendParse(sq, params, oneShot);
+        sendBind(sq, params, null, noBinaryTransfer);
+        if (!noMeta && !sq.isPortalDescribed()) {
+          sendDescribePortal(sq, null);
+        }
+        sendExecute(sq, null, rows);
+
+        slots[i] = new ResponseSlot(sq, null, false, flags);
+        pending.add(slots[i]);
+      }
+
+      sendSync();
+      pgStream.flush();
+      pending.add(ResponseSlot.SYNC_MARKER);
+    } catch (IOException e) {
+      abort();
+      handler.handleError(new PSQLException(
+          GT.tr("An I/O error occurred while sending to the backend."),
+          PSQLState.CONNECTION_FAILURE, e));
+      batchHandler.handleCompletion();
+      return;
+    }
+
+    // Wait for all slots
+    for (int i = 0; i < slots.length; i++) {
+      try {
+        slots[i].await(castNonNull(pipelineReaderThread));
+      } catch (Exception e) {
+        handler.handleError(new PSQLException(
+            "Interrupted waiting for batch response",
+            PSQLState.CONNECTION_FAILURE, e));
+        break;
+      }
+      deliverSlotResults(slots[i], handler, (SimpleQuery) queries[i]);
+      if (slots[i].error != null) {
+        break;
+      }
+      batchHandler.secureProgress();
+    }
+
+    batchHandler.handleCompletion();
+  }
+
+  /**
+   * Execute a cursor fetch in pipeline mode.
+   */
+  private void fetchPipeline(ResultCursor cursor, ResultHandler handler, int fetchSize) throws SQLException {
+    Portal portal = (Portal) cursor;
+    SimpleQuery query = castNonNull(portal.getQuery());
+
+    ResponseSlot slot = new ResponseSlot(query, portal, false, 0);
+    ConcurrentLinkedDeque<ResponseSlot> slots = pipelineSlots();
+
+    try (ResourceLock ignore = sendLock.obtain()) {
+      sendExecute(query, portal, fetchSize);
+      sendSync();
+      pgStream.flush();
+
+      slots.add(slot);
+      slots.add(ResponseSlot.SYNC_MARKER);
+    } catch (IOException e) {
+      abort();
+      handler.handleError(new PSQLException(
+          GT.tr("An I/O error occurred while sending to the backend."),
+          PSQLState.CONNECTION_FAILURE, e));
+      handler.handleCompletion();
+      return;
+    }
+
+    try {
+      slot.await(castNonNull(pipelineReaderThread));
+    } catch (Exception e) {
+      handler.handleError(new PSQLException(
+          "Interrupted waiting for fetch response",
+          PSQLState.CONNECTION_FAILURE, e));
+      handler.handleCompletion();
+      return;
+    }
+
+    // Deliver fetch results
+    if (slot.error != null) {
+      handler.handleError(slot.error);
+    } else if (slot.warnings != null) {
+      handler.handleWarning(slot.warnings);
+    }
+
+    Field[] fields = query.getFields();
+    if (fields != null) {
+      List<Tuple> tuples = slot.tuples != null ? slot.tuples : new ArrayList<>();
+      ResultCursor resultCursor = slot.portalSuspended ? portal : null;
+      handler.handleResultRows(query, fields, tuples, resultCursor);
+    } else {
+      handler.handleCommandStatus("EMPTY", 0, 0);
+    }
+
+    handler.handleCompletion();
+  }
+
+  /**
+   * Deliver results from a completed ResponseSlot to a ResultHandler.
+   */
+  private void deliverSlotResults(ResponseSlot slot, ResultHandler handler, SimpleQuery query) {
+    if (slot.error != null) {
+      handler.handleError(slot.error);
+      return;
+    }
+    if (slot.warnings != null) {
+      handler.handleWarning(slot.warnings);
+    }
+    Field[] fields = slot.fields != null ? slot.fields : query.getFields();
+    if (fields != null && slot.tuples != null) {
+      // SELECT-like query that returned rows
+      ResultCursor cursor = slot.portalSuspended ? slot.portal : null;
+      handler.handleResultRows(query, fields, slot.tuples, cursor);
+    } else if (slot.commandStatus != null) {
+      // DML or DDL — no result rows
+      handler.handleCommandStatus(slot.commandStatus, slot.updateCount, slot.insertOID);
+    }
+  }
 }

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/ResponseSlot.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/ResponseSlot.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2026, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.core.v3;
+
+import org.postgresql.core.Field;
+import org.postgresql.core.Tuple;
+import org.postgresql.util.PSQLException;
+import org.postgresql.util.PSQLState;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.sql.SQLException;
+import java.sql.SQLWarning;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.locks.LockSupport;
+
+/**
+ * Completion token for a pipelined query. Created by the sending thread,
+ * populated and completed by the reader thread.
+ *
+ * <p>Uses LockSupport.park/unpark instead of CompletableFuture to avoid
+ * per-query object allocation overhead.</p>
+ */
+class ResponseSlot {
+
+  /**
+   * Sentinel instance used to mark Sync boundaries in the pending queue.
+   * When the reader thread encounters ReadyForQuery, it drains slots up to
+   * and including the next SYNC_MARKER to handle error cascading.
+   */
+  static final ResponseSlot SYNC_MARKER = new ResponseSlot();
+
+  @Nullable SimpleQuery query;
+  @Nullable Portal portal;
+  boolean asSimple;
+  int flags;
+
+  // Results — written only by reader thread
+  @Nullable Field[] fields;
+  @Nullable List<Tuple> tuples;
+  @Nullable String commandStatus;
+  long updateCount;
+  long insertOID;
+  @Nullable SQLWarning warnings;
+  @Nullable SQLException error;
+  boolean portalSuspended;
+
+  // Signaling: reader thread sets done=true then unparks the waiter
+  private volatile boolean done;
+  private volatile @Nullable Thread waiter;
+
+  /** Sentinel constructor */
+  @SuppressWarnings("initialization.fields.uninitialized")
+  private ResponseSlot() {
+  }
+
+  ResponseSlot(@Nullable SimpleQuery query, @Nullable Portal portal, boolean asSimple, int flags) {
+    this.query = query;
+    this.portal = portal;
+    this.asSimple = asSimple;
+    this.flags = flags;
+  }
+
+  void addTuple(Tuple t) {
+    if (tuples == null) {
+      tuples = new ArrayList<>();
+    }
+    tuples.add(t);
+  }
+
+  void addWarning(SQLWarning w) {
+    if (warnings == null) {
+      warnings = w;
+    } else {
+      warnings.setNextWarning(w);
+    }
+  }
+
+  /**
+   * Called by the sending thread to block until the reader thread completes this slot.
+   *
+   * @param readerThread the pipeline reader thread; used for liveness checks
+   * @throws SQLException if the reader thread dies before completing this slot
+   */
+  void await(Thread readerThread) throws SQLException {
+    waiter = Thread.currentThread();
+    while (!done) {
+      LockSupport.parkNanos(this, 1_000_000_000L); // 1 second
+      if (!done && !readerThread.isAlive()) {
+        throw new PSQLException(
+            "Pipeline reader thread died unexpectedly",
+            PSQLState.CONNECTION_FAILURE);
+      }
+    }
+  }
+
+  /**
+   * Called by the sending thread to block until the reader thread completes this slot.
+   * No liveness check — use only when reader thread reference is unavailable.
+   */
+  void await() {
+    waiter = Thread.currentThread();
+    while (!done) {
+      LockSupport.park(this);
+    }
+  }
+
+  /**
+   * Called by the reader thread to signal completion.
+   */
+  void complete() {
+    done = true;
+    Thread w = waiter;
+    if (w != null) {
+      LockSupport.unpark(w);
+    }
+  }
+
+  void completeExceptionally(SQLException ex) {
+    if (this.error == null) {
+      this.error = ex;
+    }
+    complete();
+  }
+}

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/ResponseSlot.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/ResponseSlot.java
@@ -91,6 +91,11 @@ class ResponseSlot {
     waiter = Thread.currentThread();
     while (!done) {
       LockSupport.parkNanos(this, 1_000_000_000L); // 1 second
+      if (Thread.interrupted()) {
+        throw new PSQLException(
+            "Interrupted while waiting for pipeline response",
+            PSQLState.CONNECTION_FAILURE);
+      }
       if (!done && !readerThread.isAlive()) {
         throw new PSQLException(
             "Pipeline reader thread died unexpectedly",

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/ResponseSlot.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/ResponseSlot.java
@@ -58,6 +58,7 @@ class ResponseSlot {
   private ResponseSlot() {
   }
 
+  @SuppressWarnings("initialization.fields.uninitialized")
   ResponseSlot(@Nullable SimpleQuery query, @Nullable Portal portal, boolean asSimple, int flags) {
     this.query = query;
     this.portal = portal;

--- a/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
+++ b/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
@@ -1789,6 +1789,22 @@ public abstract class BaseDataSource implements CommonDataSource, Referenceable 
   }
 
   /**
+   * @return boolean indicating if pipeline mode is enabled.
+   * @see PGProperty#PIPELINE_MODE
+   */
+  public boolean getPipelineMode() {
+    return PGProperty.PIPELINE_MODE.getBoolean(properties);
+  }
+
+  /**
+   * @param pipelineMode boolean value to enable or disable pipeline mode
+   * @see PGProperty#PIPELINE_MODE
+   */
+  public void setPipelineMode(boolean pipelineMode) {
+    PGProperty.PIPELINE_MODE.set(properties, pipelineMode);
+  }
+
+  /**
    * @return boolean indicating property is enabled or not.
    * @see PGProperty#HIDE_UNPRIVILEGED_OBJECTS
    */

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
@@ -401,6 +401,9 @@ public class PgConnection implements BaseConnection {
 
     xmlFactoryFactoryClass = PGProperty.XML_FACTORY_FACTORY.getOrDefault(info);
     cleanable = LazyCleanerImpl.getInstance().register(leakHandle, finalizeAction);
+
+    // Start the pipeline reader thread after all setup queries are complete
+    queryExecutor.startPipelineReaderThread();
   }
 
   private static ReadOnlyBehavior getReadOnlyBehavior(@Nullable String property) {

--- a/pgjdbc/src/test/java/org/postgresql/test/core/PipelineModeTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/core/PipelineModeTest.java
@@ -38,7 +38,7 @@ public class PipelineModeTest extends BaseTest4 {
 
   @BeforeAll
   static void enableLogging() {
-    Logger logger = Logger.getLogger("org.postgresql");
+    Logger logger = Logger.getLogger("org.postgresql.core.v3");
     logger.setLevel(Level.FINEST);
     ConsoleHandler handler = new ConsoleHandler();
     handler.setLevel(Level.FINEST);

--- a/pgjdbc/src/test/java/org/postgresql/test/core/PipelineModeTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/core/PipelineModeTest.java
@@ -16,6 +16,7 @@ import org.postgresql.PGProperty;
 import org.postgresql.test.TestUtil;
 import org.postgresql.test.jdbc2.BaseTest4;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -24,6 +25,9 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Properties;
+import java.util.logging.ConsoleHandler;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Integration tests for pipeline mode (dedicated reader thread).
@@ -31,6 +35,15 @@ import java.util.Properties;
  */
 @Timeout(30)
 public class PipelineModeTest extends BaseTest4 {
+
+  @BeforeAll
+  static void enableLogging() {
+    Logger logger = Logger.getLogger("org.postgresql");
+    logger.setLevel(Level.FINEST);
+    ConsoleHandler handler = new ConsoleHandler();
+    handler.setLevel(Level.FINEST);
+    logger.addHandler(handler);
+  }
 
   @Override
   protected void updateProperties(Properties props) {

--- a/pgjdbc/src/test/java/org/postgresql/test/core/PipelineModeTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/core/PipelineModeTest.java
@@ -1,0 +1,435 @@
+/*
+ * Copyright (c) 2024, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.test.core;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.postgresql.PGProperty;
+import org.postgresql.test.TestUtil;
+import org.postgresql.test.jdbc2.BaseTest4;
+
+import org.junit.jupiter.api.Test;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Properties;
+
+/**
+ * Integration tests for pipeline mode (dedicated reader thread).
+ * Requires a running PostgreSQL server configured via build.local.properties.
+ */
+public class PipelineModeTest extends BaseTest4 {
+
+  @Override
+  protected void updateProperties(Properties props) {
+    super.updateProperties(props);
+    PGProperty.PIPELINE_MODE.set(props, true);
+  }
+
+  @Test
+  public void testSimpleSelect() throws SQLException {
+    try (Statement stmt = con.createStatement();
+         ResultSet rs = stmt.executeQuery("SELECT 1 AS x, 'hello' AS y")) {
+      assertTrue(rs.next());
+      assertEquals(1, rs.getInt("x"));
+      assertEquals("hello", rs.getString("y"));
+      assertFalse(rs.next());
+    }
+  }
+
+  @Test
+  public void testMultipleSequentialQueries() throws SQLException {
+    try (Statement stmt = con.createStatement()) {
+      for (int i = 0; i < 10; i++) {
+        try (ResultSet rs = stmt.executeQuery("SELECT " + i + " AS val")) {
+          assertTrue(rs.next());
+          assertEquals(i, rs.getInt(1));
+        }
+      }
+    }
+  }
+
+  @Test
+  public void testPreparedStatement() throws SQLException {
+    TestUtil.createTempTable(con, "pipeline_test", "id INT, name TEXT");
+    try (PreparedStatement ps = con.prepareStatement(
+        "INSERT INTO pipeline_test (id, name) VALUES (?, ?)")) {
+      ps.setInt(1, 1);
+      ps.setString(2, "alice");
+      assertEquals(1, ps.executeUpdate());
+
+      ps.setInt(1, 2);
+      ps.setString(2, "bob");
+      assertEquals(1, ps.executeUpdate());
+    }
+
+    try (Statement stmt = con.createStatement();
+         ResultSet rs = stmt.executeQuery(
+             "SELECT id, name FROM pipeline_test ORDER BY id")) {
+      assertTrue(rs.next());
+      assertEquals(1, rs.getInt(1));
+      assertEquals("alice", rs.getString(2));
+      assertTrue(rs.next());
+      assertEquals(2, rs.getInt(1));
+      assertEquals("bob", rs.getString(2));
+      assertFalse(rs.next());
+    }
+  }
+
+  @Test
+  public void testBatchInsert() throws SQLException {
+    TestUtil.createTempTable(con, "pipeline_batch", "id INT, val INT");
+    try (PreparedStatement ps = con.prepareStatement(
+        "INSERT INTO pipeline_batch (id, val) VALUES (?, ?)")) {
+      for (int i = 0; i < 100; i++) {
+        ps.setInt(1, i);
+        ps.setInt(2, i * 10);
+        ps.addBatch();
+      }
+      int[] counts = ps.executeBatch();
+      assertEquals(100, counts.length);
+      for (int count : counts) {
+        assertEquals(1, count);
+      }
+    }
+
+    try (Statement stmt = con.createStatement();
+         ResultSet rs = stmt.executeQuery("SELECT count(*) FROM pipeline_batch")) {
+      assertTrue(rs.next());
+      assertEquals(100, rs.getInt(1));
+    }
+  }
+
+  @Test
+  public void testCursorFetch() throws SQLException {
+    TestUtil.createTempTable(con, "pipeline_cursor", "id INT");
+    try (Statement stmt = con.createStatement()) {
+      StringBuilder sb = new StringBuilder("INSERT INTO pipeline_cursor VALUES ");
+      for (int i = 0; i < 200; i++) {
+        if (i > 0) {
+          sb.append(',');
+        }
+        sb.append('(').append(i).append(')');
+      }
+      stmt.executeUpdate(sb.toString());
+    }
+
+    // Use fetchSize to trigger cursor/portal mode
+    try (PreparedStatement ps = con.prepareStatement("SELECT id FROM pipeline_cursor ORDER BY id")) {
+      ps.setFetchSize(10);
+      try (ResultSet rs = ps.executeQuery()) {
+        int count = 0;
+        while (rs.next()) {
+          assertEquals(count, rs.getInt(1));
+          count++;
+        }
+        assertEquals(200, count);
+      }
+    }
+  }
+
+  @Test
+  public void testTransactionCommit() throws SQLException {
+    TestUtil.createTempTable(con, "pipeline_tx", "id INT");
+    con.setAutoCommit(false);
+    try (PreparedStatement ps = con.prepareStatement("INSERT INTO pipeline_tx VALUES (?)")) {
+      ps.setInt(1, 42);
+      ps.executeUpdate();
+    }
+    con.commit();
+
+    try (Statement stmt = con.createStatement();
+         ResultSet rs = stmt.executeQuery("SELECT id FROM pipeline_tx")) {
+      assertTrue(rs.next());
+      assertEquals(42, rs.getInt(1));
+    }
+    con.setAutoCommit(true);
+  }
+
+  @Test
+  public void testTransactionRollback() throws SQLException {
+    TestUtil.createTempTable(con, "pipeline_rb", "id INT");
+    con.setAutoCommit(false);
+    try (PreparedStatement ps = con.prepareStatement("INSERT INTO pipeline_rb VALUES (?)")) {
+      ps.setInt(1, 99);
+      ps.executeUpdate();
+    }
+    con.rollback();
+
+    try (Statement stmt = con.createStatement();
+         ResultSet rs = stmt.executeQuery("SELECT count(*) FROM pipeline_rb")) {
+      assertTrue(rs.next());
+      assertEquals(0, rs.getInt(1));
+    }
+    con.setAutoCommit(true);
+  }
+
+  @Test
+  public void testErrorHandling() throws SQLException {
+    // Query that will fail
+    try (Statement stmt = con.createStatement()) {
+      assertThrows(SQLException.class, () ->
+          stmt.executeQuery("SELECT * FROM nonexistent_table_xyz"));
+    }
+
+    // Connection should still be usable after error
+    try (Statement stmt = con.createStatement();
+         ResultSet rs = stmt.executeQuery("SELECT 1")) {
+      assertTrue(rs.next());
+      assertEquals(1, rs.getInt(1));
+    }
+  }
+
+  @Test
+  public void testBatchWithError() throws SQLException {
+    TestUtil.createTempTable(con, "pipeline_berr", "id INT PRIMARY KEY");
+    try (PreparedStatement ps = con.prepareStatement(
+        "INSERT INTO pipeline_berr VALUES (?)")) {
+      ps.setInt(1, 1);
+      ps.addBatch();
+      ps.setInt(1, 1); // duplicate key — will fail
+      ps.addBatch();
+      ps.setInt(1, 3);
+      ps.addBatch();
+
+      assertThrows(SQLException.class, ps::executeBatch);
+    }
+
+    // Connection should still be usable
+    try (Statement stmt = con.createStatement();
+         ResultSet rs = stmt.executeQuery("SELECT 1")) {
+      assertTrue(rs.next());
+    }
+  }
+
+  @Test
+  public void testLargeResultSet() throws SQLException {
+    // Test with a generated series — no temp table needed
+    try (Statement stmt = con.createStatement();
+         ResultSet rs = stmt.executeQuery(
+             "SELECT generate_series(1, 10000) AS n")) {
+      int count = 0;
+      while (rs.next()) {
+        count++;
+        assertEquals(count, rs.getInt(1));
+      }
+      assertEquals(10000, count);
+    }
+  }
+
+  @Test
+  public void testNullValues() throws SQLException {
+    try (Statement stmt = con.createStatement();
+         ResultSet rs = stmt.executeQuery("SELECT NULL::text, NULL::int, 'x'::text")) {
+      assertTrue(rs.next());
+      assertNull(rs.getString(1));
+      assertEquals(0, rs.getInt(2));
+      assertTrue(rs.wasNull());
+      assertEquals("x", rs.getString(3));
+    }
+  }
+
+  @Test
+  public void testMultipleResultColumns() throws SQLException {
+    try (Statement stmt = con.createStatement();
+         ResultSet rs = stmt.executeQuery(
+             "SELECT 1::int, 2::bigint, 3.14::float, true::bool, 'test'::text")) {
+      assertTrue(rs.next());
+      assertEquals(1, rs.getInt(1));
+      assertEquals(2L, rs.getLong(2));
+      assertEquals(3.14, rs.getDouble(3), 0.001);
+      assertTrue(rs.getBoolean(4));
+      assertEquals("test", rs.getString(5));
+    }
+  }
+
+  @Test
+  public void testPreparedStatementReuse() throws SQLException {
+    // Tests that prepared statement caching works with pipeline mode
+    try (PreparedStatement ps = con.prepareStatement("SELECT ? + 1")) {
+      for (int i = 0; i < 20; i++) {
+        ps.setInt(1, i);
+        try (ResultSet rs = ps.executeQuery()) {
+          assertTrue(rs.next());
+          assertEquals(i + 1, rs.getInt(1));
+        }
+      }
+    }
+  }
+
+  @Test
+  public void testConnectionMetadata() throws SQLException {
+    // Verify connection is functional for metadata operations
+    assertNotNull(con.getMetaData());
+    assertNotNull(con.getMetaData().getDatabaseProductName());
+    assertTrue(con.getMetaData().getDatabaseProductName().contains("PostgreSQL"));
+  }
+
+  @Test
+  public void testAutoCommitDDL() throws SQLException {
+    TestUtil.createTempTable(con, "pipeline_ddl", "id SERIAL PRIMARY KEY, data TEXT");
+    try (PreparedStatement ps = con.prepareStatement(
+        "INSERT INTO pipeline_ddl (data) VALUES (?) RETURNING id")) {
+      ps.setString(1, "test");
+      try (ResultSet rs = ps.executeQuery()) {
+        assertTrue(rs.next());
+        assertTrue(rs.getInt(1) > 0);
+      }
+    }
+  }
+
+  @Test
+  public void testSyntaxError() throws SQLException {
+    try (Statement stmt = con.createStatement()) {
+      SQLException ex = assertThrows(SQLException.class, () ->
+          stmt.executeQuery("SELEKT 1"));
+      // Should be a syntax error
+      assertTrue(ex.getSQLState().startsWith("42"),
+          "Expected syntax error SQLState 42xxx, got: " + ex.getSQLState());
+      assertTrue(ex.getMessage().contains("syntax"),
+          "Expected 'syntax' in message, got: " + ex.getMessage());
+    }
+
+    // Connection must remain usable
+    try (Statement stmt = con.createStatement();
+         ResultSet rs = stmt.executeQuery("SELECT 42")) {
+      assertTrue(rs.next());
+      assertEquals(42, rs.getInt(1));
+    }
+  }
+
+  @Test
+  public void testDivisionByZero() throws SQLException {
+    try (Statement stmt = con.createStatement()) {
+      SQLException ex = assertThrows(SQLException.class, () ->
+          stmt.executeQuery("SELECT 1/0"));
+      assertEquals("22012", ex.getSQLState(), "Expected division_by_zero SQLState");
+    }
+
+    // Connection must remain usable
+    try (Statement stmt = con.createStatement();
+         ResultSet rs = stmt.executeQuery("SELECT 99")) {
+      assertTrue(rs.next());
+      assertEquals(99, rs.getInt(1));
+    }
+  }
+
+  @Test
+  public void testUniqueViolation() throws SQLException {
+    TestUtil.createTempTable(con, "pipeline_uniq", "id INT PRIMARY KEY");
+    try (Statement stmt = con.createStatement()) {
+      stmt.executeUpdate("INSERT INTO pipeline_uniq VALUES (1)");
+
+      SQLException ex = assertThrows(SQLException.class, () ->
+          stmt.executeUpdate("INSERT INTO pipeline_uniq VALUES (1)"));
+      assertEquals("23505", ex.getSQLState(), "Expected unique_violation SQLState");
+    }
+
+    // Connection must remain usable
+    try (Statement stmt = con.createStatement();
+         ResultSet rs = stmt.executeQuery("SELECT count(*) FROM pipeline_uniq")) {
+      assertTrue(rs.next());
+      assertEquals(1, rs.getInt(1));
+    }
+  }
+
+  @Test
+  public void testErrorInTransaction() throws SQLException {
+    TestUtil.createTempTable(con, "pipeline_txerr", "id INT PRIMARY KEY");
+    con.setAutoCommit(false);
+
+    try (Statement stmt = con.createStatement()) {
+      stmt.executeUpdate("INSERT INTO pipeline_txerr VALUES (1)");
+
+      // This will fail — puts transaction in aborted state
+      assertThrows(SQLException.class, () ->
+          stmt.executeUpdate("INSERT INTO pipeline_txerr VALUES (1)"));
+
+      // Any subsequent query in the aborted transaction should fail
+      SQLException ex = assertThrows(SQLException.class, () ->
+          stmt.executeQuery("SELECT 1"));
+      assertEquals("25P02", ex.getSQLState(),
+          "Expected in_failed_sql_transaction SQLState");
+    }
+
+    // Rollback should recover the connection
+    con.rollback();
+
+    try (Statement stmt = con.createStatement();
+         ResultSet rs = stmt.executeQuery("SELECT count(*) FROM pipeline_txerr")) {
+      assertTrue(rs.next());
+      assertEquals(0, rs.getInt(1));
+    }
+    con.setAutoCommit(true);
+  }
+
+  @Test
+  public void testPreparedStatementWithWrongParamCount() throws SQLException {
+    try (PreparedStatement ps = con.prepareStatement("SELECT ?, ?")) {
+      ps.setInt(1, 1);
+      // Missing parameter 2
+      assertThrows(SQLException.class, ps::executeQuery);
+    }
+
+    // Connection must remain usable
+    try (Statement stmt = con.createStatement();
+         ResultSet rs = stmt.executeQuery("SELECT 1")) {
+      assertTrue(rs.next());
+    }
+  }
+
+  @Test
+  public void testErrorRecoveryMultipleQueries() throws SQLException {
+    // Run several queries, inject an error, then verify recovery with more queries
+    try (Statement stmt = con.createStatement()) {
+      // Successful queries before error
+      for (int i = 0; i < 5; i++) {
+        try (ResultSet rs = stmt.executeQuery("SELECT " + i)) {
+          assertTrue(rs.next());
+          assertEquals(i, rs.getInt(1));
+        }
+      }
+
+      // Error
+      assertThrows(SQLException.class, () ->
+          stmt.executeQuery("SELECT * FROM this_table_does_not_exist"));
+
+      // Successful queries after error
+      for (int i = 10; i < 15; i++) {
+        try (ResultSet rs = stmt.executeQuery("SELECT " + i)) {
+          assertTrue(rs.next());
+          assertEquals(i, rs.getInt(1));
+        }
+      }
+    }
+  }
+
+  @Test
+  public void testRaiseException() throws SQLException {
+    // Use DO block to raise a custom exception
+    try (Statement stmt = con.createStatement()) {
+      SQLException ex = assertThrows(SQLException.class, () ->
+          stmt.execute("DO $$ BEGIN RAISE EXCEPTION 'injected error' USING ERRCODE = 'P0001'; END $$"));
+      assertEquals("P0001", ex.getSQLState(), "Expected raise_exception SQLState");
+      assertTrue(ex.getMessage().contains("injected error"),
+          "Expected 'injected error' in message, got: " + ex.getMessage());
+    }
+
+    // Connection must remain usable
+    try (Statement stmt = con.createStatement();
+         ResultSet rs = stmt.executeQuery("SELECT 'recovered'")) {
+      assertTrue(rs.next());
+      assertEquals("recovered", rs.getString(1));
+    }
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/test/core/PipelineModeTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/core/PipelineModeTest.java
@@ -142,7 +142,7 @@ public class PipelineModeTest extends BaseTest4 {
   public void testTransactionCommit() throws SQLException {
     TestUtil.createTempTable(con, "pipeline_tx", "id INT");
     con.setAutoCommit(false);
-    try (PreparedStatement ps = con.prepareStatement("INSERT INTO pipeline_tx VALUES (?)")) {
+    try (PreparedStatement ps = con.prepareStatement("INSERT INTO pipeline_tx VALUES (?::int)")) {
       ps.setInt(1, 42);
       ps.executeUpdate();
     }
@@ -160,7 +160,7 @@ public class PipelineModeTest extends BaseTest4 {
   public void testTransactionRollback() throws SQLException {
     TestUtil.createTempTable(con, "pipeline_rb", "id INT");
     con.setAutoCommit(false);
-    try (PreparedStatement ps = con.prepareStatement("INSERT INTO pipeline_rb VALUES (?)")) {
+    try (PreparedStatement ps = con.prepareStatement("INSERT INTO pipeline_rb VALUES (?::int)")) {
       ps.setInt(1, 99);
       ps.executeUpdate();
     }
@@ -256,7 +256,7 @@ public class PipelineModeTest extends BaseTest4 {
   @Test
   public void testPreparedStatementReuse() throws SQLException {
     // Tests that prepared statement caching works with pipeline mode
-    try (PreparedStatement ps = con.prepareStatement("SELECT ? + 1")) {
+    try (PreparedStatement ps = con.prepareStatement("SELECT ?::int + 1")) {
       for (int i = 0; i < 20; i++) {
         ps.setInt(1, i);
         try (ResultSet rs = ps.executeQuery()) {
@@ -375,7 +375,7 @@ public class PipelineModeTest extends BaseTest4 {
 
   @Test
   public void testPreparedStatementWithWrongParamCount() throws SQLException {
-    try (PreparedStatement ps = con.prepareStatement("SELECT ?, ?")) {
+    try (PreparedStatement ps = con.prepareStatement("SELECT ?::int, ?::int")) {
       ps.setInt(1, 1);
       // Missing parameter 2
       assertThrows(SQLException.class, ps::executeQuery);

--- a/pgjdbc/src/test/java/org/postgresql/test/core/PipelineModeTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/core/PipelineModeTest.java
@@ -17,6 +17,7 @@ import org.postgresql.test.TestUtil;
 import org.postgresql.test.jdbc2.BaseTest4;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -28,6 +29,7 @@ import java.util.Properties;
  * Integration tests for pipeline mode (dedicated reader thread).
  * Requires a running PostgreSQL server configured via build.local.properties.
  */
+@Timeout(30)
 public class PipelineModeTest extends BaseTest4 {
 
   @Override

--- a/pgjdbc/src/test/java/org/postgresql/test/core/PipelineModeTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/core/PipelineModeTest.java
@@ -88,6 +88,9 @@ public class PipelineModeTest extends BaseTest4 {
 
   @Test
   public void testBatchInsert() throws SQLException {
+    org.junit.jupiter.api.Assumptions.assumeFalse(
+        Boolean.parseBoolean(System.getProperty("reWriteBatchedInserts")),
+        "reWriteBatchedInserts returns SUCCESS_NO_INFO instead of per-row counts");
     TestUtil.createTempTable(con, "pipeline_batch", "id INT, val INT");
     try (PreparedStatement ps = con.prepareStatement(
         "INSERT INTO pipeline_batch (id, val) VALUES (?, ?)")) {

--- a/pgjdbc/src/test/java/org/postgresql/test/core/PipelinePerformanceTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/core/PipelinePerformanceTest.java
@@ -225,7 +225,7 @@ public class PipelinePerformanceTest {
 
   private void runLargeResultFetch(Connection conn, int rows) throws SQLException {
     try (PreparedStatement ps = conn.prepareStatement(
-        "SELECT generate_series(1, ?)")) {
+        "SELECT generate_series(1, ?::int)")) {
       ps.setInt(1, rows);
       try (ResultSet rs = ps.executeQuery()) {
         while (rs.next()) {

--- a/pgjdbc/src/test/java/org/postgresql/test/core/PipelinePerformanceTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/core/PipelinePerformanceTest.java
@@ -11,6 +11,7 @@ import org.postgresql.test.TestUtil;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -26,6 +27,7 @@ import java.util.Properties;
  *
  * <p>Run with: ./gradlew test --tests "org.postgresql.test.core.PipelinePerformanceTest"
  */
+@Timeout(30)
 public class PipelinePerformanceTest {
 
   private static Connection syncConn;

--- a/pgjdbc/src/test/java/org/postgresql/test/core/PipelinePerformanceTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/core/PipelinePerformanceTest.java
@@ -38,7 +38,7 @@ public class PipelinePerformanceTest {
 
   @BeforeAll
   static void setUp() throws SQLException {
-    Logger logger = Logger.getLogger("org.postgresql");
+    Logger logger = Logger.getLogger("org.postgresql.core.v3");
     logger.setLevel(Level.FINEST);
     ConsoleHandler handler = new ConsoleHandler();
     handler.setLevel(Level.FINEST);

--- a/pgjdbc/src/test/java/org/postgresql/test/core/PipelinePerformanceTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/core/PipelinePerformanceTest.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright (c) 2024, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.test.core;
+
+import org.postgresql.PGProperty;
+import org.postgresql.test.TestUtil;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Properties;
+
+/**
+ * Comparative performance test: pipeline mode vs synchronous mode.
+ * Not a JMH benchmark — just a quick A/B comparison to validate
+ * that pipeline mode is at least as fast as synchronous mode.
+ *
+ * <p>Run with: ./gradlew test --tests "org.postgresql.test.core.PipelinePerformanceTest"
+ */
+public class PipelinePerformanceTest {
+
+  private static Connection syncConn;
+  private static Connection pipeConn;
+
+  @BeforeAll
+  static void setUp() throws SQLException {
+    Properties syncProps = new Properties();
+    syncConn = TestUtil.openDB(syncProps);
+
+    Properties pipeProps = new Properties();
+    PGProperty.PIPELINE_MODE.set(pipeProps, true);
+    pipeConn = TestUtil.openDB(pipeProps);
+
+    try (Statement stmt = syncConn.createStatement()) {
+      try {
+        stmt.execute("DROP TABLE IF EXISTS perf_test");
+      } catch (SQLException e) {
+        /* ignore */
+      }
+      stmt.execute("CREATE TABLE perf_test (id INT, val TEXT)");
+    }
+  }
+
+  @AfterAll
+  static void tearDown() throws SQLException {
+    if (syncConn != null) {
+      try (Statement stmt = syncConn.createStatement()) {
+        stmt.execute("DROP TABLE IF EXISTS perf_test");
+      }
+      syncConn.close();
+    }
+    if (pipeConn != null) {
+      pipeConn.close();
+    }
+  }
+
+  @Test
+  public void compareSequentialQueries() throws SQLException {
+    int iterations = 200;
+
+    // Warmup both
+    runSequentialQueries(syncConn, 50);
+    runSequentialQueries(pipeConn, 50);
+
+    // Measure synchronous
+    long syncStart = System.nanoTime();
+    runSequentialQueries(syncConn, iterations);
+    long syncElapsed = System.nanoTime() - syncStart;
+
+    // Measure pipeline
+    long pipeStart = System.nanoTime();
+    runSequentialQueries(pipeConn, iterations);
+    long pipeElapsed = System.nanoTime() - pipeStart;
+
+    double syncMs = syncElapsed / 1_000_000.0;
+    double pipeMs = pipeElapsed / 1_000_000.0;
+    double ratio = syncMs / pipeMs;
+
+    System.out.printf("%n=== Sequential Queries (%d iterations) ===%n", iterations);
+    System.out.printf("  Synchronous: %.2f ms%n", syncMs);
+    System.out.printf("  Pipeline:    %.2f ms%n", pipeMs);
+    System.out.printf("  Ratio:       %.2fx %s%n", ratio,
+        ratio > 1 ? "(pipeline faster)" : "(sync faster)");
+  }
+
+  @Test
+  public void compareBatchInsert() throws SQLException {
+    int batchSize = 500;
+
+    // Warmup
+    runBatchInsert(syncConn, 100);
+    runBatchInsert(pipeConn, 100);
+
+    // Measure synchronous
+    long syncStart = System.nanoTime();
+    runBatchInsert(syncConn, batchSize);
+    long syncElapsed = System.nanoTime() - syncStart;
+
+    // Measure pipeline
+    long pipeStart = System.nanoTime();
+    runBatchInsert(pipeConn, batchSize);
+    long pipeElapsed = System.nanoTime() - pipeStart;
+
+    double syncMs = syncElapsed / 1_000_000.0;
+    double pipeMs = pipeElapsed / 1_000_000.0;
+    double ratio = syncMs / pipeMs;
+
+    System.out.printf("%n=== Batch Insert (%d rows) ===%n", batchSize);
+    System.out.printf("  Synchronous: %.2f ms%n", syncMs);
+    System.out.printf("  Pipeline:    %.2f ms%n", pipeMs);
+    System.out.printf("  Ratio:       %.2fx %s%n", ratio,
+        ratio > 1 ? "(pipeline faster)" : "(sync faster)");
+  }
+
+  @Test
+  public void comparePreparedStatementReuse() throws SQLException {
+    int iterations = 500;
+
+    // Warmup
+    runPreparedReuse(syncConn, 100);
+    runPreparedReuse(pipeConn, 100);
+
+    // Measure synchronous
+    long syncStart = System.nanoTime();
+    runPreparedReuse(syncConn, iterations);
+    long syncElapsed = System.nanoTime() - syncStart;
+
+    // Measure pipeline
+    long pipeStart = System.nanoTime();
+    runPreparedReuse(pipeConn, iterations);
+    long pipeElapsed = System.nanoTime() - pipeStart;
+
+    double syncMs = syncElapsed / 1_000_000.0;
+    double pipeMs = pipeElapsed / 1_000_000.0;
+    double ratio = syncMs / pipeMs;
+
+    System.out.printf("%n=== Prepared Statement Reuse (%d iterations) ===%n", iterations);
+    System.out.printf("  Synchronous: %.2f ms%n", syncMs);
+    System.out.printf("  Pipeline:    %.2f ms%n", pipeMs);
+    System.out.printf("  Ratio:       %.2fx %s%n", ratio,
+        ratio > 1 ? "(pipeline faster)" : "(sync faster)");
+  }
+
+  @Test
+  public void compareLargeResultFetch() throws SQLException {
+    int rows = 10000;
+
+    // Warmup
+    runLargeResultFetch(syncConn, 1000);
+    runLargeResultFetch(pipeConn, 1000);
+
+    // Measure synchronous
+    long syncStart = System.nanoTime();
+    runLargeResultFetch(syncConn, rows);
+    long syncElapsed = System.nanoTime() - syncStart;
+
+    // Measure pipeline
+    long pipeStart = System.nanoTime();
+    runLargeResultFetch(pipeConn, rows);
+    long pipeElapsed = System.nanoTime() - pipeStart;
+
+    double syncMs = syncElapsed / 1_000_000.0;
+    double pipeMs = pipeElapsed / 1_000_000.0;
+    double ratio = syncMs / pipeMs;
+
+    System.out.printf("%n=== Large Result Fetch (%d rows) ===%n", rows);
+    System.out.printf("  Synchronous: %.2f ms%n", syncMs);
+    System.out.printf("  Pipeline:    %.2f ms%n", pipeMs);
+    System.out.printf("  Ratio:       %.2fx %s%n", ratio,
+        ratio > 1 ? "(pipeline faster)" : "(sync faster)");
+  }
+
+  private void runSequentialQueries(Connection conn, int n) throws SQLException {
+    try (PreparedStatement ps = conn.prepareStatement("SELECT ?::int + 1")) {
+      for (int i = 0; i < n; i++) {
+        ps.setInt(1, i);
+        try (ResultSet rs = ps.executeQuery()) {
+          rs.next();
+          rs.getInt(1);
+        }
+      }
+    }
+  }
+
+  private void runBatchInsert(Connection conn, int n) throws SQLException {
+    try (Statement stmt = conn.createStatement()) {
+      stmt.execute("TRUNCATE perf_test");
+    }
+    try (PreparedStatement ps = conn.prepareStatement(
+        "INSERT INTO perf_test (id, val) VALUES (?, ?)")) {
+      for (int i = 0; i < n; i++) {
+        ps.setInt(1, i);
+        ps.setString(2, "value_" + i);
+        ps.addBatch();
+      }
+      ps.executeBatch();
+    }
+  }
+
+  private void runPreparedReuse(Connection conn, int n) throws SQLException {
+    try (PreparedStatement ps = conn.prepareStatement(
+        "SELECT ?::int, ?::text, ?::float8")) {
+      for (int i = 0; i < n; i++) {
+        ps.setInt(1, i);
+        ps.setString(2, "test");
+        ps.setDouble(3, i * 1.5);
+        try (ResultSet rs = ps.executeQuery()) {
+          rs.next();
+          rs.getInt(1);
+          rs.getString(2);
+          rs.getDouble(3);
+        }
+      }
+    }
+  }
+
+  private void runLargeResultFetch(Connection conn, int rows) throws SQLException {
+    try (PreparedStatement ps = conn.prepareStatement(
+        "SELECT generate_series(1, ?)")) {
+      ps.setInt(1, rows);
+      try (ResultSet rs = ps.executeQuery()) {
+        while (rs.next()) {
+          rs.getInt(1);
+        }
+      }
+    }
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/test/core/PipelinePerformanceTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/core/PipelinePerformanceTest.java
@@ -19,6 +19,9 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Properties;
+import java.util.logging.ConsoleHandler;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Comparative performance test: pipeline mode vs synchronous mode.
@@ -35,6 +38,12 @@ public class PipelinePerformanceTest {
 
   @BeforeAll
   static void setUp() throws SQLException {
+    Logger logger = Logger.getLogger("org.postgresql");
+    logger.setLevel(Level.FINEST);
+    ConsoleHandler handler = new ConsoleHandler();
+    handler.setLevel(Level.FINEST);
+    logger.addHandler(handler);
+
     Properties syncProps = new Properties();
     syncConn = TestUtil.openDB(syncProps);
 


### PR DESCRIPTION
feat(pipeline): route simple queries through reader thread (Option B)
    
    Remove pause/unpause mechanism from PipelineReaderThread and instead
    route simple protocol queries through the pipeline via new
    executeSimplePipeline() and executeBatchSimplePipeline() methods.
    
    Key changes:
    - Remove pause()/unpause() and associated polling logic from reader thread
    - Add executeSimplePipeline() that sends 'Q' messages and waits on a
      ResponseSlot for the reader thread to deliver results
    - Add executeBatchSimplePipeline() for batch simple query execution
    - Fix slot ordering: add slots to pending queue before flush/sync to
      prevent race where reader processes response before slot exists