### PR TITLE
docs: advertise RSS feeds with an autodiscovery link

### DIFF
--- a/docs/layouts/_default/baseof.html
+++ b/docs/layouts/_default/baseof.html
@@ -14,6 +14,9 @@
     {{ $sass := resources.Get "sass/main.scss" }}
     {{ $style := $sass | css.Sass | resources.Fingerprint }}
     <link rel="stylesheet" href="{{ $style.Permalink }}" integrity="{{ $style.Data.Integrity }}">
+    {{- with .OutputFormats.Get "rss" }}
+    <link rel="{{ .Rel }}" type="{{ .MediaType.Type }}" href="{{ .Permalink }}" title="{{ with $.Title }}{{ . }} | {{ end }}{{ $.Site.Title }}">
+    {{- end }}
     {{ partial "site-manifest.html" . }}
     {{ partial "scripts.html" . }}
 


### PR DESCRIPTION
## Why

The website already generates a per-section RSS feed — for example the changelogs feed at `https://jdbc.postgresql.org/changelogs/index.xml` — but no page declares it in `<head>`. Feed readers cannot discover it, so a reader has to know and paste the URL by hand. This is the follow-up raised on #2157 after the feed itself was confirmed working: the reporter expected a `<link rel="alternate" ...>` on the changelogs page.

## What

Add a single line to the shared `<head>` in `docs/layouts/_default/baseof.html` that emits an autodiscovery link for the current page's own RSS feed:

```html
{{- with .OutputFormats.Get "rss" }}
<link rel="{{ .Rel }}" type="{{ .MediaType.Type }}" href="{{ .Permalink }}" title="{{ with $.Title }}{{ . }} | {{ end }}{{ $.Site.Title }}">
{{- end }}
```

`.OutputFormats.Get "rss"` resolves to the RSS format only on pages that actually emit one, so the tag appears on the home page and on every section list page (changelogs, documentation, ...) and is omitted on leaf pages, which output HTML only. Targeting `rss` specifically — rather than ranging over `.AlternativeOutputFormats` — avoids advertising the home page's `SearchIndex` JSON output as a bogus alternate link.

On `/changelogs/` this renders:

```html
<link rel="alternate" type="application/rss+xml" href="https://jdbc.postgresql.org/changelogs/index.xml" title="Changelogs | pgJDBC">
```

## How to verify

Build the site and inspect the output:

```
cd docs && hugo --destination /tmp/site
grep '<link rel="alternate"' /tmp/site/changelogs/index.html   # present, points at changelogs/index.xml
grep '<link rel="alternate"' /tmp/site/index.html              # present, points at index.xml
grep '<link rel="alternate"' /tmp/site/changelogs/2020-10-09-42.2.17-release/index.html  # absent (leaf page)
```

Refs #2157

🤖 Generated with [Claude Code](https://claude.com/claude-code)