### PR TITLE
fix(build): restore JaCoCo XML report so Codecov receives coverage

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -339,7 +339,7 @@ jobs:
       # coverage was not collected, or on a fork that has not set up its own token:
       # the upstream repo and any fork with a CODECOV_TOKEN still upload.
       if: ${{ !cancelled() && matrix.collectCoverage && (github.repository == 'pgjdbc/pgjdbc' || env.CODECOV_TOKEN != '') }}
-      uses: codecov/codecov-action@v6
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         # Fall back to the public upload token so fork PRs upload with authentication
         # rather than tokenless. The token only permits coverage uploads to this
@@ -476,7 +476,7 @@ jobs:
     steps:
     - name: Tell Codecov that all coverage uploads are in
       if: ${{ github.repository == 'pgjdbc/pgjdbc' || env.CODECOV_TOKEN != '' }}
-      uses: codecov/codecov-action@v6
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         # Public upload token fallback (see the upload step above).
         token: ${{ env.CODECOV_TOKEN || '75d2c960-72e1-4949-ac21-5f06ee310231' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -306,7 +306,7 @@ jobs:
       with:
         read-only: false
         job-id: jdk${{ matrix.java_version }}
-        arguments: --scan --no-parallel --no-daemon jandex test ${{ matrix.extraGradleArgs }}
+        arguments: --scan --no-parallel --no-daemon jandex test jacocoReport ${{ matrix.extraGradleArgs }}
         properties: |
           includeTestTags=${{ matrix.includeTestTags }}
           testExtraJvmArgs=${{ matrix.testExtraJvmArgs }}
@@ -315,6 +315,16 @@ jobs:
           jdkTestVendor=${{ matrix.java_vendor }}
           # We provision JDKs with GitHub Actions for caching purposes, so Gradle should rather fail in case JDK is not found
           org.gradle.java.installations.auto-download=false
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v6
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: ./build/reports/jacoco/jacocoReport/jacocoReport.xml
+        # Upload only the aggregate report; do not search the tree for other files.
+        disable_search: true
+        # A Codecov hiccup must not fail the test job.
+        fail_ci_if_error: false
 
     - name: 'Install krb5 for GSS tests'
       if: ${{ matrix.gss == 'yes' }}
@@ -425,3 +435,20 @@ jobs:
       run: |
         docker compose ps
         docker compose down -v --rmi local
+
+  # Aggregate gate that waits for the whole dynamic test matrix and finalizes
+  # coverage. Each build-test job uploads its own coverage, and Codecov holds
+  # all notifications until this job calls send-notifications (manual_trigger in
+  # codecov.yml), so the report count does not need to be known in advance.
+  tests:
+    name: Tests
+    needs: build-test
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    steps:
+    - name: Tell Codecov that all coverage uploads are in
+      uses: codecov/codecov-action@v6
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        run_command: send-notifications
+        fail_ci_if_error: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -299,6 +299,7 @@ jobs:
 
     - uses: burrunan/gradle-cache-action@4b67497abd37a511d6c1dc6299bdd84ff39f7bf5 # v3.0.2
       name: Test
+      id: test
       env:
         S3_BUILD_CACHE_ACCESS_KEY_ID: ${{ secrets.S3_BUILD_CACHE_ACCESS_KEY_ID }}
         S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.S3_BUILD_CACHE_SECRET_KEY }}
@@ -306,7 +307,7 @@ jobs:
       with:
         read-only: false
         job-id: jdk${{ matrix.java_version }}
-        arguments: --scan --no-parallel --no-daemon jandex test jacocoReport ${{ matrix.extraGradleArgs }}
+        arguments: --scan --no-parallel --no-daemon jandex test ${{ matrix.extraGradleArgs }}
         properties: |
           includeTestTags=${{ matrix.includeTestTags }}
           testExtraJvmArgs=${{ matrix.testExtraJvmArgs }}
@@ -316,7 +317,21 @@ jobs:
           # We provision JDKs with GitHub Actions for caching purposes, so Gradle should rather fail in case JDK is not found
           org.gradle.java.installations.auto-download=false
 
+    - name: Build coverage report after a test failure
+      # On success jacocoReport already ran as part of the Test step above. When a
+      # test fails, that run aborts before the report, so re-run jacocoReport on its
+      # own (excluding the test tasks) to merge the coverage that was collected.
+      if: ${{ matrix.collectCoverage && steps.test.outcome == 'failure' }}
+      uses: burrunan/gradle-cache-action@4b67497abd37a511d6c1dc6299bdd84ff39f7bf5 # v3.0.2
+      with:
+        read-only: false
+        job-id: jdk${{ matrix.java_version }}
+        arguments: --scan --no-parallel --no-daemon jacocoReport -x test
+
     - name: Upload coverage to Codecov
+      # Run on both success and failure (after the fallback report above), but skip
+      # when coverage was not collected for this job.
+      if: ${{ !cancelled() && matrix.collectCoverage }}
       uses: codecov/codecov-action@v6
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -325,7 +325,9 @@ jobs:
       # On success jacocoReport already ran as part of the Test step above. When a
       # test fails, that run aborts before the report, so re-run jacocoReport on its
       # own (excluding the test tasks) to merge the coverage that was collected.
-      if: ${{ matrix.collectCoverage && steps.test.outcome == 'failure' }}
+      # `!cancelled()` is required: without a status function the `if` is implicitly
+      # wrapped in success(), which never holds after the test step has failed.
+      if: ${{ !cancelled() && matrix.collectCoverage && steps.test.outcome == 'failure' }}
       uses: burrunan/gradle-cache-action@4b67497abd37a511d6c1dc6299bdd84ff39f7bf5 # v3.0.2
       with:
         read-only: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -148,6 +148,10 @@ jobs:
       ACTIONS_STEP_DEBUG: true
       ACTIONS_RUNNER_DEBUG: true
       TZ: ${{ matrix.tz }}
+      # Empty on fork pull requests (secrets are withheld), set on the upstream repo
+      # and on any fork that defined its own token. Used in the codecov steps' `if`,
+      # since secrets cannot be referenced from `if` conditions directly.
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
@@ -329,12 +333,13 @@ jobs:
         arguments: --scan --no-parallel --no-daemon jacocoReport -x test
 
     - name: Upload coverage to Codecov
-      # Run on both success and failure (after the fallback report above), but skip
-      # when coverage was not collected for this job.
-      if: ${{ !cancelled() && matrix.collectCoverage }}
+      # Run on both success and failure (after the fallback report above). Skip when
+      # coverage was not collected, or on a fork that has not set up its own token:
+      # the upstream repo and any fork with a CODECOV_TOKEN still upload.
+      if: ${{ !cancelled() && matrix.collectCoverage && (github.repository == 'pgjdbc/pgjdbc' || env.CODECOV_TOKEN != '') }}
       uses: codecov/codecov-action@v6
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
+        token: ${{ env.CODECOV_TOKEN }}
         files: ./build/reports/jacoco/jacocoReport/jacocoReport.xml
         # Upload only the aggregate report; do not search the tree for other files.
         disable_search: true
@@ -460,10 +465,13 @@ jobs:
     needs: build-test
     runs-on: ubuntu-latest
     if: ${{ always() }}
+    env:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
     - name: Tell Codecov that all coverage uploads are in
+      if: ${{ github.repository == 'pgjdbc/pgjdbc' || env.CODECOV_TOKEN != '' }}
       uses: codecov/codecov-action@v6
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
+        token: ${{ env.CODECOV_TOKEN }}
         run_command: send-notifications
         fail_ci_if_error: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -339,7 +339,11 @@ jobs:
       if: ${{ !cancelled() && matrix.collectCoverage && (github.repository == 'pgjdbc/pgjdbc' || env.CODECOV_TOKEN != '') }}
       uses: codecov/codecov-action@v6
       with:
-        token: ${{ env.CODECOV_TOKEN }}
+        # Fall back to the public upload token so fork PRs upload with authentication
+        # rather than tokenless. The token only permits coverage uploads to this
+        # project; the `if` above still tests the bare secret, so a fork without its
+        # own token does not upload to upstream.
+        token: ${{ env.CODECOV_TOKEN || '75d2c960-72e1-4949-ac21-5f06ee310231' }}
         files: ./build/reports/jacoco/jacocoReport/jacocoReport.xml
         # Upload only the aggregate report; do not search the tree for other files.
         disable_search: true
@@ -472,6 +476,7 @@ jobs:
       if: ${{ github.repository == 'pgjdbc/pgjdbc' || env.CODECOV_TOKEN != '' }}
       uses: codecov/codecov-action@v6
       with:
-        token: ${{ env.CODECOV_TOKEN }}
+        # Public upload token fallback (see the upload step above).
+        token: ${{ env.CODECOV_TOKEN || '75d2c960-72e1-4949-ac21-5f06ee310231' }}
         run_command: send-notifications
         fail_ci_if_error: false

--- a/.github/workflows/matrix.mjs
+++ b/.github/workflows/matrix.mjs
@@ -343,10 +343,20 @@ if (include.length === 0) {
 }
 include.sort((a, b) => a.name.localeCompare(b.name, undefined, {numeric: true}));
 include.forEach(v => {
-    let gradleArgs = [
+    // Collect JaCoCo coverage for this job. Coverage instrumentation slows the
+    // tests down, so this is a per-job toggle: every job collects coverage for now,
+    // and specific rows can opt out later if the matrix gets too slow.
+    v.collectCoverage = true;
+    let gradleArgs = [];
+    if (v.collectCoverage) {
+        // Build the aggregate report as part of the main test run. The workflow
+        // re-runs it on its own if the tests fail (see .github/workflows/main.yml).
+        gradleArgs.push('jacocoReport');
+    }
+    gradleArgs.push(
         `-Duser.country=${v.locale.country}`,
         `-Duser.language=${v.locale.language}`,
-    ];
+    );
     v.extraGradleArgs = gradleArgs.join(' ');
     // 8.0 is here to test a case when somebody configured assumeMinServerVersion=8.0, and forgot to update it.
     // The idea is that everything should still work since the option is just a hint to the driver

--- a/.github/workflows/matrix.mjs
+++ b/.github/workflows/matrix.mjs
@@ -343,10 +343,11 @@ if (include.length === 0) {
 }
 include.sort((a, b) => a.name.localeCompare(b.name, undefined, {numeric: true}));
 include.forEach(v => {
-    // Collect JaCoCo coverage for this job. Coverage instrumentation slows the
-    // tests down, so this is a per-job toggle: every job collects coverage for now,
-    // and specific rows can opt out later if the matrix gets too slow.
-    v.collectCoverage = true;
+    // Collect JaCoCo coverage on Linux only. Instrumentation slows the tests down,
+    // ubuntu runners are the fastest, and the line coverage of a pure-Java driver
+    // does not vary by OS. The extra load was crashing the Gradle test worker on the
+    // slower Windows runners. This is a per-job flag, so the gate can be relaxed later.
+    v.collectCoverage = v.os.value === 'ubuntu-latest';
     let gradleArgs = [];
     if (v.collectCoverage) {
         // Build the aggregate report as part of the main test run. The workflow

--- a/TESTING.md
+++ b/TESTING.md
@@ -114,6 +114,23 @@ If the test suite reports errors or failures that you cannot
 explain, please post the relevant parts of the output to the
 mailing list pgsql-jdbc@postgresql.org.
 
+### Code coverage
+
+The build collects JaCoCo coverage only when you ask for it, so a plain `./gradlew test` produces no coverage data. Run the tests together with the aggregate report task:
+
+```sh
+./gradlew test jacocoReport
+```
+
+Naming the `jacocoReport` task on the command line turns on instrumentation, so `-Pcoverage` is not required here. Use `-Pcoverage` when you want coverage from a plain `test` run without the report task.
+
+The aggregate report is written to:
+
+- `build/reports/jacoco/jacocoReport/html/index.html` — HTML report for browsing
+- `build/reports/jacoco/jacocoReport/jacocoReport.xml` — XML report (uploaded to Codecov in CI)
+
+`jacocoReport` writes these files; it does not print a coverage percentage to the console, so open the HTML report to read the numbers. The report reflects only the tests that ran, so configure a test database (see above) for full-suite coverage.
+
 ## 5 - Extending the test suite with new tests
 
 Most of the tests are written with JUnit4, however it is recommended to create new tests with JUnit5.

--- a/build-logic/verification/src/main/kotlin/build-logic.jacoco.gradle.kts
+++ b/build-logic/verification/src/main/kotlin/build-logic.jacoco.gradle.kts
@@ -41,11 +41,3 @@ jacocoReport {
     sourceDirectories.from(mainCode.allSource.srcDirs)
     classDirectories.from(mainCode.output)
 }
-
-// TODO: check which reports do we need
-//tasks.configureEach<JacocoReport> {
-//    reports {
-//        html.required.set(reportsForHumans())
-//        xml.required.set(!reportsForHumans())
-//    }
-//}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,6 +53,12 @@ jacoco {
 val jacocoReport by tasks.registering(JacocoReport::class) {
     group = "Coverage reports"
     description = "Generates an aggregate report from all subprojects"
+    reports {
+        // Codecov consumes the XML report in CI (see .github/workflows/omni.yml);
+        // the HTML report is for browsing coverage locally.
+        xml.required.set(true)
+        html.required.set(true)
+    }
 }
 
 allprojects {

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,9 @@
 codecov:
   notify:
-    after_n_builds: 10
+    # The CI matrix size is dynamic, so we cannot wait for a fixed number of
+    # uploads. The `Tests` job calls send-notifications once every matrix job
+    # has uploaded its coverage (see .github/workflows/main.yml).
+    manual_trigger: true
     require_ci_to_pass: false
 comment:
   layout: header, changes, diff


### PR DESCRIPTION
## Why

Running the aggregate `jacocoReport` task produces no usable coverage output, and the Codecov upload has been a no-op on PRs.

Two separate problems:

1. **No XML report.** The build-logic split (#2755) moved the JaCoCo configuration into `build-logic/verification/.../build-logic.jacoco.gradle.kts` but commented out the report-format block. A `JacocoReport` task emits HTML by default and **no XML**, so `build/reports/jacoco/jacocoReport/jacocoReport.xml` was never generated and the README badge has been frozen since #2755 (2023-02-09). This also explains #2738: the task writes a report file rather than printing a percentage, and nothing documented the command or output location.
2. **No coverage on PRs.** The PR workflow (`main.yml`) ran `jandex test` without `jacocoReport` and never uploaded anything to Codecov — coverage upload lived only in `omni.yml`, which runs on `workflow_dispatch`/`schedule`, not on pull requests. The matrix is generated at run time, so `codecov.yml`'s fixed `after_n_builds: 10` could finalize too early (more than 10 jobs) or never (fewer than 10).

## What

Build fix (`fix(build)`):
- Enable both the XML and HTML reports on the aggregate `jacocoReport` task in `build.gradle.kts`.
- Remove the obsolete commented-out report block from `build-logic.jacoco.gradle.kts`.
- Document the coverage command and the report locations in `TESTING.md`.

CI / Codecov aggregation (`ci`):
- `main.yml` `build-test` now builds the aggregate `jacocoReport` (appended to `extraGradleArgs`) and uploads its coverage to Codecov, one upload per matrix job.
- Coverage is a per-job matrix flag (`collectCoverage`), set on the ubuntu jobs only: instrumentation slows the tests down and was crashing the Gradle test worker on the slower Windows runners, and a pure-Java driver's line coverage does not vary by OS.
- When the test step fails the main run aborts before the report, so a fallback step re-runs `jacocoReport -x test` to merge the coverage already collected, and the upload still happens.
- A new `Tests` job waits for the whole dynamic matrix (`needs: build-test`, `if: always()`) and calls Codecov `send-notifications`. `codecov.yml` switches to `manual_trigger: true`, so Codecov holds all notifications until every job has uploaded — the job count need not be known in advance.
- The codecov steps are gated on `github.repository == 'pgjdbc/pgjdbc' || env.CODECOV_TOKEN != ''` (see Codecov token below).
- `omni.yml` is unchanged.

## Codecov token

The Codecov upload token for a public repository is low-sensitivity, so this PR treats it as public configuration rather than a secret:

- It only authorises uploading coverage to this repository's Codecov project. It grants no access to the source and cannot change or delete anything.
- The worst case if it leaks is a bogus coverage upload, which a maintainer can discard.
- Codecov already accepts tokenless uploads from public repositories, so the token buys reliability, not access.

This matters because GitHub withholds both secrets and configuration variables from workflows triggered by a pull request from a fork (confirmed for variables in [community#44322](https://github.com/orgs/community/discussions/44322)). No repository-settings value reaches a fork PR; the only per-repo value a fork PR can see is one committed to the repository. The PR therefore commits the public upload token as a fallback on the `token` input (`token: ${{ env.CODECOV_TOKEN || '<token>' }}`), so fork PRs upload with authentication rather than tokenless.

The codecov steps run when either the build is on `pgjdbc/pgjdbc` or a `CODECOV_TOKEN` is set:

| Run | `github.repository` | Token used | Codecov steps |
|---|---|---|---|
| push to upstream | `pgjdbc/pgjdbc` | repo secret | run, authenticated |
| fork PR to upstream | `pgjdbc/pgjdbc` | committed fallback | run, authenticated |
| fork's own push, no token | `<user>/pgjdbc` | none | skipped |
| fork's own push, with token | `<user>/pgjdbc` | fork's secret | run, to the fork's own project |

The `if` gate tests the bare secret (`env.CODECOV_TOKEN`), not the fallback, so a fork's own push without its own token still skips the upload and never pushes to upstream. A fork that wants coverage on its own pushes just adds its own `CODECOV_TOKEN` secret; it does not edit the workflow. Secrets cannot be read from `if` conditions, so the token is surfaced as a job-level `env` var for the check.

## How to verify

Locally:

```sh
./gradlew test jacocoReport
ls build/reports/jacoco/jacocoReport/jacocoReport.xml
open build/reports/jacoco/jacocoReport/html/index.html
```

The XML now exists alongside the HTML with real coverage counters, so Codecov has a file to consume.

In CI: each `build-test` job uploads coverage (authenticated, via the committed fallback token) and the `Tests` gate finalizes it. **Caveat:** a Codecov PR comment also needs the Codecov GitHub App installed and a coverage base on `master`. Both are established by upstream `push` builds, which carry `CODECOV_TOKEN`, so the full flow is validated after merge rather than on this fork PR.

Fixes #2738
