### PR TITLE
ci: update GitHub Actions and fix PostgreSQL 18 metadata query on release/42.2.x

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,8 +20,9 @@ jobs:
       with:
         fetch-depth: 50
     - name: 'Set up JDK 8'
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v3
       with:
+        distribution: zulu
         java-version: 8
     - uses: burrunan/gradle-cache-action@v3
       name: Verify code style
@@ -68,8 +69,9 @@ jobs:
       working-directory: docker
       run: docker compose up -d && docker compose logs
     - name: 'Set up JDK ${{ matrix.jdk }}'
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v3
       with:
+        distribution: zulu
         java-version: ${{ matrix.jdk }}
     - name: Prepare ssltest.local.properties
       run: echo enable_ssl_tests=true > ssltest.local.properties
@@ -96,8 +98,9 @@ jobs:
         with:
           fetch-depth: 50
       - name: 'Set up JDK 11'
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
+          distribution: zulu
           java-version: 11
       - uses: burrunan/gradle-cache-action@v3
         name: Run CheckerFramework
@@ -119,8 +122,9 @@ jobs:
         working-directory: docker
         run: docker compose up -d && docker compose logs
       - name: 'Set up JDK 11'
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
+          distribution: zulu
           java-version: 11
       - uses: burrunan/gradle-cache-action@v3
         name: Prepare source distribution
@@ -144,8 +148,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: 'Set up JDK 8'
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v3
       with:
+        distribution: zulu
         java-version: 8
     - name: 'Install software'
       run: sudo apt -y install krb5-kdc krb5-admin-server libkrb5-dev postgresql-16

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -153,7 +153,9 @@ jobs:
         distribution: zulu
         java-version: 8
     - name: 'Install software'
-      run: sudo apt -y install krb5-kdc krb5-admin-server libkrb5-dev postgresql-16
+      run: |
+        sudo apt -y update
+        sudo apt -y install krb5-kdc krb5-admin-server libkrb5-dev postgresql-16
     - name: 'Update hosts'
       run: |
         sudo -- sh -c "echo 127.0.0.1 localhost auth-test-localhost.postgresql.example.com > /etc/hosts"

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
@@ -1318,8 +1318,15 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
       select += " AND n.nspname LIKE " + escapeQuotes(schemaPattern);
     }
     if (connection.getHideUnprivilegedObjects()) {
-      select += " AND has_table_privilege(c.oid, "
-        + " 'SELECT, INSERT, UPDATE, DELETE, RULE, REFERENCES, TRIGGER')";
+      // The RULE privilege was removed from has_table_privilege() in PostgreSQL 18:
+      // https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=fefa76f70fdc75c91f80bddce2df7a8825205962
+      if (connection.getServerMajorVersion() < 18) {
+        select += " AND has_table_privilege(c.oid, "
+          + " 'SELECT, INSERT, UPDATE, DELETE, RULE, REFERENCES, TRIGGER')";
+      } else {
+        select += " AND has_table_privilege(c.oid, "
+          + " 'SELECT, INSERT, UPDATE, DELETE, REFERENCES, TRIGGER')";
+      }
     }
     orderby = " ORDER BY TABLE_TYPE,TABLE_SCHEM,TABLE_NAME ";
 


### PR DESCRIPTION
## What

- Bump `actions/setup-java` from v1 to v3 across the CI workflow, requesting the `zulu` distribution explicitly. `buildcache.yml` stays on v1 by design.
- Run `apt update` before installing the GSS test dependencies.
- Request the `RULE` privilege in `getTables`/`has_table_privilege` only on servers older than PostgreSQL 18.

## Why

- `actions/setup-java@v1` runs on a Node runtime that GitHub-hosted runners no longer provide, so those steps fail to start.
- `apt install` can fail when the runner's package index references versions the mirror has already dropped; `apt update` makes the GSS job resolve its dependencies reliably.
- PostgreSQL 18 removed the long-deprecated `RULE` privilege. CI runs against `postgres:latest`, which is now 18, so `getTables` with `hideUnprivilegedObjects` failed there with `unrecognized privilege type: RULE`. `RULE` has been a no-op since 8.2, so dropping it on 18+ changes nothing.

This mirrors the GitHub Actions and PostgreSQL 18 fixes already applied to release/42.3.x and master, adapted to the 42.2.x workflow layout. Several related items (`actions/checkout@v4`, `docker compose`, `postgresql-16` for GSS, the `Files.createTempFile` stub, the Gradle 7.6.6 / vlsi-release-plugins 1.90 bumps) are already on release/42.2.x and are not repeated here.

## How to verify

- The `RULE` premise, on PostgreSQL 18.4:
  - `SELECT has_table_privilege('pg_class'::regclass, 'SELECT, INSERT, UPDATE, DELETE, RULE, REFERENCES, TRIGGER')` → `ERROR: unrecognized privilege type: "RULE"`
  - the same call without `RULE` succeeds.
- CI: the `Code style`, `Ubuntu, PG latest`, `CheckerFramework`, `Source distribution`, and `gss encryption` jobs should start (no deprecated-runtime failure) and the metadata tests should pass against `postgres:latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)