### PR TITLE
Fix deleting temp file when spooling large stream to disk in StreamWrapper

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/util/StreamWrapper.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/StreamWrapper.java
@@ -60,7 +60,7 @@ public final class StreamWrapper implements Closeable {
             throw new PSQLException(GT.tr("Object is too large to send over the protocol."),
                 PSQLState.NUMERIC_CONSTANT_OUT_OF_RANGE);
           }
-        } catch (RuntimeException | Error | PSQLException e) {
+        } catch (RuntimeException | Error | PSQLException | IOException e) {
           try {
             tempFile.toFile().delete();
           } catch (Throwable ignore) {


### PR DESCRIPTION
The cleanup block catches the rest of exception types but is noticeably missing handling for `IOException`. So if there's an error writing to the file, the temp file will stay on disk. Even though it's a checked exception, this wasn't noticed because the outer try-catch handling `IOException`.

Fix is to just add that additional exception type in the catch. It'll get rethrown immediately after attempting to remove the temp file so there's no change in error handling behavior either.