### PR TITLE
test: silence expected SSPI warning stack trace in SSPIClientWaffleTest

### DIFF
--- a/pgjdbc/src/test/java/org/postgresql/test/sspi/SSPIClientWaffleTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/sspi/SSPIClientWaffleTest.java
@@ -78,12 +78,18 @@ class SSPIClientWaffleTest {
     };
     handler.setLevel(Level.ALL);
     logger.addHandler(handler);
+    // The probe logs the expected ClassNotFoundException at WARNING. Keep it from reaching the
+    // console handlers so the deliberate failure does not show up as stderr noise in the build;
+    // the locally added handler still captures the record for the assertion below.
+    boolean useParentHandlers = logger.getUseParentHandlers();
+    logger.setUseParentHandlers(false);
     try {
       assertFalse(isWaffleAvailable(new WaffleHidingClassLoader(getClass().getClassLoader())));
       boolean warned = records.stream().anyMatch(record -> record.getLevel() == Level.WARNING
           && String.valueOf(record.getMessage()).contains(UNAVAILABLE_MESSAGE));
       assertTrue(warned, "expected a WARNING containing: " + UNAVAILABLE_MESSAGE);
     } finally {
+      logger.setUseParentHandlers(useParentHandlers);
       logger.removeHandler(handler);
     }
   }


### PR DESCRIPTION
## Problem

`SSPIClientWaffleTest.reportsUnavailableAndWarnsWhenWaffleIsMissing()` deliberately hides the `waffle.*` packages via a custom classloader to verify that `SSPIClient.isWaffleAvailable()` degrades gracefully. As designed, the probe logs the expected `ClassNotFoundException` at `WARNING`.

That record propagates to the root console handler, so the build output shows a full stack trace on stderr:

```
AVERTISSEMENT: SSPI unavailable (no Waffle/JNA libraries?)
java.lang.ClassNotFoundException: waffle.windows.auth.impl.WindowsSecurityContextImpl
    at ...SSPIClientWaffleTest$WaffleHidingClassLoader.loadClass(...)
    ...
```

The exception is expected — it is the whole point of the negative test — but the stack trace reads like a real failure.

## Fix

Disable parent-handler propagation on the `org.postgresql.sspi.SSPIClient` logger for the duration of the test and restore it in `finally`. The locally added handler still captures the record, so the `WARNING`-was-emitted assertion is unchanged.

This keeps the change narrowly scoped to a single leaf logger, so `@Isolated` is not required: nothing else logs through `org.postgresql.sspi.SSPIClient` concurrently (the default JUnit execution mode is `SAME_THREAD`, and `SSPITest` is Windows-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)