### PR TITLE
build: ignore .codex-review scratch folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ buildNumber.properties
 
 # Ignore folders used to build binaries for old Java
 /eclipsebin/
+
+# Scratch folder used by the codex-review skill
+# https://github.com/Netcracker/qubership-ai-packages/tree/main/agent-packages/codex-review
+.codex-review


### PR DESCRIPTION
## Why

The [codex-review skill](https://github.com/Netcracker/qubership-ai-packages/tree/main/agent-packages/codex-review) writes temporary files into a `.codex-review` folder at the repository root. Without an ignore rule, these scratch files show up as untracked changes.

## What

Add `.codex-review` to `.gitignore`, with a comment explaining its purpose and a link to the skill.

## How to verify

Run the codex-review skill (or `mkdir .codex-review`) and confirm `git status` stays clean.