### PR TITLE
ci: pass CODECOV_TOKEN so protected-branch coverage uploads succeed

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -332,10 +332,12 @@ jobs:
 
     - name: Upload coverage to Codecov
       # Run on both success and failure (after the fallback report above); skip jobs that
-      # did not collect coverage. pgjdbc is public, so Codecov accepts tokenless uploads.
+      # did not collect coverage. A push to a protected branch (master) needs CODECOV_TOKEN;
+      # pull requests upload tokenlessly, since the secret is not exposed to forks.
       if: ${{ !cancelled() && matrix.collectCoverage }}
       uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         files: ./build/reports/jacoco/jacocoReport/jacocoReport.xml
         # Upload only the aggregate report; do not search the tree for other files.
         disable_search: true


### PR DESCRIPTION
## Why

Codecov now rejects tokenless uploads from protected branches. The `master` push fails the upload step with `Token required because branch is protected` ([failing run](https://github.com/pgjdbc/pgjdbc/actions/runs/28124110977/job/83283391211#step:12:322)), so coverage from the canonical branch never lands and the badge/trend stall.

## What

Pass the repository `CODECOV_TOKEN` secret to the `codecov/codecov-action` step. Pull requests keep uploading tokenlessly: the secret is not exposed to forked PRs, and the action falls back to the tokenless path when the token is empty.

## How to verify

After merge, the coverage upload on the `master` push should report success instead of `Token required because branch is protected`. Fork PRs continue to upload via the tokenless path (no secret needed).

Note: this relies on a `CODECOV_TOKEN` repository secret being present. It already exists in the repo settings.