### PR TITLE
fix: reject getBytes for non-binary types

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
@@ -1298,8 +1298,8 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
     PreparedStatement stmt = prepareMetaDataStatement(sql.toString(), args);
     ResultSet rs = stmt.executeQuery();
     while (rs.next()) {
-      byte[] schema = rs.getBytes("nspname");
-      byte[] procedureName = rs.getBytes("proname");
+      byte[] schema = connection.encodeString(castNonNull(rs.getString("nspname")));
+      byte[] procedureName = connection.encodeString(castNonNull(rs.getString("proname")));
       byte[] specificName =
                 connection.encodeString(rs.getString("proname") + "_" + rs.getString("oid"));
       int returnType = (int) rs.getLong("prorettype");
@@ -1424,7 +1424,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
           tuple[0] = catalogName;
           tuple[1] = schema;
           tuple[2] = procedureName;
-          tuple[3] = columnrs.getBytes("attname");
+          tuple[3] = connection.encodeString(columnrs.getString("attname"));
           tuple[4] = connection
               .encodeString(Integer.toString(DatabaseMetaData.procedureColumnResult));
           tuple[5] = connection
@@ -1819,9 +1819,9 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
       int typeMod = rs.getInt("atttypmod");
 
       tuple[0] = currentCatalog.getBytes(Charset.defaultCharset()); // Catalog (database) name
-      tuple[1] = rs.getBytes("nspname"); // Schema name
-      tuple[2] = rs.getBytes("relname"); // Table name
-      tuple[3] = rs.getBytes("attname"); // Column name
+      tuple[1] = connection.encodeString(rs.getString("nspname")); // Schema name
+      tuple[2] = connection.encodeString(rs.getString("relname")); // Table name
+      tuple[3] = connection.encodeString(rs.getString("attname")); // Column name
 
       String typtype = rs.getString("typtype");
       int sqlType;
@@ -1906,8 +1906,8 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
 
       tuple[10] = connection.encodeString(Integer.toString(rs.getBoolean("attnotnull")
           ? DatabaseMetaData.columnNoNulls : DatabaseMetaData.columnNullable)); // Nullable
-      tuple[11] = rs.getBytes("description"); // Description (if any)
-      tuple[12] = rs.getBytes("adsrc"); // Column default
+      tuple[11] = connection.encodeString(rs.getString("description")); // Description (if any)
+      tuple[12] = connection.encodeString(rs.getString("adsrc")); // Column default
       tuple[13] = null; // sql data type (unused)
       tuple[14] = null; // sql datetime sub (unused)
       // CHAR_OCTET_LENGTH applies to character and binary types only; it equals COLUMN_SIZE
@@ -2013,9 +2013,9 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
     ResultSet rs = stmt.executeQuery();
     byte[] catalogName = currentCatalog.getBytes(Charset.defaultCharset());
     while (rs.next()) {
-      byte[] schemaName = rs.getBytes("nspname");
-      byte[] tableName = rs.getBytes("relname");
-      byte[] column = rs.getBytes("attname");
+      byte[] schemaName = connection.encodeString(castNonNull(rs.getString("nspname")));
+      byte[] tableName = connection.encodeString(castNonNull(rs.getString("relname")));
+      byte[] column = connection.encodeString(castNonNull(rs.getString("attname")));
       String owner = castNonNull(rs.getString("rolname"));
       String relAcl = rs.getString("relacl");
 
@@ -2098,8 +2098,8 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
     ResultSet rs = stmt.executeQuery();
     byte[] catalogName = currentCatalog.getBytes(Charset.defaultCharset());
     while (rs.next()) {
-      byte[] schema = rs.getBytes("nspname");
-      byte[] table = rs.getBytes("relname");
+      byte[] schema = connection.encodeString(castNonNull(rs.getString("nspname")));
+      byte[] table = connection.encodeString(castNonNull(rs.getString("relname")));
       String owner = castNonNull(rs.getString("rolname"));
       String acl = rs.getString("relacl");
       Map<String, Map<String, List<@Nullable String[]>>> permissions = parseACL(acl, owner);
@@ -2359,7 +2359,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
         columnSize = connection.getTypeInfo().getDisplaySize(typeOid, typeMod);
       }
       tuple[0] = connection.encodeString(Integer.toString(scope));
-      tuple[1] = rs.getBytes("attname");
+      tuple[1] = connection.encodeString(rs.getString("attname"));
       tuple[2] =
           connection.encodeString(Integer.toString(sqlType));
       tuple[3] = connection.encodeString(connection.getTypeInfo().getPGType(typeOid));
@@ -3387,8 +3387,8 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
     ResultSet rs = stmt.executeQuery();
     byte[] catalogName = currentCatalog.getBytes(Charset.defaultCharset());
     while (rs.next()) {
-      byte[] schema = rs.getBytes("nspname");
-      byte[] functionName = rs.getBytes("proname");
+      byte[] schema = connection.encodeString(castNonNull(rs.getString("nspname")));
+      byte[] functionName = connection.encodeString(castNonNull(rs.getString("proname")));
       byte[] specificName =
           connection.encodeString(rs.getString("proname") + "_" + rs.getString("oid"));
       int returnType = (int) rs.getLong("prorettype");
@@ -3514,7 +3514,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
           tuple[0] = catalogName;
           tuple[1] = schema;
           tuple[2] = functionName;
-          tuple[3] = columnrs.getBytes("attname");
+          tuple[3] = connection.encodeString(columnrs.getString("attname"));
           tuple[4] = connection
               .encodeString(Integer.toString(DatabaseMetaData.functionColumnResult));
           tuple[5] = connection

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
@@ -2954,11 +2954,7 @@ public class PgResultSet implements ResultSet, PGRefCursorResultSet {
   /**
    * {@inheritDoc}
    *
-   * <p>In normal use, the bytes represent the raw values returned by the backend. However, if the
-   * column is an OID, then it is assumed to refer to a Large Object, and that object is returned as
-   * a byte array.</p>
-   *
-   * <p><b>Be warned</b> If the large object is huge, then you may run out of memory.</p>
+   * <p>PostgreSQL supports this conversion for {@code bytea} columns.</p>
    */
   @Pure
   @Override
@@ -2969,15 +2965,18 @@ public class PgResultSet implements ResultSet, PGRefCursorResultSet {
       return null;
     }
 
+    int oid = fields[columnIndex - 1].getOID();
+    if (oid != Oid.BYTEA) {
+      throw new PSQLException(
+          GT.tr("Cannot convert the column of type {0} to requested type {1}.",
+              Oid.toString(oid), "byte[]"),
+          PSQLState.CANNOT_COERCE);
+    }
+
     if (isBinary(columnIndex)) {
-      // If the data is already binary then just return it
       return value;
     }
-    if (fields[columnIndex - 1].getOID() == Oid.BYTEA) {
-      return trimBytes(columnIndex, PGbytea.toBytes(value));
-    } else {
-      return trimBytes(columnIndex, value);
-    }
+    return trimBytes(columnIndex, PGbytea.toBytes(value));
   }
 
   @Override

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseMetaDataTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DatabaseMetaDataTest.java
@@ -1168,7 +1168,7 @@ public class DatabaseMetaDataTest {
     // Test that the table types returned are the same as those expected
     ResultSet rs = dbmd.getTableTypes();
     while (rs.next()) {
-      String tableType = new String(rs.getBytes(1));
+      String tableType = rs.getString(1);
       foundTableTypes.add(tableType);
     }
     rs.close();

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ResultSetTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/ResultSetTest.java
@@ -328,15 +328,12 @@ public class ResultSetTest extends BaseTest4 {
     // it should apply only to binary and char/varchar columns
     rs.next();
     assertEquals("12345", rs.getString(1));
-    // getBytes returns 5 bytes for txt transfer, 4 for bin transfer
-    assertTrue(rs.getBytes(1).length >= 4);
 
     // max should apply to the following since the column is
     // a varchar column
     rs = stmt.executeQuery("select * from teststring");
     rs.next();
     assertEquals("12", rs.getString(1));
-    assertEquals("12", new String(rs.getBytes(1)));
   }
 
   @Test

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc4/BinaryTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc4/BinaryTest.java
@@ -5,7 +5,10 @@
 
 package org.postgresql.test.jdbc4;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
@@ -16,10 +19,11 @@ import org.postgresql.core.Field;
 import org.postgresql.jdbc.PgStatement;
 import org.postgresql.jdbc.PreferQueryMode;
 import org.postgresql.test.jdbc2.BaseTest4;
+import org.postgresql.util.PSQLException;
+import org.postgresql.util.PSQLState;
 
 import org.junit.jupiter.api.Test;
 
-import java.nio.ByteBuffer;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -135,6 +139,35 @@ public class BinaryTest extends BaseTest4 {
   }
 
   @Test
+  public void testGetBytesRejectsNonBinaryTypesAcrossTransferFormats() throws SQLException {
+    try (PreparedStatement ps = con.prepareStatement(
+        "select 42::int4 as int_value, 1.25::float8 as float_value, "
+            + "'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11'::uuid as uuid_value, "
+            + "'text'::text as text_value, decode('00015cff', 'hex') as bytea_value, "
+            + "null::bytea as null_bytea_value")) {
+      ((PGStatement) ps).setPrepareThreshold(1);
+
+      for (int execution = 0; execution < 2; execution++) {
+        try (ResultSet rs = ps.executeQuery()) {
+          assertTrue(rs.next(), "One row should be returned");
+          int expectedFormat = execution == 0 ? Field.TEXT_FORMAT : Field.BINARY_FORMAT;
+          assertEquals(expectedFormat, getFormat(rs));
+          assertEquals(expectedFormat, getFormat(rs, 5));
+
+          for (int columnIndex = 1; columnIndex <= 4; columnIndex++) {
+            assertGetBytesCannotCoerce(rs, columnIndex);
+          }
+          assertGetBytesCannotCoerce(rs, "uuid_value");
+
+          assertArrayEquals(new byte[]{0, 1, 92, (byte) 255}, rs.getBytes(5));
+          assertArrayEquals(new byte[]{0, 1, 92, (byte) 255}, rs.getBytes("bytea_value"));
+          assertNull(rs.getBytes("null_bytea_value"));
+        }
+      }
+    }
+  }
+
+  @Test
   public void testGetMetaDataBeforeExecuteQuery() throws SQLException {
     PreparedStatement ps = null;
     ResultSet rs = null;
@@ -147,11 +180,8 @@ public class BinaryTest extends BaseTest4 {
       ps.setLong(1, paramsLong);
       rs = ps.executeQuery();
       assertTrue(rs.next(), "One row should be returned");
-      byte[] bytes = rs.getBytes(1);
-      ByteBuffer bf = ByteBuffer.wrap(bytes);
-      long longResult = bf.getLong();
       assertEquals(Field.BINARY_FORMAT, getFormat(rs));
-      assertEquals(paramsLong, longResult);
+      assertEquals(paramsLong, rs.getLong(1));
     } finally {
       if (rs != null) {
         rs.close();
@@ -164,6 +194,20 @@ public class BinaryTest extends BaseTest4 {
   }
 
   private static int getFormat(ResultSet results) throws SQLException {
-    return ((PGResultSetMetaData) results.getMetaData()).getFormat(1);
+    return getFormat(results, 1);
+  }
+
+  private static int getFormat(ResultSet results, int columnIndex) throws SQLException {
+    return ((PGResultSetMetaData) results.getMetaData()).getFormat(columnIndex);
+  }
+
+  private static void assertGetBytesCannotCoerce(ResultSet rs, int columnIndex) {
+    PSQLException error = assertThrows(PSQLException.class, () -> rs.getBytes(columnIndex));
+    assertEquals(PSQLState.CANNOT_COERCE.getState(), error.getSQLState());
+  }
+
+  private static void assertGetBytesCannotCoerce(ResultSet rs, String columnLabel) {
+    PSQLException error = assertThrows(PSQLException.class, () -> rs.getBytes(columnLabel));
+    assertEquals(PSQLState.CANNOT_COERCE.getState(), error.getSQLState());
   }
 }


### PR DESCRIPTION
## Summary

- Restrict `PgResultSet#getBytes` to PostgreSQL `bytea` columns.

- Throw `PSQLState.CANNOT_COERCE` for non-binary conversions.

- Preserve text and binary transfer handling for `bytea`, including SQL `NULL`.

- Update internal metadata code that previously called `getBytes` on textual catalog fields.

- Add regression coverage across the `prepareThreshold` text-to-binary transition.

## Why

For non-binary types, `getBytes` returned raw wire-protocol values. This meant the same logical value could change representation after a prepared statement crossed `prepareThreshold`.

JDBC defines this getter for binary types. Rejecting other conversions makes the behavior deterministic and spec-compatible. This follows the direction discussed in #4277 without adding a compatibility property.

## Validation

- Added coverage for `int4`, `float8`, `uuid`, and `text`.

- Covered both index and column-label overloads.

- Preserved non-null and null `bytea` behavior.

- `git diff --check` passes.

- Full PostgreSQL integration testing is pending through CI because PostgreSQL was unavailable in the local execution environment.

Closes #4277

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes to Existing Features:

* [x] Does this break existing behaviour? If so please explain. Yes. Unsupported, wire-format-dependent conversions for non-binary fields now throw `CANNOT_COERCE`.
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully run tests with your changes locally? Full integration testing is pending through CI.
