### PR TITLE
build: pin grgit to 4.1.1 so the build can configure

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,6 +15,20 @@ import de.thetaphi.forbiddenapis.gradle.CheckForbiddenApis
 import de.thetaphi.forbiddenapis.gradle.CheckForbiddenApisExtension
 import org.postgresql.buildtools.JavaCommentPreprocessorTask
 
+buildscript {
+    // org.ajoberstar.grgit 4.0.x was published to JCenter only and is no longer
+    // available on Maven Central, so the stage-vote-release plugin's transitive
+    // grgit 4.0.1 fails to resolve. Pin grgit to 4.1.1, the oldest 4.x release
+    // that is still on Maven Central.
+    configurations.classpath {
+        resolutionStrategy.eachDependency {
+            if (requested.group == "org.ajoberstar.grgit") {
+                useVersion("4.1.1")
+            }
+        }
+    }
+}
+
 plugins {
     publishing
     // Verification


### PR DESCRIPTION
## What

Backport of 67dd0eea7e1b7d04776744bade1395ebb096d8fd (already on `release/42.3.x`) to `release/42.4.x`.

Add a `buildscript` block to `build.gradle.kts` that forces any `org.ajoberstar.grgit` dependency on the build classpath to `4.1.1`.

## Why

The `com.github.vlsi.stage-vote-release` plugin pulls `org.ajoberstar.grgit:grgit-gradle:4.0.1`, which needs `grgit-core:4.0.1`. Both 4.0.x artifacts were published to JCenter only and are gone from Maven Central, so project configuration fails with `Could not find org.ajoberstar.grgit:grgit-core:4.0.1`. 4.1.1 is the oldest 4.x release still on Maven Central, so pinning to it keeps the plugin behaviour unchanged while letting the build resolve.

## How to verify

With a JDK that suits the 42.4 toolchain (e.g. Java 11):

```
./gradlew :postgresql:compileJava
```

Before this change configuration fails at grgit resolution. After it the project configures and `:postgresql:compileJava` completes (verified locally, exit code 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)