### PR TITLE
ci: upload heap dumps from all modules and on push failures

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -111,7 +111,7 @@ jobs:
           cd postgresql-1.0-jdbc-src
           mvn --batch-mode --fail-at-end --show-version verify
       - name: Attach heap dump if any
-        if: ${{ failure() && github.event_name == 'pull_request' }}
+        if: ${{ failure() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pgjdbc-heapdump-source-distribution
@@ -338,11 +338,12 @@ jobs:
         job-id: jdk${{ matrix.java_version }}
         arguments: publishToMavenLocal -Ppgjdbc.version=1.0.0-dev-master -PskipJavadoc
     - name: Attach heap dump if any
-      if: ${{ failure() && github.event_name == 'pull_request' }}
+      if: ${{ failure() }}
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: pgjdbc-heapdump
-        path: pgjdbc/*.hprof
+        path: '**/*.hprof'
+        if-no-files-found: ignore
     - name: Collect PostgreSQL server logs (Linux)
       if: ${{ failure() && runner.os == 'Linux' }}
       shell: bash


### PR DESCRIPTION
## Why

The leak test `org.postgresql.test.jdbc4.jdbc41.DriverSupportsClassUnloadingTest` writes a heap dump on failure (via the JUnit `@Leaks(dumpHeapOnError = true)` annotation), but the CI step that uploads it never picked it up. A real failing run on `master` produced a dump that was lost. Two bugs caused this:

1. The test lives in the `pgjdbc-junit4-test` module and writes to `pgjdbc-junit4-test/*.hprof`, but the upload step globbed only `pgjdbc/*.hprof`.
2. Both heap-dump steps gated on `github.event_name == 'pull_request'`, so failures on push events (such as `master`) never uploaded anything.

## What

- Widen the matrix-test heap-dump path from `pgjdbc/*.hprof` to `**/*.hprof` so dumps from any module are captured, and add `if-no-files-found: ignore` to keep the step quiet when there is nothing to upload.
- Drop the `github.event_name == 'pull_request'` condition on both `Attach heap dump if any` steps, keeping only `failure()`, so push failures upload their dumps too.

## How to verify

The diff is two `if:` conditions and one `path`/`if-no-files-found` change in `.github/workflows/main.yml`. The YAML parses cleanly (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/main.yml'))"`). End-to-end confirmation needs a failing leak test on CI to produce and upload a `pgjdbc-heapdump` artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)