### PR TITLE
ci: derive PG test versions from a Renovate-managed maxPgVersion

### DIFF
--- a/.github/workflows/matrix.mjs
+++ b/.github/workflows/matrix.mjs
@@ -50,10 +50,21 @@ matrix.addAxis({
   ]
 });
 
+// The newest stable PostgreSQL major. It generates the pg_version axis (10..MAX_PG)
+// and pins the server of the coverage job below. Renovate bumps it when a new
+// `postgres:<major>` image reaches Docker Hub (see the custom manager in renovate.json),
+// which is also when we can start testing that release. A string so it compares equal to
+// the axis values, which are strings.
+// renovate: datasource=docker depName=postgres versioning=regex:^(?<major>\d+)$
+const MAX_PG = '18';
+
 matrix.addAxis({
   name: 'pg_version',
   title: x => 'PG ' + x,
-  // Strings allow versions like 18-ea
+  // Strings allow versions like 18-ea.
+  // PostgreSQL before 10 used an x.y major scheme, so those are listed by hand.
+  // From 10 on the major is a single number, so 10..MAX_PG is generated and adding
+  // a new major is a one-line Renovate bump of MAX_PG above.
   values: [
     '9.1',
     '9.2',
@@ -61,15 +72,8 @@ matrix.addAxis({
     '9.4',
     '9.5',
     '9.6',
-    '10',
-    '11',
-    '12',
-    '13',
-    '14',
-    '15',
-    '16',
-    '17',
-    '18'
+    // 10, 11, …, MAX_PG
+    ...Array.from({length: Number(MAX_PG) - 10 + 1}, (_, i) => String(10 + i)),
   ]
 });
 
@@ -311,7 +315,6 @@ matrix.imply({autosave: {value: 'never'}}, {cleanupSavepoints: {value: 'false'}}
 // scram, xa, replication, the latest stable server, one query mode). The other flags add at
 // most a line or two to line/branch coverage, so leaving them to the random fill keeps the
 // corpus stable between builds without a fixed seed.
-const MAX_PG = matrix.axisByName.pg_version.values.filter(v => v !== 'HEAD').slice(-1)[0];
 // Latest non-EA Java from the axis, so this need not be bumped when Java versions change.
 const LATEST_JAVA = matrix.axisByName.java_version.values.filter(v => v !== eaJava).slice(-1)[0];
 

--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,18 @@
     "description": "Security updates bypass the packageRules grouping below (Renovate resets their groupName), so apply the same groupId grouping to them here.",
     "groupName": "{{{replace ':.*' '' depName}}} security"
   },
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Track the newest PostgreSQL major (MAX_PG in matrix.mjs) against the postgres Docker image. The regex versioning keeps only single-number major tags, so Renovate bumps MAX_PG when the next major image ships, not on minor `postgres:18.x` releases.",
+      "managerFilePatterns": [
+        "/\\.github/workflows/matrix\\.mjs$/"
+      ],
+      "matchStrings": [
+        "// renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+) versioning=(?<versioning>\\S+)\\s+const MAX_PG = '(?<currentValue>\\d+)'"
+      ]
+    }
+  ],
   "packageRules": [
     {
       "description": "Group every Maven update by its groupId by default. The more specific rules below run later and override this where a group must span several groupIds, pin a version, or stay disabled.",
@@ -41,6 +53,16 @@
       ],
       "matchCurrentVersion": "1.0.0-dev-master-SNAPSHOT",
       "enabled": false
+    },
+    {
+      "description": "MAX_PG is a plain major number, not a pinnable image reference, so skip the config:best-practices digest pin. Scoped to matrix.mjs so a real `FROM postgres` Dockerfile still gets a pinned digest.",
+      "matchFileNames": [
+        ".github/workflows/matrix.mjs"
+      ],
+      "matchDepNames": [
+        "postgres"
+      ],
+      "pinDigests": false
     },
     {
       "matchPackageNames": [


### PR DESCRIPTION
## Why

The `pg_version` axis in `matrix.mjs` listed every PostgreSQL major by hand, so each new release meant a manual edit. `omni.yml` even carries a `TODO` about determining the latest server version automatically.

## What

- Introduce a `maxPgVersion` constant and generate the `10..maxPgVersion` majors, keeping the pre-10 `x.y` versions (`9.1`..`9.6`) as an explicit list — their numbering does not follow the single-number scheme.
- Add a Renovate custom (regex) manager that tracks `maxPgVersion` against the `postgres` Docker image. The `regex:^(?<major>\d+)$` versioning keeps only single-number major tags, so Renovate bumps the constant when the next major image ships, not on minor `postgres:18.x` releases. That release is also the point at which we can start testing the new major.
- Add a `packageRule` disabling the `config:best-practices` digest pin for this dependency, since `maxPgVersion` holds a bare major number rather than an image reference.

Only `matrix.mjs` is converted; `omni.yml` is left untouched.

## How to verify

Run locally against the `renovate/renovate` image (dry-run, `local` platform):

- With `maxPgVersion` temporarily lowered to `16`, Renovate proposes a single **major** update to `18` (branch `renovate/postgres-18.x`), with no minor (`18.x`) or digest noise.
- At `18` (current latest major) there is no update.
- `node .github/workflows/matrix.mjs` still emits the same `9.1`..`18` list as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)