### PR TITLE
docs: note PKCS-12 client certificate chain requirement

### DIFF
--- a/certdir/Makefile
+++ b/certdir/Makefile
@@ -23,6 +23,8 @@ clean:
 
 %.p12 : %.crt
 	@echo Exporting certificate $@
+	# These clients are signed directly by the root CA, so the .p12 needs no extra chain.
+	# With intermediate CAs, add `-certfile <intermediate-chain>.crt` so the server can build the chain.
 	openssl pkcs12 -export -in $< -inkey $*.key -out $@ -name user -CAfile $(SERVER_CRT_DIR)root.crt -caname local -passout pass:$(P12_PASSWORD)
 
 %root.key :

--- a/docs/content/documentation/ssl.md
+++ b/docs/content/documentation/ssl.md
@@ -98,6 +98,10 @@ For any other extension (including ".key"), the driver inspects the first 64 KiB
 > When using a PKCS-12 client certificate the name or alias *MUST* be `user` when using `openssl pkcs12 -export -name user ...`
 There are complete examples of how to export the certificate in the [certdir](https://raw.githubusercontent.com/pgjdbc/pgjdbc/master/certdir/Makefile) Makefile
 
+> **NOTE**
+>
+> The `.p12` archive must hold the full client certificate chain. When the client certificate is signed by one or more intermediate CAs, add `-certfile <intermediate-chain>.crt` to the `openssl pkcs12 -export` command. Without the intermediates the server rejects the connection with `connection requires a valid client certificate`.
+
 Finer control of the SSL connection can be achieved using the `sslmode` connection parameter.
 This parameter is the same as the libpq `sslmode` parameter and currently implements the
 following

--- a/docs/content/documentation/use.md
+++ b/docs/content/documentation/use.md
@@ -146,6 +146,10 @@ The auto-detection scan is bounded to avoid excessive work on malformed files. T
 > When you create a PKCS-12 key the `alias` or the `name` must be *user*. The test codes uses the following to create a .p12 key `openssl pkcs12 -export -in $< -inkey $*.key -out $@ -name user -CAfile $(SERVER_CRT_DIR)root.crt -caname local -passout pass:$(P12_PASSWORD)`
  A PEM key can be converted to DER format using the openssl command: `openssl pkcs8 -topk8 -inform PEM -in postgresql.key -outform DER -out postgresql.pk8 -v1 PBE-MD5-DES`
 
+> **NOTE**
+>
+> The `.p12` archive must hold the full client certificate chain. When the client certificate is signed by one or more intermediate CAs, add `-certfile <intermediate-chain>.crt` to the `openssl pkcs12 -export` command. Without the intermediates the server rejects the connection with `connection requires a valid client certificate`. The example above needs no `-certfile` because the test certificate is signed directly by the root CA.
+
 If your key has a password, provide it using the `sslpassword` connection parameter described below. Otherwise, you can add the flag `-nocrypt` to the above command to prevent the driver from requesting a password.
 
 > **NOTE**


### PR DESCRIPTION
## Why

The `openssl pkcs12 -export` example in the SSL docs (and the `certdir/Makefile` it points to) exports only the leaf client certificate. When that certificate is signed by one or more intermediate CAs, the resulting `.p12` omits the chain, so the server cannot build a path to a trusted root and rejects the handshake with `connection requires a valid client certificate`. Reported in #3795.

## What

- `docs/content/documentation/use.md`, `docs/content/documentation/ssl.md`: add a NOTE explaining that the `.p12` must hold the full client certificate chain, and that `-certfile <intermediate-chain>.crt` adds the intermediates.
- `certdir/Makefile`: add a comment recording why the test setup needs no `-certfile` (clients are signed directly by the root CA) and where it would go otherwise.

The example command is left unchanged: the test certificates have no intermediate CA, so adding `-certfile` there would reference a file that does not exist.

The issue's second request — documenting that the PKCS-12 alias must be `user` — is already covered by existing NOTEs on both pages, so it needs no further change.

## How to verify

Docs-only change; render `docs/content/documentation/use.md` and `ssl.md` and confirm the new NOTE reads correctly next to the existing PKCS-12 guidance.

Closes #3795

🤖 Generated with [Claude Code](https://claude.com/claude-code)