### PR TITLE
fix: flush LargeObject output stream before marking closed

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/largeobject/LargeObject.java
+++ b/pgjdbc/src/main/java/org/postgresql/largeobject/LargeObject.java
@@ -166,26 +166,27 @@ public class LargeObject
     if (closed) {
       return;
     }
-    // flush any open output streams before marking closed
-    if (os != null) {
-      try {
-        // we can't call os.close() otherwise we go into an infinite loop!
-        os.flush();
-      } catch (IOException ioe) {
-        throw new PSQLException("Exception flushing output stream", PSQLState.DATA_ERROR, ioe);
-      } finally {
-        os = null;
+    try {
+      // flush any open output streams
+      if (os != null) {
+        try {
+          // we can't call os.close() otherwise we go into an infinite loop!
+          os.flush();
+        } catch (IOException ioe) {
+          throw new PSQLException("Exception flushing output stream", PSQLState.DATA_ERROR, ioe);
+        } finally {
+          os = null;
+        }
       }
-    }
-    closed = true;
-
-    // finally close
-    FastpathArg[] args = new FastpathArg[1];
-    args[0] = new FastpathArg(fd);
-    fp.fastpath("lo_close", args); // true here as we dont care!!
-    BaseConnection conn = this.conn;
-    if (this.commitOnClose && conn != null) {
-      conn.commit();
+    } finally {
+      closed = true;
+      FastpathArg[] args = new FastpathArg[1];
+      args[0] = new FastpathArg(fd);
+      fp.fastpath("lo_close", args);
+      BaseConnection conn = this.conn;
+      if (this.commitOnClose && conn != null) {
+        conn.commit();
+      }
     }
   }
 

--- a/pgjdbc/src/main/java/org/postgresql/largeobject/LargeObject.java
+++ b/pgjdbc/src/main/java/org/postgresql/largeobject/LargeObject.java
@@ -166,27 +166,44 @@ public class LargeObject
     if (closed) {
       return;
     }
-    try {
-      // flush any open output streams
-      if (os != null) {
-        try {
-          // we can't call os.close() otherwise we go into an infinite loop!
-          os.flush();
-        } catch (IOException ioe) {
-          throw new PSQLException("Exception flushing output stream", PSQLState.DATA_ERROR, ioe);
-        } finally {
-          os = null;
-        }
+    // Flush while still open: BlobOutputStream.flush() calls back into LargeObject.write(),
+    // which would fail checkClosed() if the object were already marked closed.
+    SQLException error = null;
+    if (os != null) {
+      try {
+        // we can't call os.close() otherwise we go into an infinite loop!
+        os.flush();
+      } catch (IOException ioe) {
+        error = new PSQLException(GT.tr("Exception flushing output stream"),
+            PSQLState.DATA_ERROR, ioe);
+      } finally {
+        os = null;
       }
-    } finally {
-      closed = true;
+    }
+
+    closed = true;
+
+    // Always release the server-side descriptor, but do not let lo_close mask a flush failure.
+    try {
       FastpathArg[] args = new FastpathArg[1];
       args[0] = new FastpathArg(fd);
       fp.fastpath("lo_close", args);
-      BaseConnection conn = this.conn;
-      if (this.commitOnClose && conn != null) {
-        conn.commit();
+    } catch (SQLException e) {
+      if (error != null) {
+        error.addSuppressed(e);
+      } else {
+        error = e;
       }
+    }
+
+    // Commit only when flush and lo_close both succeeded; never commit a half-written object.
+    BaseConnection conn = this.conn;
+    if (error == null && this.commitOnClose && conn != null) {
+      conn.commit();
+    }
+
+    if (error != null) {
+      throw error;
     }
   }
 

--- a/pgjdbc/src/main/java/org/postgresql/largeobject/LargeObject.java
+++ b/pgjdbc/src/main/java/org/postgresql/largeobject/LargeObject.java
@@ -166,8 +166,7 @@ public class LargeObject
     if (closed) {
       return;
     }
-    closed = true;
-    // flush any open output streams
+    // flush any open output streams before marking closed
     if (os != null) {
       try {
         // we can't call os.close() otherwise we go into an infinite loop!
@@ -178,6 +177,7 @@ public class LargeObject
         os = null;
       }
     }
+    closed = true;
 
     // finally close
     FastpathArg[] args = new FastpathArg[1];

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BlobTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BlobTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.sql.Blob;
 import java.sql.Clob;
 import java.sql.Connection;
@@ -133,6 +134,33 @@ class BlobTest {
 
       pstmt.setObject(1, null, Types.CLOB);
       pstmt.executeUpdate();
+    }
+  }
+
+  /**
+   * Closing a LargeObject must flush its still-buffered output stream before marking the object
+   * closed. See <a href="https://github.com/pgjdbc/pgjdbc/issues/4247">issue 4247</a>.
+   */
+  @Test
+  void closeFlushesBufferedOutputStream() throws Exception {
+    LargeObjectManager lom = ((PGConnection) con).getLargeObjectAPI();
+    long oid = lom.createLO(LargeObjectManager.READWRITE);
+
+    byte[] data = "pgjdbc-4247".getBytes(StandardCharsets.US_ASCII);
+
+    LargeObject blob = lom.open(oid, LargeObjectManager.WRITE);
+    OutputStream os = blob.getOutputStream();
+    // Less than the buffer size, so the bytes stay buffered until close() flushes them
+    os.write(data);
+    // Close the LargeObject directly without flushing the stream first: this must not throw
+    blob.close();
+
+    blob = lom.open(oid, LargeObjectManager.READ);
+    try {
+      assertArrayEquals(data, blob.read(data.length));
+    } finally {
+      blob.close();
+      lom.delete(oid);
     }
   }
 


### PR DESCRIPTION
LargeObject.close() set closed=true before calling BlobOutputStream.flush(), which in turn calls LargeObject.write(). write() calls checkClosed() and throws because closed is already true.

Move closed=true to after the flush so the write can complete.

Fixes #4247


