### PR TITLE
fix: report only column-level grants in getColumnPrivileges

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
@@ -1983,16 +1983,15 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
     }
 
     StringBuilder sql = new StringBuilder(
-        "SELECT current_database() AS current_database, n.nspname,c.relname,r.rolname,c.relacl, "
-          + (connection.haveMinimumServerVersion(ServerVersion.v8_4) ? "a.attacl, " : "")
-          + " a.attname "
-          + " FROM pg_catalog.pg_namespace n, pg_catalog.pg_class c, "
-          + " pg_catalog.pg_roles r, pg_catalog.pg_attribute a "
-          + " WHERE c.relnamespace = n.oid "
-          + " AND c.relowner = r.oid "
-          + " AND c.oid = a.attrelid "
-          + " AND c.relkind = 'r' "
-          + " AND a.attnum > 0 AND NOT a.attisdropped ");
+        "SELECT current_database() AS current_database, n.nspname, c.relname, r.rolname,"
+          + " a.attacl, a.attname"
+          + " FROM pg_catalog.pg_namespace n, pg_catalog.pg_class c,"
+          + " pg_catalog.pg_roles r, pg_catalog.pg_attribute a"
+          + " WHERE c.relnamespace = n.oid"
+          + " AND c.relowner = r.oid"
+          + " AND c.oid = a.attrelid"
+          + " AND c.relkind = 'r'"
+          + " AND a.attnum > 0 AND NOT a.attisdropped");
 
     List<String> args = new ArrayList<>();
     if (schema != null) {
@@ -2017,16 +2016,14 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
       byte[] tableName = rs.getBytes("relname");
       byte[] column = rs.getBytes("attname");
       String owner = castNonNull(rs.getString("rolname"));
-      String relAcl = rs.getString("relacl");
+      String acl = rs.getString("attacl");
+      if (acl == null) {
+        // No column-level grants on this column — skip it
+        continue;
+      }
 
       // For instance: SELECT -> user1 -> list of [grantor, grantable]
-      Map<String, Map<String, List<@Nullable String[]>>> permissions = parseACL(relAcl, owner);
-
-      if (connection.haveMinimumServerVersion(ServerVersion.v8_4)) {
-        String acl = rs.getString("attacl");
-        Map<String, Map<String, List<@Nullable String[]>>> relPermissions = parseACL(acl, owner);
-        permissions.putAll(relPermissions);
-      }
+      Map<String, Map<String, List<@Nullable String[]>>> permissions = parseACL(acl, owner);
       @KeyFor("permissions") String[] permNames = permissions.keySet().toArray(new @KeyFor("permissions") String[0]);
       Arrays.sort(permNames);
       for (String permName : permNames) {

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseMetaDataTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseMetaDataTest.java
@@ -853,14 +853,91 @@ public class DatabaseMetaDataTest {
 
   @Test
   void columnPrivileges() throws SQLException {
-    // At the moment just test that no exceptions are thrown KJ
-    DatabaseMetaData dbmd = con.getMetaData();
-    assertNotNull(dbmd);
-    try (ResultSet rs = dbmd.getColumnPrivileges(null, null, "pg_statistic", null)) {
-      assertTrue(rs.next());
+    assumeTrue(TestUtil.getPrivilegedUser() != null,
+        "Test requires a privileged user to CREATE ROLE");
+
+    try (Connection privCon = TestUtil.openPrivilegedDB();
+         Statement stmt = privCon.createStatement()) {
+      stmt.execute("DROP TABLE IF EXISTS test_col_privs_basic");
+      stmt.execute("DROP ROLE IF EXISTS test_col_priv_reader");
+      stmt.execute("CREATE TABLE test_col_privs_basic (c1 int, c2 int)");
+      stmt.execute("CREATE ROLE test_col_priv_reader");
+      stmt.execute("GRANT SELECT (c1) ON test_col_privs_basic TO test_col_priv_reader");
+
+      try {
+        DatabaseMetaData dbmd = privCon.getMetaData();
+        try (ResultSet rs = dbmd.getColumnPrivileges(null, null, "test_col_privs_basic", null)) {
+          assertTrue(rs.next(), "Expected at least one column privilege row");
+        }
+        try (ResultSet rs =
+                 dbmd.getColumnPrivileges("nonsensecatalog", null, "test_col_privs_basic", null)) {
+          assertFalse(rs.next());
+        }
+      } finally {
+        stmt.execute("DROP TABLE IF EXISTS test_col_privs_basic");
+        stmt.execute("DROP ROLE IF EXISTS test_col_priv_reader");
+      }
     }
-    try (ResultSet rs = dbmd.getColumnPrivileges("nonsensecatalog", null, "pg_statistic", null)) {
-      assertFalse(rs.next());
+  }
+
+  @Test
+  void columnPrivilegesExcludesTableLevelGrants() throws SQLException {
+    assumeTrue(TestUtil.getPrivilegedUser() != null,
+        "Test requires a privileged user to CREATE ROLE");
+
+    try (Connection privCon = TestUtil.openPrivilegedDB();
+         Statement stmt = privCon.createStatement()) {
+      stmt.execute("DROP TABLE IF EXISTS test_col_privs");
+      stmt.execute("DROP ROLE IF EXISTS test_col_priv_a");
+      stmt.execute("DROP ROLE IF EXISTS test_col_priv_b");
+      stmt.execute("CREATE TABLE test_col_privs (c1 int, c2 int, c3 int)");
+      stmt.execute("CREATE ROLE test_col_priv_a");
+      stmt.execute("CREATE ROLE test_col_priv_b");
+      stmt.execute("GRANT SELECT ON test_col_privs TO test_col_priv_a");
+      stmt.execute("GRANT SELECT (c1, c2) ON test_col_privs TO test_col_priv_b");
+      stmt.execute("GRANT UPDATE (c1, c3) ON test_col_privs TO test_col_priv_b");
+
+      try {
+        DatabaseMetaData dbmd = privCon.getMetaData();
+        List<String> entries = new ArrayList<>();
+        try (ResultSet rs = dbmd.getColumnPrivileges(null, null, "test_col_privs", null)) {
+          while (rs.next()) {
+            String grantee = rs.getString("GRANTEE");
+            String column = rs.getString("COLUMN_NAME");
+            String privilege = rs.getString("PRIVILEGE");
+            entries.add(grantee + "/" + column + "/" + privilege);
+          }
+        }
+
+        // Role A must NOT appear (table-level grants should be excluded)
+        for (String entry : entries) {
+          assertFalse(entry.startsWith("test_col_priv_a/"),
+              "Table-level grant for test_col_priv_a should not appear in getColumnPrivileges, "
+                  + "but found: " + entry);
+        }
+
+        // Role B should appear with SELECT on c1 and c2
+        assertTrue(entries.contains("test_col_priv_b/c1/SELECT"),
+            "Expected column-level SELECT on c1 for test_col_priv_b, entries: " + entries);
+        assertTrue(entries.contains("test_col_priv_b/c2/SELECT"),
+            "Expected column-level SELECT on c2 for test_col_priv_b, entries: " + entries);
+
+        // Role B should appear with UPDATE on c1 and c3
+        assertTrue(entries.contains("test_col_priv_b/c1/UPDATE"),
+            "Expected column-level UPDATE on c1 for test_col_priv_b, entries: " + entries);
+        assertTrue(entries.contains("test_col_priv_b/c3/UPDATE"),
+            "Expected column-level UPDATE on c3 for test_col_priv_b, entries: " + entries);
+
+        // Role B should NOT have SELECT on c3 or UPDATE on c2
+        assertFalse(entries.contains("test_col_priv_b/c3/SELECT"),
+            "Unexpected SELECT on c3 for test_col_priv_b");
+        assertFalse(entries.contains("test_col_priv_b/c2/UPDATE"),
+            "Unexpected UPDATE on c2 for test_col_priv_b");
+      } finally {
+        stmt.execute("DROP TABLE IF EXISTS test_col_privs");
+        stmt.execute("DROP ROLE IF EXISTS test_col_priv_a");
+        stmt.execute("DROP ROLE IF EXISTS test_col_priv_b");
+      }
     }
   }
 


### PR DESCRIPTION
getColumnPrivileges() was parsing both relacl (table-level ACL) and attacl (column-level ACL), then merging them together. This caused table-level grants to appear against every column in the result set, making it impossible to distinguish table-wide privileges from column-specific ones.

Remove relacl from the query entirely — only attacl is relevant for column-level privileges. Skip columns where attacl is NULL (no column-specific grants exist). Remove the haveMinimumServerVersion check for v8_4 since the driver requires PG 9.1+ where attacl is always present.

Table-level grants remain available via getTablePrivileges(), which is unchanged.

Rewrite the columnPrivileges() test to be self-contained: it now creates its own table and column-level grants via the privileged connection rather than relying on pg_statistic system catalog state. Add a new columnPrivilegesExcludesTableLevelGrants() test that verifies table-level grants do not leak into getColumnPrivileges() results.

Fixes https://github.com/pgjdbc/pgjdbc/discussions/4265

### All Submissions:

* [ ] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Does `./gradlew styleCheck` pass ?
3. [ ] Have you added your new test classes to an existing test suite in alphabetical order?

### Changes to Existing Features:

* [ ] Does this break existing behaviour? If so please explain.
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
