### PR TITLE
ci: enable CI on release/42.4.x

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - '*'
+      - '**'
     paths-ignore:
       - 'docs/**'
       - '**/*.md'
@@ -12,7 +12,7 @@ on:
       - '.travis/**'
   pull_request:
     branches:
-      - '*'
+      - '**'
     paths-ignore:
       - 'docs/**'
       - '**/*.md'

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -364,7 +364,11 @@ allprojects {
                     "Copyright &copy; 1997-$lastEditYear PostgreSQL Global Development Group. All Rights Reserved."
                 if (JavaVersion.current() >= JavaVersion.VERSION_1_9) {
                     addBooleanOption("html5", true)
-                    links("https://docs.oracle.com/javase/9/docs/api/")
+                    // Do not register an external links() entry for the modular JDK API.
+                    // The sources are documented as the unnamed module (source 1.8); linking
+                    // them to the modular docs makes javadoc warn, and Oracle now redirects the
+                    // old non-modular URL. Either warning fails the build under -Xwerror, so the
+                    // link is dropped on JDK 9+ (master drops it on JDK 17+ for the same reason).
                 } else {
                     links("https://docs.oracle.com/javase/8/docs/api/")
                 }

--- a/pgjdbc/src/main/java/org/postgresql/util/StreamWrapper.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/StreamWrapper.java
@@ -52,7 +52,7 @@ public class StreamWrapper {
 
       if (memoryLength == -1) {
         final int diskLength;
-        final File tempFile = Files.createTempFile(TEMP_FILE_PREFIX, null).toFile();
+        final File tempFile = Files.createTempFile(TEMP_FILE_PREFIX, ".tmp").toFile();
         FileOutputStream diskOutputStream = new FileOutputStream(tempFile);
         diskOutputStream.write(rawData);
         try {

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseMetaDataTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseMetaDataTest.java
@@ -238,6 +238,7 @@ public class DatabaseMetaDataTest {
       } else {
         assertEquals("___custom", res.getString("TYPE_NAME"));
       }
+    }
   }
 
   @Test


### PR DESCRIPTION
## What

Make CI run and pass on `release/42.4.x` again. Four small, independent fixes, each surfaced once the previous one unblocked the pipeline:

1. `ci`: change the `push` and `pull_request` branch filters in `.github/workflows/main.yml` from `'*'` to `'**'`.
2. `test`: add the missing closing brace in `DatabaseMetaDataTest.testCustomArrayTypeInfo`.
3. `build`: drop the external Javadoc link on JDK 9+ so the `-Xwerror` Javadoc build stops failing.
4. `fix`: pass an explicit `".tmp"` suffix to `Files.createTempFile` so the Checker Framework job passes.

## Why

CI had never run on `release/42.4.x`, so several pre-existing breakages stayed hidden. Fixing the trigger exposed them one at a time:

- **Branch filter.** GitHub Actions treats `'*'` as "any characters except `/`". The `release/42.4.x` base branch contains a slash, so the `pull_request` filter never matched and the `CI` workflow did not run for PRs targeting this branch (for example #4136). `'**'` matches slashes; `release/42.3.x` already uses it.
- **Unbalanced brace.** Commit d70c1f0c3 (#3160) replaced an `assertEquals` with an `if/else` block and dropped the closing brace of `testCustomArrayTypeInfo`, so the test sources did not compile and every matrix job failed.
- **Javadoc under `-Xwerror`.** The sources are documented as the unnamed module (`source 1.8`). Linking them to an external JDK API made Javadoc fail two ways: Oracle now redirects the old `javase/9` URL, and the modular `javase/11` URL warns that an unnamed module links to named modules. Dropping the external link on JDK 9+ avoids both; references still resolve against the JDK on the module path. JDK 8 keeps its link. master drops the link on JDK 17+ for the same reason. Verified locally with JDK 17 and `-PfailOnJavadocWarning=true`.
- **Checker Framework.** `Files.createTempFile(TEMP_FILE_PREFIX, null)` was rejected with `[argument.type.incompatible]`. `".tmp"` is the suffix `createTempFile` already uses for a null argument, so behaviour is unchanged; master passes `".tmp"` here too.

## How to verify

The CI matrix on this PR now compiles, runs, and passes. After merge, open or update a PR against `release/42.4.x` (for example #4136) and confirm the `CI` workflow starts and is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)