### PR TITLE
fix(build): restore checker-qual and waffle-jna in the published pom

### DIFF
--- a/build-logic/publishing/src/main/kotlin/build-logic.java-shaded-published-library.gradle.kts
+++ b/build-logic/publishing/src/main/kotlin/build-logic.java-shaded-published-library.gradle.kts
@@ -29,15 +29,24 @@ publishing {
     }
 }
 
-// Shadow plugin configures shadowRuntimeElements in afterEvaluate,
-// so we must defer from(components["shadow"]) to afterEvaluate as well.
-// This afterEvaluate is registered after Shadow's (since Shadow is applied
-// in the plugins block above), so it runs after Shadow has finished configuring.
+// Publish the `java` component rather than Shadow's `shadow` component. The `shadow` component
+// flattens Gradle feature variants and drops the unshaded runtime dependencies, so the pom would
+// omit waffle-jna (the sspi feature variant) and checker-qual. The `java` component maps the
+// feature variant to an optional pom dependency and lists checker-qual, while the shaded
+// dependencies live in a separate configuration that never reaches the runtime classpath and so
+// stay out of the pom. The published main jar is replaced with the OSGi bundle by the consuming
+// project.
+//
+// from(components[...]) eagerly populates the publication, which prevents Shadow from amending the
+// Gradle Module Metadata it configures in its own afterEvaluate. Deferring our from() to a later
+// afterEvaluate (registered after Shadow's, since Shadow is applied in the plugins block above)
+// lets Shadow finish first. The sources and javadoc jars are added explicitly because Gradle
+// Module Metadata is disabled, so the component's secondary variants are not published on their own.
 afterEvaluate {
     publishing {
         publications {
             named<MavenPublication>(project.name) {
-                from(components["shadow"])
+                from(components["java"])
 
                 artifact(tasks.named<Jar>("sourcesJar"))
 

--- a/pgjdbc/build.gradle.kts
+++ b/pgjdbc/build.gradle.kts
@@ -463,3 +463,64 @@ val extraMavenPublications by configurations.getting
         classifier = "features"
     }
 }
+
+// Guards the published pom against accidental dependency leaks/losses. The driver shades its
+// compile dependencies, so the pom should declare only the two unshaded runtime dependencies:
+// checker-qual (its @Nullable annotations stay in the bytecode) and waffle-jna (the optional SSPI
+// dependency). Versions are intentionally ignored, so dependency bumps do not require touching the
+// expectation; update the list below only when the set of unshaded runtime dependencies changes.
+val verifyPublishedPomDependencies by tasks.registering {
+    description = "Verifies the published pom declares exactly the expected runtime dependencies"
+    group = LifecycleBasePlugin.VERIFICATION_GROUP
+
+    val pomFile =
+        tasks.named<org.gradle.api.publish.maven.tasks.GenerateMavenPom>(
+            "generatePomFileFor${project.name.replaceFirstChar { it.uppercase() }}Publication"
+        ).map { it.destination }
+    inputs.file(pomFile)
+
+    val expected = listOf(
+        "com.github.waffle:waffle-jna scope=runtime optional=true",
+        "org.checkerframework:checker-qual scope=runtime optional=false"
+    )
+
+    doLast {
+        fun org.w3c.dom.Element.childText(tag: String): String? =
+            (0 until childNodes.length).asSequence()
+                .mapNotNull { childNodes.item(it) as? org.w3c.dom.Element }
+                .firstOrNull { it.tagName == tag }
+                ?.textContent
+                ?.trim()
+
+        val document = javax.xml.parsers.DocumentBuilderFactory.newInstance()
+            .newDocumentBuilder()
+            .parse(pomFile.get())
+
+        // Only the project-level <dependencies>, not <dependencyManagement>
+        val dependencies = (0 until document.documentElement.childNodes.length).asSequence()
+            .mapNotNull { document.documentElement.childNodes.item(it) as? org.w3c.dom.Element }
+            .firstOrNull { it.tagName == "dependencies" }
+
+        val actual = (dependencies?.getElementsByTagName("dependency")?.let { nodes ->
+            (0 until nodes.length).map { nodes.item(it) as org.w3c.dom.Element }
+        } ?: emptyList()).map { dependency ->
+            val group = dependency.childText("groupId")
+            val artifact = dependency.childText("artifactId")
+            val scope = dependency.childText("scope") ?: "compile"
+            val optional = dependency.childText("optional") ?: "false"
+            "$group:$artifact scope=$scope optional=$optional"
+        }.sorted()
+
+        if (actual != expected.sorted()) {
+            throw GradleException(
+                "Published pom dependencies changed.\n" +
+                    "Expected:\n  ${expected.sorted().joinToString("\n  ")}\n" +
+                    "Actual:\n  ${actual.joinToString("\n  ").ifEmpty { "(none)" }}"
+            )
+        }
+    }
+}
+
+tasks.named("check") {
+    dependsOn(verifyPublishedPomDependencies)
+}


### PR DESCRIPTION
## Why

The published `postgresql` pom stopped declaring its two unshaded runtime dependencies. Commit pgjdbc/pgjdbc@fd1946946 ("chore: use different wiring for com.gradleup.shadow to support Gradle 9.4.1") switched the Maven publication from the `java` component to Shadow's `shadow` component. That component flattens Gradle feature variants and drops unshaded runtime dependencies, so the pom lost:

- `org.checkerframework:checker-qual` — its `@Nullable` type annotations remain in the published bytecode (`RuntimeVisibleTypeAnnotations`), so the class must be resolvable;
- `com.github.waffle:waffle-jna` — the optional SSPI dependency, previously `runtime` + `optional`.

The regression first shipped in 42.7.11; 42.7.10 still had both. This is the same pom-hygiene concern raised in #3787 (whose original junit complaint was already fixed by the Shadow 9 migration in 42.7.10).

## What

- Publish the `java` component again. It maps the `sspi` feature variant to an optional pom dependency and lists `checker-qual`, while the shaded scram stays in a separate `shaded` configuration that never reaches the runtime classpath and so stays out of the pom. The published main jar is still replaced with the OSGi bundle.
- Defer `from()` to a later `afterEvaluate` so Shadow finishes amending its Gradle Module Metadata first. Populating the publication eagerly fails with `Gradle Module Metadata can't be modified after an eagerly populated publication` — the error the original change worked around.
- Add a `verifyPublishedPomDependencies` task (wired into `check`) that compares the pom dependencies, ignoring versions, against the expected set, so the leak cannot return unnoticed.

The resulting pom declares exactly:

```xml
<dependency>
  <groupId>org.checkerframework</groupId>
  <artifactId>checker-qual</artifactId>
  <version>3.55.1</version>
  <scope>runtime</scope>
</dependency>
<dependency>
  <groupId>com.github.waffle</groupId>
  <artifactId>waffle-jna</artifactId>
  <version>1.9.1</version>
  <scope>runtime</scope>
  <optional>true</optional>
</dependency>
```

## How to verify

```
./gradlew :postgresql:verifyPublishedPomDependencies
./gradlew :postgresql:publishPostgresqlPublicationToTmp-mavenRepository
```

The published main jar keeps its OSGi bundle headers and the shaded scram classes; `-sources.jar`, `-javadoc.jar`, `-features.xml`, and `-jdbc-src.tar.gz` are unchanged.

Relates to #3787

🤖 Generated with [Claude Code](https://claude.com/claude-code)
