### PR TITLE
chore: Add top level /scratch to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,5 +30,8 @@ release.properties
 dependency-reduced-pom.xml
 buildNumber.properties
 
+# Ignore local scratch files
+/scratch
+
 # Ignore folders used to build binaries for old Java
 /eclipsebin/


### PR DESCRIPTION
I always have a bunch of random scratch files as I'm experimenting with things. Nice to have a default place in the repo where they won't get accidentally added to a commit. So adding a top level `/scratch` that we can put anything we'd like in that will always be ignored but also won't get wiped by any build tooling (e.g., like /build or /out).