### PR TITLE
test: guard authentication-plugin test against trust auth (#2442)

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -236,7 +236,27 @@ If you are not using Docker, ensure your `pg_hba.conf` includes the `scram-sha-2
 ALTER USER testscram WITH PASSWORD 'your_password';
 ```
 
-## 10 - Credits and Feedback
+## 10 - Authentication plugin tests
+
+`ObjectFactoryTest.invalidAuthenticationPlugin` and `AuthenticationPluginTest` (the MD5 and SASL cases) check how the driver loads a custom `authenticationPluginClassName`. The driver loads that plugin lazily: it instantiates the plugin class only when the server actually requests a password (see `AuthenticationPluginManager.withPassword`). Under `trust` authentication the server never requests a password, so the plugin is never loaded and these tests cannot exercise it.
+
+For these tests to run, the test user must authenticate with a password method (`md5`, `scram-sha-256`, or `password`) rather than `trust`. `invalidAuthenticationPlugin` skips itself with a pointed message when it detects `trust` authentication; the `AuthenticationPluginTest` cases fail instead.
+
+### Using Docker
+
+The provided Docker setup already requests a password for the `test` database, so no extra steps are needed. The rule lives in `certdir/server/pg_hba.conf`.
+
+### Manual setup
+
+If you are not using Docker, make sure the test user is not on a `trust` line in `pg_hba.conf`. Add or adjust a password rule for the test database and reload the server:
+
+```
+host    test    all    all    md5
+```
+
+The test user must also have a password set so the server can verify it (`ALTER USER test WITH PASSWORD 'test';`).
+
+## 11 - Credits and Feedback
 
 The parts of this document describing the PostgreSQL test suite
 were originally written by Rene Pijlman. Liam Stewart contributed

--- a/pgjdbc/src/test/java/org/postgresql/test/util/ObjectFactoryTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/util/ObjectFactoryTest.java
@@ -12,6 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 import org.postgresql.Driver;
 import org.postgresql.PGProperty;
@@ -46,9 +47,23 @@ class ObjectFactoryTest {
     prop.set(props, BadObject.class.getName());
 
     BadObject.wasInstantiated = false;
-    SQLException ex = assertThrows(SQLException.class, () -> {
-      TestUtil.openDB(props);
-    });
+    SQLException ex;
+    try (Connection con = TestUtil.openDB(props)) {
+      // BadObject always throws from its constructor, so a successful connection means the driver
+      // never instantiated it. authenticationPluginClassName is loaded lazily and is skipped
+      // entirely under "trust" authentication (see AuthenticationPluginManager.withPassword), so
+      // this test can only run when the server requests a password from the test user.
+      assumeFalse(prop == PGProperty.AUTHENTICATION_PLUGIN_CLASS_NAME,
+          "The test database authenticated the test user via \"trust\", so "
+              + "authenticationPluginClassName was never instantiated and this test cannot run. "
+              + "Configure pg_hba.conf to request a password (md5/scram-sha-256) for the test user; "
+              + "see the authentication tests section in TESTING.md.");
+      throw new AssertionError(
+          "Opening a connection should have failed because " + prop.getName()
+              + " points to a class that cannot be instantiated, but it succeeded.");
+    } catch (SQLException e) {
+      ex = e;
+    }
 
     try {
       assertAll(


### PR DESCRIPTION
## Why

`ObjectFactoryTest.invalidAuthenticationPlugin` fails with a cryptic `Expected java.sql.SQLException ... but nothing was thrown` when the test user authenticates via `trust` (reported in #2442; the related `AuthenticationPluginTest` MD5/SASL cases fail the same way).

This is not a driver bug. The driver loads `authenticationPluginClassName` lazily: `AuthenticationPluginManager.withPassword` instantiates the plugin class only when the server actually requests a password. Under `trust` authentication the server replies `AuthenticationOk` immediately, the bad plugin is never instantiated, the connection succeeds, and `assertThrows` finds no exception.

CI never hits this because the Docker harness forces password auth for the test database via `certdir/server/pg_hba.conf` (`host test all all md5`). A non-Docker reader following `TESTING.md` was never told the test user must not be on a `trust` line, so the failure looks like a driver defect.

## What

- `ObjectFactoryTest`: when the connection unexpectedly succeeds, skip `invalidAuthenticationPlugin` with a message that names `trust` as the cause and points to `TESTING.md`. Any other object factory (e.g. `socketFactory`, which is instantiated eagerly) still fails loudly, now with a clearer message than "nothing was thrown".
- `TESTING.md`: add an "Authentication plugin tests" section documenting the HBA requirement, mirroring the existing SCRAM section.

## How to verify

Against the bundled Docker harness (md5 for the `test` database), the test passes as before:

```sh
docker/bin/postgres-server   # in another terminal
./gradlew :postgresql:test --tests "org.postgresql.test.util.ObjectFactoryTest"
```

To exercise the new guard, point the test connection at a `trust` user (the harness authenticates `postgres` via `trust`); the test now skips instead of failing:

```sh
./gradlew :postgresql:test \
  --tests "org.postgresql.test.util.ObjectFactoryTest.invalidAuthenticationPlugin" \
  -Duser=postgres -Dpassword=postgres
# => 1 skipped, 0 failed
# skip reason: "The test database authenticated the test user via "trust", so
# authenticationPluginClassName was never instantiated ... see TESTING.md."
```

Re #2442