### PR TITLE
build: include multi-release source sets in the JaCoCo coverage report

### DIFF
--- a/build-logic/verification/src/main/kotlin/build-logic.jacoco.gradle.kts
+++ b/build-logic/verification/src/main/kotlin/build-logic.jacoco.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("java-base")
+    id("build-logic.build-params")
     id("jacoco")
 }
 
@@ -13,8 +14,25 @@ jacoco {
 val testTasks = tasks.withType<Test>()
 val javaExecTasks = tasks.withType<JavaExec>()
 
+val jacocoReport by rootProject.tasks.existing(JacocoReport::class)
+val mainCode = sourceSets["main"]
+
+// Relative paths (e.g. org/postgresql/Foo.java) of the Java sources in a source set.
+fun SourceSet.relativeJavaPaths(): Set<String> =
+    allJava.srcDirs.flatMap { root ->
+        if (root.exists()) {
+            root.walk()
+                .filter { it.isFile && it.extension == "java" }
+                .map { it.relativeTo(root).invariantSeparatorsPath }
+                .toList()
+        } else {
+            emptyList()
+        }
+    }.toSet()
+
 // This configuration must be postponed since JacocoTaskExtension might be added inside
-// configure block of a task (== before this code is run)
+// configure block of a task (== before this code is run), and the multi-release source sets
+// (java11, java17, ...) are created in the project build script, after this convention is applied.
 afterEvaluate {
     for (t in arrayOf(testTasks, javaExecTasks)) {
         t.configureEach {
@@ -24,20 +42,49 @@ afterEvaluate {
             }
         }
     }
-}
 
-val jacocoReport by rootProject.tasks.existing(JacocoReport::class)
-val mainCode = sourceSets["main"]
+    // Multi-release source sets named "javaNN" compile into META-INF/versions/NN, and the JVM loads
+    // them at runtime on JDK >= NN (the test classpath is set up the same way). Include the versions
+    // the tests actually run (testJdkVersion >= NN) so coverage is attributed to the class file that
+    // ran. Without this, JaCoCo reports "execution data does not match" for an overridden class (for
+    // example the Java 17 Unix domain socket factory) and drops its coverage, and a class that lives
+    // only in a versioned source set (for example the Unix domain socket adapter) is missing from
+    // the report entirely.
+    val multiReleaseSourceSets = sourceSets
+        .matching { it.name.matches(Regex("java\\d+")) }
+        .filter { buildParameters.testJdkVersion >= it.name.removePrefix("java").toInt() }
+        .sortedBy { it.name.removePrefix("java").toInt() }
 
-// TODO: rework with provide-consume configurations
-jacocoReport {
-    // Note: this creates a lazy collection
-    // Some projects might fail to create a file (e.g. no tests or no coverage),
-    // So we check for file existence. Otherwise, JacocoMerge would fail
-    val execFiles =
-        files(testTasks, javaExecTasks).filter { it.exists() && it.name.endsWith(".exec") }
-    executionData(execFiles)
-    additionalSourceDirs.from(mainCode.allJava.srcDirs)
-    sourceDirectories.from(mainCode.allSource.srcDirs)
-    classDirectories.from(mainCode.output)
+    // A versioned source set overrides a base class when it ships a source with the same path. Drop
+    // those classes (and their inner classes) from the base output so only the versioned copy is
+    // analysed: JaCoCo refuses two class files with the same name.
+    val baseJavaPaths = mainCode.relativeJavaPaths()
+    val overriddenClassPatterns = multiReleaseSourceSets
+        .flatMap { it.relativeJavaPaths() }
+        .filter { it in baseJavaPaths }
+        .flatMap { javaPath ->
+            val base = javaPath.removeSuffix(".java")
+            listOf("$base.class", "$base\$*.class")
+        }
+
+    jacocoReport {
+        // Note: this creates a lazy collection
+        // Some projects might fail to create a file (e.g. no tests or no coverage),
+        // So we check for file existence. Otherwise, JacocoMerge would fail
+        val execFiles =
+            files(testTasks, javaExecTasks).filter { it.exists() && it.name.endsWith(".exec") }
+        executionData(execFiles)
+
+        additionalSourceDirs.from(mainCode.allJava.srcDirs)
+        sourceDirectories.from(mainCode.allSource.srcDirs)
+        classDirectories.from(
+            mainCode.output.classesDirs.asFileTree.matching { exclude(overriddenClassPatterns) }
+        )
+
+        for (versioned in multiReleaseSourceSets) {
+            additionalSourceDirs.from(versioned.allJava.srcDirs)
+            sourceDirectories.from(versioned.allSource.srcDirs)
+            classDirectories.from(versioned.output.classesDirs)
+        }
+    }
 }


### PR DESCRIPTION
## Why

The aggregate `jacocoReport` builds its `classDirectories`/`sourceDirectories` from `sourceSets["main"]` only, so classes in the multi-release source sets (`src/main/java11` → `META-INF/versions/11`, `src/main/java17` → `META-INF/versions/17`) are misreported:

- A class **overridden** in a versioned source set has its coverage dropped. JaCoCo logs `Execution data for class ... does not match` because the report analyses the Java 8 base class file while the JVM actually loaded (and the agent recorded) the versioned one. The base stub then shows as uncovered.
- A class that exists **only** in a versioned source set is missing from the report entirely.

This surfaced on [#4188](https://github.com/pgjdbc/pgjdbc/pull/4188) (built-in Unix domain socket factory): its Java 17 adapter never appeared in coverage. The same bug already affected `LazyCleanerImpl` (java11).

## What

Overlay the `javaNN` source sets onto the report, gated by `testJdkVersion >= NN` so only the versions the tests actually load are included (a Java 8 test run does not pull in `java17`). Classes that a versioned source set overrides are excluded from the base output, so JaCoCo never sees two class files with the same name. Projects without versioned source sets are unaffected — the overlay is empty.

## How to verify

Run a coverage build that loads a versioned class, e.g.:

```
./gradlew -Pcoverage :postgresql:test --tests "org.postgresql.test.socketfactory.UnixDomainSocketFactoryTest.createsUnconnectedSocket" jacocoReport
```

Before: `jacocoReport` logs `Execution data for class org/postgresql/unixsocket/UnixDomainSocketFactory does not match`, and `UnixDomainSocket` is absent from `build/reports/jacoco/jacocoReport/jacocoReport.xml`.

After: the warning is gone and the XML lists `org/postgresql/unixsocket/UnixDomainSocketFactory` and `org/postgresql/unixsocket/UnixDomainSocket` with real line counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)