### PR TITLE
Update 42.6.x workflows and fix PostgreSQL 18 metadata + GSS tests

### DIFF
--- a/.github/workflows/buildcache.yml
+++ b/.github/workflows/buildcache.yml
@@ -48,7 +48,7 @@ jobs:
     name: '${{ matrix.os }}, ${{ matrix.jdk }} seed build cache'
     runs-on: ${{ matrix.os }}-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 50
       - name: 'Set up JDK ${{ matrix.jdk }}'

--- a/.github/workflows/debezium.yml
+++ b/.github/workflows/debezium.yml
@@ -16,7 +16,7 @@ jobs:
       ACTIONS_STEP_DEBUG: true
       ACTIONS_RUNNER_DEBUG: true
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 50
       - name: 'Set up JDK 11'

--- a/.github/workflows/fedora-copr-build.yml
+++ b/.github/workflows/fedora-copr-build.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Check out proper version of sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Submit the build
         env:

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -9,5 +9,5 @@ jobs:
     name: "Validation"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: gradle/wrapper-validation-action@v1

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -10,4 +10,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: gradle/wrapper-validation-action@v1
+      - uses: gradle/actions/wrapper-validation@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
       ACTIONS_STEP_DEBUG: true
       ACTIONS_RUNNER_DEBUG: true
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 50
     - name: 'Set up JDK 8'
@@ -62,7 +62,7 @@ jobs:
     name: 'CheckerFramework'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 50
       - name: 'Set up JDK 11'
@@ -84,7 +84,7 @@ jobs:
     name: 'Source distribution (JDK 11)'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 50
       - name: Start PostgreSQL
@@ -124,7 +124,7 @@ jobs:
     env:
       MATRIX_JOBS: 5
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 50
     - id: set-matrix
@@ -143,7 +143,7 @@ jobs:
       ACTIONS_RUNNER_DEBUG: true
       TZ: ${{ matrix.tz }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 50
     - name: Start PostgreSQL PGV=${{ matrix.pg_version }} TZ=${{ matrix.server_tz }} XA=${{ matrix.xa }} SSL=${{ matrix.ssl }} SCRAM=${{ matrix.scram }} CREATE_REPLICAS=${{ matrix.replication }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -111,7 +111,7 @@ jobs:
           mvn --batch-mode --fail-at-end --show-version verify
       - name: Attach heap dump if any
         if: ${{ failure() && github.event_name == 'pull_request' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pgjdbc-heapdump-source-distribution
           path: pgjdbc/build/distributions/postgresql-1.0-jdbc-src/target/surefire-reports/*.hprof
@@ -223,7 +223,7 @@ jobs:
         arguments: publishToMavenLocal -Ppgjdbc.version=1.0.0-dev-master -PskipJavadoc
     - name: Attach heap dump if any
       if: ${{ failure() && github.event_name == 'pull_request' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: pgjdbc-heapdump
         path: pgjdbc/*.hprof

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -208,11 +208,13 @@ jobs:
       if: ${{ matrix.gss == 'yes' }}
       run: |
         sudo apt -y update
+        sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
+        sudo apt -y install postgresql-16
         sudo apt -y install krb5-kdc krb5-admin-server libkrb5-dev postgresql
     - name: 'Update hosts for GSS tests'
       if: ${{ matrix.gss == 'yes' }}
       run: |
-        sudo -- sh -c "echo 127.0.0.1 localhost auth-test-localhost.postgresql.example.com > /etc/hosts"
+        sudo -- sh -c "echo 127.0.0.1 auth-test-localhost.postgresql.example.com localhost > /etc/hosts"
         cat /etc/hosts
     - uses: burrunan/gradle-cache-action@v1
       if: ${{ matrix.deploy_to_maven_local }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,7 +89,7 @@ jobs:
           fetch-depth: 50
       - name: Start PostgreSQL
         working-directory: docker/postgres-server
-        run: docker-compose up -d && docker-compose logs
+        run: docker compose up -d && docker compose logs
       - name: 'Set up JDK 11'
         uses: actions/setup-java@v3
         with:
@@ -157,12 +157,12 @@ jobs:
         CREATE_REPLICAS: ${{ matrix.replication }}
       # The below run command is long, however, it is intentional, and it makes the output nicer in GitHub UI
       run: |
-        echo 'Starting PostgreSQL via docker-compose down; PGV=${{ matrix.pg_version }} TZ=${{ matrix.server_tz }} XA=${{ matrix.xa }} SSL=${{ matrix.ssl }} SCRAM=${{ matrix.scram }} CREATE_REPLICAS=${{ matrix.replication }} docker-compose up'
+        echo 'Starting PostgreSQL via docker compose down; PGV=${{ matrix.pg_version }} TZ=${{ matrix.server_tz }} XA=${{ matrix.xa }} SSL=${{ matrix.ssl }} SCRAM=${{ matrix.scram }} CREATE_REPLICAS=${{ matrix.replication }} docker compose up'
 
-        docker-compose down -v --rmi local || true
+        docker compose down -v --rmi local || true
         sed -i -r '/- (543[3-4]):\1/d' docker-compose.yml
-        docker-compose up -d
-        docker-compose logs
+        docker compose up -d
+        docker compose logs
     - name: 'Get test node ARCH'
       run: echo "arch_name=$(uname -i)" >> $GITHUB_OUTPUT
       id: get_arch_name
@@ -251,5 +251,5 @@ jobs:
       if: ${{ always() }}
       working-directory: docker/postgres-server
       run: |
-        docker-compose ps
-        docker-compose down -v --rmi local
+        docker compose ps
+        docker compose down -v --rmi local

--- a/.github/workflows/matrix.js
+++ b/.github/workflows/matrix.js
@@ -46,8 +46,6 @@ matrix.addAxis({
   title: x => 'PG ' + x,
   // Strings allow versions like 18-ea
   values: [
-    '8.4',
-    '9.0',
     '9.1',
     '9.2',
     '9.3',
@@ -203,7 +201,6 @@ matrix.exclude(row => row.scram.value === 'yes' && isLessThan(row.pg_version, '1
 matrix.exclude(row => row.replication.value === 'yes' && isLessThan(row.pg_version, '9.6'));
 //org.postgresql.test.jdbc2.ArrayTest fails using simple mode for versions less than 9.0 with malformed Array literal
 matrix.exclude( row => row.query_mode.value == 'simple' && isLessThan(row.pg_version, '9.1'));
-//matrix.exclude({query_mode: {value: 'simple'}, pg_version: '8.4'});
 // Microsoft Java has no distribution for 8
 matrix.exclude({java_distribution: 'microsoft', java_version: '8'});
 matrix.exclude({gss: {value: 'yes'}, os: ['windows-latest', 'macos-latest', 'self-hosted']})

--- a/.github/workflows/matrix.js
+++ b/.github/workflows/matrix.js
@@ -88,7 +88,6 @@ matrix.addAxis({
     // We use docker-compose for launching PostgreSQL
     // 'windows-latest',
     // 'macos-latest',
-    ...(process.env.GITHUB_REPOSITORY === 'pgjdbc/pgjdbc' ? ['self-hosted'] : [])
   ]
 });
 
@@ -203,11 +202,7 @@ matrix.exclude(row => row.replication.value === 'yes' && isLessThan(row.pg_versi
 matrix.exclude( row => row.query_mode.value == 'simple' && isLessThan(row.pg_version, '9.1'));
 // Microsoft Java has no distribution for 8
 matrix.exclude({java_distribution: 'microsoft', java_version: '8'});
-matrix.exclude({gss: {value: 'yes'}, os: ['windows-latest', 'macos-latest', 'self-hosted']})
-if (process.env.GITHUB_REPOSITORY === 'pgjdbc/pgjdbc') {
-    // PG images below 9.3 are x86_64 only
-    matrix.exclude(row => row.os === 'self-hosted' && isLessThan(row.pg_version, '9.3'));
-}
+matrix.exclude({gss: {value: 'yes'}, os: ['windows-latest', 'macos-latest']})
 
 // The most rare features should be generated the first
 // For instance, we have a lot of PostgreSQL versions, so we generate the minimal the first
@@ -228,9 +223,6 @@ matrix.generateRow({ssl: {value: 'yes'}});
 // Ensure at least one Windows and at least one Linux job is present (macOS is almost the same as Linux)
 // matrix.generateRow({os: 'windows-latest'});
 matrix.generateRow({os: 'ubuntu-latest'});
-if (process.env.GITHUB_REPOSITORY === 'pgjdbc/pgjdbc') {
-  matrix.generateRow({os: 'self-hosted'});
-}
 const include = matrix.generateRows(process.env.MATRIX_JOBS || 5);
 if (include.length === 0) {
   throw new Error('Matrix list is empty');

--- a/.github/workflows/nightlysnapshot.yml
+++ b/.github/workflows/nightlysnapshot.yml
@@ -37,7 +37,7 @@ jobs:
       ACTIONS_STEP_DEBUG: true
       ACTIONS_RUNNER_DEBUG: true
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 50
       - name: 'Set up JDK 8'

--- a/.github/workflows/omni.yml
+++ b/.github/workflows/omni.yml
@@ -293,7 +293,7 @@ jobs:
       env:
           MATRIX_JSON: ${{ toJSON(matrix) }}
       run: echo "${MATRIX_JSON}"
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 50
 
@@ -373,7 +373,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 50
     - name: Compile and start PostgreSQL

--- a/.github/workflows/omni.yml
+++ b/.github/workflows/omni.yml
@@ -299,7 +299,7 @@ jobs:
 
     - name: Start PostgreSQL
       working-directory: docker/postgres-server
-      run: docker-compose up -d && docker-compose logs
+      run: docker compose up -d && docker compose logs
       env:
         PGV: ${{ matrix.pg_version }}
 
@@ -340,7 +340,7 @@ jobs:
             # Server is not online so dump some logs for debugging
             docker ps
             cd docker/postgres-server
-            docker-compose logs
+            docker compose logs
         fi
         psql -c 'SELECT version()'
 
@@ -378,7 +378,7 @@ jobs:
         fetch-depth: 50
     - name: Compile and start PostgreSQL
       working-directory: docker/postgres-head
-      run: docker-compose up -d && docker-compose logs
+      run: docker compose up -d && docker compose logs
     - name: Set up JDK
       uses: actions/setup-java@v3
       with:
@@ -398,7 +398,7 @@ jobs:
             # Server is not online so dump some logs for debugging
             docker ps
             cd docker/postgres-head
-            docker-compose logs
+            docker compose logs
         fi
         psql -c 'SELECT version()'
     - name: Prepare local properties

--- a/.github/workflows/omni.yml
+++ b/.github/workflows/omni.yml
@@ -13,7 +13,7 @@ on:
         required: false
         default: "*"
       matrix_pg_version:
-        description: PostgreSQL Server Version (8.4, 9.0, 9.1, ...)
+        description: PostgreSQL Server Version (9.1, 9.2, ...)
         required: false
         default: "*"
       matrix_query_mode:
@@ -80,8 +80,6 @@ jobs:
         ];
 
         const PG_VERSIONS = [
-            '8.4',
-            '9.0',
             '9.1',
             '9.2',
             '9.3',

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -30,7 +30,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Checkout sources
         if: ${{ env.PUBLISH_SNAPSHOT == 'true' }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up JDK 17
         if: ${{ env.PUBLISH_SNAPSHOT == 'true' }}
         uses: actions/setup-java@v3

--- a/pgjdbc/src/main/java/org/postgresql/core/ServerVersion.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/ServerVersion.java
@@ -32,7 +32,9 @@ public enum ServerVersion implements Version {
   v13("13"),
   v14("14"),
   v15("15"),
-  v16("16")
+  v16("16"),
+  v17("17"),
+  v18("18")
   ;
 
   private final int version;
@@ -51,6 +53,11 @@ public enum ServerVersion implements Version {
     return version;
   }
 
+  @Override
+  public int getMajorVersionNumber() {
+    return version / 10000;
+  }
+
   /**
    * <p>Attempt to parse the server version string into an XXYYZZ form version number into a
    * {@link Version}.</p>
@@ -66,6 +73,11 @@ public enum ServerVersion implements Version {
       @Override
       public int getVersionNum() {
         return versionNum;
+      }
+
+      @Override
+      public int getMajorVersionNumber() {
+        return versionNum / 10000;
       }
 
       @Override

--- a/pgjdbc/src/main/java/org/postgresql/core/Version.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/Version.java
@@ -14,4 +14,5 @@ public interface Version {
    */
   int getVersionNum();
 
+  int getMajorVersionNumber();
 }

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
@@ -1322,8 +1322,13 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
       select += " AND n.nspname LIKE " + escapeQuotes(schemaPattern);
     }
     if (connection.getHideUnprivilegedObjects()) {
+      // as of https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=fefa76f70fdc75c91f80bddce2df7a8825205962
+      // The RULE privilege has been removed
+      String privileges = connection.getServerMajorVersion() < ServerVersion.v18.getMajorVersionNumber()
+          ? " 'SELECT, INSERT, UPDATE, DELETE, RULE, REFERENCES, TRIGGER')"
+          : " 'SELECT, INSERT, UPDATE, DELETE, REFERENCES, TRIGGER')";
       select += " AND has_table_privilege(c.oid, "
-        + " 'SELECT, INSERT, UPDATE, DELETE, RULE, REFERENCES, TRIGGER')";
+        + privileges;
     }
     orderby = " ORDER BY TABLE_TYPE,TABLE_SCHEM,TABLE_NAME ";
 

--- a/test-gss/src/main/groovy/Postgres.groovy
+++ b/test-gss/src/main/groovy/Postgres.groovy
@@ -6,7 +6,7 @@ class Postgres {
     int port
 
     public Postgres() {
-        setupPaths('/usr/local/pgsql/14/bin/','/tmp/pgdata14')
+        setupPaths('/usr/local/pgsql/16/bin/','/tmp/pgdata16')
         initDB()
     }
     public Postgres(String binDir, String dataDir) {

--- a/test-gss/src/main/groovy/TestPostgres.groovy
+++ b/test-gss/src/main/groovy/TestPostgres.groovy
@@ -47,7 +47,7 @@ class TestPostgres {
         if (isMac)
             postgres = new Postgres()
         else
-            postgres = new Postgres('/usr/lib/postgresql/14/bin/', '/tmp/pggss')
+            postgres = new Postgres('/usr/lib/postgresql/16/bin/', '/tmp/pggss')
         /*
         make sure we can connect
          */
@@ -77,6 +77,7 @@ class TestPostgres {
                         System.err.println 'GSS authenticated and encrypted Connection succeeded'
                     } else {
                         Assert.fail 'GSS authenticated and encrypted Connection failed'
+                        System.exit( -1)
                     }
                 } catch( Exception ex ) {
                     System.err.println "PG HBA.conf: \n ${postgres.readPgHBA()}"
@@ -93,6 +94,7 @@ class TestPostgres {
                         System.err.println 'GSS authenticated and encrypted Connection succeeded'
                     } else {
                         Assert.fail 'GSS authenticated and encrypted Connection failed'
+                        System.exit( -1)
                     }
                 } catch( Exception ex ) {
                     System.err.println "PG HBA.conf: \n ${postgres.readPgHBA()}"
@@ -114,11 +116,12 @@ class TestPostgres {
                         System.err.println 'GSS authenticated and not encrypted Connection succeeded'
                     } else {
                         Assert.fail 'GSS authenticated and not encrypted Connection failed'
+                        System.exit( -1)
                     }
                 }catch( Exception ex ) {
                     System.err.println "PG HBA.conf: \n ${postgres.readPgHBA()}"
                     ex.printStackTrace()
-
+                    System.exit( -1)
 
                 } finally {
                     if (!connection) {


### PR DESCRIPTION
## What

- Bump the GitHub Actions used across the workflows: `actions/checkout` v4, `actions/upload-artifact` v4, and `gradle/actions/wrapper-validation`.
- Call the Docker Compose v2 CLI (`docker compose`) instead of the removed `docker-compose` v1 binary.
- Drop PostgreSQL 8.4 and 9.0, and the self-hosted runner, from the CI matrices.
- `fix`: omit the removed `RULE` privilege from the `getTables` metadata query on PostgreSQL 18.
- `test`: provision PostgreSQL 16 for the GSS job and point the `test-gss` harness at it.

## Why

- The 42.6.x workflows still referenced retired action versions and the `docker-compose` v1 binary, so jobs no longer started cleanly on current GitHub-hosted runners.
- PostgreSQL 18 removed the `RULE` privilege, so `has_table_privilege(..., '... RULE ...')` raises an error. With `hideUnprivilegedObjects` enabled, `DatabaseMetaData.getTables` built that list unconditionally and failed against an 18 server.
- The GSS job hardcoded the `initdb` path to `/usr/lib/postgresql/14/bin`, which does not exist on the ubuntu-24.04 runner (it ships PostgreSQL 16). `initdb` failed with `No such file or directory` and the job aborted before any GSS check ran. See the failing run: https://github.com/pgjdbc/pgjdbc/actions/runs/26802611202/job/79012456537

## How to verify

- Re-run the matrix. The GSS job (`ru_RU, gss, PG 9.4`) now installs PostgreSQL 16 from the PGDG repository, runs the `test-gss` checks to completion, and exits non-zero if a GSS assertion fails.
- The remaining jobs start on current runners with the updated actions and the `docker compose` CLI.

The GSS changes backport master commit e468ebdb8 (#3343); the PostgreSQL 18 fix backports 74d8c239d and d98b56bec.
