### PR TITLE
fix(scram): fail closed on channel-binding downgrade (no scram bump)

### DIFF
--- a/pgjdbc-mockito-test/src/test/java/org/postgresql/core/v3/ScramAuthenticatorChannelBindingTest.java
+++ b/pgjdbc-mockito-test/src/test/java/org/postgresql/core/v3/ScramAuthenticatorChannelBindingTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.core.v3;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.postgresql.core.PGStream;
+import org.postgresql.util.PSQLException;
+import org.postgresql.util.PSQLState;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.Socket;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.SSLSocket;
+
+/**
+ * Regression test for GHSA-j92g-9f8w-j867. Under {@code channelBinding=require}, the driver must
+ * fail the connection rather than fall back to a non-PLUS mechanism when it cannot extract channel
+ * binding data from the peer certificate. The test drives {@link ScramAuthenticator} over a mocked
+ * TLS socket, so it needs no live server.
+ */
+class ScramAuthenticatorChannelBindingTest {
+
+  @Test
+  void requireRejectsCertificateWithoutChannelBindingHash() throws Exception {
+    // A certificate whose signature algorithm yields no channel binding hash, such as Ed25519.
+    // getSigAlgName is stubbed rather than parsing a real Ed25519 certificate: the JDK reports the
+    // algorithm as the OID "1.3.101.112" on older JDK 11 builds and as "Ed25519" on newer ones, so
+    // a parsed certificate would make the test JDK-version-dependent.
+    X509Certificate cert = mock(X509Certificate.class);
+    when(cert.getSigAlgName()).thenReturn("Ed25519");
+    SSLSession session = mock(SSLSession.class);
+    when(session.getPeerCertificates()).thenReturn(new Certificate[]{cert});
+    SSLSocket socket = mock(SSLSocket.class);
+    when(socket.getSession()).thenReturn(session);
+    PGStream stream = mock(PGStream.class);
+    when(stream.getSocket()).thenReturn(socket);
+
+    PSQLException ex = assertThrows(PSQLException.class,
+        () -> new ScramAuthenticator("secret".toCharArray(), stream, ChannelBinding.REQUIRE, 0));
+
+    assertEquals(PSQLState.CONNECTION_REJECTED.getState(), ex.getSQLState());
+    // The message names the offending signature algorithm so an operator can act.
+    assertTrue(ex.getMessage().contains("Ed25519"), ex.getMessage());
+  }
+
+  @Test
+  void requireRejectsConnectionWithoutSsl() throws Exception {
+    PGStream stream = mock(PGStream.class);
+    when(stream.getSocket()).thenReturn(mock(Socket.class));
+
+    PSQLException ex = assertThrows(PSQLException.class,
+        () -> new ScramAuthenticator("secret".toCharArray(), stream, ChannelBinding.REQUIRE, 0));
+
+    assertEquals(PSQLState.CONNECTION_REJECTED.getState(), ex.getSQLState());
+  }
+}

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/ScramAuthenticator.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/ScramAuthenticator.java
@@ -62,6 +62,15 @@ final class ScramAuthenticator {
           .stringPreparation(StringPreparation.POSTGRESQL_PREPARATION)
           .build();
 
+      // channelBinding=require must never silently downgrade: regardless of how negotiation
+      // resolved, the selected mechanism must actually use channel binding (a -PLUS mechanism).
+      if (channelBinding == ChannelBinding.REQUIRE && !client.getScramMechanism().isPlus()) {
+        throw new PSQLException(
+            GT.tr("Channel Binding is required, but the negotiated SCRAM mechanism \"{0}\" "
+                + "does not use channel binding.", client.getScramMechanism().getName()),
+            PSQLState.CONNECTION_REJECTED);
+      }
+
       LOGGER.log(Level.FINEST, () -> " Using SCRAM mechanism: "
           + client.getScramMechanism().getName());
       return client;
@@ -111,7 +120,22 @@ final class ScramAuthenticator {
           Certificate peerCert = certificates[0]; // First certificate is the peer's certificate
           if (peerCert instanceof X509Certificate) {
             X509Certificate cert = (X509Certificate) peerCert;
-            return TlsServerEndpoint.getChannelBindingData(cert);
+            byte[] cbindData = TlsServerEndpoint.getChannelBindingData(cert);
+            if (cbindData.length > 0) {
+              return cbindData;
+            }
+            // An empty result means no channel binding hash could be derived from the
+            // certificate signature algorithm: for example Ed25519 has no associated hash
+            // under RFC 5929 tls-server-end-point. Under REQUIRE this must fail rather than
+            // silently downgrade to a non-PLUS mechanism.
+            if (channelBinding == ChannelBinding.REQUIRE) {
+              throw new PSQLException(
+                  GT.tr("Channel Binding is required, but the server certificate signature "
+                      + "algorithm \"{0}\" does not support tls-server-end-point channel "
+                      + "binding (RFC 5929). Use a server certificate signed with RSA or ECDSA.",
+                      cert.getSigAlgName()),
+                  PSQLState.CONNECTION_REJECTED);
+            }
           }
         }
       } catch (CertificateEncodingException | SSLPeerUnverifiedException e) {


### PR DESCRIPTION
This is a cherry-pick of 77df98e4e66c12936ded3478a0954f6f580bad99.

Under `channelBinding=require`, the driver silently downgraded to a non-PLUS SCRAM mechanism when it could not derive a channel-binding hash from the server certificate (for example an Ed25519 certificate, whose signature algorithm has no associated hash under RFC 5929 `tls-server-end-point`). `TlsServerEndpoint.getChannelBindingData` returns an empty array in that case, which the SCRAM client treats as `"no channel binding available"` and negotiates a bare mechanism.

Enforce channel binding on the pgjdbc side, keeping the existing scram-client 3.2 dependency (no `ChannelBindingPolicy` / `getChannelBindingHash`, which are 3.3+):

- When the binding hash cannot be derived under require, fail with a message that names the certificate signature algorithm and the remediation, instead of returning an empty array.
- After negotiation, require that the selected mechanism actually uses channel binding (isPlus). This is the authoritative guarantee: regardless of how negotiation resolved, require never connects over a non-PLUS mechanism.

The existing advertisedMechanisms check still rejects require early when the server offers no `-PLUS` mechanism.

Ref: GHSA-j92g-9f8w-j867