### PR TITLE
test: budget terminating Sync in BatchDeadlockTest small-RETURNING branch

### DIFF
--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BatchDeadlockTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BatchDeadlockTest.java
@@ -225,13 +225,16 @@ public class BatchDeadlockTest extends BaseTest4 {
       assertTrue(syncs < BATCH_SIZE, () -> "Sync should not fire per row, got " + metrics);
       assertTrue(roundtrips < BATCH_SIZE, () -> "batch should pipeline, got " + metrics);
     } else {
-      int expectedRoundtrips = BATCH_SIZE * 250 /* bytes per row */ * 2 / 64000;
-      assertTrue(syncs <= expectedRoundtrips,
-          () -> "small RETURNING fits in receive buffer — expected a few terminating Syncs, "
-              + "got " + metrics);
-      assertTrue(roundtrips <= expectedRoundtrips,
-          () -> "small RETURNING fits in receive buffer — expected a few write→read cycles, "
-              + "got " + metrics);
+      // 250 bytes/row is an intentionally loose upper bound on the per-row response; the
+      // real ID-only row is much smaller. +1 covers the terminating Sync that always fires
+      // at the end of a batch, on top of any mid-batch flushes.
+      int expectedSyncs = BATCH_SIZE * 250 /* bytes per row */ * 2 / 64000 + 1;
+      assertTrue(syncs <= expectedSyncs,
+          () -> "small RETURNING fits in receive buffer: expected at most " + expectedSyncs
+              + " Syncs (mid-batch flushes + 1 terminating), got " + metrics);
+      assertTrue(roundtrips <= expectedSyncs,
+          () -> "small RETURNING fits in receive buffer: expected at most " + expectedSyncs
+              + " write→read cycles, got " + metrics);
     }
   }
 


### PR DESCRIPTION
## Summary

- `BatchDeadlockTest.largePreparedBatchWithGeneratedKeysDoesNotDeadlock` for parameter `[6]` (`ReturningInQuery.ID` + `BinaryMode.FORCE`) intermittently fails with `expected: <true> but was: <false>` for the Sync count.
- Root cause is an off-by-one in the test bound, not a driver regression. `flushIfDeadlockRisk` ([`QueryExecutorImpl#L1650`](../blob/master/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java#L1650)) fires a Sync per mid-batch flush, and pgjdbc always sends one extra terminating Sync at the end of the batch. The formula `BATCH_SIZE * 250 * 2 / 64000 = 3` accounted only for the mid-batch flushes, so an observed `Sync=4` (3 + terminator) tripped `syncs <= 3`.

## What changed

- Single `expectedSyncs = expectedRoundtrips + 1` budget for both Sync and roundtrip assertions.
- Diagnostic messages now include the bound (`expected at most N Syncs, got …`) so future failures show why the bound was set.
- Still catches Sync-per-row regressions: the small-RETURNING budget is `~3`, far below `BATCH_SIZE = 500`.

## Test plan

- [x] `./gradlew :postgresql:test --tests "org.postgresql.test.jdbc2.BatchDeadlockTest"` x3 — 16 passed, 8 skipped (simple query mode), stable across reruns.

Spotted while triaging an unrelated CI failure on https://github.com/pgjdbc/pgjdbc/actions/runs/26447208462/job/77856581962.

🤖 Generated with [Claude Code](https://claude.com/claude-code)