### PR TITLE
docs: add 42.7.12 release changelog

### DIFF
--- a/docs/content/changelogs/2026-06-26-42.7.12-release.md
+++ b/docs/content/changelogs/2026-06-26-42.7.12-release.md
@@ -1,0 +1,146 @@
+---
+title:  PostgreSQL JDBC Driver 42.7.12 Released
+date:   2026-06-26 12:00:00 -0400
+categories:
+    - new release
+version: 42.7.12
+summary: "Adds search_path GUC_REPORT cache invalidation (PG 18+), flushCacheOnDdl, connectExecutor, classLoaderStrategy properties; caps reWriteBatchedInserts to protocol limit; improves batching performance; fixes updatable ResultSet search_path visibility, XA autoCommit, BlobInputStream seek, SSL key-format detection, FIPS trust anchors, and many more."
+---
+**Notable changes**
+
+### Added
+* feat: invalidate prepared statement cache via `search_path` GUC_REPORT (PG 18+) [PR #3399](https://github.com/pgjdbc/pgjdbc/pull/3399)
+* feat: `flushCacheOnDdl` — re-prepare server statements after CREATE/DROP/ALTER
+* feat: `connectExecutor` (Executor) instead of `connectThreadFactory` (ThreadFactory)
+* feat: add `classLoaderStrategy` for thread-context classloader fallback [PR #2112](https://github.com/pgjdbc/pgjdbc/pull/2112)
+* feat: cap `reWriteBatchedInserts` by the protocol limit, not 128
+* feat(core): add OID constants for geometric arrays, RECORD, refcursor
+* feat(largeobject): skip in `BlobInputStream` by seeking instead of reading [PR #3144](https://github.com/pgjdbc/pgjdbc/pull/3144)
+* feat(largeobject): expose server version for 64-bit LO API selection
+
+### Changed
+* refactor(metadata): derive `getPrimaryKeys` from `pg_constraint.conkey` [PR #3434](https://github.com/pgjdbc/pgjdbc/pull/3434)
+* refactor(core): drop unused encoding Writer plumbing from PGStream
+* refactor: favour composition over inheritance for `Driver.ConnectTask`
+* refactor(test-gss): convert GSS tests to Java/JUnit 5 submodule
+* chore: remove `test-anorm-sbt` module and its CI wiring
+* build: produce a multi-release jar from `reduced-pom.xml` on Java 11+
+* build: verify benchmarks under `check` and CI, skip Jandex for them
+* build: promote `MethodCanBeStatic` to error level
+* i18n: convert ISO-8859-x `.po` files to UTF-8
+* i18n: fill untranslated Italian, Simplified Chinese messages
+* i18n: revise Russian translations in `ru.po`
+* docs: note PKCS-12 client certificate chain requirement
+* docs: clarify `search_path` correctness for server-prepared statements
+* docs: fix invalid `jdbc:postgresql:/` URL form in connection guide
+* docs: redirect legacy documentation URLs to their new Hugo pages
+
+### Fixed
+* fix(jdbc): classify updatable result set by `search_path` visibility [PR #3400](https://github.com/pgjdbc/pgjdbc/pull/3400)
+* fix: render bytea text parameters in `PreparedStatement#toString`
+* fix: `PGXAConnection` no longer saves and restores the caller's autoCommit [PR #3153](https://github.com/pgjdbc/pgjdbc/pull/3153)
+* fix: detect native CALL preceded by a comment in CallableStatement [PR #2538](https://github.com/pgjdbc/pgjdbc/pull/2538)
+* fix(jdbc): return null `CHAR_OCTET_LENGTH` for non-character columns [PR #3589](https://github.com/pgjdbc/pgjdbc/pull/3589)
+* fix(jdbc): honor scale in `ResultSet.getBigDecimal(int, int)`
+* fix: support `java.time` values in updatable `ResultSet` `updateRow()`/`insertRow()` [PR #3464](https://github.com/pgjdbc/pgjdbc/pull/3464)
+* fix: `PgResultSet#getCharacterStream` wraps `String` in `StringReader` [PR #4063](https://github.com/pgjdbc/pgjdbc/pull/4063)
+* fix(protocol): defer flushes until response processing [PR #3894](https://github.com/pgjdbc/pgjdbc/pull/3894)
+* fix: improve batching when RETURNING contains varchar, numeric types
+* fix: correct `estimatedReceiveBufferBytes` accounting after forced Sync
+* fix: avoid creating transient ResultSet for describe statement purposes
+* fix: restore pre-describe for generated-key batches
+* fix: add explicit failure message when multi-statement executes in batch
+* fix(core): detect `search_path` changes case-insensitively
+* fix(largeobject): reset `BlobInputStream` relative to the LargeObject position [PR #3149](https://github.com/pgjdbc/pgjdbc/pull/3149)
+* fix: auto-detect SSL key format instead of relying on `.key` extension [PR #3942](https://github.com/pgjdbc/pgjdbc/pull/3942)
+* fix(ssl): build PKIX trust anchors without a KeyStore so FIPS JVMs work [PR #4191](https://github.com/pgjdbc/pgjdbc/pull/4191)
+* fix: make sure GSS connection uses `gssResponseTimeout` rather than `sslResponseTimeout`
+* fix: skip autosave savepoint for `SET LOCAL`/`SESSION TRANSACTION` [PR #3307](https://github.com/pgjdbc/pgjdbc/pull/3307)
+* fix: do not throw `AssertionError` from `BatchResultHandler` on a closed connection [PR #1458](https://github.com/pgjdbc/pgjdbc/pull/1458)
+* fix: reject SQL_TSI_FRAC_SECOND with an explicit, explained error [PR #4086](https://github.com/pgjdbc/pgjdbc/pull/4086)
+* fix: reject null URL in `Driver.acceptsURL` with a clear `NullPointerException`
+* fix: reject overlong inputs in `NumberParser.getFastLong` instead of wrapping
+* fix: reject out of range and NaN values in `PGInterval.setSeconds`
+* fix: close socket when `PgConnection` setup fails after connect
+* fix: avoid nulling `contextClassLoader` on shared `commonPool` workers [PR #3953](https://github.com/pgjdbc/pgjdbc/pull/3953)
+* fix: keep `LazyCleanerImpl` cleanup task alive across transient empty queue [PR #4037](https://github.com/pgjdbc/pgjdbc/pull/4037)
+* fix: append default non-proxy hosts when `socksNonProxyHosts` is set [PR #4044](https://github.com/pgjdbc/pgjdbc/pull/4044)
+* fix: simplify implementation of `Statement#cancel`
+* fix: clear `ResourceBundle` cache on deregister so the driver can unload
+* fix: delete temp file when spooling a stream to disk fails with IOException
+* fix: avoid direct `java.lang.management` dependency in `maxResultBuffer` parser [PR #4069](https://github.com/pgjdbc/pgjdbc/pull/4069)
+
+
+**Commits by author**
+
+### Vladimir Sitnikov (100 commits)
+- [feat: invalidate prepared statement cache via search_path GUC_REPORT (PG 18+)](https://github.com/pgjdbc/pgjdbc/pull/3399)
+- [feat: flushCacheOnDdl — re-prepare server statements after CREATE/DROP/ALTER](https://github.com/pgjdbc/pgjdbc/commit/3fbf771c2)
+- [feat: add classLoaderStrategy for thread-context classloader fallback](https://github.com/pgjdbc/pgjdbc/pull/2112)
+- [feat: cap reWriteBatchedInserts by the protocol limit, not 128](https://github.com/pgjdbc/pgjdbc/commit/9506e54d1)
+- [feat(core): add OID constants for geometric arrays, RECORD, refcursor](https://github.com/pgjdbc/pgjdbc/commit/8656d8ba9)
+- [feat(largeobject): skip in BlobInputStream by seeking instead of reading](https://github.com/pgjdbc/pgjdbc/pull/3144)
+- [feat(largeobject): expose server version for 64-bit LO API selection](https://github.com/pgjdbc/pgjdbc/commit/6f834d272)
+- [fix: detect native CALL preceded by a comment in CallableStatement](https://github.com/pgjdbc/pgjdbc/pull/2538)
+- [fix(jdbc): return null CHAR_OCTET_LENGTH for non-character columns](https://github.com/pgjdbc/pgjdbc/pull/3589)
+- [fix(jdbc): honor scale in ResultSet.getBigDecimal(int, int)](https://github.com/pgjdbc/pgjdbc/commit/3a4679e02)
+- [fix: support java.time values in updatable ResultSet updateRow()/insertRow()](https://github.com/pgjdbc/pgjdbc/pull/3464)
+- [fix: PgResultSet#getCharacterStream wraps String in StringReader](https://github.com/pgjdbc/pgjdbc/pull/4063)
+- [fix(protocol): defer flushes until response processing](https://github.com/pgjdbc/pgjdbc/pull/3894)
+- [fix: improve batching when RETURNING contains varchar, numeric types](https://github.com/pgjdbc/pgjdbc/commit/db021eb49)
+- [fix: correct estimatedReceiveBufferBytes accounting after forced Sync](https://github.com/pgjdbc/pgjdbc/commit/cb5fa6c41)
+- [fix: avoid creating transient ResultSet for describe statement purposes](https://github.com/pgjdbc/pgjdbc/commit/00f927114)
+- [fix: restore pre-describe for generated-key batches](https://github.com/pgjdbc/pgjdbc/commit/67083c898)
+- [fix: add explicit failure message when multi-statement executes in batch](https://github.com/pgjdbc/pgjdbc/commit/1276a3dec)
+- [fix(core): detect search_path changes case-insensitively](https://github.com/pgjdbc/pgjdbc/commit/1cc5181e7)
+- [fix(largeobject): reset BlobInputStream relative to the LargeObject position](https://github.com/pgjdbc/pgjdbc/pull/3149)
+- [fix: auto-detect SSL key format instead of relying on .key extension](https://github.com/pgjdbc/pgjdbc/pull/3942)
+- [fix(ssl): build PKIX trust anchors without a KeyStore so FIPS JVMs work](https://github.com/pgjdbc/pgjdbc/pull/4191)
+- [fix: make sure GSS connection uses gssResponseTimeout rather than sslResponseTimeout](https://github.com/pgjdbc/pgjdbc/commit/09cc8d161)
+- [fix: skip autosave savepoint for SET LOCAL/SESSION TRANSACTION](https://github.com/pgjdbc/pgjdbc/pull/3307)
+- [fix: do not throw AssertionError from BatchResultHandler on a closed connection](https://github.com/pgjdbc/pgjdbc/pull/1458)
+- [fix: reject SQL_TSI_FRAC_SECOND with an explicit, explained error](https://github.com/pgjdbc/pgjdbc/pull/4086)
+- [fix: reject null URL in Driver.acceptsURL with a clear NullPointerException](https://github.com/pgjdbc/pgjdbc/commit/d72f9a309)
+- [fix: avoid nulling contextClassLoader on shared commonPool workers](https://github.com/pgjdbc/pgjdbc/pull/3953)
+- [fix: keep LazyCleanerImpl cleanup task alive across transient empty queue](https://github.com/pgjdbc/pgjdbc/pull/4037)
+- [fix: simplify implementation of Statement#cancel](https://github.com/pgjdbc/pgjdbc/commit/41a864990)
+- [fix: clear ResourceBundle cache on deregister so the driver can unload](https://github.com/pgjdbc/pgjdbc/commit/a71e63e72)
+- [fix: close socket when PgConnection setup fails after connect](https://github.com/pgjdbc/pgjdbc/commit/05b134ab1)
+- [fix(jdbc): classify updatable result set by search_path visibility](https://github.com/pgjdbc/pgjdbc/pull/3400)
+- [fix: render bytea text parameters in PreparedStatement#toString](https://github.com/pgjdbc/pgjdbc/commit/d6535d907)
+- [fix: PGXAConnection no longer saves and restores the caller's autoCommit](https://github.com/pgjdbc/pgjdbc/pull/3153)
+- [refactor(metadata): derive getPrimaryKeys from pg_constraint.conkey](https://github.com/pgjdbc/pgjdbc/pull/3434)
+- [refactor(core): drop unused encoding Writer plumbing from PGStream](https://github.com/pgjdbc/pgjdbc/commit/a850558ad)
+- [refactor: favour composition over inheritance for Driver.ConnectTask](https://github.com/pgjdbc/pgjdbc/commit/a0045fdd8)
+
+### Sehrope Sarkuni (11 commits)
+- [feat: Add connectThreadFactory to customize connection-attempt ThreadFactory](https://github.com/pgjdbc/pgjdbc/commit/0e2f4e9f5)
+- [feat: Use connectExecutor (Executor) instead of connectThreadFactory (ThreadFactory)](https://github.com/pgjdbc/pgjdbc/commit/bab4cb85d)
+- [fix: reject overlong inputs in NumberParser.getFastLong instead of wrapping](https://github.com/pgjdbc/pgjdbc/commit/8a42913b9)
+- [fix: reject out of range and NaN values in PGInterval.setSeconds](https://github.com/pgjdbc/pgjdbc/commit/ec06d5871)
+- [fix: Delete temp file when spooling a stream to disk fails with IOException](https://github.com/pgjdbc/pgjdbc/commit/02b82aded)
+- [refactor: Use FutureTask for loginTimeout task in Driver.connect(...)](https://github.com/pgjdbc/pgjdbc/commit/32138d4f3)
+- [test: Add loginTimeout interruptible test](https://github.com/pgjdbc/pgjdbc/commit/f1d168c9e)
+- [test: Add tests for connectThreadFactory](https://github.com/pgjdbc/pgjdbc/commit/a0e078cd5)
+- [test: add overflow boundary tests for NumberParser.getFastLong](https://github.com/pgjdbc/pgjdbc/commit/32a8b8865)
+- [test: add range and NaN tests for PGInterval.setSeconds](https://github.com/pgjdbc/pgjdbc/commit/dc007f733)
+
+### Dave Cramer (3 commits)
+- [fix: append default non-proxy hosts when socksNonProxyHosts is set](https://github.com/pgjdbc/pgjdbc/pull/4044)
+- [fix: correct ja.po header to indicate Japanese (#2004)](https://github.com/pgjdbc/pgjdbc/commit/8f3cccfd6)
+- [update maintainers (#4222)](https://github.com/pgjdbc/pgjdbc/pull/4222)
+
+### Davide Angelocola (1 commit)
+- [fix: PgResultSet#getCharacterStream wraps String in StringReader (#4063)](https://github.com/pgjdbc/pgjdbc/pull/4063)
+
+### Devs (1 commit)
+- [fix: support java.time values in updatable ResultSet updateRow()/insertRow()](https://github.com/pgjdbc/pgjdbc/pull/3464)
+
+### Mark Blakley (1 commit)
+- [Avoid direct java.lang.management dependency in maxResultBuffer parser (#4069)](https://github.com/pgjdbc/pgjdbc/pull/4069)
+
+### Jens Teglhus Møller (1 commit)
+- [docs: remove null check that can never fail](https://github.com/pgjdbc/pgjdbc/commit/ce4d61516)
+
+### bshehata (1 commit)
+- [fix: restore pre-describe for generated-key batches](https://github.com/pgjdbc/pgjdbc/commit/67083c898)


### PR DESCRIPTION
Covers all changes since REL42.7.11: search_path GUC_REPORT cache invalidation (PG 18+), flushCacheOnDdl, connectExecutor, classLoaderStrategy, reWriteBatchedInserts protocol-limit cap, large object 64-bit API, updatable ResultSet search_path fix, XA autoCommit fix, FIPS trust anchors, SSL key-format auto-detection, batching improvements, and numerous other bug fixes.

This is more consistent with the previous changelog