### PR TITLE
build: verify benchmarks under check and CI, skip Jandex for them

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
         S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.S3_BUILD_CACHE_SECRET_KEY }}
       with:
         job-id: jdk21
-        arguments: styleCheck jandex -PenableErrorprone classes
+        arguments: styleCheck jandex -PenableErrorprone classes :benchmarks:jmhJar
 
   linux-checkerframework:
     name: 'CheckerFramework'

--- a/benchmarks/build.gradle.kts
+++ b/benchmarks/build.gradle.kts
@@ -48,3 +48,18 @@ if ("style" in tasks.names) {
         dependsOn(tasks.compileJmhJava)
     }
 }
+
+// The benchmarks project publishes no artifact and has an empty main source set, so a Jandex
+// index serves no purpose here. Skip Jandex entirely: it otherwise registers processJmhJandexIndex
+// as a producer of sourceSets.jmh.output, and every consumer of that output that the plugin does
+// not wire (jmhRunBytecodeGenerator, checkstyleJmh, forbiddenApisJmh) fails Gradle 9's
+// implicit-dependency validation.
+jandex {
+    skipDefaultProcessing()
+}
+
+// Build the benchmarks jar as part of `check` so build-graph regressions surface during
+// verification rather than only when someone runs the benchmarks.
+tasks.check {
+    dependsOn(tasks.jmhJar)
+}


### PR DESCRIPTION
### Why

`./gradlew :benchmarks:jmhJar` fails on `master` with Gradle 9.5.1:

```
> Task :benchmarks:processJmhJandexIndex FAILED
  Task ':benchmarks:jmhRunBytecodeGenerator' uses this output of task
  ':benchmarks:processJmhJandexIndex' without declaring an explicit or implicit dependency.
```

The `benchmarks` project applies both `com.github.vlsi.jandex` (via `build-logic.java`) and
`me.champeau.jmh`. The Jandex plugin registers `processJmhJandexIndex` as a producer of
`sourceSets.jmh.output`, but for non-main source sets it wires only the `jar`, sources-jar, and
`javadoc` tasks to depend on it. Every other consumer of that output — `jmhRunBytecodeGenerator`,
`checkstyleJmh`, `forbiddenApisJmh` — is left without the dependency and trips Gradle 9's
validation. This is a pre-existing breakage from the Gradle 9 upgrade; no CI job builds the jmh
jar, so it went unnoticed.

### What

- **Skip Jandex for `benchmarks`** (`jandex { skipDefaultProcessing() }`). The project publishes
  no artifact and has an empty main source set, so a Jandex index serves no purpose. This removes
  the spurious producer and fixes every consumer at once, rather than wiring a `dependsOn` per task.
- **Wire `jmhJar` into `check`** so a local `./gradlew check` builds the benchmarks.
- **Build `:benchmarks:jmhJar` in the code-style CI job** so the JMH build pipeline — compilation
  and the bytecode generator — runs on every push.

#4010 carries a narrower workaround (`jmhRunBytecodeGenerator dependsOn processJmhJandexIndex`);
this change makes that line unnecessary. Credit to @beikov for spotting the build break.

### How to verify

```
./gradlew :benchmarks:clean :benchmarks:jmhJar
```

Fails on current `master`; passes with this change.