### PR TITLE
fix(largeobject): flush output stream before marking LargeObject closed

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/largeobject/LargeObject.java
+++ b/pgjdbc/src/main/java/org/postgresql/largeobject/LargeObject.java
@@ -166,8 +166,8 @@ public class LargeObject
     if (closed) {
       return;
     }
-    closed = true;
-    // flush any open output streams
+    // flush any open output streams before marking the object closed, otherwise the flush
+    // would write through a closed LargeObject and fail its checkClosed() guard
     if (os != null) {
       try {
         // we can't call os.close() otherwise we go into an infinite loop!
@@ -178,6 +178,7 @@ public class LargeObject
         os = null;
       }
     }
+    closed = true;
 
     // finally close
     FastpathArg[] args = new FastpathArg[1];

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BlobTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/BlobTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.sql.Blob;
 import java.sql.Clob;
 import java.sql.Connection;
@@ -133,6 +134,35 @@ class BlobTest {
 
       pstmt.setObject(1, null, Types.CLOB);
       pstmt.executeUpdate();
+    }
+  }
+
+  /**
+   * Closing a LargeObject must flush its still-buffered output stream before marking the object
+   * closed. See <a href="https://github.com/pgjdbc/pgjdbc/issues/4247">issue 4247</a>: a regression
+   * in 42.7.11 set the closed flag first, so the implicit flush failed with
+   * "This large object has been closed.".
+   */
+  @Test
+  void closeFlushesBufferedOutputStream() throws Exception {
+    LargeObjectManager lom = ((PGConnection) con).getLargeObjectAPI();
+    long oid = lom.createLO(LargeObjectManager.READWRITE);
+
+    byte[] data = "pgjdbc-4247".getBytes(StandardCharsets.US_ASCII);
+
+    LargeObject blob = lom.open(oid, LargeObjectManager.WRITE);
+    OutputStream os = blob.getOutputStream();
+    // Less than the buffer size, so the bytes stay buffered until close() flushes them
+    os.write(data);
+    // Close the LargeObject directly without flushing the stream first: this must not throw
+    blob.close();
+
+    blob = lom.open(oid, LargeObjectManager.READ);
+    try {
+      assertArrayEquals(data, blob.read(data.length));
+    } finally {
+      blob.close();
+      lom.delete(oid);
     }
   }
 


### PR DESCRIPTION
## Why

`LargeObject.close()` throws `This large object has been closed.` whenever it has to flush a buffered output stream. Closing a `LargeObject` that still holds buffered writes fails outright, so callers lose data unless they flush the stream manually first. Reported in #4247 against 42.7.11.

The regression came in with #3905, which moved `closed = true` to the top of `close()`, ahead of the flush. The implicit `os.flush()` then writes through the closed object: `BlobOutputStream.flush()` → `LargeObject.write()` → `checkClosed()` throws.

## What

- Reorder `LargeObject.close()` to flush the output stream first and mark the object closed afterwards, restoring the pre-42.7.11 behaviour.
- The reentrant lock added in #3905 lives in `BlobOutputStream`, not `LargeObject`, so this reorder does not affect it.

## How to verify

New regression test `BlobTest.closeFlushesBufferedOutputStream` writes a small, still-buffered payload, closes the `LargeObject` directly, then reopens and checks the bytes were persisted. It reproduces the reported stack trace before the fix and passes after.

```
./gradlew :postgresql:test --tests 'org.postgresql.test.jdbc2.BlobTest.closeFlushesBufferedOutputStream'
```

Fixes #4247

🤖 Generated with [Claude Code](https://claude.com/claude-code)
