### PR TITLE
fix(core): detect search_path changes case-insensitively

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -206,6 +206,13 @@ public class QueryExecutorImpl extends QueryExecutorBase {
   private short deallocateEpoch;
 
   /**
+   * Number of leading characters of a {@code SET}/{@code RESET} statement that are scanned for the
+   * {@code search_path} token. Long statements are not scanned in full so the execute path stays
+   * cheap.
+   */
+  private static final int SEARCH_PATH_SCAN_LIMIT = 1024;
+
+  /**
    * This caches the latest observed {@code set search_path} query so the reset of prepared
    * statement cache can be skipped if using repeated calls for the same {@code set search_path}
    * value.
@@ -2529,11 +2536,21 @@ public class QueryExecutorImpl extends QueryExecutorBase {
           }
           pgStream.clearMaxRowSizeBytes();
 
-          if (status.startsWith("SET")) {
+          // A successful SET/RESET that changes the session search_path makes any server-side
+          // prepared plan or catalog-name resolution cached under the previous path potentially
+          // stale, so bump the epoch to force a rebuild. The command tag is always upper-case
+          // ("SET"/"RESET"), but the user-supplied SQL may use any case, so the search_path token
+          // is matched case-insensitively.
+          if (status.startsWith("SET") || status.startsWith("RESET")) {
             String nativeSql = currentQuery.getNativeQuery().nativeSql;
-            // Scan only the first 1024 characters to
-            // avoid big overhead for long queries.
-            if (nativeSql.lastIndexOf("search_path", 1024) != -1
+            // Scan only the first SEARCH_PATH_SCAN_LIMIT characters to avoid a big overhead for
+            // long queries.
+            boolean changesSearchPath =
+                containsIgnoreCase(nativeSql, "search_path", SEARCH_PATH_SCAN_LIMIT)
+                    // "RESET ALL" reverts every parameter, search_path included.
+                    || (status.startsWith("RESET")
+                        && containsIgnoreCase(nativeSql, "all", SEARCH_PATH_SCAN_LIMIT));
+            if (changesSearchPath
                 && !nativeSql.equals(lastSetSearchPathQuery)) {
               // Search path was changed, invalidate prepared statement cache
               lastSetSearchPathQuery = nativeSql;
@@ -2788,6 +2805,27 @@ public class QueryExecutorImpl extends QueryExecutorBase {
       }
 
     }
+  }
+
+  /**
+   * Tells whether {@code needle} occurs in {@code sql} using ASCII case-insensitive matching,
+   * starting at any offset in {@code [0, scanLimit]}. The scan is bounded so long statements are not
+   * scanned in full, and it avoids allocating a lower-cased copy of the statement on the execute
+   * path.
+   *
+   * @param sql the statement text to scan
+   * @param needle the lower-case token to look for
+   * @param scanLimit the highest start offset that is examined
+   * @return {@code true} if the token is found within the scanned range
+   */
+  private static boolean containsIgnoreCase(String sql, String needle, int scanLimit) {
+    int last = Math.min(scanLimit, sql.length() - needle.length());
+    for (int i = 0; i <= last; i++) {
+      if (sql.regionMatches(true, i, needle, 0, needle.length())) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /**

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc4/jdbc41/SchemaTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc4/jdbc41/SchemaTest.java
@@ -58,6 +58,9 @@ class SchemaTest {
       TestUtil.createTable(conn, "\"UpperCase\".table3", "id integer");
       TestUtil.createTable(conn, "schema1.sptest", "id integer");
       TestUtil.createTable(conn, "schema2.sptest", "id varchar");
+      // The user schema is first in the default search_path ("$user", public), so a RESET that
+      // restores the default resolves the unqualified sptest to this BIGINT table.
+      TestUtil.createTable(conn, TestUtil.getUser() + ".sptest", "id bigint");
       stmt.close();
     }
   }
@@ -237,6 +240,108 @@ class SchemaTest {
     assertColType(ps, "sptest should point to schema2.sptest, thus column type should be VARCHAR",
         Types.VARCHAR);
     ps.close();
+  }
+
+  /**
+   * The command tag is always upper-case, but the user-supplied SQL may use any case, so an
+   * upper-case {@code SET SEARCH_PATH} must invalidate the prepared statement cache just like the
+   * lower-case form does. With autoCommit=false a missed invalidation surfaces as a
+   * "cached plan must not change result type" error that aborts the transaction, which the
+   * reparse-on-error fallback can no longer heal, so this variant guards the regression.
+   */
+  @Test
+  void searchPathPreparedStatementUpperCaseAutoCommitFalse() throws SQLException {
+    conn.setAutoCommit(false);
+    searchPathPreparedStatementUpperCase();
+  }
+
+  @Test
+  void searchPathPreparedStatementUpperCaseAutoCommitTrue() throws SQLException {
+    searchPathPreparedStatementUpperCase();
+  }
+
+  private void searchPathPreparedStatementUpperCase() throws SQLException {
+    execute("SET SEARCH_PATH TO schema1,public");
+    try (PreparedStatement ps = conn.prepareStatement("select * from sptest")) {
+      for (int i = 0; i < 10; i++) {
+        ps.execute();
+      }
+      assertColType(ps, "sptest should point to schema1.sptest, thus column type should be INT",
+          Types.INTEGER);
+    }
+    execute("SET SEARCH_PATH TO schema2,public");
+    try (PreparedStatement ps = conn.prepareStatement("select * from sptest")) {
+      assertColType(ps, "sptest should point to schema2.sptest, thus column type should be VARCHAR",
+          Types.VARCHAR);
+    }
+  }
+
+  /**
+   * {@code RESET search_path} restores the default search_path, so it must invalidate the prepared
+   * statement cache just like {@code SET search_path} does. As with {@code SET}, the
+   * autoCommit=false variant is the real guard: under autoCommit=true the reparse-on-error
+   * fallback hides a missed invalidation.
+   */
+  @Test
+  void searchPathPreparedStatementResetAutoCommitFalse() throws SQLException {
+    conn.setAutoCommit(false);
+    searchPathPreparedStatementReset("RESET search_path");
+  }
+
+  @Test
+  void searchPathPreparedStatementResetAutoCommitTrue() throws SQLException {
+    searchPathPreparedStatementReset("RESET search_path");
+  }
+
+  /**
+   * {@code RESET ALL} reverts every session parameter, search_path included, so it must invalidate
+   * the prepared statement cache too.
+   */
+  @Test
+  void searchPathPreparedStatementResetAllAutoCommitFalse() throws SQLException {
+    conn.setAutoCommit(false);
+    searchPathPreparedStatementReset("RESET ALL");
+  }
+
+  @Test
+  void searchPathPreparedStatementResetAllAutoCommitTrue() throws SQLException {
+    searchPathPreparedStatementReset("RESET ALL");
+  }
+
+  private void searchPathPreparedStatementReset(String resetSql) throws SQLException {
+    execute("SET search_path TO schema1,public");
+    try (PreparedStatement ps = conn.prepareStatement("select * from sptest")) {
+      for (int i = 0; i < 10; i++) {
+        ps.execute();
+      }
+      assertColType(ps, "sptest should point to schema1.sptest, thus column type should be INT",
+          Types.INTEGER);
+    }
+    execute(resetSql);
+    try (PreparedStatement ps = conn.prepareStatement("select * from sptest")) {
+      assertColType(ps, resetSql + " should restore the default search_path, where sptest is the "
+          + "BIGINT table in the user schema", Types.BIGINT);
+    }
+  }
+
+  /**
+   * A {@code RESET} of an unrelated parameter leaves search_path untouched, so the prepared
+   * statement keeps resolving to the same table. This also covers the "RESET, but neither
+   * search_path nor ALL" path, where the cache must not be invalidated.
+   */
+  @Test
+  void resetUnrelatedParameterKeepsSearchPath() throws SQLException {
+    execute("SET search_path TO schema1,public");
+    try (PreparedStatement ps = conn.prepareStatement("select * from sptest")) {
+      for (int i = 0; i < 10; i++) {
+        ps.execute();
+      }
+      assertColType(ps, "sptest should point to schema1.sptest, thus column type should be INT",
+          Types.INTEGER);
+      execute("RESET statement_timeout");
+      assertColType(ps, "RESET statement_timeout must not change search_path, so sptest still "
+          + "points to schema1.sptest", Types.INTEGER);
+    }
   }
 
   @Test


### PR DESCRIPTION
## Why

The `COMMAND_COMPLETE` handler in `QueryExecutorImpl` invalidates the prepared-statement plan cache when a `SET` changes `search_path`, but it scanned the SQL for the literal lower-case `search_path`:

```java
if (status.startsWith("SET")) {
  String nativeSql = currentQuery.getNativeQuery().nativeSql;
  if (nativeSql.lastIndexOf("search_path", 1024) != -1
      && !nativeSql.equals(lastSetSearchPathQuery)) { ... }
}
```

Two gaps:

1. **Case sensitivity** — `SET SEARCH_PATH TO schema2` (or any non-lower-case form) is not detected, so the plan cache keeps stale entries. With `autoCommit=false` this surfaces as a `cached plan must not change result type` error that aborts the transaction, which the reparse-on-error fallback can no longer heal.
2. **`RESET`** — `RESET search_path` and `RESET ALL` change the effective search_path but were not handled.

This is long-standing behaviour, independent of any one feature.

## What

- Match the `search_path` token case-insensitively with a bounded `regionMatches` scan — no allocation or regex on the execute path, same 1024-char window as before (now a named `SEARCH_PATH_SCAN_LIMIT` constant).
- Also trigger on `RESET search_path` and `RESET ALL`.
- Keep the existing fast path that skips repeated identical `SET search_path` statements (`lastSetSearchPathQuery`).

The detection is the single shared place, so the type-cache epoch the typecache branch adds to this block will benefit from the same fix once it lands.

## How to verify

`SchemaTest` gains `searchPathPreparedStatementUpperCase{AutoCommitFalse,AutoCommitTrue}`, mirroring the existing lower-case tests but with an upper-case `SET SEARCH_PATH`. The `AutoCommitFalse` variant is the real guard: under `autoCommit=true` the reparse-on-error path masks the missing invalidation (the same is true of the existing lower-case tests).

```
./gradlew :postgresql:test --tests org.postgresql.test.jdbc4.jdbc41.SchemaTest
```

Reverting the production change to the case-sensitive scan makes `searchPathPreparedStatementUpperCaseAutoCommitFalse` fail; with the fix all 14 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)