### PR TITLE
fix: drop offset when buffering OffsetTime into a time column

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
@@ -2125,7 +2125,12 @@ public class PgResultSet implements ResultSet, PGRefCursorResultSet {
           // java.time.LocalTime (time) or java.time.OffsetTime (timetz).
           String stringValue;
           if (valueObject instanceof OffsetTime) {
-            stringValue = getTimestampUtils().toString((OffsetTime) valueObject);
+            // A "time without time zone" column drops the offset on the server, so store the
+            // local time to keep the row buffer in step with the persisted value. "timetz"
+            // (Oid.TIMETZ) keeps the offset.
+            stringValue = fields[columnIndex].getOID() == Oid.TIME
+                ? getTimestampUtils().toString(((OffsetTime) valueObject).toLocalTime())
+                : getTimestampUtils().toString((OffsetTime) valueObject);
           } else if (valueObject instanceof LocalTime) {
             stringValue = getTimestampUtils().toString((LocalTime) valueObject);
           } else {

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/UpdateableResultTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/UpdateableResultTest.java
@@ -976,6 +976,56 @@ public class UpdateableResultTest extends BaseTest4 {
     assertEquals(value, updateRowAndReselect("t", value, LocalTime.class));
   }
 
+  /**
+   * Updating a "time without time zone" column with an {@link OffsetTime} drops the offset on the
+   * server, so the in-memory row buffer must store the offset-stripped local time. The persisted
+   * value was already correct; before this fix the buffer disagreed with the database until the
+   * row was refreshed. See https://github.com/pgjdbc/pgjdbc/pull/3848.
+   */
+  @Test
+  public void testUpdateRowWithOffsetTimeIntoTimeColumn() throws SQLException {
+    OffsetTime value = OffsetTime.of(LocalTime.of(12, 34, 56, 123_456_000), ZoneOffset.ofHours(5));
+    LocalTime expected = value.toLocalTime();
+
+    try (Statement st = con.createStatement(ResultSet.TYPE_SCROLL_INSENSITIVE,
+        ResultSet.CONCUR_UPDATABLE);
+        ResultSet rs = st.executeQuery("SELECT id, t FROM datetimetable WHERE id = 1")) {
+      assertTrue(rs.next(), "datetimetable must contain the seeded row with id = 1");
+      rs.updateObject("t", value);
+      rs.updateRow();
+      // A time column has no offset to keep, so the row buffer must drop it to match the database
+      assertEquals(expected, rs.getObject("t", LocalTime.class),
+          "row buffer must drop the offset for a time column");
+    }
+
+    try (Statement st = con.createStatement();
+        ResultSet rs = st.executeQuery("SELECT t FROM datetimetable WHERE id = 1")) {
+      assertTrue(rs.next());
+      assertEquals(expected, rs.getObject(1, LocalTime.class),
+          "persisted time column value must match the offset-stripped local time");
+    }
+  }
+
+  /**
+   * Regression guard for {@link #testUpdateRowWithOffsetTimeIntoTimeColumn()}: a timetz column does
+   * carry an offset, so the row buffer must keep it rather than strip it.
+   */
+  @Test
+  public void testUpdateRowWithOffsetTimeIntoTimeTzColumnKeepsOffset() throws SQLException {
+    OffsetTime value = OffsetTime.of(LocalTime.of(12, 34, 56, 123_456_000), ZoneOffset.ofHours(5));
+
+    try (Statement st = con.createStatement(ResultSet.TYPE_SCROLL_INSENSITIVE,
+        ResultSet.CONCUR_UPDATABLE);
+        ResultSet rs = st.executeQuery("SELECT id, ttz FROM datetimetable WHERE id = 1")) {
+      assertTrue(rs.next(), "datetimetable must contain the seeded row with id = 1");
+      rs.updateObject("ttz", value);
+      rs.updateRow();
+      OffsetTime fromBuffer = rs.getObject("ttz", OffsetTime.class);
+      assertNotNull(fromBuffer, "row buffer value must not be null after updateRow()");
+      assertTrue(value.isEqual(fromBuffer), "expected " + value + " to equal " + fromBuffer);
+    }
+  }
+
   @Test
   public void testInsertRowWithJavaTimeValues() throws SQLException {
     OffsetTime ttz = OffsetTime.of(LocalTime.of(1, 2, 3, 456_000_000), ZoneOffset.ofHours(-8));


### PR DESCRIPTION
### Why

In an updatable `ResultSet`, writing a `java.time.OffsetTime` into a `time without time zone` column left the in-memory row buffer carrying the offset (e.g. `12:34:56+05`). Reading the value back before a `refreshRow()` or re-query then disagreed with the database, which stores `12:34:56`.

The persisted value was already correct — the server coerces the bound `timetz` to `time` and drops the offset, and a `time` has no date, so there is no shift. Only the row-buffer reflection was wrong, and it self-heals on refresh. This is cosmetic and low severity, but worth fixing for consistency.

### What

`PgResultSet.setRowBufferColumn` now checks the column's real OID in the `Types.TIME` branch: for `time` (`Oid.TIME`) it stores the offset-stripped local time, matching what the server persists; for `timetz` (`Oid.TIMETZ`) it keeps the offset as before. Persisted behaviour is unchanged, and `OffsetTime` into a `time` column is still accepted — a non-destructive conversion that cleanly drops the offset.

### How to verify

`./gradlew :postgresql:test --tests "org.postgresql.test.jdbc2.UpdateableResultTest"`

New tests in `UpdateableResultTest`:

- `testUpdateRowWithOffsetTimeIntoTimeColumn` — asserts both the in-ResultSet `getObject("t", LocalTime.class)` and a fresh re-query return the offset-stripped local time. Fails before the fix on the in-ResultSet read.
- `testUpdateRowWithOffsetTimeIntoTimeTzColumnKeepsOffset` — guards that a `timetz` column still round-trips the offset.

Follow-up to #3848 (cosmetic row-buffer reflection; the persisted value was already correct).
