### PR TITLE
feat(core): add OID constants for geometric arrays, RECORD, refcursor

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/Oid.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/Oid.java
@@ -78,19 +78,30 @@ public class Oid {
   public static final int JSONB_ARRAY = 3807;
   public static final int JSON = 114;
   public static final int JSON_ARRAY = 199;
-  public static final int REF_CURSOR = 1790;
-  public static final int REF_CURSOR_ARRAY = 2201;
+  public static final int REFCURSOR = 1790;
+  public static final int REFCURSOR_ARRAY = 2201;
+  // backward compatibility
+  public static final int REF_CURSOR = REFCURSOR;
+  // backward compatibility
+  public static final int REF_CURSOR_ARRAY = REFCURSOR_ARRAY;
   public static final int LINE = 628;
+  public static final int LINE_ARRAY = 629;
   public static final int LSEG = 601;
+  public static final int LSEG_ARRAY = 1018;
   public static final int PATH = 602;
+  public static final int PATH_ARRAY = 1019;
   public static final int POLYGON = 604;
+  public static final int POLYGON_ARRAY = 1027;
   public static final int CIRCLE = 718;
+  public static final int CIRCLE_ARRAY = 719;
   public static final int CIDR = 650;
   public static final int INET = 869;
   public static final int MACADDR = 829;
   public static final int MACADDR8 = 774;
   public static final int TSVECTOR = 3614;
   public static final int TSQUERY = 3615;
+  public static final int RECORD = 2249;
+  public static final int RECORD_ARRAY = 2287;
 
   private static final Map<Integer, String> OID_TO_NAME = new HashMap<>(100);
   private static final Map<String, Integer> NAME_TO_OID = new HashMap<>(100);

--- a/pgjdbc/src/test/java/org/postgresql/core/OidValuesCorrectnessTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/core/OidValuesCorrectnessTest.java
@@ -102,6 +102,13 @@ public class OidValuesCorrectnessTest extends BaseTest4 {
     oidTypeNames.put("JSON_ARRAY", "_JSON");
     oidTypeNames.put("REF_CURSOR", "REFCURSOR");
     oidTypeNames.put("REF_CURSOR_ARRAY", "_REFCURSOR");
+    oidTypeNames.put("REFCURSOR_ARRAY", "_REFCURSOR");
+    oidTypeNames.put("LINE_ARRAY", "_LINE");
+    oidTypeNames.put("LSEG_ARRAY", "_LSEG");
+    oidTypeNames.put("PATH_ARRAY", "_PATH");
+    oidTypeNames.put("POLYGON_ARRAY", "_POLYGON");
+    oidTypeNames.put("CIRCLE_ARRAY", "_CIRCLE");
+    oidTypeNames.put("RECORD_ARRAY", "_RECORD");
   }
 
   public static Iterable<Object[]> data() throws IllegalAccessException {


### PR DESCRIPTION
## Why

The `typecache` work resolves several types the driver had no OID constants for. Extracting just those constants here shrinks that branch's diff and lets the values land and get reviewed on their own. Same approach as #4217.

## What

Add stable system OID constants to `org.postgresql.core.Oid`:

- Geometric array types: `LINE_ARRAY` (629), `LSEG_ARRAY` (1018), `PATH_ARRAY` (1019), `POLYGON_ARRAY` (1027), `CIRCLE_ARRAY` (719).
- `RECORD` (2249) and `RECORD_ARRAY` (2287).
- Rename `REF_CURSOR` → `REFCURSOR` and `REF_CURSOR_ARRAY` → `REFCURSOR_ARRAY` to match the `pg_type` `typname`, keeping the old names as backward-compatible aliases that point at the new constants.

`Oid` builds its OID↔name maps reflectively over its public fields, so the aliases register automatically: `valueOf` accepts both `REFCURSOR` and `REF_CURSOR`, and existing references to `Oid.REF_CURSOR`/`REF_CURSOR_ARRAY` keep compiling against the same value.

`OidValuesCorrectnessTest` gains `pg_type` name mappings for the new array constants and for `REFCURSOR_ARRAY`.

## Deliberately excluded: hstore

The `typecache` branch also defines `HSTORE`/`HSTORE_ARRAY`. hstore is a contrib extension whose OID is assigned at `CREATE EXTENSION` time and varies between installations, so it cannot be a fixed constant. It is left out here and can be discussed separately.

## How to verify

    ./gradlew :postgresql:test --tests org.postgresql.core.OidValuesCorrectnessTest

The test reads each `Oid` constant's value from a live `pg_type` and asserts it matches. Locally: 81 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
