### PR TITLE
refactor(metadata): derive getPrimaryKeys from pg_constraint.conkey

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
@@ -2422,10 +2422,6 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
     if (catalog != null && !catalog.equals(currentCatalog)) {
       return ((BaseStatement) createMetaDataStatement()).createDriverResultSet(f, v);
     }
-    // Version 11 added "include columns" in index hence we need to filter only the key attributes
-    // when returning primary keys.
-    String keyCountColumn = connection.haveMinimumServerVersion(ServerVersion.v11) ? "i.indnkeyatts" : "i.indnatts";
-
     StringBuilder sql = new StringBuilder();
     sql.append(
         // language=sql
@@ -2439,18 +2435,19 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
             + "FROM "
             + "     (");
     sql.append(
+        // pg_constraint.conkey lists the primary-key columns only: it excludes INCLUDE columns,
+        // which live in the backing index but are not part of the key, so no extra filtering by
+        // key count is needed.
         // language=sql
         "SELECT current_database() AS TABLE_CAT, n.nspname AS TABLE_SCHEM, "
           + "  ct.relname AS TABLE_NAME, a.attname AS COLUMN_NAME, "
-          + "  (information_schema._pg_expandarray(i.indkey)).n AS KEY_SEQ, ci.relname AS PK_NAME, "
-          + "  information_schema._pg_expandarray(i.indkey) AS KEYS, a.attnum AS A_ATTNUM, "
-          + keyCountColumn + " as KEY_COUNT "
-          + "FROM pg_catalog.pg_class ct "
-          + "  JOIN pg_catalog.pg_attribute a ON (ct.oid = a.attrelid) "
+          + "  (information_schema._pg_expandarray(con.conkey)).n AS KEY_SEQ, con.conname AS PK_NAME, "
+          + "  information_schema._pg_expandarray(con.conkey) AS KEYS, a.attnum AS A_ATTNUM "
+          + "FROM pg_catalog.pg_constraint con "
+          + "  JOIN pg_catalog.pg_class ct ON (con.conrelid = ct.oid) "
           + "  JOIN pg_catalog.pg_namespace n ON (ct.relnamespace = n.oid) "
-          + "  JOIN pg_catalog.pg_index i ON ( a.attrelid = i.indrelid) "
-          + "  JOIN pg_catalog.pg_class ci ON (ci.oid = i.indexrelid) "
-          + "WHERE true ");
+          + "  JOIN pg_catalog.pg_attribute a ON (a.attrelid = ct.oid) "
+          + "WHERE con.contype = 'p' ");
 
     List<String> args = new ArrayList<>(2);
     if (schema != null) {
@@ -2463,11 +2460,10 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
       args.add(table);
     }
 
-    sql.append(" AND i.indisprimary ");
     sql.append(
         " ) result"
             + " where "
-            + " result.A_ATTNUM = (result.KEYS).x AND result.KEY_SEQ <= KEY_COUNT ");
+            + " result.A_ATTNUM = (result.KEYS).x ");
     sql.append(" ORDER BY result.table_name, result.pk_name, result.key_seq");
 
     return executeMetadataStatement(sql.toString(), args);


### PR DESCRIPTION
## Why

`getPrimaryKeys` reconstructs the primary-key columns from `pg_index.indkey`, then trims INCLUDE columns (PostgreSQL 11+) with a server-version-dependent count column: `indnkeyatts` on v11+, `indnatts` otherwise (added in #3434).

That has two drawbacks:

- It depends on the reported server version and on `indnatts`/`indnkeyatts` being populated. Some PostgreSQL-compatible engines report a server version below 11 yet leave `indnatts` at 0, so the `KEY_SEQ <= indnatts` filter drops every row and `getPrimaryKeys` returns an empty set. This is the compatibility problem #3533 set out to fix.
- It carries an extra version branch and two joins that are not needed.

## What

Read the key columns from `pg_constraint.conkey` instead of `pg_index.indkey`. `conkey` already lists exactly the primary-key columns (INCLUDE columns live in the backing index but are not part of the constraint), so:

- the `ServerVersion.v11` branch and the `KEY_SEQ <= key-count` filter are gone;
- the `pg_index` join and the second `pg_class` join (for the index name) are gone; `PK_NAME` now comes from `con.conname`, which equals the index name for every primary key;
- the result no longer depends on `indnatts`, `indnkeyatts`, or the reported server version.

Net: one fewer join and a marginally cheaper plan for the single-table lookup the API always performs. `EXPLAIN ANALYZE` on a table with a composite key plus several secondary indexes touched 12 shared buffers versus 54 for the old query.

## How to verify

Existing tests in `DatabaseMetaDataTest` cover the relevant cases: `primaryKeys` (system catalog), `primaryKeysWithIncludeColumns` (INCLUDE columns excluded), and `partitionedTablesIndex` / `partitionedTables` (`measurement_pkey`).

I also diffed the new query against the current one across a full database on PostgreSQL 11 and 17. They return identical rows for every user table: single-column and composite keys (including reversed key order), INCLUDE columns, named constraints, `ADD PRIMARY KEY USING INDEX`, partitioned tables, and same-named constraints across schemas. The only difference is `pg_toast`, whose internal indexes have no `pg_constraint` row. `getPrimaryKeys` always takes a concrete table name, and callers do not query `pg_toast_*`.

Supersedes #3533. That PR rewrote the query around `information_schema.key_column_usage`; this route keeps the parameterised query and avoids two issues I found while reviewing it: the unqualified join `pg_class_key.relname = constraint_name` duplicates rows for same-named constraints across schemas, and `information_schema` filters by privileges. I also checked CrateDB 6.3.3: it now reports server version 14 and populates `indnkeyatts`, so the original query already works there, while this `conkey` version is robust regardless of the reported version.
