### PR TITLE
docs: update website for the 42.7.13 release

### DIFF
--- a/docs/content/security/_index.md
+++ b/docs/content/security/_index.md
@@ -22,6 +22,38 @@ For security purposes, we sign our releases with these PGP keys:
 
 ## Security Advisories
 
+### Silent Channel-Binding Authentication Downgrade (CVE-2026-54291)
+
+#### Impact
+
+`channelBinding=require` connections can be silently downgraded from `SCRAM-SHA-256-PLUS` (with channel binding) to plain `SCRAM-SHA-256` (without it), losing the man-in-the-middle protection the setting is meant to guarantee. An attacker who can intercept the TLS connection triggers the downgrade with a certificate whose signature algorithm has no `tls-server-end-point` channel-binding hash. Examples are Ed25519, Ed448, and post-quantum algorithms.
+
+Two issues combine in releases 42.7.4 through 42.7.11:
+
+1. The bundled `com.ongres.scram:scram-client` (3.1 or 3.2) returns an empty byte array instead of failing when it cannot derive the binding hash for such a certificate. This is the library issue tracked as [CVE-2026-53712](https://github.com/advisories/GHSA-p9jg-fcr6-3mhf).
+2. pgJDBC does not enforce `channelBinding=require` where it matters. `ScramAuthenticator` checks only that the server *advertised* a `-PLUS` mechanism; it neither rejects the empty binding nor checks that the *negotiated* mechanism uses channel binding. The connection therefore downgrades silently.
+
+Only connections that set `channelBinding=require` are affected. Under the default `prefer` policy, and under `allow` or `disable`, falling back to plain SCRAM is the documented behaviour. Releases before 42.7.4 are unaffected, because they do not support channel binding.
+
+#### Patches
+
+Fixed in pgJDBC 42.7.12. The driver now enforces channel binding in its own code, independently of the `scram-client` version:
+
+- Under `channelBinding=require`, it fails the connection when no channel-binding data can be extracted from the server certificate, instead of passing an empty value to the SCRAM client. The error names the certificate signature algorithm.
+- After negotiation, it requires the selected mechanism to use channel binding (a `-PLUS` mechanism) whenever `channelBinding=require` is set, regardless of how negotiation resolved.
+
+Upgrade to 42.7.12 or later.
+
+#### Workarounds
+
+No pgJDBC setting restores channel-binding enforcement on an affected release; upgrading is the fix.
+
+If you cannot upgrade immediately, verify the server certificate at the TLS layer so that a man-in-the-middle cannot present a substitute certificate. Set `sslmode=verify-full` with a truststore that contains only your server's CA. This defence is independent of channel binding and blocks the same attacker.
+
+Reported by [KEIJOT](https://github.com/KEIJOT)
+
+See the [Security Advisory](https://github.com/pgjdbc/pgjdbc/security/advisories/GHSA-j92g-9f8w-j867) for full detail.
+
 ### SQL Injection via line comment generation
 
 #### Impact

--- a/docs/data/homepagedata.toml
+++ b/docs/data/homepagedata.toml
@@ -14,6 +14,16 @@ path = "/icons/driver-icon.svg"
 
 # Releases Info
 [[info]]
+date = "6 July 2026"
+url = "/changelogs/2026-07-06-42.7.13-release/"
+version = "42.7.13"
+
+[[info]]
+date = "29 June 2026"
+url = "/changelogs/2026-06-29-42.7.12-release/"
+version = "42.7.12"
+
+[[info]]
 date = "28 April 2026"
 url = "/changelogs/2026-04-28-42/"
 version = "42.7.11"

--- a/docs/data/versions.toml
+++ b/docs/data/versions.toml
@@ -1,10 +1,10 @@
 # Recent Versions
 [[recent]]
 j_name= "Java 8"
-version= "42.7.11"
+version= "42.7.13"
 suffix=""
 description= "If you are using Java 8 or newer then you should use the JDBC 4.2 version."
-url= "/download/postgresql-42.7.11.jar"
+url= "/download/postgresql-42.7.13.jar"
 
 [[recent]]
 j_name= "Java 7"
@@ -21,6 +21,20 @@ description= "If you are using Java 6  then you should use the  JDBC 4.0 version
 url= "/download/postgresql-42.2.27.jre6.jar"
 
 # Past Versions
+[[past]]
+j_name= "Java 8"
+version= "42.7.12"
+suffix=""
+description= "If you are using Java 8 or newer then you should use the JDBC 4.2 version."
+url= "/download/postgresql-42.7.12.jar"
+
+[[past]]
+j_name= "Java 8"
+version= "42.7.11"
+suffix=""
+description= "If you are using Java 8 or newer then you should use the JDBC 4.2 version."
+url= "/download/postgresql-42.7.11.jar"
+
 [[past]]
 j_name= "Java 8"
 version= "42.7.10"

--- a/docs/layouts/partials/home/info.html
+++ b/docs/layouts/partials/home/info.html
@@ -15,8 +15,8 @@
             Latest Releases
         </h2>
         <p>
-            Current release is 42.7.11 This is a security and maintenance release. This fixes a SCRAM PBKDF2 iteration DoS vulnerability (CVE-2026-42198), adds the require_auth connection property, and includes numerous bug fixes.
-            See the <a href="https://jdbc.postgresql.org/changelogs/2026-04-28-42/">Changelog</a> for details
+            Current release is 42.7.13. This is a maintenance release with numerous bug fixes and new connection properties (flushCacheOnDdl, connectExecutor, classLoaderStrategy). It follows the 42.7.12 security release, which fixed a silent channel-binding authentication downgrade (CVE-2026-54291).
+            See the <a href="https://jdbc.postgresql.org/changelogs/2026-07-06-42.7.13-release/">Changelog</a> for details
         </p>
         <ul role="list">
             {{ range $.Site.Data.homepagedata.info }}


### PR DESCRIPTION
- versions.toml: make 42.7.13 the recent Java 8 download; move 42.7.12 and 42.7.11 to past versions
- homepagedata.toml: add 42.7.13 and 42.7.12 to the releases list
- home/info.html: point the current-release blurb at 42.7.13 and note the preceding 42.7.12 security release
- security/_index.md: add the CVE-2026-54291 channel-binding downgrade advisory (the 42.7.12 fix), which was not yet on this branch

