### PR TITLE
feat(jdbc): resolve CallableStatement parameters by name

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/BaseConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/BaseConnection.java
@@ -216,6 +216,15 @@ public interface BaseConnection extends PGConnection, Connection {
   void setFlushCacheOnDeallocate(boolean flushCacheOnDeallocate);
 
   /**
+   * Returns the current type cache epoch.
+   * @return the current type cache epoch
+   * @see QueryExecutor#getTypeCacheEpoch()
+   */
+  default int getTypeCacheEpoch() {
+    return 0;
+  }
+
+  /**
    * Indicates if statements to backend should be hinted as read only.
    *
    * @return Indication if hints to backend (such as when transaction begins)

--- a/pgjdbc/src/main/java/org/postgresql/core/CachedQuery.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/CachedQuery.java
@@ -7,6 +7,10 @@ package org.postgresql.core;
 
 import org.postgresql.util.CanEstimateSize;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.Map;
+
 /**
  * Stores information on the parsed JDBC query. It is used to cut parsing overhead when executing
  * the same query through {@link java.sql.Connection#prepareStatement(String)}.
@@ -20,6 +24,8 @@ public class CachedQuery implements CanEstimateSize {
   public final boolean isFunction;
 
   private int executeCount;
+  private @Nullable Map<String, Integer> callableParameterNameIndexMap;
+  private int callableParameterNameIndexMapEpoch;
 
   public CachedQuery(Object key, Query query, boolean isFunction) {
     assert key instanceof String || key instanceof CanEstimateSize
@@ -50,6 +56,36 @@ public class CachedQuery implements CanEstimateSize {
    */
   public int getExecuteCount() {
     return executeCount;
+  }
+
+  /**
+   * Map of (folded) CallableStatement parameter name to 1-based JDBC index for this call, cached
+   * so that repeated executions of the same callable SQL do not re-query the catalog for the
+   * routine's argument names. The mapping is derived from the catalog, so it is tied to the
+   * connection's type-cache epoch and is treated as absent once a DDL statement bumps the epoch
+   * (the routine's signature may have changed).
+   *
+   * @param typeCacheEpoch the connection's current type-cache epoch
+   * @return the cached parameter-name map, or {@code null} if not resolved yet or stale
+   */
+  public @Nullable Map<String, Integer> getCallableParameterNameIndexMap(int typeCacheEpoch) {
+    if (callableParameterNameIndexMap != null && callableParameterNameIndexMapEpoch == typeCacheEpoch) {
+      return callableParameterNameIndexMap;
+    }
+    return null;
+  }
+
+  /**
+   * Caches the (folded) parameter name to 1-based JDBC index map for this callable SQL, stamped
+   * with the type-cache epoch it was resolved under.
+   *
+   * @param callableParameterNameIndexMap the resolved parameter-name map
+   * @param typeCacheEpoch the type-cache epoch the map was resolved under
+   */
+  public void setCallableParameterNameIndexMap(Map<String, Integer> callableParameterNameIndexMap,
+      int typeCacheEpoch) {
+    this.callableParameterNameIndexMap = callableParameterNameIndexMap;
+    this.callableParameterNameIndexMapEpoch = typeCacheEpoch;
   }
 
   @Override

--- a/pgjdbc/src/main/java/org/postgresql/core/QueryExecutor.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/QueryExecutor.java
@@ -594,6 +594,16 @@ public interface QueryExecutor extends TypeTransferModeRegistry {
   void setFlushCacheOnDdl(boolean flushCacheOnDdl);
 
   /**
+   * Returns the current type cache epoch.
+   * A new epoch means the type cache should be invalidated.
+   * For instance, if user executes {@code DROP TYPE custom_type} SQL, then we should not reuse
+   * the type cache (for instance, oid) for the type. As of now, we can't have fine-grained
+   * notifications from the backend, so we invalidate the full cache.
+   * @return the current type cache epoch
+   */
+  int getTypeCacheEpoch();
+
+  /**
    * @return the ReplicationProtocol instance for this connection.
    */
   ReplicationProtocol getReplicationProtocol();

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -204,6 +204,7 @@ public class QueryExecutorImpl extends QueryExecutorBase {
   private final SimpleQuery sync = (SimpleQuery) createQuery("SYNC", false, true).query;
 
   private short deallocateEpoch;
+  private int typeCacheEpoch;
 
   /**
    * This caches the latest observed {@code set search_path} query so the reset of prepared
@@ -247,6 +248,11 @@ public class QueryExecutorImpl extends QueryExecutorBase {
   @Override
   public ProtocolVersion getProtocolVersion() {
     return protocolVersion;
+  }
+
+  @Override
+  public int getTypeCacheEpoch() {
+    return typeCacheEpoch;
   }
 
   /**
@@ -2497,16 +2503,21 @@ public class QueryExecutorImpl extends QueryExecutorBase {
               && (status.startsWith("DEALLOCATE ALL") || status.startsWith("DISCARD ALL"))) {
             deallocateEpoch++;
           }
-          if (isFlushCacheOnDdl()
-              && (status.startsWith("CREATE ")
-                  || status.startsWith("DROP ")
-                  || status.startsWith("ALTER "))) {
-            // DDL invalidates any server-side prepared plan that references
-            // the affected relation. Bump the epoch so the driver
-            // re-prepares matching statements on next use, instead of
-            // surfacing PostgreSQL's "cached plan must not change result
-            // type" to callers that don't opt into autosave=ALWAYS.
-            deallocateEpoch++;
+          if (status.startsWith("CREATE ")
+              || status.startsWith("DROP ")
+              || status.startsWith("ALTER ")) {
+            // DDL may redefine types (e.g. DROP TYPE / ALTER TYPE), so invalidate the
+            // driver's type cache regardless of flushCacheOnDdl, which only governs
+            // server-side prepared plans.
+            typeCacheEpoch++;
+            if (isFlushCacheOnDdl()) {
+              // DDL invalidates any server-side prepared plan that references
+              // the affected relation. Bump the epoch so the driver
+              // re-prepares matching statements on next use, instead of
+              // surfacing PostgreSQL's "cached plan must not change result
+              // type" to callers that don't opt into autosave=ALWAYS.
+              deallocateEpoch++;
+            }
           }
 
           doneAfterRowDescNoData = false;
@@ -2533,8 +2544,13 @@ public class QueryExecutorImpl extends QueryExecutorBase {
             if (nativeSql.lastIndexOf("search_path", 1024) != -1
                 && !nativeSql.equals(lastSetSearchPathQuery)) {
               // Search path was changed, invalidate prepared statement cache
+              // *and* the per-connection type cache: name-keyed lookups
+              // (TypeInfoCache.getPgTypeByPgName) resolve against the
+              // current search_path, so a previously-cached "foo" might
+              // now refer to a different type.
               lastSetSearchPathQuery = nativeSql;
               deallocateEpoch++;
+              typeCacheEpoch++;
             }
           }
 

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgCallableStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgCallableStatement.java
@@ -19,6 +19,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.io.InputStream;
 import java.io.Reader;
+import java.io.StringReader;
 import java.math.BigDecimal;
 import java.net.URL;
 import java.sql.Array;
@@ -26,7 +27,9 @@ import java.sql.Blob;
 import java.sql.CallableStatement;
 import java.sql.Clob;
 import java.sql.Date;
+import java.sql.JDBCType;
 import java.sql.NClob;
+import java.sql.PreparedStatement;
 import java.sql.Ref;
 import java.sql.ResultSet;
 import java.sql.RowId;
@@ -37,6 +40,8 @@ import java.sql.Time;
 import java.sql.Timestamp;
 import java.sql.Types;
 import java.util.Calendar;
+import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 class PgCallableStatement extends PgPreparedStatement implements CallableStatement {
@@ -51,10 +56,13 @@ class PgCallableStatement extends PgPreparedStatement implements CallableStateme
   private boolean returnTypeSet;
   protected @Nullable Object @Nullable [] callResult;
   private int lastIndex;
+  // Original JDBC escape SQL ("{ ? = call f(...) }"), kept to resolve parameter names.
+  private final String jdbcSql;
 
   PgCallableStatement(PgConnection connection, String sql, int rsType, int rsConcurrency,
       int rsHoldability) throws SQLException {
     super(connection, connection.borrowCallableQuery(sql), rsType, rsConcurrency, rsHoldability);
+    this.jdbcSql = sql;
     this.isFunction = preparedQuery.isFunction;
 
     if (this.isFunction) {
@@ -430,6 +438,204 @@ class PgCallableStatement extends PgPreparedStatement implements CallableStateme
     return callResult[parameterIndex - 1];
   }
 
+  /**
+   * Resolves a JDBC parameter name to its 1-based parameter index.
+   *
+   * <p>Names are matched case-insensitively (PostgreSQL folds unquoted identifiers to lower
+   * case) against the routine's argument names, looked up once in {@code pg_catalog.pg_proc} and
+   * cached on the {@link org.postgresql.core.CachedQuery} so that repeated executions of the same
+   * callable SQL do not re-query the catalog. The cached mapping is stamped with the connection's
+   * type-cache epoch and rebuilt once a DDL statement bumps it, since the routine's signature may
+   * have changed. The catalog is the single source of truth here so that the same name resolves
+   * to the same index whether it is used before execution (e.g.
+   * {@code registerOutParameter(String, ...)}, {@code setXXX(String, ...)}) or after it (e.g.
+   * {@code getXXX(String)}).</p>
+   *
+   * @param parameterName the parameter name
+   * @return the 1-based parameter index
+   * @throws SQLException if the name cannot be resolved to a single parameter
+   */
+  private int resolveParameterIndex(String parameterName) throws SQLException {
+    checkClosed();
+    int typeCacheEpoch = connection.getTypeCacheEpoch();
+    Map<String, Integer> names = preparedQuery.getCallableParameterNameIndexMap(typeCacheEpoch);
+    if (names == null) {
+      names = resolveParameterNamesFromCatalog();
+      preparedQuery.setCallableParameterNameIndexMap(names, typeCacheEpoch);
+    }
+    Integer idx = names.get(parameterName.toLowerCase(Locale.US));
+    if (idx == null) {
+      throw new PSQLException(GT.tr("No parameter named {0} was found.", parameterName),
+          PSQLState.INVALID_PARAMETER_VALUE);
+    }
+    return idx;
+  }
+
+  /**
+   * Builds a (folded name -&gt; 1-based JDBC index) map from {@code pg_catalog.pg_proc} for the
+   * routine being called.
+   *
+   * <p>For the {@code { call proc(...) }} form every argument — IN, OUT, INOUT, TABLE — occupies
+   * its declaration-order JDBC position (1, 2, 3, …), mirroring the positional API where, for
+   * example, {@code { call f(?, ?) }} over {@code f(a INOUT, b OUT)} registers indexes 1 and 2.</p>
+   *
+   * <p>For the {@code { ? = call f(...) }} form the leading {@code ? =} return placeholder takes
+   * index 1: the first pure OUT/TABLE argument (or the scalar return) maps to index 1 and the
+   * input-bearing arguments (IN, INOUT, VARIADIC) map to 2, 3, … in declaration order. INOUT
+   * arguments are treated as inputs in this form.</p>
+   *
+   * <p>This queries {@code proargnames}/{@code proargmodes} directly rather than reusing
+   * {@link java.sql.DatabaseMetaData#getProcedureColumns} on purpose: those metadata calls take
+   * the schema and routine name as separate {@code LIKE} patterns, so reusing them would require
+   * splitting and LIKE-escaping the (possibly quoted, possibly schema-qualified) name, filtering
+   * the result rows by {@code search_path}, and disambiguating overloads by hand. A {@code regproc}
+   * cast resolves the name with the same rules as the call itself, which is both shorter and more
+   * accurate here; it raises on an absent or overloaded name, which is mapped to an actionable
+   * "use a positional parameter index" error.</p>
+   */
+  private Map<String, Integer> resolveParameterNamesFromCatalog() throws SQLException {
+    String functionName = extractRoutineName(jdbcSql);
+    if (functionName == null) {
+      throw new PSQLException(
+          GT.tr("Unable to determine the routine name to resolve parameter names; "
+              + "use a positional parameter index instead."),
+          PSQLState.INVALID_PARAMETER_VALUE);
+    }
+    String @Nullable [] argNames = null;
+    String @Nullable [] argModes = null;
+    boolean resolved = false;
+    // Resolve the (possibly quoted, schema-qualified) name through the same search_path and quoting
+    // rules as the call itself by casting it to regproc. The cast is available on every supported
+    // server, unlike pg_catalog.to_regproc (9.4+); it raises rather than returning NULL when the
+    // name is absent or overloaded, so the catch below maps that to the actionable message.
+    try (PreparedStatement ps = connection.prepareStatement(
+        "SELECT proargnames, proargmodes FROM pg_catalog.pg_proc "
+            + "WHERE oid = ?::pg_catalog.regproc")) {
+      ps.setString(1, functionName);
+      try (ResultSet rs = ps.executeQuery()) {
+        if (rs.next()) {
+          resolved = true;
+          Array namesArray = rs.getArray("proargnames");
+          if (namesArray != null) {
+            argNames = (String[]) namesArray.getArray();
+          }
+          Array modesArray = rs.getArray("proargmodes");
+          if (modesArray != null) {
+            argModes = (String[]) modesArray.getArray();
+          }
+        }
+      }
+    } catch (SQLException e) {
+      // The regproc cast raises 'function "x" does not exist' (absent) or 'more than one function
+      // named "x"' (overloaded); both mean the name is not a single routine.
+      throw new PSQLException(
+          GT.tr("Unable to resolve routine {0} to a single function; it may be overloaded "
+              + "or absent. Use a positional parameter index instead.", functionName),
+          PSQLState.INVALID_PARAMETER_VALUE, e);
+    }
+    if (!resolved) {
+      throw new PSQLException(
+          GT.tr("Unable to resolve routine {0} to a single function; it may be overloaded "
+              + "or absent. Use a positional parameter index instead.", functionName),
+          PSQLState.INVALID_PARAMETER_VALUE);
+    }
+
+    Map<String, Integer> result = new HashMap<>();
+    if (argNames == null) {
+      return result;
+    }
+    if (!hasReturnPlaceholder(jdbcSql)) {
+      // { call proc(...) }: every argument occupies its declaration-order JDBC position,
+      // regardless of mode, matching the positional API.
+      for (int i = 0; i < argNames.length; i++) {
+        String name = argNames[i];
+        if (name != null && !name.isEmpty()) {
+          result.putIfAbsent(name.toLowerCase(Locale.US), i + 1);
+        }
+      }
+      return result;
+    }
+    // { ? = call f(...) }: index 1 is the leading return placeholder (the first pure OUT/TABLE
+    // result, or the scalar return); input-bearing arguments map to 2, 3, … in declaration order.
+    int nextInIndex = 2;
+    boolean returnAssigned = false;
+    for (int i = 0; i < argNames.length; i++) {
+      String name = argNames[i];
+      char mode = argModes == null || argModes[i] == null || argModes[i].isEmpty()
+          ? 'i' : argModes[i].charAt(0);
+      if (mode == 'o' || mode == 't') {
+        if (!returnAssigned) {
+          if (name != null && !name.isEmpty()) {
+            result.putIfAbsent(name.toLowerCase(Locale.US), 1);
+          }
+          returnAssigned = true;
+        }
+        continue;
+      }
+      // Input-bearing argument (IN, INOUT, VARIADIC). Advance the position even for an unnamed
+      // argument: PostgreSQL still emits an empty proargnames entry for it, and skipping it
+      // would shift every following name by one.
+      int index = nextInIndex++;
+      if (name != null && !name.isEmpty()) {
+        result.putIfAbsent(name.toLowerCase(Locale.US), index);
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Extracts the routine name (optionally schema-qualified and/or quoted) from the JDBC escape
+   * SQL. Schema, quoting and {@code search_path} resolution are left to the {@code regproc} cast.
+   *
+   * @return the routine name, or {@code null} if it cannot be located
+   */
+  private static @Nullable String extractRoutineName(String jdbcSql) {
+    String lower = jdbcSql.toLowerCase(Locale.US);
+    int from = 0;
+    while (true) {
+      int call = lower.indexOf("call", from);
+      if (call < 0) {
+        return null;
+      }
+      boolean leftBoundary = call == 0 || !Character.isLetterOrDigit(lower.charAt(call - 1));
+      int after = call + 4;
+      boolean rightBoundary = after >= lower.length() || !Character.isLetterOrDigit(lower.charAt(after));
+      if (leftBoundary && rightBoundary) {
+        int p = after;
+        while (p < jdbcSql.length() && Character.isWhitespace(jdbcSql.charAt(p))) {
+          p++;
+        }
+        int start = p;
+        boolean inQuotes = false;
+        while (p < jdbcSql.length()) {
+          char ch = jdbcSql.charAt(p);
+          if (ch == '"') {
+            inQuotes = !inQuotes;
+          } else if (!inQuotes && (ch == '(' || ch == '}' || Character.isWhitespace(ch))) {
+            break;
+          }
+          p++;
+        }
+        String name = jdbcSql.substring(start, p).trim();
+        return name.isEmpty() ? null : name;
+      }
+      from = call + 4;
+    }
+  }
+
+  /**
+   * Returns {@code true} when the call uses the {@code { ? = call ... }} form, i.e. a return
+   * placeholder precedes the {@code call} keyword.
+   */
+  private static boolean hasReturnPlaceholder(String jdbcSql) {
+    String lower = jdbcSql.toLowerCase(Locale.US);
+    int call = lower.indexOf("call");
+    if (call < 0) {
+      return false;
+    }
+    return jdbcSql.lastIndexOf('?', call) >= 0;
+  }
+
   @Override
   protected BatchResultHandler createBatchHandler(Query[] queries,
       @Nullable ParameterList[] parameterLists) {
@@ -506,55 +712,131 @@ class PgCallableStatement extends PgPreparedStatement implements CallableStateme
   @Override
   public void registerOutParameter(@Positive int parameterIndex, int sqlType, String typeName)
       throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "registerOutParameter(int,int,String)");
+    // The composite/STRUCT type name is only needed to decode the OUT value into a user-supplied
+    // SQLData class, which is not supported here yet. Register the parameter by its SQL type and
+    // ignore the type name.
+    registerOutParameter(parameterIndex, sqlType);
   }
 
   @Override
   public void setObject(String parameterName, @Nullable Object x, SQLType targetSqlType,
       int scaleOrLength) throws SQLException {
+    // setObject(int, Object, SQLType, int) is not implemented yet, so resolving the name first
+    // would only add a catalog round-trip before failing. Fail fast instead.
     throw Driver.notImplemented(this.getClass(), "setObject");
   }
 
   @Override
   public void setObject(String parameterName, @Nullable Object x, SQLType targetSqlType)
       throws SQLException {
+    // See setObject(String, Object, SQLType, int) above.
     throw Driver.notImplemented(this.getClass(), "setObject");
+  }
+
+  /**
+   * Maps an {@link SQLType} to its {@code java.sql.Types} code.
+   *
+   * <p>Standard {@link JDBCType} values report their own code; a PostgreSQL-specific {@link SQLType}
+   * is mapped by name, falling back to {@link Types#OTHER} for types without a dedicated JDBC code
+   * (composites, enums, and so on).</p>
+   */
+  private static int getSqlTypeCode(SQLType sqlType) {
+    if (sqlType instanceof JDBCType) {
+      return ((JDBCType) sqlType).getVendorTypeNumber();
+    }
+    switch (sqlType.getName().toLowerCase(Locale.ROOT)) {
+      case "int2":
+      case "smallint":
+        return Types.SMALLINT;
+      case "int4":
+      case "integer":
+      case "serial":
+        return Types.INTEGER;
+      case "int8":
+      case "bigint":
+      case "bigserial":
+        return Types.BIGINT;
+      case "float4":
+      case "real":
+        return Types.REAL;
+      case "float8":
+      case "double precision":
+        return Types.DOUBLE;
+      case "numeric":
+      case "decimal":
+        return Types.NUMERIC;
+      case "varchar":
+      case "character varying":
+      case "text":
+        return Types.VARCHAR;
+      case "bpchar":
+      case "char":
+      case "character":
+        return Types.CHAR;
+      case "bool":
+      case "boolean":
+        return Types.BOOLEAN;
+      case "date":
+        return Types.DATE;
+      case "time":
+      case "time without time zone":
+        return Types.TIME;
+      case "timetz":
+      case "time with time zone":
+        return Types.TIME_WITH_TIMEZONE;
+      case "timestamp":
+      case "timestamp without time zone":
+        return Types.TIMESTAMP;
+      case "timestamptz":
+      case "timestamp with time zone":
+        return Types.TIMESTAMP_WITH_TIMEZONE;
+      case "bytea":
+        return Types.BINARY;
+      case "bit":
+        return Types.BIT;
+      case "xml":
+        return Types.SQLXML;
+      case "refcursor":
+        return Types.REF_CURSOR;
+      default:
+        return Types.OTHER;
+    }
   }
 
   @Override
   public void registerOutParameter(@Positive int parameterIndex, SQLType sqlType)
       throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "registerOutParameter");
+    registerOutParameter(parameterIndex, getSqlTypeCode(sqlType));
   }
 
   @Override
   public void registerOutParameter(@Positive int parameterIndex, SQLType sqlType, int scale)
       throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "registerOutParameter");
+    registerOutParameter(parameterIndex, getSqlTypeCode(sqlType), scale);
   }
 
   @Override
   public void registerOutParameter(@Positive int parameterIndex, SQLType sqlType, String typeName)
       throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "registerOutParameter");
+    registerOutParameter(parameterIndex, getSqlTypeCode(sqlType), typeName);
   }
 
   @Override
   public void registerOutParameter(String parameterName, SQLType sqlType)
       throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "registerOutParameter");
+    registerOutParameter(resolveParameterIndex(parameterName), sqlType);
   }
 
   @Override
   public void registerOutParameter(String parameterName, SQLType sqlType, int scale)
       throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "registerOutParameter");
+    registerOutParameter(resolveParameterIndex(parameterName), sqlType, scale);
   }
 
   @Override
   public void registerOutParameter(String parameterName, SQLType sqlType, String typeName)
       throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "registerOutParameter");
+    registerOutParameter(resolveParameterIndex(parameterName), sqlType, typeName);
   }
 
   @Override
@@ -564,107 +846,107 @@ class PgCallableStatement extends PgPreparedStatement implements CallableStateme
 
   @Override
   public @Nullable RowId getRowId(String parameterName) throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "getRowId(String)");
+    return getRowId(resolveParameterIndex(parameterName));
   }
 
   @Override
   public void setRowId(String parameterName, @Nullable RowId x) throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "setRowId(String, RowId)");
+    setRowId(resolveParameterIndex(parameterName), x);
   }
 
   @Override
   public void setNString(String parameterName, @Nullable String value) throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "setNString(String, String)");
+    setNString(resolveParameterIndex(parameterName), value);
   }
 
   @Override
   public void setNCharacterStream(String parameterName, @Nullable Reader value, long length)
       throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "setNCharacterStream(String, Reader, long)");
+    setNCharacterStream(resolveParameterIndex(parameterName), value, length);
   }
 
   @Override
   public void setNCharacterStream(String parameterName, @Nullable Reader value) throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "setNCharacterStream(String, Reader)");
+    setNCharacterStream(resolveParameterIndex(parameterName), value);
   }
 
   @Override
   public void setCharacterStream(String parameterName, @Nullable Reader value, long length)
       throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "setCharacterStream(String, Reader, long)");
+    setCharacterStream(resolveParameterIndex(parameterName), value, length);
   }
 
   @Override
   public void setCharacterStream(String parameterName, @Nullable Reader value) throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "setCharacterStream(String, Reader)");
+    setCharacterStream(resolveParameterIndex(parameterName), value);
   }
 
   @Override
   public void setBinaryStream(String parameterName, @Nullable InputStream value, long length)
       throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "setBinaryStream(String, InputStream, long)");
+    setBinaryStream(resolveParameterIndex(parameterName), value, length);
   }
 
   @Override
   public void setBinaryStream(String parameterName, @Nullable InputStream value) throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "setBinaryStream(String, InputStream)");
+    setBinaryStream(resolveParameterIndex(parameterName), value);
   }
 
   @Override
   public void setAsciiStream(String parameterName, @Nullable InputStream value, long length)
       throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "setAsciiStream(String, InputStream, long)");
+    setAsciiStream(resolveParameterIndex(parameterName), value, length);
   }
 
   @Override
   public void setAsciiStream(String parameterName, @Nullable InputStream value) throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "setAsciiStream(String, InputStream)");
+    setAsciiStream(resolveParameterIndex(parameterName), value);
   }
 
   @Override
   public void setNClob(String parameterName, @Nullable NClob value) throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "setNClob(String, NClob)");
+    setNClob(resolveParameterIndex(parameterName), value);
   }
 
   @Override
   public void setClob(String parameterName, @Nullable Reader reader, long length) throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "setClob(String, Reader, long)");
+    setClob(resolveParameterIndex(parameterName), reader, length);
   }
 
   @Override
   public void setClob(String parameterName, @Nullable Reader reader) throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "setClob(String, Reader)");
+    setClob(resolveParameterIndex(parameterName), reader);
   }
 
   @Override
   public void setBlob(String parameterName, @Nullable InputStream inputStream, long length)
       throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "setBlob(String, InputStream, long)");
+    setBlob(resolveParameterIndex(parameterName), inputStream, length);
   }
 
   @Override
   public void setBlob(String parameterName, @Nullable InputStream inputStream) throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "setBlob(String, InputStream)");
+    setBlob(resolveParameterIndex(parameterName), inputStream);
   }
 
   @Override
   public void setBlob(String parameterName, @Nullable Blob x) throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "setBlob(String, Blob)");
+    setBlob(resolveParameterIndex(parameterName), x);
   }
 
   @Override
   public void setClob(String parameterName, @Nullable Clob x) throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "setClob(String, Clob)");
+    setClob(resolveParameterIndex(parameterName), x);
   }
 
   @Override
   public void setNClob(String parameterName, @Nullable Reader reader, long length) throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "setNClob(String, Reader, long)");
+    setNClob(resolveParameterIndex(parameterName), reader, length);
   }
 
   @Override
   public void setNClob(String parameterName, @Nullable Reader reader) throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "setNClob(String, Reader)");
+    setNClob(resolveParameterIndex(parameterName), reader);
   }
 
   @Override
@@ -674,12 +956,12 @@ class PgCallableStatement extends PgPreparedStatement implements CallableStateme
 
   @Override
   public @Nullable NClob getNClob(String parameterName) throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "getNClob(String)");
+    return getNClob(resolveParameterIndex(parameterName));
   }
 
   @Override
   public void setSQLXML(String parameterName, @Nullable SQLXML xmlObject) throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "setSQLXML(String, SQLXML)");
+    setSQLXML(resolveParameterIndex(parameterName), xmlObject);
   }
 
   @Override
@@ -689,8 +971,8 @@ class PgCallableStatement extends PgPreparedStatement implements CallableStateme
   }
 
   @Override
-  public @Nullable SQLXML getSQLXML(String parameterIndex) throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "getSQLXML(String)");
+  public @Nullable SQLXML getSQLXML(String parameterName) throws SQLException {
+    return getSQLXML(resolveParameterIndex(parameterName));
   }
 
   @Override
@@ -700,7 +982,7 @@ class PgCallableStatement extends PgPreparedStatement implements CallableStateme
 
   @Override
   public @Nullable String getNString(String parameterName) throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "getNString(String)");
+    return getNString(resolveParameterIndex(parameterName));
   }
 
   @Override
@@ -710,17 +992,21 @@ class PgCallableStatement extends PgPreparedStatement implements CallableStateme
 
   @Override
   public @Nullable Reader getNCharacterStream(String parameterName) throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "getNCharacterStream(String)");
+    return getNCharacterStream(resolveParameterIndex(parameterName));
   }
 
   @Override
   public @Nullable Reader getCharacterStream(@Positive int parameterIndex) throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "getCharacterStream(int)");
+    Object result = checkIndex(parameterIndex, Types.VARCHAR, "String");
+    if (result == null) {
+      return null;
+    }
+    return new StringReader((String) result);
   }
 
   @Override
   public @Nullable Reader getCharacterStream(String parameterName) throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "getCharacterStream(String)");
+    return getCharacterStream(resolveParameterIndex(parameterName));
   }
 
   @Override
@@ -735,24 +1021,24 @@ class PgCallableStatement extends PgPreparedStatement implements CallableStateme
 
   @Override
   public <T> @Nullable T getObject(String parameterName, Class<T> type) throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "getObject(String, Class<T>)");
+    return getObject(resolveParameterIndex(parameterName), type);
   }
 
   @Override
   public void registerOutParameter(String parameterName, int sqlType) throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "registerOutParameter(String,int)");
+    registerOutParameter(resolveParameterIndex(parameterName), sqlType);
   }
 
   @Override
   public void registerOutParameter(String parameterName, int sqlType, int scale)
       throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "registerOutParameter(String,int,int)");
+    registerOutParameter(resolveParameterIndex(parameterName), sqlType, scale);
   }
 
   @Override
   public void registerOutParameter(String parameterName, int sqlType, String typeName)
       throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "registerOutParameter(String,int,String)");
+    registerOutParameter(resolveParameterIndex(parameterName), sqlType, typeName);
   }
 
   @Override
@@ -762,243 +1048,243 @@ class PgCallableStatement extends PgPreparedStatement implements CallableStateme
 
   @Override
   public void setURL(String parameterName, @Nullable URL val) throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "setURL(String,URL)");
+    setURL(resolveParameterIndex(parameterName), val);
   }
 
   @Override
   public void setNull(String parameterName, int sqlType) throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "setNull(String,int)");
+    setNull(resolveParameterIndex(parameterName), sqlType);
   }
 
   @Override
   public void setBoolean(String parameterName, boolean x) throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "setBoolean(String,boolean)");
+    setBoolean(resolveParameterIndex(parameterName), x);
   }
 
   @Override
   public void setByte(String parameterName, byte x) throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "setByte(String,byte)");
+    setByte(resolveParameterIndex(parameterName), x);
   }
 
   @Override
   public void setShort(String parameterName, short x) throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "setShort(String,short)");
+    setShort(resolveParameterIndex(parameterName), x);
   }
 
   @Override
   public void setInt(String parameterName, int x) throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "setInt(String,int)");
+    setInt(resolveParameterIndex(parameterName), x);
   }
 
   @Override
   public void setLong(String parameterName, long x) throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "setLong(String,long)");
+    setLong(resolveParameterIndex(parameterName), x);
   }
 
   @Override
   public void setFloat(String parameterName, float x) throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "setFloat(String,float)");
+    setFloat(resolveParameterIndex(parameterName), x);
   }
 
   @Override
   public void setDouble(String parameterName, double x) throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "setDouble(String,double)");
+    setDouble(resolveParameterIndex(parameterName), x);
   }
 
   @Override
   public void setBigDecimal(String parameterName, @Nullable BigDecimal x) throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "setBigDecimal(String,BigDecimal)");
+    setBigDecimal(resolveParameterIndex(parameterName), x);
   }
 
   @Override
   public void setString(String parameterName, @Nullable String x) throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "setString(String,String)");
+    setString(resolveParameterIndex(parameterName), x);
   }
 
   @Override
   public void setBytes(String parameterName, byte @Nullable [] x) throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "setBytes(String,byte)");
+    setBytes(resolveParameterIndex(parameterName), x);
   }
 
   @Override
   public void setDate(String parameterName, @Nullable Date x) throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "setDate(String,Date)");
+    setDate(resolveParameterIndex(parameterName), x);
   }
 
   @Override
   public void setTime(String parameterName, @Nullable Time x) throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "setTime(String,Time)");
+    setTime(resolveParameterIndex(parameterName), x);
   }
 
   @Override
   public void setTimestamp(String parameterName, @Nullable Timestamp x) throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "setTimestamp(String,Timestamp)");
+    setTimestamp(resolveParameterIndex(parameterName), x);
   }
 
   @Override
   public void setAsciiStream(String parameterName, @Nullable InputStream x, int length) throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "setAsciiStream(String,InputStream,int)");
+    setAsciiStream(resolveParameterIndex(parameterName), x, length);
   }
 
   @Override
   public void setBinaryStream(String parameterName, @Nullable InputStream x, int length) throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "setBinaryStream(String,InputStream,int)");
+    setBinaryStream(resolveParameterIndex(parameterName), x, length);
   }
 
   @Override
   public void setObject(String parameterName, @Nullable Object x, int targetSqlType, int scale)
       throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "setObject(String,Object,int,int)");
+    setObject(resolveParameterIndex(parameterName), x, targetSqlType, scale);
   }
 
   @Override
   public void setObject(String parameterName, @Nullable Object x, int targetSqlType) throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "setObject(String,Object,int)");
+    setObject(resolveParameterIndex(parameterName), x, targetSqlType);
   }
 
   @Override
   public void setObject(String parameterName, @Nullable Object x) throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "setObject(String,Object)");
+    setObject(resolveParameterIndex(parameterName), x);
   }
 
   @Override
   public void setCharacterStream(String parameterName, @Nullable Reader reader, int length)
       throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "setCharacterStream(String,Reader,int)");
+    setCharacterStream(resolveParameterIndex(parameterName), reader, length);
   }
 
   @Override
   public void setDate(String parameterName, @Nullable Date x, @Nullable Calendar cal) throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "setDate(String,Date,Calendar)");
+    setDate(resolveParameterIndex(parameterName), x, cal);
   }
 
   @Override
   public void setTime(String parameterName, @Nullable Time x, @Nullable Calendar cal) throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "setTime(String,Time,Calendar)");
+    setTime(resolveParameterIndex(parameterName), x, cal);
   }
 
   @Override
   public void setTimestamp(String parameterName, @Nullable Timestamp x, @Nullable Calendar cal) throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "setTimestamp(String,Timestamp,Calendar)");
+    setTimestamp(resolveParameterIndex(parameterName), x, cal);
   }
 
   @Override
   public void setNull(String parameterName, int sqlType, String typeName) throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "setNull(String,int,String)");
+    setNull(resolveParameterIndex(parameterName), sqlType, typeName);
   }
 
   @Override
   public @Nullable String getString(String parameterName) throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "getString(String)");
+    return getString(resolveParameterIndex(parameterName));
   }
 
   @Override
   public boolean getBoolean(String parameterName) throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "getBoolean(String)");
+    return getBoolean(resolveParameterIndex(parameterName));
   }
 
   @Override
   public byte getByte(String parameterName) throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "getByte(String)");
+    return getByte(resolveParameterIndex(parameterName));
   }
 
   @Override
   public short getShort(String parameterName) throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "getShort(String)");
+    return getShort(resolveParameterIndex(parameterName));
   }
 
   @Override
   public int getInt(String parameterName) throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "getInt(String)");
+    return getInt(resolveParameterIndex(parameterName));
   }
 
   @Override
   public long getLong(String parameterName) throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "getLong(String)");
+    return getLong(resolveParameterIndex(parameterName));
   }
 
   @Override
   public float getFloat(String parameterName) throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "getFloat(String)");
+    return getFloat(resolveParameterIndex(parameterName));
   }
 
   @Override
   public double getDouble(String parameterName) throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "getDouble(String)");
+    return getDouble(resolveParameterIndex(parameterName));
   }
 
   @Override
   public byte @Nullable [] getBytes(String parameterName) throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "getBytes(String)");
+    return getBytes(resolveParameterIndex(parameterName));
   }
 
   @Override
   public @Nullable Date getDate(String parameterName) throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "getDate(String)");
+    return getDate(resolveParameterIndex(parameterName));
   }
 
   @Override
-  public Time getTime(String parameterName) throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "getTime(String)");
+  public @Nullable Time getTime(String parameterName) throws SQLException {
+    return getTime(resolveParameterIndex(parameterName));
   }
 
   @Override
   public @Nullable Timestamp getTimestamp(String parameterName) throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "getTimestamp(String)");
+    return getTimestamp(resolveParameterIndex(parameterName));
   }
 
   @Override
   public @Nullable Object getObject(String parameterName) throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "getObject(String)");
+    return getObject(resolveParameterIndex(parameterName));
   }
 
   @Override
   public @Nullable BigDecimal getBigDecimal(String parameterName) throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "getBigDecimal(String)");
+    return getBigDecimal(resolveParameterIndex(parameterName));
   }
 
   public @Nullable Object getObjectImpl(String parameterName, @Nullable Map<String, Class<?>> map) throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "getObject(String,Map)");
+    return getObjectImpl(resolveParameterIndex(parameterName), map);
   }
 
   @Override
   public @Nullable Ref getRef(String parameterName) throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "getRef(String)");
+    return getRef(resolveParameterIndex(parameterName));
   }
 
   @Override
   public @Nullable Blob getBlob(String parameterName) throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "getBlob(String)");
+    return getBlob(resolveParameterIndex(parameterName));
   }
 
   @Override
   public @Nullable Clob getClob(String parameterName) throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "getClob(String)");
+    return getClob(resolveParameterIndex(parameterName));
   }
 
   @Override
   public @Nullable Array getArray(String parameterName) throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "getArray(String)");
+    return getArray(resolveParameterIndex(parameterName));
   }
 
   @Override
   public @Nullable Date getDate(String parameterName, @Nullable Calendar cal) throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "getDate(String,Calendar)");
+    return getDate(resolveParameterIndex(parameterName), cal);
   }
 
   @Override
   public @Nullable Time getTime(String parameterName, @Nullable Calendar cal) throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "getTime(String,Calendar)");
+    return getTime(resolveParameterIndex(parameterName), cal);
   }
 
   @Override
   public @Nullable Timestamp getTimestamp(String parameterName, @Nullable Calendar cal) throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "getTimestamp(String,Calendar)");
+    return getTimestamp(resolveParameterIndex(parameterName), cal);
   }
 
   @Override
   public @Nullable URL getURL(String parameterName) throws SQLException {
-    throw Driver.notImplemented(this.getClass(), "getURL(String)");
+    return getURL(resolveParameterIndex(parameterName));
   }
 
   @Override

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
@@ -266,6 +266,11 @@ public class PgConnection implements BaseConnection {
     LOGGER.log(Level.FINE, "  setFlushCacheOnDeallocate = {0}", flushCacheOnDeallocate);
   }
 
+  @Override
+  public int getTypeCacheEpoch() {
+    return queryExecutor.getTypeCacheEpoch();
+  }
+
   //
   // Ctor.
   //

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc3/Jdbc3CallableStatementTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc3/Jdbc3CallableStatementTest.java
@@ -51,6 +51,10 @@ public class Jdbc3CallableStatementTest extends BaseTest4 {
     stmt.execute(
         "CREATE OR REPLACE FUNCTION mysum(a int, b int) returns int AS 'BEGIN return a + b; END;' LANGUAGE plpgsql");
     stmt.execute(
+        "CREATE OR REPLACE FUNCTION mypartialnames(int, b int) returns int AS 'BEGIN return $1 * 10 + b; END;' LANGUAGE plpgsql");
+    stmt.execute(
+        "CREATE OR REPLACE FUNCTION myresultarg(result int) returns int AS 'BEGIN return result + 1; END;' LANGUAGE plpgsql");
+    stmt.execute(
         "CREATE OR REPLACE FUNCTION myiofunc(a INOUT int, b OUT int) AS 'BEGIN b := a; a := 1; END;' LANGUAGE plpgsql");
     stmt.execute(
         "CREATE OR REPLACE FUNCTION myif(a INOUT int, b IN int) AS 'BEGIN a := b; END;' LANGUAGE plpgsql");
@@ -129,6 +133,8 @@ public class Jdbc3CallableStatementTest extends BaseTest4 {
     stmt.execute("drop function test_somein_someout(int4)");
     stmt.execute("drop function test_allinout( inout int4, inout varchar, inout int8)");
     stmt.execute("drop function mysum(a int, b int)");
+    stmt.execute("drop function mypartialnames(int, int)");
+    stmt.execute("drop function myresultarg(int)");
     stmt.execute("drop function myiofunc(a INOUT int, b OUT int) ");
     stmt.execute("drop function myif(a INOUT int, b IN int)");
     stmt.execute("drop function mynoparams()");
@@ -1054,6 +1060,88 @@ public class Jdbc3CallableStatementTest extends BaseTest4 {
     cs.setInt(3, 3);
     cs.execute();
     assertEquals(5, cs.getInt(1), "2+3 should be 5 when executed via {?= call mysum(?, ?)}");
+  }
+
+  @Test
+  public void testSumByParameterName() throws SQLException {
+    CallableStatement cs = con.prepareCall("{?= call mysum(?, ?)}");
+    cs.registerOutParameter(1, Types.INTEGER);
+    cs.setInt("a", 2);
+    cs.setInt("b", 3);
+    cs.execute();
+    assertEquals(5, cs.getInt(1), "named IN parameters a=2, b=3 should sum to 5");
+    TestUtil.closeQuietly(cs);
+  }
+
+  @Test
+  public void testNamedParameterAfterUnnamedResolvesToCorrectIndex() throws SQLException {
+    // mypartialnames(int, b int): the first argument is unnamed, so "b" must resolve to JDBC
+    // index 3, not 2. Binding index 2 would overwrite the first argument and skew the result.
+    CallableStatement cs = con.prepareCall("{?= call mypartialnames(?, ?)}");
+    cs.registerOutParameter(1, Types.INTEGER);
+    cs.setInt(2, 5);
+    cs.setInt("b", 3);
+    cs.execute();
+    assertEquals(53, cs.getInt(1), "5*10 + 3 should be 53; 'b' must bind index 3, not 2");
+    TestUtil.closeQuietly(cs);
+  }
+
+  @Test
+  public void testOutParameterByNameInCallForm() throws SQLException {
+    // { call f(?,?,?) } over test_somein_someout(pa IN, pb OUT, pc OUT): every argument keeps
+    // its declaration-order JDBC position, so pa -> 1, pb -> 2, pc -> 3 by name.
+    CallableStatement cs = con.prepareCall("{ call test_somein_someout(?, ?, ?) }");
+    cs.setInt("pa", 10);
+    cs.registerOutParameter("pb", Types.VARCHAR);
+    cs.registerOutParameter("pc", Types.BIGINT);
+    cs.execute();
+    assertEquals("out", cs.getString("pb"));
+    assertEquals(11, cs.getLong("pc"));
+    TestUtil.closeQuietly(cs);
+  }
+
+  @Test
+  public void testNamedParameterMapInvalidatedAfterDdl() throws SQLException {
+    // The catalog-derived name->index map is cached per SQL; a DDL change to the routine's
+    // signature bumps the connection's type-cache epoch and must rebuild it.
+    Statement ddl = con.createStatement();
+    try {
+      ddl.execute("CREATE OR REPLACE FUNCTION myreparse(a int) returns int "
+          + "AS 'BEGIN return a; END;' LANGUAGE plpgsql");
+      try (CallableStatement cs = con.prepareCall("{?= call myreparse(?)}")) {
+        cs.registerOutParameter(1, Types.INTEGER);
+        cs.setInt("a", 7);
+        cs.execute();
+        assertEquals(7, cs.getInt(1));
+      }
+      // Redefine with a different parameter name. CREATE/DROP are DDL, so the type-cache epoch
+      // advances and the cached {a->2} mapping for the identical SQL must not be reused.
+      ddl.execute("DROP FUNCTION myreparse(int)");
+      ddl.execute("CREATE OR REPLACE FUNCTION myreparse(z int) returns int "
+          + "AS 'BEGIN return z + 1; END;' LANGUAGE plpgsql");
+      try (CallableStatement cs = con.prepareCall("{?= call myreparse(?)}")) {
+        cs.registerOutParameter(1, Types.INTEGER);
+        cs.setInt("z", 7);
+        cs.execute();
+        assertEquals(8, cs.getInt(1), "the map must be rebuilt against the new signature");
+      }
+    } finally {
+      ddl.execute("DROP FUNCTION IF EXISTS myreparse(int)");
+      ddl.close();
+    }
+  }
+
+  @Test
+  public void testInputParameterNamedLikeReturnAlias() throws SQLException {
+    // The scalar { ? = call ... } form aliases the return column as "result"; an input
+    // parameter that is itself named "result" must still bind its own index (2), not the
+    // synthetic return placeholder at index 1.
+    CallableStatement cs = con.prepareCall("{?= call myresultarg(?)}");
+    cs.registerOutParameter(1, Types.INTEGER);
+    cs.setInt("result", 41);
+    cs.execute();
+    assertEquals(42, cs.getInt(1), "input 'result'=41 -> return 42; 'result' must bind index 2");
+    TestUtil.closeQuietly(cs);
   }
 
   @Test


### PR DESCRIPTION
## Why

`CallableStatement`'s by-name API — `setXXX(String)`, `getXXX(String)`, and `registerOutParameter(String, ...)` — threw `notImplemented` in pgJDBC, forcing callers to use positional indexes. This change implements it.

It is the by-name slice of the larger `typecache` work, extracted to land early and shrink that branch's diff.

## What

- Resolve a parameter name to its 1-based JDBC index from `pg_catalog.pg_proc` through a `regproc` cast, which applies the same `search_path` and quoting rules as the call itself.
- Handle the two escape forms separately: `{ call proc(...) }` keeps every argument in declaration order, while `{ ? = call f(...) }` reserves index 1 for the return placeholder and maps the input-bearing arguments to 2, 3, … .
- Cache the name-to-index map on `CachedQuery`, stamped with a per-connection type-cache epoch. The query executor bumps the epoch on DDL (`CREATE`/`DROP`/`ALTER`) and on `SET search_path`, so a routine redefined under the same call SQL rebuilds the map instead of binding a named value to a stale index. `getTypeCacheEpoch()` is exposed through `QueryExecutor`, `BaseConnection`, and `PgConnection`.
- Wire the `SQLType` `registerOutParameter` overloads and implement `getCharacterStream(int)`.

STRUCT/SQLData OUT decoding and typemap `getObject` stay in the `typecache` branch, where the codec machinery they depend on lives; those methods remain `notImplemented` here.

## How to verify

`Jdbc3CallableStatementTest` adds `testSumByParameterName`, `testNamedParameterAfterUnnamedResolvesToCorrectIndex`, `testOutParameterByNameInCallForm`, `testInputParameterNamedLikeReturnAlias`, and `testNamedParameterMapInvalidatedAfterDdl`.

```
./gradlew :postgresql:test --tests org.postgresql.test.jdbc3.Jdbc3CallableStatementTest
```

## Known limitations (deliberately not addressed here)

These behaviours are inherited verbatim from the `typecache` branch. Changing them in this PR would diverge from that branch and complicate the planned rebase, so they are left as-is:

- **Overloaded routines.** The `regproc` cast resolves by name only, so an overloaded routine raises an actionable error ("use a positional parameter index") even when the call is unambiguous through explicit casts such as `{ ? = call f(?::int) }`. A failed cast also marks an open transaction as aborted.
- **Case-distinct quoted identifiers.** Catalog names are folded to lower case, so a routine declaring both `"A"` and `"a"` collapses to a single key and the second name maps to the first index.
- **Custom `SQLType` vendor numbers.** `registerOutParameter(int, SQLType)` maps PostgreSQL-specific `SQLType`s by name and falls back to `Types.OTHER` rather than consulting `SQLType.getVendorTypeNumber()`.

Separately, `SET search_path` is detected case-sensitively (pre-existing behaviour that also governs the prepared-statement plan cache). Case-insensitive `SET`/`RESET search_path` detection is handled in https://github.com/pgjdbc/pgjdbc/pull/4216.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
