### PR TITLE
Use nio

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -142,7 +142,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     needs: matrix_prep
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix: ${{fromJson(needs.matrix_prep.outputs.matrix)}}
     env:
       ACTIONS_STEP_DEBUG: true
@@ -394,6 +394,26 @@ jobs:
       with:
         name: ${{ steps.artifact_name.outputs.name }}
         path: ${{ runner.temp }}/pg-server-logs.txt
+    - name: Sanitize test results artifact name
+      if: ${{ always() }}
+      id: test_artifact_name
+      shell: bash
+      env:
+        MATRIX_NAME: ${{ matrix.name }}
+      run: |
+        name="test-results-${MATRIX_NAME}"
+        name="${name//[\":<>|*?\\\/]/}"
+        name="${name:0:256}"
+        echo "name=$name" >> "$GITHUB_OUTPUT"
+    - name: Upload test results
+      if: ${{ always() }}
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: ${{ steps.test_artifact_name.outputs.name }}
+        path: |
+          pgjdbc/build/test-results/test/
+          pgjdbc-*.log
+        retention-days: 7
     - name: Test GSS
       if: ${{ matrix.gss == 'yes' }}
       # language=bash

--- a/pgjdbc/build.gradle.kts
+++ b/pgjdbc/build.gradle.kts
@@ -398,6 +398,7 @@ val sourceDistribution by tasks.registering(Tar::class) {
             exclude("**/*Suite*")
             exclude("*/org/postgresql/test/sspi/*.java")
             exclude("*/org/postgresql/replication/**")
+            exclude("*/org/postgresql/test/core/PipelinePerformanceTest.java")
         }
         from(testKitSourcesWithoutAnnotationsResolved.elements.map { set ->
             set.map {

--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -482,6 +482,16 @@ public enum PGProperty {
       "Port of the PostgreSQL server (may be specified directly in the JDBC URL)"),
 
   /**
+   * Enable pipeline mode with a dedicated reader thread. When true, the driver uses a separate
+   * thread to read responses from the server, allowing send and receive to be decoupled.
+   * This enables true protocol-level pipelining for batch operations.
+   */
+  PIPELINE_MODE(
+      "pipelineMode",
+      "false",
+      "Enable pipeline mode with a dedicated reader thread for decoupled send/receive."),
+
+  /**
    * Specifies which mode is used to execute queries to database: simple means ('Q' execute, no parse, no bind, text mode only),
    * extended means always use bind/execute messages, extendedForPrepared means extended for prepared statements only,
    * extendedCacheEverything means use extended protocol and try cache every statement (including Statement.execute(String sql)) in a query cache.

--- a/pgjdbc/src/main/java/org/postgresql/core/QueryExecutorBase.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/QueryExecutorBase.java
@@ -74,6 +74,12 @@ public abstract class QueryExecutorBase implements QueryExecutor {
   protected final ResourceLock lock = new ResourceLock();
   protected final Condition lockCondition = lock.newCondition();
 
+  /**
+   * Lock used in pipeline mode to serialize access to the send path (pgOutput).
+   * In non-pipeline mode this is unused — the main {@link #lock} covers everything.
+   */
+  protected final ResourceLock sendLock = new ResourceLock();
+
   @SuppressWarnings({"assignment", "argument", "method.invocation"})
   protected QueryExecutorBase(PGStream pgStream, int cancelSignalTimeout, Properties info) throws SQLException {
     this.pgStream = pgStream;
@@ -109,6 +115,13 @@ public abstract class QueryExecutorBase implements QueryExecutor {
 
   protected QueryExecutorCloseAction createCloseAction() {
     return new QueryExecutorCloseAction(pgStream);
+  }
+
+  /**
+   * Returns whether server error detail should be included in error messages.
+   */
+  public boolean getLogServerErrorDetail() {
+    return logServerErrorDetail;
   }
 
   /**

--- a/pgjdbc/src/main/java/org/postgresql/core/QueryExecutorBase.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/QueryExecutorBase.java
@@ -76,6 +76,8 @@ public abstract class QueryExecutorBase implements QueryExecutor {
 
   /**
    * Lock used in pipeline mode to serialize access to the send path (pgOutput).
+   * In the current synchronous pipeline design this is never contended (no reader thread),
+   * but is retained for correctness if the connection is shared across threads.
    * In non-pipeline mode this is unused — the main {@link #lock} covers everything.
    */
   protected final ResourceLock sendLock = new ResourceLock();

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/PipelineResponseReader.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/PipelineResponseReader.java
@@ -1,0 +1,461 @@
+/*
+ * Copyright (c) 2026, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.core.v3;
+
+import org.postgresql.core.CommandCompleteParser;
+import org.postgresql.core.Field;
+import org.postgresql.core.Notification;
+import org.postgresql.core.PGStream;
+import org.postgresql.core.PgMessageType;
+import org.postgresql.core.TransactionState;
+import org.postgresql.core.Tuple;
+import org.postgresql.util.PSQLException;
+import org.postgresql.util.PSQLState;
+import org.postgresql.util.PSQLWarning;
+import org.postgresql.util.ServerErrorMessage;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.io.IOException;
+import java.net.SocketTimeoutException;
+import java.sql.SQLException;
+import java.sql.SQLWarning;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * NIO-style pipeline response reader. Supports both blocking reads (for final drain)
+ * and non-blocking reads (for interleaved send/receive during batch execution).
+ *
+ * <p>This implements "Option A" NIO pipelining: a single thread interleaves sending
+ * queries and reading responses using non-blocking read checks. During batch execution,
+ * the caller sends a chunk of queries, then calls {@link #readAvailableResponses} to
+ * drain any responses that have arrived without blocking, then sends more queries.
+ * After all queries are sent, {@link #readResponses} blocks until all responses arrive.</p>
+ */
+class PipelineResponseReader {
+
+  private static final Logger LOGGER = Logger.getLogger(PipelineResponseReader.class.getName());
+
+  private final PGStream pgStream;
+  private final QueryExecutorImpl executor;
+  private final CommandCompleteParser commandCompleteParser = new CommandCompleteParser();
+
+  /** Current slot index being populated — maintained across non-blocking read calls. */
+  private int slotIndex;
+  /** Current slot being populated — maintained across non-blocking read calls. */
+  private @Nullable ResponseSlot currentSlot;
+  /** The slot list for the current pipeline execution. */
+  private @Nullable List<ResponseSlot> slots;
+  /** Whether ReadyForQuery has been received for the current pipeline. */
+  private boolean receivedRFQ;
+
+  PipelineResponseReader(PGStream pgStream, QueryExecutorImpl executor) {
+    this.pgStream = pgStream;
+    this.executor = executor;
+  }
+
+  /**
+   * Read all responses for the given slots, blocking until ReadyForQuery is received.
+   * If {@link #readAvailableResponses} was previously called with the same slot list,
+   * this resumes from where it left off. Otherwise starts fresh.
+   */
+  void readResponses(List<ResponseSlot> slots) throws SQLException {
+    if (this.slots != slots) {
+      begin(slots);
+    }
+    if (receivedRFQ) {
+      end();
+      return;
+    }
+    try {
+      while (!receivedRFQ) {
+        processOneMessage();
+      }
+    } catch (IOException e) {
+      failRemaining(new PSQLException(
+          "An I/O error occurred while reading from the backend.",
+          PSQLState.CONNECTION_FAILURE, e));
+      throw new PSQLException(
+          "An I/O error occurred while reading from the backend.",
+          PSQLState.CONNECTION_FAILURE, e);
+    } finally {
+      end();
+    }
+  }
+
+  /**
+   * Non-blocking read: process any responses that are immediately available without blocking.
+   * Uses a short SO_TIMEOUT to avoid blocking when no data is available.
+   *
+   * <p>Call this between sending chunks of queries during batch execution to drain
+   * responses and keep the TCP window open.</p>
+   *
+   * @param slots the slot list (must be the same list across all calls for one pipeline)
+   * @return the number of slots completed during this call
+   */
+  int readAvailableResponses(List<ResponseSlot> slots) throws SQLException {
+    if (this.slots == null) {
+      begin(slots);
+    }
+    int completedBefore = slotIndex;
+    int savedTimeout;
+    try {
+      savedTimeout = pgStream.getNetworkTimeout();
+    } catch (IOException e) {
+      throw new PSQLException(
+          "Failed to get network timeout",
+          PSQLState.CONNECTION_FAILURE, e);
+    }
+
+    try {
+      // Set a very short timeout for non-blocking behavior
+      pgStream.setNetworkTimeout(1);
+
+      // Read as many messages as are available
+      while (!receivedRFQ && pgStream.hasMessagePending()) {
+        processOneMessage();
+      }
+    } catch (SocketTimeoutException e) {
+      // No more data available — this is expected
+    } catch (IOException e) {
+      failRemaining(new PSQLException(
+          "An I/O error occurred while reading from the backend.",
+          PSQLState.CONNECTION_FAILURE, e));
+      throw new PSQLException(
+          "An I/O error occurred while reading from the backend.",
+          PSQLState.CONNECTION_FAILURE, e);
+    } finally {
+      try {
+        pgStream.setNetworkTimeout(savedTimeout);
+      } catch (IOException e) {
+        // best effort restore
+      }
+    }
+    return slotIndex - completedBefore;
+  }
+
+  /**
+   * After non-blocking reads, block until all remaining responses arrive.
+   * Call this after all queries have been sent and flushed.
+   */
+  void drainRemaining() throws SQLException {
+    if (slots == null || receivedRFQ) {
+      end();
+      return;
+    }
+    try {
+      while (!receivedRFQ) {
+        processOneMessage();
+      }
+    } catch (IOException e) {
+      failRemaining(new PSQLException(
+          "An I/O error occurred while reading from the backend.",
+          PSQLState.CONNECTION_FAILURE, e));
+      throw new PSQLException(
+          "An I/O error occurred while reading from the backend.",
+          PSQLState.CONNECTION_FAILURE, e);
+    } finally {
+      end();
+    }
+  }
+
+  /** Returns true if ReadyForQuery has been received. */
+  boolean isComplete() {
+    return receivedRFQ;
+  }
+
+  private void begin(List<ResponseSlot> slots) {
+    this.slots = slots;
+    this.slotIndex = 0;
+    this.currentSlot = null;
+    this.receivedRFQ = false;
+  }
+
+  private void end() {
+    this.slots = null;
+    this.currentSlot = null;
+  }
+
+  private void processOneMessage() throws IOException, SQLException {
+    int c = pgStream.receiveChar();
+    List<ResponseSlot> slots = this.slots;
+    if (slots == null) {
+      throw new IOException("processOneMessage called with no active slot list");
+    }
+
+    switch (c) {
+      case PgMessageType.PARSE_COMPLETE_RESPONSE: // '1'
+        pgStream.receiveInteger4();
+        LOGGER.log(Level.FINEST, " <=BE ParseComplete");
+        break;
+
+      case PgMessageType.BIND_COMPLETE_RESPONSE: // '2'
+        pgStream.receiveInteger4();
+        LOGGER.log(Level.FINEST, " <=BE BindComplete");
+        break;
+
+      case PgMessageType.CLOSE_COMPLETE_RESPONSE: // '3'
+        pgStream.receiveInteger4();
+        LOGGER.log(Level.FINEST, " <=BE CloseComplete");
+        break;
+
+      case PgMessageType.NO_DATA_RESPONSE: // 'n'
+        pgStream.receiveInteger4();
+        LOGGER.log(Level.FINEST, " <=BE NoData");
+        break;
+
+      case PgMessageType.PARAMETER_DESCRIPTION_RESPONSE: // 't'
+        receiveParameterDescription();
+        break;
+
+      case PgMessageType.ROW_DESCRIPTION_RESPONSE: { // 'T'
+        Field[] fields = receiveRowDescription();
+        advanceSlot(slots);
+        if (currentSlot != null && currentSlot.query != null) {
+          currentSlot.fields = fields;
+          currentSlot.query.setFields(fields);
+        }
+        break;
+      }
+
+      case PgMessageType.DATA_ROW_RESPONSE: { // 'D'
+        Tuple tuple = receiveDataRow();
+        advanceSlot(slots);
+        if (currentSlot != null) {
+          currentSlot.addTuple(tuple);
+        }
+        break;
+      }
+
+      case PgMessageType.COMMAND_COMPLETE_RESPONSE: { // 'C'
+        String status = receiveCommandComplete();
+        advanceSlot(slots);
+        ResponseSlot slot = currentSlot;
+        if (slot != null) {
+          slot.commandStatus = status;
+          commandCompleteParser.parse(status);
+          slot.updateCount = commandCompleteParser.getRows();
+          slot.insertOID = commandCompleteParser.getOid();
+          if (!slot.asSimple) {
+            slot.complete();
+            currentSlot = null;
+            slotIndex++;
+          }
+        }
+        break;
+      }
+
+      case PgMessageType.EMPTY_QUERY_RESPONSE: { // 'I'
+        pgStream.receiveInteger4();
+        LOGGER.log(Level.FINEST, " <=BE EmptyQuery");
+        advanceSlot(slots);
+        if (currentSlot != null) {
+          currentSlot.commandStatus = "EMPTY";
+          currentSlot.complete();
+          currentSlot = null;
+          slotIndex++;
+        }
+        break;
+      }
+
+      case PgMessageType.PORTAL_SUSPENDED_RESPONSE: { // 's'
+        pgStream.receiveInteger4();
+        LOGGER.log(Level.FINEST, " <=BE PortalSuspended");
+        if (currentSlot != null) {
+          currentSlot.portalSuspended = true;
+          currentSlot.complete();
+          currentSlot = null;
+          slotIndex++;
+        }
+        break;
+      }
+
+      case PgMessageType.ERROR_RESPONSE: { // 'E'
+        PSQLException error = receiveError();
+        advanceSlot(slots);
+        if (currentSlot != null) {
+          currentSlot.completeExceptionally(error);
+          currentSlot = null;
+          slotIndex++;
+        }
+        break;
+      }
+
+      case PgMessageType.NOTICE_RESPONSE: { // 'N'
+        SQLWarning warning = receiveNotice();
+        if (currentSlot != null) {
+          currentSlot.addWarning(warning);
+        } else {
+          executor.addWarning(warning);
+        }
+        break;
+      }
+
+      case PgMessageType.PARAMETER_STATUS_RESPONSE: // 'S'
+        executor.receiveParameterStatus();
+        break;
+
+      case PgMessageType.ASYNCHRONOUS_NOTICE: // 'A'
+        receiveAsyncNotify();
+        break;
+
+      case PgMessageType.READY_FOR_QUERY_RESPONSE: { // 'Z'
+        receiveReadyForQuery();
+        // Complete current slot if still active (simple query case)
+        if (currentSlot != null) {
+          currentSlot.complete();
+          currentSlot = null;
+          slotIndex++;
+        }
+        // Fail any remaining slots (error cascading after server error)
+        while (slotIndex < slots.size()) {
+          ResponseSlot slot = slots.get(slotIndex);
+          if (slot != ResponseSlot.SYNC_MARKER) {
+            slot.completeExceptionally(new PSQLException(
+                "Query discarded due to prior error in pipeline batch",
+                PSQLState.IN_FAILED_SQL_TRANSACTION));
+          }
+          slotIndex++;
+        }
+        receivedRFQ = true;
+        break;
+      }
+
+      default: {
+        int len = pgStream.receiveInteger4();
+        if (len > 4) {
+          pgStream.receive(len - 4);
+        }
+        LOGGER.log(Level.WARNING, " <=BE Unknown message type: {0}", (char) c);
+        break;
+      }
+    }
+  }
+
+  private void advanceSlot(List<ResponseSlot> slots) {
+    if (currentSlot == null && slotIndex < slots.size()) {
+      currentSlot = slots.get(slotIndex);
+    }
+  }
+
+  private void failRemaining(PSQLException ex) {
+    if (currentSlot != null) {
+      currentSlot.completeExceptionally(ex);
+      currentSlot = null;
+      slotIndex++;
+    }
+    List<ResponseSlot> slots = this.slots;
+    if (slots != null) {
+      while (slotIndex < slots.size()) {
+        ResponseSlot slot = slots.get(slotIndex);
+        if (slot != ResponseSlot.SYNC_MARKER) {
+          slot.completeExceptionally(ex);
+        }
+        slotIndex++;
+      }
+    }
+  }
+
+  private Field[] receiveRowDescription() throws IOException {
+    pgStream.receiveInteger4(); // message size
+    int size = pgStream.receiveInteger2();
+    Field[] fields = new Field[size];
+
+    for (int i = 0; i < fields.length; i++) {
+      String columnLabel = pgStream.receiveCanonicalString();
+      int tableOid = pgStream.receiveInteger4();
+      short positionInTable = (short) pgStream.receiveInteger2();
+      int typeOid = pgStream.receiveInteger4();
+      short typeLength = (short) pgStream.receiveInteger2();
+      int typeModifier = pgStream.receiveInteger4();
+      short formatType = (short) pgStream.receiveInteger2();
+      fields[i] = new Field(columnLabel, typeOid, typeLength, typeModifier, tableOid, positionInTable);
+      fields[i].setFormat(formatType);
+    }
+
+    LOGGER.log(Level.FINEST, " <=BE RowDescription({0})", size);
+    return fields;
+  }
+
+  private void receiveParameterDescription() throws IOException {
+    pgStream.receiveInteger4(); // message size
+    int numParams = pgStream.receiveInteger2();
+    for (int i = 0; i < numParams; i++) {
+      pgStream.receiveInteger4(); // type OID
+    }
+    LOGGER.log(Level.FINEST, " <=BE ParameterDescription({0})", numParams);
+  }
+
+  private Tuple receiveDataRow() throws IOException {
+    try {
+      Tuple tuple = pgStream.receiveTupleV3();
+      if (LOGGER.isLoggable(Level.FINEST)) {
+        LOGGER.log(Level.FINEST, " <=BE DataRow(len={0})", tuple.length());
+      }
+      return tuple;
+    } catch (OutOfMemoryError oome) {
+      throw new IOException("Ran out of memory retrieving query results", oome);
+    } catch (SQLException e) {
+      throw new IOException("Error receiving data row", e);
+    }
+  }
+
+  private String receiveCommandComplete() throws IOException {
+    int len = pgStream.receiveInteger4();
+    String status = pgStream.receiveString(len - 5);
+    pgStream.receiveChar(); // trailing \0
+    LOGGER.log(Level.FINEST, " <=BE CommandStatus({0})", status);
+    return status;
+  }
+
+  private PSQLException receiveError() throws IOException {
+    int elen = pgStream.receiveInteger4();
+    ServerErrorMessage errorMsg = new ServerErrorMessage(
+        pgStream.receiveErrorString(elen - 4));
+    LOGGER.log(Level.FINEST, " <=BE ErrorMessage({0})", errorMsg.toString());
+    return new PSQLException(errorMsg, executor.getLogServerErrorDetail());
+  }
+
+  private SQLWarning receiveNotice() throws IOException {
+    int nlen = pgStream.receiveInteger4();
+    ServerErrorMessage warnMsg = new ServerErrorMessage(pgStream.receiveErrorString(nlen - 4));
+    LOGGER.log(Level.FINEST, " <=BE NoticeResponse({0})", warnMsg.toString());
+    return new PSQLWarning(warnMsg);
+  }
+
+  private void receiveAsyncNotify() throws IOException {
+    pgStream.receiveInteger4(); // message length
+    int pid = pgStream.receiveInteger4();
+    String msg = pgStream.receiveCanonicalString();
+    String param = pgStream.receiveString();
+    executor.addNotification(new Notification(msg, pid, param));
+    LOGGER.log(Level.FINEST, " <=BE AsyncNotify({0},{1},{2})", new Object[]{pid, msg, param});
+  }
+
+  private void receiveReadyForQuery() throws IOException {
+    if (pgStream.receiveInteger4() != 5) {
+      throw new IOException("unexpected length of ReadyForQuery message");
+    }
+    char tStatus = (char) pgStream.receiveChar();
+    LOGGER.log(Level.FINEST, " <=BE ReadyForQuery({0})", tStatus);
+
+    switch (tStatus) {
+      case 'I':
+        executor.setTransactionState(TransactionState.IDLE);
+        break;
+      case 'T':
+        executor.setTransactionState(TransactionState.OPEN);
+        break;
+      case 'E':
+        executor.setTransactionState(TransactionState.FAILED);
+        break;
+      default:
+        throw new IOException("unexpected transaction state: " + (int) tStatus);
+    }
+  }
+}

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/PipelineResponseReader.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/PipelineResponseReader.java
@@ -169,6 +169,33 @@ class PipelineResponseReader {
     return receivedRFQ;
   }
 
+  /**
+   * Read responses for a single Execute (cursor fetch) without requiring Sync/ReadyForQuery.
+   * Reads until the slot is completed by PortalSuspended or CommandComplete.
+   * This avoids the round-trip cost of Sync for each fetch iteration.
+   */
+  void readFetchResponse(List<ResponseSlot> slots) throws SQLException {
+    if (this.slots != slots) {
+      begin(slots);
+    }
+    try {
+      // Read until the slot is advanced (completed by PortalSuspended or CommandComplete)
+      int startIndex = slotIndex;
+      while (slotIndex == startIndex) {
+        processOneMessage();
+      }
+    } catch (IOException e) {
+      failRemaining(new PSQLException(
+          "An I/O error occurred while reading from the backend.",
+          PSQLState.CONNECTION_FAILURE, e));
+      throw new PSQLException(
+          "An I/O error occurred while reading from the backend.",
+          PSQLState.CONNECTION_FAILURE, e);
+    } finally {
+      end();
+    }
+  }
+
   private void begin(List<ResponseSlot> slots) {
     this.slots = slots;
     this.slotIndex = 0;

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -3660,7 +3660,8 @@ public class QueryExecutorImpl extends QueryExecutorBase {
 
     try (ResourceLock ignore = sendLock.obtain()) {
       sendExecute(query, portal, fetchSize);
-      sendSync();
+      // No Sync — read response directly after Execute.
+      // Server responds with DataRow* + PortalSuspended or CommandComplete.
       pgStream.flush();
     } catch (IOException e) {
       abort();
@@ -3671,16 +3672,14 @@ public class QueryExecutorImpl extends QueryExecutorBase {
       return;
     }
 
-    // Read responses synchronously
+    // Read until PortalSuspended or CommandComplete (no ReadyForQuery expected)
     try {
-      castNonNull(pipelineResponseReader).readResponses(slots);
+      castNonNull(pipelineResponseReader).readFetchResponse(slots);
     } catch (SQLException e) {
-      clearPipelinePendingQueues();
       handler.handleError(e);
       handler.handleCompletion();
       return;
     }
-    clearPipelinePendingQueues();
 
     // Deliver fetch results
     if (slot.error != null) {

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -239,9 +239,16 @@ public class QueryExecutorImpl extends QueryExecutorBase {
 
     this.allowEncodingChanges = PGProperty.ALLOW_ENCODING_CHANGES.getBoolean(info);
     this.cleanupSavePoints = PGProperty.CLEANUP_SAVEPOINTS.getBoolean(info);
+    this.pipelineMode = PGProperty.PIPELINE_MODE.getBoolean(info);
     // assignment, argument
     this.replicationProtocol = new V3ReplicationProtocol(this, pgStream);
     readStartupMessages();
+
+    if (pipelineMode) {
+      this.pipelineResponseReader = new PipelineResponseReader(pgStream, this);
+    } else {
+      this.pipelineResponseReader = null;
+    }
   }
 
   @Override
@@ -398,6 +405,21 @@ public class QueryExecutorImpl extends QueryExecutorBase {
 
   @Override
   public void execute(Query query, @Nullable ParameterList parameters,
+      ResultHandler handler,
+      int maxRows, int fetchSize, int flags, boolean adaptiveFetch) throws SQLException {
+    if (pipelineMode) {
+      if ((flags & QueryExecutor.QUERY_EXECUTE_AS_SIMPLE) == 0) {
+        executePipeline(query, parameters, handler, maxRows, fetchSize, flags);
+        return;
+      }
+      // Simple queries can't use pipeline protocol — execute synchronously
+      executeSynchronous(query, parameters, handler, maxRows, fetchSize, flags, adaptiveFetch);
+      return;
+    }
+    executeSynchronous(query, parameters, handler, maxRows, fetchSize, flags, adaptiveFetch);
+  }
+
+  private void executeSynchronous(Query query, @Nullable ParameterList parameters,
       ResultHandler handler,
       int maxRows, int fetchSize, int flags, boolean adaptiveFetch) throws SQLException {
     try (ResourceLock ignore = lock.obtain()) {
@@ -629,6 +651,20 @@ public class QueryExecutorImpl extends QueryExecutorBase {
 
   @Override
   public void execute(Query[] queries, @Nullable ParameterList[] parameterLists,
+      BatchResultHandler batchHandler, int maxRows, int fetchSize, int flags, boolean adaptiveFetch)
+      throws SQLException {
+    if (pipelineMode) {
+      if ((flags & QueryExecutor.QUERY_EXECUTE_AS_SIMPLE) != 0) {
+        executeBatchSynchronous(queries, parameterLists, batchHandler, maxRows, fetchSize, flags, adaptiveFetch);
+        return;
+      }
+      executeBatchPipeline(queries, parameterLists, batchHandler, maxRows, flags);
+      return;
+    }
+    executeBatchSynchronous(queries, parameterLists, batchHandler, maxRows, fetchSize, flags, adaptiveFetch);
+  }
+
+  private void executeBatchSynchronous(Query[] queries, @Nullable ParameterList[] parameterLists,
       BatchResultHandler batchHandler, int maxRows, int fetchSize, int flags, boolean adaptiveFetch)
       throws SQLException {
     try (ResourceLock ignore = lock.obtain()) {
@@ -2792,6 +2828,10 @@ public class QueryExecutorImpl extends QueryExecutorBase {
   @Override
   public void fetch(ResultCursor cursor, ResultHandler handler, int fetchSize,
       boolean adaptiveFetch) throws SQLException {
+    if (pipelineMode) {
+      fetchPipeline(cursor, handler, fetchSize);
+      return;
+    }
     try (ResourceLock ignore = lock.obtain()) {
       waitOnLock();
       final Portal portal = (Portal) cursor;
@@ -2888,9 +2928,9 @@ public class QueryExecutorImpl extends QueryExecutorBase {
       int tableOid = pgStream.receiveInteger4();
       short positionInTable = (short) pgStream.receiveInteger2();
       int typeOid = pgStream.receiveInteger4();
-      short typeLength = (short) pgStream.receiveInteger2();
+      short typeLength = (short)pgStream.receiveInteger2();
       int typeModifier = pgStream.receiveInteger4();
-      int formatType = pgStream.receiveInteger2();
+      short formatType = (short)pgStream.receiveInteger2();
       fields[i] = new Field(columnLabel,
           typeOid, typeLength, typeModifier, tableOid, positionInTable);
       fields[i].setFormat(formatType);
@@ -3277,6 +3317,21 @@ public class QueryExecutorImpl extends QueryExecutorBase {
       new ArrayDeque<>();
   private final Deque<SimpleQuery> pendingDescribePortalQueue = new ArrayDeque<>();
 
+  /**
+   * Clear pending queues after pipeline execution. The pipeline path uses
+   * {@link PipelineResponseReader} to process responses independently, but the send methods
+   * (sendParse, sendBind, sendDescribePortal, sendExecute, sendSync) still add entries to these
+   * queues. If not cleared, subsequent {@link #executeSynchronous} calls will find stale entries
+   * and {@code processResults} will misinterpret responses.
+   */
+  private void clearPipelinePendingQueues() {
+    pendingParseQueue.clear();
+    pendingBindQueue.clear();
+    pendingExecuteQueue.clear();
+    pendingDescribeStatementQueue.clear();
+    pendingDescribePortalQueue.clear();
+  }
+
   private long nextUniqueID = 1;
   private final boolean allowEncodingChanges;
   private final boolean cleanupSavePoints;
@@ -3324,4 +3379,363 @@ public class QueryExecutorImpl extends QueryExecutorBase {
       new SimpleQuery(
           new NativeQuery("ROLLBACK TO SAVEPOINT PGJDBC_AUTOSAVE", null, false, SqlCommand.BLANK),
           null, false);
+
+  @Override
+  public void close() {
+    shutdownPipelineReader();
+    super.close();
+  }
+
+  @Override
+  public void abort() {
+    shutdownPipelineReader();
+    super.abort();
+  }
+
+  private void shutdownPipelineReader() {
+    // No-op: no reader thread to shut down in NIO mode
+  }
+
+  // --- Pipeline mode fields ---
+  private final boolean pipelineMode;
+  private final @Nullable PipelineResponseReader pipelineResponseReader;
+
+  /**
+   * Execute a single query in pipeline mode. Sends messages, flushes,
+   * then reads all responses synchronously on the calling thread.
+   */
+  private void executePipeline(Query query, @Nullable ParameterList parameters,
+      ResultHandler handler, int maxRows, int fetchSize, int flags) throws SQLException {
+
+    // Handle CompositeQuery (multi-statement SQL) by executing each subquery
+    Query[] subqueries = query.getSubqueries();
+    if (subqueries != null) {
+      SimpleParameterList[] subparams = parameters != null
+          ? ((SimpleParameterList) parameters).getSubparams() : null;
+      for (int i = 0; i < subqueries.length; i++) {
+        ParameterList subparam = subparams != null ? subparams[i] : null;
+        executePipeline(subqueries[i], subparam, handler, maxRows, fetchSize, flags);
+        if (handler.getException() != null) {
+          break;
+        }
+      }
+      return;
+    }
+
+    if (parameters == null) {
+      parameters = SimpleQuery.NO_PARAMETERS;
+    }
+
+    flags = updateQueryMode(flags);
+    boolean noMeta = (flags & QueryExecutor.QUERY_NO_METADATA) != 0;
+    boolean oneShot = (flags & QueryExecutor.QUERY_ONESHOT) != 0;
+    boolean noBinaryTransfer = (flags & QUERY_NO_BINARY_TRANSFER) != 0;
+    boolean noResults = (flags & QueryExecutor.QUERY_NO_RESULTS) != 0;
+    boolean usePortal = (flags & QueryExecutor.QUERY_FORWARD_CURSOR) != 0 && !noResults && !noMeta
+        && fetchSize > 0;
+
+    SimpleQuery sq = (SimpleQuery) query;
+    SimpleParameterList params = (SimpleParameterList) parameters;
+    params.checkAllParametersSet();
+
+    int rows;
+    if (noResults) {
+      rows = 1;
+    } else if (usePortal) {
+      rows = fetchSize;
+    } else if (maxRows != 0) {
+      rows = maxRows;
+    } else {
+      rows = 0;
+    }
+
+    Portal portal = null;
+    if (usePortal) {
+      portal = new Portal(sq, "C_" + (nextUniqueID++));
+    }
+
+    List<ResponseSlot> slots = new ArrayList<>();
+    ResponseSlot beginSlot = null;
+
+    try (ResourceLock ignore = sendLock.obtain()) {
+      processDeadParsedQueries();
+      processDeadPortals();
+
+      // Send BEGIN if needed — as extended protocol so it shares our Sync
+      boolean needsBegin = (flags & QueryExecutor.QUERY_SUPPRESS_BEGIN) == 0
+          && getTransactionState() == TransactionState.IDLE;
+      if (needsBegin) {
+        SimpleQuery beginQuery = (flags & QueryExecutor.QUERY_READ_ONLY_HINT) == 0
+            ? beginTransactionQuery : beginReadOnlyTransactionQuery;
+        sendOneQuery(beginQuery, SimpleQuery.NO_PARAMETERS, 0, 0,
+            QueryExecutor.QUERY_NO_METADATA | QueryExecutor.QUERY_ONESHOT);
+        beginSlot = new ResponseSlot(beginQuery, null, false, 0);
+        slots.add(beginSlot);
+      }
+
+      sendParse(sq, params, oneShot);
+      sendBind(sq, params, portal, noBinaryTransfer);
+      if (!noMeta && !noResults && (!sq.isPortalDescribed() || sq.getFields() == null)) {
+        if (LOGGER.isLoggable(Level.FINEST)) {
+          LOGGER.log(Level.FINEST, " FE=> pipeline sendDescribePortal, portalDescribed={0}, fields={1}, query={2}",
+              new Object[]{sq.isPortalDescribed(), sq.getFields() != null, sq});
+        }
+        sendDescribePortal(sq, portal);
+      }
+      sendExecute(sq, portal, rows);
+      sendSync();
+
+      ResponseSlot slot = new ResponseSlot(sq, portal, false, flags);
+      if ((noMeta || sq.isPortalDescribed()) && sq.getFields() != null) {
+        slot.fields = castNonNull(sq.getFields());
+      }
+      slots.add(slot);
+
+      pgStream.flush();
+    } catch (IOException e) {
+      abort();
+      handler.handleError(new PSQLException(
+          GT.tr("An I/O error occurred while sending to the backend."),
+          PSQLState.CONNECTION_FAILURE, e));
+      handler.handleCompletion();
+      return;
+    }
+
+    // Read all responses synchronously on this thread
+    try {
+      castNonNull(pipelineResponseReader).readResponses(slots);
+    } catch (SQLException e) {
+      clearPipelinePendingQueues();
+      handler.handleError(e);
+      handler.handleCompletion();
+      return;
+    }
+    clearPipelinePendingQueues();
+
+    // Check BEGIN result
+    if (beginSlot != null && beginSlot.error != null) {
+      handler.handleError(beginSlot.error);
+      handler.handleCompletion();
+      return;
+    }
+
+    // Deliver results to handler
+    ResponseSlot slot = slots.get(slots.size() - 1);
+    deliverSlotResults(slot, handler, sq);
+    handler.handleCompletion();
+  }
+
+  /**
+   * Execute a batch of queries in pipeline mode. Sends all queries under a single
+   * sendLock acquisition with one Sync at the end, then reads all responses.
+   */
+  private void executeBatchPipeline(Query[] queries, @Nullable ParameterList[] parameterLists,
+      BatchResultHandler batchHandler, int maxRows, int flags) throws SQLException {
+
+    flags = updateQueryMode(flags);
+    boolean oneShot = (flags & QueryExecutor.QUERY_ONESHOT) != 0;
+    boolean noBinaryTransfer = (flags & QUERY_NO_BINARY_TRANSFER) != 0;
+    boolean noResults = (flags & QueryExecutor.QUERY_NO_RESULTS) != 0;
+    boolean noMeta = (flags & QueryExecutor.QUERY_NO_METADATA) != 0;
+
+    int rows;
+    if (noResults) {
+      rows = 1;
+    } else if (maxRows != 0) {
+      rows = maxRows;
+    } else {
+      rows = 0;
+    }
+
+    List<ResponseSlot> slots = new ArrayList<>();
+    int firstQuerySlotIndex = 0;
+
+    // NIO-style interleaved send/receive: send queries in chunks, reading
+    // available responses between chunks to keep the TCP window open and
+    // overlap server processing with client sending.
+    final int sendChunkSize = 128;
+
+    ResultHandler handler = batchHandler;
+    PipelineResponseReader reader = castNonNull(pipelineResponseReader);
+    try (ResourceLock ignore = sendLock.obtain()) {
+      processDeadParsedQueries();
+      processDeadPortals();
+
+      // Send BEGIN if needed — as extended protocol
+      boolean needsBegin = (flags & QueryExecutor.QUERY_SUPPRESS_BEGIN) == 0
+          && getTransactionState() == TransactionState.IDLE;
+      if (needsBegin) {
+        SimpleQuery beginQuery = (flags & QueryExecutor.QUERY_READ_ONLY_HINT) == 0
+            ? beginTransactionQuery : beginReadOnlyTransactionQuery;
+        sendOneQuery(beginQuery, SimpleQuery.NO_PARAMETERS, 0, 0,
+            QueryExecutor.QUERY_NO_METADATA | QueryExecutor.QUERY_ONESHOT);
+        ResponseSlot beginSlot = new ResponseSlot(beginQuery, null, false, 0);
+        slots.add(beginSlot);
+        firstQuerySlotIndex = 1;
+      }
+
+      for (int i = 0; i < queries.length; i++) {
+        SimpleQuery sq = (SimpleQuery) queries[i];
+        SimpleParameterList params = (SimpleParameterList) parameterLists[i];
+        if (params == null) {
+          params = SimpleQuery.NO_PARAMETERS;
+        }
+        params.checkAllParametersSet();
+
+        sendParse(sq, params, oneShot);
+        sendBind(sq, params, null, noBinaryTransfer);
+        if (!noMeta && !noResults && (!sq.isPortalDescribed() || sq.getFields() == null)) {
+          sendDescribePortal(sq, null);
+        }
+        sendExecute(sq, null, rows);
+
+        ResponseSlot slot = new ResponseSlot(sq, null, false, flags);
+        if ((noMeta || sq.isPortalDescribed()) && sq.getFields() != null) {
+          slot.fields = castNonNull(sq.getFields());
+        }
+        slots.add(slot);
+
+        // NIO interleave: after each chunk, flush and read any available responses
+        if ((i + 1) % sendChunkSize == 0 && i < queries.length - 1) {
+          pgStream.flush();
+          reader.readAvailableResponses(slots);
+        }
+      }
+
+      sendSync();
+      pgStream.flush();
+    } catch (IOException e) {
+      abort();
+      handler.handleError(new PSQLException(
+          GT.tr("An I/O error occurred while sending to the backend."),
+          PSQLState.CONNECTION_FAILURE, e));
+      batchHandler.handleCompletion();
+      return;
+    }
+
+    // Read all responses (blocks until ReadyForQuery)
+    try {
+      reader.readResponses(slots);
+    } catch (SQLException e) {
+      clearPipelinePendingQueues();
+      handler.handleError(e);
+      batchHandler.handleCompletion();
+      return;
+    }
+    clearPipelinePendingQueues();
+
+    // Check BEGIN result
+    if (firstQuerySlotIndex > 0 && slots.get(0).error != null) {
+      handler.handleError(slots.get(0).error);
+      batchHandler.handleCompletion();
+      return;
+    }
+
+    // Deliver results for each query
+    for (int i = firstQuerySlotIndex; i < slots.size(); i++) {
+      ResponseSlot slot = slots.get(i);
+      deliverSlotResults(slot, handler, (SimpleQuery) queries[i - firstQuerySlotIndex]);
+      if (slot.error != null) {
+        break;
+      }
+      batchHandler.secureProgress();
+    }
+
+    batchHandler.handleCompletion();
+  }
+
+  /**
+   * Execute a cursor fetch in pipeline mode.
+   */
+  private void fetchPipeline(ResultCursor cursor, ResultHandler handler, int fetchSize) throws SQLException {
+    Portal portal = (Portal) cursor;
+    SimpleQuery query = castNonNull(portal.getQuery());
+
+    ResponseSlot slot = new ResponseSlot(query, portal, false, 0);
+    if (query.getFields() != null) {
+      slot.fields = castNonNull(query.getFields());
+    }
+    List<ResponseSlot> slots = new ArrayList<>();
+    slots.add(slot);
+
+    try (ResourceLock ignore = sendLock.obtain()) {
+      sendExecute(query, portal, fetchSize);
+      sendSync();
+      pgStream.flush();
+    } catch (IOException e) {
+      abort();
+      handler.handleError(new PSQLException(
+          GT.tr("An I/O error occurred while sending to the backend."),
+          PSQLState.CONNECTION_FAILURE, e));
+      handler.handleCompletion();
+      return;
+    }
+
+    // Read responses synchronously
+    try {
+      castNonNull(pipelineResponseReader).readResponses(slots);
+    } catch (SQLException e) {
+      clearPipelinePendingQueues();
+      handler.handleError(e);
+      handler.handleCompletion();
+      return;
+    }
+    clearPipelinePendingQueues();
+
+    // Deliver fetch results
+    if (slot.error != null) {
+      handler.handleError(slot.error);
+    } else if (slot.warnings != null) {
+      handler.handleWarning(slot.warnings);
+    }
+
+    Field[] fields = query.getFields();
+    if (fields != null) {
+      List<Tuple> tuples = slot.tuples != null ? slot.tuples : new ArrayList<>();
+      ResultCursor resultCursor = slot.portalSuspended ? portal : null;
+      handler.handleResultRows(query, fields, tuples, resultCursor);
+    } else {
+      handler.handleCommandStatus("EMPTY", 0, 0);
+    }
+
+    handler.handleCompletion();
+  }
+
+  /**
+   * Deliver results from a completed ResponseSlot to a ResultHandler.
+   */
+  private void deliverSlotResults(ResponseSlot slot, ResultHandler handler, SimpleQuery query) {
+    if (slot.error != null) {
+      handler.handleError(slot.error);
+      return;
+    }
+    if (slot.warnings != null) {
+      handler.handleWarning(slot.warnings);
+    }
+    @SuppressWarnings("nullness")
+    Field @Nullable [] fields = slot.fields != null ? slot.fields : query.getFields();
+    if (LOGGER.isLoggable(Level.FINEST)) {
+      Field @Nullable [] qf = query.getFields();
+      LOGGER.log(Level.FINEST, " pipeline deliverSlotResults: slot.fields={0}, query.getFields()={1}, tuples={2}, commandStatus={3}, query={4}",
+          new Object[]{
+              slot.fields != null ? slot.fields.length : null,
+              qf != null ? qf.length : null,
+              slot.tuples != null ? slot.tuples.size() : null,
+              slot.commandStatus,
+              query});
+    }
+    if (fields != null && slot.tuples != null) {
+      // SELECT-like query that returned rows
+      ResultCursor cursor = slot.portalSuspended ? slot.portal : null;
+      handler.handleResultRows(query, fields, slot.tuples, cursor);
+    } else if (slot.commandStatus != null) {
+      // DML or DDL — no result rows
+      handler.handleCommandStatus(slot.commandStatus, slot.updateCount, slot.insertOID);
+    } else {
+      if (LOGGER.isLoggable(Level.FINEST)) {
+        LOGGER.log(Level.FINEST, " pipeline deliverSlotResults: NO RESULT DELIVERED, fields={0}, tuples={1}, commandStatus={2}",
+            new Object[]{fields != null, slot.tuples != null, slot.commandStatus});
+      }
+    }
+  }
 }

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/ResponseSlot.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/ResponseSlot.java
@@ -14,21 +14,17 @@ import java.sql.SQLException;
 import java.sql.SQLWarning;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.locks.LockSupport;
 
 /**
- * Completion token for a pipelined query. Created by the sending thread,
- * populated and completed by the reader thread.
- *
- * <p>Uses LockSupport.park/unpark instead of CompletableFuture to avoid
- * per-query object allocation overhead.</p>
+ * Completion token for a pipelined query. Created before sending,
+ * populated during response processing in {@code readResponses()}.
  */
 class ResponseSlot {
 
   /**
    * Sentinel instance used to mark Sync boundaries in the pending queue.
-   * When the reader thread encounters ReadyForQuery, it drains slots up to
-   * and including the next SYNC_MARKER to handle error cascading.
+   * When ReadyForQuery is received, slots are drained up to and including
+   * the next SYNC_MARKER to handle error cascading.
    */
   static final ResponseSlot SYNC_MARKER = new ResponseSlot();
 
@@ -37,7 +33,7 @@ class ResponseSlot {
   boolean asSimple;
   int flags;
 
-  // Results — written only by reader thread
+  // Results — populated during readResponses()
   @Nullable Field[] fields;
   @Nullable List<Tuple> tuples;
   @Nullable String commandStatus;
@@ -46,10 +42,6 @@ class ResponseSlot {
   @Nullable SQLWarning warnings;
   @Nullable SQLException error;
   boolean portalSuspended;
-
-  // Signaling: reader thread sets done=true then unparks the waiter
-  private volatile boolean done;
-  private volatile @Nullable Thread waiter;
 
   /** Sentinel constructor */
   @SuppressWarnings("initialization.fields.uninitialized")
@@ -79,32 +71,20 @@ class ResponseSlot {
     }
   }
 
-  /**
-   * Called by the sending thread to block until the reader thread completes this slot.
-   * No liveness check — use only when reader thread reference is unavailable.
-   */
-  void await() {
-    waiter = Thread.currentThread();
-    while (!done) {
-      LockSupport.park(this);
-    }
-  }
-
-  /**
-   * Called by the reader thread to signal completion.
-   */
-  void complete() {
-    done = true;
-    Thread w = waiter;
-    if (w != null) {
-      LockSupport.unpark(w);
-    }
-  }
-
-  void completeExceptionally(SQLException ex) {
+  void setError(SQLException ex) {
     if (this.error == null) {
       this.error = ex;
     }
-    complete();
+  }
+
+  /**
+   * Mark this slot as fully populated. In the synchronous pipeline model
+   * this is a logical marker only (no thread signaling needed).
+   */
+  void complete() {
+  }
+
+  void completeExceptionally(SQLException ex) {
+    setError(ex);
   }
 }

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/ResponseSlot.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/ResponseSlot.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2026, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.core.v3;
+
+import org.postgresql.core.Field;
+import org.postgresql.core.Tuple;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.sql.SQLException;
+import java.sql.SQLWarning;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.locks.LockSupport;
+
+/**
+ * Completion token for a pipelined query. Created by the sending thread,
+ * populated and completed by the reader thread.
+ *
+ * <p>Uses LockSupport.park/unpark instead of CompletableFuture to avoid
+ * per-query object allocation overhead.</p>
+ */
+class ResponseSlot {
+
+  /**
+   * Sentinel instance used to mark Sync boundaries in the pending queue.
+   * When the reader thread encounters ReadyForQuery, it drains slots up to
+   * and including the next SYNC_MARKER to handle error cascading.
+   */
+  static final ResponseSlot SYNC_MARKER = new ResponseSlot();
+
+  @Nullable SimpleQuery query;
+  @Nullable Portal portal;
+  boolean asSimple;
+  int flags;
+
+  // Results — written only by reader thread
+  @Nullable Field[] fields;
+  @Nullable List<Tuple> tuples;
+  @Nullable String commandStatus;
+  long updateCount;
+  long insertOID;
+  @Nullable SQLWarning warnings;
+  @Nullable SQLException error;
+  boolean portalSuspended;
+
+  // Signaling: reader thread sets done=true then unparks the waiter
+  private volatile boolean done;
+  private volatile @Nullable Thread waiter;
+
+  /** Sentinel constructor */
+  @SuppressWarnings("initialization.fields.uninitialized")
+  private ResponseSlot() {
+  }
+
+  @SuppressWarnings("initialization.fields.uninitialized")
+  ResponseSlot(@Nullable SimpleQuery query, @Nullable Portal portal, boolean asSimple, int flags) {
+    this.query = query;
+    this.portal = portal;
+    this.asSimple = asSimple;
+    this.flags = flags;
+  }
+
+  void addTuple(Tuple t) {
+    if (tuples == null) {
+      tuples = new ArrayList<>();
+    }
+    tuples.add(t);
+  }
+
+  void addWarning(SQLWarning w) {
+    if (warnings == null) {
+      warnings = w;
+    } else {
+      warnings.setNextWarning(w);
+    }
+  }
+
+  /**
+   * Called by the sending thread to block until the reader thread completes this slot.
+   * No liveness check — use only when reader thread reference is unavailable.
+   */
+  void await() {
+    waiter = Thread.currentThread();
+    while (!done) {
+      LockSupport.park(this);
+    }
+  }
+
+  /**
+   * Called by the reader thread to signal completion.
+   */
+  void complete() {
+    done = true;
+    Thread w = waiter;
+    if (w != null) {
+      LockSupport.unpark(w);
+    }
+  }
+
+  void completeExceptionally(SQLException ex) {
+    if (this.error == null) {
+      this.error = ex;
+    }
+    complete();
+  }
+}

--- a/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
+++ b/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
@@ -1789,6 +1789,22 @@ public abstract class BaseDataSource implements CommonDataSource, Referenceable 
   }
 
   /**
+   * @return boolean indicating if pipeline mode is enabled.
+   * @see PGProperty#PIPELINE_MODE
+   */
+  public boolean getPipelineMode() {
+    return PGProperty.PIPELINE_MODE.getBoolean(properties);
+  }
+
+  /**
+   * @param pipelineMode boolean value to enable or disable pipeline mode
+   * @see PGProperty#PIPELINE_MODE
+   */
+  public void setPipelineMode(boolean pipelineMode) {
+    PGProperty.PIPELINE_MODE.set(properties, pipelineMode);
+  }
+
+  /**
    * @return boolean indicating property is enabled or not.
    * @see PGProperty#HIDE_UNPRIVILEGED_OBJECTS
    */

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
@@ -401,6 +401,7 @@ public class PgConnection implements BaseConnection {
 
     xmlFactoryFactoryClass = PGProperty.XML_FACTORY_FACTORY.getOrDefault(info);
     cleanable = LazyCleanerImpl.getInstance().register(leakHandle, finalizeAction);
+
   }
 
   private static ReadOnlyBehavior getReadOnlyBehavior(@Nullable String property) {

--- a/pgjdbc/src/test/java/org/postgresql/test/core/PipelineModeTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/core/PipelineModeTest.java
@@ -1,0 +1,441 @@
+/*
+ * Copyright (c) 2024, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.test.core;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.postgresql.PGProperty;
+import org.postgresql.test.TestUtil;
+import org.postgresql.test.jdbc2.BaseTest4;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Properties;
+
+
+/**
+ * Integration tests for pipeline mode (dedicated reader thread).
+ * Requires a running PostgreSQL server configured via build.local.properties.
+ */
+@Timeout(30)
+public class PipelineModeTest extends BaseTest4 {
+
+  @Override
+  protected void updateProperties(Properties props) {
+    super.updateProperties(props);
+    PGProperty.PIPELINE_MODE.set(props, true);
+  }
+
+  @Test
+  public void testSimpleSelect() throws SQLException {
+    try (Statement stmt = con.createStatement();
+         ResultSet rs = stmt.executeQuery("SELECT 1 AS x, 'hello' AS y")) {
+      assertTrue(rs.next());
+      assertEquals(1, rs.getInt("x"));
+      assertEquals("hello", rs.getString("y"));
+      assertFalse(rs.next());
+    }
+  }
+
+  @Test
+  public void testMultipleSequentialQueries() throws SQLException {
+    try (Statement stmt = con.createStatement()) {
+      for (int i = 0; i < 10; i++) {
+        try (ResultSet rs = stmt.executeQuery("SELECT " + i + " AS val")) {
+          assertTrue(rs.next());
+          assertEquals(i, rs.getInt(1));
+        }
+      }
+    }
+  }
+
+  @Test
+  public void testPreparedStatement() throws SQLException {
+    TestUtil.createTempTable(con, "pipeline_test", "id INT, name TEXT");
+    try (PreparedStatement ps = con.prepareStatement(
+        "INSERT INTO pipeline_test (id, name) VALUES (?, ?)")) {
+      ps.setInt(1, 1);
+      ps.setString(2, "alice");
+      assertEquals(1, ps.executeUpdate());
+
+      ps.setInt(1, 2);
+      ps.setString(2, "bob");
+      assertEquals(1, ps.executeUpdate());
+    }
+
+    try (Statement stmt = con.createStatement();
+         ResultSet rs = stmt.executeQuery(
+             "SELECT id, name FROM pipeline_test ORDER BY id")) {
+      assertTrue(rs.next());
+      assertEquals(1, rs.getInt(1));
+      assertEquals("alice", rs.getString(2));
+      assertTrue(rs.next());
+      assertEquals(2, rs.getInt(1));
+      assertEquals("bob", rs.getString(2));
+      assertFalse(rs.next());
+    }
+  }
+
+  @Test
+  public void testBatchInsert() throws SQLException {
+    org.junit.jupiter.api.Assumptions.assumeFalse(
+        Boolean.parseBoolean(System.getProperty("reWriteBatchedInserts")),
+        "reWriteBatchedInserts returns SUCCESS_NO_INFO instead of per-row counts");
+    TestUtil.createTempTable(con, "pipeline_batch", "id INT, val INT");
+    try (PreparedStatement ps = con.prepareStatement(
+        "INSERT INTO pipeline_batch (id, val) VALUES (?, ?)")) {
+      for (int i = 0; i < 100; i++) {
+        ps.setInt(1, i);
+        ps.setInt(2, i * 10);
+        ps.addBatch();
+      }
+      int[] counts = ps.executeBatch();
+      assertEquals(100, counts.length);
+      for (int count : counts) {
+        assertEquals(1, count);
+      }
+    }
+
+    try (Statement stmt = con.createStatement();
+         ResultSet rs = stmt.executeQuery("SELECT count(*) FROM pipeline_batch")) {
+      assertTrue(rs.next());
+      assertEquals(100, rs.getInt(1));
+    }
+  }
+
+  @Test
+  public void testCursorFetch() throws SQLException {
+    TestUtil.createTempTable(con, "pipeline_cursor", "id INT");
+    try (Statement stmt = con.createStatement()) {
+      StringBuilder sb = new StringBuilder("INSERT INTO pipeline_cursor VALUES ");
+      for (int i = 0; i < 200; i++) {
+        if (i > 0) {
+          sb.append(',');
+        }
+        sb.append('(').append(i).append(')');
+      }
+      stmt.executeUpdate(sb.toString());
+    }
+
+    // Use fetchSize to trigger cursor/portal mode
+    try (PreparedStatement ps = con.prepareStatement("SELECT id FROM pipeline_cursor ORDER BY id")) {
+      ps.setFetchSize(10);
+      try (ResultSet rs = ps.executeQuery()) {
+        int count = 0;
+        while (rs.next()) {
+          assertEquals(count, rs.getInt(1));
+          count++;
+        }
+        assertEquals(200, count);
+      }
+    }
+  }
+
+  @Test
+  public void testTransactionCommit() throws SQLException {
+    TestUtil.createTempTable(con, "pipeline_tx", "id INT");
+    con.setAutoCommit(false);
+    try (PreparedStatement ps = con.prepareStatement("INSERT INTO pipeline_tx VALUES (?::int)")) {
+      ps.setInt(1, 42);
+      ps.executeUpdate();
+    }
+    con.commit();
+
+    try (Statement stmt = con.createStatement();
+         ResultSet rs = stmt.executeQuery("SELECT id FROM pipeline_tx")) {
+      assertTrue(rs.next());
+      assertEquals(42, rs.getInt(1));
+    }
+    con.setAutoCommit(true);
+  }
+
+  @Test
+  public void testTransactionRollback() throws SQLException {
+    TestUtil.createTempTable(con, "pipeline_rb", "id INT");
+    con.setAutoCommit(false);
+    try (PreparedStatement ps = con.prepareStatement("INSERT INTO pipeline_rb VALUES (?::int)")) {
+      ps.setInt(1, 99);
+      ps.executeUpdate();
+    }
+    con.rollback();
+
+    try (Statement stmt = con.createStatement();
+         ResultSet rs = stmt.executeQuery("SELECT count(*) FROM pipeline_rb")) {
+      assertTrue(rs.next());
+      assertEquals(0, rs.getInt(1));
+    }
+    con.setAutoCommit(true);
+  }
+
+  @Test
+  public void testErrorHandling() throws SQLException {
+    // Query that will fail
+    try (Statement stmt = con.createStatement()) {
+      assertThrows(SQLException.class, () ->
+          stmt.executeQuery("SELECT * FROM nonexistent_table_xyz"));
+    }
+
+    // Connection should still be usable after error
+    try (Statement stmt = con.createStatement();
+         ResultSet rs = stmt.executeQuery("SELECT 1")) {
+      assertTrue(rs.next());
+      assertEquals(1, rs.getInt(1));
+    }
+  }
+
+  @Test
+  public void testBatchWithError() throws SQLException {
+    TestUtil.createTempTable(con, "pipeline_berr", "id INT PRIMARY KEY");
+    try (PreparedStatement ps = con.prepareStatement(
+        "INSERT INTO pipeline_berr VALUES (?)")) {
+      ps.setInt(1, 1);
+      ps.addBatch();
+      ps.setInt(1, 1); // duplicate key — will fail
+      ps.addBatch();
+      ps.setInt(1, 3);
+      ps.addBatch();
+
+      assertThrows(SQLException.class, ps::executeBatch);
+    }
+
+    // Connection should still be usable
+    try (Statement stmt = con.createStatement();
+         ResultSet rs = stmt.executeQuery("SELECT 1")) {
+      assertTrue(rs.next());
+    }
+  }
+
+  @Test
+  public void testLargeResultSet() throws SQLException {
+    // Test with a generated series — no temp table needed
+    try (Statement stmt = con.createStatement();
+         ResultSet rs = stmt.executeQuery(
+             "SELECT generate_series(1, 10000) AS n")) {
+      int count = 0;
+      while (rs.next()) {
+        count++;
+        assertEquals(count, rs.getInt(1));
+      }
+      assertEquals(10000, count);
+    }
+  }
+
+  @Test
+  public void testNullValues() throws SQLException {
+    try (Statement stmt = con.createStatement();
+         ResultSet rs = stmt.executeQuery("SELECT NULL::text, NULL::int, 'x'::text")) {
+      assertTrue(rs.next());
+      assertNull(rs.getString(1));
+      assertEquals(0, rs.getInt(2));
+      assertTrue(rs.wasNull());
+      assertEquals("x", rs.getString(3));
+    }
+  }
+
+  @Test
+  public void testMultipleResultColumns() throws SQLException {
+    try (Statement stmt = con.createStatement();
+         ResultSet rs = stmt.executeQuery(
+             "SELECT 1::int, 2::bigint, 3.14::float, true::bool, 'test'::text")) {
+      assertTrue(rs.next());
+      assertEquals(1, rs.getInt(1));
+      assertEquals(2L, rs.getLong(2));
+      assertEquals(3.14, rs.getDouble(3), 0.001);
+      assertTrue(rs.getBoolean(4));
+      assertEquals("test", rs.getString(5));
+    }
+  }
+
+  @Test
+  public void testPreparedStatementReuse() throws SQLException {
+    // Tests that prepared statement caching works with pipeline mode
+    try (PreparedStatement ps = con.prepareStatement("SELECT ?::int + 1")) {
+      for (int i = 0; i < 20; i++) {
+        ps.setInt(1, i);
+        try (ResultSet rs = ps.executeQuery()) {
+          assertTrue(rs.next());
+          assertEquals(i + 1, rs.getInt(1));
+        }
+      }
+    }
+  }
+
+  @Test
+  public void testConnectionMetadata() throws SQLException {
+    // Verify connection is functional for metadata operations
+    assertNotNull(con.getMetaData());
+    assertNotNull(con.getMetaData().getDatabaseProductName());
+    assertTrue(con.getMetaData().getDatabaseProductName().contains("PostgreSQL"));
+  }
+
+  @Test
+  public void testAutoCommitDDL() throws SQLException {
+    TestUtil.createTempTable(con, "pipeline_ddl", "id SERIAL PRIMARY KEY, data TEXT");
+    try (PreparedStatement ps = con.prepareStatement(
+        "INSERT INTO pipeline_ddl (data) VALUES (?) RETURNING id")) {
+      ps.setString(1, "test");
+      try (ResultSet rs = ps.executeQuery()) {
+        assertTrue(rs.next());
+        assertTrue(rs.getInt(1) > 0);
+      }
+    }
+  }
+
+  @Test
+  public void testSyntaxError() throws SQLException {
+    try (Statement stmt = con.createStatement()) {
+      SQLException ex = assertThrows(SQLException.class, () ->
+          stmt.executeQuery("SELEKT 1"));
+      // Should be a syntax error
+      assertTrue(ex.getSQLState().startsWith("42"),
+          "Expected syntax error SQLState 42xxx, got: " + ex.getSQLState());
+      assertTrue(ex.getMessage().contains("syntax"),
+          "Expected 'syntax' in message, got: " + ex.getMessage());
+    }
+
+    // Connection must remain usable
+    try (Statement stmt = con.createStatement();
+         ResultSet rs = stmt.executeQuery("SELECT 42")) {
+      assertTrue(rs.next());
+      assertEquals(42, rs.getInt(1));
+    }
+  }
+
+  @Test
+  public void testDivisionByZero() throws SQLException {
+    try (Statement stmt = con.createStatement()) {
+      SQLException ex = assertThrows(SQLException.class, () ->
+          stmt.executeQuery("SELECT 1/0"));
+      assertEquals("22012", ex.getSQLState(), "Expected division_by_zero SQLState");
+    }
+
+    // Connection must remain usable
+    try (Statement stmt = con.createStatement();
+         ResultSet rs = stmt.executeQuery("SELECT 99")) {
+      assertTrue(rs.next());
+      assertEquals(99, rs.getInt(1));
+    }
+  }
+
+  @Test
+  public void testUniqueViolation() throws SQLException {
+    TestUtil.createTempTable(con, "pipeline_uniq", "id INT PRIMARY KEY");
+    try (Statement stmt = con.createStatement()) {
+      stmt.executeUpdate("INSERT INTO pipeline_uniq VALUES (1)");
+
+      SQLException ex = assertThrows(SQLException.class, () ->
+          stmt.executeUpdate("INSERT INTO pipeline_uniq VALUES (1)"));
+      assertEquals("23505", ex.getSQLState(), "Expected unique_violation SQLState");
+    }
+
+    // Connection must remain usable
+    try (Statement stmt = con.createStatement();
+         ResultSet rs = stmt.executeQuery("SELECT count(*) FROM pipeline_uniq")) {
+      assertTrue(rs.next());
+      assertEquals(1, rs.getInt(1));
+    }
+  }
+
+  @Test
+  public void testErrorInTransaction() throws SQLException {
+    TestUtil.createTempTable(con, "pipeline_txerr", "id INT PRIMARY KEY");
+    con.setAutoCommit(false);
+
+    try (Statement stmt = con.createStatement()) {
+      stmt.executeUpdate("INSERT INTO pipeline_txerr VALUES (1)");
+
+      // This will fail — puts transaction in aborted state
+      assertThrows(SQLException.class, () ->
+          stmt.executeUpdate("INSERT INTO pipeline_txerr VALUES (1)"));
+
+      // Any subsequent query in the aborted transaction should fail
+      SQLException ex = assertThrows(SQLException.class, () ->
+          stmt.executeQuery("SELECT 1"));
+      assertEquals("25P02", ex.getSQLState(),
+          "Expected in_failed_sql_transaction SQLState");
+    }
+
+    // Rollback should recover the connection
+    con.rollback();
+
+    try (Statement stmt = con.createStatement();
+         ResultSet rs = stmt.executeQuery("SELECT count(*) FROM pipeline_txerr")) {
+      assertTrue(rs.next());
+      assertEquals(0, rs.getInt(1));
+    }
+    con.setAutoCommit(true);
+  }
+
+  @Test
+  public void testPreparedStatementWithWrongParamCount() throws SQLException {
+    try (PreparedStatement ps = con.prepareStatement("SELECT ?::int, ?::int")) {
+      ps.setInt(1, 1);
+      // Missing parameter 2
+      assertThrows(SQLException.class, ps::executeQuery);
+    }
+
+    // Connection must remain usable
+    try (Statement stmt = con.createStatement();
+         ResultSet rs = stmt.executeQuery("SELECT 1")) {
+      assertTrue(rs.next());
+    }
+  }
+
+  @Test
+  public void testErrorRecoveryMultipleQueries() throws SQLException {
+    // Run several queries, inject an error, then verify recovery with more queries
+    try (Statement stmt = con.createStatement()) {
+      // Successful queries before error
+      for (int i = 0; i < 5; i++) {
+        try (ResultSet rs = stmt.executeQuery("SELECT " + i)) {
+          assertTrue(rs.next());
+          assertEquals(i, rs.getInt(1));
+        }
+      }
+
+      // Error
+      assertThrows(SQLException.class, () ->
+          stmt.executeQuery("SELECT * FROM this_table_does_not_exist"));
+
+      // Successful queries after error
+      for (int i = 10; i < 15; i++) {
+        try (ResultSet rs = stmt.executeQuery("SELECT " + i)) {
+          assertTrue(rs.next());
+          assertEquals(i, rs.getInt(1));
+        }
+      }
+    }
+  }
+
+  @Test
+  public void testRaiseException() throws SQLException {
+    // Use DO block to raise a custom exception
+    try (Statement stmt = con.createStatement()) {
+      SQLException ex = assertThrows(SQLException.class, () ->
+          stmt.execute("DO $$ BEGIN RAISE EXCEPTION 'injected error' USING ERRCODE = 'P0001'; END $$"));
+      assertEquals("P0001", ex.getSQLState(), "Expected raise_exception SQLState");
+      assertTrue(ex.getMessage().contains("injected error"),
+          "Expected 'injected error' in message, got: " + ex.getMessage());
+    }
+
+    // Connection must remain usable
+    try (Statement stmt = con.createStatement();
+         ResultSet rs = stmt.executeQuery("SELECT 'recovered'")) {
+      assertTrue(rs.next());
+      assertEquals("recovered", rs.getString(1));
+    }
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/test/core/PipelinePerformanceTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/core/PipelinePerformanceTest.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright (c) 2024, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.test.core;
+
+import org.postgresql.PGProperty;
+import org.postgresql.test.TestUtil;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Properties;
+
+
+/**
+ * Comparative performance test: pipeline mode vs synchronous mode.
+ * Not a JMH benchmark — just a quick A/B comparison to validate
+ * that pipeline mode is at least as fast as synchronous mode.
+ *
+ * <p>Run with: ./gradlew test --tests "org.postgresql.test.core.PipelinePerformanceTest"
+ */
+@Timeout(30)
+public class PipelinePerformanceTest {
+
+  private static Connection syncConn;
+  private static Connection pipeConn;
+
+  @BeforeAll
+  static void setUp() throws SQLException {
+    Properties syncProps = new Properties();
+    syncConn = TestUtil.openDB(syncProps);
+
+    Properties pipeProps = new Properties();
+    PGProperty.PIPELINE_MODE.set(pipeProps, true);
+    pipeConn = TestUtil.openDB(pipeProps);
+
+    try (Statement stmt = syncConn.createStatement()) {
+      try {
+        stmt.execute("DROP TABLE IF EXISTS perf_test");
+      } catch (SQLException e) {
+        /* ignore */
+      }
+      stmt.execute("CREATE TABLE perf_test (id INT, val TEXT)");
+    }
+  }
+
+  @AfterAll
+  static void tearDown() throws SQLException {
+    if (syncConn != null) {
+      try (Statement stmt = syncConn.createStatement()) {
+        stmt.execute("DROP TABLE IF EXISTS perf_test");
+      }
+      syncConn.close();
+    }
+    if (pipeConn != null) {
+      pipeConn.close();
+    }
+  }
+
+  @Test
+  public void compareSequentialQueries() throws SQLException {
+    int iterations = 200;
+
+    // Warmup both
+    runSequentialQueries(syncConn, 50);
+    runSequentialQueries(pipeConn, 50);
+
+    // Measure synchronous
+    long syncStart = System.nanoTime();
+    runSequentialQueries(syncConn, iterations);
+    long syncElapsed = System.nanoTime() - syncStart;
+
+    // Measure pipeline
+    long pipeStart = System.nanoTime();
+    runSequentialQueries(pipeConn, iterations);
+    long pipeElapsed = System.nanoTime() - pipeStart;
+
+    double syncMs = syncElapsed / 1_000_000.0;
+    double pipeMs = pipeElapsed / 1_000_000.0;
+    double ratio = syncMs / pipeMs;
+
+    System.out.printf("%n=== Sequential Queries (%d iterations) ===%n", iterations);
+    System.out.printf("  Synchronous: %.2f ms%n", syncMs);
+    System.out.printf("  Pipeline:    %.2f ms%n", pipeMs);
+    System.out.printf("  Ratio:       %.2fx %s%n", ratio,
+        ratio > 1 ? "(pipeline faster)" : "(sync faster)");
+  }
+
+  @Test
+  public void compareBatchInsert() throws SQLException {
+    int batchSize = 500;
+
+    // Warmup
+    runBatchInsert(syncConn, 100);
+    runBatchInsert(pipeConn, 100);
+
+    // Measure synchronous
+    long syncStart = System.nanoTime();
+    runBatchInsert(syncConn, batchSize);
+    long syncElapsed = System.nanoTime() - syncStart;
+
+    // Measure pipeline
+    long pipeStart = System.nanoTime();
+    runBatchInsert(pipeConn, batchSize);
+    long pipeElapsed = System.nanoTime() - pipeStart;
+
+    double syncMs = syncElapsed / 1_000_000.0;
+    double pipeMs = pipeElapsed / 1_000_000.0;
+    double ratio = syncMs / pipeMs;
+
+    System.out.printf("%n=== Batch Insert (%d rows) ===%n", batchSize);
+    System.out.printf("  Synchronous: %.2f ms%n", syncMs);
+    System.out.printf("  Pipeline:    %.2f ms%n", pipeMs);
+    System.out.printf("  Ratio:       %.2fx %s%n", ratio,
+        ratio > 1 ? "(pipeline faster)" : "(sync faster)");
+  }
+
+  @Test
+  public void comparePreparedStatementReuse() throws SQLException {
+    int iterations = 500;
+
+    // Warmup
+    runPreparedReuse(syncConn, 100);
+    runPreparedReuse(pipeConn, 100);
+
+    // Measure synchronous
+    long syncStart = System.nanoTime();
+    runPreparedReuse(syncConn, iterations);
+    long syncElapsed = System.nanoTime() - syncStart;
+
+    // Measure pipeline
+    long pipeStart = System.nanoTime();
+    runPreparedReuse(pipeConn, iterations);
+    long pipeElapsed = System.nanoTime() - pipeStart;
+
+    double syncMs = syncElapsed / 1_000_000.0;
+    double pipeMs = pipeElapsed / 1_000_000.0;
+    double ratio = syncMs / pipeMs;
+
+    System.out.printf("%n=== Prepared Statement Reuse (%d iterations) ===%n", iterations);
+    System.out.printf("  Synchronous: %.2f ms%n", syncMs);
+    System.out.printf("  Pipeline:    %.2f ms%n", pipeMs);
+    System.out.printf("  Ratio:       %.2fx %s%n", ratio,
+        ratio > 1 ? "(pipeline faster)" : "(sync faster)");
+  }
+
+  @Test
+  public void compareLargeResultFetch() throws SQLException {
+    int rows = 10000;
+
+    // Warmup
+    runLargeResultFetch(syncConn, 1000);
+    runLargeResultFetch(pipeConn, 1000);
+
+    // Measure synchronous
+    long syncStart = System.nanoTime();
+    runLargeResultFetch(syncConn, rows);
+    long syncElapsed = System.nanoTime() - syncStart;
+
+    // Measure pipeline
+    long pipeStart = System.nanoTime();
+    runLargeResultFetch(pipeConn, rows);
+    long pipeElapsed = System.nanoTime() - pipeStart;
+
+    double syncMs = syncElapsed / 1_000_000.0;
+    double pipeMs = pipeElapsed / 1_000_000.0;
+    double ratio = syncMs / pipeMs;
+
+    System.out.printf("%n=== Large Result Fetch (%d rows) ===%n", rows);
+    System.out.printf("  Synchronous: %.2f ms%n", syncMs);
+    System.out.printf("  Pipeline:    %.2f ms%n", pipeMs);
+    System.out.printf("  Ratio:       %.2fx %s%n", ratio,
+        ratio > 1 ? "(pipeline faster)" : "(sync faster)");
+  }
+
+  private void runSequentialQueries(Connection conn, int n) throws SQLException {
+    try (PreparedStatement ps = conn.prepareStatement("SELECT ?::int + 1")) {
+      for (int i = 0; i < n; i++) {
+        ps.setInt(1, i);
+        try (ResultSet rs = ps.executeQuery()) {
+          rs.next();
+          rs.getInt(1);
+        }
+      }
+    }
+  }
+
+  private void runBatchInsert(Connection conn, int n) throws SQLException {
+    try (Statement stmt = conn.createStatement()) {
+      stmt.execute("TRUNCATE perf_test");
+    }
+    try (PreparedStatement ps = conn.prepareStatement(
+        "INSERT INTO perf_test (id, val) VALUES (?, ?)")) {
+      for (int i = 0; i < n; i++) {
+        ps.setInt(1, i);
+        ps.setString(2, "value_" + i);
+        ps.addBatch();
+      }
+      ps.executeBatch();
+    }
+  }
+
+  private void runPreparedReuse(Connection conn, int n) throws SQLException {
+    try (PreparedStatement ps = conn.prepareStatement(
+        "SELECT ?::int, ?::text, ?::float8")) {
+      for (int i = 0; i < n; i++) {
+        ps.setInt(1, i);
+        ps.setString(2, "test");
+        ps.setDouble(3, i * 1.5);
+        try (ResultSet rs = ps.executeQuery()) {
+          rs.next();
+          rs.getInt(1);
+          rs.getString(2);
+          rs.getDouble(3);
+        }
+      }
+    }
+  }
+
+  private void runLargeResultFetch(Connection conn, int rows) throws SQLException {
+    try (PreparedStatement ps = conn.prepareStatement(
+        "SELECT generate_series(1, ?::int)")) {
+      ps.setInt(1, rows);
+      try (ResultSet rs = ps.executeQuery()) {
+        while (rs.next()) {
+          rs.getInt(1);
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Replace the dedicated reader thread approach with a single-threaded
    NIO-style pipeline reader that interleaves sending and receiving on
    the calling thread. This eliminates all socket-sharing races between
    the reader thread and synchronous execution path.
