### PR TITLE
feat: invalidate prepared statement cache via search_path GUC_REPORT (PG 18+)

### DIFF
--- a/docs/content/documentation/server-prepare.md
+++ b/docs/content/documentation/server-prepare.md
@@ -394,18 +394,21 @@ plan and, since PostgreSQL® 9.3, re-plans the statement when that path changes,
 statement still returns rows from the table the current `search_path` selects. (Releases before 9.3 keep the old plan
 and may read the previously resolved table.)
 
-What pgJDBC adds is a cache optimisation. It watches for top-level `set search_path...` commands and invalidates its
-prepared statement cache so the next execution re-prepares against the new path. This avoids the
-`cached plan must not change result type` error when the new path resolves to a table with a different column layout
-(for example, `SELECT *` over `app_v1.mytable` and `app_v2.mytable` with different columns).
+What pgJDBC adds is a cache optimisation. It watches for `search_path` changes and invalidates its prepared statement
+cache so the next execution re-prepares against the new path: top-level `set search_path...` and `reset` commands on any
+server, and, on PostgreSQL® 18 and later that report `search_path` to the client (`GUC_REPORT`), changes made anywhere,
+including inside pl/pgsql. This avoids the `cached plan must not change result type` error when the new path resolves to
+a table with a different column layout (for example, `SELECT *` over `app_v1.mytable` and `app_v2.mytable` with
+different columns).
 
 The recommendation is:
 
-1. Avoid changing `search_path` often. Each top-level `set search_path` that pgJDBC detects invalidates the server side
-prepared statement cache, so the affected statements have to be re-prepared.
-2. Keep `set search_path` at the top level. pgJDBC does not detect changes hidden inside pl/pgsql or a function, so it
-cannot re-prepare against the new path, and reusing a cached statement can then fail with
-`cached plan must not change result type`.
+1. Avoid changing `search_path` often. Each change pgJDBC detects invalidates the server side prepared statement cache,
+so the affected statements have to be re-prepared.
+2. Keep `set search_path` at the top level on PostgreSQL® 17 and older. There pgJDBC detects only top-level commands, so
+a change hidden inside pl/pgsql or a function is invisible to it: it cannot re-prepare against the new path, and reusing
+a cached statement can then fail with `cached plan must not change result type`. PostgreSQL® 18 reports `search_path`
+changes to the client (`GUC_REPORT`), so pgJDBC detects them wherever they happen and re-prepares automatically.
 
 #### Re-execution of failed statements
 

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -2541,7 +2541,13 @@ public class QueryExecutorImpl extends QueryExecutorBase {
           // stale, so bump the epoch to force a rebuild. The command tag is always upper-case
           // ("SET"/"RESET"), but the user-supplied SQL may use any case, so the search_path token
           // is matched case-insensitively.
-          if (status.startsWith("SET") || status.startsWith("RESET")) {
+          // PostgreSQL 18+ reports search_path via ParameterStatus (GUC_REPORT), which
+          // receiveParameterStatus turns into a value-based invalidation covering SET, RESET,
+          // RESET ALL and changes the driver cannot see in the command tag (e.g. a SET inside
+          // PL/pgSQL). Once the server has reported search_path (it is then in the parameter status
+          // map) this scan is redundant, so skip it.
+          if ((status.startsWith("SET") || status.startsWith("RESET"))
+              && getParameterStatus("search_path") == null) {
             String nativeSql = currentQuery.getNativeQuery().nativeSql;
             // Scan only the first SEARCH_PATH_SCAN_LIMIT characters to avoid a big overhead for
             // long queries.
@@ -3147,6 +3153,20 @@ public class QueryExecutorImpl extends QueryExecutorBase {
     // if the name is empty, there is nothing to do
     if (name.isEmpty()) {
       return;
+    }
+
+    if ("search_path".equals(name)) {
+      // PostgreSQL 18 and later report search_path changes to the client (GUC_REPORT) wherever the
+      // change happens, including inside PL/pgSQL or a function. Invalidate the server-prepared
+      // statement cache only when the value actually changes -- compared against the previously
+      // reported value, which is still in the parameter status map until onParameterStatus updates
+      // it below -- so the next execution re-prepares against the new path. The first report just
+      // records the baseline; from then on the SET/RESET command-tag scan in processResults is
+      // skipped in favour of this report.
+      String previousSearchPath = getParameterStatus(name);
+      if (previousSearchPath != null && !previousSearchPath.equals(value)) {
+        deallocateEpoch++;
+      }
     }
 
     // Update client-visible parameter status map for getParameterStatuses()

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc4/jdbc41/SchemaTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc4/jdbc41/SchemaTest.java
@@ -13,6 +13,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
@@ -20,6 +21,8 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import org.postgresql.PGConnection;
 import org.postgresql.PGProperty;
 import org.postgresql.core.ServerVersion;
+import org.postgresql.jdbc.AutoSave;
+import org.postgresql.jdbc.PreferQueryMode;
 import org.postgresql.test.TestUtil;
 import org.postgresql.util.PSQLException;
 import org.postgresql.util.PSQLState;
@@ -352,11 +355,12 @@ class SchemaTest {
   }
 
   /**
-   * A search_path change the driver does not detect -- here wrapped in {@code set_config()}, which
-   * reports a SELECT command tag rather than SET -- still leaves a reused server-side prepared
-   * statement correct: PostgreSQL re-plans the cached statement, so it returns rows from the table
-   * the current search_path selects. PostgreSQL re-plans on a search_path change since 9.3; 9.1
-   * silently keeps the old plan and would read the previously resolved table.
+   * A search_path change wrapped in {@code set_config()} reports a SELECT command tag, so the driver
+   * does not detect it from the command tag, yet a reused server-side prepared statement still
+   * returns rows from the table the current search_path selects. On PostgreSQL 17 and older the
+   * backend re-plans the reused cached statement (since 9.3; 9.1 keeps the old plan); on 18+ the
+   * driver also invalidates its cache from the GUC_REPORT and re-prepares. Either way the rows are
+   * correct.
    *
    * @see <a href="https://github.com/pgjdbc/pgjdbc/issues/3399">issue 3399</a>
    */
@@ -372,8 +376,8 @@ class SchemaTest {
       TestUtil.execute(conn, "INSERT INTO sphidden1.hidden_tbl VALUES ('from_1')");
       TestUtil.execute(conn, "INSERT INTO sphidden2.hidden_tbl VALUES ('from_2')");
 
-      // set_config() reports a SELECT command tag, so the driver does not detect the change and
-      // keeps the cached server-side statement.
+      // set_config() reports a SELECT command tag, so the driver does not detect the change from the
+      // command tag (on PostgreSQL 18+ it still learns of it from the GUC_REPORT).
       execute("SELECT set_config('search_path', 'sphidden1', false)");
       try (PreparedStatement ps = conn.prepareStatement("SELECT val FROM hidden_tbl")) {
         for (int i = 0; i < 10; i++) {
@@ -385,7 +389,7 @@ class SchemaTest {
         execute("SELECT set_config('search_path', 'sphidden2', false)");
         assertEquals("from_2", selectSingleValue(ps),
             "after the undetected search_path change the reused statement must resolve hidden_tbl "
-                + "to sphidden2.hidden_tbl, because PostgreSQL re-plans the cached statement");
+                + "to sphidden2.hidden_tbl");
       }
     } finally {
       TestUtil.dropSchema(conn, "sphidden1");
@@ -394,12 +398,13 @@ class SchemaTest {
   }
 
   /**
-   * A {@code set search_path} hidden inside a PL/pgSQL routine is also invisible to the driver (the
-   * command it sees is a SELECT, not a SET), yet a reused server-side prepared statement stays
-   * correct because PostgreSQL re-plans the cached statement (since 9.3). The test also checks
-   * whether the server reports search_path back to the client: PostgreSQL marks it as
-   * {@code GUC_REPORT} from version 18, so the value is visible through
-   * {@link PGConnection#getParameterStatus} on 18+ and absent on older servers.
+   * A {@code set search_path} hidden inside a PL/pgSQL routine reports a SELECT command tag, so the
+   * driver does not detect it from the command tag, yet a reused server-side prepared statement
+   * stays correct: on PostgreSQL 17 and older the backend re-plans the cached statement (since 9.3),
+   * and on 18+ the driver invalidates its cache from the GUC_REPORT. The test also checks whether the
+   * server reports search_path back to the client: PostgreSQL marks it as {@code GUC_REPORT} from
+   * version 18, so the value is visible through {@link PGConnection#getParameterStatus} on 18+ and
+   * absent on older servers.
    *
    * @see <a href="https://github.com/pgjdbc/pgjdbc/issues/3399">issue 3399</a>
    */
@@ -414,7 +419,8 @@ class SchemaTest {
       TestUtil.execute(conn, "INSERT INTO splpgsql1.plpgsql_tbl VALUES ('from_1')");
       TestUtil.execute(conn, "INSERT INTO splpgsql2.plpgsql_tbl VALUES ('from_2')");
       // A PL/pgSQL routine that changes search_path. Calling it reports a SELECT command tag, so the
-      // driver does not detect the change; it lives in a test schema and is dropped with it.
+      // driver does not detect the change from the command tag; it lives in a test schema and is
+      // dropped with it.
       TestUtil.execute(conn,
           "CREATE FUNCTION splpgsql1.set_search_path(p_schema text) RETURNS void AS $$ "
               + "BEGIN PERFORM set_config('search_path', p_schema, false); END; $$ LANGUAGE plpgsql");
@@ -430,7 +436,7 @@ class SchemaTest {
         execute("SELECT splpgsql1.set_search_path('splpgsql2')");
         assertEquals("from_2", selectSingleValue(ps),
             "after the PL/pgSQL search_path change the reused statement must resolve plpgsql_tbl "
-                + "to splpgsql2.plpgsql_tbl, because PostgreSQL re-plans the cached statement");
+                + "to splpgsql2.plpgsql_tbl");
 
         // search_path is GUC_REPORT from PostgreSQL 18 on, so the server reports the new value even
         // when the change happened inside PL/pgSQL; older servers never report it.
@@ -448,6 +454,64 @@ class SchemaTest {
     } finally {
       TestUtil.dropSchema(conn, "splpgsql1");
       TestUtil.dropSchema(conn, "splpgsql2");
+    }
+  }
+
+  /**
+   * A {@code set search_path} hidden inside a PL/pgSQL routine changes which {@code sptest} the
+   * statement resolves to, and the two tables have different column types. The driver cannot see the
+   * change in the command tag, so on PostgreSQL 17 and older it keeps the cached statement and the
+   * reused plan's result type changes, which fails with {@code cached plan must not change result
+   * type}. PostgreSQL 18 reports the change (GUC_REPORT), so the driver invalidates its cache and the
+   * statement re-prepares cleanly against the new table.
+   *
+   * @see <a href="https://github.com/pgjdbc/pgjdbc/issues/3399">issue 3399</a>
+   */
+  @Test
+  void searchPathPreparedStatementInPlpgsqlInvalidatesOnGucReport() throws SQLException {
+    assumeTrue(TestUtil.haveMinimumServerVersion(conn, ServerVersion.v9_3));
+    // The version difference shows up only with server-side prepared statements -- the cached plan
+    // that goes stale -- which the simple query protocol does not use.
+    assumeTrue(conn.unwrap(PGConnection.class).getPreferQueryMode() != PreferQueryMode.SIMPLE,
+        "server-side prepared statements are not used in simple protocol");
+    // autosave (conservative/always) heals the cached-plan error by rolling back to a savepoint and
+    // retrying, which would hide the missed invalidation this test checks for.
+    assumeTrue(conn.unwrap(PGConnection.class).getAutosave() == AutoSave.NEVER,
+        "autosave would heal the cached-plan error");
+    // schema1.sptest is INT, schema2.sptest is VARCHAR, so the reused statement's result type
+    // changes across the schemas. The routine changes search_path from inside PL/pgSQL, which the
+    // driver cannot see in the command tag.
+    TestUtil.execute(conn, "CREATE FUNCTION schema1.set_search_path(p_schema text) RETURNS void AS $$"
+        + " BEGIN PERFORM set_config('search_path', p_schema, false); END; $$ LANGUAGE plpgsql");
+    try {
+      // autoCommit=false stops the reparse-on-error retry, so on PostgreSQL 17 and older the
+      // cached-plan error surfaces instead of being healed (autosave is required to be NEVER above).
+      conn.setAutoCommit(false);
+      execute("SELECT schema1.set_search_path('schema1')");
+      try (PreparedStatement ps = conn.prepareStatement("select * from sptest")) {
+        for (int i = 0; i < 10; i++) {
+          ps.execute(); // warm up so the statement is prepared server-side and then reused
+        }
+        assertColType(ps, "sptest resolves to schema1.sptest (INT) under search_path schema1",
+            Types.INTEGER);
+
+        // Hidden search_path change to schema2, where sptest is VARCHAR.
+        execute("SELECT schema1.set_search_path('schema2')");
+        if (TestUtil.haveMinimumServerVersion(conn, ServerVersion.v18)) {
+          // PostgreSQL 18+ reports the change, so the driver invalidates its cache and the reused
+          // statement re-prepares cleanly against schema2.sptest (VARCHAR).
+          assertColType(ps, "PostgreSQL 18+ invalidates the cache from the GUC_REPORT, so the reused "
+              + "statement re-prepares to schema2.sptest (VARCHAR)", Types.VARCHAR);
+        } else {
+          // Older servers do not report the change, so the driver keeps the cached statement; the
+          // backend re-plan then changes the result type and fails the statement.
+          PSQLException e = assertThrows(PSQLException.class, ps::executeQuery);
+          assertThat(e.getMessage(), containsString("cached plan must not change result type"));
+        }
+      }
+    } finally {
+      conn.setAutoCommit(true);
+      TestUtil.execute(conn, "DROP FUNCTION IF EXISTS schema1.set_search_path(text)");
     }
   }
 


### PR DESCRIPTION
## Why

pgJDBC invalidates its server-prepared statement cache when `search_path` changes, so a reused statement re-prepares against the new path. Until now it recognised only top-level `SET`/`RESET` commands by scanning the command text, so a change hidden inside PL/pgSQL or a function was invisible to it. On a column-layout change that left a reused statement failing with `cached plan must not change result type`.

PostgreSQL marks `search_path` as `GUC_REPORT` from version 18, so the server reports every change to the client in a `ParameterStatus` message, wherever the change happens. The driver can rely on that instead of guessing from the command text.

## What

- Consume the `search_path` `ParameterStatus` in `receiveParameterStatus` and invalidate the prepared-statement cache, comparing against the previously reported value so an unchanged `search_path` costs nothing. No new field — the existing parameter-status map already tracks the value.
- On servers that report `search_path` (18+) the report is authoritative and covers `SET`, `RESET` and `RESET ALL`, so the command-tag scan from #4216 is skipped entirely. Servers older than 18 do not report `search_path`, so they keep using the command-tag scan and behave exactly as before.
- Add a `SchemaTest` case that changes `search_path` from inside PL/pgSQL between two differently typed tables: PostgreSQL 17 and older keep the cached statement and fail with `cached plan must not change result type`, while 18+ invalidates the cache from the report and re-prepares cleanly.
- Update the `set search_path = ...` documentation to describe the 18+ behaviour.

## How to verify

- `./gradlew :postgresql:test --tests "org.postgresql.test.jdbc4.jdbc41.SchemaTest"`: the existing `searchPathPreparedStatement*` tests (`SET` / `RESET` / `RESET ALL`) pass on PostgreSQL 18 through the report with the command-tag scan disabled, and the new `searchPathPreparedStatementInPlpgsqlInvalidatesOnGucReport` exercises both the pre-18 and 18+ paths.
- Verified locally against PostgreSQL 16 (command-tag scan, unchanged) and 18 (full GUC_REPORT switch).

Refs #3399

🤖 Generated with [Claude Code](https://claude.com/claude-code)
