### PR TITLE
fix: clear ResourceBundle cache on deregister so the driver can unload

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/Driver.java
+++ b/pgjdbc/src/main/java/org/postgresql/Driver.java
@@ -39,6 +39,7 @@ import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.Objects;
 import java.util.Properties;
+import java.util.ResourceBundle;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
@@ -798,6 +799,11 @@ public class Driver implements java.sql.Driver {
     }
     DriverManager.deregisterDriver(registeredDriver);
     registeredDriver = null;
+    // Release the cached localized message bundle. A class-based translation bundle (for example
+    // messages_tr) otherwise keeps this classloader alive through the JVM-wide ResourceBundle cache,
+    // which defeats the very purpose of deregistering the driver. The no-arg clearCache() clears the
+    // entries for this caller's classloader, which is the one GT used to load the bundle.
+    ResourceBundle.clearCache();
   }
 
   /**


### PR DESCRIPTION
## Why

In a non-English locale (for example `tr_TR`), the first time the driver formats a localised message, `GT` loads a class-based translation bundle such as `messages_tr` through `ResourceBundle.getBundle`. The JVM-wide `ResourceBundle` cache holds that bundle behind a `SoftReference`, which an ordinary garbage collection does not clear. The bundle instance keeps its `messages_<locale>` class — and the classloader that defined it — reachable.

`Driver.deregister()` exists so an application can drop the driver and let its classes be unloaded (servlet-container redeploys, OSGi, and so on). The cached bundle silently defeats that once any localised message has been formatted.

It shows up as a flaky failure of `DriverSupportsClassUnloadingTest` on the `tr_TR` CI job:

```
java.lang.AssertionError: ClassLoader (...RedefiningClassLoader[...driverUnloadsWhenConnectionLeaks]) has not been garbage collected, despite running the leak preventor ...
```

## What

`Driver.deregister()` now calls `ResourceBundle.clearCache()` after deregistering from `DriverManager`. The no-arg form clears the cache entries for the caller's classloader, which is the one `GT` used to load the bundle. No new public API.

## How to verify

- The class-based bundle pins the classloader under a framework-style GC (a `WeakReference` loop that does not clear soft references), and `ResourceBundle.clearCache(loader)` releases it — confirmed in isolation on JDK 11 and 21.
- With the bundle loaded under `tr_TR`, `DriverSupportsClassUnloadingTest` fails before this change and passes after it (both test methods). On the happy path the bundle is never loaded, so the unmodified test stays green either way.

## Follow-ups (not in this PR)

- The existing test only catches this when a localised message has been loaded, which the happy path never does, so it does not guard the regression deterministically. Forcing a bundle load under a non-English locale would close that gap.
- The lasting fix is to ship the translations as property bundles: a `PropertyResourceBundle` is loaded by the system classloader and never pins the driver's classloader, which would make this cache-clearing unnecessary.
