### PR TITLE
fix(ci): read java_vendor before overwriting java_distribution

### DIFF
--- a/.github/workflows/matrix.mjs
+++ b/.github/workflows/matrix.mjs
@@ -410,8 +410,9 @@ include.forEach(v => {
   jvmArgs.push(`-Duser.language=${v.locale.language}`);
 
   v.os = v.os.value;
-  v.java_distribution = v.java_distribution.value;
-  v.java_vendor = v.java_distribution.vendor;
+  const {value: javaDistribution, vendor: javaVendor} = v.java_distribution;
+  v.java_distribution = javaDistribution;
+  v.java_vendor = javaVendor;
   if (v.java_distribution === 'oracle') {
       v.oracle_java_website = v.java_version === eaJava ? 'jdk.java.net' : 'oracle.com';
   }


### PR DESCRIPTION
Why
---

In the matrix generator, per-row post-processing overwrote `v.java_distribution` with its string `.value` and only afterwards read `.vendor` from it:

```js
v.java_distribution = v.java_distribution.value;   // now a string, e.g. ""oracle""
v.java_vendor = v.java_distribution.vendor;         // ""oracle"".vendor === undefined
```

So `v.java_vendor` was always `undefined`. It feeds `jdkTestVendor=${{ matrix.java_vendor }}` in `main.yml`, which sets the Gradle test toolchain vendor (`JvmVendorSpec.matching(...)` in `build-logic/basics/src/main/kotlin/configureToolchain.kt`). An empty value left the test JDK unconstrained by vendor.

What
----

Destructure `value` and `vendor` before the overwrite, so the read no longer depends on statement order:

```js
const {value: javaDistribution, vendor: javaVendor} = v.java_distribution;
v.java_distribution = javaDistribution;
v.java_vendor = javaVendor;
```

The later `v.java_distribution === ""oracle""` checks run after this block and rely on `v.java_distribution` already being the string value, which the fix preserves.

`main.yml` provisions the matching-vendor JDK via `actions/setup-java` with `distribution: ${{ matrix.java_distribution }}`, so pinning the vendor in the toolchain spec resolves against an already-installed JDK and does not need `org.gradle.java.installations.auto-download`.

The same bug and the same destructuring fix were applied in apache/jmeter""s `.github/workflows/matrix.js`.

How to verify
-------------

1. `npm ci --prefix .github/workflows`
2. `MATRIX_JOBS=8 node .github/workflows/matrix.mjs`
3. Every row now has a real `java_vendor` — one of amazon, bellsoft, microsoft, oracle, eclipse, azul — and none is `undefined`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)