### PR TITLE
ci: run GSS tests against the runner's default postgresql

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -201,7 +201,7 @@ jobs:
       if: ${{ matrix.gss == 'yes' }}
       run: |
         sudo apt -y update
-        sudo apt -y install krb5-kdc krb5-admin-server libkrb5-dev postgresql-12
+        sudo apt -y install krb5-kdc krb5-admin-server libkrb5-dev postgresql
     - name: 'Update hosts for GSS tests'
       if: ${{ matrix.gss == 'yes' }}
       run: |

--- a/test-gss/src/main/groovy/TestPostgres.groovy
+++ b/test-gss/src/main/groovy/TestPostgres.groovy
@@ -47,7 +47,7 @@ class TestPostgres {
         if (isMac)
             postgres = new Postgres()
         else
-            postgres = new Postgres('/usr/lib/postgresql/12/bin/', '/tmp/pggss')
+            postgres = new Postgres('/usr/lib/postgresql/16/bin/', '/tmp/pggss')
         /*
         make sure we can connect
          */


### PR DESCRIPTION
## What

Backport of 30ea40dd7013874815eeb9cd103a0c334674e488 (already on `release/42.5.x`) to `release/42.4.x`.

- `main.yml`: install the `postgresql` meta-package instead of `postgresql-12` for the GSS jobs.
- `test-gss/.../TestPostgres.groovy`: point the harness at `/usr/lib/postgresql/16/bin/` instead of `/12/bin/`.

## Why

`ubuntu-24.04` runners no longer ship `postgresql-12`, so the GSS jobs failed first at `apt install` (`Unable to locate package postgresql-12`) and then at `/usr/lib/postgresql/12/bin/initdb: No such file or directory`. The meta-package pulls PostgreSQL 16 on `ubuntu-24.04`, which lives under `/usr/lib/postgresql/16/bin/`. This matches `master` and `release/42.5.x`.

## How to verify

Run the `main` workflow with a `gss == 'yes'` matrix entry and confirm the GSS job installs PostgreSQL and reaches the test phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)