### PR TITLE
docs: scope search_path GUC_REPORT wording to value changes

### DIFF
--- a/docs/content/documentation/server-prepare.md
+++ b/docs/content/documentation/server-prepare.md
@@ -394,12 +394,12 @@ plan and, since PostgreSQL® 9.3, re-plans the statement when that path changes,
 statement still returns rows from the table the current `search_path` selects. (Releases before 9.3 keep the old plan
 and may read the previously resolved table.)
 
-What pgJDBC adds is a cache optimisation. It watches for `search_path` changes and invalidates its prepared statement
-cache so the next execution re-prepares against the new path: top-level `set search_path...` and `reset` commands on any
-server, and, on PostgreSQL® 18 and later that report `search_path` to the client (`GUC_REPORT`), changes made anywhere,
-including inside pl/pgsql. This avoids the `cached plan must not change result type` error when the new path resolves to
-a table with a different column layout (for example, `SELECT *` over `app_v1.mytable` and `app_v2.mytable` with
-different columns).
+What pgJDBC adds is a cache optimisation. It watches for `search_path` value changes and invalidates its prepared
+statement cache so the next execution re-prepares against the new path: top-level `set search_path...` and `reset`
+commands on any server, and, on PostgreSQL® 18 and later that report `search_path` to the client (`GUC_REPORT`), any
+change to that value, wherever it is made, including inside pl/pgsql. This avoids the
+`cached plan must not change result type` error when the new path resolves to a table with a different column layout
+(for example, `SELECT *` over `app_v1.mytable` and `app_v2.mytable` with different columns).
 
 The recommendation is:
 
@@ -408,7 +408,13 @@ so the affected statements have to be re-prepared.
 2. Keep `set search_path` at the top level on PostgreSQL® 17 and older. There pgJDBC detects only top-level commands, so
 a change hidden inside pl/pgsql or a function is invisible to it: it cannot re-prepare against the new path, and reusing
 a cached statement can then fail with `cached plan must not change result type`. PostgreSQL® 18 reports `search_path`
-changes to the client (`GUC_REPORT`), so pgJDBC detects them wherever they happen and re-prepares automatically.
+value changes to the client (`GUC_REPORT`), so pgJDBC detects those wherever they happen and re-prepares automatically.
+
+> **Note**
+>
+> Detection keys on the `search_path` value. `SET ROLE` and `SET SESSION AUTHORIZATION` change the schema `"$user"`
+> selects without changing the `search_path` value, so the change is not reported and pgJDBC does not re-prepare. On any
+> server version, reusing a cached statement after such a change can fail with `cached plan must not change result type`.
 
 #### Re-execution of failed statements
 

--- a/docs/content/documentation/server-prepare.md
+++ b/docs/content/documentation/server-prepare.md
@@ -394,12 +394,12 @@ plan and, since PostgreSQL® 9.3, re-plans the statement when that path changes,
 statement still returns rows from the table the current `search_path` selects. (Releases before 9.3 keep the old plan
 and may read the previously resolved table.)
 
-What pgJDBC adds is a cache optimisation. It watches for `search_path` changes and invalidates its prepared statement
-cache so the next execution re-prepares against the new path: top-level `set search_path...` and `reset` commands on any
-server, and, on PostgreSQL® 18 and later that report `search_path` to the client (`GUC_REPORT`), changes made anywhere,
-including inside pl/pgsql. This avoids the `cached plan must not change result type` error when the new path resolves to
-a table with a different column layout (for example, `SELECT *` over `app_v1.mytable` and `app_v2.mytable` with
-different columns).
+What pgJDBC adds is a cache optimisation. It invalidates its prepared statement cache when the `search_path` value
+changes, so the next execution re-prepares against the new path. On any server it detects top-level
+`set search_path...` and `reset` commands. PostgreSQL® 18 and later report `search_path` to the client (`GUC_REPORT`),
+so there pgJDBC detects every change to that value, including one made inside pl/pgsql. This avoids the
+`cached plan must not change result type` error when the new path resolves to a table with a different column layout
+(for example, `SELECT *` over `app_v1.mytable` and `app_v2.mytable` with different columns).
 
 The recommendation is:
 
@@ -407,8 +407,19 @@ The recommendation is:
 so the affected statements have to be re-prepared.
 2. Keep `set search_path` at the top level on PostgreSQL® 17 and older. There pgJDBC detects only top-level commands, so
 a change hidden inside pl/pgsql or a function is invisible to it: it cannot re-prepare against the new path, and reusing
-a cached statement can then fail with `cached plan must not change result type`. PostgreSQL® 18 reports `search_path`
-changes to the client (`GUC_REPORT`), so pgJDBC detects them wherever they happen and re-prepares automatically.
+a cached statement can then fail with `cached plan must not change result type`. PostgreSQL® 18 and later report a
+changed `search_path` value to the client (`GUC_REPORT`), so pgJDBC detects the change wherever it happens and
+re-prepares automatically.
+
+> **Note**
+>
+> pgJDBC detects a change in the `search_path` value itself. `SET ROLE` and `SET SESSION AUTHORIZATION` change which
+> schema `"$user"` resolves to and leave that value unchanged, so pgJDBC does not re-prepare. On any server version,
+> reusing a cached statement after such a change can fail with `cached plan must not change result type`.
+>
+> To make pgJDBC re-prepare, follow the role change with a top-level `set search_path` that names the schemas
+> explicitly, for example `set search_path to app_v2, public`. On PostgreSQL® 18 and later the new value has to differ
+> from the current one, because pgJDBC compares values.
 
 #### Re-execution of failed statements
 


### PR DESCRIPTION
## Why

#4259 added a line saying that on PostgreSQL 18 pgJDBC "detects [search_path changes] wherever they happen and re-prepares automatically". As @sehrope pointed out in review, that reads as a stronger guarantee than the driver gives. `GUC_REPORT` reports a change to the `search_path` *value*, and `receiveParameterStatus` invalidates the cache only when the reported value differs from the previously reported one, so a change in how that value resolves is invisible to the driver.

`SET ROLE` and `SET SESSION AUTHORIZATION` are such a change: they change which schema `"$user"` resolves to while `search_path` stays `"$user", public`, so pgJDBC does not re-prepare and a reused server-side prepared statement fails with `cached plan must not change result type`. The gap holds on every server version, because the pre-18 command-tag scan never matched `SET ROLE` either. It predates #4259 and is documented here, not introduced.

## What

- Scope the wording to `search_path` *value* changes, in both the optimisation description and recommendation 2, so neither reads as "detects every change".
- Add a note describing the `"$user"` resolution gap and its symptom, plus the way around it: a top-level `set search_path` that names the schemas explicitly after the role change. On PostgreSQL 18 and later the new value has to differ from the current one, because pgJDBC compares values.

Documentation only; no behaviour change.

## How to verify

`cd docs && hugo --minify` builds cleanly, and the rendered `documentation/server-prepare/` page shows the reworded section and the new note.

The failure the note describes reproduces on PostgreSQL 16:

```sql
CREATE ROLE r; CREATE SCHEMA r AUTHORIZATION r;
CREATE TABLE public.t(id int);
CREATE TABLE r.t(id int, extra text);
SET search_path TO "$user", public;
PREPARE p AS SELECT * FROM t;
EXECUTE p;                       -- returns (id)
SET ROLE r;                      -- search_path is still "$user", public
EXECUTE p;                       -- ERROR:  cached plan must not change result type
```

## Scope

Teaching the driver to detect the change is out of scope here; this pull request only stops the page from promising that it does. Refs #4259, #3399.
