### PR TITLE
feat: support SQL_TSI_FRAC_SECOND in timestampadd/timestampdiff escapes

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/EscapedFunctions2.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/EscapedFunctions2.java
@@ -514,6 +514,8 @@ public final class EscapedFunctions2 {
       throw new PSQLException(GT.tr("Interval {0} not yet implemented", type),
           PSQLState.SYNTAX_ERROR);
     }
+    // JDBC defines SQL_TSI_FRAC_SECOND as billionths (nanoseconds), but a PostgreSQL
+    // interval only has microsecond resolution, so the value is treated as microseconds.
     if (appendSingleIntervalCast(buf, SQL_TSI_DAY, type, value, "day")
         || appendSingleIntervalCast(buf, SQL_TSI_SECOND, type, value, "second")
         || appendSingleIntervalCast(buf, SQL_TSI_HOUR, type, value, "hour")
@@ -521,6 +523,7 @@ public final class EscapedFunctions2 {
         || appendSingleIntervalCast(buf, SQL_TSI_MONTH, type, value, "month")
         || appendSingleIntervalCast(buf, SQL_TSI_WEEK, type, value, "week")
         || appendSingleIntervalCast(buf, SQL_TSI_YEAR, type, value, "year")
+        || appendSingleIntervalCast(buf, SQL_TSI_FRAC_SECOND, type, value, "microsecond")
     ) {
       return;
     }
@@ -574,8 +577,20 @@ public final class EscapedFunctions2 {
           GT.tr("{0} function takes three and only three arguments.", "timestampdiff"),
           PSQLState.SYNTAX_ERROR);
     }
+    String type = parsedArgs.get(0).toString();
+    if (isTsi(type) && areSameTsi(SQL_TSI_FRAC_SECOND, type)) {
+      // JDBC SQL_TSI_FRAC_SECOND is fractional seconds and PostgreSQL interval
+      // resolution is microseconds, so report the total difference in microseconds.
+      // extract(microseconds ...) only returns the seconds field, hence epoch * 1000000.
+      buf.append("extract( epoch from (")
+          .append(parsedArgs.get(2))
+          .append("-")
+          .append(parsedArgs.get(1))
+          .append("))*1000000");
+      return;
+    }
     buf.append("extract( ")
-        .append(constantToDatePart(parsedArgs.get(0).toString()))
+        .append(constantToDatePart(type))
         .append(" from (")
         .append(parsedArgs.get(2))
         .append("-")

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ReplaceProcessingTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ReplaceProcessingTest.java
@@ -32,12 +32,16 @@ public class ReplaceProcessingTest extends BaseTest4 {
         {"{fn timestampadd(SQL_TSI_WEEK, ?, {fn now()})}", "(CAST( $1||' week' as interval)+ now())"},
         {"{fn timestampadd(SQL_TSI_MINUTE, ?, {fn now()})}", "(CAST( $1||' minute' as interval)+ now())"},
         {"{fn timestampadd(SQL_TSI_SECOND, ?, {fn now()})}", "(CAST( $1||' second' as interval)+ now())"},
+        // SQL_TSI_FRAC_SECOND maps to microseconds, the finest PostgreSQL interval resolution
+        {"{fn timestampadd(SQL_TSI_FRAC_SECOND, ?, {fn now()})}", "(CAST( $1||' microsecond' as interval)+ now())"},
+        // case-insensitive interval name is accepted, like the other units
+        {"{fn timestampadd(sql_tsi_frac_second, ?, {fn now()})}", "(CAST( $1||' microsecond' as interval)+ now())"},
+        {"{fn timestampdiff(SQL_TSI_FRAC_SECOND, ?, ?)}", "extract( epoch from ( $2- $1))*1000000"},
         {"{fn user()}", "user"},
         {"{fn ifnull(?,?)}", "coalesce($1,$2)"},
         {"{fn database()}", "current_database()"},
         // Not yet supported
         // {"{fn timestampadd(SQL_TSI_QUARTER, ?, {fn now()})}", "(CAST( $1||' quarter' as interval)+ now())"},
-        // {"{fn timestampadd(SQL_TSI_FRAC_SECOND, ?, {fn now()})}", "(CAST( $1||' second' as interval)+ now())"},
     });
   }
 


### PR DESCRIPTION
## Summary

Adds support for the JDBC `SQL_TSI_FRAC_SECOND` interval in the `timestampadd` and `timestampdiff` escape functions. The constant was declared in `EscapedFunctions2` but never mapped, so `{fn timestampadd(SQL_TSI_FRAC_SECOND, ...)}` and `{fn timestampdiff(SQL_TSI_FRAC_SECOND, ...)}` were rejected with a "not yet implemented" error.

- `timestampadd`: maps `SQL_TSI_FRAC_SECOND` to a microsecond interval cast, reusing the existing `appendSingleIntervalCast` helper, producing `CAST(<value>||' microsecond' as interval)`.
- `timestampdiff`: emits `extract( epoch from (b-a))*1000000` to return the total difference in microseconds, the correct inverse of the add mapping (the `microseconds` extract field only returns the seconds component, so epoch is used instead).

## Why this matters

JDBC escape syntax defines fractional-second intervals, but `EscapedFunctions2` (pgjdbc/src/main/java/org/postgresql/jdbc/EscapedFunctions2.java:512 for the add path, :574 for the diff path) declared `SQL_TSI_FRAC_SECOND` without handling it, so any escape using it failed. PostgreSQL `interval` has microsecond resolution, so the JDBC frac-second value is treated as microseconds, consistent with how the other `SQL_TSI_*` units are handled. This closes the gap described in #4086.

## Testing

Added parser-level cases in `ReplaceProcessingTest` asserting the generated SQL for `timestampadd` and `timestampdiff` with `SQL_TSI_FRAC_SECOND`, including the case-insensitive interval name, matching the existing assertion style for the other interval units. Arity validation is unchanged.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests? Added unit tests in ReplaceProcessingTest; CI will run the suite.
2. [ ] Does `./gradlew styleCheck` pass ? Not run locally (no Java runtime in this environment).
3. [x] Have you added your new test classes to an existing test suite in alphabetical order? Cases added to the existing ReplaceProcessingTest data set.

### Changes to Existing Features:

* [x] Does this break existing behaviour? No. It only adds a previously-rejected interval unit; existing units and arity validation are unchanged.
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?

Fixes #4086
