### PR TITLE
fix: reject SQL_TSI_FRAC_SECOND with an explicit, explained error

### DIFF
--- a/docs/content/documentation/escapes.md
+++ b/docs/content/documentation/escapes.md
@@ -147,8 +147,8 @@ see the translated SQL requires more parameters than before the translation but 
 |second(arg1)|yes| extract(second from arg1)                                          ||
 |week(arg1)|yes| extract(week from arg1)                                            ||
 |year(arg1)|yes| extract(year from arg1)                                            ||
-|timestampadd(argIntervalType, argCount, argTimeStamp)|yes| ((interval according to argIntervalType and argCount)+argTimeStamp)| an argIntervalType value of SQL_TSI_FRAC_SECOND is not implemented since backend does not support it |
-|timestampdiff(argIntervalType, argTimeStamp1, argTimeStamp2)|not| extract((interval according to argIntervalType) from argTimeStamp2-argTimeStamp1 ) | only an argIntervalType value of SQL_TSI_FRAC_SECOND, SQL_TSI_FRAC_MINUTE, SQL_TSI_FRAC_HOUR or SQL_TSI_FRAC_DAY is supported |
+|timestampadd(argIntervalType, argCount, argTimeStamp)|yes| ((interval according to argIntervalType and argCount)+argTimeStamp)| an argIntervalType value of SQL_TSI_FRAC_SECOND is rejected with an explicit error: the unit has no portable size (nanoseconds in ODBC/SQL Server, microseconds in MySQL), so it is not mapped. Use SQL_TSI_SECOND with a fractional value instead. |
+|timestampdiff(argIntervalType, argTimeStamp1, argTimeStamp2)|not| extract((interval according to argIntervalType) from argTimeStamp2-argTimeStamp1 ) | supported for SQL_TSI_SECOND, SQL_TSI_MINUTE, SQL_TSI_HOUR and SQL_TSI_DAY; SQL_TSI_FRAC_SECOND is rejected with an explicit error, as for timestampadd |
 
 ##### Table 8.4. Supported escaped misc functions
 

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/EscapedFunctions2.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/EscapedFunctions2.java
@@ -528,7 +528,31 @@ public final class EscapedFunctions2 {
       buf.append("CAST((").append(value).append("::int * 3) || ' month' as interval)");
       return;
     }
+    if (areSameTsi(SQL_TSI_FRAC_SECOND, type)) {
+      throw fracSecondNotSupported(type);
+    }
     throw new PSQLException(GT.tr("Interval {0} not yet implemented", type),
+        PSQLState.NOT_IMPLEMENTED);
+  }
+
+  /**
+   * Builds the error for the JDBC {@code SQL_TSI_FRAC_SECOND} interval, which pgjdbc intentionally
+   * does not map. The unit has no portable size: ODBC and SQL Server define it as nanoseconds, while
+   * MySQL treats it as microseconds. Mapping it to any fixed multiplier would silently produce
+   * values that are off by a factor of 1000 for part of the ecosystem, so an explicit error is
+   * raised instead of returning wrong data.
+   *
+   * @param type the interval name as written in the escape
+   * @return the exception explaining why the interval is rejected
+   */
+  private static PSQLException fracSecondNotSupported(String type) {
+    return new PSQLException(
+        GT.tr("Interval {0} is not supported: the JDBC fractional-second unit has no portable size "
+                + "(ODBC and SQL Server treat it as nanoseconds, MySQL as microseconds), so pgjdbc "
+                + "does not map it to avoid silently producing values that are off by a factor of "
+                + "1000. Use SQL_TSI_SECOND with a fractional value instead, since PostgreSQL "
+                + "intervals have microsecond resolution.",
+            type),
         PSQLState.NOT_IMPLEMENTED);
   }
 
@@ -596,6 +620,8 @@ public final class EscapedFunctions2 {
       return "hour";
     } else if (areSameTsi(SQL_TSI_MINUTE, type)) {
       return "minute";
+    } else if (areSameTsi(SQL_TSI_FRAC_SECOND, type)) {
+      throw fracSecondNotSupported(type);
     } else {
       throw new PSQLException(GT.tr("Interval {0} not yet implemented", type),
           PSQLState.SYNTAX_ERROR);

--- a/pgjdbc/src/test/java/org/postgresql/core/ParserTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/core/ParserTest.java
@@ -8,9 +8,12 @@ package org.postgresql.core;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.postgresql.jdbc.EscapeSyntaxCallMode;
+import org.postgresql.util.PSQLException;
+import org.postgresql.util.PSQLState;
 
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -135,6 +138,23 @@ class ParserTest {
 
     // nothing should be changed in that case, no valid escape code
     assertEquals("{obj : 1}", Parser.replaceProcessing("{obj : 1}", true, false));
+  }
+
+  @Test
+  void timestampAddDiffFracSecondIsRejected() throws Exception {
+    // SQL_TSI_FRAC_SECOND has no portable size across databases (nanoseconds in ODBC/SQL Server,
+    // microseconds in MySQL), so pgjdbc rejects it with an explicit error rather than risk
+    // silently producing values off by a factor of 1000. See issue #4086.
+    PSQLException add = assertThrows(PSQLException.class,
+        () -> Parser.replaceProcessing("{fn timestampadd(SQL_TSI_FRAC_SECOND, ?, {fn now()})}", true, false));
+    assertEquals(PSQLState.NOT_IMPLEMENTED.getState(), add.getSQLState());
+    assertTrue(add.getMessage().contains("SQL_TSI_FRAC_SECOND"), add.getMessage());
+
+    // timestampdiff is rejected the same way, including the case-insensitive interval name
+    PSQLException diff = assertThrows(PSQLException.class,
+        () -> Parser.replaceProcessing("{fn timestampdiff(sql_tsi_frac_second, ?, ?)}", true, false));
+    assertEquals(PSQLState.NOT_IMPLEMENTED.getState(), diff.getSQLState());
+    assertTrue(diff.getMessage().contains("sql_tsi_frac_second"), diff.getMessage());
   }
 
   @Test


### PR DESCRIPTION
## Why

`SQL_TSI_FRAC_SECOND` has no portable size across databases: ODBC and SQL Server define it as nanoseconds, while MySQL treats it as microseconds. PostgreSQL intervals have microsecond resolution, so any fixed mapping would silently produce values off by a factor of 1000 for part of the ecosystem.

pgjdbc already rejects the unit, but the errors were unhelpful: `timestampadd` fell through to a generic `Interval SQL_TSI_FRAC_SECOND not yet implemented`, and `timestampdiff` raised a `SYNTAX_ERROR`. Neither said why, so a developer porting from another database had no hint that the rejection is deliberate.

Following the decision in #4086, an explicit error is preferred over a fixed mapping that would corrupt data silently. This PR makes that rejection clear.

## What

- `timestampadd` and `timestampdiff` now raise one message that names the reason (no portable size; nanoseconds vs microseconds) and points to `SQL_TSI_SECOND` with a fractional value as the workaround.
- Both paths now report `NOT_IMPLEMENTED` (`0A000`). Previously `timestampdiff` reported `SYNTAX_ERROR` (`42601`), which wrongly implied malformed input.
- Docs: the escapes table claimed FRAC_SECOND was unsupported "since backend does not support it" (misleading — the backend supports microsecond intervals) and wrongly listed it as supported for `timestampdiff`. Both cells are corrected.

This does not change any unit that already worked; it only replaces the message and SQLState for the already-rejected FRAC_SECOND case.

## How to verify

`ParserTest.timestampAddDiffFracSecondIsRejected` covers both escapes (including the case-insensitive interval name) with no database:

```
./gradlew :postgresql:test --tests "org.postgresql.core.ParserTest"
```

### Submission checklist

- [x] Followed the [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) guidelines.
- [x] Checked for other open PRs for the same change (supersedes the mapping approach in the closed #4226).
- [x] `./gradlew :postgresql:checkstyleMain :postgresql:checkstyleTest :postgresql:autostyleCheck` pass locally.
- [x] Added a unit test in `ParserTest`.

### Changes to existing features

- [x] Does this break existing behaviour? No working unit changes. `timestampdiff(SQL_TSI_FRAC_SECOND, …)` now reports `NOT_IMPLEMENTED` instead of `SYNTAX_ERROR`, and both escapes carry a clearer message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)