### PR TITLE
42.4: publish to Maven Central via nmcp (OSSRH sunset)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,7 +79,7 @@ jobs:
         with:
           read-only: ${{ matrix.os == 'self-hosted' }}
           job-id: checker-jdk11
-          arguments: --scan --no-parallel --no-daemon -PenableCheckerframework classes -PjdkBuildVersion=11
+          arguments: --scan --no-parallel --no-daemon -PenableCheckerframework classes -PjdkBuildVersion=11 -PignoreJdkCheck
 
   source-distribution-check:
     name: 'Source distribution (JDK 17)'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -217,28 +217,41 @@ is used for releasing artifacts.
 
 ## Releasing a new version
 
+Releases go to Maven Central through the [Central Portal](https://central.sonatype.com/).
+OSSRH (`oss.sonatype.org`) is shut down, so this branch uploads with the
+[nmcp](https://github.com/GradleUp/nmcp) plugin rather than the old Nexus 2 staging flow.
+
 Prerequisites:
-- Java 8
+- Java 17 to launch Gradle (enforced in `settings.gradle.kts`). The driver is compiled with
+  the Java toolchain set by `jdkBuildVersion` in `gradle.properties`.
 - a PostgreSQL instance for running tests; it must have a user named `test` as well as a database named `test`
+- a Central Portal user token (not the retired OSSRH password) in the `ghNexusUsername` and
+  `ghNexusPassword` Gradle properties, plus a PGP signing key published to a public keyserver
 - ensure that the RPM packaging CI isn't failing at
   [copr web page](https://copr.fedorainfracloud.org/coprs/g/pgjdbc/pgjdbc-travis/builds/)
 
 ### Manual release procedure
 
-See details in [Stage Vote Release readme](https://github.com/vlsi/vlsi-release-plugins/tree/master/plugins/stage-vote-release-plugin#making-a-release-candidate)
+1. Set `pgjdbc.version` in `gradle.properties` to the release version and commit.
 
-Prepare release candidate:
+2. Build, sign, and upload the artifacts to the Central Portal:
 
-    ./gradlew prepareVote -Prc=1 -Pgh
+        ./gradlew :postgresql:publishAllPublicationsToCentralPortal \
+          -Prc=1 -PuseGpgCmd=true -Psigning.gnupg.keyName=<your-key-id>
 
-It will create a release candidate tag, push the artifacts to Maven Central and print the announcement draft.
-The staged repository will become open for smoke testing access at https://oss.sonatype.org/content/repositories/orgpostgresql-1082/
+   `-Prc=1` selects the release (non-snapshot) version and turns on signing. The upload is
+   `USER_MANAGED`, so nothing reaches Maven Central until you publish it in the next step.
 
-If staged artifacts look fine, release it
+3. Open the deployment at <https://central.sonatype.com/publishing>,
+   [smoke-test the staged artifacts](https://central.sonatype.org/publish/publish-portal-api/),
+   then publish it. If something is wrong, drop it, fix it and repeat.
 
-    ./gradlew publishDist -Prc=1 -Pgh
+4. Tag the release and push the tag to the pgjdbc repository:
 
-Then update version, and readme as required.
+        git tag REL<version>
+        git push origin REL<version>
+
+5. Bump `pgjdbc.version` (in `gradle.properties`) to the next development version and update the README as needed.
 
 ### Updating changelog
 

--- a/pgjdbc/build.gradle.kts
+++ b/pgjdbc/build.gradle.kts
@@ -23,12 +23,23 @@ plugins {
     id("com.github.vlsi.gettext")
     id("com.github.vlsi.gradle-extensions")
     id("com.github.vlsi.ide")
+    id("com.gradleup.nmcp")
 }
 
 buildscript {
     repositories {
         // E.g. for biz.aQute.bnd.builder which is not published to Gradle Plugin Portal
         mavenCentral()
+    }
+}
+
+nmcp {
+    publishAllPublications {
+        // Central Portal user token, reusing the credentials of the legacy release flow
+        username.set(providers.gradleProperty("ghNexusUsername"))
+        password.set(providers.gradleProperty("ghNexusPassword"))
+        // Upload and validate only; publish or drop the deployment from the Portal UI
+        publicationType.set("USER_MANAGED")
     }
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -27,6 +27,7 @@ pluginManagement {
         idv("org.jetbrains.gradle.plugin.idea-ext")
         idv("org.nosphere.gradle.github.actions")
         idv("org.owasp.dependencycheck")
+        id("com.gradleup.nmcp") version "0.0.9"
         kotlin("jvm") version "kotlin".v()
     }
 }
@@ -37,6 +38,14 @@ plugins {
     // See https://github.com/gradle/gradle/issues/17361
     id("com.gradle.enterprise") version "3.10.1"
     id("com.github.burrunan.s3-build-cache")
+}
+
+// nmcp (Central Portal publishing) does not resolve on Java 8, and the build compiles with
+// a Java 17 toolchain, so launching Gradle needs Java 17. The CheckerFramework job still runs
+// on Java 11 and passes -PignoreJdkCheck to skip this check.
+if (!startParameter.projectProperties.containsKey("ignoreJdkCheck") &&
+    JavaVersion.current() < JavaVersion.VERSION_17) {
+    throw UnsupportedOperationException("Please use Java 17 for launching Gradle when building pgjdbc, the current Java is ${JavaVersion.current().majorVersion}. To skip the check, add -PignoreJdkCheck")
 }
 
 // This is the name of a current project


### PR DESCRIPTION
## Why

OSSRH (`oss.sonatype.org`) was shut down on 30 June 2025. The `stage-vote-release` Nexus 2 staging flow (`prepareVote` / `publishDist`) no longer reaches Maven Central, so releases from this branch can no longer be published.

## What

- Add the [nmcp](https://github.com/GradleUp/nmcp) plugin and publish the signed `postgresql` publication straight to the Central Portal API. Version `0.0.9` is the last nmcp release compatible with this branch's Gradle.
- Reuse the existing `ghNexusUsername` / `ghNexusPassword` properties, which must now hold a Central Portal user token instead of the retired OSSRH password.
- Upload as `USER_MANAGED`: the deployment is validated and then published (or dropped) from the Portal UI.
- Update `CONTRIBUTING.md`: drop `prepareVote` / `publishDist` and the dead `oss.sonatype.org` staging URL; document the nmcp flow, manual tagging, and the Java 11 requirement.
- `stage-vote-release` stays in place for versioning, the `-SNAPSHOT` suffix, signing, and POM metadata.

## How to verify

On JDK 11 (nmcp 0.0.9 does not resolve on Java 8; Java 17 fails the javadoc check on this branch):

    ./gradlew :postgresql:publishAllPublicationsToCentralPortal \
      -Prc=1 -PuseGpgCmd=true -Psigning.gnupg.keyName=<key-id>

Verified end-to-end against a personal namespace (`io.github.vlsi`): the deployment reached `VALIDATED` with no errors, then dropped.