### PR TITLE
fix: default logServerErrorDetail to false to avoid leaking sensitive information

### DIFF
--- a/docs/content/documentation/use.md
+++ b/docs/content/documentation/use.md
@@ -449,10 +449,10 @@ By default, minimum of rows calculated by `adaptiveFetch` is 0.
 Specifies the highest number of rows which can be calculated by `adaptiveFetch`. Requires `adaptiveFetch` set to `true` to work.
 By default, maximum of rows calculated by `adaptiveFetch` is -1, which is understood as infinite.
 
-* **`logServerErrorDetail (`*boolean*`)`** *Default `true`*\
+* **`logServerErrorDetail (`*boolean*`)`** *Default `false`*\
 Whether to include server error details in exceptions and log messages (for example inlined query parameters).
-Setting to `false` will only include minimal, not sensitive messages.
-By default, this is set to `true`, server error details are propagated. This may include sensitive details such as query parameters.
+Setting to `true` will propagate full server error details, which may include sensitive information such as query parameters.
+By default, this is set to `false` to avoid leaking sensitive details.
 
 * **`quoteReturningIdentifiers (`*boolean*`)`** *Default `true`*\
 Quote returning columns. There are some ORM's that quote everything, including returning columns

--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -419,7 +419,7 @@ public enum PGProperty {
    */
   LOG_SERVER_ERROR_DETAIL(
       "logServerErrorDetail",
-      "true",
+      "false",
       "Include full server error detail in exception messages. If disabled then only the error itself will be included."),
 
   /**

--- a/pgjdbc/src/test/java/org/postgresql/test/core/LogServerMessagePropertyTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/core/LogServerMessagePropertyTest.java
@@ -84,6 +84,7 @@ class LogServerMessagePropertyTest {
   @Test
   void withDefaults() throws SQLException {
     Properties props = new Properties();
+    props.setProperty(PGProperty.LOG_SERVER_ERROR_DETAIL.getName(), "true");
     String message = testViolatePrimaryKey(props);
     assertMessageContains(message, PRIMARY_KEY_NAME);
     // TODO: Detail is locale-specific assertMessageContains(message, "Detail:");
@@ -116,6 +117,7 @@ class LogServerMessagePropertyTest {
   @Test
   void batchWithDefaults() throws SQLException {
     Properties props = new Properties();
+    props.setProperty(PGProperty.LOG_SERVER_ERROR_DETAIL.getName(), "true");
     String message = testViolatePrimaryKey(props, true);
     assertMessageContains(message, PRIMARY_KEY_NAME);
     // TODO: Detail is locale-specific assertMessageContains(message, "Detail:");


### PR DESCRIPTION

  Server error details can contain query parameters and other sensitive data.
  Defaulting to false prevents accidental exposure in logs and exception messages.

fixes #3050 