### PR TITLE
fix(jdbc): return null CHAR_OCTET_LENGTH for non-character columns

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
@@ -1731,7 +1731,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
     f[12] = new Field("COLUMN_DEF", Oid.VARCHAR);
     f[13] = new Field("SQL_DATA_TYPE", Oid.INT4);
     f[14] = new Field("SQL_DATETIME_SUB", Oid.INT4);
-    f[15] = new Field("CHAR_OCTET_LENGTH", Oid.VARCHAR);
+    f[15] = new Field("CHAR_OCTET_LENGTH", Oid.INT4);
     f[16] = new Field("ORDINAL_POSITION", Oid.INT4);
     f[17] = new Field("IS_NULLABLE", Oid.VARCHAR);
     f[18] = new Field("SCOPE_CATALOG", Oid.VARCHAR);
@@ -1910,7 +1910,27 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
       tuple[12] = rs.getBytes("adsrc"); // Column default
       tuple[13] = null; // sql data type (unused)
       tuple[14] = null; // sql datetime sub (unused)
-      tuple[15] = tuple[6]; // char octet length
+      // CHAR_OCTET_LENGTH applies to character and binary types only; it equals COLUMN_SIZE
+      // there and is null for every other type (for example integer, numeric, or integer[]).
+      switch (sqlType) {
+        case Types.CHAR:
+        case Types.VARCHAR:
+        case Types.LONGVARCHAR:
+        case Types.NCHAR:
+        case Types.NVARCHAR:
+        case Types.LONGNVARCHAR:
+        case Types.CLOB:
+        case Types.NCLOB:
+        case Types.BINARY:
+        case Types.VARBINARY:
+        case Types.LONGVARBINARY:
+        case Types.BLOB:
+          tuple[15] = tuple[6]; // char octet length, same as column size
+          break;
+        default:
+          tuple[15] = null; // char octet length, not applicable
+          break;
+      }
       tuple[16] = connection.encodeString(String.valueOf(rs.getInt("attnum"))); // ordinal position
       // Is nullable
       tuple[17] = connection.encodeString(rs.getBoolean("attnotnull") ? "NO" : "YES");

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseMetaDataTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseMetaDataTest.java
@@ -81,6 +81,9 @@ public class DatabaseMetaDataTest {
       TestUtil.createTable(con, "\"a'\"", "a int4");
       TestUtil.createTable(con, "arraytable", "a numeric(5,2)[], b varchar(100)[]");
       TestUtil.createTable(con, "intarraytable", "a int4[], b int4[][]");
+      TestUtil.createTable(con, "char_octet_test",
+          "c_int integer, c_intarray integer[], c_numeric numeric(8,3), "
+              + "c_varchar varchar(100), c_char char(10), c_text text, c_bytea bytea");
       TestUtil.dropType(con, "custom");
       TestUtil.dropType(con, "_custom");
       TestUtil.createCompositeType(con, "custom", "i int", false);
@@ -154,6 +157,7 @@ public class DatabaseMetaDataTest {
       TestUtil.dropTable(con, "\"a'\"");
       TestUtil.dropTable(con, "arraytable");
       TestUtil.dropTable(con, "intarraytable");
+      TestUtil.dropTable(con, "char_octet_test");
       TestUtil.dropTable(con, "customtable");
       TestUtil.dropType(con, "custom");
       TestUtil.dropType(con, "_custom");
@@ -2002,6 +2006,44 @@ public class DatabaseMetaDataTest {
     assertFalse(rs.next());
 
     rs.close();
+  }
+
+  @Test
+  void getColumnsCharOctetLength() throws SQLException {
+    DatabaseMetaData dbmd = con.getMetaData();
+
+    // Character types report CHAR_OCTET_LENGTH equal to COLUMN_SIZE.
+    assertEquals(Integer.valueOf(100), charOctetLength(dbmd, "c_varchar"),
+        "CHAR_OCTET_LENGTH for varchar(100)");
+    assertEquals(Integer.valueOf(10), charOctetLength(dbmd, "c_char"),
+        "CHAR_OCTET_LENGTH for char(10)");
+    // Unbounded character and binary types still report a value, equal to COLUMN_SIZE.
+    assertEquals(columnSize(dbmd, "c_text"), charOctetLength(dbmd, "c_text"),
+        "CHAR_OCTET_LENGTH for text should match COLUMN_SIZE");
+    assertEquals(columnSize(dbmd, "c_bytea"), charOctetLength(dbmd, "c_bytea"),
+        "CHAR_OCTET_LENGTH for bytea should match COLUMN_SIZE");
+
+    // Non-character types report no CHAR_OCTET_LENGTH.
+    assertNull(charOctetLength(dbmd, "c_int"), "CHAR_OCTET_LENGTH for integer");
+    assertNull(charOctetLength(dbmd, "c_intarray"), "CHAR_OCTET_LENGTH for integer[]");
+    assertNull(charOctetLength(dbmd, "c_numeric"), "CHAR_OCTET_LENGTH for numeric(8,3)");
+  }
+
+  private Integer charOctetLength(DatabaseMetaData dbmd, String column) throws SQLException {
+    return intColumn(dbmd, column, "CHAR_OCTET_LENGTH");
+  }
+
+  private Integer columnSize(DatabaseMetaData dbmd, String column) throws SQLException {
+    return intColumn(dbmd, column, "COLUMN_SIZE");
+  }
+
+  private Integer intColumn(DatabaseMetaData dbmd, String column, String metadataColumn)
+      throws SQLException {
+    try (ResultSet rs = dbmd.getColumns(null, null, "char_octet_test", column)) {
+      assertTrue(rs.next(), () -> "dbmd.getColumns returned no row for column " + column);
+      int value = rs.getInt(metadataColumn);
+      return rs.wasNull() ? null : value;
+    }
   }
 
   @Test


### PR DESCRIPTION
## Why

`DatabaseMetaData.getColumns` reported `CHAR_OCTET_LENGTH` as `COLUMN_SIZE` for every column, including non-character types such as `integer` or `integer[]`. JDBC defines `CHAR_OCTET_LENGTH` only for character and binary types, so a numeric or array column should report no value.

## What

- Copy `CHAR_OCTET_LENGTH` from `COLUMN_SIZE` only for character and binary JDBC types (`CHAR`, `VARCHAR`, `LONGVARCHAR`, `NCHAR`, `NVARCHAR`, `LONGNVARCHAR`, `CLOB`, `NCLOB`, `BINARY`, `VARBINARY`, `LONGVARBINARY`, `BLOB`); report `null` for every other type.
- Declare the `CHAR_OCTET_LENGTH` result column as `INTEGER` rather than `VARCHAR`, matching the JDBC type and the sibling `COLUMN_SIZE` column.

## How to verify

`DatabaseMetaDataTest.getColumnsCharOctetLength` covers the character, binary, and non-character cases. Run:

```
./gradlew :postgresql:test --tests "org.postgresql.test.jdbc2.DatabaseMetaDataTest"
```

This reworks #3589 on top of the current test layout and folds in the review feedback there (table created in `@BeforeAll`/`@AfterAll`, lazy assertion messages, exact expected values). Credit to @tirthgajera for the original change.

Closes #3589