### PR TITLE
refactor(core): drop unused encoding Writer plumbing from PGStream

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/Encoding.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/Encoding.java
@@ -312,7 +312,10 @@ public class Encoding {
    * @param out the underlying stream to encode to
    * @return a non-null Writer implementation.
    * @throws IOException if something goes wrong
+   * @deprecated the driver encodes strings to bytes directly and no longer routes output through a
+   *     {@link Writer}. This method is unused and will be removed in a future release.
    */
+  @Deprecated
   public Writer getEncodingWriter(OutputStream out) throws IOException {
     return new OutputStreamWriter(out, encoding);
   }

--- a/pgjdbc/src/main/java/org/postgresql/core/PGStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/PGStream.java
@@ -91,7 +91,6 @@ public class PGStream implements Closeable, Flushable {
   private int minStreamAvailableCheckDelay = 1000;
 
   private Encoding encoding;
-  private Writer encodingWriter;
 
   private long maxResultBuffer = -1;
   private long resultBufferByteCount;
@@ -325,13 +324,26 @@ public class PGStream implements Closeable, Flushable {
     if (this.encoding != null && this.encoding.name().equals(encoding.name())) {
       return;
     }
-    // Close down any old writer.
-    if (encodingWriter != null) {
-      encodingWriter.close();
-    }
-
     this.encoding = encoding;
+  }
 
+  /**
+   * Get a Writer instance that encodes directly onto the underlying stream.
+   *
+   * <p>The returned Writer should not be closed. {@link Writer#flush()} must be called before
+   * switching back to the {@code PGStream} write methods, but it won't actually flush output all
+   * the way out -- call {@link #flush} to ensure all output has been pushed to the server.</p>
+   *
+   * @return a Writer that encodes onto the underlying stream
+   * @throws IOException if something goes wrong.
+   * @deprecated the driver writes encoded bytes directly and no longer routes output through an
+   *     encoding {@link Writer}. This method is unused and will be removed in a future release.
+   */
+  @Deprecated
+  public Writer getEncodingWriter() throws IOException {
+    if (encoding == null) {
+      throw new IOException("No encoding has been set on this connection");
+    }
     // Intercept flush() downcalls from the writer; our caller
     // will call PGStream.flush() as needed.
     OutputStream interceptor = new FilterOutputStream(pgOutput) {
@@ -344,26 +356,7 @@ public class PGStream implements Closeable, Flushable {
         super.flush();
       }
     };
-
-    encodingWriter = encoding.getEncodingWriter(interceptor);
-  }
-
-  /**
-   * Get a Writer instance that encodes directly onto the underlying stream.
-   *
-   * <p>The returned Writer should not be closed, as it's a shared object. Writer.flush needs to be
-   * called when switching between use of the Writer and use of the PGStream write methods, but it
-   * won't actually flush output all the way out -- call {@link #flush} to actually ensure all
-   * output has been pushed to the server.</p>
-   *
-   * @return the shared Writer instance
-   * @throws IOException if something goes wrong.
-   */
-  public Writer getEncodingWriter() throws IOException {
-    if (encodingWriter == null) {
-      throw new IOException("No encoding has been set on this connection");
-    }
-    return encodingWriter;
+    return encoding.getEncodingWriter(interceptor);
   }
 
   /**
@@ -712,9 +705,6 @@ public class PGStream implements Closeable, Flushable {
    */
   @Override
   public void flush() throws IOException {
-    if (encodingWriter != null) {
-      encodingWriter.flush();
-    }
     pgOutput.flush();
   }
 
@@ -740,10 +730,6 @@ public class PGStream implements Closeable, Flushable {
    */
   @Override
   public void close() throws IOException {
-    if (encodingWriter != null) {
-      encodingWriter.close();
-    }
-
     pgOutput.close();
     pgInput.close();
     connection.close();


### PR DESCRIPTION
## Why

`PGStream` carried a per-connection `encodingWriter`: set up in `setEncoding`, then flushed and closed in `flush()` and `close()`. The only way to feed data into it is the public `getEncodingWriter()`, and that method has **no callers** anywhere in the driver or its tests. The `Writer` was never written to, so the field and its flush/close handling were dead weight — the driver encodes strings to bytes directly and sends them through `PgBufferedOutputStream`.

This follows up on the discussion in #3002, which proposed optimising the `FilterOutputStream` interceptor on this path. That PR was closed once it became clear the path is unused; this change removes the dead plumbing instead.

## What

- Remove the `encodingWriter` field and the related branches in `setEncoding`, `flush()`, and `close()`.
- Keep the public `getEncodingWriter()` on `PGStream` and `getEncodingWriter(OutputStream)` on `Encoding` so any downstream caller still compiles, but mark both `@Deprecated` for removal.
- `PGStream.getEncodingWriter()` now builds the `Writer` on demand rather than caching it.

No behaviour change on any exercised path.

## How to verify

- `getEncodingWriter` has no in-tree callers: `grep -rn getEncodingWriter --include='*.java' pgjdbc/src`.
- `./gradlew :postgresql:compileJava` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)