### PR TITLE
docs: remove null check that can never fail

### DIFF
--- a/docs/content/documentation/datasource.md
+++ b/docs/content/documentation/datasource.md
@@ -270,8 +270,6 @@ public class DBTest {
     public void init() {
         try {
             Context ctx = new InitialContext();
-            if (ctx == null)
-                throw new Exception("Boom - No Context");
 
             // /jdbc/postgres is the name of the resource above
             DataSource ds = (DataSource) ctx.lookup("java:comp/env/jdbc/postgres");


### PR DESCRIPTION
I was browsing the docs and noticed this pointless null check in the datasource example.

### All Submissions:

* [✅] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [✅] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
