### PR TITLE
fix: call scalar function via select f(?) for { ? = call f } escape syntax

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/Parser.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/Parser.java
@@ -1205,8 +1205,13 @@ public class Parser {
     String suffix;
     if (escapeSyntaxCallMode == EscapeSyntaxCallMode.SELECT || serverVersion < 110000
         || (outParamBeforeFunc && escapeSyntaxCallMode == EscapeSyntaxCallMode.CALL_IF_NO_RETURN)) {
-      prefix = "select * from ";
-      suffix = " as result";
+      if (outParamBeforeFunc) {
+        prefix = "select ";
+        suffix = " as result";
+      } else {
+        prefix = "select * from ";
+        suffix = " as result";
+      }
     } else {
       prefix = "call ";
       suffix = "";

--- a/pgjdbc/src/test/java/org/postgresql/core/ParserTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/core/ParserTest.java
@@ -140,19 +140,19 @@ class ParserTest {
   @Test
   void modifyJdbcCall() throws SQLException {
     ProtocolVersion protocolVersion = ProtocolVersion.fromMajorMinor(3,0);
-    assertEquals("select * from pack_getValue(?) as result", Parser.modifyJdbcCall("{ ? = call pack_getValue}", true, ServerVersion.v9_6.getVersionNum(),
+    assertEquals("select pack_getValue(?) as result", Parser.modifyJdbcCall("{ ? = call pack_getValue}", true, ServerVersion.v9_6.getVersionNum(),
         EscapeSyntaxCallMode.SELECT).getSql());
-    assertEquals("select * from pack_getValue(?,?)  as result", Parser.modifyJdbcCall("{ ? = call pack_getValue(?) }", true, ServerVersion.v9_6.getVersionNum(),
+    assertEquals("select pack_getValue(?,?)  as result", Parser.modifyJdbcCall("{ ? = call pack_getValue(?) }", true, ServerVersion.v9_6.getVersionNum(),
         EscapeSyntaxCallMode.SELECT).getSql());
-    assertEquals("select * from pack_getValue(?) as result", Parser.modifyJdbcCall("{ ? = call pack_getValue()}", true, ServerVersion.v9_6.getVersionNum(),
+    assertEquals("select pack_getValue(?) as result", Parser.modifyJdbcCall("{ ? = call pack_getValue()}", true, ServerVersion.v9_6.getVersionNum(),
         EscapeSyntaxCallMode.SELECT).getSql());
-    assertEquals("select * from pack_getValue(?,?,?,?)  as result", Parser.modifyJdbcCall("{ ? = call pack_getValue(?,?,?) }", true, ServerVersion.v9_6.getVersionNum(),
+    assertEquals("select pack_getValue(?,?,?,?)  as result", Parser.modifyJdbcCall("{ ? = call pack_getValue(?,?,?) }", true, ServerVersion.v9_6.getVersionNum(),
         EscapeSyntaxCallMode.SELECT).getSql());
-    assertEquals("select * from lower(?,?) as result", Parser.modifyJdbcCall("{ ? = call lower(?)}", true, ServerVersion.v9_6.getVersionNum(),
+    assertEquals("select lower(?,?) as result", Parser.modifyJdbcCall("{ ? = call lower(?)}", true, ServerVersion.v9_6.getVersionNum(),
         EscapeSyntaxCallMode.SELECT).getSql());
-    assertEquals("select * from lower(?,?) as result", Parser.modifyJdbcCall("{ ? = call lower(?)}", true, ServerVersion.v9_6.getVersionNum(),
+    assertEquals("select lower(?,?) as result", Parser.modifyJdbcCall("{ ? = call lower(?)}", true, ServerVersion.v9_6.getVersionNum(),
         EscapeSyntaxCallMode.CALL_IF_NO_RETURN).getSql());
-    assertEquals("select * from lower(?,?) as result", Parser.modifyJdbcCall("{ ? = call lower(?)}", true, ServerVersion.v9_6.getVersionNum(),
+    assertEquals("select lower(?,?) as result", Parser.modifyJdbcCall("{ ? = call lower(?)}", true, ServerVersion.v9_6.getVersionNum(),
         EscapeSyntaxCallMode.CALL).getSql());
     assertEquals("select * from lower(?,?) as result", Parser.modifyJdbcCall("{call lower(?,?)}", true, ServerVersion.v9_6.getVersionNum(),
         EscapeSyntaxCallMode.SELECT).getSql());
@@ -160,9 +160,9 @@ class ParserTest {
         EscapeSyntaxCallMode.CALL_IF_NO_RETURN).getSql());
     assertEquals("select * from lower(?,?) as result", Parser.modifyJdbcCall("{call lower(?,?)}", true, ServerVersion.v9_6.getVersionNum(),
         EscapeSyntaxCallMode.CALL).getSql());
-    assertEquals("select * from lower(?,?) as result", Parser.modifyJdbcCall("{ ? = call lower(?)}", true, ServerVersion.v11.getVersionNum(),
+    assertEquals("select lower(?,?) as result", Parser.modifyJdbcCall("{ ? = call lower(?)}", true, ServerVersion.v11.getVersionNum(),
         EscapeSyntaxCallMode.SELECT).getSql());
-    assertEquals("select * from lower(?,?) as result", Parser.modifyJdbcCall("{ ? = call lower(?)}", true, ServerVersion.v11.getVersionNum(),
+    assertEquals("select lower(?,?) as result", Parser.modifyJdbcCall("{ ? = call lower(?)}", true, ServerVersion.v11.getVersionNum(),
         EscapeSyntaxCallMode.CALL_IF_NO_RETURN).getSql());
     assertEquals("call lower(?,?)", Parser.modifyJdbcCall("{ ? = call lower(?)}", true, ServerVersion.v11.getVersionNum(),
         EscapeSyntaxCallMode.CALL).getSql());


### PR DESCRIPTION
## Why

The JDBC escape `{ ? = call func(...) }` registers a single scalar OUT parameter, so the function returns one value bound to that parameter. `Parser.modifyJdbcCall` rewrote it to `select * from func(?) as result`, putting the function in the `FROM` clause as a set-returning table source. For a scalar function that is the wrong call shape: it can fail outright or expose the result under the wrong column shape.

## What

When an OUT parameter precedes the function (`outParamBeforeFunc`), generate `select func(?) as result` — a scalar function call — instead of `select * from func(?) as result`.

The `{ call func(...) }` form (no OUT parameter) is unchanged and still produces `select * from func(...) as result`, so genuinely set-returning functions keep their table-source invocation.

## Compatibility

The change applies only to the `{ ? = call func(...) }` escape syntax (a single OUT parameter, `outParamBeforeFunc`). The value-level result changes for one function class only — functions returning a composite or record type. Scalar and `SETOF` functions are unaffected; only the result column label differs, which `CallableStatement` does not read (it reads OUT parameters by index).

| Function return type | `select * from f(?)` (old) | `select f(?)` (new) | `CallableStatement` impact |
| --- | --- | --- | --- |
| Scalar, e.g. `returns int` | 1 row, 1 column (labelled after the function) | 1 row, 1 column (labelled `result`) | None — OUT parameter read by index; only the column label changes |
| `SETOF` scalar | N rows, 1 column | N rows, 1 column | None — only the column label changes |
| Composite / record, e.g. `returns comp_t` | composite fields expanded into separate columns (`a`, `b`, …) | single column holding the whole composite value | **Changes** — OUT parameter 1 is the first field (old) vs the whole composite (new) |

For a single registered OUT parameter the new form is arguably the more correct one: `getObject(1)` returns the whole composite, matching the one declared parameter, whereas the old table-source form exposed only the first field. The existing test suite does not cover the composite case, so the old behaviour was not pinned by a test.

## How to verify

- `./gradlew :postgresql:test --tests 'org.postgresql.core.ParserTest'`
- Callable / escape-call-mode integration tests, all green: `Jdbc3CallableStatementTest`, `EscapeSyntaxCallModeSelectTest`, `EscapeSyntaxCallModeCallTest`, `EscapeSyntaxCallModeCallIfNoReturnTest`, `CallableStmtTest`, `RefCursorTest`, `RefCursorFetchTest`, `ProcedureTransactionTest`.

---

### Changes to Existing Features:

* **Does this break existing behaviour?** Yes, for the `{ ? = call func(...) }` escape syntax against composite/record-returning functions only (see the Compatibility table). Scalar and `SETOF` functions are unaffected, and the `{ call func(...) }` form is unchanged.
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable? `ParserTest` expectations updated.
* [x] Have you successfully run tests with your changes locally?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
