### PR TITLE
fix(largeobject): correct BlobInputStream mark/reset position and add efficient skip

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/fastpath/Fastpath.java
+++ b/pgjdbc/src/main/java/org/postgresql/fastpath/Fastpath.java
@@ -53,6 +53,18 @@ public class Fastpath {
   }
 
   /**
+   * Returns the numeric version of the connected server, for example {@code 90300} for 9.3.
+   *
+   * <p>The value is negotiated at connection startup, so reading it costs no round-trip. Use it to
+   * pick between fastpath functions that exist only on newer servers, such as {@code lo_tell64}.</p>
+   *
+   * @return the server version number
+   */
+  public int getServerVersionNum() {
+    return executor.getServerVersionNum();
+  }
+
+  /**
    * Send a function call to the PostgreSQL backend.
    *
    * @param fnId Function id

--- a/pgjdbc/src/main/java/org/postgresql/largeobject/BlobInputStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/largeobject/BlobInputStream.java
@@ -13,11 +13,14 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.sql.SQLException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * This is an implementation of an InputStream from a large object.
  */
 public class BlobInputStream extends InputStream {
+  private static final Logger LOGGER = Logger.getLogger(BlobInputStream.class.getName());
   static final int DEFAULT_MAX_BUFFER_SIZE = 512 * 1024;
   static final int INITIAL_BUFFER_SIZE = 64 * 1024;
 
@@ -28,9 +31,10 @@ public class BlobInputStream extends InputStream {
   private final ResourceLock lock = new ResourceLock();
 
   /**
-   * The absolute position.
+   * The absolute position. A negative value means the position has not been initialised yet;
+   * {@link #getLo()} reads it lazily from the LargeObject on first use.
    */
-  private long absolutePosition;
+  private long absolutePosition = -1;
 
   /**
    * Buffer used to improve performance.
@@ -54,14 +58,14 @@ public class BlobInputStream extends InputStream {
   private final int maxBufferSize;
 
   /**
-   * The mark position.
+   * The mark position. Initialised together with {@link #absolutePosition} in {@link #getLo()}.
    */
-  private long markPosition;
+  private long markPosition = -1;
 
   /**
-   * The limit.
+   * The limit, relative to the initial position. Resolved to an absolute value in {@link #getLo()}.
    */
-  private final long limit;
+  private long limit;
 
   /**
    * @param lo LargeObject to read from
@@ -76,7 +80,7 @@ public class BlobInputStream extends InputStream {
    */
 
   public BlobInputStream(LargeObject lo, int bsize) {
-    this(lo, bsize, Long.MAX_VALUE);
+    this(lo, bsize, -1);
   }
 
   /**
@@ -90,8 +94,9 @@ public class BlobInputStream extends InputStream {
     // The very first read multiplies the last buffer size by two, so we divide by two to get
     // the first read to be exactly the initial buffer size
     this.lastBufferSize = INITIAL_BUFFER_SIZE / 2;
-    // Treat -1 as no limit for backward compatibility
-    this.limit = limit == -1 ? Long.MAX_VALUE : limit;
+    // The limit and position are resolved lazily by getLo(), as the initial position depends on
+    // the LargeObject and reading it can fail. -1 means "no limit".
+    this.limit = limit;
   }
 
   /**
@@ -288,7 +293,14 @@ public class BlobInputStream extends InputStream {
   @Override
   public void mark(int readlimit) {
     try (ResourceLock ignore = lock.obtain()) {
-      markPosition = absolutePosition;
+      // mark() must not throw, but initialising the position can fail. Log and leave the mark
+      // unset; the next read/reset surfaces the underlying error as a checked IOException.
+      try {
+        getLo();
+        markPosition = absolutePosition;
+      } catch (IOException e) {
+        LOGGER.log(Level.SEVERE, "Failed to set mark position", e);
+      }
     }
   }
 
@@ -304,13 +316,14 @@ public class BlobInputStream extends InputStream {
     try (ResourceLock ignore = lock.obtain()) {
       LargeObject lo = getLo();
       long loId = lo.getLongOID();
+      // Invalidate the buffer first, so a failed seek cannot leave stale data behind
+      buffer = null;
       try {
         if (markPosition <= Integer.MAX_VALUE) {
           lo.seek((int) markPosition);
         } else {
           lo.seek64(markPosition, LargeObject.SEEK_SET);
         }
-        buffer = null;
         absolutePosition = markPosition;
       } catch (SQLException e) {
         throw new IOException(
@@ -336,9 +349,28 @@ public class BlobInputStream extends InputStream {
   }
 
   private LargeObject getLo() throws IOException {
+    LargeObject lo = this.lo;
     if (lo == null) {
-      throw new IOException("BlobOutputStream is closed");
+      throw new IOException("BlobInputStream is closed");
     }
+    assert lock.isLocked();
+
+    if (absolutePosition < 0) {
+      // Initialise the position lazily, here rather than in the constructor, so the failure can be
+      // reported as a checked IOException. The LargeObject may already be positioned past the
+      // start, so mark/reset must be relative to its current position, not to 0 (issue #3149).
+      try {
+        // lo_tell64 requires PostgreSQL 9.3+, so fall back to lo_tell on older servers
+        this.absolutePosition = lo.supports64BitOffsets() ? lo.tell64() : lo.tell();
+      } catch (SQLException e) {
+        throw new IOException("Failed to initialize BlobInputStream position", e);
+      }
+
+      // The constructor limit is relative to the initial position; -1 means no limit
+      limit = limit == -1 ? Long.MAX_VALUE : limit + absolutePosition;
+      markPosition = absolutePosition;
+    }
+
     return lo;
   }
 }

--- a/pgjdbc/src/main/java/org/postgresql/largeobject/BlobInputStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/largeobject/BlobInputStream.java
@@ -348,6 +348,66 @@ public class BlobInputStream extends InputStream {
     return true;
   }
 
+  /**
+   * Skips over and discards {@code n} bytes of data from this input stream.
+   *
+   * <p>Unlike the default implementation, this seeks instead of reading and discarding the bytes,
+   * so the cost does not grow with {@code n}.</p>
+   *
+   * <p>Large objects are sparse, so the stream allows skipping past the current end of the object.
+   * Subsequent reads then return {@code -1}, and the skipped count still reflects the requested
+   * distance, as the {@link InputStream#skip(long)} contract permits.</p>
+   *
+   * @param n the number of bytes to be skipped
+   * @return the actual number of bytes skipped, which may be zero
+   * @throws IOException if the underlying seek fails, in particular when the target position
+   *     exceeds the maximum large object size the server accepts
+   * @see java.io.InputStream#skip(long)
+   * @see <a href="https://www.postgresql.org/docs/14/lo-implementation.html">Large Objects:
+   *     Implementation Features</a>
+   */
+  @Override
+  public long skip(long n) throws IOException {
+    if (n <= 0) {
+      // The contract allows skipping backwards, but this stream does not.
+      return 0;
+    }
+
+    try (ResourceLock ignore = lock.obtain()) {
+      LargeObject lo = getLo();
+      long loId = lo.getLongOID();
+
+      long targetPosition = absolutePosition + n;
+      if (targetPosition > limit || targetPosition < 0) {
+        // Clamp to the limit, and guard against overflow when n is close to Long.MAX_VALUE
+        targetPosition = limit;
+      }
+      long currentPosition = absolutePosition;
+      long skipped = targetPosition - currentPosition;
+
+      if (buffer != null && buffer.length - bufferPosition > skipped) {
+        // The target is still inside the current buffer, so just advance within it
+        bufferPosition += (int) skipped;
+      } else {
+        buffer = null;
+        try {
+          if (targetPosition <= Integer.MAX_VALUE) {
+            lo.seek((int) targetPosition, LargeObject.SEEK_SET);
+          } else {
+            lo.seek64(targetPosition, LargeObject.SEEK_SET);
+          }
+        } catch (SQLException e) {
+          throw new IOException(
+              GT.tr("Can not skip stream for large object {0} by {1} (currently @{2})",
+                  loId, n, currentPosition),
+              e);
+        }
+      }
+      absolutePosition = targetPosition;
+      return skipped;
+    }
+  }
+
   private LargeObject getLo() throws IOException {
     LargeObject lo = this.lo;
     if (lo == null) {

--- a/pgjdbc/src/main/java/org/postgresql/largeobject/LargeObject.java
+++ b/pgjdbc/src/main/java/org/postgresql/largeobject/LargeObject.java
@@ -346,6 +346,17 @@ public class LargeObject
   }
 
   /**
+   * Reports whether the server supports the 64-bit large object functions {@code lo_tell64} and
+   * {@code lo_lseek64}, added in PostgreSQL 9.3. Callers can use this to choose the 64-bit
+   * functions by version rather than calling them and recovering from the failure.
+   *
+   * @return {@code true} if the server is 9.3 or newer
+   */
+  boolean supports64BitOffsets() {
+    return fp.getServerVersionNum() >= 90300;
+  }
+
+  /**
    * This method is inefficient, as the only way to find out the size of the object is to seek to
    * the end, record the current position, then return to the original position.
    *

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BlobTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BlobTest.java
@@ -8,6 +8,7 @@ package org.postgresql.test.jdbc2;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -16,6 +17,8 @@ import org.postgresql.core.ServerVersion;
 import org.postgresql.largeobject.LargeObject;
 import org.postgresql.largeobject.LargeObjectManager;
 import org.postgresql.test.TestUtil;
+import org.postgresql.test.annotations.EnabledForServerVersionRange;
+import org.postgresql.util.PSQLState;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -25,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.sql.Blob;
@@ -35,6 +39,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Types;
+import java.util.Arrays;
 import java.util.concurrent.ThreadLocalRandom;
 
 import javax.sql.rowset.serial.SerialBlob;
@@ -338,6 +343,123 @@ class BlobTest {
   }
 
   @Test
+  void skip() throws Exception {
+    LargeObjectManager lom = ((PGConnection) con).getLargeObjectAPI();
+    long loid = createMediumLargeObject();
+
+    try (LargeObject blob = lom.open(loid, LargeObjectManager.READ)) {
+      InputStream bis = blob.getInputStream();
+      assertEquals(0, bis.read());
+      assertEquals(1024L, bis.skip(1024));
+      assertEquals(1, bis.read());
+      assertEquals(64 * 1024L, bis.skip(64 * 1024));
+      assertEquals(65, bis.read());
+    }
+  }
+
+  @Test
+  void skipBackwards() throws Exception {
+    assertTrue(uploadFile(TEST_FILE, NATIVE_STREAM) > 0);
+
+    try (Statement stmt = con.createStatement()) {
+      try (ResultSet rs = stmt.executeQuery("SELECT lo FROM testblob where id = '/test-file.xml'")) {
+        assertTrue(rs.next());
+
+        LargeObjectManager lom = ((PGConnection) con).getLargeObjectAPI();
+        long loid = rs.getLong(1);
+
+        try (LargeObject blob = lom.open(loid, LargeObjectManager.READ)) {
+          InputStream bis = blob.getInputStream();
+          assertEquals('<', bis.read());
+          // This stream does not skip backwards, so skip(-1) is a no-op
+          assertEquals(0, bis.skip(-1));
+          assertEquals('?', bis.read());
+        }
+      }
+    }
+  }
+
+  @Test
+  void skipToEnd() throws Exception {
+    LargeObjectManager lom = ((PGConnection) con).getLargeObjectAPI();
+    long loid = createMediumLargeObject();
+
+    try (LargeObject blob = lom.open(loid, LargeObjectManager.READ)) {
+      InputStream bis = blob.getInputStream();
+      assertEquals(96 * 1024, bis.skip(96 * 1024));
+      assertEquals(-1, bis.read());
+    }
+  }
+
+  @Test
+  void skipPastEnd() throws Exception {
+    LargeObjectManager lom = ((PGConnection) con).getLargeObjectAPI();
+    long loid = createMediumLargeObject();
+
+    try (LargeObject blob = lom.open(loid, LargeObjectManager.READ)) {
+      // Large objects are sparse: skipping past the end is allowed and reads then return -1
+      InputStream bis = blob.getInputStream();
+      assertEquals(1024 * 1024, bis.skip(1024 * 1024));
+      assertEquals(-1, bis.read());
+      assertEquals(1024, bis.skip(1024));
+      assertEquals(-1, bis.read());
+    }
+  }
+
+  @Test
+  @EnabledForServerVersionRange(gte = "9.3")
+  void skipPastMax() throws Exception {
+    LargeObjectManager lom = ((PGConnection) con).getLargeObjectAPI();
+    long loid = createMediumLargeObject();
+
+    // Not try-with-resources: seeking beyond the server maximum fails and aborts the transaction,
+    // so a later close() on the same connection would fail too
+    LargeObject blob = lom.open(loid, LargeObjectManager.READ);
+    InputStream bis = blob.getInputStream();
+    assertEquals(0, bis.read());
+    assertThrows(IOException.class, () -> bis.skip(Long.MAX_VALUE / 2));
+
+    // The failed seek aborted the transaction, so further statements fail until rolled back
+    try (Statement stmt = con.createStatement()) {
+      SQLException ex = assertThrows(SQLException.class, () -> stmt.execute("SELECT 1"));
+      assertEquals(PSQLState.IN_FAILED_SQL_TRANSACTION.getState(), ex.getSQLState());
+    }
+    con.rollback();
+  }
+
+  @Test
+  void skipWithInitialOffset() throws Exception {
+    LargeObjectManager lom = ((PGConnection) con).getLargeObjectAPI();
+    long loid = createMediumLargeObject();
+
+    try (LargeObject blob = lom.open(loid, LargeObjectManager.READ)) {
+      blob.seek(1024);
+
+      InputStream bis = blob.getInputStream();
+      assertEquals(1, bis.read());
+      assertEquals(1024L, bis.skip(1024));
+      assertEquals(2, bis.read());
+      assertEquals(64 * 1024L, bis.skip(64 * 1024));
+      assertEquals(66, bis.read());
+    }
+  }
+
+  @Test
+  void skipWithLimit() throws Exception {
+    LargeObjectManager lom = ((PGConnection) con).getLargeObjectAPI();
+    long loid = createMediumLargeObject();
+
+    try (LargeObject blob = lom.open(loid, LargeObjectManager.READ)) {
+      InputStream bis = blob.getInputStream(65 * 1024);
+      assertEquals(0, bis.read());
+      assertEquals(64 * 1024L, bis.skip(64 * 1024));
+      assertEquals(64, bis.read());
+      assertEquals(1022L, bis.skip(1024));
+      assertEquals(-1, bis.read());
+    }
+  }
+
+  @Test
   void getBytesOffset() throws Exception {
     assertTrue(uploadFile(TEST_FILE, NATIVE_STREAM) > 0);
 
@@ -524,6 +646,27 @@ class BlobTest {
     st.close();
 
     return oid;
+  }
+
+  /**
+   * Creates a large object big enough to require several read buffers, filled so that byte
+   * {@code i} of every 1024-byte block equals the block index. This lets the skip tests assert the
+   * exact byte they land on.
+   *
+   * @return the OID of the created large object
+   * @see org.postgresql.largeobject.BlobInputStream#INITIAL_BUFFER_SIZE
+   */
+  private long createMediumLargeObject() throws Exception {
+    LargeObjectManager lom = ((PGConnection) con).getLargeObjectAPI();
+    long loid = lom.createLO();
+    try (LargeObject blob = lom.open(loid, LargeObjectManager.WRITE)) {
+      byte[] buf = new byte[1024];
+      for (byte i = 0; i < 96; i++) {
+        Arrays.fill(buf, i);
+        blob.write(buf);
+      }
+    }
+    return loid;
   }
 
   /*

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BlobTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BlobTest.java
@@ -290,17 +290,49 @@ class BlobTest {
         LargeObjectManager lom = ((PGConnection) con).getLargeObjectAPI();
 
         long oid = rs.getLong(1);
-        LargeObject blob = lom.open(oid);
-        InputStream bis = blob.getInputStream();
+        try (LargeObject blob = lom.open(oid)) {
+          InputStream bis = blob.getInputStream();
 
-        assertEquals('<', bis.read());
-        bis.mark(4);
-        assertEquals('?', bis.read());
-        assertEquals('x', bis.read());
-        assertEquals('m', bis.read());
-        assertEquals('l', bis.read());
-        bis.reset();
-        assertEquals('?', bis.read());
+          assertEquals('<', bis.read());
+          bis.mark(4);
+          assertEquals('?', bis.read());
+          assertEquals('x', bis.read());
+          assertEquals('m', bis.read());
+          assertEquals('l', bis.read());
+          bis.reset();
+          assertEquals('?', bis.read());
+        }
+      }
+    }
+  }
+
+  @Test
+  void markResetWithInitialOffset() throws Exception {
+    assertTrue(uploadFile(TEST_FILE, NATIVE_STREAM) > 0);
+
+    try (Statement stmt = con.createStatement()) {
+      try (ResultSet rs = stmt.executeQuery("SELECT lo FROM testblob where id = '/test-file.xml'")) {
+        assertTrue(rs.next());
+
+        LargeObjectManager lom = ((PGConnection) con).getLargeObjectAPI();
+
+        long oid = rs.getLong(1);
+        try (LargeObject blob = lom.open(oid)) {
+          // Position the LargeObject before creating the stream: mark/reset must be relative to
+          // this offset, not to the start of the object (issue #3149)
+          blob.seek(4);
+          InputStream bis = blob.getInputStream();
+
+          assertEquals('l', bis.read());
+          bis.reset();
+          assertEquals('l', bis.read());
+          assertEquals(' ', bis.read());
+          bis.mark(4);
+          assertEquals('v', bis.read());
+          assertEquals('e', bis.read());
+          bis.reset();
+          assertEquals('v', bis.read());
+        }
       }
     }
   }


### PR DESCRIPTION
## Why

- `BlobInputStream` computed `mark`/`reset` offsets from position 0, so `reset()` returned to the wrong byte when the stream was created from a `LargeObject` that had already been seeked (#3149).
- `skip(long)` used the default `InputStream` implementation, which reads and discards the bytes, so skipping a large distance cost a full read (#3144).

## What

- Initialise the stream position lazily from the `LargeObject`'s current position (`lo_tell64`, or `lo_tell` below 9.3) and make the read limit relative to that position.
- Override `skip(long)` to seek with `lo_lseek`/`lo_lseek64`; skips that stay within the current buffer advance the buffer pointer without a round-trip. Large objects are sparse, so skipping past the end is allowed and later reads return `-1`, as the `InputStream.skip` contract permits.
- Select the 64-bit fastpath functions by server version through the new `Fastpath#getServerVersionNum` and `LargeObject#supports64BitOffsets`, rather than calling `lo_tell64` and recovering from the failure. Older servers pay no extra round-trip, and the public `tell64` semantics are unchanged.

This takes over and reworks #3148 by @OrangeDog, whose commits are credited via `Co-authored-by`. Differences from that PR:

- version-based dispatch instead of `try { tell64 } catch { tell }`, which removes the extra round-trip on pre-9.3 servers that the original review flagged;
- drop the `castNonNull` calls — assigning the field to a local satisfies the nullness checker;
- simplify the skip-past-max test: the original asserted that a second `close()` throws, but `LargeObject.close()` is idempotent, so the assertion could not hold.

Closes #3144
Closes #3149

## How to verify

```
./gradlew :postgresql:test --tests "org.postgresql.test.jdbc2.BlobTest"
```

All 27 `BlobTest` cases pass locally against PostgreSQL 18; `autostyleCheck`, `checkstyleMain`, and `checkstyleTest` are clean.
