### PR TITLE
ci: generate the whole matrix in one batch, coverage job included

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -123,7 +123,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     env:
-      MATRIX_JOBS: 5
+      MATRIX_JOBS: 6
       GITHUB_PR_NUMBER: ${{ github.event.number }}
       RNG_SEED: ${{ github.event.inputs.matrix_rng_seed }}
     steps:

--- a/.github/workflows/matrix.mjs
+++ b/.github/workflows/matrix.mjs
@@ -307,36 +307,6 @@ matrix.imply({pg_version: 'HEAD'}, {os: {value: 'ubuntu-latest'}});
 // cleanupSavepoints is not relevant when autosave=never
 matrix.imply({autosave: {value: 'never'}}, {cleanupSavepoints: {value: 'false'}});
 
-// The most rare features should be generated the first
-// For instance, we have a lot of PostgreSQL versions, so we generate the minimal the first
-// It would have to generate other parameters, and it might happen it would cover "most recent Java" automatically
-// Ensure at least one job with "same" hashcode exists
-matrix.generateRow({hash: {value: 'same'}});
-matrix.generateRow({scram: {value: 'yes'}});
-// Ensure there's a row for Java EA. It is at the beginning to increase chances of covering cases like ssl=yes below
-matrix.generateRow({java_version: eaJava});
-// Ensure we have a job with the minimal and maximal PostgreSQL versions
-matrix.generateRow({pg_version: matrix.axisByName.pg_version.values[0]});
-matrix.generateRow({pg_version: matrix.axisByName.pg_version.values.slice(-1)[0]});
-//Ensure at least one job with "simple" query_mode exists
-matrix.generateRow({query_mode: {value: 'simple'}});
-// Ensure there will be at least one job with minimal supported Java
-matrix.generateRow({java_version: matrix.axisByName.java_version.values[0]});
-// Ensure there will be at least one job with Java 17
-matrix.generateRow({java_version: "17"});
-// Ensure there will be at least one job with the latest Java (excluding EA)
-matrix.generateRow({java_version: matrix.axisByName.java_version.values.slice(-2)[0]});
-// Ensure we test all query_mode values
-matrix.ensureAllAxisValuesCovered('query_mode');
-matrix.ensureAllAxisValuesCovered('gss');
-matrix.ensureAllAxisValuesCovered('xa');
-matrix.ensureAllAxisValuesCovered('ssl');
-matrix.ensureAllAxisValuesCovered('replication');
-matrix.ensureAllAxisValuesCovered('os');
-matrix.ensureAllAxisValuesCovered('cpu_count');
-matrix.ensureAllAxisValuesCovered('assertions');
-// Ensure at least one job with autosave=always
-matrix.generateRow({autosave: {value: 'always'}});
 // Collect coverage from a single job that turns on every feature that moves coverage (ssl,
 // scram, xa, replication, the latest stable server, one query mode). The other flags add at
 // most a line or two to line/branch coverage, so leaving them to the random fill keeps the
@@ -344,24 +314,64 @@ matrix.generateRow({autosave: {value: 'always'}});
 const MAX_PG = matrix.axisByName.pg_version.values.filter(v => v !== 'HEAD').slice(-1)[0];
 // Latest non-EA Java from the axis, so this need not be bumped when Java versions change.
 const LATEST_JAVA = matrix.axisByName.java_version.values.filter(v => v !== eaJava).slice(-1)[0];
-const coverageRow = matrix.generateRow({
-  os: {value: 'ubuntu-latest'},            // coverage needs the Docker PostgreSQL (Linux only)
-  pg_version: MAX_PG,
-  java_version: LATEST_JAVA, java_distribution: {value: 'temurin'},
-  query_mode: {value: 'extended'},
-  ssl: {value: 'yes'}, scram: {value: 'yes'},
-  xa: {value: 'yes'}, replication: {value: 'yes'},
-  // slow tests add ~0 coverage but cost runtime; GSS auth needs its own krb5 job.
-  slow_tests: {value: 'no'}, gss: {value: 'no'},
-});
-if (!coverageRow) {
-  throw new Error('Could not generate the coverage job; check that the pinned axes are satisfiable');
-}
-coverageRow.collectCoverage = true;
 
-const include = matrix.generateRows(process.env.MATRIX_JOBS || 5);
+// Drive the whole matrix from one batch of requirements. generateRows guarantees a row for
+// each entry, packs them into as few jobs as it can, and spends the rest of the MATRIX_JOBS
+// budget on pairwise coverage. Unlike a sequence of generateRow() calls, the job count is
+// exactly MATRIX_JOBS and the result no longer depends on the order of the list, so the
+// rarest-first ordering the imperative version relied on is gone. Requirements already met by
+// another row (e.g. the coverage job pins scram=yes and the latest Java) cost no extra job.
+const include = matrix.generateRows(Number(process.env.MATRIX_JOBS || 6), {
+  require: [
+    // Collect coverage on one pinned job. It is the most specific requirement, so the batch
+    // packer anchors a row on it; tag() flags that row without a second pass over the result.
+    {
+      filter: {
+        os: {value: 'ubuntu-latest'},        // coverage needs the Docker PostgreSQL (Linux only)
+        pg_version: MAX_PG,
+        java_version: LATEST_JAVA, java_distribution: {value: 'temurin'},
+        query_mode: {value: 'extended'},
+        ssl: {value: 'yes'}, scram: {value: 'yes'},
+        xa: {value: 'yes'}, replication: {value: 'yes'},
+        // slow tests add ~0 coverage but cost runtime; GSS auth needs its own krb5 job.
+        slow_tests: {value: 'no'}, gss: {value: 'no'},
+      },
+      tag: row => { row.collectCoverage = true; },
+    },
+    // Ensure at least one job with "same" hashcode exists
+    {hash: {value: 'same'}},
+    {scram: {value: 'yes'}},
+    // Ensure there's a row for Java EA
+    {java_version: eaJava},
+    // Ensure we have a job with the minimal and maximal PostgreSQL versions
+    {pg_version: matrix.axisByName.pg_version.values[0]},
+    {pg_version: matrix.axisByName.pg_version.values.slice(-1)[0]},
+    // Ensure at least one job with "simple" query_mode exists
+    {query_mode: {value: 'simple'}},
+    // Ensure there will be at least one job with minimal supported Java
+    {java_version: matrix.axisByName.java_version.values[0]},
+    // Ensure there will be at least one job with Java 17
+    {java_version: "17"},
+    // Ensure there will be at least one job with the latest Java (excluding EA)
+    {java_version: LATEST_JAVA},
+    // Ensure at least one job with autosave=always
+    {autosave: {value: 'always'}},
+    // Ensure we test all values of the axes below
+    ...matrix.allAxisValues('query_mode'),
+    ...matrix.allAxisValues('gss'),
+    ...matrix.allAxisValues('xa'),
+    ...matrix.allAxisValues('ssl'),
+    ...matrix.allAxisValues('replication'),
+    ...matrix.allAxisValues('os'),
+    ...matrix.allAxisValues('cpu_count'),
+    ...matrix.allAxisValues('assertions'),
+  ],
+});
 if (include.length === 0) {
   throw new Error('Matrix list is empty');
+}
+if (!include.some(v => v.collectCoverage)) {
+  throw new Error('Could not generate the coverage job; check that the pinned axes are satisfiable');
 }
 include.sort((a, b) => a.name.localeCompare(b.name, undefined, {numeric: true}));
 include.forEach(v => {

--- a/.github/workflows/package-lock.json
+++ b/.github/workflows/package-lock.json
@@ -5,13 +5,13 @@
   "packages": {
     "": {
       "dependencies": {
-        "@vlsi/github-actions-random-matrix": "2.0.0"
+        "@vlsi/github-actions-random-matrix": "2.1.0"
       }
     },
     "node_modules/@vlsi/github-actions-random-matrix": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@vlsi/github-actions-random-matrix/-/github-actions-random-matrix-2.0.0.tgz",
-      "integrity": "sha512-8lEb4eadMBKs+Hnj9dCmcHtgHoWelT4RMXAQ/VcQ1r3vjR8P2hSMVGhkRXaXibCBf0lMttS934CGo2mlBMopPA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@vlsi/github-actions-random-matrix/-/github-actions-random-matrix-2.1.0.tgz",
+      "integrity": "sha512-+KDQS/+AwEUBRrQR3WbBGva2Z2X5NAXDzWvaPAijSB0zNtUEAepw0YJWdsXDnSESeFpQ/rtna+SfEdKkTcIW8A==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=16"

--- a/.github/workflows/package.json
+++ b/.github/workflows/package.json
@@ -2,6 +2,6 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "@vlsi/github-actions-random-matrix": "2.0.0"
+    "@vlsi/github-actions-random-matrix": "2.1.0"
   }
 }


### PR DESCRIPTION
## What

Bump `@vlsi/github-actions-random-matrix` to 2.1.0 and drive `.github/workflows/matrix.mjs` from a single `generateRows(n, {require: [...]})` call, replacing the previous sequence of imperative `generateRow()` / `ensureAllAxisValuesCovered()` calls. The coverage job is now generated as part of the same batch.

## Why

The 2.1.0 batch API (vlsi/github-actions-random-matrix#5) takes all the requirements at once: it guarantees a row for each one, packs them into as few jobs as it can, and spends the rest of the budget on pairwise coverage. Unlike the old one-row-at-a-time approach, the outcome no longer depends on the order of the calls.

This fixes two long-standing quirks:

- **Job count was non-deterministic.** With the old API `MATRIX_JOBS` acted as a floor, so the total drifted between 5 and 9 depending on the seed and call order. `generateRows(n)` now produces exactly `n` jobs.
- **The coverage job needed a separate pass.** It used a standalone `generateRow()` and then mutated the returned row. It is now a `require` entry with a `tag(row)` callback that flags the row in place, so it is part of the same batch as everything else — which is the goal of this change. A post-check still fails the build if no coverage row was produced.

`ensureAllAxisValuesCovered('ssl')` and friends become `...matrix.allAxisValues('ssl')` spread into the `require` list. The old "rarest-first" ordering comment is gone, because order no longer matters.

## Job count

Because `generateRows(n)` now means *exactly* `n` jobs rather than a floor, `MATRIX_JOBS` is bumped from 5 to 6 so the matrix lands in the middle of the old 5–9 range. For reference, pair / weight coverage by budget: 5 → ~41% / ~70%, **6 → ~45% / ~76%**, 7 → ~50% / ~80%, 8 → ~54% / ~82%. It is tunable in one place (the `MATRIX_JOBS` env in `main.yml`).

## Verification

Run locally against the installed 2.1.0:

- 50 seeds at `n=6`: every run yields exactly 6 jobs, exactly one coverage row, all required axis values covered (`query_mode`×4, `gss`/`xa`/`ssl`/`replication`/`os`×2, Java {8,17,25,26}, PG {9.1,18}), and zero "did not fit" warnings.
- The coverage job keeps its pinned combination (`pg=18`, latest stable Java on Temurin, `extended`, `ssl`/`scram`/`xa`/`replication=yes`, `os=ubuntu`, `slow=no`, `gss=no`), gets `jacocoReport`, `assumeMinServerVersion=''`, and the `, coverage` name suffix.
- Branch builds (`refs/heads/*`) still add the `HEAD` server to the matrix and keep the coverage job pinned to the latest stable PostgreSQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)