### PR TITLE
ci: apply -DqueryTimeout from the matrix query_timeout axis

### DIFF
--- a/.github/workflows/matrix.mjs
+++ b/.github/workflows/matrix.mjs
@@ -393,7 +393,6 @@ include.forEach(v => {
   v.query_mode = v.query_mode.value;
   v.adaptive_fetch = v.adaptive_fetch.value;
   v.rewrite_batch_inserts = v.rewrite_batch_inserts.value;
-  v.query_timeout = v.query_timeout.value;
   v.autosave = v.autosave.value;
   v.cleanupSavepoints = v.cleanupSavepoints.value;
 

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/SharedTimerRefCountTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/SharedTimerRefCountTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2004, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.test.jdbc2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.postgresql.Driver;
+import org.postgresql.test.TestUtil;
+import org.postgresql.util.PSQLState;
+import org.postgresql.util.SharedTimer;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+/**
+ * Verifies the acquire/release lifecycle of the process-global {@link SharedTimer} reference that a
+ * connection holds while a query-timeout cancel task is scheduled.
+ *
+ * <p>The ref count is JVM-wide, so these assertions only hold when no other test mutates the timer
+ * concurrently; the class is therefore {@link Isolated}. A JVM-wide default {@code queryTimeout}
+ * (the {@code query_timeout} CI matrix axis) also makes unrelated connections hold references, so
+ * the assertions track deltas from a baseline captured at the start rather than an absolute zero.</p>
+ */
+@Isolated("Asserts the process-global SharedTimer ref count, which concurrent tests would perturb")
+class SharedTimerRefCountTest {
+  @Test
+  void multipleCancels() throws Exception {
+    SharedTimer sharedTimer = Driver.getSharedTimer();
+    int baseRefCount = sharedTimer.getRefCount();
+
+    try (Connection connA = TestUtil.openDB();
+         Connection connB = TestUtil.openDB();
+         Statement stmtA = connA.createStatement();
+         Statement stmtB = connB.createStatement();
+    ) {
+      assertEquals(baseRefCount, sharedTimer.getRefCount());
+      stmtA.setQueryTimeout(1);
+      stmtB.setQueryTimeout(1);
+      try (ResultSet rsA = stmtA.executeQuery("SELECT pg_sleep(2)")) {
+        fail("statement should have been canceled by query timeout since the sleep should take 2 sec and the timeout was 1 sec");
+      } catch (SQLException e) {
+        assertEquals(
+            PSQLState.QUERY_CANCELED.getState(), e.getSQLState(),
+            "Query is expected to be cancelled since the sleep should take 2 sec and the timeout was 1 sec");
+      }
+      assertEquals(baseRefCount + 1, sharedTimer.getRefCount());
+      try (ResultSet rsB = stmtB.executeQuery("SELECT pg_sleep(2)");) {
+        fail("statement should have been canceled by query timeout since the sleep should take 2 sec and the timeout was 1 sec");
+      } catch (SQLException e) {
+        assertEquals(
+            PSQLState.QUERY_CANCELED.getState(), e.getSQLState(),
+            "Query is expected to be cancelled since the sleep should take 2 sec and the timeout was 1 sec");
+      }
+    }
+    assertEquals(baseRefCount, sharedTimer.getRefCount());
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/StatementTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/StatementTest.java
@@ -14,7 +14,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-import org.postgresql.Driver;
 import org.postgresql.PGProperty;
 import org.postgresql.core.ServerVersion;
 import org.postgresql.jdbc.PgStatement;
@@ -23,7 +22,6 @@ import org.postgresql.test.util.StrangeProxyServer;
 import org.postgresql.util.LazyCleaner;
 import org.postgresql.util.LazyCleanerImpl;
 import org.postgresql.util.PSQLState;
-import org.postgresql.util.SharedTimer;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -818,37 +816,6 @@ class StatementTest {
 
     ResultSet rsOther = stmt.getResultSet();
     assertNotNull(rsOther);
-  }
-
-  @Test
-  void multipleCancels() throws Exception {
-    SharedTimer sharedTimer = Driver.getSharedTimer();
-
-    try (Connection connA = TestUtil.openDB();
-         Connection connB = TestUtil.openDB();
-         Statement stmtA = connA.createStatement();
-         Statement stmtB = connB.createStatement();
-    ) {
-      assertEquals(0, sharedTimer.getRefCount());
-      stmtA.setQueryTimeout(1);
-      stmtB.setQueryTimeout(1);
-      try (ResultSet rsA = stmtA.executeQuery("SELECT pg_sleep(2)")) {
-        fail("statement should have been canceled by query timeout since the sleep should take 2 sec and the timeout was 1 sec");
-      } catch (SQLException e) {
-        assertEquals(
-            PSQLState.QUERY_CANCELED.getState(), e.getSQLState(),
-            "Query is expected to be cancelled since the sleep should take 2 sec and the timeout was 1 sec");
-      }
-      assertEquals(1, sharedTimer.getRefCount());
-      try (ResultSet rsB = stmtB.executeQuery("SELECT pg_sleep(2)");) {
-        fail("statement should have been canceled by query timeout since the sleep should take 2 sec and the timeout was 1 sec");
-      } catch (SQLException e) {
-        assertEquals(
-            PSQLState.QUERY_CANCELED.getState(), e.getSQLState(),
-            "Query is expected to be cancelled since the sleep should take 2 sec and the timeout was 1 sec");
-      }
-    }
-    assertEquals(0, sharedTimer.getRefCount());
   }
 
   @Test


### PR DESCRIPTION
The `query_timeout` axis in `.github/workflows/matrix.mjs` was inert. Job names showed e.g. `query_timeout 15`, but `-DqueryTimeout` was never passed to the test JVMs, so the per-statement timeout was never exercised.

## Why

The axis uses plain-string values (`['', '15']`). The per-row builder ran `v.query_timeout = v.query_timeout.value`, and `.value` on a string is `undefined`. The downstream `if (v.query_timeout) { testJvmArgs.push(`-DqueryTimeout=...`) }` guard was therefore always false. Object-valued axes such as `query_mode`/`adaptive_fetch` legitimately need `.value`; a plain-string axis does not.

## What

- Drop the `.value` access for `query_timeout` (the row value is already the string).
- Move `StatementTest.multipleCancels`, the one test the now-active axis broke, into its own `@Isolated` class (see below).

## How to verify

```
cd .github/workflows && npm ci && GITHUB_OUTPUT=/tmp/m node matrix.mjs >/dev/null
```

Extract the matrix JSON between the `MATRIX_BODY` markers in `/tmp/m`. Rows that drew `query_timeout=15` now carry `query_timeout: "15"` and a `-DqueryTimeout=15` entry in `testExtraJvmArgs`; the empty-value rows carry neither. A 60-job sample produced 27 rows with the flag and 0 rows with an `undefined` value.

## The one test the change broke

Enabling the option broke exactly one test across the whole matrix (including a `slow_tests=yes` run of 11490 tests): `StatementTest.multipleCancels`. It was not a timeout overrun. The test asserts the process-global `SharedTimer` ref count is exactly `0 → 1 → 0`, which only holds when no other open connection has scheduled a cancel task. A JVM-wide default `queryTimeout` makes the `setUp` connection hold a reference, so the count starts at 1 and the first assertion failed with `expected: <0> but was: <1>`.

The ref count is JVM-wide, so the assertion is fragile against any concurrent test as well. The fix moves the test into a dedicated `@Isolated` class (`SharedTimerRefCountTest`) so no concurrent test can perturb the count — mirroring the existing convention (e.g. `CursorFetchSqlTransactionTest` is `@Isolated` for the same class of pg_cursors-count problem) — and asserts deltas from a baseline captured at the start rather than an absolute `0/1/0`, so unrelated references (a default `queryTimeout`, a leaked connection) are tolerated. Verified locally: the test fails under `-DqueryTimeout=15` before the fix and passes after, with and without the option; `autostyleCheck` and `checkstyleTest` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
