### PR TITLE
Adjust EditorConfig for Makefile

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -51,3 +51,7 @@ ij_java_space_before_colon = true
 ij_java_ternary_operation_signs_on_next_line = true
 ij_java_use_single_class_imports = true
 ij_java_wrap_long_lines = true
+
+[Makefile]
+# Indentation with spaces are syntactically not correct
+indent_style = tab


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

---

This Pull Request adds a section for all Makefile in the project, to set `indent_style = tab` as using spaces in them is syntactically not correct. Currently, it is one Makefile at `certdir/Makefile`.

This change is part of PR #4273, which will be not merged as all other changes from it will be addressed with PR #4276.