### PR TITLE
ci: validate renovate.json on push and pull request

### DIFF
--- a/.github/workflows/renovate-config-lint.yaml
+++ b/.github/workflows/renovate-config-lint.yaml
@@ -1,0 +1,26 @@
+name: Validate Renovate Config
+
+on:
+  push:
+    paths:
+      - renovate.json
+      - .github/workflows/renovate-config-lint.yaml
+  pull_request:
+    paths:
+      - renovate.json
+      - .github/workflows/renovate-config-lint.yaml
+
+permissions: read-all
+
+jobs:
+  validate-renovate-config:
+    name: Validate renovate.json
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Validate renovate.json
+        run: docker run --rm -v "$PWD":/work -w /work renovate/renovate:latest renovate-config-validator renovate.json


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/renovate-config-lint.yaml` that runs `renovate-config-validator` from the official `renovate/renovate` image whenever `renovate.json` (or the workflow itself) changes on `push` or `pull_request`.
- Catches Renovate config mistakes before they silently break dependency-update PRs.

Based on the pattern used in [Netcracker/qubership-profiler-agent](https://github.com/Netcracker/qubership-profiler-agent/blob/main/.github/workflows/renovate-config-lint.yaml). Permissions follow the existing pgjdbc convention (`permissions: read-all`, pinned action SHA).

## Test plan
- [ ] Workflow triggers and passes on this PR (no `renovate.json` change, so the path filter should keep it from running — verify by editing `renovate.json` if needed).
- [ ] Intentionally break `renovate.json` locally and confirm `renovate-config-validator` reports the error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)