### PR TITLE
fix: parse sql_standard intervals

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/util/PGInterval.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/PGInterval.java
@@ -13,6 +13,8 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
 import java.util.StringTokenizer;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * This implements a class that handles the PostgreSQL interval type.
@@ -20,6 +22,16 @@ import java.util.StringTokenizer;
 public class PGInterval extends PGobject implements Serializable, Cloneable {
 
   private static final int MICROS_IN_SECOND = 1000000;
+  private static final Pattern SQL_STANDARD_YEAR_MONTH = Pattern.compile(
+      "^([+-]?)(\\d+)-(\\d+)$");
+  private static final Pattern SQL_STANDARD_YEAR_MONTH_CANDIDATE = Pattern.compile(
+      "^[+-]?\\d+-.*$");
+  private static final Pattern SQL_STANDARD_DAY_TIME = Pattern.compile(
+      "^([+-]?)(\\d+)\\s+([+-]?)(\\d+):(\\d{2}):(\\d{2}(?:\\.\\d+)?)$");
+  private static final Pattern SQL_STANDARD_DAY_TIME_CANDIDATE = Pattern.compile(
+      "^[+-]?\\d+\\s+[+-]?\\d+:.*$");
+  private static final Pattern SQL_STANDARD_COMPOUND = Pattern.compile(
+      "^([+-]?)(\\d+)-(\\d+)\\s+([+-])(\\d+)\\s+([+-])(\\d+):(\\d{2}):(\\d{2}(?:\\.\\d+)?)$");
 
   private int years;
   private int months;
@@ -109,6 +121,50 @@ public class PGInterval extends PGobject implements Serializable, Cloneable {
     }
   }
 
+  private boolean parseSqlStandardFormat(String value) throws SQLException {
+    try {
+      Matcher yearMonthMatcher = SQL_STANDARD_YEAR_MONTH.matcher(value);
+      if (yearMonthMatcher.matches()) {
+        String sign = yearMonthMatcher.group(1);
+        setValue(
+            Integer.parseInt(sign + yearMonthMatcher.group(2)),
+            Integer.parseInt(sign + yearMonthMatcher.group(3)), 0, 0, 0, 0);
+        return true;
+      }
+
+      Matcher dayTimeMatcher = SQL_STANDARD_DAY_TIME.matcher(value);
+      if (dayTimeMatcher.matches()) {
+        String daySign = dayTimeMatcher.group(1);
+        String timeSign = dayTimeMatcher.group(3).isEmpty()
+            ? daySign : dayTimeMatcher.group(3);
+        setValue(0, 0,
+            Integer.parseInt(daySign + dayTimeMatcher.group(2)),
+            Integer.parseInt(timeSign + dayTimeMatcher.group(4)),
+            Integer.parseInt(timeSign + dayTimeMatcher.group(5)),
+            Double.parseDouble(timeSign + dayTimeMatcher.group(6)));
+        return true;
+      }
+
+      Matcher compoundMatcher = SQL_STANDARD_COMPOUND.matcher(value);
+      if (!compoundMatcher.matches()) {
+        return false;
+      }
+
+      String yearMonthSign = compoundMatcher.group(1);
+      setValue(
+          Integer.parseInt(yearMonthSign + compoundMatcher.group(2)),
+          Integer.parseInt(yearMonthSign + compoundMatcher.group(3)),
+          Integer.parseInt(compoundMatcher.group(4) + compoundMatcher.group(5)),
+          Integer.parseInt(compoundMatcher.group(6) + compoundMatcher.group(7)),
+          Integer.parseInt(compoundMatcher.group(6) + compoundMatcher.group(8)),
+          Double.parseDouble(compoundMatcher.group(6) + compoundMatcher.group(9)));
+      return true;
+    } catch (NumberFormatException e) {
+      throw new PSQLException(GT.tr("Conversion of interval failed"),
+          PSQLState.NUMERIC_CONSTANT_OUT_OF_RANGE, e);
+    }
+  }
+
   /**
    * Initializes all values of this interval to the specified values.
    *
@@ -145,6 +201,14 @@ public class PGInterval extends PGobject implements Serializable, Cloneable {
     if (value.startsWith("P")) {
       parseISO8601Format(value);
       return;
+    }
+    if (parseSqlStandardFormat(value)) {
+      return;
+    }
+    if (SQL_STANDARD_YEAR_MONTH_CANDIDATE.matcher(value).matches()
+        || SQL_STANDARD_DAY_TIME_CANDIDATE.matcher(value).matches()) {
+      throw new PSQLException(GT.tr("Conversion of interval failed"),
+          PSQLState.NUMERIC_CONSTANT_OUT_OF_RANGE);
     }
     // Just a simple '0'
     if (!postgresFormat && value.length() == 3 && value.charAt(2) == '0') {

--- a/pgjdbc/src/main/java/org/postgresql/util/PGInterval.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/PGInterval.java
@@ -160,8 +160,8 @@ public class PGInterval extends PGobject implements Serializable, Cloneable {
           Double.parseDouble(compoundMatcher.group(6) + compoundMatcher.group(9)));
       return true;
     } catch (NumberFormatException e) {
-      throw new PSQLException(GT.tr("Conversion of interval failed"),
-          PSQLState.NUMERIC_CONSTANT_OUT_OF_RANGE, e);
+      throw new PSQLException(GT.tr("Cannot convert value to {0}: {1}", "interval", value),
+          PSQLState.BAD_DATETIME_FORMAT, e);
     }
   }
 
@@ -207,8 +207,8 @@ public class PGInterval extends PGobject implements Serializable, Cloneable {
     }
     if (SQL_STANDARD_YEAR_MONTH_CANDIDATE.matcher(value).matches()
         || SQL_STANDARD_DAY_TIME_CANDIDATE.matcher(value).matches()) {
-      throw new PSQLException(GT.tr("Conversion of interval failed"),
-          PSQLState.NUMERIC_CONSTANT_OUT_OF_RANGE);
+      throw new PSQLException(GT.tr("Cannot convert value to {0}: {1}", "interval", value),
+          PSQLState.BAD_DATETIME_FORMAT);
     }
     // Just a simple '0'
     if (!postgresFormat && value.length() == 3 && value.charAt(2) == '0') {

--- a/pgjdbc/src/test/java/org/postgresql/util/PGIntervalTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/util/PGIntervalTest.java
@@ -6,6 +6,7 @@
 package org.postgresql.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
@@ -91,12 +92,26 @@ class PGIntervalTest {
 
   @Test
   void rejectsMalformedSqlStandardInterval() {
-    assertThrows(SQLException.class, () -> new PGInterval("1-"));
+    PSQLException error = assertThrows(PSQLException.class, () -> new PGInterval("1-"));
+
+    assertEquals(PSQLState.BAD_DATETIME_FORMAT.getState(), error.getSQLState());
+    assertEquals("Cannot convert value to interval: 1-", error.getMessage());
   }
 
   @Test
   void rejectsMalformedSqlStandardDayTimeInterval() {
     assertThrows(SQLException.class, () -> new PGInterval("1 2:3"));
+  }
+
+  @Test
+  void rejectsOutOfRangeSqlStandardInterval() {
+    String value = "999999999999999999999-1";
+
+    PSQLException error = assertThrows(PSQLException.class, () -> new PGInterval(value));
+
+    assertEquals(PSQLState.BAD_DATETIME_FORMAT.getState(), error.getSQLState());
+    assertEquals("Cannot convert value to interval: " + value, error.getMessage());
+    assertInstanceOf(NumberFormatException.class, error.getCause());
   }
 
   @ParameterizedTest

--- a/pgjdbc/src/test/java/org/postgresql/util/PGIntervalTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/util/PGIntervalTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2026, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.sql.SQLException;
+
+class PGIntervalTest {
+
+  @Test
+  void parsesSqlStandardCompoundInterval() throws SQLException {
+    PGInterval interval = new PGInterval("+1-2 +3 +4:05:06");
+
+    assertEquals(1, interval.getYears());
+    assertEquals(2, interval.getMonths());
+    assertEquals(3, interval.getDays());
+    assertEquals(4, interval.getHours());
+    assertEquals(5, interval.getMinutes());
+    assertEquals(6, interval.getSeconds());
+  }
+
+  @Test
+  void parsesSqlStandardYearMonthInterval() throws SQLException {
+    PGInterval interval = new PGInterval("1-2");
+
+    assertEquals(1, interval.getYears());
+    assertEquals(2, interval.getMonths());
+  }
+
+  @Test
+  void appliesSqlStandardLeadingSignToYearAndMonth() throws SQLException {
+    PGInterval interval = new PGInterval("-1-2");
+
+    assertEquals(-1, interval.getYears());
+    assertEquals(-2, interval.getMonths());
+  }
+
+  @Test
+  void parsesSqlStandardDayTimeInterval() throws SQLException {
+    PGInterval interval = new PGInterval("1 2:03:04");
+
+    assertEquals(1, interval.getDays());
+    assertEquals(2, interval.getHours());
+    assertEquals(3, interval.getMinutes());
+    assertEquals(4, interval.getSeconds());
+  }
+
+  @Test
+  void parsesSqlStandardDayTimeIntervalWithMixedSigns() throws SQLException {
+    PGInterval interval = new PGInterval("-1 +2:03:04");
+
+    assertEquals(-1, interval.getDays());
+    assertEquals(2, interval.getHours());
+    assertEquals(3, interval.getMinutes());
+    assertEquals(4, interval.getSeconds());
+  }
+
+  @Test
+  void appliesSqlStandardLeadingSignToAllDayTimeFields() throws SQLException {
+    PGInterval interval = new PGInterval("-1 2:03:04.5");
+
+    assertEquals(-1, interval.getDays());
+    assertEquals(-2, interval.getHours());
+    assertEquals(-3, interval.getMinutes());
+    assertEquals(-4.5, interval.getSeconds());
+  }
+
+  @Test
+  void parsesSqlStandardFullySignedIntervals() throws SQLException {
+    assertInterval(new PGInterval("+0-0 +1 -1:00:00"), 0, 0, 1, -1, 0, 0);
+    assertInterval(new PGInterval("-1-2 -3 -4:05:06.7"), -1, -2, -3, -4, -5, -6.7);
+    assertInterval(new PGInterval("-0-10 +1 +23:45:12.34"), 0, -10, 1, 23, 45, 12.34);
+  }
+
+  @Test
+  void preservesZeroAndTimeOnlyIntervalFormats() throws SQLException {
+    assertInterval(new PGInterval("0"), 0, 0, 0, 0, 0, 0);
+    assertInterval(new PGInterval("4:05:06.7"), 0, 0, 0, 4, 5, 6.7);
+    assertInterval(new PGInterval("-0:00:00.1"), 0, 0, 0, 0, 0, -0.1);
+    assertInterval(new PGInterval("15:57"), 0, 0, 0, 15, 57, 0);
+  }
+
+  @Test
+  void rejectsMalformedSqlStandardInterval() {
+    assertThrows(SQLException.class, () -> new PGInterval("1-"));
+  }
+
+  @Test
+  void rejectsMalformedSqlStandardDayTimeInterval() {
+    assertThrows(SQLException.class, () -> new PGInterval("1 2:3"));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {
+      "+1-2 +3 +4:05",
+      "+1-2 3 +4:05:06",
+      "+1-2 +3 4:05:06"
+  })
+  void rejectsMalformedSqlStandardCompoundInterval(String value) {
+    assertThrows(SQLException.class, () -> new PGInterval(value));
+  }
+
+  private static void assertInterval(PGInterval interval, int years, int months, int days,
+      int hours, int minutes, double seconds) {
+    assertEquals(years, interval.getYears());
+    assertEquals(months, interval.getMonths());
+    assertEquals(days, interval.getDays());
+    assertEquals(hours, interval.getHours());
+    assertEquals(minutes, interval.getMinutes());
+    assertEquals(seconds, interval.getSeconds());
+  }
+}


### PR DESCRIPTION
Fixes #4294.

`PGInterval` currently drops the year-month and day fields from PostgreSQL text output when `IntervalStyle=sql_standard`, silently returning zero fields. This affects interval values transferred as text, including connections configured with `binaryTransfer=false` or `binaryTransferDisable=interval`.

This change parses year-month, day-time and signed compound server output, with fractional seconds and the SQL-standard leading-sign rule. Seconds-less day-time values are also accepted for consistency with the existing time-only parser. Existing `postgres`, `postgres_verbose`, `iso_8601`, zero and time-only formats remain covered by compatibility tests.

Malformed SQL-standard-like values, including ambiguous unsigned compound values such as `1-2 3 4:05:06`, now throw `SQLException` rather than silently becoming zero. This is an output-format parser, not PostgreSQL's general `interval_in` parser. `PGInterval` still uses integer fields, so PostgreSQL values outside that range (for example server output `1 2147483648:00:00`) are not representable and now fail explicitly. SQL-standard parsing failures and the existing tokenizer's numeric failures share `BAD_DATETIME_FORMAT`, the same translated error format and the original cause where available.

### Integration with #3062

This fix can land independently of draft #3062. That branch will need a rebase, reconciliation of the two `PGIntervalTest` files, and removal of `rejectsNumberFollowedByTimeToken` after this parser accepts the day-time format. The shared `badLiteral` signatures and message match that branch; the candidate patterns are documented as removable once unknown literals are rejected generally.

### All Submissions

- [x] Followed the contributing guidelines and current AGENTS.md.
- [x] Checked related work, including #3062.
- [x] Added regression tests and an Unreleased changelog entry.
- [x] Documented compatibility changes and representation limits.

### Validation

- RED: 21 focused tests, with the two expected failures before this revision (seconds-less day-time; inconsistent SQLState for legacy numeric overflow).
- Java 21: `:postgresql:test --tests 'org.postgresql.util.*' :postgresql:styleCheck :postgresql:javadoc` — 554 tests, 0 failures; style and Javadoc pass.
- Java 8/German locale: `:postgresql:cleanTest :postgresql:test -PjdkTestVersion=8 -Duser.language=de -Duser.country=DE --tests org.postgresql.util.PGIntervalTest` — 21 tests, 0 failures.
- PostgreSQL 18.6 full suite: 9770 tests, 1 failure, 88 skipped. The sole failure is `ConnectTimeoutTest.timeout` (10 seconds vs an expected 5 seconds); the same test also fails on untouched upstream master `e107cca7` in this environment (EOFException rather than SocketTimeoutException). This connection test does not invoke `PGInterval`. The 26 database interval tests pass.
- Verified example literals using PostgreSQL 18.6 `interval_out` under `IntervalStyle=sql_standard`.

Remote CI results are separate from these local checks.
