### PR TITLE
ci: make Codecov project and patch statuses informational

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -9,7 +9,19 @@ comment:
   layout: header, changes, diff
 coverage:
   status:
-    patch: false
+    # Report coverage but never block a PR. The CI matrix is a random subset of
+    # jobs (.github/workflows/matrix.mjs), so two builds of the same code collect
+    # coverage on different paths: the project total swings by dozens of lines
+    # between commits, and a changed line covered only by an unsampled config
+    # (ssl-only, a specific PG version, SIMPLE vs EXTENDED, ...) reads as
+    # uncovered. Either status would then gate merges on noise. Keep both
+    # informational until coverage runs on a fixed, deterministic job set.
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
   range: "60...100"
 ignore:
   - "**/translation/message*.java"


### PR DESCRIPTION
## Why

Coverage in this repo is the union of a random subset of CI jobs ([`matrix.mjs`](https://github.com/pgjdbc/pgjdbc/blob/master/.github/workflows/matrix.mjs)), so the corpus differs between any two builds of the same code. That makes both Codecov statuses noisy:

- **project**: the total swings by dozens of lines between commits (see #4196, where a +4-line diff showed Hits +80 / Misses −86), purely from which configs each run happened to sample.
- **patch**: a changed line covered only by an unsampled config (ssl-only, a specific PG version, `SIMPLE` vs `EXTENDED`, ...) reads as uncovered.

Either status would then gate a PR on sampling noise rather than on the change. `patch` had been off entirely (`patch: false`) since `codecov.yml` was first added, so the noisy `project` check was the only signal.

## What

Mark both statuses informational — Codecov keeps reporting the numbers, but neither blocks the merge:

```yaml
coverage:
  status:
    project:
      default:
        informational: true
    patch:
      default:
        informational: true
```

## How to verify

- Codecov parses the config on push; `codecov/project` and `codecov/patch` appear on the PR as informational (no red X even if they dip).
- `curl --data-binary @codecov.yml https://codecov.io/validate` returns the parsed config with no errors.

## Follow-up

A later change can collect coverage on a fixed, fully-pinned job set in `matrix.mjs` (feature axes pinned, `assumeMinServerVersion` and `slow_tests` fixed, `collectCoverage` only on that set) to make the corpus deterministic and restore a meaningful gate.