### PR TITLE
build: promote MethodCanBeStatic to error level

### DIFF
--- a/build-logic/verification/src/main/kotlin/build-logic.errorprone.gradle.kts
+++ b/build-logic/verification/src/main/kotlin/build-logic.errorprone.gradle.kts
@@ -31,11 +31,9 @@ if (!project.hasProperty("skipErrorprone")) {
                 disableWarningsInGeneratedCode.set(true)
                 errorproneArgs.add("-XepExcludedPaths:.*/translation/messages_.*.java")
                 error(
+                    "MethodCanBeStatic",
                     "PackageLocation",
                     "UnusedVariable",
-                )
-                enable(
-                    "MethodCanBeStatic",
                 )
                 disable(
                     "EqualsGetClass",


### PR DESCRIPTION
## What

Move the `MethodCanBeStatic` Error Prone check from `enable(...)` to the `error(...)` block in `build-logic.errorprone.gradle.kts`.

## Why

`MethodCanBeStatic` was only emitting a warning, which is easy to overlook. Promoting it to error level makes methods that can be made `static` fail the build, keeping the codebase consistent.

## Notes for reviewers

This affects the main `JavaCompile` tasks only; test code already has Error Prone disabled, so the new error level does not apply there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)