### PR TITLE
fix(jdbc): honor scale in ResultSet.getBigDecimal(int, int)

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
@@ -51,6 +51,7 @@ import java.io.Reader;
 import java.io.StringReader;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.math.RoundingMode;
 import java.net.InetAddress;
 import java.net.URL;
 import java.net.UnknownHostException;
@@ -234,7 +235,7 @@ public class PgResultSet implements ResultSet, PGRefCursorResultSet {
       case Types.NUMERIC:
       case Types.DECIMAL:
         return getNumeric(columnIndex,
-            field.getMod() == -1 ? -1 : ((field.getMod() - 4) & 0xffff), true);
+            field.getMod() == -1 ? null : (Integer) decodeNumericScale(field.getMod()), true);
       case Types.REAL:
         return getFloat(columnIndex);
       case Types.FLOAT:
@@ -442,7 +443,7 @@ public class PgResultSet implements ResultSet, PGRefCursorResultSet {
 
   @Override
   public @Nullable BigDecimal getBigDecimal(@Positive int columnIndex) throws SQLException {
-    return getBigDecimal(columnIndex, -1);
+    return (BigDecimal) getNumeric(columnIndex, null, false);
   }
 
   @Override
@@ -2884,7 +2885,7 @@ public class PgResultSet implements ResultSet, PGRefCursorResultSet {
 
   @Pure
   private @Nullable Number getNumeric(
-      int columnIndex, int scale, boolean allowSpecial) throws SQLException {
+      int columnIndex, @Nullable Integer scale, boolean allowSpecial) throws SQLException {
     byte[] value = getRawValue(columnIndex);
     if (value == null) {
       return null;
@@ -2909,6 +2910,9 @@ public class PgResultSet implements ResultSet, PGRefCursorResultSet {
           String val = Double.toString(num.doubleValue());
           throw new PSQLException(GT.tr("Bad value for type {0} : {1}", "BigDecimal", val),
               PSQLState.NUMERIC_VALUE_OUT_OF_RANGE);
+        }
+        if (num instanceof BigDecimal) {
+          return scaleBigDecimal((BigDecimal) num, scale);
         }
 
         return num;
@@ -3542,6 +3546,11 @@ public class PgResultSet implements ResultSet, PGRefCursorResultSet {
   }
 
   public static @PolyNull BigDecimal toBigDecimal(@PolyNull String s, int scale) throws SQLException {
+    return toBigDecimal(s, (Integer) scale);
+  }
+
+  private static @PolyNull BigDecimal toBigDecimal(@PolyNull String s,
+      @Nullable Integer scale) throws SQLException {
     if (s == null) {
       return null;
     }
@@ -3549,12 +3558,25 @@ public class PgResultSet implements ResultSet, PGRefCursorResultSet {
     return scaleBigDecimal(val, scale);
   }
 
-  private static BigDecimal scaleBigDecimal(BigDecimal val, int scale) throws PSQLException {
-    if (scale == -1) {
+  /**
+   * Extracts the scale of a {@code numeric} column from its type modifier. Since PostgreSQL 15 the
+   * scale is a signed 11-bit value (e.g. {@code numeric(2,-2)}), so it must be sign-extended rather
+   * than masked with {@code 0xffff}.
+   *
+   * @param typmod the column type modifier, which must not be {@code -1}
+   * @return the (possibly negative) scale
+   */
+  private static int decodeNumericScale(int typmod) {
+    return ((((typmod - 4) & 0x7ff) ^ 0x400) - 0x400);
+  }
+
+  private static BigDecimal scaleBigDecimal(BigDecimal val, @Nullable Integer scale)
+      throws PSQLException {
+    if (scale == null) {
       return val;
     }
     try {
-      return val.setScale(scale);
+      return val.setScale(scale, RoundingMode.HALF_EVEN);
     } catch (ArithmeticException e) {
       throw new PSQLException(
           GT.tr("Bad value for type {0} : {1}", "BigDecimal", val),

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PreparedStatementTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PreparedStatementTest.java
@@ -1248,11 +1248,37 @@ public class PreparedStatementTest extends BaseTest4 {
     assertTrue(rs.wasNull(), "rs.getBigDecimal after rs.getLong");
     assertEquals(BigDecimal.valueOf(maxInt).setScale(1, RoundingMode.HALF_EVEN), rs.getBigDecimal(1, 1), "maxInt as rs.getBigDecimal(scale=1)");
     assertEquals(BigDecimal.valueOf(minInt).setScale(1, RoundingMode.HALF_EVEN), rs.getBigDecimal(2, 1), "minInt as rs.getBigDecimal(scale=1)");
+    assertEquals(BigDecimal.valueOf(maxInt).setScale(-1, RoundingMode.HALF_EVEN), rs.getBigDecimal(1, -1), "maxInt as rs.getBigDecimal(scale=-1)");
+    assertEquals(BigDecimal.valueOf(minInt).setScale(-1, RoundingMode.HALF_EVEN), rs.getBigDecimal(2, -1), "minInt as rs.getBigDecimal(scale=-1)");
     rs.getFloat(3);
     assertTrue(rs.wasNull());
     rs.close();
     pstmt.close();
 
+  }
+
+  @Test
+  public void testNegativeNumericScale() throws SQLException {
+    assumeMinimumServerVersion("numeric with a negative scale typmod requires v15",
+        ServerVersion.v15);
+    try (PreparedStatement pstmt = con.prepareStatement("select 1500::numeric(2,-2)");
+         ResultSet rs = pstmt.executeQuery()) {
+      assertTrue(rs.next());
+      BigDecimal expected = new BigDecimal("1500").setScale(-2, RoundingMode.HALF_EVEN);
+      assertEquals(expected, rs.getObject(1), "1500::numeric(2,-2) as rs.getObject");
+    }
+  }
+
+  @Test
+  @SuppressWarnings("deprecation")
+  public void testBigDecimalWithScale() throws SQLException {
+    final String bigDecimalString = "1.1234";
+    try (PreparedStatement pstmt = con.prepareStatement("select " + bigDecimalString);
+         ResultSet rs = pstmt.executeQuery()) {
+      assertTrue(rs.next());
+      assertEquals(new BigDecimal(bigDecimalString).setScale(2, RoundingMode.HALF_EVEN),
+          rs.getBigDecimal(1, 2), "rs.getBigDecimal(scale=2) should round to the requested scale");
+    }
   }
 
   @Test


### PR DESCRIPTION
## Problem

`ResultSet.getBigDecimal(int columnIndex, int scale)` does not behave per the JDBC contract:

1. **`scale = -1` is silently ignored.** The driver used `-1` internally as a "do not rescale" sentinel, so an explicit, valid request such as `rs.getBigDecimal(col, -1)` (round to tens) was dropped instead of honoured. Other JDBC drivers do not special-case `-1`.
2. **Requesting a smaller scale throws instead of rounding.** `scaleBigDecimal` called `BigDecimal.setScale(scale)` without a rounding mode, so `rs.getBigDecimal(col, 2)` on `1.1234` raised `PSQLException "Bad value"` (the underlying `ArithmeticException`) rather than returning `1.12`.

This revives the intent of #1460, reworked on top of the current code.

## Changes

- Replace the `-1` sentinel with a nullable `Integer` scale (`null` = "no rescale").
- Round with `RoundingMode.HALF_EVEN` so a requested scale is applied instead of throwing.
- Apply the requested scale in the **binary** numeric path too, matching the text path (previously the binary path ignored `scale`).
- Keep the public `static toBigDecimal(String, int)` public; it now delegates to a private nullable overload, so the API is unchanged.
- Decode the numeric typmod scale as a **signed 11-bit** value, so numeric types with a negative scale (e.g. `numeric(2,-2)`, supported since PostgreSQL 15) are scaled correctly in both paths instead of being masked to a large positive scale.

## Tests

- `testSetTinyIntFloat` — added `scale = -1` assertions (the sentinel regression).
- `testBigDecimalWithScale` — rounding of a fractional numeric to the requested scale.
- `testNegativeNumericScale` — `numeric(2,-2)` via `getObject` (gated to PostgreSQL 15+), run in both `binaryMode=REGULAR` and `FORCE`.

All `PreparedStatementTest` and `ResultSetTest` cases pass in both binary modes.

Co-authored-by: eperez

🤖 Generated with [Claude Code](https://claude.com/claude-code)