### PR TITLE
fix: reject OffsetDateTime for Types.TIMESTAMP and Types.DATE

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
@@ -639,6 +639,14 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
           } else if (in instanceof LocalDate) {
             setDate(parameterIndex, (LocalDate) in);
             break;
+          } else if (in instanceof OffsetDateTime) {
+            // A date has neither time nor offset, so an OffsetDateTime cannot be stored without
+            // silently discarding them. Reject it: pass a LocalDate to store the date part.
+            // (The JDBC spec pairs OffsetDateTime with TIMESTAMP_WITH_TIMEZONE.)
+            throw new PSQLException(
+                GT.tr("Cannot cast an instance of {0} to type {1}",
+                    in.getClass().getName(), "Types.DATE"),
+                PSQLState.INVALID_PARAMETER_TYPE);
           } else {
             tmpd = getTimestampUtils().toDate(getDefaultCalendar(), in.toString());
           }
@@ -682,6 +690,15 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
           } else if (in instanceof LocalDateTime) {
             setTimestamp(parameterIndex, (LocalDateTime) in);
             break;
+          } else if (in instanceof OffsetDateTime) {
+            // A timestamp (without time zone) carries no offset, so an OffsetDateTime cannot be
+            // stored without silently discarding it. Reject it instead: use
+            // Types.TIMESTAMP_WITH_TIMEZONE to keep the instant, or pass a LocalDateTime to store
+            // the local part. (The JDBC spec pairs OffsetDateTime with TIMESTAMP_WITH_TIMEZONE.)
+            throw new PSQLException(
+                GT.tr("Cannot cast an instance of {0} to type {1}",
+                    in.getClass().getName(), "Types.TIMESTAMP"),
+                PSQLState.INVALID_PARAMETER_TYPE);
           } else {
             Charset connectionCharset = Charset.forName(connection.getEncoding().name());
             tmpts = getTimestampUtils().toTimestamp(getDefaultCalendar(), in.toString().getBytes(connectionCharset));

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc42/SetObject310Test.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc42/SetObject310Test.java
@@ -7,11 +7,13 @@ package org.postgresql.test.jdbc42;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import org.postgresql.test.TestUtil;
 import org.postgresql.test.jdbc2.BaseTest4;
+import org.postgresql.util.PSQLState;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -416,6 +418,44 @@ public class SetObject310Test extends BaseTest4 {
       }
       localTimestamps(ZoneOffset.UTC, bcDate, expected);
     }
+  }
+
+  /**
+   * Regression test for <a href="https://github.com/pgjdbc/pgjdbc/issues/3428">#3428</a>.
+   * A {@code timestamp without time zone} carries no offset, so {@code setObject(i, value,
+   * Types.TIMESTAMP)} rejects an {@code OffsetDateTime} rather than silently discarding it: the
+   * JDBC spec pairs {@code OffsetDateTime} with {@code TIMESTAMP_WITH_TIMEZONE}, not
+   * {@code TIMESTAMP}. The BC value of #3428 used to surface as a confusing
+   * {@code NumberFormatException}; both AD and BC now fail with a clear
+   * {@code INVALID_PARAMETER_TYPE} error. Callers that want the local part can pass a
+   * {@code LocalDateTime}; callers that want the instant can use {@code TIMESTAMP_WITH_TIMEZONE}.
+   */
+  @Test
+  public void testSetObjectRejectsOffsetDateTimeForTimestamp() throws SQLException {
+    List<OffsetDateTime> values = Arrays.asList(
+        OffsetDateTime.parse("2020-01-01T00:00:00+08:00"),
+        OffsetDateTime.parse("-3000-01-01T00:00:00+08:00"));
+    for (OffsetDateTime value : values) {
+      SQLException e = assertThrows(SQLException.class,
+          () -> insert(value, "timestamp_without_time_zone_column", Types.TIMESTAMP));
+      assertEquals(PSQLState.INVALID_PARAMETER_TYPE.getState(), e.getSQLState(),
+          () -> "setObject(OffsetDateTime=" + value + ", Types.TIMESTAMP) must be rejected");
+    }
+  }
+
+  /**
+   * A {@code date} has neither time nor offset, so {@code setObject(i, value, Types.DATE)} rejects
+   * an {@code OffsetDateTime} rather than silently discarding them (the JDBC spec pairs
+   * {@code OffsetDateTime} with {@code TIMESTAMP_WITH_TIMEZONE}). Pass a {@code LocalDate} to store
+   * the date part.
+   */
+  @Test
+  public void testSetObjectRejectsOffsetDateTimeForDate() throws SQLException {
+    OffsetDateTime value = OffsetDateTime.parse("2024-01-31T12:34:56+08:00");
+    SQLException e = assertThrows(SQLException.class,
+        () -> insert(value, "date_column", Types.DATE));
+    assertEquals(PSQLState.INVALID_PARAMETER_TYPE.getState(), e.getSQLState(),
+        "setObject(OffsetDateTime, Types.DATE) must be rejected");
   }
 
   /**


### PR DESCRIPTION
## Why

`setObject(i, value, Types.TIMESTAMP)` throws a confusing error when `value` is an `OffsetDateTime`. #3428 reports the BC-year case (`OffsetDateTime.parse("-3000-01-01T00:00:00+08:00")`), which fails with `NumberFormatException`; the AD case fails too, on the `T` separator. `setObject(.., Types.DATE)` fails the same confusing way.

## What

`Types.TIMESTAMP` and `Types.DATE` did not special-case `OffsetDateTime`, so the value was stringified with `OffsetDateTime.toString()` and handed to the backend parser, which rejected the ISO-8601 string (`Trailing junk on timestamp` for AD, `NumberFormatException` for BC).

A `timestamp`/`date` without time zone has no offset, and the JDBC spec pairs `OffsetDateTime` with `TIMESTAMP_WITH_TIMEZONE`, not `TIMESTAMP`/`DATE`. Rather than silently dropping the offset (and, for `DATE`, the time too), this rejects the value with a clear `INVALID_PARAMETER_TYPE` error (`Cannot cast an instance of java.time.OffsetDateTime to type Types.TIMESTAMP`), the same way the `Types.TIMESTAMP_WITH_TIMEZONE` branch already rejects a mismatched type.

The error points to two workarounds:
- use `Types.TIMESTAMP_WITH_TIMEZONE` to keep the instant, or
- pass a `LocalDateTime` / `LocalDate` (`offsetDateTime.toLocalDateTime()`) to store the local value.

## Scope

`OffsetTime` to `Types.TIME` is intentionally left unchanged. Unlike the timestamp case, `setObject(offsetTime, Types.TIME)` has always been accepted in released versions and stores the local time (dropping the offset without a shift, because a `time` has no date and so no instant conversion is involved). It is a released, non-destructive conversion, so rejecting it would be a breaking change for no safety gain.

## How to verify

`SetObject310Test`:
- `testSetObjectRejectsOffsetDateTimeForTimestamp` — an AD and a BC `OffsetDateTime` through `setObject(.., Types.TIMESTAMP)` both fail with `INVALID_PARAMETER_TYPE`.
- `testSetObjectRejectsOffsetDateTimeForDate` — `setObject(.., Types.DATE)` fails with `INVALID_PARAMETER_TYPE`.

Both run in regular and binary modes.

Closes #3428
