### PR TITLE
test(replication): shrink big-transaction inserts to avoid CI timeouts

### DIFF
--- a/pgjdbc/src/test/java/org/postgresql/replication/LogicalReplicationTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/replication/LogicalReplicationTest.java
@@ -341,8 +341,10 @@ class LogicalReplicationTest {
     LogSequenceNumber lsn = getCurrentLSN();
 
     Statement st = sqlConnection.createStatement();
+    // Insert enough rows that the server is still streaming the transaction when the
+    // connection drops below. A larger transaction only makes the test slower.
     st.execute("insert into test_logic_table\n"
-        + "  select id, md5(random()::text) as name from generate_series(1, 200000) as id;");
+        + "  select id, md5(random()::text) as name from generate_series(1, 20000) as id;");
     st.close();
 
     PGReplicationStream stream =
@@ -396,8 +398,12 @@ class LogicalReplicationTest {
     LogSequenceNumber lsn = getCurrentLSN();
 
     Statement st = sqlConnection.createStatement();
+    // Insert enough rows that the server is still streaming the transaction when
+    // stream.close() runs below. close() drains the remainder of the in-progress
+    // transaction, so keep the row count modest: a larger transaction makes the
+    // drain slow enough to time out under coverage or a loaded CI runner.
     st.execute("insert into test_logic_table\n"
-        + "  select id, md5(random()::text) as name from generate_series(1, 200000) as id;");
+        + "  select id, md5(random()::text) as name from generate_series(1, 20000) as id;");
     st.close();
 
     PGReplicationStream stream =


### PR DESCRIPTION
## Why

`LogicalReplicationTest.duringSendBigTransactionReplicationStreamCloseNotActive` flakes on CI with `TimeoutException ... timed out after 60 seconds` (for example [run 28018246434](https://github.com/pgjdbc/pgjdbc/actions/runs/28018246434/job/82927872665)). It and its sibling `duringSendBigTransactionConnectionCloseSlotStatusNotActive` each insert a 200k-row transaction. `stream.close()` sends `CopyDone` and then drains the remainder of the in-progress transaction, because current PostgreSQL emits a committed transaction in full before it honours `CopyDone`, so the close cost is O(transaction size). With coverage instrumentation on the per-message decode path and a loaded runner, the 200k drain crosses the 60s `@Timeout` and the test times out.

This is not parallel-test contention: replication tests run in a dedicated CI matrix job (`includeTags('replication')`) against their own PostgreSQL, in JUnit `same_thread` mode, with a single test fork — nothing else runs alongside them.

## What

Reduce both transactions from 200000 to 20000 rows and add a comment explaining the bound.

Measured locally on PostgreSQL 16 (`test_decoding`), `stream.close()` scales linearly with the row count:

| rows | `read()` | `close()` |
| ---- | -------- | --------- |
| 20k | 28 ms | 154 ms |
| 200k | 248 ms | 1229 ms |
| 1M | 1908 ms | 4832 ms |

20k rows is still ~2.4 MB, well above the OS socket buffers, so the server is still mid-send when `close()` runs and the same code path is exercised, only ~8x faster. The test asserts only that the slot becomes inactive after close, which holds for any size, so the smaller transaction loses no coverage.

## How to verify

```
./gradlew :postgresql:test --tests "org.postgresql.replication.LogicalReplicationTest.duringSendBigTransaction*"
```

Needs a server with `wal_level=logical`. Both tests pass; under `-Pcoverage` the whole `LogicalReplicationTest` class runs in ~6 s locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
