### PR TITLE
i18n: convert ISO-8859-x .po files to UTF-8

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/translation/cs.po
+++ b/pgjdbc/src/main/java/org/postgresql/translation/cs.po
@@ -12,12 +12,12 @@ msgstr ""
 "Language-Team: \n"
 "Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=ISO-8859-2\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
 #: src/main/java/org/postgresql/Driver.java:259
 msgid "Error loading default settings from driverconfig.properties"
-msgstr "Chyba naèítání standardního nastavení z driverconfig.properties"
+msgstr "Chyba naÄÃ­tÃ¡nÃ­ standardnÃ­ho nastavenÃ­ z driverconfig.properties"
 
 #: src/main/java/org/postgresql/Driver.java:271
 #, java-format
@@ -42,22 +42,22 @@ msgid ""
 "Something unusual has occurred to cause the driver to fail. Please report "
 "this exception."
 msgstr ""
-"Nìco neobvyklého pøinutilo ovladaè selhat. Prosím nahlaste tuto vyjímku."
+"NÄ›co neobvyklÃ©ho pÅ™inutilo ovladaÄ selhat. ProsÃ­m nahlaste tuto vyjÃ­mku."
 
 #: src/main/java/org/postgresql/Driver.java:412
 #, fuzzy
 msgid "Connection attempt timed out."
-msgstr "Pokus o pøipojení selhal."
+msgstr "Pokus o pÅ™ipojenÃ­ selhal."
 
 #: src/main/java/org/postgresql/Driver.java:425
 #, fuzzy
 msgid "Interrupted while attempting to connect."
-msgstr "Nastala chyba pøi nastavení SSL spojení."
+msgstr "Nastala chyba pÅ™i nastavenÃ­ SSL spojenÃ­."
 
 #: src/main/java/org/postgresql/Driver.java:744
 #, java-format
 msgid "Method {0} is not yet implemented."
-msgstr "Metoda {0} není implementována."
+msgstr "Metoda {0} nenÃ­ implementovÃ¡na."
 
 #: src/main/java/org/postgresql/PGConnection.java:298
 msgid "Expected a row when reading password_encryption but none was found"
@@ -97,7 +97,7 @@ msgstr ""
 #: src/main/java/org/postgresql/copy/PGCopyOutputStream.java:104
 #, fuzzy
 msgid "This copy stream is closed."
-msgstr "Tento ResultSet je uzavøenı."
+msgstr "Tento ResultSet je uzavÅ™enÃ½."
 
 #: src/main/java/org/postgresql/copy/PGCopyInputStream.java:125
 msgid "Read from copy failed."
@@ -111,7 +111,7 @@ msgstr ""
 #: src/main/java/org/postgresql/core/AuthMethod.java:30
 #, fuzzy, java-format
 msgid "Invalid authentication method: {0}"
-msgstr "©patnı smìr ètení: {0}."
+msgstr "Å patnÃ½ smÄ›r ÄtenÃ­: {0}."
 
 #: src/main/java/org/postgresql/core/AuthMethod.java:51
 msgid "requireAuth cannot mix positive and negative authentication methods"
@@ -133,7 +133,7 @@ msgstr ""
 #: src/main/java/org/postgresql/core/ConnectionFactory.java:60
 #, java-format
 msgid "A connection could not be made using the requested protocol {0}."
-msgstr "Spojení nelze vytvoøit s pou¾itím ¾ádaného protokolu {0}."
+msgstr "SpojenÃ­ nelze vytvoÅ™it s pouÅ¾itÃ­m Å¾Ã¡danÃ©ho protokolu {0}."
 
 #: src/main/java/org/postgresql/core/Oid.java:143
 #, java-format
@@ -154,7 +154,7 @@ msgstr ""
 #: src/main/java/org/postgresql/core/Parser.java:1200
 #, java-format
 msgid "Malformed function or procedure escape syntax at offset {0}."
-msgstr "Po¹kozená funkce nebo opu¹tìní procedury na pozici {0}."
+msgstr "PoÅ¡kozenÃ¡ funkce nebo opuÅ¡tÄ›nÃ­ procedury na pozici {0}."
 
 #: src/main/java/org/postgresql/core/ProtocolVersion.java:53
 #, java-format
@@ -163,17 +163,17 @@ msgstr ""
 
 #: src/main/java/org/postgresql/core/SetupQueryRunner.java:68
 msgid "An unexpected result was returned by a query."
-msgstr "Obdr¾en neoèekávanı vısledek dotazu."
+msgstr "ObdrÅ¾en neoÄekÃ¡vanÃ½ vÃ½sledek dotazu."
 
 #: src/main/java/org/postgresql/core/SocketFactoryFactory.java:43
 #, fuzzy, java-format
 msgid "The SocketFactory class provided {0} could not be instantiated."
-msgstr "Tøída SSLSocketFactory poskytla {0} co¾ nemù¾e bıt instancionizováno."
+msgstr "TÅ™Ã­da SSLSocketFactory poskytla {0} coÅ¾ nemÅ¯Å¾e bÃ½t instancionizovÃ¡no."
 
 #: src/main/java/org/postgresql/core/SocketFactoryFactory.java:68
 #, java-format
 msgid "The SSLSocketFactory class provided {0} could not be instantiated."
-msgstr "Tøída SSLSocketFactory poskytla {0} co¾ nemù¾e bıt instancionizováno."
+msgstr "TÅ™Ã­da SSLSocketFactory poskytla {0} coÅ¾ nemÅ¯Å¾e bÃ½t instancionizovÃ¡no."
 
 #: src/main/java/org/postgresql/core/Utils.java:72
 #: src/main/java/org/postgresql/core/Utils.java:89
@@ -199,12 +199,12 @@ msgstr ""
 msgid ""
 "The server requested password-based authentication, but no password was "
 "provided by plugin {0}"
-msgstr "Server vy¾aduje ovìøení heslem, ale ¾ádné nebylo posláno."
+msgstr "Server vyÅ¾aduje ovÄ›Å™enÃ­ heslem, ale Å¾Ã¡dnÃ© nebylo poslÃ¡no."
 
 #: src/main/java/org/postgresql/core/v3/ChannelBinding.java:40
 #, fuzzy, java-format
 msgid "Invalid channelBinding value: {0}"
-msgstr "Vadná délka proudu {0}."
+msgstr "VadnÃ¡ dÃ©lka proudu {0}."
 
 #: src/main/java/org/postgresql/core/v3/CompositeParameterList.java:38
 #: src/main/java/org/postgresql/core/v3/SimpleParameterList.java:60
@@ -214,7 +214,7 @@ msgstr "Vadná délka proudu {0}."
 #: src/main/java/org/postgresql/jdbc/PgResultSetMetaData.java:428
 #, java-format
 msgid "The column index is out of range: {0}, number of columns: {1}."
-msgstr "Index sloupece je mimo rozsah: {0}, poèet sloupcù: {1}."
+msgstr "Index sloupece je mimo rozsah: {0}, poÄet sloupcÅ¯: {1}."
 
 #: src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java:212
 msgid "User cannot be null"
@@ -227,7 +227,7 @@ msgstr ""
 #: src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java:330
 #, fuzzy, java-format
 msgid "Invalid targetServerType value: {0}"
-msgstr "Vadná délka proudu {0}."
+msgstr "VadnÃ¡ dÃ©lka proudu {0}."
 
 #: src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java:426
 #, fuzzy, java-format
@@ -235,13 +235,13 @@ msgid ""
 "Connection to {0} refused. Check that the hostname and port are correct and "
 "that the postmaster is accepting TCP/IP connections."
 msgstr ""
-"Spojení odmítnuto. Zkontrolujte zda je jméno hosta a port správné a zda "
-"postmaster pøijímá TCP/IP spojení."
+"SpojenÃ­ odmÃ­tnuto. Zkontrolujte zda je jmÃ©no hosta a port sprÃ¡vnÃ© a zda "
+"postmaster pÅ™ijÃ­mÃ¡ TCP/IP spojenÃ­."
 
 #: src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java:437
 #: src/main/java/org/postgresql/core/v3/replication/V3ReplicationProtocol.java:140
 msgid "The connection attempt failed."
-msgstr "Pokus o pøipojení selhal."
+msgstr "Pokus o pÅ™ipojenÃ­ selhal."
 
 #: src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java:452
 #, java-format
@@ -261,7 +261,7 @@ msgstr "Server nepodporuje SSL."
 #: src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java:639
 #, fuzzy
 msgid "An error occurred while setting up the GSS Encoded connection."
-msgstr "Nastala chyba pøi nastavení SSL spojení."
+msgstr "Nastala chyba pÅ™i nastavenÃ­ SSL spojenÃ­."
 
 #: src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java:689
 #: src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java:701
@@ -270,7 +270,7 @@ msgstr "Server nepodporuje SSL."
 
 #: src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java:715
 msgid "An error occurred while setting up the SSL connection."
-msgstr "Nastala chyba pøi nastavení SSL spojení."
+msgstr "Nastala chyba pÅ™i nastavenÃ­ SSL spojenÃ­."
 
 #: src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java:849
 msgid ""
@@ -297,14 +297,14 @@ msgstr ""
 msgid ""
 "The server requested SCRAM-based authentication, but no password was "
 "provided."
-msgstr "Server vy¾aduje ovìøení heslem, ale ¾ádné nebylo posláno."
+msgstr "Server vyÅ¾aduje ovÄ›Å™enÃ­ heslem, ale Å¾Ã¡dnÃ© nebylo poslÃ¡no."
 
 #: src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java:1016
 #, fuzzy
 msgid ""
 "The server requested SCRAM-based authentication, but the password is an "
 "empty string."
-msgstr "Server vy¾aduje ovìøení heslem, ale ¾ádné nebylo posláno."
+msgstr "Server vyÅ¾aduje ovÄ›Å™enÃ­ heslem, ale Å¾Ã¡dnÃ© nebylo poslÃ¡no."
 
 #: src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java:1051
 #, java-format
@@ -313,9 +313,9 @@ msgid ""
 "the pg_hba.conf file to include the client''s IP address or subnet, and that "
 "it is using an authentication scheme supported by the driver."
 msgstr ""
-"Ovìøení typu {0} není podporováno. Zkontrolujte zda konfiguraèní soubor "
-"pg_hba.conf obsahuje klientskou IP adresu èi podsí» a zda je pou¾ité "
-"ovìøenovací schéma podporováno ovladaèem."
+"OvÄ›Å™enÃ­ typu {0} nenÃ­ podporovÃ¡no. Zkontrolujte zda konfiguraÄnÃ­ soubor "
+"pg_hba.conf obsahuje klientskou IP adresu Äi podsÃ­Å¥ a zda je pouÅ¾itÃ© "
+"ovÄ›Å™enovacÃ­ schÃ©ma podporovÃ¡no ovladaÄem."
 
 #: src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java:1058
 #: src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java:3087
@@ -323,7 +323,7 @@ msgstr ""
 #: src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java:3167
 #: src/main/java/org/postgresql/gss/GssAction.java:165
 msgid "Protocol error.  Session setup failed."
-msgstr "Chyba protokolu. Nastavení relace selhalo."
+msgstr "Chyba protokolu. NastavenÃ­ relace selhalo."
 
 #: src/main/java/org/postgresql/core/v3/CopyInImpl.java:58
 msgid "CopyIn copy direction can't receive data"
@@ -345,7 +345,7 @@ msgstr ""
 #: src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java:308
 #, fuzzy
 msgid "Interrupted while waiting to obtain lock on database connection"
-msgstr "Nastala chyba pøi nastavení SSL spojení."
+msgstr "Nastala chyba pÅ™i nastavenÃ­ SSL spojenÃ­."
 
 #: src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java:459
 msgid "Unable to bind parameter values for statement."
@@ -359,7 +359,7 @@ msgstr ""
 #: src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java:2835
 #: src/main/java/org/postgresql/util/StreamWrapper.java:86
 msgid "An I/O error occurred while sending to the backend."
-msgstr "Vystupnì/vıstupní chyba pøi odesílání k backend."
+msgstr "VystupnÄ›/vÃ½stupnÃ­ chyba pÅ™i odesÃ­lÃ¡nÃ­ k backend."
 
 #: src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java:544
 msgid "Error releasing savepoint"
@@ -369,29 +369,29 @@ msgstr ""
 #: src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java:803
 #, java-format
 msgid "Expected command status BEGIN, got {0}."
-msgstr "Oèekáván pøíkaz BEGIN, obdr¾en {0}."
+msgstr "OÄekÃ¡vÃ¡n pÅ™Ã­kaz BEGIN, obdrÅ¾en {0}."
 
 #: src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java:808
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:2204
 #, java-format
 msgid "Unexpected command status: {0}."
-msgstr "Neoèekávanı stav pøíkazu: {0}."
+msgstr "NeoÄekÃ¡vanÃ½ stav pÅ™Ã­kazu: {0}."
 
 #: src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java:923
 #, fuzzy
 msgid "An error occurred while trying to get the socket timeout."
-msgstr "Vystupnì/vıstupní chyba pøi odesílání k backend."
+msgstr "VystupnÄ›/vÃ½stupnÃ­ chyba pÅ™i odesÃ­lÃ¡nÃ­ k backend."
 
 #: src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java:958
 #: src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java:1049
 #, java-format
 msgid "Unknown Response Type {0}."
-msgstr "Neznámı typ odpovìdi {0}."
+msgstr "NeznÃ¡mÃ½ typ odpovÄ›di {0}."
 
 #: src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java:982
 #, fuzzy
 msgid "An error occurred while trying to reset the socket timeout."
-msgstr "Vystupnì/vıstupní chyba pøi odesílání k backend."
+msgstr "VystupnÄ›/vÃ½stupnÃ­ chyba pÅ™i odesÃ­lÃ¡nÃ­ k backend."
 
 #: src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java:1102
 msgid "Database connection failed when starting copy"
@@ -445,7 +445,7 @@ msgstr ""
 #: src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java:1376
 #, fuzzy
 msgid "PGStream is closed"
-msgstr "Tento ResultSet je uzavøenı."
+msgstr "Tento ResultSet je uzavÅ™enÃ½."
 
 #: src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java:1435
 #, java-format
@@ -474,7 +474,7 @@ msgstr ""
 #: src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java:1511
 #, fuzzy, java-format
 msgid "Unexpected copydata from server for {0}"
-msgstr "Neoèekávanı stav pøíkazu: {0}."
+msgstr "NeoÄekÃ¡vanÃ½ stav pÅ™Ã­kazu: {0}."
 
 #: src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java:1571
 #, java-format
@@ -576,12 +576,12 @@ msgstr ""
 #: src/main/java/org/postgresql/core/v3/SimpleParameterList.java:407
 #, java-format
 msgid "No value specified for parameter {0}."
-msgstr "Nespecifikována hodnota parametru {0}."
+msgstr "NespecifikovÃ¡na hodnota parametru {0}."
 
 #: src/main/java/org/postgresql/core/v3/SimpleParameterList.java:612
 #, fuzzy, java-format
 msgid "Added parameters index out of range: {0}, number of columns: {1}."
-msgstr "Index parametru mimo rozsah: {0}, poèet parametrù {1}."
+msgstr "Index parametru mimo rozsah: {0}, poÄet parametrÅ¯ {1}."
 
 #: src/main/java/org/postgresql/core/v3/replication/V3PGReplicationStream.java:154
 #, java-format
@@ -591,11 +591,11 @@ msgstr ""
 #: src/main/java/org/postgresql/core/v3/replication/V3PGReplicationStream.java:288
 #, fuzzy
 msgid "This replication stream has been closed."
-msgstr "Spojeni bylo uzavøeno."
+msgstr "Spojeni bylo uzavÅ™eno."
 
 #: src/main/java/org/postgresql/ds/PGPooledConnection.java:130
 msgid "This PooledConnection has already been closed."
-msgstr "Tento PooledConnection byl uzavøen."
+msgstr "Tento PooledConnection byl uzavÅ™en."
 
 #: src/main/java/org/postgresql/ds/PGPooledConnection.java:331
 msgid ""
@@ -605,11 +605,11 @@ msgstr ""
 
 #: src/main/java/org/postgresql/ds/PGPooledConnection.java:332
 msgid "Connection has been closed."
-msgstr "Spojeni bylo uzavøeno."
+msgstr "Spojeni bylo uzavÅ™eno."
 
 #: src/main/java/org/postgresql/ds/PGPooledConnection.java:440
 msgid "Statement has been closed."
-msgstr "Statement byl uzavøen."
+msgstr "Statement byl uzavÅ™en."
 
 #: src/main/java/org/postgresql/ds/PGPoolingDataSource.java:287
 msgid "Failed to setup DataSource."
@@ -617,13 +617,13 @@ msgstr ""
 
 #: src/main/java/org/postgresql/ds/PGPoolingDataSource.java:393
 msgid "DataSource has been closed."
-msgstr "DataSource byl uzavøen."
+msgstr "DataSource byl uzavÅ™en."
 
 #: src/main/java/org/postgresql/ds/common/BaseDataSource.java:1558
 #: src/main/java/org/postgresql/ds/common/BaseDataSource.java:1568
 #, fuzzy, java-format
 msgid "Unsupported property name: {0}"
-msgstr "Nepodporovaná hodnota typu: {0}"
+msgstr "NepodporovanÃ¡ hodnota typu: {0}"
 
 #: src/main/java/org/postgresql/fastpath/Fastpath.java:83
 #, java-format
@@ -645,7 +645,7 @@ msgstr ""
 #: src/main/java/org/postgresql/fastpath/Fastpath.java:189
 #, fuzzy, java-format
 msgid "Fastpath call {0} - No result was returned and we expected a long."
-msgstr "Obdr¾en vısledek, ikdy¾ ¾ádnı nebyl oèekáván."
+msgstr "ObdrÅ¾en vÃ½sledek, ikdyÅ¾ Å¾Ã¡dnÃ½ nebyl oÄekÃ¡vÃ¡n."
 
 #: src/main/java/org/postgresql/fastpath/Fastpath.java:197
 #, java-format
@@ -705,7 +705,7 @@ msgstr ""
 
 #: src/main/java/org/postgresql/jdbc/AbstractBlobClob.java:245
 msgid "LOB positioning offsets start at 1."
-msgstr "Zaèátek pozicování LOB zaèína na 1."
+msgstr "ZaÄÃ¡tek pozicovÃ¡nÃ­ LOB zaÄÃ­na na 1."
 
 #: src/main/java/org/postgresql/jdbc/AbstractBlobClob.java:261
 msgid "free() was called on this LOB previously"
@@ -721,27 +721,27 @@ msgid ""
 "was created in.  The most common example of this is storing 8bit data in a "
 "SQL_ASCII database."
 msgstr ""
-"Nalezena vada ve znakovıch datech. Toto mù¾e bıt zpùsobeno ulo¾enımi daty "
-"obsahujícími znaky, které jsou závadné pro znakovou sadu nastavenou pøi "
-"zakládání databáze. Nejznámej¹í pøíklad je ukládání 8bitovıch dat vSQL_ASCII "
-"databázi."
+"Nalezena vada ve znakovÃ½ch datech. Toto mÅ¯Å¾e bÃ½t zpÅ¯sobeno uloÅ¾enÃ½mi daty "
+"obsahujÃ­cÃ­mi znaky, kterÃ© jsou zÃ¡vadnÃ© pro znakovou sadu nastavenou pÅ™i "
+"zaklÃ¡dÃ¡nÃ­ databÃ¡ze. NejznÃ¡mejÅ¡Ã­ pÅ™Ã­klad je uklÃ¡dÃ¡nÃ­ 8bitovÃ½ch dat vSQL_ASCII "
+"databÃ¡zi."
 
 #: src/main/java/org/postgresql/jdbc/ArrayEncoding.java:801
 #: src/main/java/org/postgresql/jdbc/ArrayEncoding.java:835
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:1212
 msgid "Unable to translate data into the desired encoding."
-msgstr "Nemohu pøelo¾it data do po¾adovaného kódování."
+msgstr "Nemohu pÅ™eloÅ¾it data do poÅ¾adovanÃ©ho kÃ³dovÃ¡nÃ­."
 
 #: src/main/java/org/postgresql/jdbc/ArrayEncoding.java:1040
 #: src/main/java/org/postgresql/jdbc/ArrayEncoding.java:1051
 #: src/main/java/org/postgresql/jdbc/ArrayEncoding.java:1077
 #, fuzzy, java-format
 msgid "Invalid elements {0}"
-msgstr "Vadná délka proudu {0}."
+msgstr "VadnÃ¡ dÃ©lka proudu {0}."
 
 #: src/main/java/org/postgresql/jdbc/BatchResultHandler.java:102
 msgid "Too many update results were returned."
-msgstr "Bylo vráceno pøíli¹ mnoho vısledkù aktualizací."
+msgstr "Bylo vrÃ¡ceno pÅ™Ã­liÅ¡ mnoho vÃ½sledkÅ¯ aktualizacÃ­."
 
 #: src/main/java/org/postgresql/jdbc/BatchResultHandler.java:163
 #, java-format
@@ -759,7 +759,7 @@ msgstr ""
 #: src/main/java/org/postgresql/jdbc/EscapedFunctions2.java:171
 #, java-format
 msgid "{0} function takes four and only four argument."
-msgstr "Funkce {0} bere pøesnì ètyøi argumenty."
+msgstr "Funkce {0} bere pÅ™esnÄ› ÄtyÅ™i argumenty."
 
 #: src/main/java/org/postgresql/jdbc/EscapedFunctions.java:270
 #: src/main/java/org/postgresql/jdbc/EscapedFunctions.java:337
@@ -769,7 +769,7 @@ msgstr "Funkce {0} bere pøesnì ètyøi argumenty."
 #: src/main/java/org/postgresql/jdbc/EscapedFunctions2.java:668
 #, java-format
 msgid "{0} function takes two and only two arguments."
-msgstr "Funkce {0} bere právì dva argumenty."
+msgstr "Funkce {0} bere prÃ¡vÄ› dva argumenty."
 
 #: src/main/java/org/postgresql/jdbc/EscapedFunctions.java:288
 #: src/main/java/org/postgresql/jdbc/EscapedFunctions.java:441
@@ -791,7 +791,7 @@ msgstr "Funkce {0} bere jeden argument."
 #: src/main/java/org/postgresql/jdbc/EscapedFunctions2.java:311
 #, java-format
 msgid "{0} function takes two or three arguments."
-msgstr "Funkce {0} bere dva nebo tøi argumenty."
+msgstr "Funkce {0} bere dva nebo tÅ™i argumenty."
 
 #: src/main/java/org/postgresql/jdbc/EscapedFunctions.java:411
 #: src/main/java/org/postgresql/jdbc/EscapedFunctions.java:426
@@ -800,7 +800,7 @@ msgstr "Funkce {0} bere dva nebo tøi argumenty."
 #: src/main/java/org/postgresql/jdbc/EscapedFunctions2.java:648
 #, java-format
 msgid "{0} function doesn''t take any argument."
-msgstr "Funkce {0} nebere ¾ádnı argument."
+msgstr "Funkce {0} nebere Å¾Ã¡dnÃ½ argument."
 
 #: src/main/java/org/postgresql/jdbc/EscapedFunctions.java:587
 #: src/main/java/org/postgresql/jdbc/EscapedFunctions.java:640
@@ -808,7 +808,7 @@ msgstr "Funkce {0} nebere ¾ádnı argument."
 #: src/main/java/org/postgresql/jdbc/EscapedFunctions2.java:574
 #, fuzzy, java-format
 msgid "{0} function takes three and only three arguments."
-msgstr "Funkce {0} bere právì dva argumenty."
+msgstr "Funkce {0} bere prÃ¡vÄ› dva argumenty."
 
 #: src/main/java/org/postgresql/jdbc/EscapedFunctions.java:600
 #: src/main/java/org/postgresql/jdbc/EscapedFunctions.java:621
@@ -822,26 +822,26 @@ msgstr "Funkce {0} bere právì dva argumenty."
 #: src/main/java/org/postgresql/jdbc/EscapedFunctions2.java:600
 #, fuzzy, java-format
 msgid "Interval {0} not yet implemented"
-msgstr "Metoda {0} není implementována."
+msgstr "Metoda {0} nenÃ­ implementovÃ¡na."
 
 #: src/main/java/org/postgresql/jdbc/GSSEncMode.java:61
 #, fuzzy, java-format
 msgid "Invalid gssEncMode value: {0}"
-msgstr "Vadná délka proudu {0}."
+msgstr "VadnÃ¡ dÃ©lka proudu {0}."
 
 #: src/main/java/org/postgresql/jdbc/PSQLSavepoint.java:40
 #: src/main/java/org/postgresql/jdbc/PSQLSavepoint.java:55
 #: src/main/java/org/postgresql/jdbc/PSQLSavepoint.java:73
 msgid "Cannot reference a savepoint after it has been released."
-msgstr "Nemohu získat odkaz na savepoint, kdy¾ byl uvolnìn."
+msgstr "Nemohu zÃ­skat odkaz na savepoint, kdyÅ¾ byl uvolnÄ›n."
 
 #: src/main/java/org/postgresql/jdbc/PSQLSavepoint.java:45
 msgid "Cannot retrieve the id of a named savepoint."
-msgstr "Nemohu získat id nepojmenovaného savepointu."
+msgstr "Nemohu zÃ­skat id nepojmenovanÃ©ho savepointu."
 
 #: src/main/java/org/postgresql/jdbc/PSQLSavepoint.java:60
 msgid "Cannot retrieve the name of an unnamed savepoint."
-msgstr "Nemohu získat název nepojmenovaného savepointu."
+msgstr "Nemohu zÃ­skat nÃ¡zev nepojmenovanÃ©ho savepointu."
 
 #: src/main/java/org/postgresql/jdbc/PgArray.java:153
 #: src/main/java/org/postgresql/jdbc/PgArray.java:371
@@ -853,17 +853,17 @@ msgstr "Index pole mimo rozsah: {0}"
 #: src/main/java/org/postgresql/jdbc/PgArray.java:388
 #, java-format
 msgid "The array index is out of range: {0}, number of elements: {1}."
-msgstr "Index pole mimo rozsah: {0}, poèet prvkù: {1}."
+msgstr "Index pole mimo rozsah: {0}, poÄet prvkÅ¯: {1}."
 
 #: src/main/java/org/postgresql/jdbc/PgCallableStatement.java:99
 #: src/main/java/org/postgresql/jdbc/PgCallableStatement.java:105
 msgid "A CallableStatement was executed with nothing returned."
-msgstr "CallableStatement byl spu¹tìn, leè nic nebylo vráceno."
+msgstr "CallableStatement byl spuÅ¡tÄ›n, leÄ nic nebylo vrÃ¡ceno."
 
 #: src/main/java/org/postgresql/jdbc/PgCallableStatement.java:116
 #, fuzzy
 msgid "A CallableStatement was executed with an invalid number of parameters"
-msgstr "CallableStatement byl spu¹tìn, leè nic nebylo vráceno."
+msgstr "CallableStatement byl spuÅ¡tÄ›n, leÄ nic nebylo vrÃ¡ceno."
 
 #: src/main/java/org/postgresql/jdbc/PgCallableStatement.java:154
 #, java-format
@@ -908,12 +908,12 @@ msgstr ""
 #: src/main/java/org/postgresql/jdbc/PgCallableStatement.java:732
 #, fuzzy, java-format
 msgid "Unsupported type conversion to {0}."
-msgstr "Nepodporovaná hodnota typu: {0}"
+msgstr "NepodporovanÃ¡ hodnota typu: {0}"
 
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:353
 #, fuzzy, java-format
 msgid "Unsupported value for stringtype parameter: {0}"
-msgstr "Nepodporovaná hodnota typu: {0}"
+msgstr "NepodporovanÃ¡ hodnota typu: {0}"
 
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:612
 #: src/main/java/org/postgresql/jdbc/PgPreparedStatement.java:141
@@ -927,13 +927,13 @@ msgstr "Nepodporovaná hodnota typu: {0}"
 #: src/main/java/org/postgresql/jdbc/TypeInfoCache.java:705
 #: src/main/java/org/postgresql/jdbc/TypeInfoCache.java:710
 msgid "No results were returned by the query."
-msgstr "Neobdr¾en ¾ádnı vısledek dotazu."
+msgstr "NeobdrÅ¾en Å¾Ã¡dnÃ½ vÃ½sledek dotazu."
 
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:630
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:647
 #: src/main/java/org/postgresql/jdbc/PgStatement.java:317
 msgid "A result was returned when none was expected."
-msgstr "Obdr¾en vısledek, ikdy¾ ¾ádnı nebyl oèekáván."
+msgstr "ObdrÅ¾en vÃ½sledek, ikdyÅ¾ Å¾Ã¡dnÃ½ nebyl oÄekÃ¡vÃ¡n."
 
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:754
 msgid "Custom type maps are not supported."
@@ -942,12 +942,12 @@ msgstr ""
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:796
 #, java-format
 msgid "Failed to create object for: {0}."
-msgstr "Selhalo vytvoøení objektu: {0}."
+msgstr "Selhalo vytvoÅ™enÃ­ objektu: {0}."
 
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:864
 #, java-format
 msgid "Unable to load the class {0} responsible for the datatype {1}"
-msgstr "Nemohu naèíst tøídu {0} odpovìdnou za typ {1}"
+msgstr "Nemohu naÄÃ­st tÅ™Ã­du {0} odpovÄ›dnou za typ {1}"
 
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:892
 msgid "Unable to close connection properly"
@@ -967,7 +967,7 @@ msgstr ""
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:1655
 #, fuzzy
 msgid "This connection has been closed."
-msgstr "Spojeni bylo uzavøeno."
+msgstr "Spojeni bylo uzavÅ™eno."
 
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:1041
 msgid "Cannot rollback when autoCommit is enabled."
@@ -987,12 +987,12 @@ msgstr ""
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:2242
 #: src/main/java/org/postgresql/jdbc/PgStatement.java:1026
 msgid "Fetch size must be a value greater than or equal to 0."
-msgstr "Nabraná velikost musí bıt nezáporná."
+msgstr "NabranÃ¡ velikost musÃ­ bÃ½t nezÃ¡pornÃ¡."
 
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:1290
 #, fuzzy
 msgid "Query timeout must be a value greater than or equal to 0."
-msgstr "Èasovı limit dotazu musí bıt nezáporné èíslo."
+msgstr "ÄŒasovÃ½ limit dotazu musÃ­ bÃ½t nezÃ¡pornÃ© ÄÃ­slo."
 
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:1536
 #, java-format
@@ -1002,7 +1002,7 @@ msgstr ""
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:1562
 #, fuzzy, java-format
 msgid "Invalid timeout ({0}<0)."
-msgstr "Vadná délka proudu {0}."
+msgstr "VadnÃ¡ dÃ©lka proudu {0}."
 
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:1599
 msgid "Validating connection."
@@ -1011,12 +1011,12 @@ msgstr ""
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:1632
 #, fuzzy, java-format
 msgid "Failed to set ClientInfo property: {0}"
-msgstr "Selhalo vytvoøení objektu: {0}."
+msgstr "Selhalo vytvoÅ™enÃ­ objektu: {0}."
 
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:1642
 #, fuzzy
 msgid "ClientInfo property not supported."
-msgstr "Vrácení automaticky generovanıch klíèù není podporováno."
+msgstr "VrÃ¡cenÃ­ automaticky generovanÃ½ch klÃ­ÄÅ¯ nenÃ­ podporovÃ¡no."
 
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:1668
 msgid "One or more ClientInfo failed."
@@ -1025,7 +1025,7 @@ msgstr ""
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:1775
 #, fuzzy
 msgid "Network timeout must be a value greater than or equal to 0."
-msgstr "Èasovı limit dotazu musí bıt nezáporné èíslo."
+msgstr "ÄŒasovÃ½ limit dotazu musÃ­ bÃ½t nezÃ¡pornÃ© ÄÃ­slo."
 
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:1784
 msgid "Unable to set network timeout."
@@ -1043,11 +1043,11 @@ msgstr ""
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:1842
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:1863
 msgid "Cannot establish a savepoint in auto-commit mode."
-msgstr "Nemohu vytvoøit savepoint v auto-commit modu."
+msgstr "Nemohu vytvoÅ™it savepoint v auto-commit modu."
 
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:1932
 msgid "Returning autogenerated keys is not supported."
-msgstr "Vrácení automaticky generovanıch klíèù není podporováno."
+msgstr "VrÃ¡cenÃ­ automaticky generovanÃ½ch klÃ­ÄÅ¯ nenÃ­ podporovÃ¡no."
 
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:1994
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:2003
@@ -1064,16 +1064,16 @@ msgstr ""
 msgid ""
 "Unable to determine a value for MaxIndexKeys due to missing system catalog "
 "data."
-msgstr "Nemohu najít oid a oidvector typu v systémovém katalogu."
+msgstr "Nemohu najÃ­t oid a oidvector typu v systÃ©movÃ©m katalogu."
 
 #: src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java:98
 msgid "Unable to find name datatype in the system catalogs."
-msgstr "Nemohu najít název typu v systémovém katalogu."
+msgstr "Nemohu najÃ­t nÃ¡zev typu v systÃ©movÃ©m katalogu."
 
 #: src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java:358
 #, fuzzy
 msgid "Unable to find keywords in the system catalogs."
-msgstr "Nemohu najít název typu v systémovém katalogu."
+msgstr "Nemohu najÃ­t nÃ¡zev typu v systÃ©movÃ©m katalogu."
 
 #: src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java:1085
 msgid ""
@@ -1084,7 +1084,7 @@ msgstr ""
 #: src/main/java/org/postgresql/jdbc/PgParameterMetaData.java:96
 #, java-format
 msgid "The parameter index is out of range: {0}, number of parameters: {1}."
-msgstr "Index parametru mimo rozsah: {0}, poèet parametrù {1}."
+msgstr "Index parametru mimo rozsah: {0}, poÄet parametrÅ¯ {1}."
 
 #: src/main/java/org/postgresql/jdbc/PgPreparedStatement.java:108
 #, java-format
@@ -1104,7 +1104,7 @@ msgstr ""
 
 #: src/main/java/org/postgresql/jdbc/PgPreparedStatement.java:300
 msgid "Unknown Types value."
-msgstr "Neznámá hodnota typu."
+msgstr "NeznÃ¡mÃ¡ hodnota typu."
 
 #: src/main/java/org/postgresql/jdbc/PgPreparedStatement.java:454
 #: src/main/java/org/postgresql/jdbc/PgPreparedStatement.java:1335
@@ -1112,24 +1112,24 @@ msgstr "Neznámá hodnota typu."
 #: src/main/java/org/postgresql/jdbc/PgPreparedStatement.java:1704
 #, java-format
 msgid "Invalid stream length {0}."
-msgstr "Vadná délka proudu {0}."
+msgstr "VadnÃ¡ dÃ©lka proudu {0}."
 
 #: src/main/java/org/postgresql/jdbc/PgPreparedStatement.java:483
 #, java-format
 msgid "The JVM claims not to support the {0} encoding."
-msgstr "JVM tvrdí, ¾e nepodporuje kodování {0}."
+msgstr "JVM tvrdÃ­, Å¾e nepodporuje kodovÃ¡nÃ­ {0}."
 
 #: src/main/java/org/postgresql/jdbc/PgPreparedStatement.java:486
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:1325
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:1364
 msgid "Provided InputStream failed."
-msgstr "Selhal poskytnutı InputStream."
+msgstr "Selhal poskytnutÃ½ InputStream."
 
 #: src/main/java/org/postgresql/jdbc/PgPreparedStatement.java:528
 #: src/main/java/org/postgresql/jdbc/PgPreparedStatement.java:1239
 #, java-format
 msgid "Unknown type {0}."
-msgstr "Neznámı typ {0}."
+msgstr "NeznÃ¡mÃ½ typ {0}."
 
 #: src/main/java/org/postgresql/jdbc/PgPreparedStatement.java:550
 msgid "No hstore extension installed."
@@ -1142,17 +1142,17 @@ msgstr ""
 #: src/main/java/org/postgresql/jdbc/PgPreparedStatement.java:1084
 #, java-format
 msgid "Cannot cast an instance of {0} to type {1}"
-msgstr "Nemohu pøetypovat instanci {0} na typ {1}"
+msgstr "Nemohu pÅ™etypovat instanci {0} na typ {1}"
 
 #: src/main/java/org/postgresql/jdbc/PgPreparedStatement.java:762
 #, java-format
 msgid "Unsupported Types value: {0}"
-msgstr "Nepodporovaná hodnota typu: {0}"
+msgstr "NepodporovanÃ¡ hodnota typu: {0}"
 
 #: src/main/java/org/postgresql/jdbc/PgPreparedStatement.java:1005
 #, fuzzy, java-format
 msgid "Cannot convert an instance of {0} to type {1}"
-msgstr "Nemohu pøetypovat instanci {0} na typ {1}"
+msgstr "Nemohu pÅ™etypovat instanci {0} na typ {1}"
 
 #: src/main/java/org/postgresql/jdbc/PgPreparedStatement.java:1090
 #, java-format
@@ -1164,17 +1164,17 @@ msgstr ""
 #: src/main/java/org/postgresql/jdbc/PgPreparedStatement.java:1275
 #: src/main/java/org/postgresql/jdbc/PgPreparedStatement.java:1382
 msgid "Unexpected error writing large object to database."
-msgstr "Neoèekávaná chyba pøi zapisování velkého objektu do databáze."
+msgstr "NeoÄekÃ¡vanÃ¡ chyba pÅ™i zapisovÃ¡nÃ­ velkÃ©ho objektu do databÃ¡ze."
 
 #: src/main/java/org/postgresql/jdbc/PgPreparedStatement.java:1301
 #, fuzzy
 msgid "Unexpected error when closing Blob binary stream"
-msgstr "Neoèekávaná chyba pøi zapisování velkého objektu do databáze."
+msgstr "NeoÄekÃ¡vanÃ¡ chyba pÅ™i zapisovÃ¡nÃ­ velkÃ©ho objektu do databÃ¡ze."
 
 #: src/main/java/org/postgresql/jdbc/PgPreparedStatement.java:1320
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:1427
 msgid "Provided Reader failed."
-msgstr "Selhal poskytnutı Reader."
+msgstr "Selhal poskytnutÃ½ Reader."
 
 #: src/main/java/org/postgresql/jdbc/PgPreparedStatement.java:1640
 #: src/main/java/org/postgresql/util/StreamWrapper.java:60
@@ -1199,27 +1199,27 @@ msgstr ""
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:3721
 #, fuzzy, java-format
 msgid "Cannot convert the column of type {0} to requested type {1}."
-msgstr "Nemohu pøetypovat instanci {0} na typ {1}"
+msgstr "Nemohu pÅ™etypovat instanci {0} na typ {1}"
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:1024
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:1045
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:2276
 msgid "Can''t use relative move methods while on the insert row."
-msgstr "Nemù¾ete pou¾ívat relativní pøesuny pøi vkládání øádku."
+msgstr "NemÅ¯Å¾ete pouÅ¾Ã­vat relativnÃ­ pÅ™esuny pÅ™i vklÃ¡dÃ¡nÃ­ Å™Ã¡dku."
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:1069
 #: src/main/java/org/postgresql/jdbc/PgStatement.java:1017
 #, java-format
 msgid "Invalid fetch direction constant: {0}."
-msgstr "©patnı smìr ètení: {0}."
+msgstr "Å patnÃ½ smÄ›r ÄtenÃ­: {0}."
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:1081
 msgid "Cannot call cancelRowUpdates() when on the insert row."
-msgstr "Nemù¾ete volat cancelRowUpdates() pøi vkládání øádku."
+msgstr "NemÅ¯Å¾ete volat cancelRowUpdates() pÅ™i vklÃ¡dÃ¡nÃ­ Å™Ã¡dku."
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:1099
 msgid "Cannot call deleteRow() when on the insert row."
-msgstr "Nemù¾ete volat deleteRow() pøi vkládání øádku."
+msgstr "NemÅ¯Å¾ete volat deleteRow() pÅ™i vklÃ¡dÃ¡nÃ­ Å™Ã¡dku."
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:1106
 msgid ""
@@ -1232,27 +1232,27 @@ msgid ""
 "Currently positioned after the end of the ResultSet.  You cannot call "
 "deleteRow() here."
 msgstr ""
-"Právì jste za pozicí konce ResultSetu. Zde nemù¾ete volat deleteRow().s"
+"PrÃ¡vÄ› jste za pozicÃ­ konce ResultSetu. Zde nemÅ¯Å¾ete volat deleteRow().s"
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:1117
 msgid "There are no rows in this ResultSet."
-msgstr "®ádnı øádek v ResultSet."
+msgstr "Å½Ã¡dnÃ½ Å™Ã¡dek v ResultSet."
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:1158
 msgid "Not on the insert row."
-msgstr "Ne na vkládaném øádku."
+msgstr "Ne na vklÃ¡danÃ©m Å™Ã¡dku."
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:1162
 msgid "You must specify at least one column value to insert a row."
-msgstr "Musíte vyplnit alespoò jeden sloupec pro vlo¾ení øádku."
+msgstr "MusÃ­te vyplnit alespoÅˆ jeden sloupec pro vloÅ¾enÃ­ Å™Ã¡dku."
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:1497
 msgid "Can''t refresh the insert row."
-msgstr "Nemohu obnovit vkládanı øádek."
+msgstr "Nemohu obnovit vklÃ¡danÃ½ Å™Ã¡dek."
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:1573
 msgid "Cannot call updateRow() when on the insert row."
-msgstr "Nemohu volat updateRow() na vlkádaném øádku."
+msgstr "Nemohu volat updateRow() na vlkÃ¡danÃ©m Å™Ã¡dku."
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:1581
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:3738
@@ -1263,17 +1263,17 @@ msgstr ""
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:1844
 msgid "ResultSets with concurrency CONCUR_READ_ONLY cannot be updated."
-msgstr "ResultSets se soubì¾ností CONCUR_READ_ONLY nemù¾e bıt aktualizováno"
+msgstr "ResultSets se soubÄ›Å¾nostÃ­ CONCUR_READ_ONLY nemÅ¯Å¾e bÃ½t aktualizovÃ¡no"
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:1948
 #, fuzzy, java-format
 msgid "No eligible primary or unique key found for table {0}."
-msgstr "Nenalezen primární klíè pro tabulku {0}."
+msgstr "Nenalezen primÃ¡rnÃ­ klÃ­Ä pro tabulku {0}."
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:2148
 #, java-format
 msgid "The JVM claims not to support the encoding: {0}"
-msgstr "JVM tvrdí, ¾e nepodporuje kodování: {0}"
+msgstr "JVM tvrdÃ­, Å¾e nepodporuje kodovÃ¡nÃ­: {0}"
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:2597
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:2602
@@ -1294,12 +1294,12 @@ msgstr "JVM tvrdí, ¾e nepodporuje kodování: {0}"
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:3726
 #, java-format
 msgid "Bad value for type {0} : {1}"
-msgstr "©patná hodnota pro typ {0} : {1}"
+msgstr "Å patnÃ¡ hodnota pro typ {0} : {1}"
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:3207
 #, java-format
 msgid "The column name {0} was not found in this ResultSet."
-msgstr "Sloupec pojmenovanı {0} nebyl nalezen v ResultSet."
+msgstr "Sloupec pojmenovanÃ½ {0} nebyl nalezen v ResultSet."
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:3348
 msgid ""
@@ -1307,13 +1307,13 @@ msgid ""
 "select only one table, and must select all primary keys from that table. See "
 "the JDBC 2.1 API Specification, section 5.6 for more details."
 msgstr ""
-"ResultSet není aktualizavatelnı. Dotaz musí vybírat pouze z jedné tabulky a "
-"musí obsahovat v¹echny primární klíèe tabulky. Koukni do JDBC 2.1 API "
-"Specifikace, sekce 5.6 pro více podrobností."
+"ResultSet nenÃ­ aktualizavatelnÃ½. Dotaz musÃ­ vybÃ­rat pouze z jednÃ© tabulky a "
+"musÃ­ obsahovat vÅ¡echny primÃ¡rnÃ­ klÃ­Äe tabulky. Koukni do JDBC 2.1 API "
+"Specifikace, sekce 5.6 pro vÃ­ce podrobnostÃ­."
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:3364
 msgid "This ResultSet is closed."
-msgstr "Tento ResultSet je uzavøenı."
+msgstr "Tento ResultSet je uzavÅ™enÃ½."
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:3398
 msgid "ResultSet not positioned properly, perhaps you need to call next."
@@ -1363,7 +1363,7 @@ msgstr ""
 #: src/main/java/org/postgresql/jdbc/PgSQLXML.java:229
 #, fuzzy
 msgid "Unable to create SAXResult for SQLXML."
-msgstr "Selhalo vytvoøení objektu: {0}."
+msgstr "Selhalo vytvoÅ™enÃ­ objektu: {0}."
 
 #: src/main/java/org/postgresql/jdbc/PgSQLXML.java:245
 msgid "Unable to create StAXResult for SQLXML"
@@ -1377,7 +1377,7 @@ msgstr ""
 #: src/main/java/org/postgresql/jdbc/PgSQLXML.java:266
 #, fuzzy
 msgid "This SQLXML object has already been freed."
-msgstr "Tento PooledConnection byl uzavøen."
+msgstr "Tento PooledConnection byl uzavÅ™en."
 
 #: src/main/java/org/postgresql/jdbc/PgSQLXML.java:275
 msgid ""
@@ -1414,7 +1414,7 @@ msgstr ""
 
 #: src/main/java/org/postgresql/jdbc/PgStatement.java:295
 msgid "Multiple ResultSets were returned by the query."
-msgstr "Vícenásobnı ResultSet byl vrácen dotazem."
+msgstr "VÃ­cenÃ¡sobnÃ½ ResultSet byl vrÃ¡cen dotazem."
 
 #: src/main/java/org/postgresql/jdbc/PgStatement.java:381
 msgid "Can''t use executeWithFlags(int) on a Statement."
@@ -1423,19 +1423,19 @@ msgstr ""
 #: src/main/java/org/postgresql/jdbc/PgStatement.java:593
 #, fuzzy
 msgid "Maximum number of rows must be a value greater than or equal to 0."
-msgstr "Maximální poèet øádek musí bıt nezáporné èíslo."
+msgstr "MaximÃ¡lnÃ­ poÄet Å™Ã¡dek musÃ­ bÃ½t nezÃ¡pornÃ© ÄÃ­slo."
 
 #: src/main/java/org/postgresql/jdbc/PgStatement.java:642
 msgid "Query timeout must be a value greater than or equals to 0."
-msgstr "Èasovı limit dotazu musí bıt nezáporné èíslo."
+msgstr "ÄŒasovÃ½ limit dotazu musÃ­ bÃ½t nezÃ¡pornÃ© ÄÃ­slo."
 
 #: src/main/java/org/postgresql/jdbc/PgStatement.java:685
 msgid "The maximum field size must be a value greater than or equal to 0."
-msgstr "Maximální velikost pole musí bıt nezáporné èíslo."
+msgstr "MaximÃ¡lnÃ­ velikost pole musÃ­ bÃ½t nezÃ¡pornÃ© ÄÃ­slo."
 
 #: src/main/java/org/postgresql/jdbc/PgStatement.java:791
 msgid "This statement has been closed."
-msgstr "Pøíkaz byl uzavøen."
+msgstr "PÅ™Ã­kaz byl uzavÅ™en."
 
 #: src/main/java/org/postgresql/jdbc/PgStatement.java:833
 msgid ""
@@ -1448,14 +1448,14 @@ msgstr ""
 #: src/main/java/org/postgresql/jdbc/PgStatement.java:1350
 #, fuzzy, java-format
 msgid "Invalid value for autoGeneratedKeys {0}"
-msgstr "Vadná délka proudu {0}."
+msgstr "VadnÃ¡ dÃ©lka proudu {0}."
 
 #: src/main/java/org/postgresql/jdbc/PgStatement.java:1182
 #: src/main/java/org/postgresql/jdbc/PgStatement.java:1323
 #: src/main/java/org/postgresql/jdbc/PgStatement.java:1360
 #, fuzzy
 msgid "Returning autogenerated keys by column index is not supported."
-msgstr "Vrácení automaticky generovanıch klíèù není podporováno."
+msgstr "VrÃ¡cenÃ­ automaticky generovanÃ½ch klÃ­ÄÅ¯ nenÃ­ podporovÃ¡no."
 
 #: src/main/java/org/postgresql/jdbc/QueryExecutorTimeZoneProvider.java:33
 msgid ""
@@ -1466,13 +1466,13 @@ msgstr ""
 #: src/main/java/org/postgresql/jdbc/SslMode.java:78
 #, fuzzy, java-format
 msgid "Invalid sslmode value: {0}"
-msgstr "Vadná délka proudu {0}."
+msgstr "VadnÃ¡ dÃ©lka proudu {0}."
 
 #: src/main/java/org/postgresql/jdbc/TimestampUtils.java:379
 #: src/main/java/org/postgresql/jdbc/TimestampUtils.java:491
 #, fuzzy, java-format
 msgid "Bad value for type timestamp/date/time: {0}"
-msgstr "©patná hodnota pro typ {0} : {1}"
+msgstr "Å patnÃ¡ hodnota pro typ {0} : {1}"
 
 #: src/main/java/org/postgresql/jdbc/TimestampUtils.java:506
 #: src/main/java/org/postgresql/jdbc/TimestampUtils.java:1313
@@ -1482,7 +1482,7 @@ msgstr "©patná hodnota pro typ {0} : {1}"
 #: src/main/java/org/postgresql/jdbc/TimestampUtils.java:1593
 #, fuzzy, java-format
 msgid "Unsupported binary encoding of {0}."
-msgstr "Nepodporovaná hodnota typu: {0}"
+msgstr "NepodporovanÃ¡ hodnota typu: {0}"
 
 #: src/main/java/org/postgresql/jdbc/TypeInfoCache.java:1119
 #, java-format
@@ -1500,7 +1500,7 @@ msgstr ""
 #: src/main/java/org/postgresql/largeobject/BlobOutputStream.java:236
 #, fuzzy, java-format
 msgid "Can not close large object {0}"
-msgstr "Selhalo vytvoøení objektu: {0}."
+msgstr "Selhalo vytvoÅ™enÃ­ objektu: {0}."
 
 #: src/main/java/org/postgresql/largeobject/BlobInputStream.java:317
 #, java-format
@@ -1521,17 +1521,17 @@ msgstr ""
 #: src/main/java/org/postgresql/largeobject/LargeObject.java:85
 #, fuzzy
 msgid "This large object has been closed."
-msgstr "Pøíkaz byl uzavøen."
+msgstr "PÅ™Ã­kaz byl uzavÅ™en."
 
 #: src/main/java/org/postgresql/largeobject/LargeObjectManager.java:244
 #: src/main/java/org/postgresql/largeobject/LargeObjectManager.java:285
 msgid "Large Objects may not be used in auto-commit mode."
-msgstr "Velké objecky nemohou bıt pou¾ity v auto-commit modu."
+msgstr "VelkÃ© objecky nemohou bÃ½t pouÅ¾ity v auto-commit modu."
 
 #: src/main/java/org/postgresql/osgi/PGDataSourceFactory.java:86
 #, fuzzy, java-format
 msgid "Unsupported properties: {0}"
-msgstr "Nepodporovaná hodnota typu: {0}"
+msgstr "NepodporovanÃ¡ hodnota typu: {0}"
 
 #: src/main/java/org/postgresql/replication/fluent/AbstractCreateSlotBuilder.java:40
 msgid "Server does not support temporary replication slots"
@@ -1632,7 +1632,7 @@ msgstr ""
 #: src/main/java/org/postgresql/ssl/LibPQFactory.java:64
 #, fuzzy, java-format
 msgid "The password callback class provided {0} could not be instantiated."
-msgstr "Tøída SSLSocketFactory poskytla {0} co¾ nemù¾e bıt instancionizováno."
+msgstr "TÅ™Ã­da SSLSocketFactory poskytla {0} coÅ¾ nemÅ¯Å¾e bÃ½t instancionizovÃ¡no."
 
 #: src/main/java/org/postgresql/ssl/LibPQFactory.java:110
 msgid "Could not initialize PEMKeyManager."
@@ -1665,7 +1665,7 @@ msgstr ""
 #: src/main/java/org/postgresql/ssl/MakeSSL.java:82
 #, fuzzy, java-format
 msgid "The HostnameVerifier class provided {0} could not be instantiated."
-msgstr "Tøída SSLSocketFactory poskytla {0} co¾ nemù¾e bıt instancionizováno."
+msgstr "TÅ™Ã­da SSLSocketFactory poskytla {0} coÅ¾ nemÅ¯Å¾e bÃ½t instancionizovÃ¡no."
 
 #: src/main/java/org/postgresql/ssl/MakeSSL.java:93
 #, java-format
@@ -1688,7 +1688,7 @@ msgstr ""
 #: src/main/java/org/postgresql/ssl/PGjdbcHostnameVerifier.java:92
 #, fuzzy, java-format
 msgid "No certificates found for hostname {0}"
-msgstr "Nenalezen primární klíè pro tabulku {0}."
+msgstr "Nenalezen primÃ¡rnÃ­ klÃ­Ä pro tabulku {0}."
 
 #: src/main/java/org/postgresql/ssl/PGjdbcHostnameVerifier.java:111
 #, java-format
@@ -1736,7 +1736,7 @@ msgstr ""
 #: src/main/java/org/postgresql/ssl/PKCS12KeyManager.java:42
 #, fuzzy
 msgid "Unable to find pkcs12 keystore."
-msgstr "Nemohu najít název typu v systémovém katalogu."
+msgstr "Nemohu najÃ­t nÃ¡zev typu v systÃ©movÃ©m katalogu."
 
 #: src/main/java/org/postgresql/ssl/SingleCertValidatingFactory.java:92
 msgid "The sslfactoryarg property may not be empty."
@@ -1773,7 +1773,7 @@ msgstr ""
 #: src/main/java/org/postgresql/ssl/SingleCertValidatingFactory.java:153
 #, fuzzy
 msgid "An error occurred reading the certificate"
-msgstr "Nastala chyba pøi nastavení SSL spojení."
+msgstr "Nastala chyba pÅ™i nastavenÃ­ SSL spojenÃ­."
 
 #: src/main/java/org/postgresql/ssl/SingleCertValidatingFactory.java:186
 msgid "No X509TrustManager found"
@@ -1790,7 +1790,7 @@ msgstr ""
 #: src/main/java/org/postgresql/util/PGInterval.java:220
 #, fuzzy
 msgid "Conversion of interval failed"
-msgstr "Pøevod penìz selhal."
+msgstr "PÅ™evod penÄ›z selhal."
 
 #: src/main/java/org/postgresql/util/PGPropertyMaxResultBufferParser.java:153
 #, java-format
@@ -1816,7 +1816,7 @@ msgstr ""
 
 #: src/main/java/org/postgresql/util/PGmoney.java:74
 msgid "Conversion of money failed."
-msgstr "Pøevod penìz selhal."
+msgstr "PÅ™evod penÄ›z selhal."
 
 #: src/main/java/org/postgresql/util/ServerErrorMessage.java:45
 #, java-format
@@ -1859,7 +1859,7 @@ msgstr "Pozice: {0}"
 #: src/main/java/org/postgresql/util/ServerErrorMessage.java:220
 #, java-format
 msgid "Location: File: {0}, Routine: {1}, Line: {2}"
-msgstr "Poloha: Soubor: {0}, Rutina: {1}, Øádek: {2}"
+msgstr "Poloha: Soubor: {0}, Rutina: {1}, Å˜Ã¡dek: {2}"
 
 #: src/main/java/org/postgresql/util/ServerErrorMessage.java:225
 #, java-format
@@ -1881,7 +1881,7 @@ msgstr ""
 #: src/main/java/org/postgresql/xa/PGXAConnection.java:387
 #, fuzzy, java-format
 msgid "Invalid flags {0}"
-msgstr "Vadná délka proudu {0}."
+msgstr "VadnÃ¡ dÃ©lka proudu {0}."
 
 #: src/main/java/org/postgresql/xa/PGXAConnection.java:196
 #: src/main/java/org/postgresql/xa/PGXAConnection.java:282

--- a/pgjdbc/src/main/java/org/postgresql/translation/de.po
+++ b/pgjdbc/src/main/java/org/postgresql/translation/de.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: Deutsch\n"
 "Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=ISO-8859-1\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: KBabel 1.0.2\n"
 "X-Poedit-Language: German\n"
@@ -40,8 +40,8 @@ msgid ""
 "server host and port that you wish to connect to."
 msgstr ""
 "Ihre Sicherheitsrichtlinie hat den Versuch des Verbindungsaufbaus "
-"verhindert. Sie müssen wahrscheinlich der Verbindung zum Datenbankrechner "
-"java.net.SocketPermission gewähren, um den Rechner auf dem gewählten Port zu "
+"verhindert. Sie mÃ¼ssen wahrscheinlich der Verbindung zum Datenbankrechner "
+"java.net.SocketPermission gewÃ¤hren, um den Rechner auf dem gewÃ¤hlten Port zu "
 "erreichen."
 
 #: src/main/java/org/postgresql/Driver.java:322
@@ -50,12 +50,12 @@ msgid ""
 "Something unusual has occurred to cause the driver to fail. Please report "
 "this exception."
 msgstr ""
-"Etwas Ungewöhnliches ist passiert, das den Treiber fehlschlagen ließ. Bitte "
+"Etwas UngewÃ¶hnliches ist passiert, das den Treiber fehlschlagen lieÃŸ. Bitte "
 "teilen Sie diesen Fehler mit."
 
 #: src/main/java/org/postgresql/Driver.java:412
 msgid "Connection attempt timed out."
-msgstr "Keine Verbindung innerhalb des Zeitintervalls möglich."
+msgstr "Keine Verbindung innerhalb des Zeitintervalls mÃ¶glich."
 
 #: src/main/java/org/postgresql/Driver.java:425
 msgid "Interrupted while attempting to connect."
@@ -98,7 +98,7 @@ msgstr ""
 #: src/main/java/org/postgresql/copy/PGCopyInputStream.java:60
 #, fuzzy, java-format
 msgid "Copying from database failed: {0}"
-msgstr "Konnte »{0}« nicht in Typ »box« umwandeln"
+msgstr "Konnte Â»{0}Â« nicht in Typ Â»boxÂ« umwandeln"
 
 #: src/main/java/org/postgresql/copy/PGCopyInputStream.java:74
 #: src/main/java/org/postgresql/copy/PGCopyOutputStream.java:104
@@ -118,7 +118,7 @@ msgstr ""
 #: src/main/java/org/postgresql/core/AuthMethod.java:30
 #, fuzzy, java-format
 msgid "Invalid authentication method: {0}"
-msgstr "Unzulässige Richtungskonstante bei fetch: {0}."
+msgstr "UnzulÃ¤ssige Richtungskonstante bei fetch: {0}."
 
 #: src/main/java/org/postgresql/core/AuthMethod.java:51
 msgid "requireAuth cannot mix positive and negative authentication methods"
@@ -136,7 +136,7 @@ msgstr ""
 #, fuzzy, java-format
 msgid "Unable to parse the count in command completion tag: {0}."
 msgstr ""
-"Der Updatecount aus der Kommandovervollständigungsmarkierung(?) {0} konnte "
+"Der Updatecount aus der KommandovervollstÃ¤ndigungsmarkierung(?) {0} konnte "
 "nicht interpretiert werden."
 
 #: src/main/java/org/postgresql/core/ConnectionFactory.java:60
@@ -166,7 +166,7 @@ msgstr ""
 #, java-format
 msgid "Malformed function or procedure escape syntax at offset {0}."
 msgstr ""
-"Unzulässige Syntax für ein Funktions- oder Prozedur-Escape an Offset {0}."
+"UnzulÃ¤ssige Syntax fÃ¼r ein Funktions- oder Prozedur-Escape an Offset {0}."
 
 #: src/main/java/org/postgresql/core/ProtocolVersion.java:53
 #, java-format
@@ -194,7 +194,7 @@ msgstr ""
 #: src/main/java/org/postgresql/core/Utils.java:72
 #: src/main/java/org/postgresql/core/Utils.java:89
 msgid "Zero bytes may not occur in string parameters."
-msgstr "Stringparameter dürfen keine Nullbytes enthalten."
+msgstr "Stringparameter dÃ¼rfen keine Nullbytes enthalten."
 
 #: src/main/java/org/postgresql/core/Utils.java:99
 #: src/main/java/org/postgresql/core/Utils.java:149
@@ -203,13 +203,13 @@ msgstr ""
 
 #: src/main/java/org/postgresql/core/Utils.java:138
 msgid "Zero bytes may not occur in identifiers."
-msgstr "Nullbytes dürfen in Bezeichnern nicht vorkommen."
+msgstr "Nullbytes dÃ¼rfen in Bezeichnern nicht vorkommen."
 
 #: src/main/java/org/postgresql/core/v3/AuthenticationPluginManager.java:73
 #, fuzzy, java-format
 msgid "Unable to load Authentication Plugin {0}"
 msgstr ""
-"Der Updatecount aus der Kommandovervollständigungsmarkierung(?) {0} konnte "
+"Der Updatecount aus der KommandovervollstÃ¤ndigungsmarkierung(?) {0} konnte "
 "nicht interpretiert werden."
 
 #: src/main/java/org/postgresql/core/v3/AuthenticationPluginManager.java:113
@@ -224,7 +224,7 @@ msgstr ""
 #: src/main/java/org/postgresql/core/v3/ChannelBinding.java:40
 #, fuzzy, java-format
 msgid "Invalid channelBinding value: {0}"
-msgstr "Ungültige Länge des Datenstroms: {0}."
+msgstr "UngÃ¼ltige LÃ¤nge des Datenstroms: {0}."
 
 #: src/main/java/org/postgresql/core/v3/CompositeParameterList.java:38
 #: src/main/java/org/postgresql/core/v3/SimpleParameterList.java:60
@@ -235,7 +235,7 @@ msgstr "Ungültige Länge des Datenstroms: {0}."
 #, java-format
 msgid "The column index is out of range: {0}, number of columns: {1}."
 msgstr ""
-"Der Spaltenindex {0} ist außerhalb des gültigen Bereichs. Anzahl Spalten: "
+"Der Spaltenindex {0} ist auÃŸerhalb des gÃ¼ltigen Bereichs. Anzahl Spalten: "
 "{1}."
 
 #: src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java:212
@@ -251,7 +251,7 @@ msgstr "Die xid darf nicht null sein."
 #: src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java:330
 #, fuzzy, java-format
 msgid "Invalid targetServerType value: {0}"
-msgstr "Ungültige Länge des Datenstroms: {0}."
+msgstr "UngÃ¼ltige LÃ¤nge des Datenstroms: {0}."
 
 #: src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java:426
 #, fuzzy, java-format
@@ -259,7 +259,7 @@ msgid ""
 "Connection to {0} refused. Check that the hostname and port are correct and "
 "that the postmaster is accepting TCP/IP connections."
 msgstr ""
-"Verbindung verweigert. Überprüfen Sie die Korrektheit von Hostnamen und der "
+"Verbindung verweigert. ÃœberprÃ¼fen Sie die Korrektheit von Hostnamen und der "
 "Portnummer und dass der Datenbankserver TCP/IP-Verbindungen annimmt."
 
 #: src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java:437
@@ -275,12 +275,12 @@ msgstr ""
 #: src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java:594
 #, fuzzy
 msgid "The server does not support GSS Encoding."
-msgstr "Der Server unterstützt SSL nicht."
+msgstr "Der Server unterstÃ¼tzt SSL nicht."
 
 #: src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java:609
 #, fuzzy
 msgid "The server does not support GSS Encryption."
-msgstr "Der Server unterstützt SSL nicht."
+msgstr "Der Server unterstÃ¼tzt SSL nicht."
 
 #: src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java:639
 #, fuzzy
@@ -290,7 +290,7 @@ msgstr "Beim Aufbau der SSL-Verbindung trat ein Fehler auf."
 #: src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java:689
 #: src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java:701
 msgid "The server does not support SSL."
-msgstr "Der Server unterstützt SSL nicht."
+msgstr "Der Server unterstÃ¼tzt SSL nicht."
 
 #: src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java:715
 msgid "An error occurred while setting up the SSL connection."
@@ -341,10 +341,10 @@ msgid ""
 "the pg_hba.conf file to include the client''s IP address or subnet, and that "
 "it is using an authentication scheme supported by the driver."
 msgstr ""
-"Der Authentifizierungstyp {0} wird nicht unterstützt. Stellen Sie sicher, "
+"Der Authentifizierungstyp {0} wird nicht unterstÃ¼tzt. Stellen Sie sicher, "
 "dass die Datei ''pg_hba.conf'' die IP-Adresse oder das Subnetz des Clients "
-"enthält und dass der Client ein Authentifizierungsschema nutzt, das vom "
-"Treiber unterstützt wird."
+"enthÃ¤lt und dass der Client ein Authentifizierungsschema nutzt, das vom "
+"Treiber unterstÃ¼tzt wird."
 
 #: src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java:1058
 #: src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java:3087
@@ -517,12 +517,12 @@ msgid ""
 "Bind message length {0} too long.  This can be caused by very large or "
 "incorrect length specifications on InputStream parameters."
 msgstr ""
-"Die Nachrichtenlänge {0} ist zu groß. Das kann von sehr großen oder "
-"inkorrekten Längenangaben eines InputStream-Parameters herrühren."
+"Die NachrichtenlÃ¤nge {0} ist zu groÃŸ. Das kann von sehr groÃŸen oder "
+"inkorrekten LÃ¤ngenangaben eines InputStream-Parameters herrÃ¼hren."
 
 #: src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java:2601
 msgid "Ran out of memory retrieving query results."
-msgstr "Nicht genügend Speicher beim Abholen der Abfrageergebnisse."
+msgstr "Nicht genÃ¼gend Speicher beim Abholen der Abfrageergebnisse."
 
 #: src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java:2769
 msgid "COPY commands are only supported using the CopyManager API."
@@ -548,8 +548,8 @@ msgid ""
 "The server''s client_encoding parameter was changed to {0}. The JDBC driver "
 "requires client_encoding to be UTF8 for correct operation."
 msgstr ""
-"Der Parameter ''client_encoding'' wurde auf dem Server auf {0} verändert. "
-"Der JDBC-Treiber setzt für korrektes Funktionieren die Einstellung UNICODE "
+"Der Parameter ''client_encoding'' wurde auf dem Server auf {0} verÃ¤ndert. "
+"Der JDBC-Treiber setzt fÃ¼r korrektes Funktionieren die Einstellung UNICODE "
 "voraus."
 
 #: src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java:3134
@@ -558,8 +558,8 @@ msgid ""
 "The server''s DateStyle parameter was changed to {0}. The JDBC driver "
 "requires DateStyle to begin with ISO for correct operation."
 msgstr ""
-"Der Parameter ''Date Style'' wurde auf dem Server auf {0} verändert. Der "
-"JDBC-Treiber setzt für korrekte Funktion voraus, dass ''Date Style'' mit "
+"Der Parameter ''Date Style'' wurde auf dem Server auf {0} verÃ¤ndert. Der "
+"JDBC-Treiber setzt fÃ¼r korrekte Funktion voraus, dass ''Date Style'' mit "
 "''ISO'' beginnt."
 
 #: src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java:3147
@@ -616,13 +616,13 @@ msgstr ""
 #: src/main/java/org/postgresql/core/v3/SimpleParameterList.java:407
 #, java-format
 msgid "No value specified for parameter {0}."
-msgstr "Für den Parameter {0} wurde kein Wert angegeben."
+msgstr "FÃ¼r den Parameter {0} wurde kein Wert angegeben."
 
 #: src/main/java/org/postgresql/core/v3/SimpleParameterList.java:612
 #, fuzzy, java-format
 msgid "Added parameters index out of range: {0}, number of columns: {1}."
 msgstr ""
-"Der Parameterindex {0} ist außerhalb des gültigen Bereichs. Es gibt {1} "
+"Der Parameterindex {0} ist auÃŸerhalb des gÃ¼ltigen Bereichs. Es gibt {1} "
 "Parameter."
 
 #: src/main/java/org/postgresql/core/v3/replication/V3PGReplicationStream.java:154
@@ -645,7 +645,7 @@ msgid ""
 "for the same PooledConnection or the PooledConnection has been closed."
 msgstr ""
 "Die Verbindung wurde automatisch geschlossen, da entweder eine neue "
-"Verbindung für die gleiche PooledConnection geöffnet wurde, oder die "
+"Verbindung fÃ¼r die gleiche PooledConnection geÃ¶ffnet wurde, oder die "
 "PooledConnection geschlossen worden ist.."
 
 #: src/main/java/org/postgresql/ds/PGPooledConnection.java:332
@@ -674,14 +674,14 @@ msgstr "Unbekannter Typ: {0}."
 #, fuzzy, java-format
 msgid "Fastpath call {0} - No result was returned and we expected a numeric."
 msgstr ""
-"Der Fastpath-Aufruf {0} gab kein Ergebnis zurück, jedoch wurde ein Integer "
+"Der Fastpath-Aufruf {0} gab kein Ergebnis zurÃ¼ck, jedoch wurde ein Integer "
 "erwartet."
 
 #: src/main/java/org/postgresql/fastpath/Fastpath.java:164
 #, java-format
 msgid "Fastpath call {0} - No result was returned and we expected an integer."
 msgstr ""
-"Der Fastpath-Aufruf {0} gab kein Ergebnis zurück, jedoch wurde ein Integer "
+"Der Fastpath-Aufruf {0} gab kein Ergebnis zurÃ¼ck, jedoch wurde ein Integer "
 "erwartet."
 
 #: src/main/java/org/postgresql/fastpath/Fastpath.java:172
@@ -690,14 +690,14 @@ msgid ""
 "Fastpath call {0} - No result was returned or wrong size while expecting an "
 "integer."
 msgstr ""
-"Der Fastpath-Aufruf {0} gab kein Ergebnis zurück, jedoch wurde ein Integer "
+"Der Fastpath-Aufruf {0} gab kein Ergebnis zurÃ¼ck, jedoch wurde ein Integer "
 "erwartet."
 
 #: src/main/java/org/postgresql/fastpath/Fastpath.java:189
 #, fuzzy, java-format
 msgid "Fastpath call {0} - No result was returned and we expected a long."
 msgstr ""
-"Der Fastpath-Aufruf {0} gab kein Ergebnis zurück, jedoch wurde ein Integer "
+"Der Fastpath-Aufruf {0} gab kein Ergebnis zurÃ¼ck, jedoch wurde ein Integer "
 "erwartet."
 
 #: src/main/java/org/postgresql/fastpath/Fastpath.java:197
@@ -706,7 +706,7 @@ msgid ""
 "Fastpath call {0} - No result was returned or wrong size while expecting a "
 "long."
 msgstr ""
-"Der Fastpath-Aufruf {0} gab kein Ergebnis zurück, jedoch wurde ein Integer "
+"Der Fastpath-Aufruf {0} gab kein Ergebnis zurÃ¼ck, jedoch wurde ein Integer "
 "erwartet."
 
 #: src/main/java/org/postgresql/fastpath/Fastpath.java:300
@@ -749,7 +749,7 @@ msgstr ""
 msgid ""
 "Truncation of large objects is only implemented in 8.3 and later servers."
 msgstr ""
-"Das Abschneiden großer Objekte ist nur in Versionen nach 8.3 implementiert."
+"Das Abschneiden groÃŸer Objekte ist nur in Versionen nach 8.3 implementiert."
 
 #: src/main/java/org/postgresql/jdbc/AbstractBlobClob.java:89
 msgid "Cannot truncate LOB to a negative length."
@@ -759,15 +759,15 @@ msgstr ""
 #: src/main/java/org/postgresql/jdbc/AbstractBlobClob.java:249
 #, java-format
 msgid "PostgreSQL LOBs can only index to: {0}"
-msgstr "LOBs in PostgreSQL können nur auf {0} verweisen."
+msgstr "LOBs in PostgreSQL kÃ¶nnen nur auf {0} verweisen."
 
 #: src/main/java/org/postgresql/jdbc/AbstractBlobClob.java:245
 msgid "LOB positioning offsets start at 1."
-msgstr "Positionsoffsets für LOBs beginnen bei 1."
+msgstr "Positionsoffsets fÃ¼r LOBs beginnen bei 1."
 
 #: src/main/java/org/postgresql/jdbc/AbstractBlobClob.java:261
 msgid "free() was called on this LOB previously"
-msgstr "free() wurde bereits für dieses LOB aufgerufen."
+msgstr "free() wurde bereits fÃ¼r dieses LOB aufgerufen."
 
 #: src/main/java/org/postgresql/jdbc/ArrayDecoding.java:284
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:2442
@@ -779,27 +779,27 @@ msgid ""
 "was created in.  The most common example of this is storing 8bit data in a "
 "SQL_ASCII database."
 msgstr ""
-"Ungültige Zeichendaten.  Das ist höchstwahrscheinlich von in der Datenbank "
+"UngÃ¼ltige Zeichendaten.  Das ist hÃ¶chstwahrscheinlich von in der Datenbank "
 "gespeicherten Zeichen hervorgerufen, die in einer anderen Kodierung "
-"vorliegen, als die, in der die Datenbank erstellt wurde.  Das häufigste "
-"Beispiel dafür ist es, 8Bit-Daten in SQL_ASCII-Datenbanken abzulegen."
+"vorliegen, als die, in der die Datenbank erstellt wurde.  Das hÃ¤ufigste "
+"Beispiel dafÃ¼r ist es, 8Bit-Daten in SQL_ASCII-Datenbanken abzulegen."
 
 #: src/main/java/org/postgresql/jdbc/ArrayEncoding.java:801
 #: src/main/java/org/postgresql/jdbc/ArrayEncoding.java:835
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:1212
 msgid "Unable to translate data into the desired encoding."
-msgstr "Die Daten konnten nicht in die gewünschte Kodierung gewandelt werden."
+msgstr "Die Daten konnten nicht in die gewÃ¼nschte Kodierung gewandelt werden."
 
 #: src/main/java/org/postgresql/jdbc/ArrayEncoding.java:1040
 #: src/main/java/org/postgresql/jdbc/ArrayEncoding.java:1051
 #: src/main/java/org/postgresql/jdbc/ArrayEncoding.java:1077
 #, fuzzy, java-format
 msgid "Invalid elements {0}"
-msgstr "Ungültige Länge des Datenstroms: {0}."
+msgstr "UngÃ¼ltige LÃ¤nge des Datenstroms: {0}."
 
 #: src/main/java/org/postgresql/jdbc/BatchResultHandler.java:102
 msgid "Too many update results were returned."
-msgstr "Zu viele Updateergebnisse wurden zurückgegeben."
+msgstr "Zu viele Updateergebnisse wurden zurÃ¼ckgegeben."
 
 #: src/main/java/org/postgresql/jdbc/BatchResultHandler.java:163
 #, fuzzy, java-format
@@ -887,7 +887,7 @@ msgstr "Intervall {0} ist noch nicht implementiert."
 #: src/main/java/org/postgresql/jdbc/GSSEncMode.java:61
 #, fuzzy, java-format
 msgid "Invalid gssEncMode value: {0}"
-msgstr "Ungültige Länge des Datenstroms: {0}."
+msgstr "UngÃ¼ltige LÃ¤nge des Datenstroms: {0}."
 
 #: src/main/java/org/postgresql/jdbc/PSQLSavepoint.java:40
 #: src/main/java/org/postgresql/jdbc/PSQLSavepoint.java:55
@@ -908,25 +908,25 @@ msgstr "Der Name eines namenlosen Rettungpunktes kann nicht ermittelt werden."
 #: src/main/java/org/postgresql/jdbc/PgArray.java:371
 #, java-format
 msgid "The array index is out of range: {0}"
-msgstr "Der Arrayindex ist außerhalb des gültigen Bereichs: {0}."
+msgstr "Der Arrayindex ist auÃŸerhalb des gÃ¼ltigen Bereichs: {0}."
 
 #: src/main/java/org/postgresql/jdbc/PgArray.java:174
 #: src/main/java/org/postgresql/jdbc/PgArray.java:388
 #, java-format
 msgid "The array index is out of range: {0}, number of elements: {1}."
 msgstr ""
-"Der Arrayindex {0} ist außerhalb des gültigen Bereichs. Vorhandene Elemente: "
+"Der Arrayindex {0} ist auÃŸerhalb des gÃ¼ltigen Bereichs. Vorhandene Elemente: "
 "{1}."
 
 #: src/main/java/org/postgresql/jdbc/PgCallableStatement.java:99
 #: src/main/java/org/postgresql/jdbc/PgCallableStatement.java:105
 msgid "A CallableStatement was executed with nothing returned."
-msgstr "Ein CallableStatement wurde ausgeführt ohne etwas zurückzugeben."
+msgstr "Ein CallableStatement wurde ausgefÃ¼hrt ohne etwas zurÃ¼ckzugeben."
 
 #: src/main/java/org/postgresql/jdbc/PgCallableStatement.java:116
 msgid "A CallableStatement was executed with an invalid number of parameters"
 msgstr ""
-"Ein CallableStatement wurde mit einer falschen Anzahl Parameter ausgeführt."
+"Ein CallableStatement wurde mit einer falschen Anzahl Parameter ausgefÃ¼hrt."
 
 #: src/main/java/org/postgresql/jdbc/PgCallableStatement.java:154
 #, java-format
@@ -934,8 +934,8 @@ msgid ""
 "A CallableStatement function was executed and the out parameter {0} was of "
 "type {1} however type {2} was registered."
 msgstr ""
-"Eine CallableStatement-Funktion wurde ausgeführt und der Rückgabewert {0} "
-"war vom Typ {1}. Jedoch wurde der Typ {2} dafür registriert."
+"Eine CallableStatement-Funktion wurde ausgefÃ¼hrt und der RÃ¼ckgabewert {0} "
+"war vom Typ {1}. Jedoch wurde der Typ {2} dafÃ¼r registriert."
 
 #: src/main/java/org/postgresql/jdbc/PgCallableStatement.java:217
 msgid ""
@@ -977,8 +977,8 @@ msgstr "Es wurden keine Funktionsausgaben registriert."
 msgid ""
 "Results cannot be retrieved from a CallableStatement before it is executed."
 msgstr ""
-"Ergebnisse können nicht von einem CallableStatement abgerufen werden, bevor "
-"es ausgeführt wurde."
+"Ergebnisse kÃ¶nnen nicht von einem CallableStatement abgerufen werden, bevor "
+"es ausgefÃ¼hrt wurde."
 
 #: src/main/java/org/postgresql/jdbc/PgCallableStatement.java:732
 #, fuzzy, java-format
@@ -988,7 +988,7 @@ msgstr "Unbekannter Typ: {0}."
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:353
 #, java-format
 msgid "Unsupported value for stringtype parameter: {0}"
-msgstr "Nichtunterstützter Wert für den Stringparameter: {0}"
+msgstr "NichtunterstÃ¼tzter Wert fÃ¼r den Stringparameter: {0}"
 
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:612
 #: src/main/java/org/postgresql/jdbc/PgPreparedStatement.java:141
@@ -1013,18 +1013,18 @@ msgstr "Die Anweisung lieferte ein Ergebnis obwohl keines erwartet wurde."
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:754
 #, fuzzy
 msgid "Custom type maps are not supported."
-msgstr "Selbstdefinierte Typabbildungen werden nicht unterstützt."
+msgstr "Selbstdefinierte Typabbildungen werden nicht unterstÃ¼tzt."
 
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:796
 #, java-format
 msgid "Failed to create object for: {0}."
-msgstr "Erstellung des Objektes schlug fehl für: {0}."
+msgstr "Erstellung des Objektes schlug fehl fÃ¼r: {0}."
 
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:864
 #, java-format
 msgid "Unable to load the class {0} responsible for the datatype {1}"
 msgstr ""
-"Die für den Datentyp {1} verantwortliche Klasse {0} konnte nicht geladen "
+"Die fÃ¼r den Datentyp {1} verantwortliche Klasse {0} konnte nicht geladen "
 "werden."
 
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:892
@@ -1035,8 +1035,8 @@ msgstr ""
 msgid ""
 "Cannot change transaction read-only property in the middle of a transaction."
 msgstr ""
-"Die Nur-Lesen-Eigenschaft einer Transaktion kann nicht während der "
-"Transaktion verändert werden."
+"Die Nur-Lesen-Eigenschaft einer Transaktion kann nicht wÃ¤hrend der "
+"Transaktion verÃ¤ndert werden."
 
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:1020
 msgid "Cannot commit when autoCommit is enabled."
@@ -1057,35 +1057,35 @@ msgstr ""
 msgid ""
 "Cannot change transaction isolation level in the middle of a transaction."
 msgstr ""
-"Die Transaktions-Trennungsstufe kann nicht während einer Transaktion "
-"verändert werden."
+"Die Transaktions-Trennungsstufe kann nicht wÃ¤hrend einer Transaktion "
+"verÃ¤ndert werden."
 
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:1103
 #, java-format
 msgid "Transaction isolation level {0} not supported."
-msgstr "Die Transaktions-Trennungsstufe {0} ist nicht unterstützt."
+msgstr "Die Transaktions-Trennungsstufe {0} ist nicht unterstÃ¼tzt."
 
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:1274
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:2242
 #: src/main/java/org/postgresql/jdbc/PgStatement.java:1026
 msgid "Fetch size must be a value greater than or equal to 0."
-msgstr "Die Fetch-Größe muss ein Wert größer oder gleich Null sein."
+msgstr "Die Fetch-GrÃ¶ÃŸe muss ein Wert grÃ¶ÃŸer oder gleich Null sein."
 
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:1290
 #, fuzzy
 msgid "Query timeout must be a value greater than or equal to 0."
-msgstr "Das Abfragetimeout muss ein Wert größer oder gleich Null sein."
+msgstr "Das Abfragetimeout muss ein Wert grÃ¶ÃŸer oder gleich Null sein."
 
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:1536
 #, fuzzy, java-format
 msgid "Unable to find server array type for provided name {0}."
 msgstr ""
-"Für den angegebenen Namen {0} konnte kein Serverarraytyp gefunden werden."
+"FÃ¼r den angegebenen Namen {0} konnte kein Serverarraytyp gefunden werden."
 
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:1562
 #, fuzzy, java-format
 msgid "Invalid timeout ({0}<0)."
-msgstr "Ungültige Länge des Datenstroms: {0}."
+msgstr "UngÃ¼ltige LÃ¤nge des Datenstroms: {0}."
 
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:1599
 msgid "Validating connection."
@@ -1094,11 +1094,11 @@ msgstr ""
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:1632
 #, fuzzy, java-format
 msgid "Failed to set ClientInfo property: {0}"
-msgstr "Erstellung des Objektes schlug fehl für: {0}."
+msgstr "Erstellung des Objektes schlug fehl fÃ¼r: {0}."
 
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:1642
 msgid "ClientInfo property not supported."
-msgstr "Die ClientInfo-Eigenschaft ist nicht unterstützt."
+msgstr "Die ClientInfo-Eigenschaft ist nicht unterstÃ¼tzt."
 
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:1668
 msgid "One or more ClientInfo failed."
@@ -1107,7 +1107,7 @@ msgstr ""
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:1775
 #, fuzzy
 msgid "Network timeout must be a value greater than or equal to 0."
-msgstr "Das Abfragetimeout muss ein Wert größer oder gleich Null sein."
+msgstr "Das Abfragetimeout muss ein Wert grÃ¶ÃŸer oder gleich Null sein."
 
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:1784
 msgid "Unable to set network timeout."
@@ -1120,7 +1120,7 @@ msgstr ""
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:1824
 #, java-format
 msgid "Unknown ResultSet holdability setting: {0}."
-msgstr "Unbekannte Einstellung für die Haltbarkeit des ResultSets: {0}."
+msgstr "Unbekannte Einstellung fÃ¼r die Haltbarkeit des ResultSets: {0}."
 
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:1842
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:1863
@@ -1129,7 +1129,7 @@ msgstr "Ein Rettungspunkt kann im Modus ''auto-commit'' nicht erstellt werden."
 
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:1932
 msgid "Returning autogenerated keys is not supported."
-msgstr "Die Rückgabe automatisch generierter Schlüssel wird nicht unterstützt,"
+msgstr "Die RÃ¼ckgabe automatisch generierter SchlÃ¼ssel wird nicht unterstÃ¼tzt,"
 
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:1994
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:2003
@@ -1146,7 +1146,7 @@ msgid ""
 "Unable to determine a value for MaxIndexKeys due to missing system catalog "
 "data."
 msgstr ""
-"Es konnte kein Wert für MaxIndexKeys gefunden werden, da die "
+"Es konnte kein Wert fÃ¼r MaxIndexKeys gefunden werden, da die "
 "Systemkatalogdaten fehlen."
 
 #: src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java:98
@@ -1170,7 +1170,7 @@ msgstr ""
 #, java-format
 msgid "The parameter index is out of range: {0}, number of parameters: {1}."
 msgstr ""
-"Der Parameterindex {0} ist außerhalb des gültigen Bereichs. Es gibt {1} "
+"Der Parameterindex {0} ist auÃŸerhalb des gÃ¼ltigen Bereichs. Es gibt {1} "
 "Parameter."
 
 #: src/main/java/org/postgresql/jdbc/PgPreparedStatement.java:108
@@ -1189,7 +1189,7 @@ msgstr ""
 msgid ""
 "Can''t use query methods that take a query string on a PreparedStatement."
 msgstr ""
-"Abfragemethoden, die einen Abfragestring annehmen, können nicht auf ein "
+"Abfragemethoden, die einen Abfragestring annehmen, kÃ¶nnen nicht auf ein "
 "PreparedStatement angewandt werden."
 
 #: src/main/java/org/postgresql/jdbc/PgPreparedStatement.java:300
@@ -1202,12 +1202,12 @@ msgstr "Unbekannter Typ."
 #: src/main/java/org/postgresql/jdbc/PgPreparedStatement.java:1704
 #, java-format
 msgid "Invalid stream length {0}."
-msgstr "Ungültige Länge des Datenstroms: {0}."
+msgstr "UngÃ¼ltige LÃ¤nge des Datenstroms: {0}."
 
 #: src/main/java/org/postgresql/jdbc/PgPreparedStatement.java:483
 #, java-format
 msgid "The JVM claims not to support the {0} encoding."
-msgstr "Die JVM behauptet, die Zeichenkodierung {0} nicht zu unterstützen."
+msgstr "Die JVM behauptet, die Zeichenkodierung {0} nicht zu unterstÃ¼tzen."
 
 #: src/main/java/org/postgresql/jdbc/PgPreparedStatement.java:486
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:1325
@@ -1232,7 +1232,7 @@ msgstr ""
 #: src/main/java/org/postgresql/jdbc/PgPreparedStatement.java:1084
 #, java-format
 msgid "Cannot cast an instance of {0} to type {1}"
-msgstr "Die Typwandlung für eine Instanz von {0} nach {1} ist nicht möglich."
+msgstr "Die Typwandlung fÃ¼r eine Instanz von {0} nach {1} ist nicht mÃ¶glich."
 
 #: src/main/java/org/postgresql/jdbc/PgPreparedStatement.java:762
 #, java-format
@@ -1242,7 +1242,7 @@ msgstr "Unbekannter Typ: {0}."
 #: src/main/java/org/postgresql/jdbc/PgPreparedStatement.java:1005
 #, java-format
 msgid "Cannot convert an instance of {0} to type {1}"
-msgstr "Die Typwandlung für eine Instanz von {0} nach {1} ist nicht möglich."
+msgstr "Die Typwandlung fÃ¼r eine Instanz von {0} nach {1} ist nicht mÃ¶glich."
 
 #: src/main/java/org/postgresql/jdbc/PgPreparedStatement.java:1090
 #, java-format
@@ -1250,7 +1250,7 @@ msgid ""
 "Can''t infer the SQL type to use for an instance of {0}. Use setObject() "
 "with an explicit Types value to specify the type to use."
 msgstr ""
-"Der in SQL für eine Instanz von {0} zu verwendende Datentyp kann nicht "
+"Der in SQL fÃ¼r eine Instanz von {0} zu verwendende Datentyp kann nicht "
 "abgeleitet werden. Benutzen Sie ''setObject()'' mit einem expliziten Typ, um "
 "ihn festzulegen."
 
@@ -1298,29 +1298,29 @@ msgstr ""
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:3721
 #, fuzzy, java-format
 msgid "Cannot convert the column of type {0} to requested type {1}."
-msgstr "Die Typwandlung für eine Instanz von {0} nach {1} ist nicht möglich."
+msgstr "Die Typwandlung fÃ¼r eine Instanz von {0} nach {1} ist nicht mÃ¶glich."
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:1024
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:1045
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:2276
 msgid "Can''t use relative move methods while on the insert row."
 msgstr ""
-"Relative Bewegungen können in der Einfügezeile nicht durchgeführt werden."
+"Relative Bewegungen kÃ¶nnen in der EinfÃ¼gezeile nicht durchgefÃ¼hrt werden."
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:1069
 #: src/main/java/org/postgresql/jdbc/PgStatement.java:1017
 #, java-format
 msgid "Invalid fetch direction constant: {0}."
-msgstr "Unzulässige Richtungskonstante bei fetch: {0}."
+msgstr "UnzulÃ¤ssige Richtungskonstante bei fetch: {0}."
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:1081
 msgid "Cannot call cancelRowUpdates() when on the insert row."
 msgstr ""
-"''cancelRowUpdates()'' kann in der Einfügezeile nicht aufgerufen werden."
+"''cancelRowUpdates()'' kann in der EinfÃ¼gezeile nicht aufgerufen werden."
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:1099
 msgid "Cannot call deleteRow() when on the insert row."
-msgstr "''deleteRow()'' kann in der Einfügezeile nicht aufgerufen werden."
+msgstr "''deleteRow()'' kann in der EinfÃ¼gezeile nicht aufgerufen werden."
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:1106
 msgid ""
@@ -1344,20 +1344,20 @@ msgstr "Es gibt keine Zeilen in diesem ResultSet."
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:1158
 msgid "Not on the insert row."
-msgstr "Nicht in der Einfügezeile."
+msgstr "Nicht in der EinfÃ¼gezeile."
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:1162
 msgid "You must specify at least one column value to insert a row."
 msgstr ""
-"Sie müssen mindestens einen Spaltenwert angeben, um eine Zeile einzufügen."
+"Sie mÃ¼ssen mindestens einen Spaltenwert angeben, um eine Zeile einzufÃ¼gen."
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:1497
 msgid "Can''t refresh the insert row."
-msgstr "Die Einfügezeile kann nicht aufgefrischt werden."
+msgstr "Die EinfÃ¼gezeile kann nicht aufgefrischt werden."
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:1573
 msgid "Cannot call updateRow() when on the insert row."
-msgstr "''updateRow()'' kann in der Einfügezeile nicht aufgerufen werden."
+msgstr "''updateRow()'' kann in der EinfÃ¼gezeile nicht aufgerufen werden."
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:1581
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:3738
@@ -1371,18 +1371,18 @@ msgstr ""
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:1844
 msgid "ResultSets with concurrency CONCUR_READ_ONLY cannot be updated."
 msgstr ""
-"ResultSets, deren Zugriffsart CONCUR_READ_ONLY ist, können nicht "
+"ResultSets, deren Zugriffsart CONCUR_READ_ONLY ist, kÃ¶nnen nicht "
 "aktualisiert werden."
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:1948
 #, fuzzy, java-format
 msgid "No eligible primary or unique key found for table {0}."
-msgstr "Für die Tabelle {0} konnte kein Primärschlüssel gefunden werden."
+msgstr "FÃ¼r die Tabelle {0} konnte kein PrimÃ¤rschlÃ¼ssel gefunden werden."
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:2148
 #, java-format
 msgid "The JVM claims not to support the encoding: {0}"
-msgstr "Die JVM behauptet, die Zeichenkodierung {0} nicht zu unterstützen."
+msgstr "Die JVM behauptet, die Zeichenkodierung {0} nicht zu unterstÃ¼tzen."
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:2597
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:2602
@@ -1403,7 +1403,7 @@ msgstr "Die JVM behauptet, die Zeichenkodierung {0} nicht zu unterstützen."
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:3726
 #, java-format
 msgid "Bad value for type {0} : {1}"
-msgstr "Unzulässiger Wert für den Typ {0} : {1}."
+msgstr "UnzulÃ¤ssiger Wert fÃ¼r den Typ {0} : {1}."
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:3207
 #, java-format
@@ -1417,8 +1417,8 @@ msgid ""
 "the JDBC 2.1 API Specification, section 5.6 for more details."
 msgstr ""
 "Das ResultSet kann nicht aktualisiert werden.  Die Abfrage, die es erzeugte, "
-"darf nur eine Tabelle und muss darin alle Primärschlüssel auswählen. Siehe "
-"JDBC 2.1 API-Spezifikation, Abschnitt 5.6 für mehr Details."
+"darf nur eine Tabelle und muss darin alle PrimÃ¤rschlÃ¼ssel auswÃ¤hlen. Siehe "
+"JDBC 2.1 API-Spezifikation, Abschnitt 5.6 fÃ¼r mehr Details."
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:3364
 msgid "This ResultSet is closed."
@@ -1433,7 +1433,7 @@ msgstr ""
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:3760
 #, fuzzy
 msgid "Invalid UUID data."
-msgstr "Ungültiges Flag."
+msgstr "UngÃ¼ltiges Flag."
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:3860
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:3867
@@ -1457,12 +1457,12 @@ msgstr "Ungültiges Flag."
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:4067
 #, fuzzy, java-format
 msgid "conversion to {0} from {1} not supported"
-msgstr "Die Transaktions-Trennungsstufe {0} ist nicht unterstützt."
+msgstr "Die Transaktions-Trennungsstufe {0} ist nicht unterstÃ¼tzt."
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:4044
 #, fuzzy
 msgid "Invalid Inet data."
-msgstr "Ungültiges Flag."
+msgstr "UngÃ¼ltiges Flag."
 
 #: src/main/java/org/postgresql/jdbc/PgSQLXML.java:170
 msgid "Unable to decode xml data."
@@ -1476,7 +1476,7 @@ msgstr ""
 #: src/main/java/org/postgresql/jdbc/PgSQLXML.java:229
 #, fuzzy
 msgid "Unable to create SAXResult for SQLXML."
-msgstr "Erstellung des Objektes schlug fehl für: {0}."
+msgstr "Erstellung des Objektes schlug fehl fÃ¼r: {0}."
 
 #: src/main/java/org/postgresql/jdbc/PgSQLXML.java:245
 msgid "Unable to create StAXResult for SQLXML"
@@ -1485,7 +1485,7 @@ msgstr ""
 #: src/main/java/org/postgresql/jdbc/PgSQLXML.java:250
 #, fuzzy, java-format
 msgid "Unknown XML Result class: {0}"
-msgstr "Unbekannte Einstellung für die Haltbarkeit des ResultSets: {0}."
+msgstr "Unbekannte Einstellung fÃ¼r die Haltbarkeit des ResultSets: {0}."
 
 #: src/main/java/org/postgresql/jdbc/PgSQLXML.java:266
 #, fuzzy
@@ -1524,7 +1524,7 @@ msgstr ""
 #: src/main/java/org/postgresql/jdbc/PgStatement.java:187
 #, fuzzy
 msgid "Unknown value for ResultSet holdability"
-msgstr "Unbekannte Einstellung für die Haltbarkeit des ResultSets: {0}."
+msgstr "Unbekannte Einstellung fÃ¼r die Haltbarkeit des ResultSets: {0}."
 
 #: src/main/java/org/postgresql/jdbc/PgStatement.java:295
 msgid "Multiple ResultSets were returned by the query."
@@ -1537,15 +1537,15 @@ msgstr ""
 #: src/main/java/org/postgresql/jdbc/PgStatement.java:593
 #, fuzzy
 msgid "Maximum number of rows must be a value greater than or equal to 0."
-msgstr "Die maximale Zeilenzahl muss ein Wert größer oder gleich Null sein."
+msgstr "Die maximale Zeilenzahl muss ein Wert grÃ¶ÃŸer oder gleich Null sein."
 
 #: src/main/java/org/postgresql/jdbc/PgStatement.java:642
 msgid "Query timeout must be a value greater than or equals to 0."
-msgstr "Das Abfragetimeout muss ein Wert größer oder gleich Null sein."
+msgstr "Das Abfragetimeout muss ein Wert grÃ¶ÃŸer oder gleich Null sein."
 
 #: src/main/java/org/postgresql/jdbc/PgStatement.java:685
 msgid "The maximum field size must be a value greater than or equal to 0."
-msgstr "Die maximale Feldgröße muss ein Wert größer oder gleich Null sein."
+msgstr "Die maximale FeldgrÃ¶ÃŸe muss ein Wert grÃ¶ÃŸer oder gleich Null sein."
 
 #: src/main/java/org/postgresql/jdbc/PgStatement.java:791
 msgid "This statement has been closed."
@@ -1562,14 +1562,14 @@ msgstr ""
 #: src/main/java/org/postgresql/jdbc/PgStatement.java:1350
 #, fuzzy, java-format
 msgid "Invalid value for autoGeneratedKeys {0}"
-msgstr "Ungültige Länge des Datenstroms: {0}."
+msgstr "UngÃ¼ltige LÃ¤nge des Datenstroms: {0}."
 
 #: src/main/java/org/postgresql/jdbc/PgStatement.java:1182
 #: src/main/java/org/postgresql/jdbc/PgStatement.java:1323
 #: src/main/java/org/postgresql/jdbc/PgStatement.java:1360
 #, fuzzy
 msgid "Returning autogenerated keys by column index is not supported."
-msgstr "Die Rückgabe automatisch generierter Schlüssel wird nicht unterstützt,"
+msgstr "Die RÃ¼ckgabe automatisch generierter SchlÃ¼ssel wird nicht unterstÃ¼tzt,"
 
 #: src/main/java/org/postgresql/jdbc/QueryExecutorTimeZoneProvider.java:33
 msgid ""
@@ -1580,13 +1580,13 @@ msgstr ""
 #: src/main/java/org/postgresql/jdbc/SslMode.java:78
 #, fuzzy, java-format
 msgid "Invalid sslmode value: {0}"
-msgstr "Ungültige Länge des Datenstroms: {0}."
+msgstr "UngÃ¼ltige LÃ¤nge des Datenstroms: {0}."
 
 #: src/main/java/org/postgresql/jdbc/TimestampUtils.java:379
 #: src/main/java/org/postgresql/jdbc/TimestampUtils.java:491
 #, fuzzy, java-format
 msgid "Bad value for type timestamp/date/time: {0}"
-msgstr "Unzulässiger Wert für den Typ {0} : {1}."
+msgstr "UnzulÃ¤ssiger Wert fÃ¼r den Typ {0} : {1}."
 
 #: src/main/java/org/postgresql/jdbc/TimestampUtils.java:506
 #: src/main/java/org/postgresql/jdbc/TimestampUtils.java:1313
@@ -1614,7 +1614,7 @@ msgstr ""
 #: src/main/java/org/postgresql/largeobject/BlobOutputStream.java:236
 #, fuzzy, java-format
 msgid "Can not close large object {0}"
-msgstr "Erstellung des Objektes schlug fehl für: {0}."
+msgstr "Erstellung des Objektes schlug fehl fÃ¼r: {0}."
 
 #: src/main/java/org/postgresql/largeobject/BlobInputStream.java:317
 #, java-format
@@ -1641,7 +1641,7 @@ msgstr "Die Anweisung wurde geschlossen."
 #: src/main/java/org/postgresql/largeobject/LargeObjectManager.java:285
 msgid "Large Objects may not be used in auto-commit mode."
 msgstr ""
-"LargeObjects (LOB) dürfen im Modus ''auto-commit'' nicht verwendet werden."
+"LargeObjects (LOB) dÃ¼rfen im Modus ''auto-commit'' nicht verwendet werden."
 
 #: src/main/java/org/postgresql/osgi/PGDataSourceFactory.java:86
 #, fuzzy, java-format
@@ -1803,12 +1803,12 @@ msgstr ""
 #, fuzzy, java-format
 msgid "Unable to parse X509Certificate for hostname {0}"
 msgstr ""
-"Für den angegebenen Namen {0} konnte kein Serverarraytyp gefunden werden."
+"FÃ¼r den angegebenen Namen {0} konnte kein Serverarraytyp gefunden werden."
 
 #: src/main/java/org/postgresql/ssl/PGjdbcHostnameVerifier.java:92
 #, fuzzy, java-format
 msgid "No certificates found for hostname {0}"
-msgstr "Für die Tabelle {0} konnte kein Primärschlüssel gefunden werden."
+msgstr "FÃ¼r die Tabelle {0} konnte kein PrimÃ¤rschlÃ¼ssel gefunden werden."
 
 #: src/main/java/org/postgresql/ssl/PGjdbcHostnameVerifier.java:111
 #, java-format
@@ -1939,7 +1939,7 @@ msgstr ""
 
 #: src/main/java/org/postgresql/util/PGmoney.java:74
 msgid "Conversion of money failed."
-msgstr "Die Umwandlung eines Währungsbetrags schlug fehl."
+msgstr "Die Umwandlung eines WÃ¤hrungsbetrags schlug fehl."
 
 #: src/main/java/org/postgresql/util/ServerErrorMessage.java:45
 #, java-format
@@ -2004,7 +2004,7 @@ msgstr ""
 #: src/main/java/org/postgresql/xa/PGXAConnection.java:387
 #, fuzzy, java-format
 msgid "Invalid flags {0}"
-msgstr "Ungültige Flags"
+msgstr "UngÃ¼ltige Flags"
 
 #: src/main/java/org/postgresql/xa/PGXAConnection.java:196
 #: src/main/java/org/postgresql/xa/PGXAConnection.java:282
@@ -2014,7 +2014,7 @@ msgstr "Die xid darf nicht null sein."
 
 #: src/main/java/org/postgresql/xa/PGXAConnection.java:200
 msgid "Connection is busy with another transaction"
-msgstr "Die Verbindung ist derzeit mit einer anderen Transaktion beschäftigt."
+msgstr "Die Verbindung ist derzeit mit einer anderen Transaktion beschÃ¤ftigt."
 
 #: src/main/java/org/postgresql/xa/PGXAConnection.java:209
 #: src/main/java/org/postgresql/xa/PGXAConnection.java:292
@@ -2040,7 +2040,7 @@ msgid ""
 "tried to call end without corresponding start call. state={0}, start "
 "xid={1}, currentXid={2}, preparedXid={3}"
 msgstr ""
-"Es wurde versucht, ohne dazugehörigen ''start''-Aufruf ''end'' aufzurufen."
+"Es wurde versucht, ohne dazugehÃ¶rigen ''start''-Aufruf ''end'' aufzurufen."
 
 #: src/main/java/org/postgresql/xa/PGXAConnection.java:332
 #, java-format
@@ -2059,7 +2059,7 @@ msgid ""
 "Not implemented: Prepare must be issued using the same connection that "
 "started the transaction. currentXid={0}, prepare xid={1}"
 msgstr ""
-"Nicht implementiert: ''Prepare'' muss über die selbe Verbindung abgesetzt "
+"Nicht implementiert: ''Prepare'' muss Ã¼ber die selbe Verbindung abgesetzt "
 "werden, die die Transaktion startete."
 
 #: src/main/java/org/postgresql/xa/PGXAConnection.java:346
@@ -2094,7 +2094,7 @@ msgid ""
 "Not implemented: one-phase commit must be issued using the same connection "
 "that was used to start it"
 msgstr ""
-"Nicht implementiert: Die einphasige Bestätigung muss über die selbe "
+"Nicht implementiert: Die einphasige BestÃ¤tigung muss Ã¼ber die selbe "
 "Verbindung abgewickelt werden, die verwendet wurde, um sie zu beginnen."
 
 #: src/main/java/org/postgresql/xa/PGXAConnection.java:542
@@ -2110,7 +2110,7 @@ msgstr "''Commit'' wurde vor ''end'' aufgerufen."
 #: src/main/java/org/postgresql/xa/PGXAConnection.java:557
 #, fuzzy, java-format
 msgid "Error during one-phase commit. commit xid={0}"
-msgstr "Bei der einphasigen Bestätigung trat ein Fehler auf."
+msgstr "Bei der einphasigen BestÃ¤tigung trat ein Fehler auf."
 
 #: src/main/java/org/postgresql/xa/PGXAConnection.java:585
 #, fuzzy, java-format
@@ -2118,7 +2118,7 @@ msgid ""
 "Not implemented: 2nd phase commit must be issued using an idle connection. "
 "commit xid={0}, currentXid={1}, state={2}, transactionState={3}"
 msgstr ""
-"Nicht implementiert: Die zweite Bestätigungsphase muss über eine im Leerlauf "
+"Nicht implementiert: Die zweite BestÃ¤tigungsphase muss Ã¼ber eine im Leerlauf "
 "befindliche Verbindung abgewickelt werden."
 
 #: src/main/java/org/postgresql/xa/PGXAConnection.java:618
@@ -2131,4 +2131,4 @@ msgstr "Fehler beim Rollback einer vorbereiteten Transaktion."
 #: src/main/java/org/postgresql/xa/PGXAConnection.java:635
 #, fuzzy, java-format
 msgid "Heuristic commit/rollback not supported. forget xid={0}"
-msgstr "Heuristisches Commit/Rollback wird nicht unterstützt."
+msgstr "Heuristisches Commit/Rollback wird nicht unterstÃ¼tzt."

--- a/pgjdbc/src/main/java/org/postgresql/translation/fr.po
+++ b/pgjdbc/src/main/java/org/postgresql/translation/fr.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team:  <en@li.org>\n"
 "Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=ISO-8859-1\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: KBabel 1.11.4\n"
 "Plural-Forms:  nplurals=2; plural=(n > 1);\n"
@@ -21,7 +21,7 @@ msgstr ""
 #: src/main/java/org/postgresql/Driver.java:259
 msgid "Error loading default settings from driverconfig.properties"
 msgstr ""
-"Erreur de chargement des valeurs par défaut depuis driverconfig.properties"
+"Erreur de chargement des valeurs par dÃ©faut depuis driverconfig.properties"
 
 #: src/main/java/org/postgresql/Driver.java:271
 #, java-format
@@ -46,21 +46,21 @@ msgid ""
 "Something unusual has occurred to cause the driver to fail. Please report "
 "this exception."
 msgstr ""
-"Quelque chose d''inhabituel a provoqué l''échec du pilote. Veuillez faire un "
+"Quelque chose d''inhabituel a provoquÃ© l''Ã©chec du pilote. Veuillez faire un "
 "rapport sur cette erreur."
 
 #: src/main/java/org/postgresql/Driver.java:412
 msgid "Connection attempt timed out."
-msgstr "La tentative de connexion a échoué dans le délai imparti."
+msgstr "La tentative de connexion a Ã©chouÃ© dans le dÃ©lai imparti."
 
 #: src/main/java/org/postgresql/Driver.java:425
 msgid "Interrupted while attempting to connect."
-msgstr "Interrompu pendant l''établissement de la connexion."
+msgstr "Interrompu pendant l''Ã©tablissement de la connexion."
 
 #: src/main/java/org/postgresql/Driver.java:744
 #, java-format
 msgid "Method {0} is not yet implemented."
-msgstr "La fonction {0} n''est pas encore implémentée."
+msgstr "La fonction {0} n''est pas encore implÃ©mentÃ©e."
 
 #: src/main/java/org/postgresql/PGConnection.java:298
 msgid "Expected a row when reading password_encryption but none was found"
@@ -100,7 +100,7 @@ msgstr ""
 #: src/main/java/org/postgresql/copy/PGCopyOutputStream.java:104
 #, fuzzy
 msgid "This copy stream is closed."
-msgstr "Ce ResultSet est fermé."
+msgstr "Ce ResultSet est fermÃ©."
 
 #: src/main/java/org/postgresql/copy/PGCopyInputStream.java:125
 msgid "Read from copy failed."
@@ -114,7 +114,7 @@ msgstr ""
 #: src/main/java/org/postgresql/core/AuthMethod.java:30
 #, fuzzy, java-format
 msgid "Invalid authentication method: {0}"
-msgstr "Constante de direction pour la récupération invalide : {0}."
+msgstr "Constante de direction pour la rÃ©cupÃ©ration invalideÂ : {0}."
 
 #: src/main/java/org/postgresql/core/AuthMethod.java:51
 msgid "requireAuth cannot mix positive and negative authentication methods"
@@ -132,14 +132,14 @@ msgstr ""
 #, fuzzy, java-format
 msgid "Unable to parse the count in command completion tag: {0}."
 msgstr ""
-"Incapable d''interpréter le nombre de mise à jour dans la balise de "
-"complétion de commande : {0}."
+"Incapable d''interprÃ©ter le nombre de mise Ã  jour dans la balise de "
+"complÃ©tion de commandeÂ : {0}."
 
 #: src/main/java/org/postgresql/core/ConnectionFactory.java:60
 #, java-format
 msgid "A connection could not be made using the requested protocol {0}."
 msgstr ""
-"Aucune connexion n''a pu être établie en utilisant le protocole demandé {0}. "
+"Aucune connexion n''a pu Ãªtre Ã©tablie en utilisant le protocole demandÃ© {0}. "
 
 #: src/main/java/org/postgresql/core/Oid.java:143
 #, java-format
@@ -149,7 +149,7 @@ msgstr ""
 #: src/main/java/org/postgresql/core/PGStream.java:732
 #, java-format
 msgid "Expected an EOF from server, got: {0}"
-msgstr "Attendait une fin de fichier du serveur, reçu: {0}"
+msgstr "Attendait une fin de fichier du serveur, reÃ§u: {0}"
 
 #: src/main/java/org/postgresql/core/PGStream.java:840
 #, java-format
@@ -161,7 +161,7 @@ msgstr ""
 #, java-format
 msgid "Malformed function or procedure escape syntax at offset {0}."
 msgstr ""
-"Syntaxe de fonction ou d''échappement de procédure malformée à l''indice {0}."
+"Syntaxe de fonction ou d''Ã©chappement de procÃ©dure malformÃ©e Ã  l''indice {0}."
 
 #: src/main/java/org/postgresql/core/ProtocolVersion.java:53
 #, java-format
@@ -170,24 +170,24 @@ msgstr ""
 
 #: src/main/java/org/postgresql/core/SetupQueryRunner.java:68
 msgid "An unexpected result was returned by a query."
-msgstr "Un résultat inattendu a été retourné par une requête."
+msgstr "Un rÃ©sultat inattendu a Ã©tÃ© retournÃ© par une requÃªte."
 
 #: src/main/java/org/postgresql/core/SocketFactoryFactory.java:43
 #, fuzzy, java-format
 msgid "The SocketFactory class provided {0} could not be instantiated."
-msgstr "La classe SSLSocketFactory fournie {0} n''a pas pu être instanciée."
+msgstr "La classe SSLSocketFactory fournie {0} n''a pas pu Ãªtre instanciÃ©e."
 
 #: src/main/java/org/postgresql/core/SocketFactoryFactory.java:68
 #, java-format
 msgid "The SSLSocketFactory class provided {0} could not be instantiated."
-msgstr "La classe SSLSocketFactory fournie {0} n''a pas pu être instanciée."
+msgstr "La classe SSLSocketFactory fournie {0} n''a pas pu Ãªtre instanciÃ©e."
 
 #: src/main/java/org/postgresql/core/Utils.java:72
 #: src/main/java/org/postgresql/core/Utils.java:89
 msgid "Zero bytes may not occur in string parameters."
 msgstr ""
-"Zéro octets ne devrait pas se produire dans les paramètres de type chaîne de "
-"caractères."
+"ZÃ©ro octets ne devrait pas se produire dans les paramÃ¨tres de type chaÃ®ne de "
+"caractÃ¨res."
 
 #: src/main/java/org/postgresql/core/Utils.java:99
 #: src/main/java/org/postgresql/core/Utils.java:149
@@ -196,14 +196,14 @@ msgstr ""
 
 #: src/main/java/org/postgresql/core/Utils.java:138
 msgid "Zero bytes may not occur in identifiers."
-msgstr "Des octects à 0 ne devraient pas apparaître dans les identifiants."
+msgstr "Des octects Ã  0 ne devraient pas apparaÃ®tre dans les identifiants."
 
 #: src/main/java/org/postgresql/core/v3/AuthenticationPluginManager.java:73
 #, fuzzy, java-format
 msgid "Unable to load Authentication Plugin {0}"
 msgstr ""
-"Incapable d''interpréter le nombre de mise à jour dans la balise de "
-"complétion de commande : {0}."
+"Incapable d''interprÃ©ter le nombre de mise Ã  jour dans la balise de "
+"complÃ©tion de commandeÂ : {0}."
 
 #: src/main/java/org/postgresql/core/v3/AuthenticationPluginManager.java:113
 #, fuzzy, java-format
@@ -211,8 +211,8 @@ msgid ""
 "The server requested password-based authentication, but no password was "
 "provided by plugin {0}"
 msgstr ""
-"Le serveur a demandé une authentification par mots de passe, mais aucun mot "
-"de passe n''a été fourni."
+"Le serveur a demandÃ© une authentification par mots de passe, mais aucun mot "
+"de passe n''a Ã©tÃ© fourni."
 
 #: src/main/java/org/postgresql/core/v3/ChannelBinding.java:40
 #, fuzzy, java-format
@@ -228,17 +228,17 @@ msgstr "Longueur de flux invalide {0}."
 #, java-format
 msgid "The column index is out of range: {0}, number of columns: {1}."
 msgstr ""
-"L''indice de la colonne est hors limite : {0}, nombre de colonnes : {1}."
+"L''indice de la colonne est hors limiteÂ : {0}, nombre de colonnesÂ : {1}."
 
 #: src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java:212
 #, fuzzy
 msgid "User cannot be null"
-msgstr "xid ne doit pas être nul"
+msgstr "xid ne doit pas Ãªtre nul"
 
 #: src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java:215
 #, fuzzy
 msgid "Database cannot be null"
-msgstr "xid ne doit pas être nul"
+msgstr "xid ne doit pas Ãªtre nul"
 
 #: src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java:330
 #, fuzzy, java-format
@@ -251,13 +251,13 @@ msgid ""
 "Connection to {0} refused. Check that the hostname and port are correct and "
 "that the postmaster is accepting TCP/IP connections."
 msgstr ""
-"Connexion refusée. Vérifiez que le nom de machine et le port sont corrects "
+"Connexion refusÃ©e. VÃ©rifiez que le nom de machine et le port sont corrects "
 "et que postmaster accepte les connexions TCP/IP."
 
 #: src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java:437
 #: src/main/java/org/postgresql/core/v3/replication/V3ReplicationProtocol.java:140
 msgid "The connection attempt failed."
-msgstr "La tentative de connexion a échoué."
+msgstr "La tentative de connexion a Ã©chouÃ©."
 
 #: src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java:452
 #, java-format
@@ -278,7 +278,7 @@ msgstr "Le serveur ne supporte pas SSL."
 #, fuzzy
 msgid "An error occurred while setting up the GSS Encoded connection."
 msgstr ""
-"Une erreur s''est produite pendant l''établissement de la connexion SSL."
+"Une erreur s''est produite pendant l''Ã©tablissement de la connexion SSL."
 
 #: src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java:689
 #: src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java:701
@@ -288,7 +288,7 @@ msgstr "Le serveur ne supporte pas SSL."
 #: src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java:715
 msgid "An error occurred while setting up the SSL connection."
 msgstr ""
-"Une erreur s''est produite pendant l''établissement de la connexion SSL."
+"Une erreur s''est produite pendant l''Ã©tablissement de la connexion SSL."
 
 #: src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java:849
 msgid ""
@@ -316,8 +316,8 @@ msgid ""
 "The server requested SCRAM-based authentication, but no password was "
 "provided."
 msgstr ""
-"Le serveur a demandé une authentification par mots de passe, mais aucun mot "
-"de passe n''a été fourni."
+"Le serveur a demandÃ© une authentification par mots de passe, mais aucun mot "
+"de passe n''a Ã©tÃ© fourni."
 
 #: src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java:1016
 #, fuzzy
@@ -325,8 +325,8 @@ msgid ""
 "The server requested SCRAM-based authentication, but the password is an "
 "empty string."
 msgstr ""
-"Le serveur a demandé une authentification par mots de passe, mais aucun mot "
-"de passe n''a été fourni."
+"Le serveur a demandÃ© une authentification par mots de passe, mais aucun mot "
+"de passe n''a Ã©tÃ© fourni."
 
 #: src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java:1051
 #, java-format
@@ -335,9 +335,9 @@ msgid ""
 "the pg_hba.conf file to include the client''s IP address or subnet, and that "
 "it is using an authentication scheme supported by the driver."
 msgstr ""
-"Le type d''authentification {0} n''est pas supporté. Vérifiez que vous avez "
-"configuré le fichier pg_hba.conf pour inclure l''adresse IP du client ou le "
-"sous-réseau et qu''il utilise un schéma d''authentification supporté par le "
+"Le type d''authentification {0} n''est pas supportÃ©. VÃ©rifiez que vous avez "
+"configurÃ© le fichier pg_hba.conf pour inclure l''adresse IP du client ou le "
+"sous-rÃ©seau et qu''il utilise un schÃ©ma d''authentification supportÃ© par le "
 "pilote."
 
 #: src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java:1058
@@ -346,7 +346,7 @@ msgstr ""
 #: src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java:3167
 #: src/main/java/org/postgresql/gss/GssAction.java:165
 msgid "Protocol error.  Session setup failed."
-msgstr "Erreur de protocole. Ouverture de la session en échec."
+msgstr "Erreur de protocole. Ouverture de la session en Ã©chec."
 
 #: src/main/java/org/postgresql/core/v3/CopyInImpl.java:58
 msgid "CopyIn copy direction can't receive data"
@@ -368,11 +368,11 @@ msgstr ""
 #: src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java:308
 #, fuzzy
 msgid "Interrupted while waiting to obtain lock on database connection"
-msgstr "Interrompu pendant l''établissement de la connexion."
+msgstr "Interrompu pendant l''Ã©tablissement de la connexion."
 
 #: src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java:459
 msgid "Unable to bind parameter values for statement."
-msgstr "Incapable de lier les valeurs des paramètres pour la commande."
+msgstr "Incapable de lier les valeurs des paramÃ¨tres pour la commande."
 
 #: src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java:465
 #: src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java:692
@@ -382,7 +382,7 @@ msgstr "Incapable de lier les valeurs des paramètres pour la commande."
 #: src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java:2835
 #: src/main/java/org/postgresql/util/StreamWrapper.java:86
 msgid "An I/O error occurred while sending to the backend."
-msgstr "Une erreur d''entrée/sortie a eu lieu lors d''envoi vers le serveur."
+msgstr "Une erreur d''entrÃ©e/sortie a eu lieu lors d''envoi vers le serveur."
 
 #: src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java:544
 msgid "Error releasing savepoint"
@@ -398,23 +398,23 @@ msgstr "Attendait le statut de commande BEGIN, obtenu {0}."
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:2204
 #, java-format
 msgid "Unexpected command status: {0}."
-msgstr "Statut de commande inattendu : {0}."
+msgstr "Statut de commande inattenduÂ : {0}."
 
 #: src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java:923
 #, fuzzy
 msgid "An error occurred while trying to get the socket timeout."
-msgstr "Une erreur d''entrée/sortie a eu lieu lors d''envoi vers le serveur."
+msgstr "Une erreur d''entrÃ©e/sortie a eu lieu lors d''envoi vers le serveur."
 
 #: src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java:958
 #: src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java:1049
 #, java-format
 msgid "Unknown Response Type {0}."
-msgstr "Type de réponse inconnu {0}."
+msgstr "Type de rÃ©ponse inconnu {0}."
 
 #: src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java:982
 #, fuzzy
 msgid "An error occurred while trying to reset the socket timeout."
-msgstr "Une erreur d''entrée/sortie a eu lieu lors d''envoi vers le serveur."
+msgstr "Une erreur d''entrÃ©e/sortie a eu lieu lors d''envoi vers le serveur."
 
 #: src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java:1102
 msgid "Database connection failed when starting copy"
@@ -468,7 +468,7 @@ msgstr ""
 #: src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java:1376
 #, fuzzy
 msgid "PGStream is closed"
-msgstr "Ce ResultSet est fermé."
+msgstr "Ce ResultSet est fermÃ©."
 
 #: src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java:1435
 #, java-format
@@ -497,7 +497,7 @@ msgstr ""
 #: src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java:1511
 #, fuzzy, java-format
 msgid "Unexpected copydata from server for {0}"
-msgstr "Attendait une fin de fichier du serveur, reçu: {0}"
+msgstr "Attendait une fin de fichier du serveur, reÃ§u: {0}"
 
 #: src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java:1571
 #, java-format
@@ -510,13 +510,13 @@ msgid ""
 "Bind message length {0} too long.  This can be caused by very large or "
 "incorrect length specifications on InputStream parameters."
 msgstr ""
-"La longueur du message de liaison {0} est trop grande. Cela peut être causé "
-"par des spécification de longueur très grandes ou incorrectes pour les "
-"paramètres de type InputStream."
+"La longueur du message de liaison {0} est trop grande. Cela peut Ãªtre causÃ© "
+"par des spÃ©cification de longueur trÃ¨s grandes ou incorrectes pour les "
+"paramÃ¨tres de type InputStream."
 
 #: src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java:2601
 msgid "Ran out of memory retrieving query results."
-msgstr "Ai manqué de mémoire en récupérant les résultats de la requête."
+msgstr "Ai manquÃ© de mÃ©moire en rÃ©cupÃ©rant les rÃ©sultats de la requÃªte."
 
 #: src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java:2769
 msgid "COPY commands are only supported using the CopyManager API."
@@ -542,8 +542,8 @@ msgid ""
 "The server''s client_encoding parameter was changed to {0}. The JDBC driver "
 "requires client_encoding to be UTF8 for correct operation."
 msgstr ""
-"Le paramètre client_encoding du serveur a été changé pour {0}. Le pilote "
-"JDBC nécessite l''affectation de la valeur UNICODE à client_encoding pour un "
+"Le paramÃ¨tre client_encoding du serveur a Ã©tÃ© changÃ© pour {0}. Le pilote "
+"JDBC nÃ©cessite l''affectation de la valeur UNICODE Ã  client_encoding pour un "
 "fonctionnement correct."
 
 #: src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java:3134
@@ -552,8 +552,8 @@ msgid ""
 "The server''s DateStyle parameter was changed to {0}. The JDBC driver "
 "requires DateStyle to begin with ISO for correct operation."
 msgstr ""
-"Le paramètre DateStyle du serveur a été changé pour {0}. Le pilote JDBC "
-"nécessite que DateStyle commence par ISO pour un fonctionnement correct."
+"Le paramÃ¨tre DateStyle du serveur a Ã©tÃ© changÃ© pour {0}. Le pilote JDBC "
+"nÃ©cessite que DateStyle commence par ISO pour un fonctionnement correct."
 
 #: src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java:3147
 #, java-format
@@ -561,7 +561,7 @@ msgid ""
 "The server''s standard_conforming_strings parameter was reported as {0}. The "
 "JDBC driver expected on or off."
 msgstr ""
-"Le paramètre serveur standard_conforming_strings a pour valeur {0}. Le "
+"Le paramÃ¨tre serveur standard_conforming_strings a pour valeur {0}. Le "
 "driver JDBC attend on ou off."
 
 #: src/main/java/org/postgresql/core/v3/ScramAuthenticator.java:70
@@ -609,13 +609,13 @@ msgstr ""
 #: src/main/java/org/postgresql/core/v3/SimpleParameterList.java:407
 #, java-format
 msgid "No value specified for parameter {0}."
-msgstr "Pas de valeur spécifiée pour le paramètre {0}."
+msgstr "Pas de valeur spÃ©cifiÃ©e pour le paramÃ¨tre {0}."
 
 #: src/main/java/org/postgresql/core/v3/SimpleParameterList.java:612
 #, fuzzy, java-format
 msgid "Added parameters index out of range: {0}, number of columns: {1}."
 msgstr ""
-"L''indice du paramètre est hors limites : {0}, nombre de paramètres : {1}."
+"L''indice du paramÃ¨tre est hors limitesÂ : {0}, nombre de paramÃ¨tresÂ : {1}."
 
 #: src/main/java/org/postgresql/core/v3/replication/V3PGReplicationStream.java:154
 #, java-format
@@ -625,27 +625,27 @@ msgstr ""
 #: src/main/java/org/postgresql/core/v3/replication/V3PGReplicationStream.java:288
 #, fuzzy
 msgid "This replication stream has been closed."
-msgstr "La connexion a été fermée."
+msgstr "La connexion a Ã©tÃ© fermÃ©e."
 
 #: src/main/java/org/postgresql/ds/PGPooledConnection.java:130
 msgid "This PooledConnection has already been closed."
-msgstr "Cette PooledConnection a déjà été fermée."
+msgstr "Cette PooledConnection a dÃ©jÃ  Ã©tÃ© fermÃ©e."
 
 #: src/main/java/org/postgresql/ds/PGPooledConnection.java:331
 msgid ""
 "Connection has been closed automatically because a new connection was opened "
 "for the same PooledConnection or the PooledConnection has been closed."
 msgstr ""
-"La connexion a été fermée automatiquement car une nouvelle connexion a été "
-"ouverte pour la même PooledConnection ou la PooledConnection a été fermée."
+"La connexion a Ã©tÃ© fermÃ©e automatiquement car une nouvelle connexion a Ã©tÃ© "
+"ouverte pour la mÃªme PooledConnection ou la PooledConnection a Ã©tÃ© fermÃ©e."
 
 #: src/main/java/org/postgresql/ds/PGPooledConnection.java:332
 msgid "Connection has been closed."
-msgstr "La connexion a été fermée."
+msgstr "La connexion a Ã©tÃ© fermÃ©e."
 
 #: src/main/java/org/postgresql/ds/PGPooledConnection.java:440
 msgid "Statement has been closed."
-msgstr "Statement a été fermé."
+msgstr "Statement a Ã©tÃ© fermÃ©."
 
 #: src/main/java/org/postgresql/ds/PGPoolingDataSource.java:287
 msgid "Failed to setup DataSource."
@@ -653,26 +653,26 @@ msgstr ""
 
 #: src/main/java/org/postgresql/ds/PGPoolingDataSource.java:393
 msgid "DataSource has been closed."
-msgstr "DataSource a été fermée."
+msgstr "DataSource a Ã©tÃ© fermÃ©e."
 
 #: src/main/java/org/postgresql/ds/common/BaseDataSource.java:1558
 #: src/main/java/org/postgresql/ds/common/BaseDataSource.java:1568
 #, fuzzy, java-format
 msgid "Unsupported property name: {0}"
-msgstr "Valeur de type non supportée : {0}"
+msgstr "Valeur de type non supportÃ©eÂ : {0}"
 
 #: src/main/java/org/postgresql/fastpath/Fastpath.java:83
 #, fuzzy, java-format
 msgid "Fastpath call {0} - No result was returned and we expected a numeric."
 msgstr ""
-"Appel Fastpath {0} - Aucun résultat n''a été retourné et nous attendions un "
+"Appel Fastpath {0} - Aucun rÃ©sultat n''a Ã©tÃ© retournÃ© et nous attendions un "
 "entier."
 
 #: src/main/java/org/postgresql/fastpath/Fastpath.java:164
 #, java-format
 msgid "Fastpath call {0} - No result was returned and we expected an integer."
 msgstr ""
-"Appel Fastpath {0} - Aucun résultat n''a été retourné et nous attendions un "
+"Appel Fastpath {0} - Aucun rÃ©sultat n''a Ã©tÃ© retournÃ© et nous attendions un "
 "entier."
 
 #: src/main/java/org/postgresql/fastpath/Fastpath.java:172
@@ -681,14 +681,14 @@ msgid ""
 "Fastpath call {0} - No result was returned or wrong size while expecting an "
 "integer."
 msgstr ""
-"Appel Fastpath {0} - Aucun résultat n''a été retourné et nous attendions un "
+"Appel Fastpath {0} - Aucun rÃ©sultat n''a Ã©tÃ© retournÃ© et nous attendions un "
 "entier."
 
 #: src/main/java/org/postgresql/fastpath/Fastpath.java:189
 #, fuzzy, java-format
 msgid "Fastpath call {0} - No result was returned and we expected a long."
 msgstr ""
-"Appel Fastpath {0} - Aucun résultat n''a été retourné et nous attendions un "
+"Appel Fastpath {0} - Aucun rÃ©sultat n''a Ã©tÃ© retournÃ© et nous attendions un "
 "entier."
 
 #: src/main/java/org/postgresql/fastpath/Fastpath.java:197
@@ -697,7 +697,7 @@ msgid ""
 "Fastpath call {0} - No result was returned or wrong size while expecting a "
 "long."
 msgstr ""
-"Appel Fastpath {0} - Aucun résultat n''a été retourné et nous attendions un "
+"Appel Fastpath {0} - Aucun rÃ©sultat n''a Ã©tÃ© retournÃ© et nous attendions un "
 "entier."
 
 #: src/main/java/org/postgresql/fastpath/Fastpath.java:300
@@ -714,12 +714,12 @@ msgstr "La fonction fastpath {0} est inconnue."
 #: src/main/java/org/postgresql/geometric/PGpoint.java:88
 #, java-format
 msgid "Conversion to type {0} failed: {1}."
-msgstr "La conversion vers le type {0} a échoué : {1}."
+msgstr "La conversion vers le type {0} a Ã©chouÃ©Â : {1}."
 
 #: src/main/java/org/postgresql/geometric/PGpath.java:78
 #, java-format
 msgid "Cannot tell if path is open or closed: {0}."
-msgstr "Impossible de dire si path est fermé ou ouvert : {0}."
+msgstr "Impossible de dire si path est fermÃ© ou ouvertÂ : {0}."
 
 #: src/main/java/org/postgresql/gss/GssAction.java:176
 #: src/main/java/org/postgresql/gss/GssEncAction.java:155
@@ -738,8 +738,8 @@ msgstr ""
 msgid ""
 "Truncation of large objects is only implemented in 8.3 and later servers."
 msgstr ""
-"Le troncage des large objects n''est implémenté que dans les serveurs 8.3 et "
-"supérieurs."
+"Le troncage des large objects n''est implÃ©mentÃ© que dans les serveurs 8.3 et "
+"supÃ©rieurs."
 
 #: src/main/java/org/postgresql/jdbc/AbstractBlobClob.java:89
 msgid "Cannot truncate LOB to a negative length."
@@ -749,15 +749,15 @@ msgstr ""
 #: src/main/java/org/postgresql/jdbc/AbstractBlobClob.java:249
 #, java-format
 msgid "PostgreSQL LOBs can only index to: {0}"
-msgstr "Les LOB PostgreSQL peuvent seulement s''indicer à: {0}"
+msgstr "Les LOB PostgreSQL peuvent seulement s''indicer Ã : {0}"
 
 #: src/main/java/org/postgresql/jdbc/AbstractBlobClob.java:245
 msgid "LOB positioning offsets start at 1."
-msgstr "Les décalages de position des LOB commencent à 1."
+msgstr "Les dÃ©calages de position des LOB commencent Ã  1."
 
 #: src/main/java/org/postgresql/jdbc/AbstractBlobClob.java:261
 msgid "free() was called on this LOB previously"
-msgstr "free() a été appelée auparavant sur ce LOB"
+msgstr "free() a Ã©tÃ© appelÃ©e auparavant sur ce LOB"
 
 #: src/main/java/org/postgresql/jdbc/ArrayDecoding.java:284
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:2442
@@ -769,16 +769,16 @@ msgid ""
 "was created in.  The most common example of this is storing 8bit data in a "
 "SQL_ASCII database."
 msgstr ""
-"Des données de caractères invalides ont été trouvées. C''est probablement "
-"causé par le stockage de caractères invalides pour le jeu de caractères de "
-"création de la base. L''exemple le plus courant est le stockage de données "
+"Des donnÃ©es de caractÃ¨res invalides ont Ã©tÃ© trouvÃ©es. C''est probablement "
+"causÃ© par le stockage de caractÃ¨res invalides pour le jeu de caractÃ¨res de "
+"crÃ©ation de la base. L''exemple le plus courant est le stockage de donnÃ©es "
 "8bit dans une base SQL_ASCII."
 
 #: src/main/java/org/postgresql/jdbc/ArrayEncoding.java:801
 #: src/main/java/org/postgresql/jdbc/ArrayEncoding.java:835
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:1212
 msgid "Unable to translate data into the desired encoding."
-msgstr "Impossible de traduire les données dans l''encodage désiré."
+msgstr "Impossible de traduire les donnÃ©es dans l''encodage dÃ©sirÃ©."
 
 #: src/main/java/org/postgresql/jdbc/ArrayEncoding.java:1040
 #: src/main/java/org/postgresql/jdbc/ArrayEncoding.java:1051
@@ -789,7 +789,7 @@ msgstr "Longueur de flux invalide {0}."
 
 #: src/main/java/org/postgresql/jdbc/BatchResultHandler.java:102
 msgid "Too many update results were returned."
-msgstr "Trop de résultats de mise à jour ont été retournés."
+msgstr "Trop de rÃ©sultats de mise Ã  jour ont Ã©tÃ© retournÃ©s."
 
 #: src/main/java/org/postgresql/jdbc/BatchResultHandler.java:163
 #, fuzzy, java-format
@@ -797,8 +797,8 @@ msgid ""
 "Batch entry {0} {1} was aborted: {2}  Call getNextException to see other "
 "errors in the batch."
 msgstr ""
-"L''élément du batch {0} {1} a été annulé. Appeler getNextException pour en "
-"connaître la cause."
+"L''Ã©lÃ©ment du batch {0} {1} a Ã©tÃ© annulÃ©. Appeler getNextException pour en "
+"connaÃ®tre la cause."
 
 #: src/main/java/org/postgresql/jdbc/BooleanTypeUtil.java:99
 #, java-format
@@ -872,7 +872,7 @@ msgstr "La fonction {0} n''accepte que trois et seulement trois arguments."
 #: src/main/java/org/postgresql/jdbc/EscapedFunctions2.java:600
 #, java-format
 msgid "Interval {0} not yet implemented"
-msgstr "L''interval {0} n''est pas encore implémenté"
+msgstr "L''interval {0} n''est pas encore implÃ©mentÃ©"
 
 #: src/main/java/org/postgresql/jdbc/GSSEncMode.java:61
 #, fuzzy, java-format
@@ -883,11 +883,11 @@ msgstr "Longueur de flux invalide {0}."
 #: src/main/java/org/postgresql/jdbc/PSQLSavepoint.java:55
 #: src/main/java/org/postgresql/jdbc/PSQLSavepoint.java:73
 msgid "Cannot reference a savepoint after it has been released."
-msgstr "Impossible de référencer un savepoint après qu''il ait été libéré."
+msgstr "Impossible de rÃ©fÃ©rencer un savepoint aprÃ¨s qu''il ait Ã©tÃ© libÃ©rÃ©."
 
 #: src/main/java/org/postgresql/jdbc/PSQLSavepoint.java:45
 msgid "Cannot retrieve the id of a named savepoint."
-msgstr "Impossible de retrouver l''identifiant d''un savepoint nommé."
+msgstr "Impossible de retrouver l''identifiant d''un savepoint nommÃ©."
 
 #: src/main/java/org/postgresql/jdbc/PSQLSavepoint.java:60
 msgid "Cannot retrieve the name of an unnamed savepoint."
@@ -897,24 +897,24 @@ msgstr "Impossible de retrouver le nom d''un savepoint sans nom."
 #: src/main/java/org/postgresql/jdbc/PgArray.java:371
 #, java-format
 msgid "The array index is out of range: {0}"
-msgstr "L''indice du tableau est hors limites : {0}"
+msgstr "L''indice du tableau est hors limitesÂ : {0}"
 
 #: src/main/java/org/postgresql/jdbc/PgArray.java:174
 #: src/main/java/org/postgresql/jdbc/PgArray.java:388
 #, java-format
 msgid "The array index is out of range: {0}, number of elements: {1}."
-msgstr "L''indice du tableau est hors limites : {0}, nombre d''éléments : {1}."
+msgstr "L''indice du tableau est hors limitesÂ : {0}, nombre d''Ã©lÃ©mentsÂ : {1}."
 
 #: src/main/java/org/postgresql/jdbc/PgCallableStatement.java:99
 #: src/main/java/org/postgresql/jdbc/PgCallableStatement.java:105
 msgid "A CallableStatement was executed with nothing returned."
-msgstr "Un CallableStatement a été exécuté mais n''a rien retourné."
+msgstr "Un CallableStatement a Ã©tÃ© exÃ©cutÃ© mais n''a rien retournÃ©."
 
 #: src/main/java/org/postgresql/jdbc/PgCallableStatement.java:116
 #, fuzzy
 msgid "A CallableStatement was executed with an invalid number of parameters"
 msgstr ""
-"Un CallableStatement a été exécuté avec un nombre de paramètres incorrect"
+"Un CallableStatement a Ã©tÃ© exÃ©cutÃ© avec un nombre de paramÃ¨tres incorrect"
 
 #: src/main/java/org/postgresql/jdbc/PgCallableStatement.java:154
 #, java-format
@@ -922,20 +922,20 @@ msgid ""
 "A CallableStatement function was executed and the out parameter {0} was of "
 "type {1} however type {2} was registered."
 msgstr ""
-"Une fonction CallableStatement a été exécutée et le paramètre en sortie {0} "
-"était du type {1} alors que le type {2} était prévu."
+"Une fonction CallableStatement a Ã©tÃ© exÃ©cutÃ©e et le paramÃ¨tre en sortie {0} "
+"Ã©tait du type {1} alors que le type {2} Ã©tait prÃ©vu."
 
 #: src/main/java/org/postgresql/jdbc/PgCallableStatement.java:217
 msgid ""
 "This statement does not declare an OUT parameter.  Use '{' ?= call ... '}' "
 "to declare one."
 msgstr ""
-"Cette requête ne déclare pas de paramètre OUT. Utilisez '{' ?= call ... '}' "
-"pour en déclarer un."
+"Cette requÃªte ne dÃ©clare pas de paramÃ¨tre OUT. Utilisez '{' ?= call ... '}' "
+"pour en dÃ©clarer un."
 
 #: src/main/java/org/postgresql/jdbc/PgCallableStatement.java:240
 msgid "wasNull cannot be call before fetching a result."
-msgstr "wasNull ne peut pas être appelé avant la récupération d''un résultat."
+msgstr "wasNull ne peut pas Ãªtre appelÃ© avant la rÃ©cupÃ©ration d''un rÃ©sultat."
 
 #: src/main/java/org/postgresql/jdbc/PgCallableStatement.java:377
 #: src/main/java/org/postgresql/jdbc/PgCallableStatement.java:399
@@ -944,38 +944,38 @@ msgid ""
 "Parameter of type {0} was registered, but call to get{1} (sqltype={2}) was "
 "made."
 msgstr ""
-"Un paramètre de type {0} a été enregistré, mais un appel à get{1} "
-"(sqltype={2}) a été fait."
+"Un paramÃ¨tre de type {0} a Ã©tÃ© enregistrÃ©, mais un appel Ã  get{1} "
+"(sqltype={2}) a Ã©tÃ© fait."
 
 #: src/main/java/org/postgresql/jdbc/PgCallableStatement.java:413
 msgid ""
 "A CallableStatement was declared, but no call to registerOutParameter(1, "
 "<some type>) was made."
 msgstr ""
-"Un CallableStatement a été déclaré, mais aucun appel à "
-"registerOutParameter(1, <un type>) n''a été fait."
+"Un CallableStatement a Ã©tÃ© dÃ©clarÃ©, mais aucun appel Ã  "
+"registerOutParameter(1, <un type>) n''a Ã©tÃ© fait."
 
 #: src/main/java/org/postgresql/jdbc/PgCallableStatement.java:418
 msgid "No function outputs were registered."
-msgstr "Aucune fonction outputs n''a été enregistrée."
+msgstr "Aucune fonction outputs n''a Ã©tÃ© enregistrÃ©e."
 
 #: src/main/java/org/postgresql/jdbc/PgCallableStatement.java:425
 msgid ""
 "Results cannot be retrieved from a CallableStatement before it is executed."
 msgstr ""
-"Les résultats ne peuvent être récupérés à partir d''un CallableStatement "
-"avant qu''il ne soit exécuté."
+"Les rÃ©sultats ne peuvent Ãªtre rÃ©cupÃ©rÃ©s Ã  partir d''un CallableStatement "
+"avant qu''il ne soit exÃ©cutÃ©."
 
 #: src/main/java/org/postgresql/jdbc/PgCallableStatement.java:732
 #, fuzzy, java-format
 msgid "Unsupported type conversion to {0}."
-msgstr "Valeur de type non supportée : {0}"
+msgstr "Valeur de type non supportÃ©eÂ : {0}"
 
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:353
 #, java-format
 msgid "Unsupported value for stringtype parameter: {0}"
 msgstr ""
-"Valeur non supportée pour les paramètre de type chaîne de caractères : {0}"
+"Valeur non supportÃ©e pour les paramÃ¨tre de type chaÃ®ne de caractÃ¨resÂ : {0}"
 
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:612
 #: src/main/java/org/postgresql/jdbc/PgPreparedStatement.java:141
@@ -989,13 +989,13 @@ msgstr ""
 #: src/main/java/org/postgresql/jdbc/TypeInfoCache.java:705
 #: src/main/java/org/postgresql/jdbc/TypeInfoCache.java:710
 msgid "No results were returned by the query."
-msgstr "Aucun résultat retourné par la requête."
+msgstr "Aucun rÃ©sultat retournÃ© par la requÃªte."
 
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:630
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:647
 #: src/main/java/org/postgresql/jdbc/PgStatement.java:317
 msgid "A result was returned when none was expected."
-msgstr "Un résultat a été retourné alors qu''aucun n''était attendu."
+msgstr "Un rÃ©sultat a Ã©tÃ© retournÃ© alors qu''aucun n''Ã©tait attendu."
 
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:754
 msgid "Custom type maps are not supported."
@@ -1004,12 +1004,12 @@ msgstr ""
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:796
 #, java-format
 msgid "Failed to create object for: {0}."
-msgstr "Échec à la création de l''objet pour : {0}."
+msgstr "Ã‰chec Ã  la crÃ©ation de l''objet pourÂ : {0}."
 
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:864
 #, java-format
 msgid "Unable to load the class {0} responsible for the datatype {1}"
-msgstr "Incapable de charger la classe {0} responsable du type de données {1}"
+msgstr "Incapable de charger la classe {0} responsable du type de donnÃ©es {1}"
 
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:892
 msgid "Unable to close connection properly"
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid ""
 "Cannot change transaction read-only property in the middle of a transaction."
 msgstr ""
-"Impossible de changer la propriété read-only d''une transaction au milieu "
+"Impossible de changer la propriÃ©tÃ© read-only d''une transaction au milieu "
 "d''une transaction."
 
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:1020
@@ -1031,7 +1031,7 @@ msgstr ""
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:1655
 #, fuzzy
 msgid "This connection has been closed."
-msgstr "La connexion a été fermée."
+msgstr "La connexion a Ã©tÃ© fermÃ©e."
 
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:1041
 msgid "Cannot rollback when autoCommit is enabled."
@@ -1047,18 +1047,18 @@ msgstr ""
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:1103
 #, java-format
 msgid "Transaction isolation level {0} not supported."
-msgstr "Le niveau d''isolation de transaction {0} n''est pas supporté."
+msgstr "Le niveau d''isolation de transaction {0} n''est pas supportÃ©."
 
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:1274
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:2242
 #: src/main/java/org/postgresql/jdbc/PgStatement.java:1026
 msgid "Fetch size must be a value greater than or equal to 0."
-msgstr "Fetch size doit être une valeur supérieur ou égal à 0."
+msgstr "Fetch size doit Ãªtre une valeur supÃ©rieur ou Ã©gal Ã  0."
 
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:1290
 #, fuzzy
 msgid "Query timeout must be a value greater than or equal to 0."
-msgstr "Query timeout doit être une valeur supérieure ou égale à 0."
+msgstr "Query timeout doit Ãªtre une valeur supÃ©rieure ou Ã©gale Ã  0."
 
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:1536
 #, java-format
@@ -1077,12 +1077,12 @@ msgstr ""
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:1632
 #, fuzzy, java-format
 msgid "Failed to set ClientInfo property: {0}"
-msgstr "Échec à la création de l''objet pour : {0}."
+msgstr "Ã‰chec Ã  la crÃ©ation de l''objet pourÂ : {0}."
 
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:1642
 #, fuzzy
 msgid "ClientInfo property not supported."
-msgstr "Le renvoi des clés automatiquement générées n''est pas supporté."
+msgstr "Le renvoi des clÃ©s automatiquement gÃ©nÃ©rÃ©es n''est pas supportÃ©."
 
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:1668
 msgid "One or more ClientInfo failed."
@@ -1091,7 +1091,7 @@ msgstr ""
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:1775
 #, fuzzy
 msgid "Network timeout must be a value greater than or equal to 0."
-msgstr "Query timeout doit être une valeur supérieure ou égale à 0."
+msgstr "Query timeout doit Ãªtre une valeur supÃ©rieure ou Ã©gale Ã  0."
 
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:1784
 msgid "Unable to set network timeout."
@@ -1104,16 +1104,16 @@ msgstr ""
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:1824
 #, java-format
 msgid "Unknown ResultSet holdability setting: {0}."
-msgstr "Paramètre holdability du ResultSet inconnu : {0}."
+msgstr "ParamÃ¨tre holdability du ResultSet inconnuÂ : {0}."
 
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:1842
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:1863
 msgid "Cannot establish a savepoint in auto-commit mode."
-msgstr "Impossible d''établir un savepoint en mode auto-commit."
+msgstr "Impossible d''Ã©tablir un savepoint en mode auto-commit."
 
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:1932
 msgid "Returning autogenerated keys is not supported."
-msgstr "Le renvoi des clés automatiquement générées n''est pas supporté."
+msgstr "Le renvoi des clÃ©s automatiquement gÃ©nÃ©rÃ©es n''est pas supportÃ©."
 
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:1994
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:2003
@@ -1130,19 +1130,19 @@ msgid ""
 "Unable to determine a value for MaxIndexKeys due to missing system catalog "
 "data."
 msgstr ""
-"Incapable de déterminer la valeur de MaxIndexKeys en raison de données "
-"manquante dans lecatalogue système."
+"Incapable de dÃ©terminer la valeur de MaxIndexKeys en raison de donnÃ©es "
+"manquante dans lecatalogue systÃ¨me."
 
 #: src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java:98
 msgid "Unable to find name datatype in the system catalogs."
 msgstr ""
-"Incapable de trouver le type de donnée name dans les catalogues systèmes."
+"Incapable de trouver le type de donnÃ©e name dans les catalogues systÃ¨mes."
 
 #: src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java:358
 #, fuzzy
 msgid "Unable to find keywords in the system catalogs."
 msgstr ""
-"Incapable de trouver le type de donnée name dans les catalogues systèmes."
+"Incapable de trouver le type de donnÃ©e name dans les catalogues systÃ¨mes."
 
 #: src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java:1085
 msgid ""
@@ -1154,7 +1154,7 @@ msgstr ""
 #, java-format
 msgid "The parameter index is out of range: {0}, number of parameters: {1}."
 msgstr ""
-"L''indice du paramètre est hors limites : {0}, nombre de paramètres : {1}."
+"L''indice du paramÃ¨tre est hors limitesÂ : {0}, nombre de paramÃ¨tresÂ : {1}."
 
 #: src/main/java/org/postgresql/jdbc/PgPreparedStatement.java:108
 #, java-format
@@ -1171,8 +1171,8 @@ msgstr ""
 msgid ""
 "Can''t use query methods that take a query string on a PreparedStatement."
 msgstr ""
-"Impossible d''utiliser les fonctions de requête qui utilisent une chaîne de "
-"caractères sur un PreparedStatement."
+"Impossible d''utiliser les fonctions de requÃªte qui utilisent une chaÃ®ne de "
+"caractÃ¨res sur un PreparedStatement."
 
 #: src/main/java/org/postgresql/jdbc/PgPreparedStatement.java:300
 msgid "Unknown Types value."
@@ -1189,19 +1189,19 @@ msgstr "Longueur de flux invalide {0}."
 #: src/main/java/org/postgresql/jdbc/PgPreparedStatement.java:483
 #, java-format
 msgid "The JVM claims not to support the {0} encoding."
-msgstr "La JVM prétend ne pas supporter l''encodage {0}."
+msgstr "La JVM prÃ©tend ne pas supporter l''encodage {0}."
 
 #: src/main/java/org/postgresql/jdbc/PgPreparedStatement.java:486
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:1325
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:1364
 msgid "Provided InputStream failed."
-msgstr "L''InputStream fourni a échoué."
+msgstr "L''InputStream fourni a Ã©chouÃ©."
 
 #: src/main/java/org/postgresql/jdbc/PgPreparedStatement.java:528
 #: src/main/java/org/postgresql/jdbc/PgPreparedStatement.java:1239
 #, java-format
 msgid "Unknown type {0}."
-msgstr "Type inconnu : {0}."
+msgstr "Type inconnuÂ : {0}."
 
 #: src/main/java/org/postgresql/jdbc/PgPreparedStatement.java:550
 msgid "No hstore extension installed."
@@ -1219,7 +1219,7 @@ msgstr "Impossible de convertir une instance de {0} vers le type {1}"
 #: src/main/java/org/postgresql/jdbc/PgPreparedStatement.java:762
 #, java-format
 msgid "Unsupported Types value: {0}"
-msgstr "Valeur de type non supportée : {0}"
+msgstr "Valeur de type non supportÃ©eÂ : {0}"
 
 #: src/main/java/org/postgresql/jdbc/PgPreparedStatement.java:1005
 #, java-format
@@ -1232,24 +1232,24 @@ msgid ""
 "Can''t infer the SQL type to use for an instance of {0}. Use setObject() "
 "with an explicit Types value to specify the type to use."
 msgstr ""
-"Impossible de déduire le type SQL à utiliser pour une instance de {0}. "
-"Utilisez setObject() avec une valeur de type explicite pour spécifier le "
-"type à utiliser."
+"Impossible de dÃ©duire le type SQL Ã  utiliser pour une instance de {0}. "
+"Utilisez setObject() avec une valeur de type explicite pour spÃ©cifier le "
+"type Ã  utiliser."
 
 #: src/main/java/org/postgresql/jdbc/PgPreparedStatement.java:1275
 #: src/main/java/org/postgresql/jdbc/PgPreparedStatement.java:1382
 msgid "Unexpected error writing large object to database."
-msgstr "Erreur inattendue pendant l''écriture de large object dans la base."
+msgstr "Erreur inattendue pendant l''Ã©criture de large object dans la base."
 
 #: src/main/java/org/postgresql/jdbc/PgPreparedStatement.java:1301
 #, fuzzy
 msgid "Unexpected error when closing Blob binary stream"
-msgstr "Erreur inattendue pendant l''écriture de large object dans la base."
+msgstr "Erreur inattendue pendant l''Ã©criture de large object dans la base."
 
 #: src/main/java/org/postgresql/jdbc/PgPreparedStatement.java:1320
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:1427
 msgid "Provided Reader failed."
-msgstr "Le Reader fourni a échoué."
+msgstr "Le Reader fourni a Ã©chouÃ©."
 
 #: src/main/java/org/postgresql/jdbc/PgPreparedStatement.java:1640
 #: src/main/java/org/postgresql/util/StreamWrapper.java:60
@@ -1261,7 +1261,7 @@ msgid ""
 "Operation requires a scrollable ResultSet, but this ResultSet is "
 "FORWARD_ONLY."
 msgstr ""
-"L''opération nécessite un scrollable ResultSet, mais ce ResultSet est "
+"L''opÃ©ration nÃ©cessite un scrollable ResultSet, mais ce ResultSet est "
 "FORWARD_ONLY."
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:545
@@ -1283,14 +1283,14 @@ msgstr "Impossible de convertir une instance de type {0} vers le type {1}"
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:2276
 msgid "Can''t use relative move methods while on the insert row."
 msgstr ""
-"Impossible d''utiliser les fonctions de déplacement relatif pendant "
+"Impossible d''utiliser les fonctions de dÃ©placement relatif pendant "
 "l''insertion d''une ligne."
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:1069
 #: src/main/java/org/postgresql/jdbc/PgStatement.java:1017
 #, java-format
 msgid "Invalid fetch direction constant: {0}."
-msgstr "Constante de direction pour la récupération invalide : {0}."
+msgstr "Constante de direction pour la rÃ©cupÃ©ration invalideÂ : {0}."
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:1081
 msgid "Cannot call cancelRowUpdates() when on the insert row."
@@ -1306,7 +1306,7 @@ msgid ""
 "Currently positioned before the start of the ResultSet.  You cannot call "
 "deleteRow() here."
 msgstr ""
-"Actuellement positionné avant le début du ResultSet. Vous ne pouvez pas "
+"Actuellement positionnÃ© avant le dÃ©but du ResultSet. Vous ne pouvez pas "
 "appeler deleteRow() ici."
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:1112
@@ -1314,7 +1314,7 @@ msgid ""
 "Currently positioned after the end of the ResultSet.  You cannot call "
 "deleteRow() here."
 msgstr ""
-"Actuellement positionné après la fin du ResultSet. Vous ne pouvez pas "
+"Actuellement positionnÃ© aprÃ¨s la fin du ResultSet. Vous ne pouvez pas "
 "appeler deleteRow() ici."
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:1117
@@ -1328,16 +1328,16 @@ msgstr "Pas sur la ligne en insertion."
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:1162
 msgid "You must specify at least one column value to insert a row."
 msgstr ""
-"Vous devez spécifier au moins une valeur de colonne pour insérer une ligne."
+"Vous devez spÃ©cifier au moins une valeur de colonne pour insÃ©rer une ligne."
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:1497
 msgid "Can''t refresh the insert row."
-msgstr "Impossible de rafraîchir la ligne insérée."
+msgstr "Impossible de rafraÃ®chir la ligne insÃ©rÃ©e."
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:1573
 msgid "Cannot call updateRow() when on the insert row."
 msgstr ""
-"Impossible d''appeler updateRow() tant que l''on est sur la ligne insérée."
+"Impossible d''appeler updateRow() tant que l''on est sur la ligne insÃ©rÃ©e."
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:1581
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:3738
@@ -1345,24 +1345,24 @@ msgid ""
 "Cannot update the ResultSet because it is either before the start or after "
 "the end of the results."
 msgstr ""
-"Impossible de mettre à jour le ResultSet car c''est soit avant le début ou "
-"après la fin des résultats."
+"Impossible de mettre Ã  jour le ResultSet car c''est soit avant le dÃ©but ou "
+"aprÃ¨s la fin des rÃ©sultats."
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:1844
 msgid "ResultSets with concurrency CONCUR_READ_ONLY cannot be updated."
 msgstr ""
-"Les ResultSets avec la concurrence CONCUR_READ_ONLY ne peuvent être mis à "
+"Les ResultSets avec la concurrence CONCUR_READ_ONLY ne peuvent Ãªtre mis Ã  "
 "jour."
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:1948
 #, fuzzy, java-format
 msgid "No eligible primary or unique key found for table {0}."
-msgstr "Pas de clé primaire trouvée pour la table {0}."
+msgstr "Pas de clÃ© primaire trouvÃ©e pour la table {0}."
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:2148
 #, java-format
 msgid "The JVM claims not to support the encoding: {0}"
-msgstr "La JVM prétend ne pas supporter l''encodage: {0}"
+msgstr "La JVM prÃ©tend ne pas supporter l''encodage: {0}"
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:2597
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:2602
@@ -1383,12 +1383,12 @@ msgstr "La JVM prétend ne pas supporter l''encodage: {0}"
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:3726
 #, java-format
 msgid "Bad value for type {0} : {1}"
-msgstr "Mauvaise valeur pour le type {0} : {1}"
+msgstr "Mauvaise valeur pour le type {0}Â : {1}"
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:3207
 #, java-format
 msgid "The column name {0} was not found in this ResultSet."
-msgstr "Le nom de colonne {0} n''a pas été trouvé dans ce ResultSet."
+msgstr "Le nom de colonne {0} n''a pas Ã©tÃ© trouvÃ© dans ce ResultSet."
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:3348
 msgid ""
@@ -1396,19 +1396,19 @@ msgid ""
 "select only one table, and must select all primary keys from that table. See "
 "the JDBC 2.1 API Specification, section 5.6 for more details."
 msgstr ""
-"Le ResultSet n''est pas modifiable. La requête qui a généré ce résultat doit "
-"sélectionner seulement une table, et doit sélectionner toutes les clés "
-"primaires de cette table. Voir la spécification de l''API JDBC 2.1, section "
-"5.6 pour plus de détails."
+"Le ResultSet n''est pas modifiable. La requÃªte qui a gÃ©nÃ©rÃ© ce rÃ©sultat doit "
+"sÃ©lectionner seulement une table, et doit sÃ©lectionner toutes les clÃ©s "
+"primaires de cette table. Voir la spÃ©cification de l''API JDBC 2.1, section "
+"5.6 pour plus de dÃ©tails."
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:3364
 msgid "This ResultSet is closed."
-msgstr "Ce ResultSet est fermé."
+msgstr "Ce ResultSet est fermÃ©."
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:3398
 msgid "ResultSet not positioned properly, perhaps you need to call next."
 msgstr ""
-"Le ResultSet n''est pas positionné correctement, vous devez peut-être "
+"Le ResultSet n''est pas positionnÃ© correctement, vous devez peut-Ãªtre "
 "appeler next()."
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:3760
@@ -1438,7 +1438,7 @@ msgstr "Drapeau invalide"
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:4067
 #, fuzzy, java-format
 msgid "conversion to {0} from {1} not supported"
-msgstr "Le niveau d''isolation de transaction {0} n''est pas supporté."
+msgstr "Le niveau d''isolation de transaction {0} n''est pas supportÃ©."
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:4044
 #, fuzzy
@@ -1457,7 +1457,7 @@ msgstr ""
 #: src/main/java/org/postgresql/jdbc/PgSQLXML.java:229
 #, fuzzy
 msgid "Unable to create SAXResult for SQLXML."
-msgstr "Échec à la création de l''objet pour : {0}."
+msgstr "Ã‰chec Ã  la crÃ©ation de l''objet pourÂ : {0}."
 
 #: src/main/java/org/postgresql/jdbc/PgSQLXML.java:245
 msgid "Unable to create StAXResult for SQLXML"
@@ -1466,12 +1466,12 @@ msgstr ""
 #: src/main/java/org/postgresql/jdbc/PgSQLXML.java:250
 #, fuzzy, java-format
 msgid "Unknown XML Result class: {0}"
-msgstr "Paramètre holdability du ResultSet inconnu : {0}."
+msgstr "ParamÃ¨tre holdability du ResultSet inconnuÂ : {0}."
 
 #: src/main/java/org/postgresql/jdbc/PgSQLXML.java:266
 #, fuzzy
 msgid "This SQLXML object has already been freed."
-msgstr "Cette PooledConnection a déjà été fermée."
+msgstr "Cette PooledConnection a dÃ©jÃ  Ã©tÃ© fermÃ©e."
 
 #: src/main/java/org/postgresql/jdbc/PgSQLXML.java:275
 msgid ""
@@ -1505,11 +1505,11 @@ msgstr ""
 #: src/main/java/org/postgresql/jdbc/PgStatement.java:187
 #, fuzzy
 msgid "Unknown value for ResultSet holdability"
-msgstr "Paramètre holdability du ResultSet inconnu : {0}."
+msgstr "ParamÃ¨tre holdability du ResultSet inconnuÂ : {0}."
 
 #: src/main/java/org/postgresql/jdbc/PgStatement.java:295
 msgid "Multiple ResultSets were returned by the query."
-msgstr "Plusieurs ResultSets ont été retournés par la requête."
+msgstr "Plusieurs ResultSets ont Ã©tÃ© retournÃ©s par la requÃªte."
 
 #: src/main/java/org/postgresql/jdbc/PgStatement.java:381
 msgid "Can''t use executeWithFlags(int) on a Statement."
@@ -1519,20 +1519,20 @@ msgstr ""
 #, fuzzy
 msgid "Maximum number of rows must be a value greater than or equal to 0."
 msgstr ""
-"Le nombre maximum de lignes doit être une valeur supérieure ou égale à 0."
+"Le nombre maximum de lignes doit Ãªtre une valeur supÃ©rieure ou Ã©gale Ã  0."
 
 #: src/main/java/org/postgresql/jdbc/PgStatement.java:642
 msgid "Query timeout must be a value greater than or equals to 0."
-msgstr "Query timeout doit être une valeur supérieure ou égale à 0."
+msgstr "Query timeout doit Ãªtre une valeur supÃ©rieure ou Ã©gale Ã  0."
 
 #: src/main/java/org/postgresql/jdbc/PgStatement.java:685
 msgid "The maximum field size must be a value greater than or equal to 0."
 msgstr ""
-"La taille maximum des champs doit être une valeur supérieure ou égale à 0."
+"La taille maximum des champs doit Ãªtre une valeur supÃ©rieure ou Ã©gale Ã  0."
 
 #: src/main/java/org/postgresql/jdbc/PgStatement.java:791
 msgid "This statement has been closed."
-msgstr "Ce statement a été fermé."
+msgstr "Ce statement a Ã©tÃ© fermÃ©."
 
 #: src/main/java/org/postgresql/jdbc/PgStatement.java:833
 msgid ""
@@ -1552,7 +1552,7 @@ msgstr "Longueur de flux invalide {0}."
 #: src/main/java/org/postgresql/jdbc/PgStatement.java:1360
 #, fuzzy
 msgid "Returning autogenerated keys by column index is not supported."
-msgstr "Le renvoi des clés automatiquement générées n''est pas supporté."
+msgstr "Le renvoi des clÃ©s automatiquement gÃ©nÃ©rÃ©es n''est pas supportÃ©."
 
 #: src/main/java/org/postgresql/jdbc/QueryExecutorTimeZoneProvider.java:33
 msgid ""
@@ -1569,7 +1569,7 @@ msgstr "Longueur de flux invalide {0}."
 #: src/main/java/org/postgresql/jdbc/TimestampUtils.java:491
 #, fuzzy, java-format
 msgid "Bad value for type timestamp/date/time: {0}"
-msgstr "Mauvaise valeur pour le type {0} : {1}"
+msgstr "Mauvaise valeur pour le type {0}Â : {1}"
 
 #: src/main/java/org/postgresql/jdbc/TimestampUtils.java:506
 #: src/main/java/org/postgresql/jdbc/TimestampUtils.java:1313
@@ -1579,7 +1579,7 @@ msgstr "Mauvaise valeur pour le type {0} : {1}"
 #: src/main/java/org/postgresql/jdbc/TimestampUtils.java:1593
 #, fuzzy, java-format
 msgid "Unsupported binary encoding of {0}."
-msgstr "Valeur de type non supportée : {0}"
+msgstr "Valeur de type non supportÃ©eÂ : {0}"
 
 #: src/main/java/org/postgresql/jdbc/TypeInfoCache.java:1119
 #, java-format
@@ -1597,7 +1597,7 @@ msgstr ""
 #: src/main/java/org/postgresql/largeobject/BlobOutputStream.java:236
 #, fuzzy, java-format
 msgid "Can not close large object {0}"
-msgstr "Échec à la création de l''objet pour : {0}."
+msgstr "Ã‰chec Ã  la crÃ©ation de l''objet pourÂ : {0}."
 
 #: src/main/java/org/postgresql/largeobject/BlobInputStream.java:317
 #, java-format
@@ -1618,17 +1618,17 @@ msgstr ""
 #: src/main/java/org/postgresql/largeobject/LargeObject.java:85
 #, fuzzy
 msgid "This large object has been closed."
-msgstr "Ce statement a été fermé."
+msgstr "Ce statement a Ã©tÃ© fermÃ©."
 
 #: src/main/java/org/postgresql/largeobject/LargeObjectManager.java:244
 #: src/main/java/org/postgresql/largeobject/LargeObjectManager.java:285
 msgid "Large Objects may not be used in auto-commit mode."
-msgstr "Les Large Objects ne devraient pas être utilisés en mode auto-commit."
+msgstr "Les Large Objects ne devraient pas Ãªtre utilisÃ©s en mode auto-commit."
 
 #: src/main/java/org/postgresql/osgi/PGDataSourceFactory.java:86
 #, fuzzy, java-format
 msgid "Unsupported properties: {0}"
-msgstr "Valeur de type non supportée : {0}"
+msgstr "Valeur de type non supportÃ©eÂ : {0}"
 
 #: src/main/java/org/postgresql/replication/fluent/AbstractCreateSlotBuilder.java:40
 msgid "Server does not support temporary replication slots"
@@ -1729,7 +1729,7 @@ msgstr ""
 #: src/main/java/org/postgresql/ssl/LibPQFactory.java:64
 #, fuzzy, java-format
 msgid "The password callback class provided {0} could not be instantiated."
-msgstr "La classe SSLSocketFactory fournie {0} n''a pas pu être instanciée."
+msgstr "La classe SSLSocketFactory fournie {0} n''a pas pu Ãªtre instanciÃ©e."
 
 #: src/main/java/org/postgresql/ssl/LibPQFactory.java:110
 msgid "Could not initialize PEMKeyManager."
@@ -1762,7 +1762,7 @@ msgstr ""
 #: src/main/java/org/postgresql/ssl/MakeSSL.java:82
 #, fuzzy, java-format
 msgid "The HostnameVerifier class provided {0} could not be instantiated."
-msgstr "La classe SSLSocketFactory fournie {0} n''a pas pu être instanciée."
+msgstr "La classe SSLSocketFactory fournie {0} n''a pas pu Ãªtre instanciÃ©e."
 
 #: src/main/java/org/postgresql/ssl/MakeSSL.java:93
 #, java-format
@@ -1785,7 +1785,7 @@ msgstr ""
 #: src/main/java/org/postgresql/ssl/PGjdbcHostnameVerifier.java:92
 #, fuzzy, java-format
 msgid "No certificates found for hostname {0}"
-msgstr "Pas de clé primaire trouvée pour la table {0}."
+msgstr "Pas de clÃ© primaire trouvÃ©e pour la table {0}."
 
 #: src/main/java/org/postgresql/ssl/PGjdbcHostnameVerifier.java:111
 #, java-format
@@ -1795,7 +1795,7 @@ msgstr ""
 #: src/main/java/org/postgresql/ssl/PGjdbcHostnameVerifier.java:128
 #, fuzzy, java-format
 msgid "Unable to parse certificates for hostname {0}"
-msgstr "Incapable de lier les valeurs des paramètres pour la commande."
+msgstr "Incapable de lier les valeurs des paramÃ¨tres pour la commande."
 
 #: src/main/java/org/postgresql/ssl/PGjdbcHostnameVerifier.java:159
 #, java-format
@@ -1834,7 +1834,7 @@ msgstr ""
 #, fuzzy
 msgid "Unable to find pkcs12 keystore."
 msgstr ""
-"Incapable de trouver le type de donnée name dans les catalogues systèmes."
+"Incapable de trouver le type de donnÃ©e name dans les catalogues systÃ¨mes."
 
 #: src/main/java/org/postgresql/ssl/SingleCertValidatingFactory.java:92
 msgid "The sslfactoryarg property may not be empty."
@@ -1872,7 +1872,7 @@ msgstr ""
 #, fuzzy
 msgid "An error occurred reading the certificate"
 msgstr ""
-"Une erreur s''est produite pendant l''établissement de la connexion SSL."
+"Une erreur s''est produite pendant l''Ã©tablissement de la connexion SSL."
 
 #: src/main/java/org/postgresql/ssl/SingleCertValidatingFactory.java:186
 msgid "No X509TrustManager found"
@@ -1885,11 +1885,11 @@ msgstr ""
 #: src/main/java/org/postgresql/util/HStoreConverter.java:61
 #, fuzzy
 msgid "hstore key must not be null"
-msgstr "xid ne doit pas être nul"
+msgstr "xid ne doit pas Ãªtre nul"
 
 #: src/main/java/org/postgresql/util/PGInterval.java:220
 msgid "Conversion of interval failed"
-msgstr "La conversion de l''intervalle a échoué"
+msgstr "La conversion de l''intervalle a Ã©chouÃ©"
 
 #: src/main/java/org/postgresql/util/PGPropertyMaxResultBufferParser.java:153
 #, java-format
@@ -1908,7 +1908,7 @@ msgstr ""
 #, java-format
 msgid "Premature end of input stream, expected {0} bytes, but only read {1}."
 msgstr ""
-"Fin prématurée du flux en entrée, {0} octets attendus, mais seulement {1} "
+"Fin prÃ©maturÃ©e du flux en entrÃ©e, {0} octets attendus, mais seulement {1} "
 "lus."
 
 #: src/main/java/org/postgresql/util/PGbytea.java:256
@@ -1917,7 +1917,7 @@ msgstr ""
 
 #: src/main/java/org/postgresql/util/PGmoney.java:74
 msgid "Conversion of money failed."
-msgstr "La conversion de money a échoué."
+msgstr "La conversion de money a Ã©chouÃ©."
 
 #: src/main/java/org/postgresql/util/ServerErrorMessage.java:45
 #, java-format
@@ -1930,42 +1930,42 @@ msgstr ""
 #: src/main/java/org/postgresql/util/ServerErrorMessage.java:190
 #, java-format
 msgid "Detail: {0}"
-msgstr "Détail : {0}"
+msgstr "DÃ©tailÂ : {0}"
 
 #: src/main/java/org/postgresql/util/ServerErrorMessage.java:195
 #, java-format
 msgid "Hint: {0}"
-msgstr "Indice : {0}"
+msgstr "IndiceÂ : {0}"
 
 #: src/main/java/org/postgresql/util/ServerErrorMessage.java:199
 #, java-format
 msgid "Position: {0}"
-msgstr "Position : {0}"
+msgstr "PositionÂ : {0}"
 
 #: src/main/java/org/postgresql/util/ServerErrorMessage.java:203
 #, java-format
 msgid "Where: {0}"
-msgstr "Où : {0}"
+msgstr "OÃ¹Â : {0}"
 
 #: src/main/java/org/postgresql/util/ServerErrorMessage.java:209
 #, java-format
 msgid "Internal Query: {0}"
-msgstr "Requête interne: {0}"
+msgstr "RequÃªte interne: {0}"
 
 #: src/main/java/org/postgresql/util/ServerErrorMessage.java:213
 #, java-format
 msgid "Internal Position: {0}"
-msgstr "Position interne : {0}"
+msgstr "Position interneÂ : {0}"
 
 #: src/main/java/org/postgresql/util/ServerErrorMessage.java:220
 #, java-format
 msgid "Location: File: {0}, Routine: {1}, Line: {2}"
-msgstr "Localisation : Fichier : {0}, Routine : {1}, Ligne : {2}"
+msgstr "LocalisationÂ : FichierÂ : {0}, RoutineÂ : {1}, LigneÂ : {2}"
 
 #: src/main/java/org/postgresql/util/ServerErrorMessage.java:225
 #, java-format
 msgid "Server SQLState: {0}"
-msgstr "SQLState serveur : {0}"
+msgstr "SQLState serveurÂ : {0}"
 
 #: src/main/java/org/postgresql/util/TempFileHolder.java:45
 msgid "StreamWrapper leak detected StreamWrapper.close() was not called. "
@@ -1988,16 +1988,16 @@ msgstr "Drapeaux invalides"
 #: src/main/java/org/postgresql/xa/PGXAConnection.java:282
 #: src/main/java/org/postgresql/xa/PGXAConnection.java:500
 msgid "xid must not be null"
-msgstr "xid ne doit pas être nul"
+msgstr "xid ne doit pas Ãªtre nul"
 
 #: src/main/java/org/postgresql/xa/PGXAConnection.java:200
 msgid "Connection is busy with another transaction"
-msgstr "La connection est occupée avec une autre transaction"
+msgstr "La connection est occupÃ©e avec une autre transaction"
 
 #: src/main/java/org/postgresql/xa/PGXAConnection.java:209
 #: src/main/java/org/postgresql/xa/PGXAConnection.java:292
 msgid "suspend/resume not implemented"
-msgstr "suspend/resume pas implémenté"
+msgstr "suspend/resume pas implÃ©mentÃ©"
 
 #: src/main/java/org/postgresql/xa/PGXAConnection.java:217
 #: src/main/java/org/postgresql/xa/PGXAConnection.java:224
@@ -2010,7 +2010,7 @@ msgstr ""
 
 #: src/main/java/org/postgresql/xa/PGXAConnection.java:239
 msgid "Error disabling autocommit"
-msgstr "Erreur en désactivant autocommit"
+msgstr "Erreur en dÃ©sactivant autocommit"
 
 #: src/main/java/org/postgresql/xa/PGXAConnection.java:286
 #, fuzzy, java-format
@@ -2036,18 +2036,18 @@ msgid ""
 "Not implemented: Prepare must be issued using the same connection that "
 "started the transaction. currentXid={0}, prepare xid={1}"
 msgstr ""
-"Pas implémenté: Prepare doit être envoyé sur la même connection qui a "
-"démarré la transaction"
+"Pas implÃ©mentÃ©: Prepare doit Ãªtre envoyÃ© sur la mÃªme connection qui a "
+"dÃ©marrÃ© la transaction"
 
 #: src/main/java/org/postgresql/xa/PGXAConnection.java:346
 #, fuzzy, java-format
 msgid "Prepare called before end. prepare xid={0}, state={1}"
-msgstr "Préparation appelée avant la fin"
+msgstr "PrÃ©paration appelÃ©e avant la fin"
 
 #: src/main/java/org/postgresql/xa/PGXAConnection.java:366
 #, fuzzy, java-format
 msgid "Error preparing transaction. prepare xid={0}"
-msgstr "Erreur en préparant la transaction"
+msgstr "Erreur en prÃ©parant la transaction"
 
 #: src/main/java/org/postgresql/xa/PGXAConnection.java:425
 msgid "Error during recover"
@@ -2058,7 +2058,7 @@ msgstr "Erreur durant la restauration"
 msgid ""
 "Error rolling back prepared transaction. rollback xid={0}, preparedXid={1}, "
 "currentXid={2}"
-msgstr "Erreur en annulant une transaction préparée"
+msgstr "Erreur en annulant une transaction prÃ©parÃ©e"
 
 #: src/main/java/org/postgresql/xa/PGXAConnection.java:530
 #, java-format
@@ -2071,8 +2071,8 @@ msgid ""
 "Not implemented: one-phase commit must be issued using the same connection "
 "that was used to start it"
 msgstr ""
-"Pas implémenté: le commit à une phase doit avoir lieu en utilisant la même "
-"connection que celle où il a commencé"
+"Pas implÃ©mentÃ©: le commit Ã  une phase doit avoir lieu en utilisant la mÃªme "
+"connection que celle oÃ¹ il a commencÃ©"
 
 #: src/main/java/org/postgresql/xa/PGXAConnection.java:542
 #, java-format
@@ -2082,12 +2082,12 @@ msgstr ""
 #: src/main/java/org/postgresql/xa/PGXAConnection.java:546
 #, fuzzy, java-format
 msgid "commit called before end. commit xid={0}, state={1}"
-msgstr "Commit appelé avant la fin"
+msgstr "Commit appelÃ© avant la fin"
 
 #: src/main/java/org/postgresql/xa/PGXAConnection.java:557
 #, fuzzy, java-format
 msgid "Error during one-phase commit. commit xid={0}"
-msgstr "Erreur pendant le commit à une phase"
+msgstr "Erreur pendant le commit Ã  une phase"
 
 #: src/main/java/org/postgresql/xa/PGXAConnection.java:585
 #, fuzzy, java-format
@@ -2095,17 +2095,17 @@ msgid ""
 "Not implemented: 2nd phase commit must be issued using an idle connection. "
 "commit xid={0}, currentXid={1}, state={2}, transactionState={3}"
 msgstr ""
-"Pas implémenté: le commit à deux phase doit être envoyé sur une connection "
-"inutilisée"
+"Pas implÃ©mentÃ©: le commit Ã  deux phase doit Ãªtre envoyÃ© sur une connection "
+"inutilisÃ©e"
 
 #: src/main/java/org/postgresql/xa/PGXAConnection.java:618
 #, fuzzy, java-format
 msgid ""
 "Error committing prepared transaction. commit xid={0}, preparedXid={1}, "
 "currentXid={2}"
-msgstr "Erreur en annulant une transaction préparée"
+msgstr "Erreur en annulant une transaction prÃ©parÃ©e"
 
 #: src/main/java/org/postgresql/xa/PGXAConnection.java:635
 #, fuzzy, java-format
 msgid "Heuristic commit/rollback not supported. forget xid={0}"
-msgstr "Heuristic commit/rollback non supporté"
+msgstr "Heuristic commit/rollback non supportÃ©"

--- a/pgjdbc/src/main/java/org/postgresql/translation/it.po
+++ b/pgjdbc/src/main/java/org/postgresql/translation/it.po
@@ -14,14 +14,14 @@ msgstr ""
 "Language-Team: Italian <tp@lists.linux.it>\n"
 "Language: it\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=ISO-8859-1\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
 #: src/main/java/org/postgresql/Driver.java:259
 msgid "Error loading default settings from driverconfig.properties"
 msgstr ""
-"Si è verificato un errore caricando le impostazioni predefinite da "
-"«driverconfig.properties»."
+"Si Ã¨ verificato un errore caricando le impostazioni predefinite da "
+"Â«driverconfig.propertiesÂ»."
 
 #: src/main/java/org/postgresql/Driver.java:271
 #, java-format
@@ -46,21 +46,21 @@ msgid ""
 "Something unusual has occurred to cause the driver to fail. Please report "
 "this exception."
 msgstr ""
-"Qualcosa di insolito si è verificato causando il fallimento del driver. Per "
+"Qualcosa di insolito si Ã¨ verificato causando il fallimento del driver. Per "
 "favore riferire all''autore del driver questa eccezione."
 
 #: src/main/java/org/postgresql/Driver.java:412
 msgid "Connection attempt timed out."
-msgstr "Il tentativo di connessione è scaduto."
+msgstr "Il tentativo di connessione Ã¨ scaduto."
 
 #: src/main/java/org/postgresql/Driver.java:425
 msgid "Interrupted while attempting to connect."
-msgstr "Si è verificata una interruzione durante il tentativo di connessione."
+msgstr "Si Ã¨ verificata una interruzione durante il tentativo di connessione."
 
 #: src/main/java/org/postgresql/Driver.java:744
 #, java-format
 msgid "Method {0} is not yet implemented."
-msgstr "Il metodo «{0}» non è stato ancora implementato."
+msgstr "Il metodo Â«{0}Â» non Ã¨ stato ancora implementato."
 
 #: src/main/java/org/postgresql/PGConnection.java:298
 msgid "Expected a row when reading password_encryption but none was found"
@@ -100,7 +100,7 @@ msgstr "Fallita la conversione di un ``box'': {0}."
 #: src/main/java/org/postgresql/copy/PGCopyOutputStream.java:104
 #, fuzzy
 msgid "This copy stream is closed."
-msgstr "Questo «ResultSet» è chiuso."
+msgstr "Questo Â«ResultSetÂ» Ã¨ chiuso."
 
 #: src/main/java/org/postgresql/copy/PGCopyInputStream.java:125
 msgid "Read from copy failed."
@@ -132,14 +132,14 @@ msgstr ""
 #, fuzzy, java-format
 msgid "Unable to parse the count in command completion tag: {0}."
 msgstr ""
-"Impossibile interpretare il numero degli aggiornamenti nel «tag» di "
+"Impossibile interpretare il numero degli aggiornamenti nel Â«tagÂ» di "
 "completamento del comando: {0}."
 
 #: src/main/java/org/postgresql/core/ConnectionFactory.java:60
 #, java-format
 msgid "A connection could not be made using the requested protocol {0}."
 msgstr ""
-"Non è stato possibile attivare la connessione utilizzando il protocollo "
+"Non Ã¨ stato possibile attivare la connessione utilizzando il protocollo "
 "richiesto {0}."
 
 #: src/main/java/org/postgresql/core/Oid.java:143
@@ -150,7 +150,7 @@ msgstr ""
 #: src/main/java/org/postgresql/core/PGStream.java:732
 #, java-format
 msgid "Expected an EOF from server, got: {0}"
-msgstr "Ricevuto dal server «{0}» mentre era atteso un EOF"
+msgstr "Ricevuto dal server Â«{0}Â» mentre era atteso un EOF"
 
 #: src/main/java/org/postgresql/core/PGStream.java:840
 #, java-format
@@ -172,19 +172,19 @@ msgstr ""
 
 #: src/main/java/org/postgresql/core/SetupQueryRunner.java:68
 msgid "An unexpected result was returned by a query."
-msgstr "Un risultato inaspettato è stato ricevuto dalla query."
+msgstr "Un risultato inaspettato Ã¨ stato ricevuto dalla query."
 
 #: src/main/java/org/postgresql/core/SocketFactoryFactory.java:43
 #, fuzzy, java-format
 msgid "The SocketFactory class provided {0} could not be instantiated."
 msgstr ""
-"La classe «SSLSocketFactory» specificata, «{0}», non può essere istanziata."
+"La classe Â«SSLSocketFactoryÂ» specificata, Â«{0}Â», non puÃ² essere istanziata."
 
 #: src/main/java/org/postgresql/core/SocketFactoryFactory.java:68
 #, java-format
 msgid "The SSLSocketFactory class provided {0} could not be instantiated."
 msgstr ""
-"La classe «SSLSocketFactory» specificata, «{0}», non può essere istanziata."
+"La classe Â«SSLSocketFactoryÂ» specificata, Â«{0}Â», non puÃ² essere istanziata."
 
 #: src/main/java/org/postgresql/core/Utils.java:72
 #: src/main/java/org/postgresql/core/Utils.java:89
@@ -207,7 +207,7 @@ msgstr ""
 #, fuzzy, java-format
 msgid "Unable to load Authentication Plugin {0}"
 msgstr ""
-"Impossibile interpretare il numero degli aggiornamenti nel «tag» di "
+"Impossibile interpretare il numero degli aggiornamenti nel Â«tagÂ» di "
 "completamento del comando: {0}."
 
 #: src/main/java/org/postgresql/core/v3/AuthenticationPluginManager.java:113
@@ -217,12 +217,12 @@ msgid ""
 "provided by plugin {0}"
 msgstr ""
 "Il server ha richiesto l''autenticazione con password, ma tale password non "
-"è stata fornita."
+"Ã¨ stata fornita."
 
 #: src/main/java/org/postgresql/core/v3/ChannelBinding.java:40
 #, fuzzy, java-format
 msgid "Invalid channelBinding value: {0}"
-msgstr "La dimensione specificata, {0}, per lo «stream» non è valida."
+msgstr "La dimensione specificata, {0}, per lo Â«streamÂ» non Ã¨ valida."
 
 #: src/main/java/org/postgresql/core/v3/CompositeParameterList.java:38
 #: src/main/java/org/postgresql/core/v3/SimpleParameterList.java:60
@@ -232,22 +232,22 @@ msgstr "La dimensione specificata, {0}, per lo «stream» non è valida."
 #: src/main/java/org/postgresql/jdbc/PgResultSetMetaData.java:428
 #, java-format
 msgid "The column index is out of range: {0}, number of columns: {1}."
-msgstr "Indice di colonna, {0}, è maggiore del numero di colonne {1}."
+msgstr "Indice di colonna, {0}, Ã¨ maggiore del numero di colonne {1}."
 
 #: src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java:212
 #, fuzzy
 msgid "User cannot be null"
-msgstr "xid non può essere NULL"
+msgstr "xid non puÃ² essere NULL"
 
 #: src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java:215
 #, fuzzy
 msgid "Database cannot be null"
-msgstr "xid non può essere NULL"
+msgstr "xid non puÃ² essere NULL"
 
 #: src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java:330
 #, fuzzy, java-format
 msgid "Invalid targetServerType value: {0}"
-msgstr "La dimensione specificata, {0}, per lo «stream» non è valida."
+msgstr "La dimensione specificata, {0}, per lo Â«streamÂ» non Ã¨ valida."
 
 #: src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java:426
 #, fuzzy, java-format
@@ -262,7 +262,7 @@ msgstr ""
 #: src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java:437
 #: src/main/java/org/postgresql/core/v3/replication/V3ReplicationProtocol.java:140
 msgid "The connection attempt failed."
-msgstr "Il tentativo di connessione è fallito."
+msgstr "Il tentativo di connessione Ã¨ fallito."
 
 #: src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java:452
 #, java-format
@@ -282,7 +282,7 @@ msgstr "Il server non supporta SSL."
 #: src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java:639
 #, fuzzy
 msgid "An error occurred while setting up the GSS Encoded connection."
-msgstr "Si è verificato un errore impostando la connessione SSL."
+msgstr "Si Ã¨ verificato un errore impostando la connessione SSL."
 
 #: src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java:689
 #: src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java:701
@@ -291,7 +291,7 @@ msgstr "Il server non supporta SSL."
 
 #: src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java:715
 msgid "An error occurred while setting up the SSL connection."
-msgstr "Si è verificato un errore impostando la connessione SSL."
+msgstr "Si Ã¨ verificato un errore impostando la connessione SSL."
 
 #: src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java:849
 msgid ""
@@ -320,7 +320,7 @@ msgid ""
 "provided."
 msgstr ""
 "Il server ha richiesto l''autenticazione con password, ma tale password non "
-"è stata fornita."
+"Ã¨ stata fornita."
 
 #: src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java:1016
 #, fuzzy
@@ -329,7 +329,7 @@ msgid ""
 "empty string."
 msgstr ""
 "Il server ha richiesto l''autenticazione con password, ma tale password non "
-"è stata fornita."
+"Ã¨ stata fornita."
 
 #: src/main/java/org/postgresql/core/v3/ConnectionFactoryImpl.java:1051
 #, java-format
@@ -338,7 +338,7 @@ msgid ""
 "the pg_hba.conf file to include the client''s IP address or subnet, and that "
 "it is using an authentication scheme supported by the driver."
 msgstr ""
-"L''autenticazione di tipo {0} non è supportata. Verificare che nel file di "
+"L''autenticazione di tipo {0} non Ã¨ supportata. Verificare che nel file di "
 "configurazione pg_hba.conf sia presente l''indirizzo IP o la sottorete del "
 "client, e che lo schema di autenticazione utilizzato sia supportato dal "
 "driver."
@@ -371,12 +371,12 @@ msgstr ""
 #: src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java:308
 #, fuzzy
 msgid "Interrupted while waiting to obtain lock on database connection"
-msgstr "Si è verificata una interruzione durante il tentativo di connessione."
+msgstr "Si Ã¨ verificata una interruzione durante il tentativo di connessione."
 
 #: src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java:459
 msgid "Unable to bind parameter values for statement."
 msgstr ""
-"Impossibile fare il «bind» dei valori passati come parametri per lo "
+"Impossibile fare il Â«bindÂ» dei valori passati come parametri per lo "
 "statement."
 
 #: src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java:465
@@ -387,7 +387,7 @@ msgstr ""
 #: src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java:2835
 #: src/main/java/org/postgresql/util/StreamWrapper.java:86
 msgid "An I/O error occurred while sending to the backend."
-msgstr "Si è verificato un errore di I/O nella spedizione di dati al server."
+msgstr "Si Ã¨ verificato un errore di I/O nella spedizione di dati al server."
 
 #: src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java:544
 msgid "Error releasing savepoint"
@@ -397,7 +397,7 @@ msgstr ""
 #: src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java:803
 #, java-format
 msgid "Expected command status BEGIN, got {0}."
-msgstr "Lo stato del comando avrebbe dovuto essere BEGIN, mentre invece è {0}."
+msgstr "Lo stato del comando avrebbe dovuto essere BEGIN, mentre invece Ã¨ {0}."
 
 #: src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java:808
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:2204
@@ -408,7 +408,7 @@ msgstr "Stato del comando non previsto: {0}."
 #: src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java:923
 #, fuzzy
 msgid "An error occurred while trying to get the socket timeout."
-msgstr "Si è verificato un errore di I/O nella spedizione di dati al server."
+msgstr "Si Ã¨ verificato un errore di I/O nella spedizione di dati al server."
 
 #: src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java:958
 #: src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java:1049
@@ -419,7 +419,7 @@ msgstr "Risposta di tipo sconosciuto {0}."
 #: src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java:982
 #, fuzzy
 msgid "An error occurred while trying to reset the socket timeout."
-msgstr "Si è verificato un errore di I/O nella spedizione di dati al server."
+msgstr "Si Ã¨ verificato un errore di I/O nella spedizione di dati al server."
 
 #: src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java:1102
 msgid "Database connection failed when starting copy"
@@ -473,7 +473,7 @@ msgstr ""
 #: src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java:1376
 #, fuzzy
 msgid "PGStream is closed"
-msgstr "Questo «ResultSet» è chiuso."
+msgstr "Questo Â«ResultSetÂ» Ã¨ chiuso."
 
 #: src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java:1435
 #, java-format
@@ -502,7 +502,7 @@ msgstr ""
 #: src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java:1511
 #, fuzzy, java-format
 msgid "Unexpected copydata from server for {0}"
-msgstr "Ricevuto dal server «{0}» mentre era atteso un EOF"
+msgstr "Ricevuto dal server Â«{0}Â» mentre era atteso un EOF"
 
 #: src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java:1571
 #, java-format
@@ -515,8 +515,8 @@ msgid ""
 "Bind message length {0} too long.  This can be caused by very large or "
 "incorrect length specifications on InputStream parameters."
 msgstr ""
-"Il messaggio di «bind» è troppo lungo ({0}). Questo può essere causato da "
-"una dimensione eccessiva o non corretta dei parametri dell''«InputStream»."
+"Il messaggio di Â«bindÂ» Ã¨ troppo lungo ({0}). Questo puÃ² essere causato da "
+"una dimensione eccessiva o non corretta dei parametri dell''Â«InputStreamÂ»."
 
 #: src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java:2601
 msgid "Ran out of memory retrieving query results."
@@ -546,8 +546,8 @@ msgid ""
 "The server''s client_encoding parameter was changed to {0}. The JDBC driver "
 "requires client_encoding to be UTF8 for correct operation."
 msgstr ""
-"Il parametro «client_encoding» del server è stato cambiato in {0}. Il driver "
-"JDBC richiede che «client_encoding» sia UNICODE per un corretto "
+"Il parametro Â«client_encodingÂ» del server Ã¨ stato cambiato in {0}. Il driver "
+"JDBC richiede che Â«client_encodingÂ» sia UNICODE per un corretto "
 "funzionamento."
 
 #: src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java:3134
@@ -556,8 +556,8 @@ msgid ""
 "The server''s DateStyle parameter was changed to {0}. The JDBC driver "
 "requires DateStyle to begin with ISO for correct operation."
 msgstr ""
-"Il parametro del server «DateStyle» è stato cambiato in {0}. Il driver JDBC "
-"richiede che «DateStyle» cominci con «ISO» per un corretto funzionamento."
+"Il parametro del server Â«DateStyleÂ» Ã¨ stato cambiato in {0}. Il driver JDBC "
+"richiede che Â«DateStyleÂ» cominci con Â«ISOÂ» per un corretto funzionamento."
 
 #: src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java:3147
 #, fuzzy, java-format
@@ -565,8 +565,8 @@ msgid ""
 "The server''s standard_conforming_strings parameter was reported as {0}. The "
 "JDBC driver expected on or off."
 msgstr ""
-"Il parametro «client_encoding» del server è stato cambiato in {0}. Il driver "
-"JDBC richiede che «client_encoding» sia UNICODE per un corretto "
+"Il parametro Â«client_encodingÂ» del server Ã¨ stato cambiato in {0}. Il driver "
+"JDBC richiede che Â«client_encodingÂ» sia UNICODE per un corretto "
 "funzionamento."
 
 #: src/main/java/org/postgresql/core/v3/ScramAuthenticator.java:70
@@ -619,7 +619,7 @@ msgstr "Nessun valore specificato come parametro {0}."
 #: src/main/java/org/postgresql/core/v3/SimpleParameterList.java:612
 #, fuzzy, java-format
 msgid "Added parameters index out of range: {0}, number of columns: {1}."
-msgstr "Il parametro indice è fuori intervallo: {0}, numero di elementi: {1}."
+msgstr "Il parametro indice Ã¨ fuori intervallo: {0}, numero di elementi: {1}."
 
 #: src/main/java/org/postgresql/core/v3/replication/V3PGReplicationStream.java:154
 #, java-format
@@ -629,28 +629,28 @@ msgstr ""
 #: src/main/java/org/postgresql/core/v3/replication/V3PGReplicationStream.java:288
 #, fuzzy
 msgid "This replication stream has been closed."
-msgstr "Questo «Connection» è stato chiuso."
+msgstr "Questo Â«ConnectionÂ» Ã¨ stato chiuso."
 
 #: src/main/java/org/postgresql/ds/PGPooledConnection.java:130
 msgid "This PooledConnection has already been closed."
-msgstr "Questo «PooledConnection» è stato chiuso."
+msgstr "Questo Â«PooledConnectionÂ» Ã¨ stato chiuso."
 
 #: src/main/java/org/postgresql/ds/PGPooledConnection.java:331
 msgid ""
 "Connection has been closed automatically because a new connection was opened "
 "for the same PooledConnection or the PooledConnection has been closed."
 msgstr ""
-"La «Connection» è stata chiusa automaticamente perché una nuova l''ha "
-"sostituita nello stesso «PooledConnection», oppure il «PooledConnection» è "
+"La Â«ConnectionÂ» Ã¨ stata chiusa automaticamente perchÃ© una nuova l''ha "
+"sostituita nello stesso Â«PooledConnectionÂ», oppure il Â«PooledConnectionÂ» Ã¨ "
 "stato chiuso."
 
 #: src/main/java/org/postgresql/ds/PGPooledConnection.java:332
 msgid "Connection has been closed."
-msgstr "Questo «Connection» è stato chiuso."
+msgstr "Questo Â«ConnectionÂ» Ã¨ stato chiuso."
 
 #: src/main/java/org/postgresql/ds/PGPooledConnection.java:440
 msgid "Statement has been closed."
-msgstr "Questo «Statement» è stato chiuso."
+msgstr "Questo Â«StatementÂ» Ã¨ stato chiuso."
 
 #: src/main/java/org/postgresql/ds/PGPoolingDataSource.java:287
 msgid "Failed to setup DataSource."
@@ -658,26 +658,26 @@ msgstr ""
 
 #: src/main/java/org/postgresql/ds/PGPoolingDataSource.java:393
 msgid "DataSource has been closed."
-msgstr "Questo «DataSource» è stato chiuso."
+msgstr "Questo Â«DataSourceÂ» Ã¨ stato chiuso."
 
 #: src/main/java/org/postgresql/ds/common/BaseDataSource.java:1558
 #: src/main/java/org/postgresql/ds/common/BaseDataSource.java:1568
 #, fuzzy, java-format
 msgid "Unsupported property name: {0}"
-msgstr "Valore di tipo «{0}» non supportato."
+msgstr "Valore di tipo Â«{0}Â» non supportato."
 
 #: src/main/java/org/postgresql/fastpath/Fastpath.java:83
 #, fuzzy, java-format
 msgid "Fastpath call {0} - No result was returned and we expected a numeric."
 msgstr ""
-"Chiamata Fastpath «{0}»: Nessun risultato restituito mentre ci si aspettava "
+"Chiamata Fastpath Â«{0}Â»: Nessun risultato restituito mentre ci si aspettava "
 "un intero."
 
 #: src/main/java/org/postgresql/fastpath/Fastpath.java:164
 #, java-format
 msgid "Fastpath call {0} - No result was returned and we expected an integer."
 msgstr ""
-"Chiamata Fastpath «{0}»: Nessun risultato restituito mentre ci si aspettava "
+"Chiamata Fastpath Â«{0}Â»: Nessun risultato restituito mentre ci si aspettava "
 "un intero."
 
 #: src/main/java/org/postgresql/fastpath/Fastpath.java:172
@@ -686,14 +686,14 @@ msgid ""
 "Fastpath call {0} - No result was returned or wrong size while expecting an "
 "integer."
 msgstr ""
-"Chiamata Fastpath «{0}»: Nessun risultato restituito mentre ci si aspettava "
+"Chiamata Fastpath Â«{0}Â»: Nessun risultato restituito mentre ci si aspettava "
 "un intero."
 
 #: src/main/java/org/postgresql/fastpath/Fastpath.java:189
 #, fuzzy, java-format
 msgid "Fastpath call {0} - No result was returned and we expected a long."
 msgstr ""
-"Chiamata Fastpath «{0}»: Nessun risultato restituito mentre ci si aspettava "
+"Chiamata Fastpath Â«{0}Â»: Nessun risultato restituito mentre ci si aspettava "
 "un intero."
 
 #: src/main/java/org/postgresql/fastpath/Fastpath.java:197
@@ -702,13 +702,13 @@ msgid ""
 "Fastpath call {0} - No result was returned or wrong size while expecting a "
 "long."
 msgstr ""
-"Chiamata Fastpath «{0}»: Nessun risultato restituito mentre ci si aspettava "
+"Chiamata Fastpath Â«{0}Â»: Nessun risultato restituito mentre ci si aspettava "
 "un intero."
 
 #: src/main/java/org/postgresql/fastpath/Fastpath.java:300
 #, java-format
 msgid "The fastpath function {0} is unknown."
-msgstr "La funzione fastpath «{0}» è sconosciuta."
+msgstr "La funzione fastpath Â«{0}Â» Ã¨ sconosciuta."
 
 #: src/main/java/org/postgresql/geometric/PGbox.java:83
 #: src/main/java/org/postgresql/geometric/PGcircle.java:81
@@ -724,7 +724,7 @@ msgstr "Conversione al tipo {0} fallita: {1}."
 #: src/main/java/org/postgresql/geometric/PGpath.java:78
 #, java-format
 msgid "Cannot tell if path is open or closed: {0}."
-msgstr "Impossibile stabilire se il percorso è aperto o chiuso: {0}."
+msgstr "Impossibile stabilire se il percorso Ã¨ aperto o chiuso: {0}."
 
 #: src/main/java/org/postgresql/gss/GssAction.java:176
 #: src/main/java/org/postgresql/gss/GssEncAction.java:155
@@ -752,7 +752,7 @@ msgstr ""
 #: src/main/java/org/postgresql/jdbc/AbstractBlobClob.java:249
 #, java-format
 msgid "PostgreSQL LOBs can only index to: {0}"
-msgstr "Il massimo valore per l''indice dei LOB di PostgreSQL è {0}. "
+msgstr "Il massimo valore per l''indice dei LOB di PostgreSQL Ã¨ {0}. "
 
 #: src/main/java/org/postgresql/jdbc/AbstractBlobClob.java:245
 msgid "LOB positioning offsets start at 1."
@@ -774,7 +774,7 @@ msgid ""
 msgstr ""
 "Sono stati trovati caratteri non validi tra i dati. Molto probabilmente sono "
 "stati memorizzati dei caratteri che non sono validi per la codifica dei "
-"caratteri impostata alla creazione del database. Il caso più diffuso è "
+"caratteri impostata alla creazione del database. Il caso piÃ¹ diffuso Ã¨ "
 "quello nel quale si memorizzano caratteri a 8bit in un database con codifica "
 "SQL_ASCII."
 
@@ -789,7 +789,7 @@ msgstr "Impossibile tradurre i dati nella codifica richiesta."
 #: src/main/java/org/postgresql/jdbc/ArrayEncoding.java:1077
 #, fuzzy, java-format
 msgid "Invalid elements {0}"
-msgstr "La dimensione specificata, {0}, per lo «stream» non è valida."
+msgstr "La dimensione specificata, {0}, per lo Â«streamÂ» non Ã¨ valida."
 
 #: src/main/java/org/postgresql/jdbc/BatchResultHandler.java:102
 msgid "Too many update results were returned."
@@ -801,8 +801,8 @@ msgid ""
 "Batch entry {0} {1} was aborted: {2}  Call getNextException to see other "
 "errors in the batch."
 msgstr ""
-"L''operazione «batch» {0} {1} è stata interrotta. Chiamare "
-"«getNextException» per scoprirne il motivo."
+"L''operazione Â«batchÂ» {0} {1} Ã¨ stata interrotta. Chiamare "
+"Â«getNextExceptionÂ» per scoprirne il motivo."
 
 #: src/main/java/org/postgresql/jdbc/BooleanTypeUtil.java:99
 #, java-format
@@ -813,7 +813,7 @@ msgstr ""
 #: src/main/java/org/postgresql/jdbc/EscapedFunctions2.java:171
 #, java-format
 msgid "{0} function takes four and only four argument."
-msgstr "Il metodo «{0}» accetta quattro e solo quattro argomenti."
+msgstr "Il metodo Â«{0}Â» accetta quattro e solo quattro argomenti."
 
 #: src/main/java/org/postgresql/jdbc/EscapedFunctions.java:270
 #: src/main/java/org/postgresql/jdbc/EscapedFunctions.java:337
@@ -823,7 +823,7 @@ msgstr "Il metodo «{0}» accetta quattro e solo quattro argomenti."
 #: src/main/java/org/postgresql/jdbc/EscapedFunctions2.java:668
 #, java-format
 msgid "{0} function takes two and only two arguments."
-msgstr "Il metodo «{0}» accetta due e solo due argomenti."
+msgstr "Il metodo Â«{0}Â» accetta due e solo due argomenti."
 
 #: src/main/java/org/postgresql/jdbc/EscapedFunctions.java:288
 #: src/main/java/org/postgresql/jdbc/EscapedFunctions.java:441
@@ -837,7 +837,7 @@ msgstr "Il metodo «{0}» accetta due e solo due argomenti."
 #: src/main/java/org/postgresql/jdbc/EscapedFunctions2.java:657
 #, java-format
 msgid "{0} function takes one and only one argument."
-msgstr "Il metodo «{0}» accetta un ed un solo argomento."
+msgstr "Il metodo Â«{0}Â» accetta un ed un solo argomento."
 
 #: src/main/java/org/postgresql/jdbc/EscapedFunctions.java:312
 #: src/main/java/org/postgresql/jdbc/EscapedFunctions.java:386
@@ -845,7 +845,7 @@ msgstr "Il metodo «{0}» accetta un ed un solo argomento."
 #: src/main/java/org/postgresql/jdbc/EscapedFunctions2.java:311
 #, java-format
 msgid "{0} function takes two or three arguments."
-msgstr "Il metodo «{0}» accetta due o tre argomenti."
+msgstr "Il metodo Â«{0}Â» accetta due o tre argomenti."
 
 #: src/main/java/org/postgresql/jdbc/EscapedFunctions.java:411
 #: src/main/java/org/postgresql/jdbc/EscapedFunctions.java:426
@@ -854,7 +854,7 @@ msgstr "Il metodo «{0}» accetta due o tre argomenti."
 #: src/main/java/org/postgresql/jdbc/EscapedFunctions2.java:648
 #, java-format
 msgid "{0} function doesn''t take any argument."
-msgstr "Il metodo «{0}» non accetta argomenti."
+msgstr "Il metodo Â«{0}Â» non accetta argomenti."
 
 #: src/main/java/org/postgresql/jdbc/EscapedFunctions.java:587
 #: src/main/java/org/postgresql/jdbc/EscapedFunctions.java:640
@@ -862,7 +862,7 @@ msgstr "Il metodo «{0}» non accetta argomenti."
 #: src/main/java/org/postgresql/jdbc/EscapedFunctions2.java:574
 #, java-format
 msgid "{0} function takes three and only three arguments."
-msgstr "Il metodo «{0}» accetta tre e solo tre argomenti."
+msgstr "Il metodo Â«{0}Â» accetta tre e solo tre argomenti."
 
 #: src/main/java/org/postgresql/jdbc/EscapedFunctions.java:600
 #: src/main/java/org/postgresql/jdbc/EscapedFunctions.java:621
@@ -876,28 +876,28 @@ msgstr "Il metodo «{0}» accetta tre e solo tre argomenti."
 #: src/main/java/org/postgresql/jdbc/EscapedFunctions2.java:600
 #, java-format
 msgid "Interval {0} not yet implemented"
-msgstr "L''intervallo «{0}» non è stato ancora implementato."
+msgstr "L''intervallo Â«{0}Â» non Ã¨ stato ancora implementato."
 
 #: src/main/java/org/postgresql/jdbc/GSSEncMode.java:61
 #, fuzzy, java-format
 msgid "Invalid gssEncMode value: {0}"
-msgstr "La dimensione specificata, {0}, per lo «stream» non è valida."
+msgstr "La dimensione specificata, {0}, per lo Â«streamÂ» non Ã¨ valida."
 
 #: src/main/java/org/postgresql/jdbc/PSQLSavepoint.java:40
 #: src/main/java/org/postgresql/jdbc/PSQLSavepoint.java:55
 #: src/main/java/org/postgresql/jdbc/PSQLSavepoint.java:73
 msgid "Cannot reference a savepoint after it has been released."
 msgstr ""
-"Non è possibile utilizzare un punto di ripristino successivamente al suo "
+"Non Ã¨ possibile utilizzare un punto di ripristino successivamente al suo "
 "rilascio."
 
 #: src/main/java/org/postgresql/jdbc/PSQLSavepoint.java:45
 msgid "Cannot retrieve the id of a named savepoint."
-msgstr "Non è possibile trovare l''id del punto di ripristino indicato."
+msgstr "Non Ã¨ possibile trovare l''id del punto di ripristino indicato."
 
 #: src/main/java/org/postgresql/jdbc/PSQLSavepoint.java:60
 msgid "Cannot retrieve the name of an unnamed savepoint."
-msgstr "Non è possibile trovare il nome di un punto di ripristino anonimo."
+msgstr "Non Ã¨ possibile trovare il nome di un punto di ripristino anonimo."
 
 #: src/main/java/org/postgresql/jdbc/PgArray.java:153
 #: src/main/java/org/postgresql/jdbc/PgArray.java:371
@@ -910,19 +910,19 @@ msgstr "Indice di colonna fuori dall''intervallo ammissibile: {0}"
 #, java-format
 msgid "The array index is out of range: {0}, number of elements: {1}."
 msgstr ""
-"L''indice dell''array è fuori intervallo: {0}, numero di elementi: {1}."
+"L''indice dell''array Ã¨ fuori intervallo: {0}, numero di elementi: {1}."
 
 #: src/main/java/org/postgresql/jdbc/PgCallableStatement.java:99
 #: src/main/java/org/postgresql/jdbc/PgCallableStatement.java:105
 msgid "A CallableStatement was executed with nothing returned."
 msgstr ""
-"Un «CallableStatement» è stato eseguito senza produrre alcun risultato. "
+"Un Â«CallableStatementÂ» Ã¨ stato eseguito senza produrre alcun risultato. "
 
 #: src/main/java/org/postgresql/jdbc/PgCallableStatement.java:116
 #, fuzzy
 msgid "A CallableStatement was executed with an invalid number of parameters"
 msgstr ""
-"Un «CallableStatement» è stato eseguito con un numero errato di parametri."
+"Un Â«CallableStatementÂ» Ã¨ stato eseguito con un numero errato di parametri."
 
 #: src/main/java/org/postgresql/jdbc/PgCallableStatement.java:154
 #, java-format
@@ -930,16 +930,16 @@ msgid ""
 "A CallableStatement function was executed and the out parameter {0} was of "
 "type {1} however type {2} was registered."
 msgstr ""
-"È stato eseguito un «CallableStatement» ma il parametro in uscita «{0}» era "
-"di tipo «{1}» al posto di «{2}», che era stato dichiarato."
+"Ãˆ stato eseguito un Â«CallableStatementÂ» ma il parametro in uscita Â«{0}Â» era "
+"di tipo Â«{1}Â» al posto di Â«{2}Â», che era stato dichiarato."
 
 #: src/main/java/org/postgresql/jdbc/PgCallableStatement.java:217
 msgid ""
 "This statement does not declare an OUT parameter.  Use '{' ?= call ... '}' "
 "to declare one."
 msgstr ""
-"Questo statement non dichiara il parametro in uscita. Usare «{ ?= "
-"call ... }» per farlo."
+"Questo statement non dichiara il parametro in uscita. Usare Â«{ ?= "
+"call ... }Â» per farlo."
 
 #: src/main/java/org/postgresql/jdbc/PgCallableStatement.java:240
 msgid "wasNull cannot be call before fetching a result."
@@ -952,16 +952,16 @@ msgid ""
 "Parameter of type {0} was registered, but call to get{1} (sqltype={2}) was "
 "made."
 msgstr ""
-"È stato definito il parametro di tipo «{0}», ma poi è stato invocato il "
-"metodo «get{1}()» (sqltype={2})."
+"Ãˆ stato definito il parametro di tipo Â«{0}Â», ma poi Ã¨ stato invocato il "
+"metodo Â«get{1}()Â» (sqltype={2})."
 
 #: src/main/java/org/postgresql/jdbc/PgCallableStatement.java:413
 msgid ""
 "A CallableStatement was declared, but no call to registerOutParameter(1, "
 "<some type>) was made."
 msgstr ""
-"È stato definito un «CallableStatement» ma non è stato invocato il metodo "
-"«registerOutParameter(1, <tipo>)»."
+"Ãˆ stato definito un Â«CallableStatementÂ» ma non Ã¨ stato invocato il metodo "
+"Â«registerOutParameter(1, <tipo>)Â»."
 
 #: src/main/java/org/postgresql/jdbc/PgCallableStatement.java:418
 msgid "No function outputs were registered."
@@ -975,12 +975,12 @@ msgstr ""
 #: src/main/java/org/postgresql/jdbc/PgCallableStatement.java:732
 #, fuzzy, java-format
 msgid "Unsupported type conversion to {0}."
-msgstr "Valore di tipo «{0}» non supportato."
+msgstr "Valore di tipo Â«{0}Â» non supportato."
 
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:353
 #, java-format
 msgid "Unsupported value for stringtype parameter: {0}"
-msgstr "Il valore per il parametro di tipo string «{0}» non è supportato."
+msgstr "Il valore per il parametro di tipo string Â«{0}Â» non Ã¨ supportato."
 
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:612
 #: src/main/java/org/postgresql/jdbc/PgPreparedStatement.java:141
@@ -994,13 +994,13 @@ msgstr "Il valore per il parametro di tipo string «{0}» non è supportato."
 #: src/main/java/org/postgresql/jdbc/TypeInfoCache.java:705
 #: src/main/java/org/postgresql/jdbc/TypeInfoCache.java:710
 msgid "No results were returned by the query."
-msgstr "Nessun risultato è stato restituito dalla query."
+msgstr "Nessun risultato Ã¨ stato restituito dalla query."
 
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:630
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:647
 #: src/main/java/org/postgresql/jdbc/PgStatement.java:317
 msgid "A result was returned when none was expected."
-msgstr "È stato restituito un valore nonostante non ne fosse atteso nessuno."
+msgstr "Ãˆ stato restituito un valore nonostante non ne fosse atteso nessuno."
 
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:754
 msgid "Custom type maps are not supported."
@@ -1014,7 +1014,7 @@ msgstr "Fallita la creazione dell''oggetto per: {0}."
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:864
 #, java-format
 msgid "Unable to load the class {0} responsible for the datatype {1}"
-msgstr "Non è possibile caricare la class «{0}» per gestire il tipo «{1}»."
+msgstr "Non Ã¨ possibile caricare la class Â«{0}Â» per gestire il tipo Â«{1}Â»."
 
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:892
 msgid "Unable to close connection properly"
@@ -1024,7 +1024,7 @@ msgstr ""
 msgid ""
 "Cannot change transaction read-only property in the middle of a transaction."
 msgstr ""
-"Non è possibile modificare la proprietà «read-only» delle transazioni nel "
+"Non Ã¨ possibile modificare la proprietÃ  Â«read-onlyÂ» delle transazioni nel "
 "mezzo di una transazione."
 
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:1020
@@ -1036,7 +1036,7 @@ msgstr ""
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:1655
 #, fuzzy
 msgid "This connection has been closed."
-msgstr "Questo «Connection» è stato chiuso."
+msgstr "Questo Â«ConnectionÂ» Ã¨ stato chiuso."
 
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:1041
 msgid "Cannot rollback when autoCommit is enabled."
@@ -1046,19 +1046,19 @@ msgstr ""
 msgid ""
 "Cannot change transaction isolation level in the middle of a transaction."
 msgstr ""
-"Non è possibile cambiare il livello di isolamento delle transazioni nel "
+"Non Ã¨ possibile cambiare il livello di isolamento delle transazioni nel "
 "mezzo di una transazione."
 
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:1103
 #, java-format
 msgid "Transaction isolation level {0} not supported."
-msgstr "Il livello di isolamento delle transazioni «{0}» non è supportato."
+msgstr "Il livello di isolamento delle transazioni Â«{0}Â» non Ã¨ supportato."
 
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:1274
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:2242
 #: src/main/java/org/postgresql/jdbc/PgStatement.java:1026
 msgid "Fetch size must be a value greater than or equal to 0."
-msgstr "La dimensione dell''area di «fetch» deve essere maggiore o eguale a 0."
+msgstr "La dimensione dell''area di Â«fetchÂ» deve essere maggiore o eguale a 0."
 
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:1290
 #, fuzzy
@@ -1073,7 +1073,7 @@ msgstr ""
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:1562
 #, fuzzy, java-format
 msgid "Invalid timeout ({0}<0)."
-msgstr "La dimensione specificata, {0}, per lo «stream» non è valida."
+msgstr "La dimensione specificata, {0}, per lo Â«streamÂ» non Ã¨ valida."
 
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:1599
 msgid "Validating connection."
@@ -1087,7 +1087,7 @@ msgstr "Fallita la creazione dell''oggetto per: {0}."
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:1642
 #, fuzzy
 msgid "ClientInfo property not supported."
-msgstr "La restituzione di chiavi autogenerate non è supportata."
+msgstr "La restituzione di chiavi autogenerate non Ã¨ supportata."
 
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:1668
 msgid "One or more ClientInfo failed."
@@ -1109,17 +1109,17 @@ msgstr ""
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:1824
 #, java-format
 msgid "Unknown ResultSet holdability setting: {0}."
-msgstr "Il parametro «holdability» per il «ResultSet» è sconosciuto: {0}."
+msgstr "Il parametro Â«holdabilityÂ» per il Â«ResultSetÂ» Ã¨ sconosciuto: {0}."
 
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:1842
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:1863
 msgid "Cannot establish a savepoint in auto-commit mode."
 msgstr ""
-"Non è possibile impostare i punti di ripristino in modalità «auto-commit»."
+"Non Ã¨ possibile impostare i punti di ripristino in modalitÃ  Â«auto-commitÂ»."
 
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:1932
 msgid "Returning autogenerated keys is not supported."
-msgstr "La restituzione di chiavi autogenerate non è supportata."
+msgstr "La restituzione di chiavi autogenerate non Ã¨ supportata."
 
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:1994
 #: src/main/java/org/postgresql/jdbc/PgConnection.java:2003
@@ -1136,16 +1136,16 @@ msgid ""
 "Unable to determine a value for MaxIndexKeys due to missing system catalog "
 "data."
 msgstr ""
-"Non è possibile trovare il valore di «MaxIndexKeys» nel catalogo si sistema."
+"Non Ã¨ possibile trovare il valore di Â«MaxIndexKeysÂ» nel catalogo si sistema."
 
 #: src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java:98
 msgid "Unable to find name datatype in the system catalogs."
-msgstr "Non è possibile trovare il datatype «name» nel catalogo di sistema."
+msgstr "Non Ã¨ possibile trovare il datatype Â«nameÂ» nel catalogo di sistema."
 
 #: src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java:358
 #, fuzzy
 msgid "Unable to find keywords in the system catalogs."
-msgstr "Non è possibile trovare il datatype «name» nel catalogo di sistema."
+msgstr "Non Ã¨ possibile trovare il datatype Â«nameÂ» nel catalogo di sistema."
 
 #: src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java:1085
 msgid ""
@@ -1156,7 +1156,7 @@ msgstr ""
 #: src/main/java/org/postgresql/jdbc/PgParameterMetaData.java:96
 #, java-format
 msgid "The parameter index is out of range: {0}, number of parameters: {1}."
-msgstr "Il parametro indice è fuori intervallo: {0}, numero di elementi: {1}."
+msgstr "Il parametro indice Ã¨ fuori intervallo: {0}, numero di elementi: {1}."
 
 #: src/main/java/org/postgresql/jdbc/PgPreparedStatement.java:108
 #, java-format
@@ -1174,7 +1174,7 @@ msgid ""
 "Can''t use query methods that take a query string on a PreparedStatement."
 msgstr ""
 "Non si possono utilizzare i metodi \"query\" che hanno come argomento una "
-"stringa nel caso di «PreparedStatement»."
+"stringa nel caso di Â«PreparedStatementÂ»."
 
 #: src/main/java/org/postgresql/jdbc/PgPreparedStatement.java:300
 msgid "Unknown Types value."
@@ -1186,7 +1186,7 @@ msgstr "Valore di tipo sconosciuto."
 #: src/main/java/org/postgresql/jdbc/PgPreparedStatement.java:1704
 #, java-format
 msgid "Invalid stream length {0}."
-msgstr "La dimensione specificata, {0}, per lo «stream» non è valida."
+msgstr "La dimensione specificata, {0}, per lo Â«streamÂ» non Ã¨ valida."
 
 #: src/main/java/org/postgresql/jdbc/PgPreparedStatement.java:483
 #, java-format
@@ -1197,7 +1197,7 @@ msgstr "La JVM sostiene di non supportare la codifica {0}."
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:1325
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:1364
 msgid "Provided InputStream failed."
-msgstr "L''«InputStream» fornito è fallito."
+msgstr "L''Â«InputStreamÂ» fornito Ã¨ fallito."
 
 #: src/main/java/org/postgresql/jdbc/PgPreparedStatement.java:528
 #: src/main/java/org/postgresql/jdbc/PgPreparedStatement.java:1239
@@ -1216,17 +1216,17 @@ msgstr ""
 #: src/main/java/org/postgresql/jdbc/PgPreparedStatement.java:1084
 #, java-format
 msgid "Cannot cast an instance of {0} to type {1}"
-msgstr "Non è possibile fare il cast di una istanza di «{0}» al tipo «{1}»."
+msgstr "Non Ã¨ possibile fare il cast di una istanza di Â«{0}Â» al tipo Â«{1}Â»."
 
 #: src/main/java/org/postgresql/jdbc/PgPreparedStatement.java:762
 #, java-format
 msgid "Unsupported Types value: {0}"
-msgstr "Valore di tipo «{0}» non supportato."
+msgstr "Valore di tipo Â«{0}Â» non supportato."
 
 #: src/main/java/org/postgresql/jdbc/PgPreparedStatement.java:1005
 #, java-format
 msgid "Cannot convert an instance of {0} to type {1}"
-msgstr "Non è possibile convertire una istanza di «{0}» nel tipo «{1}»"
+msgstr "Non Ã¨ possibile convertire una istanza di Â«{0}Â» nel tipo Â«{1}Â»"
 
 #: src/main/java/org/postgresql/jdbc/PgPreparedStatement.java:1090
 #, java-format
@@ -1234,24 +1234,24 @@ msgid ""
 "Can''t infer the SQL type to use for an instance of {0}. Use setObject() "
 "with an explicit Types value to specify the type to use."
 msgstr ""
-"Non è possibile identificare il tipo SQL da usare per l''istanza di tipo "
-"«{0}». Usare «setObject()» specificando esplicitamente il tipo da usare per "
+"Non Ã¨ possibile identificare il tipo SQL da usare per l''istanza di tipo "
+"Â«{0}Â». Usare Â«setObject()Â» specificando esplicitamente il tipo da usare per "
 "questo valore."
 
 #: src/main/java/org/postgresql/jdbc/PgPreparedStatement.java:1275
 #: src/main/java/org/postgresql/jdbc/PgPreparedStatement.java:1382
 msgid "Unexpected error writing large object to database."
-msgstr "Errore inatteso inviando un «large object» al database."
+msgstr "Errore inatteso inviando un Â«large objectÂ» al database."
 
 #: src/main/java/org/postgresql/jdbc/PgPreparedStatement.java:1301
 #, fuzzy
 msgid "Unexpected error when closing Blob binary stream"
-msgstr "Errore inatteso inviando un «large object» al database."
+msgstr "Errore inatteso inviando un Â«large objectÂ» al database."
 
 #: src/main/java/org/postgresql/jdbc/PgPreparedStatement.java:1320
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:1427
 msgid "Provided Reader failed."
-msgstr "Il «Reader» fornito è fallito."
+msgstr "Il Â«ReaderÂ» fornito Ã¨ fallito."
 
 #: src/main/java/org/postgresql/jdbc/PgPreparedStatement.java:1640
 #: src/main/java/org/postgresql/util/StreamWrapper.java:60
@@ -1263,8 +1263,8 @@ msgid ""
 "Operation requires a scrollable ResultSet, but this ResultSet is "
 "FORWARD_ONLY."
 msgstr ""
-"L''operazione richiete un «ResultSet» scorribile mentre questo è "
-"«FORWARD_ONLY»."
+"L''operazione richiete un Â«ResultSetÂ» scorribile mentre questo Ã¨ "
+"Â«FORWARD_ONLYÂ»."
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:545
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:588
@@ -1278,14 +1278,14 @@ msgstr ""
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:3721
 #, fuzzy, java-format
 msgid "Cannot convert the column of type {0} to requested type {1}."
-msgstr "Non è possibile convertire una istanza di «{0}» nel tipo «{1}»"
+msgstr "Non Ã¨ possibile convertire una istanza di Â«{0}Â» nel tipo Â«{1}Â»"
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:1024
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:1045
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:2276
 msgid "Can''t use relative move methods while on the insert row."
 msgstr ""
-"Non è possibile utilizzare gli spostamenti relativi durante l''inserimento "
+"Non Ã¨ possibile utilizzare gli spostamenti relativi durante l''inserimento "
 "di una riga."
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:1069
@@ -1297,37 +1297,37 @@ msgstr "Costante per la direzione dell''estrazione non valida: {0}."
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:1081
 msgid "Cannot call cancelRowUpdates() when on the insert row."
 msgstr ""
-"Non è possibile invocare «cancelRowUpdates()» durante l''inserimento di una "
+"Non Ã¨ possibile invocare Â«cancelRowUpdates()Â» durante l''inserimento di una "
 "riga."
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:1099
 msgid "Cannot call deleteRow() when on the insert row."
 msgstr ""
-"Non è possibile invocare «deleteRow()» durante l''inserimento di una riga."
+"Non Ã¨ possibile invocare Â«deleteRow()Â» durante l''inserimento di una riga."
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:1106
 msgid ""
 "Currently positioned before the start of the ResultSet.  You cannot call "
 "deleteRow() here."
 msgstr ""
-"La posizione attuale è precedente all''inizio del ResultSet. Non è possibile "
-"invocare «deleteRow()» qui."
+"La posizione attuale Ã¨ precedente all''inizio del ResultSet. Non Ã¨ possibile "
+"invocare Â«deleteRow()Â» qui."
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:1112
 msgid ""
 "Currently positioned after the end of the ResultSet.  You cannot call "
 "deleteRow() here."
 msgstr ""
-"La posizione attuale è successiva alla fine del ResultSet. Non è possibile "
-"invocare «deleteRow()» qui."
+"La posizione attuale Ã¨ successiva alla fine del ResultSet. Non Ã¨ possibile "
+"invocare Â«deleteRow()Â» qui."
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:1117
 msgid "There are no rows in this ResultSet."
-msgstr "Non ci sono righe in questo «ResultSet»."
+msgstr "Non ci sono righe in questo Â«ResultSetÂ»."
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:1158
 msgid "Not on the insert row."
-msgstr "Non si è in una nuova riga."
+msgstr "Non si Ã¨ in una nuova riga."
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:1162
 msgid "You must specify at least one column value to insert a row."
@@ -1336,12 +1336,12 @@ msgstr ""
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:1497
 msgid "Can''t refresh the insert row."
-msgstr "Non è possibile aggiornare la riga in inserimento."
+msgstr "Non Ã¨ possibile aggiornare la riga in inserimento."
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:1573
 msgid "Cannot call updateRow() when on the insert row."
 msgstr ""
-"Non è possibile invocare «updateRow()» durante l''inserimento di una riga."
+"Non Ã¨ possibile invocare Â«updateRow()Â» durante l''inserimento di una riga."
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:1581
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:3738
@@ -1349,18 +1349,18 @@ msgid ""
 "Cannot update the ResultSet because it is either before the start or after "
 "the end of the results."
 msgstr ""
-"Non è possibile aggiornare il «ResultSet» perché la posizione attuale è "
+"Non Ã¨ possibile aggiornare il Â«ResultSetÂ» perchÃ© la posizione attuale Ã¨ "
 "precedente all''inizio o successiva alla file dei risultati."
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:1844
 msgid "ResultSets with concurrency CONCUR_READ_ONLY cannot be updated."
 msgstr ""
-"I «ResultSet» in modalità CONCUR_READ_ONLY non possono essere aggiornati."
+"I Â«ResultSetÂ» in modalitÃ  CONCUR_READ_ONLY non possono essere aggiornati."
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:1948
 #, fuzzy, java-format
 msgid "No eligible primary or unique key found for table {0}."
-msgstr "Non è stata trovata la chiave primaria della tabella «{0}»."
+msgstr "Non Ã¨ stata trovata la chiave primaria della tabella Â«{0}Â»."
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:2148
 #, java-format
@@ -1386,12 +1386,12 @@ msgstr "La JVM sostiene di non supportare la codifica: {0}."
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:3726
 #, java-format
 msgid "Bad value for type {0} : {1}"
-msgstr "Il valore «{1}» non è adeguato al tipo «{0}»."
+msgstr "Il valore Â«{1}Â» non Ã¨ adeguato al tipo Â«{0}Â»."
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:3207
 #, java-format
 msgid "The column name {0} was not found in this ResultSet."
-msgstr "Colonna denominata «{0}» non è presente in questo «ResultSet»."
+msgstr "Colonna denominata Â«{0}Â» non Ã¨ presente in questo Â«ResultSetÂ»."
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:3348
 msgid ""
@@ -1399,20 +1399,20 @@ msgid ""
 "select only one table, and must select all primary keys from that table. See "
 "the JDBC 2.1 API Specification, section 5.6 for more details."
 msgstr ""
-"Il «ResultSet» non è aggiornabile. La query che lo genera deve selezionare "
+"Il Â«ResultSetÂ» non Ã¨ aggiornabile. La query che lo genera deve selezionare "
 "una sola tabella e deve selezionarne tutti i campi che ne compongono la "
 "chiave primaria. Si vedano le specifiche dell''API JDBC 2.1, sezione 5.6, "
 "per ulteriori dettagli."
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:3364
 msgid "This ResultSet is closed."
-msgstr "Questo «ResultSet» è chiuso."
+msgstr "Questo Â«ResultSetÂ» Ã¨ chiuso."
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:3398
 msgid "ResultSet not positioned properly, perhaps you need to call next."
 msgstr ""
-"Il «ResultSet» non è correttamente posizionato; forse è necessario invocare "
-"«next()»."
+"Il Â«ResultSetÂ» non Ã¨ correttamente posizionato; forse Ã¨ necessario invocare "
+"Â«next()Â»."
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:3760
 #, fuzzy
@@ -1441,7 +1441,7 @@ msgstr "Flag non valido"
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:4067
 #, fuzzy, java-format
 msgid "conversion to {0} from {1} not supported"
-msgstr "Il livello di isolamento delle transazioni «{0}» non è supportato."
+msgstr "Il livello di isolamento delle transazioni Â«{0}Â» non Ã¨ supportato."
 
 #: src/main/java/org/postgresql/jdbc/PgResultSet.java:4044
 #, fuzzy
@@ -1469,12 +1469,12 @@ msgstr ""
 #: src/main/java/org/postgresql/jdbc/PgSQLXML.java:250
 #, fuzzy, java-format
 msgid "Unknown XML Result class: {0}"
-msgstr "Il parametro «holdability» per il «ResultSet» è sconosciuto: {0}."
+msgstr "Il parametro Â«holdabilityÂ» per il Â«ResultSetÂ» Ã¨ sconosciuto: {0}."
 
 #: src/main/java/org/postgresql/jdbc/PgSQLXML.java:266
 #, fuzzy
 msgid "This SQLXML object has already been freed."
-msgstr "Questo «PooledConnection» è stato chiuso."
+msgstr "Questo Â«PooledConnectionÂ» Ã¨ stato chiuso."
 
 #: src/main/java/org/postgresql/jdbc/PgSQLXML.java:275
 msgid ""
@@ -1508,11 +1508,11 @@ msgstr ""
 #: src/main/java/org/postgresql/jdbc/PgStatement.java:187
 #, fuzzy
 msgid "Unknown value for ResultSet holdability"
-msgstr "Il parametro «holdability» per il «ResultSet» è sconosciuto: {0}."
+msgstr "Il parametro Â«holdabilityÂ» per il Â«ResultSetÂ» Ã¨ sconosciuto: {0}."
 
 #: src/main/java/org/postgresql/jdbc/PgStatement.java:295
 msgid "Multiple ResultSets were returned by the query."
-msgstr "La query ha restituito «ResultSet» multipli."
+msgstr "La query ha restituito Â«ResultSetÂ» multipli."
 
 #: src/main/java/org/postgresql/jdbc/PgStatement.java:381
 msgid "Can''t use executeWithFlags(int) on a Statement."
@@ -1533,7 +1533,7 @@ msgstr "La dimensione massima del campo deve essere maggiore o eguale a 0."
 
 #: src/main/java/org/postgresql/jdbc/PgStatement.java:791
 msgid "This statement has been closed."
-msgstr "Questo statement è stato chiuso."
+msgstr "Questo statement Ã¨ stato chiuso."
 
 #: src/main/java/org/postgresql/jdbc/PgStatement.java:833
 msgid ""
@@ -1546,14 +1546,14 @@ msgstr ""
 #: src/main/java/org/postgresql/jdbc/PgStatement.java:1350
 #, fuzzy, java-format
 msgid "Invalid value for autoGeneratedKeys {0}"
-msgstr "La dimensione specificata, {0}, per lo «stream» non è valida."
+msgstr "La dimensione specificata, {0}, per lo Â«streamÂ» non Ã¨ valida."
 
 #: src/main/java/org/postgresql/jdbc/PgStatement.java:1182
 #: src/main/java/org/postgresql/jdbc/PgStatement.java:1323
 #: src/main/java/org/postgresql/jdbc/PgStatement.java:1360
 #, fuzzy
 msgid "Returning autogenerated keys by column index is not supported."
-msgstr "La restituzione di chiavi autogenerate non è supportata."
+msgstr "La restituzione di chiavi autogenerate non Ã¨ supportata."
 
 #: src/main/java/org/postgresql/jdbc/QueryExecutorTimeZoneProvider.java:33
 msgid ""
@@ -1564,13 +1564,13 @@ msgstr ""
 #: src/main/java/org/postgresql/jdbc/SslMode.java:78
 #, fuzzy, java-format
 msgid "Invalid sslmode value: {0}"
-msgstr "La dimensione specificata, {0}, per lo «stream» non è valida."
+msgstr "La dimensione specificata, {0}, per lo Â«streamÂ» non Ã¨ valida."
 
 #: src/main/java/org/postgresql/jdbc/TimestampUtils.java:379
 #: src/main/java/org/postgresql/jdbc/TimestampUtils.java:491
 #, fuzzy, java-format
 msgid "Bad value for type timestamp/date/time: {0}"
-msgstr "Il valore «{1}» non è adeguato al tipo «{0}»."
+msgstr "Il valore Â«{1}Â» non Ã¨ adeguato al tipo Â«{0}Â»."
 
 #: src/main/java/org/postgresql/jdbc/TimestampUtils.java:506
 #: src/main/java/org/postgresql/jdbc/TimestampUtils.java:1313
@@ -1580,7 +1580,7 @@ msgstr "Il valore «{1}» non è adeguato al tipo «{0}»."
 #: src/main/java/org/postgresql/jdbc/TimestampUtils.java:1593
 #, fuzzy, java-format
 msgid "Unsupported binary encoding of {0}."
-msgstr "Valore di tipo «{0}» non supportato."
+msgstr "Valore di tipo Â«{0}Â» non supportato."
 
 #: src/main/java/org/postgresql/jdbc/TypeInfoCache.java:1119
 #, java-format
@@ -1619,17 +1619,17 @@ msgstr ""
 #: src/main/java/org/postgresql/largeobject/LargeObject.java:85
 #, fuzzy
 msgid "This large object has been closed."
-msgstr "Questo statement è stato chiuso."
+msgstr "Questo statement Ã¨ stato chiuso."
 
 #: src/main/java/org/postgresql/largeobject/LargeObjectManager.java:244
 #: src/main/java/org/postgresql/largeobject/LargeObjectManager.java:285
 msgid "Large Objects may not be used in auto-commit mode."
-msgstr "Non è possibile impostare i «Large Object» in modalità «auto-commit»."
+msgstr "Non Ã¨ possibile impostare i Â«Large ObjectÂ» in modalitÃ  Â«auto-commitÂ»."
 
 #: src/main/java/org/postgresql/osgi/PGDataSourceFactory.java:86
 #, fuzzy, java-format
 msgid "Unsupported properties: {0}"
-msgstr "Valore di tipo «{0}» non supportato."
+msgstr "Valore di tipo Â«{0}Â» non supportato."
 
 #: src/main/java/org/postgresql/replication/fluent/AbstractCreateSlotBuilder.java:40
 msgid "Server does not support temporary replication slots"
@@ -1731,7 +1731,7 @@ msgstr ""
 #, fuzzy, java-format
 msgid "The password callback class provided {0} could not be instantiated."
 msgstr ""
-"La classe «SSLSocketFactory» specificata, «{0}», non può essere istanziata."
+"La classe Â«SSLSocketFactoryÂ» specificata, Â«{0}Â», non puÃ² essere istanziata."
 
 #: src/main/java/org/postgresql/ssl/LibPQFactory.java:110
 msgid "Could not initialize PEMKeyManager."
@@ -1765,7 +1765,7 @@ msgstr ""
 #, fuzzy, java-format
 msgid "The HostnameVerifier class provided {0} could not be instantiated."
 msgstr ""
-"La classe «SSLSocketFactory» specificata, «{0}», non può essere istanziata."
+"La classe Â«SSLSocketFactoryÂ» specificata, Â«{0}Â», non puÃ² essere istanziata."
 
 #: src/main/java/org/postgresql/ssl/MakeSSL.java:93
 #, java-format
@@ -1788,7 +1788,7 @@ msgstr ""
 #: src/main/java/org/postgresql/ssl/PGjdbcHostnameVerifier.java:92
 #, fuzzy, java-format
 msgid "No certificates found for hostname {0}"
-msgstr "Non è stata trovata la chiave primaria della tabella «{0}»."
+msgstr "Non Ã¨ stata trovata la chiave primaria della tabella Â«{0}Â»."
 
 #: src/main/java/org/postgresql/ssl/PGjdbcHostnameVerifier.java:111
 #, java-format
@@ -1799,7 +1799,7 @@ msgstr ""
 #, fuzzy, java-format
 msgid "Unable to parse certificates for hostname {0}"
 msgstr ""
-"Impossibile fare il «bind» dei valori passati come parametri per lo "
+"Impossibile fare il Â«bindÂ» dei valori passati come parametri per lo "
 "statement."
 
 #: src/main/java/org/postgresql/ssl/PGjdbcHostnameVerifier.java:159
@@ -1838,7 +1838,7 @@ msgstr ""
 #: src/main/java/org/postgresql/ssl/PKCS12KeyManager.java:42
 #, fuzzy
 msgid "Unable to find pkcs12 keystore."
-msgstr "Non è possibile trovare il datatype «name» nel catalogo di sistema."
+msgstr "Non Ã¨ possibile trovare il datatype Â«nameÂ» nel catalogo di sistema."
 
 #: src/main/java/org/postgresql/ssl/SingleCertValidatingFactory.java:92
 msgid "The sslfactoryarg property may not be empty."
@@ -1875,7 +1875,7 @@ msgstr ""
 #: src/main/java/org/postgresql/ssl/SingleCertValidatingFactory.java:153
 #, fuzzy
 msgid "An error occurred reading the certificate"
-msgstr "Si è verificato un errore impostando la connessione SSL."
+msgstr "Si Ã¨ verificato un errore impostando la connessione SSL."
 
 #: src/main/java/org/postgresql/ssl/SingleCertValidatingFactory.java:186
 msgid "No X509TrustManager found"
@@ -1888,11 +1888,11 @@ msgstr ""
 #: src/main/java/org/postgresql/util/HStoreConverter.java:61
 #, fuzzy
 msgid "hstore key must not be null"
-msgstr "xid non può essere NULL"
+msgstr "xid non puÃ² essere NULL"
 
 #: src/main/java/org/postgresql/util/PGInterval.java:220
 msgid "Conversion of interval failed"
-msgstr "Fallita la conversione di un «interval»."
+msgstr "Fallita la conversione di un Â«intervalÂ»."
 
 #: src/main/java/org/postgresql/util/PGPropertyMaxResultBufferParser.java:153
 #, java-format
@@ -1911,7 +1911,7 @@ msgstr ""
 #, java-format
 msgid "Premature end of input stream, expected {0} bytes, but only read {1}."
 msgstr ""
-"Il flusso di input è stato interrotto, sono arrivati {1} byte al posto dei "
+"Il flusso di input Ã¨ stato interrotto, sono arrivati {1} byte al posto dei "
 "{0} attesi."
 
 #: src/main/java/org/postgresql/util/PGbytea.java:256
@@ -1920,7 +1920,7 @@ msgstr ""
 
 #: src/main/java/org/postgresql/util/PGmoney.java:74
 msgid "Conversion of money failed."
-msgstr "Fallita la conversione di un «money»."
+msgstr "Fallita la conversione di un Â«moneyÂ»."
 
 #: src/main/java/org/postgresql/util/ServerErrorMessage.java:45
 #, java-format
@@ -1991,16 +1991,16 @@ msgstr "Flag non validi"
 #: src/main/java/org/postgresql/xa/PGXAConnection.java:282
 #: src/main/java/org/postgresql/xa/PGXAConnection.java:500
 msgid "xid must not be null"
-msgstr "xid non può essere NULL"
+msgstr "xid non puÃ² essere NULL"
 
 #: src/main/java/org/postgresql/xa/PGXAConnection.java:200
 msgid "Connection is busy with another transaction"
-msgstr "La connessione è utilizzata da un''altra transazione"
+msgstr "La connessione Ã¨ utilizzata da un''altra transazione"
 
 #: src/main/java/org/postgresql/xa/PGXAConnection.java:209
 #: src/main/java/org/postgresql/xa/PGXAConnection.java:292
 msgid "suspend/resume not implemented"
-msgstr "«suspend»/«resume» non implementato"
+msgstr "Â«suspendÂ»/Â«resumeÂ» non implementato"
 
 #: src/main/java/org/postgresql/xa/PGXAConnection.java:217
 #: src/main/java/org/postgresql/xa/PGXAConnection.java:224
@@ -2021,7 +2021,7 @@ msgstr "Errore durante il commit \"one-phase\""
 msgid ""
 "tried to call end without corresponding start call. state={0}, start "
 "xid={1}, currentXid={2}, preparedXid={3}"
-msgstr "È stata chiamata «end» senza la corrispondente chiamata a «start»"
+msgstr "Ãˆ stata chiamata Â«endÂ» senza la corrispondente chiamata a Â«startÂ»"
 
 #: src/main/java/org/postgresql/xa/PGXAConnection.java:332
 #, java-format
@@ -2040,13 +2040,13 @@ msgid ""
 "Not implemented: Prepare must be issued using the same connection that "
 "started the transaction. currentXid={0}, prepare xid={1}"
 msgstr ""
-"Non implementato: «Prepare» deve essere eseguito nella stessa connessione "
+"Non implementato: Â«PrepareÂ» deve essere eseguito nella stessa connessione "
 "che ha iniziato la transazione."
 
 #: src/main/java/org/postgresql/xa/PGXAConnection.java:346
 #, fuzzy, java-format
 msgid "Prepare called before end. prepare xid={0}, state={1}"
-msgstr "«Prepare» invocato prima della fine"
+msgstr "Â«PrepareÂ» invocato prima della fine"
 
 #: src/main/java/org/postgresql/xa/PGXAConnection.java:366
 #, fuzzy, java-format
@@ -2062,7 +2062,7 @@ msgstr "Errore durante il ripristino"
 msgid ""
 "Error rolling back prepared transaction. rollback xid={0}, preparedXid={1}, "
 "currentXid={2}"
-msgstr "Errore durante il «rollback» di una transazione preparata"
+msgstr "Errore durante il Â«rollbackÂ» di una transazione preparata"
 
 #: src/main/java/org/postgresql/xa/PGXAConnection.java:530
 #, java-format
@@ -2086,7 +2086,7 @@ msgstr ""
 #: src/main/java/org/postgresql/xa/PGXAConnection.java:546
 #, fuzzy, java-format
 msgid "commit called before end. commit xid={0}, state={1}"
-msgstr "«Commit» è stato chiamato prima della fine"
+msgstr "Â«CommitÂ» Ã¨ stato chiamato prima della fine"
 
 #: src/main/java/org/postgresql/xa/PGXAConnection.java:557
 #, fuzzy, java-format
@@ -2099,7 +2099,7 @@ msgid ""
 "Not implemented: 2nd phase commit must be issued using an idle connection. "
 "commit xid={0}, currentXid={1}, state={2}, transactionState={3}"
 msgstr ""
-"Non implementato: la seconda fase del «commit» deve essere effettuata con "
+"Non implementato: la seconda fase del Â«commitÂ» deve essere effettuata con "
 "una connessione non in uso"
 
 #: src/main/java/org/postgresql/xa/PGXAConnection.java:618
@@ -2107,9 +2107,9 @@ msgstr ""
 msgid ""
 "Error committing prepared transaction. commit xid={0}, preparedXid={1}, "
 "currentXid={2}"
-msgstr "Errore durante il «rollback» di una transazione preparata"
+msgstr "Errore durante il Â«rollbackÂ» di una transazione preparata"
 
 #: src/main/java/org/postgresql/xa/PGXAConnection.java:635
 #, fuzzy, java-format
 msgid "Heuristic commit/rollback not supported. forget xid={0}"
-msgstr "«Commit» e «rollback» euristici non sono supportati"
+msgstr "Â«CommitÂ» e Â«rollbackÂ» euristici non sono supportati"

--- a/pgjdbc/src/main/java/org/postgresql/translation/nl.po
+++ b/pgjdbc/src/main/java/org/postgresql/translation/nl.po
@@ -11,7 +11,7 @@ msgstr ""
 "Language-Team: Dutch <ajkuiper@wxs.nl>\n"
 "Language: nl\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=ISO-8859-1\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
 #: src/main/java/org/postgresql/Driver.java:259


### PR DESCRIPTION
## What

Re-encode five translation files from legacy 8-bit encodings to UTF-8 and update the `Content-Type` charset declaration to match. No other changes.

| file | was | now |
| --- | --- | --- |
| `cs.po` | ISO-8859-2 | UTF-8 |
| `de.po` | ISO-8859-1 | UTF-8 |
| `fr.po` | ISO-8859-1 | UTF-8 |
| `it.po` | ISO-8859-1 | UTF-8 |
| `nl.po` | ISO-8859-1 | UTF-8 (file body is pure ASCII; only the header changed) |

The other 11 `.po` files were already UTF-8 with a matching header and are untouched.

## Why

The translation sources used a mix of encodings, which makes tooling (editors, grep, diff viewers, future xgettext runs) treat the files inconsistently. Standardising on UTF-8 lets every `.po` file in the tree be opened, searched, and patched the same way, and is the de-facto modern default for gettext catalogues.

GitHub diffs looks better for UTF-8 files.
Here's an example from `cs.po`:
<img width="511" height="59" alt="cs po" src="https://github.com/user-attachments/assets/2d3d565c-3fd3-4645-a6d7-365bb6a36d4c" />


## How to verify

For each converted file, round-trip the new version back through `iconv` to its original encoding and diff against the parent commit. Only the single `Content-Type` line should differ:

```sh
for entry in "cs.po:ISO-8859-2" "de.po:ISO-8859-1" "fr.po:ISO-8859-1" \
             "it.po:ISO-8859-1" "nl.po:ISO-8859-1"; do
  f="${entry%%:*}"; src="${entry##*:}"
  cur="pgjdbc/src/main/java/org/postgresql/translation/$f"
  diff <(git show "HEAD~1:$cur") <(iconv -f UTF-8 -t "$src" "$cur")
done
```

Each diff shows exactly one changed line: `charset=<old>` -> `charset=UTF-8`.