### PR TITLE
fix: skip autosave savepoint for SET LOCAL/SESSION TRANSACTION (#3307)

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -509,13 +509,17 @@ public class QueryExecutorImpl extends QueryExecutorBase {
       return true;
     }
     String sql = query.getNativeSql();
-    // SET TRANSACTION ISOLATION LEVEL and SET SESSION CHARACTERISTICS cannot be called in subtransaction
+    // SET TRANSACTION ISOLATION LEVEL and SET SESSION CHARACTERISTICS cannot be called in subtransaction.
+    // The optional LOCAL/SESSION qualifier (SET LOCAL TRANSACTION, SET SESSION TRANSACTION) hits the same
+    // restriction, so all of those forms must not be preceded by an automatic SAVEPOINT either.
     // SAVEPOINT commands cannot use autosave because:
     // - SAVEPOINT: releasing the autosave would destroy the user's savepoint (created after autosave)
     // - RELEASE SAVEPOINT: same issue, plus the released savepoint might no longer exist
     // - ROLLBACK TO SAVEPOINT: destroys savepoints created after the target, including autosave
     return "COMMIT".equalsIgnoreCase(sql)
         || startsWithIgnoreCase(sql, "SET TRANSACTION")
+        || startsWithIgnoreCase(sql, "SET LOCAL TRANSACTION")
+        || startsWithIgnoreCase(sql, "SET SESSION TRANSACTION")
         || startsWithIgnoreCase(sql, "SET SESSION CHARACTERISTICS")
         || startsWithIgnoreCase(sql, "SAVEPOINT")
         || startsWithIgnoreCase(sql, "RELEASE")

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/AutoSaveTransactionSettingsTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/AutoSaveTransactionSettingsTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2026, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.test.jdbc2;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import org.postgresql.PGProperty;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.sql.Connection;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Properties;
+
+/**
+ * Tests for GitHub issue #3307: with {@code autosave=always} the driver injected a
+ * {@code SAVEPOINT PGJDBC_AUTOSAVE} before a {@code SET TRANSACTION ISOLATION LEVEL} statement, so
+ * the statement failed with "SET TRANSACTION ISOLATION LEVEL must not be called in a subtransaction".
+ *
+ * <p>The same server-side restriction applies to the {@code SET LOCAL TRANSACTION ...} and
+ * {@code SET SESSION TRANSACTION ...} forms, so none of them must be preceded by an automatic
+ * savepoint.</p>
+ *
+ * @see <a href="https://github.com/pgjdbc/pgjdbc/issues/3307">Issue #3307</a>
+ */
+@ParameterizedClass
+@MethodSource("data")
+class AutoSaveTransactionSettingsTest extends BaseTest4 {
+  AutoSaveTransactionSettingsTest(BinaryMode binaryMode) {
+    setBinaryMode(binaryMode);
+  }
+
+  static Iterable<Arguments> data() {
+    Collection<Arguments> ids = new ArrayList<>();
+    for (BinaryMode binaryMode : BinaryMode.values()) {
+      ids.add(arguments(binaryMode));
+    }
+    return ids;
+  }
+
+  @Override
+  protected void updateProperties(Properties props) {
+    super.updateProperties(props);
+    PGProperty.AUTOSAVE.set(props, "always");
+  }
+
+  @Test
+  void setTransactionIsolationLevelAsFirstStatement() throws Exception {
+    assertIsolationLevelCanBeSet("SET TRANSACTION ISOLATION LEVEL SERIALIZABLE READ ONLY DEFERRABLE");
+  }
+
+  @Test
+  void setLocalTransactionIsolationLevelAsFirstStatement() throws Exception {
+    assertIsolationLevelCanBeSet("SET LOCAL TRANSACTION ISOLATION LEVEL SERIALIZABLE READ ONLY DEFERRABLE");
+  }
+
+  @Test
+  void setSessionTransactionIsolationLevelAsFirstStatement() throws Exception {
+    assertIsolationLevelCanBeSet("SET SESSION TRANSACTION ISOLATION LEVEL SERIALIZABLE");
+  }
+
+  /**
+   * Runs {@code sql} as the very first statement of a transaction with {@code autosave=always}. The
+   * statement must reach the server without a preceding {@code SAVEPOINT}, otherwise the server
+   * rejects it as called in a subtransaction.
+   */
+  private void assertIsolationLevelCanBeSet(String sql) throws Exception {
+    con.setAutoCommit(false);
+    try (Statement stmt = con.createStatement()) {
+      assertDoesNotThrow(() -> stmt.execute(sql),
+          () -> "autosave=always must not inject a SAVEPOINT before \"" + sql + "\"");
+      assertEquals(Connection.TRANSACTION_SERIALIZABLE, con.getTransactionIsolation(),
+          "transaction isolation level should be SERIALIZABLE after \"" + sql + "\"");
+    }
+    con.commit();
+  }
+}


### PR DESCRIPTION
## Problem

With `autosave=always`, a `SET TRANSACTION ISOLATION LEVEL ...` issued as the first statement of a transaction failed with:

```
ERROR: SET TRANSACTION ISOLATION LEVEL must not be called in a subtransaction
```

The driver wrapped the statement in `SAVEPOINT PGJDBC_AUTOSAVE`, and PostgreSQL forbids `SET TRANSACTION` inside a subtransaction.

`isSpecialQuery()` was already taught to skip the savepoint for `SET TRANSACTION`, but the optional `LOCAL`/`SESSION` qualifier hits the *same* server-side restriction and was still being wrapped:

| Statement inside a `SAVEPOINT` | Server result | Skipped autosave before this fix? |
| --- | --- | --- |
| `SET TRANSACTION ISOLATION LEVEL ...` | error | yes |
| `SET LOCAL TRANSACTION ISOLATION LEVEL ...` | error | **no** |
| `SET SESSION TRANSACTION ISOLATION LEVEL ...` | error | **no** |

The reproduction in #3307 uses the `SET LOCAL TRANSACTION ...` form, so that exact case was still broken.

## Fix

Recognise the optional `LOCAL`/`SESSION` qualifier in `isSpecialQuery()`, so `SET LOCAL TRANSACTION ...` and `SET SESSION TRANSACTION ...` are no longer preceded by an automatic savepoint.

## Test

`AutoSaveTransactionSettingsTest` (extends `BaseTest4`, runs across all binary modes) executes each of the three forms as the first statement of a transaction with `autosave=always` and asserts it reaches the server. Without the production change, the `SET LOCAL` and `SET SESSION` cases fail; with it, all pass.

This supersedes #3370, which detected the statement with `getNativeSql().toLowerCase().contains("isolation")` — too broad (matches any query containing the substring, e.g. a table named `isolation_log`) and adds a `toLowerCase()` scan to every execute.

Closes #3307

🤖 Generated with [Claude Code](https://claude.com/claude-code)