### PR TITLE
ci: skip Codecov upload on failed branch builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -321,9 +321,11 @@ jobs:
       # On success jacocoReport already ran as part of the Test step above. When a
       # test fails, that run aborts before the report, so re-run jacocoReport on its
       # own (excluding the test tasks) to merge the coverage that was collected.
+      # Pull requests only: a failed branch build (master, release) skips the upload
+      # below, so rebuilding the report there would be wasted work.
       # `!cancelled()` is required: without a status function the `if` is implicitly
       # wrapped in success(), which never holds after the test step has failed.
-      if: ${{ !cancelled() && matrix.collectCoverage && steps.test.outcome == 'failure' }}
+      if: ${{ !cancelled() && matrix.collectCoverage && steps.test.outcome == 'failure' && github.event_name == 'pull_request' }}
       uses: burrunan/gradle-cache-action@4b67497abd37a511d6c1dc6299bdd84ff39f7bf5 # v3.0.2
       with:
         read-only: false
@@ -331,10 +333,13 @@ jobs:
         arguments: --scan --no-parallel --no-daemon jacocoReport -x test
 
     - name: Upload coverage to Codecov
-      # Run on both success and failure (after the fallback report above); skip jobs that
-      # did not collect coverage. A push to a protected branch (master) needs CODECOV_TOKEN;
-      # pull requests upload tokenlessly, since the secret is not exposed to forks.
-      if: ${{ !cancelled() && matrix.collectCoverage }}
+      # Pull requests always upload, even after a test failure, so the PR shows how much of
+      # the changed code is already covered. Branch builds (master, release) upload only when
+      # tests pass: a failed run reports partial coverage, which would lower the baseline that
+      # PR diffs compare against. Skip jobs that did not collect coverage. A push to a protected
+      # branch needs CODECOV_TOKEN; pull requests upload tokenlessly, since the secret is not
+      # exposed to forks.
+      if: ${{ !cancelled() && matrix.collectCoverage && (github.event_name == 'pull_request' || steps.test.outcome == 'success') }}
       uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Why
----

When a test run on `master` (or `release`) fails, the coverage step still uploads to Codecov. The report is merged from whatever the aborted test step managed to collect, so it covers only part of the code. Codecov treats that partial report as the new project baseline: the global project coverage drops, and every subsequent PR diff compares against this poisoned reference and shows misleading numbers.

What
----

- Branch builds (`push` / `workflow_dispatch`, including `master` and `release`) upload coverage only when tests pass, so PR diffs compare against the last *successful* branch run.
- Pull requests still upload coverage even after a test failure, so a PR shows how much of the changed code is already covered.
- The post-failure report rebuild ("Build coverage report after a test failure") now runs on pull requests only — a failed branch build no longer uploads, so rebuilding the report there would be wasted CI time.

Behaviour matrix:

| Event | Tests pass | Tests fail |
|---|---|---|
| `pull_request` | upload | upload |
| `push` / `workflow_dispatch` | upload | skip |

How to verify
-------------

- `master` build with a green test job: coverage uploads as before.
- `master` build with a failing test job: no Codecov upload, baseline stays at the last successful run.
- PR with a failing test job: coverage still uploads, so the PR diff shows partial coverage of the changed code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)