### PR TITLE
fix: avoid forcing temp-namespace creation in getSchemas()

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
@@ -1662,12 +1662,19 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
       f[1] = new Field("TABLE_SCHEM", Oid.VARCHAR);
       return ((BaseStatement) createMetaDataStatement()).createDriverResultSet(f, v);
     }
+    // Identify the session's own temporary namespace via pg_my_temp_schema() rather than
+    // current_schemas()/current_schema(). current_schemas() calls the backend's
+    // fetch_search_path(), which forces creation of the temp namespace when pg_temp is first in
+    // search_path and none exists yet. On a hot standby that fails with "cannot create temporary
+    // tables during recovery" (see issue #4274). pg_my_temp_schema() returns the temp namespace
+    // OID, or 0 (InvalidOid) when none exists, without ever creating it.
     StringBuilder sql = new StringBuilder(
-        // langauge=sql
+        // language=sql
         "SELECT nspname AS \"TABLE_SCHEM\", current_database() AS \"TABLE_CATALOG\" FROM pg_catalog.pg_namespace "
           + " WHERE nspname <> 'pg_toast' AND (nspname !~ '^pg_temp_' "
-          + " OR nspname = (pg_catalog.current_schemas(true))[1]) AND (nspname !~ '^pg_toast_temp_' "
-          + " OR nspname = replace((pg_catalog.current_schemas(true))[1], 'pg_temp_', 'pg_toast_temp_')) ");
+          + " OR oid = pg_catalog.pg_my_temp_schema()) AND (nspname !~ '^pg_toast_temp_' "
+          + " OR nspname = replace((SELECT nspname FROM pg_catalog.pg_namespace "
+          + " WHERE oid = pg_catalog.pg_my_temp_schema()), 'pg_temp_', 'pg_toast_temp_')) ");
     List<String> args = new ArrayList<>(1);
     if (schemaPattern != null) {
       sql.append(" AND nspname LIKE ?");

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseMetaDataTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseMetaDataTest.java
@@ -1385,6 +1385,65 @@ public class DatabaseMetaDataTest {
   }
 
   @Test
+  void getSchemasDoesNotForceTempNamespaceCreation() throws Exception {
+    // getSchemas() must not force creation of the session's temporary namespace, even when
+    // pg_temp is the first entry of search_path. Forcing it (as current_schemas() did) fails on
+    // a hot standby with "cannot create temporary tables during recovery". See issue #4274.
+    // The connection is created fresh per test (@BeforeEach) and closed in @AfterEach, so the
+    // search_path change here does not leak to other tests and needs no explicit reset.
+    try (Statement stmt = con.createStatement()) {
+      stmt.execute("SET search_path = pg_temp, public");
+    }
+
+    DatabaseMetaData dbmd = con.getMetaData();
+    boolean foundPublic = false;
+    try (ResultSet rs = dbmd.getSchemas()) {
+      while (rs.next()) {
+        if ("public".equals(rs.getString("TABLE_SCHEM"))) {
+          foundPublic = true;
+        }
+      }
+    }
+    assertTrue(foundPublic, "getSchemas() should list the public schema");
+
+    // The metadata call must not have created a temporary namespace as a side effect.
+    try (Statement stmt = con.createStatement();
+         ResultSet rs = stmt.executeQuery("SELECT pg_my_temp_schema()")) {
+      assertTrue(rs.next());
+      assertEquals(0, rs.getLong(1),
+          "getSchemas() must not force temp-namespace creation");
+    }
+  }
+
+  @Test
+  void getSchemasReportsSessionTempSchema() throws Exception {
+    // When the session already has a temporary namespace, getSchemas() reports it (and its
+    // matching toast temp namespace). Note this differs from the pre-#4274 behaviour, which only
+    // surfaced the temp schema when pg_temp resolved to the first entry of search_path; keying
+    // off pg_my_temp_schema() reports it whenever it exists, regardless of search_path order.
+    try (Statement stmt = con.createStatement()) {
+      stmt.execute("CREATE TEMP TABLE temp_schema_probe (a int)");
+    }
+
+    DatabaseMetaData dbmd = con.getMetaData();
+    boolean foundTemp = false;
+    boolean foundToastTemp = false;
+    try (ResultSet rs = dbmd.getSchemas()) {
+      while (rs.next()) {
+        String schema = rs.getString("TABLE_SCHEM");
+        if (schema.startsWith("pg_temp_")) {
+          foundTemp = true;
+        } else if (schema.startsWith("pg_toast_temp_")) {
+          foundToastTemp = true;
+        }
+      }
+    }
+    assertTrue(foundTemp, "getSchemas() should report the session's temp schema when it exists");
+    assertTrue(foundToastTemp,
+        "getSchemas() should report the session's toast temp schema when it exists");
+  }
+
+  @Test
   @EnabledForServerVersionRange(gte = "9.2")
   void escaping() throws SQLException {
     DatabaseMetaData dbmd = con.getMetaData();

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/GetSchemasOnReplicaTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/GetSchemasOnReplicaTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2026, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.test.jdbc2;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.postgresql.test.TestUtil.closeDB;
+import static org.postgresql.test.TestUtil.openDB;
+
+import org.postgresql.PGProperty;
+import org.postgresql.test.TestUtil;
+import org.postgresql.test.annotations.tags.Replication;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.Properties;
+
+/**
+ * Regression test for issue #4274: {@code DatabaseMetaData.getSchemas()} must not force creation
+ * of the session's temporary namespace, which fails on a hot standby with
+ * "cannot create temporary tables during recovery".
+ *
+ * <p>Requires a streaming replica. The test infrastructure exposes one on
+ * {@code secondaryServer1}/{@code secondaryPort1} (defaulting to the primary host and
+ * {@code port + 1}), created by the {@code CREATE_REPLICAS=on} docker option. When no replica is
+ * available, or the configured secondary is not actually in recovery mode, the test is skipped.</p>
+ */
+@Replication
+class GetSchemasOnReplicaTest {
+
+  @BeforeAll
+  static void checkReplicaAvailable() {
+    assumeTrue(isReplicaAvailable(), "No streaming replica available; skipping standby test");
+  }
+
+  @Test
+  void getSchemasDoesNotForceTempNamespaceCreation() throws Exception {
+    try (Connection replica = openReplicaDB()) {
+      assumeTrue(isInRecovery(replica),
+          "Configured secondary is not in recovery mode; skipping standby-only test");
+
+      // Put pg_temp first in search_path so the pre-fix current_schemas() query would force
+      // temp-namespace creation and fail on the standby.
+      try (Statement stmt = replica.createStatement()) {
+        stmt.execute("SET search_path = pg_temp, public");
+      }
+
+      DatabaseMetaData dbmd = replica.getMetaData();
+      boolean foundPublic = false;
+      try (ResultSet rs = dbmd.getSchemas()) {
+        while (rs.next()) {
+          if ("public".equals(rs.getString("TABLE_SCHEM"))) {
+            foundPublic = true;
+          }
+        }
+      }
+      assertTrue(foundPublic, "getSchemas() should list the public schema on a standby");
+    }
+  }
+
+  private static boolean isInRecovery(Connection con) throws Exception {
+    try (Statement stmt = con.createStatement();
+         ResultSet rs = stmt.executeQuery("SELECT pg_is_in_recovery()")) {
+      return rs.next() && rs.getBoolean(1);
+    }
+  }
+
+  private static boolean isReplicaAvailable() {
+    try {
+      closeDB(openReplicaDB());
+      return true;
+    } catch (Exception e) {
+      return false;
+    }
+  }
+
+  private static Connection openReplicaDB() throws Exception {
+    TestUtil.initDriver();
+    Properties props = new Properties();
+    PGProperty.USER.set(props, TestUtil.getUser());
+    PGProperty.PASSWORD.set(props, TestUtil.getPassword());
+    TestUtil.setTestUrlProperty(props, PGProperty.PG_HOST, getReplicaServer());
+    TestUtil.setTestUrlProperty(props, PGProperty.PG_PORT, String.valueOf(getReplicaPort()));
+    return openDB(props);
+  }
+
+  private static String getReplicaServer() {
+    return System.getProperty("secondaryServer1", TestUtil.getServer());
+  }
+
+  private static int getReplicaPort() {
+    return Integer.parseInt(
+        System.getProperty("secondaryPort1", String.valueOf(TestUtil.getPort() + 1)));
+  }
+}


### PR DESCRIPTION
getSchemas() used (current_schemas(true))[1] to identify the session's own temporary namespace. current_schemas() calls the backend's fetch_search_path(), which forces creation of the temp namespace when pg_temp is the first entry of search_path and none exists yet. On a hot standby that hits the recovery guard in InitTempTableNamespace() and the read-only metadata call fails with:

    ERROR: cannot create temporary tables during recovery

The forcing is independent of the include_implicit argument, so current_schemas(false) or current_schema() would fail the same way.

Use pg_my_temp_schema() instead, which returns the temp namespace OID (or 0 when none exists) without ever creating it, and match the temp and toast-temp namespaces by that OID.

Behavioural change: the temp schema is now reported whenever the session has one, regardless of search_path order. The previous expression only surfaced it when pg_temp resolved to the first search_path entry. This is documented in a comment on the query.

Add two tests:
- getSchemasDoesNotForceTempNamespaceCreation: with pg_temp first in search_path, getSchemas() succeeds and pg_my_temp_schema() remains 0, proving no namespace was forced into existence.
- getSchemasReportsSessionTempSchema: with a temp table present, getSchemas() reports the pg_temp_N and pg_toast_temp_N schemas.

Fixes #4274

