### PR TITLE
docs(translation): clean up leftover German header in ja.po

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/translation/ja.po
+++ b/pgjdbc/src/main/java/org/postgresql/translation/ja.po
@@ -1,8 +1,8 @@
-# translation of head-de.po to Japanese
+# translation of head-ja.po to Japanese
 # Japanese message translation for the PostgreSQL JDBC driver
 # This file is distributed under the same license as the package.
 #
-# Andre Bialojahn <ab.spamnews@freenet.de>, 2005, 2006, 2008.
+# Kyotaro Horiguchi <horiguchi.kyotaro@lab.ntt.co.jp>, 2018.
 #
 msgid ""
 msgstr ""


### PR DESCRIPTION
## Why

`ja.po` was originally copied from the German `de.po`, and its header still carried German leftovers after #2004 fixed the language line:

- the source reference pointed at `head-de.po`;
- the translator credit named the German translator (Andre Bialojahn), not the Japanese one.

## What

- Point the source line at `head-ja.po`.
- Credit the actual Japanese translator (`Kyotaro Horiguchi`), taken from the file's own `Last-Translator` / `PO-Revision-Date` metadata.

Comment-only change; no `msgid`/`msgstr` content is touched.

## How to verify

`head -6 pgjdbc/src/main/java/org/postgresql/translation/ja.po` — the header now reads Japanese throughout, with no `de.po` reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)