### PR TITLE
ci: collect coverage on one pinned job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -148,10 +148,6 @@ jobs:
       ACTIONS_STEP_DEBUG: true
       ACTIONS_RUNNER_DEBUG: true
       TZ: ${{ matrix.tz }}
-      # Empty on fork pull requests (secrets are withheld), set on the upstream repo
-      # and on any fork that defined its own token. Used in the codecov steps' `if`,
-      # since secrets cannot be referenced from `if` conditions directly.
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
@@ -335,17 +331,11 @@ jobs:
         arguments: --scan --no-parallel --no-daemon jacocoReport -x test
 
     - name: Upload coverage to Codecov
-      # Run on both success and failure (after the fallback report above). Skip when
-      # coverage was not collected, or on a fork that has not set up its own token:
-      # the upstream repo and any fork with a CODECOV_TOKEN still upload.
-      if: ${{ !cancelled() && matrix.collectCoverage && (github.repository == 'pgjdbc/pgjdbc' || env.CODECOV_TOKEN != '') }}
+      # Run on both success and failure (after the fallback report above); skip jobs that
+      # did not collect coverage. pgjdbc is public, so Codecov accepts tokenless uploads.
+      if: ${{ !cancelled() && matrix.collectCoverage }}
       uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
-        # Fall back to the public upload token so fork PRs upload with authentication
-        # rather than tokenless. The token only permits coverage uploads to this
-        # project; the `if` above still tests the bare secret, so a fork without its
-        # own token does not upload to upstream.
-        token: ${{ env.CODECOV_TOKEN || '75d2c960-72e1-4949-ac21-5f06ee310231' }}
         files: ./build/reports/jacoco/jacocoReport/jacocoReport.xml
         # Upload only the aggregate report; do not search the tree for other files.
         disable_search: true
@@ -461,24 +451,3 @@ jobs:
       run: |
         docker compose ps
         docker compose down -v --rmi local
-
-  # Aggregate gate that waits for the whole dynamic test matrix and finalizes
-  # coverage. Each build-test job uploads its own coverage, and Codecov holds
-  # all notifications until this job calls send-notifications (manual_trigger in
-  # codecov.yml), so the report count does not need to be known in advance.
-  tests:
-    name: Tests
-    needs: build-test
-    runs-on: ubuntu-latest
-    if: ${{ always() }}
-    env:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-    steps:
-    - name: Tell Codecov that all coverage uploads are in
-      if: ${{ github.repository == 'pgjdbc/pgjdbc' || env.CODECOV_TOKEN != '' }}
-      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
-      with:
-        # Public upload token fallback (see the upload step above).
-        token: ${{ env.CODECOV_TOKEN || '75d2c960-72e1-4949-ac21-5f06ee310231' }}
-        run_command: send-notifications
-        fail_ci_if_error: false

--- a/.github/workflows/matrix.mjs
+++ b/.github/workflows/matrix.mjs
@@ -337,17 +337,34 @@ matrix.ensureAllAxisValuesCovered('cpu_count');
 matrix.ensureAllAxisValuesCovered('assertions');
 // Ensure at least one job with autosave=always
 matrix.generateRow({autosave: {value: 'always'}});
+// Collect coverage from a single job that turns on every feature that moves coverage (ssl,
+// scram, xa, replication, the latest stable server, one query mode). The other flags add at
+// most a line or two to line/branch coverage, so leaving them to the random fill keeps the
+// corpus stable between builds without a fixed seed.
+const MAX_PG = matrix.axisByName.pg_version.values.filter(v => v !== 'HEAD').slice(-1)[0];
+// Latest non-EA Java from the axis, so this need not be bumped when Java versions change.
+const LATEST_JAVA = matrix.axisByName.java_version.values.filter(v => v !== eaJava).slice(-1)[0];
+const coverageRow = matrix.generateRow({
+  os: {value: 'ubuntu-latest'},            // coverage needs the Docker PostgreSQL (Linux only)
+  pg_version: MAX_PG,
+  java_version: LATEST_JAVA, java_distribution: {value: 'temurin'},
+  query_mode: {value: 'extended'},
+  ssl: {value: 'yes'}, scram: {value: 'yes'},
+  xa: {value: 'yes'}, replication: {value: 'yes'},
+  // slow tests add ~0 coverage but cost runtime; GSS auth needs its own krb5 job.
+  slow_tests: {value: 'no'}, gss: {value: 'no'},
+});
+if (!coverageRow) {
+  throw new Error('Could not generate the coverage job; check that the pinned axes are satisfiable');
+}
+coverageRow.collectCoverage = true;
+
 const include = matrix.generateRows(process.env.MATRIX_JOBS || 5);
 if (include.length === 0) {
   throw new Error('Matrix list is empty');
 }
 include.sort((a, b) => a.name.localeCompare(b.name, undefined, {numeric: true}));
 include.forEach(v => {
-    // Collect JaCoCo coverage on Linux only. Instrumentation slows the tests down,
-    // ubuntu runners are the fastest, and the line coverage of a pure-Java driver
-    // does not vary by OS. The extra load was crashing the Gradle test worker on the
-    // slower Windows runners. This is a per-job flag, so the gate can be relaxed later.
-    v.collectCoverage = v.os.value === 'ubuntu-latest';
     let gradleArgs = [];
     if (v.collectCoverage) {
         // Build the aggregate report as part of the main test run. The workflow
@@ -359,11 +376,17 @@ include.forEach(v => {
         `-Duser.language=${v.locale.language}`,
     );
     v.extraGradleArgs = gradleArgs.join(' ');
-    // 8.0 is here to test a case when somebody configured assumeMinServerVersion=8.0, and forgot to update it.
-    // The idea is that everything should still work since the option is just a hint to the driver
-    // on the minimal set of features it can use when connecting to the database.
-    let assumeMinServerVersion = ['', '', '8.0', ...matrix.axisByName.pg_version.values.filter(x => Number(x) <= Number(v.pg_version))];
-    v.assumeMinServerVersion = assumeMinServerVersion[Math.floor(random() * assumeMinServerVersion.length)];
+    if (v.collectCoverage) {
+        // Pin a fixed value so the coverage corpus is stable.
+        v.assumeMinServerVersion = '';
+        v.name += ', coverage';
+    } else {
+        // 8.0 is here to test a case when somebody configured assumeMinServerVersion=8.0, and forgot to update it.
+        // The idea is that everything should still work since the option is just a hint to the driver
+        // on the minimal set of features it can use when connecting to the database.
+        let assumeMinServerVersion = ['', '', '8.0', ...matrix.axisByName.pg_version.values.filter(x => Number(x) <= Number(v.pg_version))];
+        v.assumeMinServerVersion = assumeMinServerVersion[Math.floor(random() * assumeMinServerVersion.length)];
+    }
     if (v.assumeMinServerVersion !== '') {
         v.name += ', assume min version ' + v.assumeMinServerVersion;
     }

--- a/.github/workflows/omni.yml
+++ b/.github/workflows/omni.yml
@@ -367,11 +367,7 @@ jobs:
       with:
         # Separate cache for each JDK distribution and version
         job-id: jdk${{ matrix.jdk_version}}_${{ matrix.jdk_group }}
-        arguments: --no-parallel --no-daemon --scan jandex test jacocoReport
+        arguments: --no-parallel --no-daemon --scan jandex test
         properties: |
           includeTestTags=${{ matrix.junit_include_tags }}
-    - name: 'Upload code coverage'
-      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6
-      with:
-        file: ./build/reports/jacoco/jacocoReport/jacocoReport.xml
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,9 +1,8 @@
 codecov:
   notify:
-    # The CI matrix size is dynamic, so we cannot wait for a fixed number of
-    # uploads. The `Tests` job calls send-notifications once every matrix job
-    # has uploaded its coverage (see .github/workflows/main.yml).
-    manual_trigger: true
+    # Exactly one job collects coverage (the pinned coverage job in matrix.mjs),
+    # so finalise the report as soon as that single upload arrives.
+    after_n_builds: 1
     require_ci_to_pass: false
 comment:
   layout: header, changes, diff


### PR DESCRIPTION
> Draft / proposal — follow-up to #4244.

## Why

Coverage is collected on every ubuntu job, but the CI matrix is a random sample of jobs ([`matrix.mjs`](https://github.com/pgjdbc/pgjdbc/blob/master/.github/workflows/matrix.mjs)), so the union of covered code differs between any two builds. The Codecov project total then swings by dozens of lines purely from which configs each run sampled (see #4196). #4244 made both statuses informational for this reason; this PR removes the root cause.

## What

Collect coverage on a **single pinned job** instead of on every ubuntu job:

```js
const coverageRow = matrix.generateRow({
  os: {value: ubuntu-latest}, pg_version: MAX_PG,
  java_version: 21, java_distribution: {value: temurin},
  query_mode: {value: extended},
  ssl: {value: yes}, scram: {value: yes},
  xa: {value: yes}, replication: {value: yes},
  slow_tests: {value: no}, gss: {value: no},
});
coverageRow.collectCoverage = true;
```

The pinned axes are the only ones that **empirically move coverage** — I measured each connection-property / tag axis with a per-axis run-and-diff harness (line *and* branch coverage). The movers are `ssl`/`scram` (TLS + auth), `xa` and `replication` (whole packages: +185 / +408 lines), the query mode (+130 lines for `simple`, modes cover disjoint code), and the server version. Everything else — `autosave`, `cleanupSavepoints`, `adaptiveFetch`, `reWriteBatchedInserts`, `slow_tests`, locale, timezone — adds at most a line or two (already covered by dedicated tests), so leaving those axes to the random fill keeps the corpus stable **without a private RNG, a fixed seed, or a contract to assert**. The random part of the matrix keeps its own budget on top, so bug-hunting is unchanged.

## How to verify

```bash
cd .github/workflows && npm ci
GITHUB_OUTPUT=/tmp/m node matrix.mjs >/dev/null
sed -n "/^matrix<<MATRIX_BODY$/,/^MATRIX_BODY$/p" /tmp/m | sed "1d;\$d" | jq "{
  coverageJobs: [.include[]|select(.collectCoverage)]|length,
  nonCoverageWithJacoco: [.include[]|select(.collectCoverage!=true)|.extraGradleArgs|test(\"jacocoReport\")]|any
}"   # => {coverageJobs: 1, nonCoverageWithJacoco: false}
```

The pinned axes are identical between a PR build and a push build (so the corpus matches a PR and its base); `HEAD` is appended to the version axis only for branch builds and never lands in the coverage job (it pins `MAX_PG`).

## Follow-up (deliberately not extra coverage rows)

Measured gaps, to be closed by **targeted unit tests** or a dedicated job:
- Other query modes literal serialisation — `SimpleParameterList.toString` / `ArrayEncoding` / `PGbytea` are pure, DB-free serialisers (+130 lines), directly unit-testable.
- Java 8 `LazyCleanerImpl` — multi-release (`src/main/java` vs `src/main/java11`); the Java 8 variant needs a Java 8 run.
- GSS auth and the old-server fallback paths (~7 lines).