### PR TITLE
build: produce a multi-release jar from reduced-pom.xml on Java 11+

### DIFF
--- a/pgjdbc/reduced-pom.xml
+++ b/pgjdbc/reduced-pom.xml
@@ -163,17 +163,42 @@
                 <jdk>[11,)</jdk>
             </activation>
             <build>
-                <pluginManagement>
-                    <plugins>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-compiler-plugin</artifactId>
-                            <configuration>
-                                <release>${java.target.release}</release>
-                            </configuration>
-                        </plugin>
-                    </plugins>
-                </pluginManagement>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <executions>
+                            <!-- The base classes target Java 8 bytecode -->
+                            <execution>
+                                <id>default-compile</id>
+                                <configuration>
+                                    <release>${java.target.release}</release>
+                                </configuration>
+                            </execution>
+                            <!--
+                              On Java 11+ additionally compile the java.lang.ref.Cleaner-based
+                              implementation from src/main/java11 into META-INF/versions/11, so the
+                              resulting jar is a multi-release jar. multiReleaseOutput places the
+                              classes under META-INF/versions/11; the Multi-Release: true manifest
+                              entry comes from src/main/resources/META-INF/MANIFEST.MF.
+                              -->
+                            <execution>
+                                <id>compile-java11</id>
+                                <phase>compile</phase>
+                                <goals>
+                                    <goal>compile</goal>
+                                </goals>
+                                <configuration>
+                                    <release>11</release>
+                                    <compileSourceRoots>
+                                        <compileSourceRoot>${project.basedir}/src/main/java11</compileSourceRoot>
+                                    </compileSourceRoots>
+                                    <multiReleaseOutput>true</multiReleaseOutput>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
             </build>
         </profile>
         <!--


### PR DESCRIPTION
## Why

The source-distribution Maven build (`reduced-pom.xml`) compiled only the Java 8, `PhantomReference`-based `LazyCleanerImpl`. A jar built from the source tarball therefore never used the `java.lang.ref.Cleaner`-based implementation, even on Java 11+. The Gradle build already ships that implementation under `META-INF/versions/11`, so the two builds produced different artifacts.

## What

- Add a second `maven-compiler-plugin` execution to the `jdkge11` profile that compiles `src/main/java11` with `release` 11 and `multiReleaseOutput=true`, placing the classes in `META-INF/versions/11`.
- Uses only stock `maven-compiler-plugin` parameters (`compileSourceRoots`, `multiReleaseOutput`) — no extra plugins.
- No Gradle changes: the `java11` sources are already in the source tarball (with checker annotations stripped) and the bundled manifest already carries `Multi-Release: true`.

On Java 8 the `jdkge11` profile stays inactive, so the build keeps producing a plain (non-multi-release) jar, unchanged.

## How to verify

Built the source distribution, extracted it, and ran Maven on JDK 21 (Maven on JDK 25):

- `mvn package -DskipShadeDependencies=true` → `META-INF/versions/11/.../LazyCleanerImpl.class` present.
- `mvn package` (shade, the default, with `minimizeJar=true`) → the `versions/11` overlay survives.
- Bytecode major versions: base `52` (Java 8), `versions/11` `55` (Java 11).
- Manifest carries `Multi-Release: true`.
- Runtime on JDK 17 from the shaded jar loads the `Cleaner`-based implementation.
- `:postgresql:sourceDistributionTest` (`mvn verify`) succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)