### PR TITLE
fix: honour prepareThreshold when describing a PreparedStatement

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
@@ -1204,6 +1204,9 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
 
       int flags = QueryExecutor.QUERY_DESCRIBE_ONLY
           | QueryExecutor.QUERY_SUPPRESS_BEGIN;
+      if (isOneShotQuery(null)) {
+        flags |= QueryExecutor.QUERY_ONESHOT;
+      }
       StatementResultHandler handler = new StatementResultHandler();
       connection.getQueryExecutor().execute(preparedQuery.query, preparedParameters, handler, 0, 0,
           flags);

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PreparedStatementTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/PreparedStatementTest.java
@@ -1736,6 +1736,40 @@ public class PreparedStatementTest extends BaseTest4 {
   }
 
   @Test
+  public void testGetMetaDataWithPrepareThreshold0() throws SQLException {
+    assumeBinaryModeRegular();
+    assumeTrue(preferQueryMode != PreferQueryMode.SIMPLE, "simple protocol only does not support prepared statement requests");
+
+    PreparedStatement pstmt = null;
+    try {
+      pstmt = con.prepareStatement("SELECT 43");
+      ((PgStatement) pstmt).setPrepareThreshold(0);
+      assertNotNull(pstmt.getMetaData(), "getMetaData() should describe the statement");
+    } finally {
+      TestUtil.closeQuietly(pstmt);
+    }
+
+    assertEquals(0, getNumberOfServerPreparedStatements("SELECT 43"), "prepareThreshold=0, so getMetaData() should not server-prepare the statement");
+  }
+
+  @Test
+  public void testGetMetaDataDoesNotBypassPrepareThreshold() throws SQLException {
+    assumeBinaryModeRegular();
+    assumeTrue(preferQueryMode != PreferQueryMode.SIMPLE, "simple protocol only does not support prepared statement requests");
+
+    PreparedStatement pstmt = null;
+    try {
+      pstmt = con.prepareStatement("SELECT 44");
+      ((PgStatement) pstmt).setPrepareThreshold(5);
+      assertNotNull(pstmt.getMetaData(), "getMetaData() should describe the statement");
+    } finally {
+      TestUtil.closeQuietly(pstmt);
+    }
+
+    assertEquals(0, getNumberOfServerPreparedStatements("SELECT 44"), "prepareThreshold=5 and the statement was never executed, so describing it should not server-prepare it");
+  }
+
+  @Test
   public void testInappropriateStatementSharing() throws SQLException {
     PreparedStatement ps = con.prepareStatement("SELECT ?::timestamp");
     assertFirstParameterTypeName("after prepare ?::timestamp bind type should be timestamp", "timestamp", ps);


### PR DESCRIPTION
Closes #3896.

### The regression

`getMetaData()` used to pass `QUERY_ONESHOT`, exactly like its sibling `getParameterMetaData()` still does. #3783 (1163a8c6) removed it as a perf win, and that first shipped in **42.7.8** — which matches the reporter's 42.7.5 → 42.7.8 bisect (`git tag --contains 1163a8c6` → `REL42.7.8`).

Since then, describing a statement always sends a named parse. `prepareThreshold=0` is documented as never using named prepared statements, but one `getMetaData()` call still leaves an `S_1` behind, so a pooler that doesn't keep named statements across sessions fails with `prepared statement "S_1" already exists`.

Against master with `prepareThreshold=0`, reading `pg_prepared_statements` on the same session:

```
== after getParameterMetaData()  [stmt still open] ==
  (none — correct for prepareThreshold=0)

== after getMetaData()  [stmt still open] ==
  NAMED STATEMENT: S_1 (from_sql=false) -> SELECT 1 AS a, 'x'::text AS b
```

It isn't only the 0 case — the threshold is bypassed at any value. With `prepareThreshold=5`, a single `getMetaData()` and no execute at all is enough to server-prepare:

```
#### prepareThreshold=5 ####
== after ONE getMetaData() call ==
  NAMED STATEMENT: S_1 -> SELECT 5 AS a
```

One note on scoping: the issue links the 42.7.8 changelog entry `perf: enable server-prepared statements for DatabaseMetaData` (29bd7e80), but that one looks fine — I ran `getTables`/`getColumns`/`getPrimaryKeys`/`getIndexInfo` in a loop under `prepareThreshold=0` and no named statements appear, since those go through the normal execute path that already consults `isOneShotQuery`. The path that actually misbehaves is the `statement.getMetaData()` in the issue's repro steps, i.e. #3783's.

### The change

**This is not a revert of #3783.** Describing now consults `isOneShotQuery` — the same gate `PgStatement` already uses on its execute paths (`:497`, `:896`) — instead of deciding on its own, so #3783's win is kept everywhere it applied except where the user explicitly asked for no named statements.

I did first try the obvious thing, adding `QUERY_ONESHOT` back unconditionally to match `getParameterMetaData()`. That's a straight revert of #3783 and `BinaryTest.testGetMetaDataBeforeExecuteQuery` — the test #3783 added — catches it: it uses `setPrepareThreshold(-1)` and expects `BINARY_FORMAT`, and forcing binary transfers needs the named statement to negotiate the format, so the result came back as text (`BufferUnderflowException`). `isOneShotQuery` already returns false for `forceBinaryTransfers`, so routing through it keeps that test green and #3783's behaviour intact.

The named statement is still created by the execute ramp, so nothing is lost for the normal path:

```
#### named statement still created by the execute() ramp (threshold=3) ####
  after getMetaData(): (none)
  after execute #1: (none)
  after execute #2: S_1
  after execute #3: S_1
```

Worth a second opinion: `isOneShotQuery` calls `increaseExecuteCount()`, so a describe now counts as a use of the statement — with `prepareThreshold=3` the named statement appears on the 2nd execute rather than the 3rd (visible above). That moves caching slightly earlier rather than losing it, so it seemed acceptable, but happy to do it differently if you'd rather the describe not count.

### Tests

Two tests in `PreparedStatementTest`, next to the existing `testSelectPrepareThreshold0AutoCommitFalseFetchSizeNonZero` and reusing its `getNumberOfServerPreparedStatements` helper: one for `prepareThreshold=0`, one for the bypass at 5. Both fail on master with `expected: <0> but was: <1>` and pass with the change. `BinaryTest.testGetMetaDataBeforeExecuteQuery` passes before and after.

Ran `PreparedStatementTest`, `ResultSetTest`, `UpdateableResultTest`, `BatchExecuteTest`, `DatabaseMetaDataTest`, `ParameterMetaDataTest`, `GeneratedKeysTest`, `BinaryTest` and the jdbc4 metadata tests against PostgreSQL 17.10 — 720 tests, no failures. `./gradlew styleCheck` passes.

### Changes to Existing Features

* Does this break existing behaviour? `getMetaData()` stops server-preparing a statement the driver was told not to server-prepare. `forceBinaryTransfers` and `prepareThreshold > 0` keep #3783's behaviour; the describe now counts toward the threshold as noted above.
* Have you written new tests for your core changes, as applicable? Yes.
* Have you successfully run tests with your changes locally? Yes.

---

Written with AI assistance (Claude), as noted in the commit trailer. I've gone through the change and the protocol behaviour myself and can speak to it.