### PR TITLE
build: tidy .gitattributes for generated files and java diffs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,5 +7,14 @@
 *.yaml text
 *.yml text
 *.bat text eol=crlf
+
+# Java-aware diff hunk headers (git built-in funcname pattern)
+*.java diff=java
+
 /CHANGELOG.md merge=union
 /contributors.json merge=union
+
+# Generated files: collapse in PR diffs and exclude from language stats
+/pgjdbc/src/main/java/org/postgresql/translation/messages_*.java linguist-generated=true
+/pgjdbc/src/main/java/org/postgresql/translation/messages.pot linguist-generated=true
+/.github/workflows/package-lock.json linguist-generated=true


### PR DESCRIPTION
## What

- Mark `messages_*.java`, `messages.pot`, and `.github/workflows/package-lock.json` as `linguist-generated` so GitHub collapses them in PR diffs and excludes them from language stats.
- Enable git's built-in `java` funcname patterns (`*.java diff=java`) for clearer hunk headers in local diffs.

## Why

The translation `messages_*.java` bundles and the `.pot` template are regenerated by the gettext tasks, so their diffs are pure noise on review (the `.pot` in particular churns its `#: src/...:NNN` source-line refs on every edit). The npm lockfile is the textbook `linguist-generated` case.

`.po` files are intentionally left untouched: they hold human-authored translations, so reviewers should still see those diffs.

## How to verify

- After merge, open a PR that touches translations and confirm the generated files appear collapsed on GitHub.
- `git diff` on a Java change now shows the enclosing method in the hunk header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)