### PR TITLE
fix(build): resolve the Temurin 8 test toolchain by vendor

### DIFF
--- a/build-logic/basics/src/main/kotlin/configureToolchain.kt
+++ b/build-logic/basics/src/main/kotlin/configureToolchain.kt
@@ -15,10 +15,27 @@ fun JavaToolchainSpec.configureToolchain(jdk: ToolchainProperties?) {
         return
     }
     languageVersion.set(JavaLanguageVersion.of(jdk.version))
-    jdk.vendor?.let {
-        vendor.set(JvmVendorSpec.matching(it))
+    jdk.vendor?.takeIf { it.isNotBlank() }?.let {
+        vendor.set(jvmVendorSpecFor(it))
     }
     if (jdk.implementation.equals("J9", ignoreCase = true)) {
         implementation.set(JvmImplementation.J9)
     }
 }
+
+// The CI matrix passes a short vendor token such as "eclipse". Map the known ones to Gradle's
+// built-in JvmVendorSpec constants, which recognise every alias a distribution reports across
+// versions; fall back to a substring match for anything unmapped. This matters for Temurin:
+// JDK 8 reports java.vendor="Temurin" while 11+ report "Eclipse Adoptium", so a plain
+// matching("eclipse") cannot resolve a Temurin 8 toolchain (JvmVendorSpec.matching probes the
+// runtime java.vendor, not the IMPLEMENTOR field of the release file).
+private fun jvmVendorSpecFor(vendor: String): JvmVendorSpec =
+    when (vendor.lowercase()) {
+        "eclipse", "adoptium", "temurin" -> JvmVendorSpec.ADOPTIUM
+        "amazon", "corretto" -> JvmVendorSpec.AMAZON
+        "azul", "zulu" -> JvmVendorSpec.AZUL
+        "bellsoft", "liberica" -> JvmVendorSpec.BELLSOFT
+        "microsoft" -> JvmVendorSpec.MICROSOFT
+        "oracle" -> JvmVendorSpec.ORACLE
+        else -> JvmVendorSpec.matching(vendor)
+    }


### PR DESCRIPTION
## Why

CI jobs for `Java 8 + temurin` fail before any test runs:

```
> Error while evaluating property 'javaLauncher' of task ':pgjdbc-junit4-test:test'.
   > Cannot find a Java installation on your machine matching: {languageVersion=8, vendor=vendor matching('eclipse'), ...}. Toolchain auto-provisioning is not enabled.
```

The matrix maps the `temurin` distribution to the vendor token `eclipse` and passes it as `jdkTestVendor`, which [`configureToolchain`](build-logic/basics/src/main/kotlin/configureToolchain.kt) turned into `JvmVendorSpec.matching("eclipse")`. That spec is matched against the **runtime `java.vendor`** property (Gradle probes the JVM), not the `IMPLEMENTOR` field of the `release` file. Eclipse Temurin reports it differently per major version:

| JDK | `release` IMPLEMENTOR | runtime `java.vendor` |
| --- | --- | --- |
| Temurin 8 (8u492) | `Eclipse Adoptium` | `Temurin` |
| Temurin 11+ | `Eclipse Adoptium` | `Eclipse Adoptium` |

So `matching("eclipse")` resolves Temurin 11+ but not Temurin 8, and no single substring covers both. (JDK 8 has no `IMPLEMENTOR` field at all — it was added in JDK 9 — so Gradle has only the runtime property to go on.)

The vendor pin was a silent no-op from its introduction until cc7947b8f started populating `java_vendor`, which activated `jdkTestVendor=eclipse` and exposed the mismatch. Since the matrix always emits one minimal-Java (8) job whose distribution is drawn at random, this now fails roughly one run in four on master and PRs. It is unrelated to whichever PR happens to surface it.

## What

Map the known vendor tokens to Gradle's built-in `JvmVendorSpec` constants, which recognise every alias a distribution reports across versions (`ADOPTIUM` matches both `Temurin` and `Eclipse Adoptium`). Anything unmapped still falls back to `matching()`, and a blank token is now ignored rather than turned into `matching("")`.

```kotlin
when (vendor.lowercase()) {
    "eclipse", "adoptium", "temurin" -> JvmVendorSpec.ADOPTIUM
    "amazon", "corretto" -> JvmVendorSpec.AMAZON
    "azul", "zulu" -> JvmVendorSpec.AZUL
    "bellsoft", "liberica" -> JvmVendorSpec.BELLSOFT
    "microsoft" -> JvmVendorSpec.MICROSOFT
    "oracle" -> JvmVendorSpec.ORACLE
    else -> JvmVendorSpec.matching(vendor)
}
```

The `corretto`/`zulu`/`liberica` jobs were already fine (their `java.vendor` contains the token at every version); only Temurin 8 was broken.

## How to verify

With a real Adoptium Temurin 8 install on the toolchain search path, run the test toolchain resolution that CI performs:

```
./gradlew :pgjdbc-junit4-test:test \
  -PjdkBuildVersion=21 -PjdkTestVersion=8 -PjdkTestVendor=eclipse \
  -Porg.gradle.java.installations.auto-download=false \
  -Porg.gradle.java.installations.paths=<temurin-8-home> \
  --tests no.such.Test
```

Before: the build fails at `Cannot find a Java installation ... matching('eclipse')`. After: the toolchain resolves to Temurin 8 and the run proceeds (here it stops at `No tests found` because of the deliberately empty `--tests` filter). Verified locally against Adoptium Temurin 8u492 and 11.0.31 with Gradle 9.5.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)