### PR TITLE
ci: update GitHub Actions on release/42.3.x

### DIFF
--- a/.github/workflows/buildcache.yml
+++ b/.github/workflows/buildcache.yml
@@ -45,7 +45,7 @@ jobs:
     name: '${{ matrix.os }}, ${{ matrix.jdk }} seed build cache'
     runs-on: ${{ matrix.os }}-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 50
       - name: 'Set up JDK ${{ matrix.jdk }}'

--- a/.github/workflows/debezium.yml
+++ b/.github/workflows/debezium.yml
@@ -13,7 +13,7 @@ jobs:
       ACTIONS_STEP_DEBUG: true
       ACTIONS_RUNNER_DEBUG: true
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 50
       - name: 'Set up JDK 11'

--- a/.github/workflows/debezium.yml
+++ b/.github/workflows/debezium.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           fetch-depth: 50
       - name: 'Set up JDK 11'
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: zulu
           java-version: 11

--- a/.github/workflows/fedora-copr-build.yml
+++ b/.github/workflows/fedora-copr-build.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Check out proper version of sources
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
 
       - name: Submit the build
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ on:
       - '.travis/**'
   pull_request:
     branches:
-      - '*'
+      - '**'
     paths-ignore:
       - 'docs/**'
       - '**/*.md'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
       with:
         fetch-depth: 50
     - name: 'Set up JDK 8'
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         distribution: zulu
         java-version: 8
@@ -63,7 +63,7 @@ jobs:
         with:
           fetch-depth: 50
       - name: 'Set up JDK 11'
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: zulu
           java-version: 11
@@ -88,7 +88,7 @@ jobs:
         working-directory: docker/postgres-server
         run: docker-compose up -d && docker-compose logs
       - name: 'Set up JDK 11'
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: zulu
           java-version: 11
@@ -154,8 +154,9 @@ jobs:
       id: get_arch_name
     - name: 'Set up JDK ${{ matrix.jdk }}'
       if: ${{ steps.get_arch_name.outputs.arch_name != 'aarch64' }}
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v3
       with:
+        distribution: zulu
         java-version: ${{ matrix.jdk }}
         architecture: x64
     - name: 'Setup JDK ${{ matrix.jdk }} on ARM64'
@@ -202,8 +203,9 @@ jobs:
       id: get_arch_name
     - name: 'Set up JDK 8'
       if: ${{ steps.get_arch_name.outputs.arch_name != 'aarch64' }}
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v3
       with:
+        distribution: zulu
         java-version: 8
     - name: 'Setup JDK 8 on ARM64'
       if: ${{ steps.get_arch_name.outputs.arch_name == 'aarch64' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -216,7 +216,7 @@ jobs:
       if: ${{ steps.get_arch_name.outputs.arch_name != 'aarch64' }}
       run: |
         sudo apt -y update
-        sudo apt -y install krb5-kdc krb5-admin-server libkrb5-dev postgresql-12
+        sudo apt -y install krb5-kdc krb5-admin-server libkrb5-dev postgresql
     - name: 'Update hosts'
       run: |
         sudo -- sh -c "echo 127.0.0.1 localhost auth-test-localhost.postgresql.example.com > /etc/hosts"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,7 +86,7 @@ jobs:
           fetch-depth: 50
       - name: Start PostgreSQL
         working-directory: docker/postgres-server
-        run: docker-compose up -d && docker-compose logs
+        run: docker compose up -d && docker compose logs
       - name: 'Set up JDK 11'
         uses: actions/setup-java@v3
         with:
@@ -145,10 +145,10 @@ jobs:
     - name: Start PostgreSQL
       working-directory: docker/postgres-server
       run: |
-        docker-compose down -v --rmi local || true
+        docker compose down -v --rmi local || true
         sed -i -r '/- (543[3-4]):\1/d' docker-compose.yml
-        docker-compose up -d
-        docker-compose logs
+        docker compose up -d
+        docker compose logs
     - name: 'Get test node ARCH'
       run: echo "::set-output name=arch_name::$(uname -i)"
       id: get_arch_name
@@ -183,8 +183,8 @@ jobs:
       if: ${{ always() }}
       working-directory: docker/postgres-server
       run: |
-        docker-compose ps
-        docker-compose down -v --rmi local
+        docker compose ps
+        docker compose down -v --rmi local
 
   gss-encryption:
     name: 'GSS Test - JDK ${{ matrix.jdk }} on ${{ matrix.os }}'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
       ACTIONS_STEP_DEBUG: true
       ACTIONS_RUNNER_DEBUG: true
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 50
     - name: 'Set up JDK 8'
@@ -59,7 +59,7 @@ jobs:
     name: 'CheckerFramework'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 50
       - name: 'Set up JDK 11'
@@ -81,7 +81,7 @@ jobs:
     name: 'Source distribution (JDK 11)'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 50
       - name: Start PostgreSQL
@@ -139,7 +139,7 @@ jobs:
       ACTIONS_STEP_DEBUG: true
       ACTIONS_RUNNER_DEBUG: true
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 50
     - name: Start PostgreSQL
@@ -196,7 +196,7 @@ jobs:
       ACTIONS_STEP_DEBUG: true
       ACTIONS_RUNNER_DEBUG: true
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: 'Get test node ARCH'
       run: echo "::set-output name=arch_name::$(uname -i)"
       id: get_arch_name

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -123,8 +123,6 @@ jobs:
             ],
             os: [
               'ubuntu-latest',
-              // Disable self-hosted on forks:
-              ...(process.env.GITHUB_REPOSITORY === 'pgjdbc/pgjdbc' ? ['self-hosted'] : [])
             ],
           })"
 

--- a/.github/workflows/nightlysnapshot.yml
+++ b/.github/workflows/nightlysnapshot.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           fetch-depth: 50
       - name: 'Set up JDK 8'
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: zulu
           java-version: 8

--- a/.github/workflows/nightlysnapshot.yml
+++ b/.github/workflows/nightlysnapshot.yml
@@ -15,7 +15,7 @@ jobs:
       ACTIONS_STEP_DEBUG: true
       ACTIONS_RUNNER_DEBUG: true
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 50
       - name: 'Set up JDK 8'

--- a/.github/workflows/omni.yml
+++ b/.github/workflows/omni.yml
@@ -13,7 +13,7 @@ on:
         required: false
         default: "*"
       matrix_pg_version:
-        description: PostgreSQL Server Version (8.4, 9.0, 9.1, ...)
+        description: PostgreSQL Server Version (9.1, 9.2, ...)
         required: false
         default: "*"
       matrix_query_mode:
@@ -75,8 +75,6 @@ jobs:
         ];
 
         const PG_VERSIONS = [
-            '8.4',
-            '9.0',
             '9.1',
             '9.2',
             '9.3',

--- a/.github/workflows/omni.yml
+++ b/.github/workflows/omni.yml
@@ -289,7 +289,7 @@ jobs:
 
     - name: Start PostgreSQL
       working-directory: docker/postgres-server
-      run: docker-compose up -d && docker-compose logs
+      run: docker compose up -d && docker compose logs
       env:
         PGV: ${{ matrix.pg_version }}
 
@@ -330,7 +330,7 @@ jobs:
             # Server is not online so dump some logs for debugging
             docker ps
             cd docker/postgres-server
-            docker-compose logs
+            docker compose logs
         fi
         psql -c 'SELECT version()'
 
@@ -368,7 +368,7 @@ jobs:
         fetch-depth: 50
     - name: Compile and start PostgreSQL
       working-directory: docker/postgres-head
-      run: docker-compose up -d && docker-compose logs
+      run: docker compose up -d && docker compose logs
     - name: Set up JDK
       uses: actions/setup-java@v3
       with:
@@ -388,7 +388,7 @@ jobs:
             # Server is not online so dump some logs for debugging
             docker ps
             cd docker/postgres-head
-            docker-compose logs
+            docker compose logs
         fi
         psql -c 'SELECT version()'
     - name: Prepare local properties

--- a/.github/workflows/omni.yml
+++ b/.github/workflows/omni.yml
@@ -283,7 +283,7 @@ jobs:
       env:
           MATRIX_JSON: ${{ toJSON(matrix) }}
       run: echo "${MATRIX_JSON}"
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 50
 
@@ -363,7 +363,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 50
     - name: Compile and start PostgreSQL

--- a/.github/workflows/omni.yml
+++ b/.github/workflows/omni.yml
@@ -295,7 +295,7 @@ jobs:
 
     # Install built-in JDK
     - name: 'Set up JDK ${{ matrix.jdk_version }} / ${{ matrix.jdk_distribution }}'
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       if: ${{ matrix.jdk_distribution != 'jdkfile' }}
       with:
         distribution: ${{ matrix.jdk_distribution }}
@@ -308,7 +308,7 @@ jobs:
         jdk_url="${{ matrix.jdk_url }}"
         wget -nv -O "${{ runner.temp }}/java_package.tar.gz" "${jdk_url}"
     - name: 'Set up JDK ${{ matrix.jdk_version }} / ${{ matrix.jdk_url }}'
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       if: ${{ matrix.jdk_distribution == 'jdkfile' }}
       with:
         distribution: ${{ matrix.jdk_distribution }}
@@ -370,7 +370,7 @@ jobs:
       working-directory: docker/postgres-head
       run: docker-compose up -d && docker-compose logs
     - name: Set up JDK
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         distribution: zulu
         java-version: 11

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,6 +16,20 @@ import de.thetaphi.forbiddenapis.gradle.CheckForbiddenApis
 import de.thetaphi.forbiddenapis.gradle.CheckForbiddenApisExtension
 import org.postgresql.buildtools.JavaCommentPreprocessorTask
 
+buildscript {
+    // org.ajoberstar.grgit 4.0.x was published to JCenter only and is no longer
+    // available on Maven Central, so the stage-vote-release plugin's transitive
+    // grgit 4.0.1 fails to resolve. Pin grgit to 4.1.1, the oldest 4.x release
+    // that is still on Maven Central.
+    configurations.classpath {
+        resolutionStrategy.eachDependency {
+            if (requested.group == "org.ajoberstar.grgit") {
+                useVersion("4.1.1")
+            }
+        }
+    }
+}
+
 plugins {
     publishing
     // Verification

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
@@ -1318,8 +1318,15 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
       select += " AND n.nspname LIKE " + escapeQuotes(schemaPattern);
     }
     if (connection.getHideUnprivilegedObjects()) {
-      select += " AND has_table_privilege(c.oid, "
-        + " 'SELECT, INSERT, UPDATE, DELETE, RULE, REFERENCES, TRIGGER')";
+      // The RULE privilege was removed from has_table_privilege() in PostgreSQL 18:
+      // https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=fefa76f70fdc75c91f80bddce2df7a8825205962
+      if (connection.getServerMajorVersion() < 18) {
+        select += " AND has_table_privilege(c.oid, "
+          + " 'SELECT, INSERT, UPDATE, DELETE, RULE, REFERENCES, TRIGGER')";
+      } else {
+        select += " AND has_table_privilege(c.oid, "
+          + " 'SELECT, INSERT, UPDATE, DELETE, REFERENCES, TRIGGER')";
+      }
     }
     orderby = " ORDER BY TABLE_TYPE,TABLE_SCHEM,TABLE_NAME ";
 

--- a/pgjdbc/src/main/java/org/postgresql/util/StreamWrapper.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/StreamWrapper.java
@@ -52,7 +52,7 @@ public class StreamWrapper {
 
       if (memoryLength == -1) {
         final int diskLength;
-        final File tempFile = Files.createTempFile(TEMP_FILE_PREFIX, null).toFile();
+        final File tempFile = Files.createTempFile(TEMP_FILE_PREFIX, ".tmp").toFile();
         FileOutputStream diskOutputStream = new FileOutputStream(tempFile);
         diskOutputStream.write(rawData);
         try {

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseMetaDataTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseMetaDataTest.java
@@ -221,7 +221,8 @@ public class DatabaseMetaDataTest {
         assertEquals("__custom_1", res.getString("TYPE_NAME"));
       } else {
         assertEquals("___custom", res.getString("TYPE_NAME"));
-      }    }
+      }
+    }
     if (TestUtil.haveMinimumServerVersion(con, ServerVersion.v8_3)) {
       con.createArrayOf("custom", new Object[]{});
       res = dbmd.getColumns(null, null, "customtable", null);

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc42/DatabaseMetaDataTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc42/DatabaseMetaDataTest.java
@@ -104,9 +104,9 @@ public class DatabaseMetaDataTest {
     assertEquals("c", rs.getString("COLUMN_NAME"));
     // = array of TYPE test_enum AS ENUM ('value')
     if (TestUtil.haveMinimumServerVersion(conn, ServerVersion.v16)) {
-      assertEquals("_test_enum_1", rs.getString("TYPE_NAME"), "Correctly detects shadowed array type name");
+      assertEquals("Correctly detects shadowed array type name", "_test_enum_1", rs.getString("TYPE_NAME"));
     } else {
-      assertEquals("___test_enum", rs.getString("TYPE_NAME"), "Correctly detects shadowed array type name");
+      assertEquals("Correctly detects shadowed array type name", "___test_enum", rs.getString("TYPE_NAME"));
     }
     assertEquals("Correctly detects type of shadowed name", Types.ARRAY, rs.getInt("DATA_TYPE"));
 

--- a/test-gss/src/main/groovy/TestPostgres.groovy
+++ b/test-gss/src/main/groovy/TestPostgres.groovy
@@ -47,7 +47,7 @@ class TestPostgres {
         if (isMac)
             postgres = new Postgres()
         else
-            postgres = new Postgres('/usr/lib/postgresql/12/bin/', '/tmp/pggss')
+            postgres = new Postgres('/usr/lib/postgresql/16/bin/', '/tmp/pggss')
         /*
         make sure we can connect
          */


### PR DESCRIPTION
## What

Refresh the GitHub Actions workflows on `release/42.3.x` so CI runs on current GitHub-hosted runners, then fix the build and test failures that change uncovered. The action updates mirror `release/42.4.x`, adapted to the older 42.3 layout (no `matrix.js`, no `gradle-wrapper-validation.yml`).

GitHub Actions:
- `actions/checkout` → v4 in every workflow.
- `actions/setup-java` → v3 (all jobs except `buildcache.yml`, which keeps v1); `build-test` and `gss-encryption` now request the `zulu` distribution explicitly.
- Replace the standalone `docker-compose` binary with the `docker compose` plugin; the `docker-compose.yml` file name is unchanged.
- Drop PostgreSQL 8.4/9.0 and the self-hosted runners from the matrices.
- Run the CI workflow for pull requests targeting `release/*` branches (`pull_request` branch filter `*` → `**`). Without this the workflow never ran on this branch.

Build and tests (pre-existing failures the branch-filter change exposed):
- Pin `org.ajoberstar.grgit` to 4.1.1 so project configuration resolves; grgit 4.0.x was JCenter-only and is gone from Maven Central.
- GSS tests: install the `postgresql` meta-package and point the test-gss harness at `/usr/lib/postgresql/16/bin`.
- Drop the `RULE` privilege from `has_table_privilege` on PostgreSQL 18+, which removed it.
- Fix a checkstyle `RightCurly` violation, a `Files.createTempFile` nullness error flagged by the Checker Framework, and an `assertEquals` argument order in a metadata test.

## Why

The pinned `actions/checkout@v1/v2` and `actions/setup-java@v1/v2` run on Node runtimes the runners no longer provide, the standalone `docker-compose` binary is gone, and the PostgreSQL 8.4/9.0 images and self-hosted runners are unavailable. The `*` branch filter also meant the workflow never triggered on `release/42.3.x` pull requests, which hid build and test failures that only appear on current runners and PostgreSQL.

## How to verify

Every `main.yml` job is green on this PR: code style, CheckerFramework, source distribution, the JDK 8/11 test matrix, and GSS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)