### PR TITLE
ci: group Renovate updates by Maven groupId

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,18 +9,17 @@
   "schedule": [
     "every 3 weeks on Monday"
   ],
+  "vulnerabilityAlerts": {
+    "description": "Security updates bypass the packageRules grouping below (Renovate resets their groupName), so apply the same groupId grouping to them here.",
+    "groupName": "{{{replace ':.*' '' depName}}} security"
+  },
   "packageRules": [
     {
-      "groupName": "logback",
-      "matchPackageNames": [
-        "ch.qos.logback{/,}**"
-      ]
-    },
-    {
-      "groupName": "com.github.vlsi",
-      "matchPackageNames": [
-        "com.github.vlsi{/,}**"
-      ]
+      "description": "Group every Maven update by its groupId by default. The more specific rules below run later and override this where a group must span several groupIds, pin a version, or stay disabled.",
+      "matchDatasources": [
+        "maven"
+      ],
+      "groupName": "{{{replace ':.*' '' depName}}}"
     },
     {
       "groupName": "checkerframework",
@@ -30,29 +29,11 @@
       "allowedVersions": "<4.0.0"
     },
     {
-      "groupName": "jmh",
-      "matchPackageNames": [
-        "org.openjdk.jmh{/,}**"
-      ]
-    },
-    {
       "groupName": "junit-bom",
       "matchPackageNames": [
         "org.junit:junit-bom"
       ],
       "allowedVersions": "<6.0.0"
-    },
-    {
-      "groupName": "com.gradleup.nmcp",
-      "matchPackageNames": [
-        "com.gradleup.nmcp{/,}**"
-      ]
-    },
-    {
-      "groupName": "pax-exam",
-      "matchPackageNames": [
-        "org.ops4j.pax.exam{/,}**"
-      ]
     },
     {
       "matchPackageNames": [


### PR DESCRIPTION
## What

- Add a default `packageRule` that groups every Maven update by its `groupId` using `{{{replace ':.*' '' depName}}}`.
- Apply the same grouping to security updates via `vulnerabilityAlerts`, since Renovate resets their `groupName` and would otherwise open one PR per artifact.
- Remove redundant single-`groupId` rules now covered by the default (`logback`, `com.github.vlsi`, `jmh`, `com.gradleup.nmcp`, `pax-exam`).

## Why

Previously each grouped dependency needed its own `packageRule` listing the package prefix. Grouping by `groupId` by default keeps related artifacts in a single PR automatically and trims the config.

## Kept on purpose

Rules that do more than group remain:
- `checkerframework`, `junit-bom` — pin `allowedVersions`.
- `org.postgresql:postgresql`, `system-stubs-jupiter` — version-specific enable/disable.

## Notes

Validated with `renovate-config-validator`. Approach mirrors apache/jmeter#6710.

🤖 Generated with [Claude Code](https://claude.com/claude-code)