### PR TITLE
ci(renovate): cap junit-bom <6.0 and checkerframework <4.0

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -26,13 +26,21 @@
       "groupName": "checkerframework",
       "matchPackageNames": [
         "org.checkerframework{/,}**"
-      ]
+      ],
+      "allowedVersions": "<4.0.0"
     },
     {
       "groupName": "jmh",
       "matchPackageNames": [
         "org.openjdk.jmh{/,}**"
       ]
+    },
+    {
+      "groupName": "junit-bom",
+      "matchPackageNames": [
+        "org.junit:junit-bom"
+      ],
+      "allowedVersions": "<6.0.0"
     },
     {
       "groupName": "com.gradleup.nmcp",


### PR DESCRIPTION
### Changes to Existing Features:

Adds upper-bound version caps to Renovate so updates stay within the current major lines:

- `org.junit:junit-bom` → `<6.0.0`
- `org.checkerframework*` → `<4.0.0` (added to the existing checkerframework group rule)

### Why

JUnit 6 and Checker Framework 4 are not compatible with the Java 8 target, so adopting either would require a coordinated migration rather than a drive-by Renovate PR. Capping via `allowedVersions` is preferable to the `matchCurrentVersion` / `enabled: false` pattern used elsewhere in this file because Renovate simply will not propose disallowed versions, instead of opening then disabling them.

### Submission checklist

* [x] Followed Contributing guidelines
* [x] No other open PR for the same change
* [x] Does not break existing behaviour (Renovate config only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)