### PR TITLE
fix: reject null URL in Driver.acceptsURL with a clear NullPointerException

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/Driver.java
+++ b/pgjdbc/src/main/java/org/postgresql/Driver.java
@@ -37,6 +37,7 @@ import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.util.ArrayList;
 import java.util.Enumeration;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
@@ -446,6 +447,7 @@ public class Driver implements java.sql.Driver {
    */
   @Override
   public boolean acceptsURL(String url) {
+    Objects.requireNonNull(url, "url");
     return parseURL(url, null) != null;
   }
 

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DriverTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DriverTest.java
@@ -66,6 +66,20 @@ class DriverTest {
     assertThrows(SQLException.class, () -> driver.connect(null, new Properties()));
   }
 
+  /**
+   * A null URL reaching acceptsURL() is a caller bug. It already threw an NPE before, but an
+   * opaque one from deep inside URL parsing; assert the explicit, message-carrying NPE so the
+   * fail-fast check is not silently dropped.
+   */
+  @Test
+  void acceptsUrlRejectsNull() {
+    Driver driver = new Driver();
+
+    NullPointerException npe =
+        assertThrows(NullPointerException.class, () -> driver.acceptsURL(null));
+    assertEquals("url", npe.getMessage());
+  }
+
   /*
    * This tests the acceptsURL() method with a couple of well and poorly formed jdbc urls.
    */


### PR DESCRIPTION
## Why

A misconfigured J2EE container (e.g. Tomcat) can hand the driver a null URL. `Driver.connect(null, ...)` already rejects this with a clear `SQLException("url is null")`, but `Driver.acceptsURL(null)` still falls through to URL parsing and throws an opaque `NullPointerException` that looks like a driver bug.

This revives the intent of #1317. The original blocker there — `Objects.requireNonNull` not compiling under Java 1.6 — no longer applies: the driver requires Java 8+ and already uses `Objects.requireNonNull` throughout.

## What

- `acceptsURL` now calls `Objects.requireNonNull(url, "url")` before parsing, so a null URL fails fast with a clear message instead of an opaque NPE. This matches how `connect` treats a null URL as a caller error.
- Adds `DriverTest.acceptsUrlRejectsNull` covering the null case.

## How to verify

```
./gradlew :postgresql:test --tests "org.postgresql.test.jdbc2.DriverTest.acceptsUrlRejectsNull"
```

Co-authored-by: @yevster, whose original patch in #1317 proposed this check.