### PR TITLE
Update GitHub Actions for 42.4

### DIFF
--- a/.github/workflows/buildcache.yml
+++ b/.github/workflows/buildcache.yml
@@ -48,7 +48,7 @@ jobs:
     name: '${{ matrix.os }}, ${{ matrix.jdk }} seed build cache'
     runs-on: ${{ matrix.os }}-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 50
       - name: 'Set up JDK ${{ matrix.jdk }}'

--- a/.github/workflows/debezium.yml
+++ b/.github/workflows/debezium.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           fetch-depth: 50
       - name: 'Set up JDK 11'
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: zulu
           java-version: 11

--- a/.github/workflows/debezium.yml
+++ b/.github/workflows/debezium.yml
@@ -16,7 +16,7 @@ jobs:
       ACTIONS_STEP_DEBUG: true
       ACTIONS_RUNNER_DEBUG: true
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 50
       - name: 'Set up JDK 11'

--- a/.github/workflows/fedora-copr-build.yml
+++ b/.github/workflows/fedora-copr-build.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Check out proper version of sources
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
 
       - name: Submit the build
         env:

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -9,5 +9,5 @@ jobs:
     name: "Validation"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: gradle/wrapper-validation-action@v1

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -10,4 +10,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: gradle/wrapper-validation-action@v1
+      - uses: gradle/actions/wrapper-validation@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,7 +45,7 @@ jobs:
       with:
         fetch-depth: 50
     - name: 'Set up JDK 8'
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         distribution: zulu
         java-version: 8
@@ -66,7 +66,7 @@ jobs:
         with:
           fetch-depth: 50
       - name: 'Set up JDK 11'
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: zulu
           java-version: 11
@@ -91,7 +91,7 @@ jobs:
         working-directory: docker/postgres-server
         run: docker-compose up -d && docker-compose logs
       - name: 'Set up JDK 11'
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: zulu
           java-version: 11
@@ -162,7 +162,7 @@ jobs:
       id: get_arch_name
     - name: Set up Java ${{ matrix.java_version }}, ${{ matrix.java_distribution }}
       if: ${{ steps.get_arch_name.outputs.arch_name != 'aarch64' }}
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         java-version: ${{ matrix.java_version }}
         distribution: ${{ matrix.java_distribution }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,7 +89,7 @@ jobs:
           fetch-depth: 50
       - name: Start PostgreSQL
         working-directory: docker/postgres-server
-        run: docker-compose up -d && docker-compose logs
+        run: docker compose up -d && docker compose logs
       - name: 'Set up JDK 11'
         uses: actions/setup-java@v3
         with:
@@ -151,12 +151,12 @@ jobs:
         CREATE_REPLICAS: ${{ matrix.replication }}
       # The below run command is long, however, it is intentional, and it makes the output nicer in GitHub UI
       run: |
-        echo 'Starting PostgreSQL via docker-compose down; PGV=${{ matrix.pg_version }} TZ=${{ matrix.server_tz }} XA=${{ matrix.xa }} SSL=${{ matrix.ssl }} SCRAM=${{ matrix.scram }} CREATE_REPLICAS=${{ matrix.replication }} docker-compose up'
+        echo 'Starting PostgreSQL via docker compose down; PGV=${{ matrix.pg_version }} TZ=${{ matrix.server_tz }} XA=${{ matrix.xa }} SSL=${{ matrix.ssl }} SCRAM=${{ matrix.scram }} CREATE_REPLICAS=${{ matrix.replication }} docker compose up'
 
-        docker-compose down -v --rmi local || true
+        docker compose down -v --rmi local || true
         sed -i -r '/- (543[3-4]):\1/d' docker-compose.yml
-        docker-compose up -d
-        docker-compose logs
+        docker compose up -d
+        docker compose logs
     - name: 'Get test node ARCH'
       run: echo "::set-output name=arch_name::$(uname -i)"
       id: get_arch_name
@@ -238,5 +238,5 @@ jobs:
       if: ${{ always() }}
       working-directory: docker/postgres-server
       run: |
-        docker-compose ps
-        docker-compose down -v --rmi local
+        docker compose ps
+        docker compose down -v --rmi local

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
       ACTIONS_STEP_DEBUG: true
       ACTIONS_RUNNER_DEBUG: true
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 50
     - name: 'Set up JDK 8'
@@ -62,7 +62,7 @@ jobs:
     name: 'CheckerFramework'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 50
       - name: 'Set up JDK 11'
@@ -84,7 +84,7 @@ jobs:
     name: 'Source distribution (JDK 11)'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 50
       - name: Start PostgreSQL
@@ -118,7 +118,7 @@ jobs:
     env:
       MATRIX_JOBS: 7
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 50
     - id: set-matrix
@@ -137,7 +137,7 @@ jobs:
       ACTIONS_RUNNER_DEBUG: true
       TZ: ${{ matrix.tz }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 50
     - name: Start PostgreSQL PGV=${{ matrix.pg_version }} TZ=${{ matrix.server_tz }} XA=${{ matrix.xa }} SSL=${{ matrix.ssl }} SCRAM=${{ matrix.scram }} CREATE_REPLICAS=${{ matrix.replication }}

--- a/.github/workflows/matrix.js
+++ b/.github/workflows/matrix.js
@@ -44,8 +44,6 @@ matrix.addAxis({
   title: x => 'PG ' + x,
   // Strings allow versions like 18-ea
   values: [
-    '8.4',
-    '9.0',
     '9.1',
     '9.2',
     '9.3',
@@ -88,7 +86,6 @@ matrix.addAxis({
     // We use docker-compose for launching PostgreSQL
     // 'windows-latest',
     // 'macos-latest',
-    ...(process.env.GITHUB_REPOSITORY === 'pgjdbc/pgjdbc' ? ['self-hosted'] : [])
   ]
 });
 
@@ -202,11 +199,7 @@ matrix.exclude(row => row.replication.value === 'yes' && isLessThan(row.pg_versi
 
 // Microsoft Java has no distribution for 8
 matrix.exclude({java_distribution: 'microsoft', java_version: '8'});
-matrix.exclude({gss: {value: 'yes'}, os: ['windows-latest', 'macos-latest', 'self-hosted']})
-if (process.env.GITHUB_REPOSITORY === 'pgjdbc/pgjdbc') {
-    // PG images below 9.3 are x86_64 only
-    matrix.exclude(row => row.os === 'self-hosted' && isLessThan(row.pg_version, '9.3'));
-}
+matrix.exclude({gss: {value: 'yes'}, os: ['windows-latest', 'macos-latest']})
 
 // The most rare features should be generated the first
 // For instance, we have a lot of PostgreSQL versions, so we generate the minimal the first
@@ -227,9 +220,6 @@ matrix.generateRow({ssl: {value: 'yes'}});
 // Ensure at least one Windows and at least one Linux job is present (macOS is almost the same as Linux)
 // matrix.generateRow({os: 'windows-latest'});
 matrix.generateRow({os: 'ubuntu-latest'});
-if (process.env.GITHUB_REPOSITORY === 'pgjdbc/pgjdbc') {
-  matrix.generateRow({os: 'self-hosted'});
-}
 const include = matrix.generateRows(process.env.MATRIX_JOBS || 5);
 if (include.length === 0) {
   throw new Error('Matrix list is empty');

--- a/.github/workflows/nightlysnapshot.yml
+++ b/.github/workflows/nightlysnapshot.yml
@@ -37,7 +37,7 @@ jobs:
       ACTIONS_STEP_DEBUG: true
       ACTIONS_RUNNER_DEBUG: true
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 50
       - name: 'Set up JDK 8'

--- a/.github/workflows/nightlysnapshot.yml
+++ b/.github/workflows/nightlysnapshot.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           fetch-depth: 50
       - name: 'Set up JDK 8'
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: zulu
           java-version: 8

--- a/.github/workflows/omni.yml
+++ b/.github/workflows/omni.yml
@@ -286,7 +286,7 @@ jobs:
       env:
           MATRIX_JSON: ${{ toJSON(matrix) }}
       run: echo "${MATRIX_JSON}"
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 50
 
@@ -366,7 +366,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 50
     - name: Compile and start PostgreSQL

--- a/.github/workflows/omni.yml
+++ b/.github/workflows/omni.yml
@@ -13,7 +13,7 @@ on:
         required: false
         default: "*"
       matrix_pg_version:
-        description: PostgreSQL Server Version (8.4, 9.0, 9.1, ...)
+        description: PostgreSQL Server Version (9.1, 9.2, ...)
         required: false
         default: "*"
       matrix_query_mode:
@@ -78,8 +78,6 @@ jobs:
         ];
 
         const PG_VERSIONS = [
-            '8.4',
-            '9.0',
             '9.1',
             '9.2',
             '9.3',

--- a/.github/workflows/omni.yml
+++ b/.github/workflows/omni.yml
@@ -292,7 +292,7 @@ jobs:
 
     - name: Start PostgreSQL
       working-directory: docker/postgres-server
-      run: docker-compose up -d && docker-compose logs
+      run: docker compose up -d && docker compose logs
       env:
         PGV: ${{ matrix.pg_version }}
 
@@ -333,7 +333,7 @@ jobs:
             # Server is not online so dump some logs for debugging
             docker ps
             cd docker/postgres-server
-            docker-compose logs
+            docker compose logs
         fi
         psql -c 'SELECT version()'
 
@@ -371,7 +371,7 @@ jobs:
         fetch-depth: 50
     - name: Compile and start PostgreSQL
       working-directory: docker/postgres-head
-      run: docker-compose up -d && docker-compose logs
+      run: docker compose up -d && docker compose logs
     - name: Set up JDK
       uses: actions/setup-java@v3
       with:
@@ -391,7 +391,7 @@ jobs:
             # Server is not online so dump some logs for debugging
             docker ps
             cd docker/postgres-head
-            docker-compose logs
+            docker compose logs
         fi
         psql -c 'SELECT version()'
     - name: Prepare local properties

--- a/.github/workflows/omni.yml
+++ b/.github/workflows/omni.yml
@@ -298,7 +298,7 @@ jobs:
 
     # Install built-in JDK
     - name: 'Set up JDK ${{ matrix.jdk_version }} / ${{ matrix.jdk_distribution }}'
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       if: ${{ matrix.jdk_distribution != 'jdkfile' }}
       with:
         distribution: ${{ matrix.jdk_distribution }}
@@ -311,7 +311,7 @@ jobs:
         jdk_url="${{ matrix.jdk_url }}"
         wget -nv -O "${{ runner.temp }}/java_package.tar.gz" "${jdk_url}"
     - name: 'Set up JDK ${{ matrix.jdk_version }} / ${{ matrix.jdk_url }}'
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       if: ${{ matrix.jdk_distribution == 'jdkfile' }}
       with:
         distribution: ${{ matrix.jdk_distribution }}
@@ -373,7 +373,7 @@ jobs:
       working-directory: docker/postgres-head
       run: docker-compose up -d && docker-compose logs
     - name: Set up JDK
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         distribution: zulu
         java-version: 11


### PR DESCRIPTION
## What

- Bump `actions/checkout` to v4 across every workflow.
- Bump `actions/setup-java` to v3 (the `setup-java@v1` step in `buildcache.yml` stays, matching 42.5).
- Replace `gradle/wrapper-validation-action@v1` with `gradle/actions/wrapper-validation@v4`.
- Switch `docker-compose` invocations to `docker compose`.
- Drop the PostgreSQL 8.4/9.0 entries and the `self-hosted` runner axis from the test matrix in `matrix.js` and `omni.yml`.

## Why

The pinned action versions run on deprecated Node runtimes, and the standalone `docker-compose` binary is gone from current GitHub-hosted runners, so the workflows no longer run. The PostgreSQL 8.4/9.0 images and the self-hosted runners are also no longer available. This mirrors the 42.5 update on `codex/update-actions-42.5`, adapted to the older action versions on this branch.

## How to verify

- `node .github/workflows/matrix.js` generates a non-empty matrix.
- All eight changed workflow files parse as valid YAML, and the inline matrix script in `omni.yml` passes `node --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)