### PR TITLE
perf: cache statement describe results for getParameterMetaData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 Notable changes since version 42.0.0, read the complete [History of Changes](https://jdbc.postgresql.org/documentation/changelog.html).
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
+## [42.7.14] (2026-xx-xx)
+
+### Security
+### Added
+### Changed
+* chore: `PreparedStatement.getParameterMetaData()` no longer describes a statement that binds no parameters, as the server has nothing to resolve for one. Such a statement reports its empty parameter list without a network round trip, and no longer throws when the server would reject its SQL, since the describe that used to surface that error is gone [PR #4299](https://github.com/pgjdbc/pgjdbc/pull/4299)
+* chore: the `preparedStatementCacheSizeMiB` budget now counts the parameter type arrays a cached query retains instead of estimating an entry from the length of its SQL text alone. A query with many parameters is charged closer to what it actually holds, so such a query may now be evicted, or skipped by the cache entirely when it would take more than half of it [PR #4299](https://github.com/pgjdbc/pgjdbc/pull/4299)
+
+### Fixed
+* fix: `PreparedStatement.getParameterMetaData()` no longer fails with `prepared statement "S_1" does not exist` when the server-side statement was dropped without the driver noticing, which is what a connection pooler resetting the session between checkouts does. The driver re-parses and describes again instead [Issue #621](https://github.com/pgjdbc/pgjdbc/issues/621) [PR #4299](https://github.com/pgjdbc/pgjdbc/pull/4299)
+* perf: `PreparedStatement.getParameterMetaData()` no longer costs a `Describe` round trip on every call. The driver remembers up to four describe results per query and reuses one when the parameter types are compatible, which removes a round trip per row for frameworks that read parameter metadata while binding, such as Spring's `setNull` path. Changing a parameter type, DDL, and `SET search_path` all force a fresh describe, so a reused result never reports a type the server would resolve differently [Issue #621](https://github.com/pgjdbc/pgjdbc/issues/621) [PR #4299](https://github.com/pgjdbc/pgjdbc/pull/4299). Supersedes [PR #3429](https://github.com/pgjdbc/pgjdbc/pull/3429).
+
 ## [42.7.13] (2026-07-06)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 Notable changes since version 42.0.0, read the complete [History of Changes](https://jdbc.postgresql.org/documentation/changelog.html).
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
+## [42.7.14] (2026-xx-xx)
+
+### Security
+### Added
+### Changed
+* chore: `PreparedStatement.getParameterMetaData()` no longer describes a statement that binds no parameters, because there is nothing for the server to resolve. Such a statement reports its empty parameter list without a network round trip, and no longer throws when the server would reject its SQL, since the describe that used to surface that error is gone [PR #4299](https://github.com/pgjdbc/pgjdbc/pull/4299)
+* chore: the `preparedStatementCacheSizeMiB` budget now counts the parameter type arrays a cached query retains instead of estimating an entry from the length of its SQL text alone. A query with many parameters is charged closer to what it actually holds, so such a query may now be evicted, or skipped by the cache entirely when its retained size exceeds half the budget [PR #4299](https://github.com/pgjdbc/pgjdbc/pull/4299)
+
+### Fixed
+* fix: `PreparedStatement.getParameterMetaData()` no longer fails with `prepared statement "S_1" does not exist` when the server-side statement was dropped without the driver noticing, for instance when a connection pooler resets the session between checkouts. The driver re-parses and describes again instead [Issue #621](https://github.com/pgjdbc/pgjdbc/issues/621) [PR #4299](https://github.com/pgjdbc/pgjdbc/pull/4299)
+* perf: `PreparedStatement.getParameterMetaData()` no longer costs a `Describe` round trip on every call. The driver remembers up to four describe results per query and reuses one when the parameter types are compatible, which removes a round trip per row for frameworks that read parameter metadata while binding, such as Spring's `setNull` path. A parameter type change, DDL, and `SET search_path` all force a fresh describe, so a reused result never reports a type the server would resolve differently [Issue #621](https://github.com/pgjdbc/pgjdbc/issues/621) [PR #4299](https://github.com/pgjdbc/pgjdbc/pull/4299). Supersedes [PR #3429](https://github.com/pgjdbc/pgjdbc/pull/3429).
+
 ## [42.7.13] (2026-07-06)
 
 ### Added

--- a/pgjdbc/src/main/java/org/postgresql/core/CachedQuery.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/CachedQuery.java
@@ -61,6 +61,7 @@ public class CachedQuery implements CanEstimateSize {
       queryLength = ((CanEstimateSize) key).getSize();
     }
     return queryLength * 2 /* original query and native sql */
+        + query.getRetainedSizeExcludingSql()
         + 100L /* entry in hash map, CachedQuery wrapper, etc */;
   }
 

--- a/pgjdbc/src/main/java/org/postgresql/core/Query.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/Query.java
@@ -103,4 +103,18 @@ public interface Query {
    *         single-statement query.
    */
   Query @Nullable [] getSubqueries();
+
+  /**
+   * Estimates the number of bytes this query retains on top of its SQL text.
+   *
+   * <p>{@link CachedQuery#getSize()} derives the text estimate from the cache key, so an
+   * implementation must report only what it retains in addition: protocol state whose size follows
+   * the parameter count rather than the length of the text, such as the resolved parameter types.
+   * Reporting the text here would count it twice.</p>
+   *
+   * @return estimated retained bytes, excluding the SQL text
+   */
+  default long getRetainedSizeExcludingSql() {
+    return 0;
+  }
 }

--- a/pgjdbc/src/main/java/org/postgresql/core/QueryExecutor.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/QueryExecutor.java
@@ -222,6 +222,29 @@ public interface QueryExecutor extends TypeTransferModeRegistry {
   void fetch(ResultCursor cursor, ResultHandler handler, int fetchSize, boolean adaptiveFetch) throws SQLException;
 
   /**
+   * Attempts to resolve the parameter types of the given query from the results of previous
+   * "describe statement" requests, avoiding a network round trip.
+   *
+   * <p>On success, the unspecified types in {@code parameters} are updated to the server-resolved
+   * ones, exactly as an actual describe would update them. The cached results are reused only for
+   * a compatible set of parameter types: the server infers unspecified types from the specified
+   * ones, so a type change invalidates the resolution (see
+   * {@code SimpleQuery#getCachedDescribeResult(int[], short)}). Events after which the server may
+   * resolve the types differently, such as DDL or {@code SET search_path}, discard the cached
+   * results as well.</p>
+   *
+   * <p>A query that binds no parameters leaves the server nothing to resolve, so it succeeds
+   * without ever describing.</p>
+   *
+   * @param query a query created by this executor
+   * @param parameters parameters of the query, created by {@link Query#createParameterList()}
+   * @return true if all parameter types are known without a network round trip
+   */
+  default boolean tryResolveParameterTypes(Query query, ParameterList parameters) {
+    return false;
+  }
+
+  /**
    * Create an unparameterized Query object suitable for execution by this QueryExecutor. The
    * provided query string is not parsed for parameter placeholders ('?' characters), and the
    * {@link Query#createParameterList} of the returned object will always return an empty

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/CompositeQuery.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/CompositeQuery.java
@@ -112,6 +112,15 @@ class CompositeQuery implements Query {
   }
 
   @Override
+  public long getRetainedSizeExcludingSql() {
+    long size = 0;
+    for (SimpleQuery subquery : subqueries) {
+      size += subquery.getRetainedSizeExcludingSql();
+    }
+    return size;
+  }
+
+  @Override
   public @Nullable Map<String, Integer> getResultSetColumnNameIndexMap() {
     return null; // unsupported
   }

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/DescribeRequest.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/DescribeRequest.java
@@ -17,12 +17,18 @@ class DescribeRequest {
   public final SimpleParameterList parameterList;
   public final boolean describeOnly;
   public final @Nullable String statementName;
+  /**
+   * The parameter types sent in Parse. The response overwrites the parameter list with the types
+   * the server resolved, so the types that produced the response are kept here to key them with.
+   */
+  public final int[] requestedParameterTypes;
 
   DescribeRequest(SimpleQuery query, SimpleParameterList parameterList,
-      boolean describeOnly, @Nullable String statementName) {
+      boolean describeOnly, @Nullable String statementName, int[] requestedParameterTypes) {
     this.query = query;
     this.parameterList = parameterList;
     this.describeOnly = describeOnly;
     this.statementName = statementName;
+    this.requestedParameterTypes = requestedParameterTypes;
   }
 }

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/DescribeRequest.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/DescribeRequest.java
@@ -17,12 +17,19 @@ class DescribeRequest {
   public final SimpleParameterList parameterList;
   public final boolean describeOnly;
   public final @Nullable String statementName;
+  /**
+   * The parameter types sent in Parse. The response overwrites the parameter list with the
+   * server-resolved types, so this field keeps the types that produced the response: they key the
+   * cached describe result.
+   */
+  public final int[] requestedParameterTypes;
 
   DescribeRequest(SimpleQuery query, SimpleParameterList parameterList,
-      boolean describeOnly, @Nullable String statementName) {
+      boolean describeOnly, @Nullable String statementName, int[] requestedParameterTypes) {
     this.query = query;
     this.parameterList = parameterList;
     this.describeOnly = describeOnly;
     this.statementName = statementName;
+    this.requestedParameterTypes = requestedParameterTypes;
   }
 }

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -2027,7 +2027,8 @@ public class QueryExecutorImpl extends QueryExecutorBase {
     // Note: statement name can change over time for the same query object
     // Thus we take a snapshot of the query name
     pendingDescribeStatementQueue.add(
-        new DescribeRequest(query, params, describeOnly, query.getStatementName()));
+        new DescribeRequest(query, params, describeOnly, query.getStatementName(),
+            params.getTypeOIDs().clone()));
     pendingDescribePortalQueue.add(query);
     query.setStatementDescribed(true);
     query.setPortalDescribed(true);
@@ -2241,12 +2242,58 @@ public class QueryExecutorImpl extends QueryExecutorBase {
   }
 
   private static void resolveParameterTypes(SimpleQuery query, SimpleParameterList params) {
-    int[] queryOIDs = castNonNull(query.getPrepareTypes());
+    applyResolvedTypes(params, castNonNull(query.getPrepareTypes()));
+  }
+
+  private static void applyResolvedTypes(SimpleParameterList params, int[] resolvedTypes) {
     int[] paramOIDs = params.getTypeOIDs();
     for (int i = 0; i < paramOIDs.length; i++) {
       if (paramOIDs[i] == Oid.UNSPECIFIED) {
-        params.setResolvedType(i + 1, queryOIDs[i]);
+        params.setResolvedType(i + 1, resolvedTypes[i]);
       }
+    }
+  }
+
+  @Override
+  public boolean tryResolveParameterTypes(Query query, ParameterList parameters) {
+    if (parameters.getParameterCount() == 0) {
+      // There is no type for the server to resolve, so all of them are known already
+      return true;
+    }
+    try (ResourceLock ignore = lock.obtain()) {
+      Query[] subqueries = query.getSubqueries();
+      if (subqueries == null) {
+        SimpleQuery simpleQuery = (SimpleQuery) query;
+        int[] resolvedTypes =
+            simpleQuery.getCachedDescribeResult(((SimpleParameterList) parameters).getTypeOIDs(),
+                deallocateEpoch);
+        if (resolvedTypes == null) {
+          return false;
+        }
+        applyResolvedTypes((SimpleParameterList) parameters, resolvedTypes);
+        return true;
+      }
+
+      SimpleParameterList[] subparams = ((V3ParameterList) parameters).getSubparams();
+      // Resolve all subqueries before mutating any parameters, so a miss on a later
+      // subquery does not leave the parameters partially resolved
+      int[][] resolvedTypes = new int[subqueries.length][];
+      for (int i = 0; i < subqueries.length; i++) {
+        SimpleQuery subquery = (SimpleQuery) subqueries[i];
+        SimpleParameterList subparam =
+            subparams == null ? SimpleQuery.NO_PARAMETERS : subparams[i];
+        int[] resolved = subquery.getCachedDescribeResult(subparam.getTypeOIDs(), deallocateEpoch);
+        if (resolved == null) {
+          return false;
+        }
+        resolvedTypes[i] = resolved;
+      }
+      if (subparams != null) {
+        for (int i = 0; i < subqueries.length; i++) {
+          applyResolvedTypes(subparams[i], resolvedTypes[i]);
+        }
+      }
+      return true;
     }
   }
 
@@ -2420,10 +2467,10 @@ public class QueryExecutorImpl extends QueryExecutorBase {
           // sure the describe results we requested are still
           // applicable to the latest parsed query.
           //
-          if ((origStatementName == null && query.getStatementName() == null)
-              || (origStatementName != null
-                  && origStatementName.equals(query.getStatementName()))) {
+          if (Objects.equals(origStatementName, query.getStatementName())) {
             query.setPrepareTypes(params.getTypeOIDs());
+            query.addDescribeResult(describeData.requestedParameterTypes,
+                params.getTypeOIDs().clone(), deallocateEpoch);
           }
 
           if (describeOnly) {

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/SimpleQuery.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/SimpleQuery.java
@@ -19,6 +19,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.lang.ref.PhantomReference;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.BitSet;
 import java.util.Map;
 import java.util.logging.Level;
@@ -218,6 +219,147 @@ class SimpleQuery implements Query {
     return this.unspecifiedParams != null && !this.unspecifiedParams.isEmpty();
   }
 
+  /**
+   * Returns the server-resolved parameter types from a cached "describe statement" result that is
+   * compatible with the given parameter types, or {@code null} if no such result is cached and a
+   * network round trip is required.
+   *
+   * <p>A cached result is compatible when every given type either equals the resolved type, or is
+   * {@link Oid#UNSPECIFIED} and the describe request was sent with that position unspecified as
+   * well. The latter restriction matters: the server infers unspecified types from the specified
+   * ones (consider overloaded functions), so a result described with a type set at some position
+   * says nothing about describing with that position unset.</p>
+   *
+   * <p>A result is reused only while {@code deallocateEpoch} still equals the one the result was
+   * captured at. The epoch is bumped whenever the server may resolve the types differently, for
+   * instance after DDL or after {@code SET search_path}. Results captured at an older epoch are
+   * discarded.</p>
+   *
+   * <p>Callers must not modify the returned array.</p>
+   *
+   * @param paramTypes current parameter type OIDs, {@link Oid#UNSPECIFIED} for unset ones
+   * @param deallocateEpoch the connection's current deallocate epoch
+   * @return parameter type OIDs resolved by the server, or {@code null} on cache miss
+   */
+  int @Nullable [] getCachedDescribeResult(int[] paramTypes, short deallocateEpoch) {
+    @Nullable DescribeResult[] results = describeResults;
+    if (results == null) {
+      return null;
+    }
+    if (describeResultsEpoch != deallocateEpoch) {
+      this.describeResults = null;
+      return null;
+    }
+    for (int i = 0; i < results.length; i++) {
+      @Nullable DescribeResult result = results[i];
+      if (result == null) {
+        break;
+      }
+      if (result.matches(paramTypes)) {
+        // Keep the results in most-recently-used order, so alternating type patterns
+        // do not evict each other
+        System.arraycopy(results, 0, results, 1, i);
+        results[0] = result;
+        return result.resolvedTypes;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Caches the result of a "describe statement" round trip for {@link #getCachedDescribeResult}.
+   * A repeated describe with the same request types replaces the old result, so a re-describe
+   * (e.g. after DDL changed the inferred types) refreshes the cache. The least recently used
+   * result is evicted when the cache is full.
+   *
+   * <p>Unlike the server-prepared statement state, the cached results survive
+   * {@link #unprepare()}: they capture how the server resolves the types for this SQL text,
+   * not the state of a server-side statement.</p>
+   *
+   * <p>The results are stamped with the given {@code deallocateEpoch} and are discarded once it
+   * changes, which covers the events after which the server may resolve the types differently
+   * (DDL, {@code SET search_path}). The epoch also changes on {@code DEALLOCATE ALL}, which the
+   * results would survive; dropping them there merely costs one extra describe.</p>
+   *
+   * @param requestTypes parameter type OIDs sent in the Parse message, cloned by the caller
+   * @param resolvedTypes parameter type OIDs from the ParameterDescription response, cloned by
+   *                      the caller
+   * @param deallocateEpoch the connection's deallocate epoch the describe was answered at
+   */
+  void addDescribeResult(int[] requestTypes, int[] resolvedTypes, short deallocateEpoch) {
+    @Nullable DescribeResult[] results = describeResults;
+    if (results == null || describeResultsEpoch != deallocateEpoch) {
+      this.describeResults = results = new DescribeResult[MAX_CACHED_DESCRIBE_RESULTS];
+      this.describeResultsEpoch = deallocateEpoch;
+    }
+    int insertionPoint = results.length - 1;
+    for (int i = 0; i < results.length; i++) {
+      @Nullable DescribeResult result = results[i];
+      if (result == null || Arrays.equals(result.requestTypes, requestTypes)) {
+        insertionPoint = i;
+        break;
+      }
+    }
+    System.arraycopy(results, 0, results, 1, insertionPoint);
+    results[0] = new DescribeResult(requestTypes, resolvedTypes);
+  }
+
+  /**
+   * The result of a single "describe statement" request: the parameter types the driver sent in
+   * the Parse message, and the types the server resolved them to.
+   */
+  private static final class DescribeResult {
+    final int[] requestTypes;
+    final int[] resolvedTypes;
+
+    DescribeResult(int[] requestTypes, int[] resolvedTypes) {
+      this.requestTypes = requestTypes;
+      this.resolvedTypes = resolvedTypes;
+    }
+
+    boolean matches(int[] paramTypes) {
+      int[] resolvedTypes = this.resolvedTypes;
+      if (paramTypes.length != resolvedTypes.length) {
+        return false;
+      }
+      // Same compatibility rule as isPreparedFor: a set type must match the resolved type,
+      // and an unset type is compatible only when the describe request had it unset as well
+      for (int i = 0; i < paramTypes.length; i++) {
+        int paramType = paramTypes[i];
+        if (paramType != resolvedTypes[i]
+            && (paramType != Oid.UNSPECIFIED || requestTypes[i] != Oid.UNSPECIFIED)) {
+          return false;
+        }
+      }
+      return true;
+    }
+  }
+
+  /**
+   * Reports the parameter type arrays, whose size follows the parameter count rather than the
+   * length of the SQL text. A query with many parameters retains far more than its text suggests:
+   * the prepared types, plus two arrays per cached describe result.
+   */
+  @Override
+  public long getRetainedSizeExcludingSql() {
+    long size = 0;
+    int[] preparedTypes = this.preparedTypes;
+    if (preparedTypes != null) {
+      size += 4L * preparedTypes.length;
+    }
+    @Nullable DescribeResult[] results = describeResults;
+    if (results != null) {
+      for (@Nullable DescribeResult result : results) {
+        if (result == null) {
+          // The results are packed, so the first empty slot ends the used ones
+          break;
+        }
+        size += 4L * (result.requestTypes.length + result.resolvedTypes.length);
+      }
+    }
+    return size;
+  }
+
   byte @Nullable [] getEncodedStatementName() {
     return encodedStatementName;
   }
@@ -382,6 +524,25 @@ class SimpleQuery implements Query {
   private int @Nullable [] preparedTypes;
   private @Nullable BitSet unspecifiedParams;
   private short deallocateEpoch;
+
+  /**
+   * Maximum number of cached "describe statement" results per query. Real workloads use one or
+   * two type patterns per SQL text (no types set, plus the application's usual typed pattern),
+   * so a few slots avoid cache thrashing without a per-connection memory cost worth accounting.
+   */
+  private static final int MAX_CACHED_DESCRIBE_RESULTS = 4;
+
+  /**
+   * Cached "describe statement" results in most-recently-used order, lazily allocated,
+   * {@code null}-padded at the tail. See {@link #getCachedDescribeResult(int[], short)}.
+   */
+  private @Nullable DescribeResult @Nullable [] describeResults;
+
+  /**
+   * The {@code deallocateEpoch} the cached {@link #describeResults} were captured at. All the
+   * cached results share it, since a bump discards them all at once.
+   */
+  private short describeResultsEpoch;
 
   private @Nullable Integer cachedMaxResultRowSize;
 

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
@@ -1798,14 +1798,33 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
 
   @Override
   public ParameterMetaData getParameterMetaData() throws SQLException {
-    int flags = QueryExecutor.QUERY_ONESHOT | QueryExecutor.QUERY_DESCRIBE_ONLY
-        | QueryExecutor.QUERY_SUPPRESS_BEGIN;
-    ResultHandler handler = new DiscardResultHandler();
-    connection.getQueryExecutor().execute(preparedQuery.query, preparedParameters, handler, 0, 0,
-        flags);
+    QueryExecutor queryExecutor = connection.getQueryExecutor();
+    // Describe the statement on the server only when a previous describe with a compatible
+    // set of parameter types is not cached yet
+    if (!queryExecutor.tryResolveParameterTypes(preparedQuery.query, preparedParameters)) {
+      try {
+        describeParameters(queryExecutor);
+      } catch (SQLException e) {
+        // The describe names a server-side statement that may be gone without the driver having
+        // noticed, for instance when a connection pooler resets the session. Describing has no
+        // side effects, so drop the statement and ask again rather than fail the caller
+        if (!queryExecutor.willHealOnRetry(e)) {
+          throw e;
+        }
+        preparedQuery.query.close();
+        describeParameters(queryExecutor);
+      }
+    }
 
     int[] oids = preparedParameters.getTypeOIDs();
     return createParameterMetaData(connection, oids);
+  }
+
+  private void describeParameters(QueryExecutor queryExecutor) throws SQLException {
+    int flags = QueryExecutor.QUERY_ONESHOT | QueryExecutor.QUERY_DESCRIBE_ONLY
+        | QueryExecutor.QUERY_SUPPRESS_BEGIN;
+    ResultHandler handler = new DiscardResultHandler();
+    queryExecutor.execute(preparedQuery.query, preparedParameters, handler, 0, 0, flags);
   }
 
   @Override

--- a/pgjdbc/src/test/java/org/postgresql/core/v3/SimpleQueryDescribeCacheTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/core/v3/SimpleQueryDescribeCacheTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.core.v3;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.postgresql.core.NativeQuery;
+import org.postgresql.core.Oid;
+import org.postgresql.core.SqlCommand;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers the arity guard of the describe result cache. A {@code SimpleQuery} binds a fixed number
+ * of parameters, so JDBC callers cannot reach a lookup of a different length. The guard still earns
+ * its place: without it a shorter request would match on a prefix and resolve to types that belong
+ * to another parameter, and a longer one would read past the cached array.
+ */
+class SimpleQueryDescribeCacheTest {
+  private static final short EPOCH = 0;
+
+  private static SimpleQuery newQuery() {
+    return new SimpleQuery(
+        new NativeQuery("SELECT $1, $2", new int[]{7, 11}, false, SqlCommand.BLANK), null, false);
+  }
+
+  private static SimpleQuery queryDescribedForTwoParameters() {
+    SimpleQuery query = newQuery();
+    query.addDescribeResult(new int[]{Oid.UNSPECIFIED, Oid.UNSPECIFIED},
+        new int[]{Oid.INT4, Oid.TEXT}, EPOCH);
+    return query;
+  }
+
+  @Test
+  void resultIsReusedForTheSameParameterCount() {
+    SimpleQuery query = queryDescribedForTwoParameters();
+
+    assertArrayEquals(new int[]{Oid.INT4, Oid.TEXT},
+        query.getCachedDescribeResult(new int[]{Oid.UNSPECIFIED, Oid.UNSPECIFIED}, EPOCH),
+        "the describe result resolves the types it was captured for");
+  }
+
+  @Test
+  void resultIsNotReusedForFewerParameters() {
+    SimpleQuery query = queryDescribedForTwoParameters();
+
+    assertNull(query.getCachedDescribeResult(new int[]{Oid.UNSPECIFIED}, EPOCH),
+        "a result described for two parameters must not resolve one parameter from its prefix");
+  }
+
+  @Test
+  void resultIsNotReusedForMoreParameters() {
+    SimpleQuery query = queryDescribedForTwoParameters();
+
+    assertNull(
+        query.getCachedDescribeResult(
+            new int[]{Oid.UNSPECIFIED, Oid.UNSPECIFIED, Oid.UNSPECIFIED}, EPOCH),
+        "a result described for two parameters must not be read past its end");
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/core/v3/SimpleQueryRetainedSizeTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/core/v3/SimpleQueryRetainedSizeTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.core.v3;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.postgresql.core.CachedQuery;
+import org.postgresql.core.NativeQuery;
+import org.postgresql.core.Oid;
+import org.postgresql.core.SqlCommand;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+/**
+ * The statement cache budgets memory in bytes, so a query must report the parameter type arrays it
+ * retains. They follow the parameter count, which the SQL text alone does not reveal.
+ */
+class SimpleQueryRetainedSizeTest {
+  private static final int PARAMS = 1000;
+
+  private static SimpleQuery newQuery() {
+    int[] bindPositions = new int[PARAMS];
+    return new SimpleQuery(
+        new NativeQuery("SELECT 1", bindPositions, false, SqlCommand.BLANK), null, false);
+  }
+
+  private static int[] types(int oid) {
+    int[] types = new int[PARAMS];
+    Arrays.fill(types, oid);
+    return types;
+  }
+
+  @Test
+  void freshQueryRetainsNothingBeyondSql() {
+    assertEquals(0, newQuery().getRetainedSizeExcludingSql(),
+        "a query that was never described retains no parameter type arrays");
+  }
+
+  @Test
+  void describeResultsAreReported() {
+    SimpleQuery query = newQuery();
+    query.addDescribeResult(types(Oid.UNSPECIFIED), types(Oid.INT4), (short) 0);
+
+    assertEquals(2 * 4L * PARAMS, query.getRetainedSizeExcludingSql(),
+        "one describe result retains the request and the resolved types");
+  }
+
+  @Test
+  void everyCachedResultIsReported() {
+    SimpleQuery query = newQuery();
+    // Distinct request types, so the results do not replace each other
+    query.addDescribeResult(types(Oid.UNSPECIFIED), types(Oid.INT4), (short) 0);
+    query.addDescribeResult(types(Oid.INT4), types(Oid.INT4), (short) 0);
+
+    assertEquals(4 * 4L * PARAMS, query.getRetainedSizeExcludingSql(),
+        "both cached results are accounted for");
+  }
+
+  @Test
+  void cachedQuerySizeGrowsWithDescribeResults() {
+    SimpleQuery query = newQuery();
+    CachedQuery cachedQuery = new CachedQuery("SELECT 1", query, false);
+    long before = cachedQuery.getSize();
+
+    query.addDescribeResult(types(Oid.UNSPECIFIED), types(Oid.INT4), (short) 0);
+
+    assertEquals(before + 2 * 4L * PARAMS, cachedQuery.getSize(),
+        "the cache budget sees the describe result, not just the SQL text");
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc3/ParameterMetaDataRoundtripTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc3/ParameterMetaDataRoundtripTest.java
@@ -1,0 +1,388 @@
+/*
+ * Copyright (c) 2026, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.test.jdbc3;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import org.postgresql.PGProperty;
+import org.postgresql.PGStatement;
+import org.postgresql.core.BaseConnection;
+import org.postgresql.jdbc.PreferQueryMode;
+import org.postgresql.test.TestUtil;
+import org.postgresql.test.jdbc2.BaseTest4;
+import org.postgresql.test.util.CountingSocketFactory;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.sql.ParameterMetaData;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Types;
+import java.util.Arrays;
+import java.util.Properties;
+
+/**
+ * Tests that {@link PreparedStatement#getParameterMetaData()} reuses the cached results of
+ * previous "describe statement" requests instead of a network round trip per call, and that the
+ * cache is invalidated when the resolution can change: a different set of parameter types, DDL,
+ * or a new search_path.
+ *
+ * @see <a href="https://github.com/pgjdbc/pgjdbc/issues/621">Issue #621</a>
+ */
+@ParameterizedClass
+@MethodSource("data")
+public class ParameterMetaDataRoundtripTest extends BaseTest4 {
+  private final CountingSocketFactory.Counters socketCounters = CountingSocketFactory.register();
+  private final int prepareThreshold;
+
+  public ParameterMetaDataRoundtripTest(int prepareThreshold) {
+    this.prepareThreshold = prepareThreshold;
+  }
+
+  public static Iterable<Object[]> data() {
+    return Arrays.asList(new Object[][]{{0}, {5}});
+  }
+
+  @Override
+  protected void updateProperties(Properties props) {
+    super.updateProperties(props);
+    PGProperty.PREPARE_THRESHOLD.set(props, prepareThreshold);
+    PGProperty.SOCKET_FACTORY.set(props, CountingSocketFactory.class.getName());
+    PGProperty.SOCKET_FACTORY_ARG.set(props, socketCounters.key());
+  }
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    assumeTrue(preferQueryMode != PreferQueryMode.SIMPLE,
+        "simple protocol only does not support describe statement requests");
+  }
+
+  @Override
+  protected void tearDown() throws SQLException {
+    try {
+      super.tearDown();
+    } finally {
+      CountingSocketFactory.unregister(socketCounters);
+    }
+  }
+
+  private interface SqlAction {
+    void run() throws SQLException;
+  }
+
+  private void assertRoundtrips(long expected, String message, SqlAction action)
+      throws SQLException {
+    long before = socketCounters.roundtrips.get();
+    action.run();
+    assertEquals(expected, socketCounters.roundtrips.get() - before, message);
+  }
+
+  @Test
+  void repeatedGetParameterMetaDataDescribesOnce() throws SQLException {
+    try (PreparedStatement ps = con.prepareStatement("SELECT ?::int4, ?::text")) {
+      assertRoundtrips(1, "the first getParameterMetaData() should describe the statement", () -> {
+        ParameterMetaData pmd = ps.getParameterMetaData();
+        assertEquals(Types.INTEGER, pmd.getParameterType(1));
+        assertEquals(Types.VARCHAR, pmd.getParameterType(2));
+      });
+      assertRoundtrips(0, "the second getParameterMetaData() should reuse the cached describe result", () -> {
+        ParameterMetaData pmd = ps.getParameterMetaData();
+        assertEquals(Types.INTEGER, pmd.getParameterType(1));
+        assertEquals(Types.VARCHAR, pmd.getParameterType(2));
+      });
+    }
+  }
+
+  @Test
+  void newStatementWithSameSqlUsesCachedDescribe() throws SQLException {
+    String sql = "SELECT ?::int4 + ?::int4";
+    try (PreparedStatement ps = con.prepareStatement(sql)) {
+      assertRoundtrips(1, "the first getParameterMetaData() should describe the statement",
+          () -> ps.getParameterMetaData());
+    }
+    try (PreparedStatement ps = con.prepareStatement(sql)) {
+      assertRoundtrips(0, "the describe result should be cached in the connection query cache,"
+          + " so a new PreparedStatement with the same SQL should reuse it", () -> {
+            ParameterMetaData pmd = ps.getParameterMetaData();
+            assertEquals(Types.INTEGER, pmd.getParameterType(1));
+            assertEquals(Types.INTEGER, pmd.getParameterType(2));
+          });
+    }
+  }
+
+  @Test
+  void changedParameterTypeIsDescribedAgain() throws SQLException {
+    try (PreparedStatement ps = con.prepareStatement("SELECT ?::timestamp")) {
+      assertRoundtrips(1, "an unset parameter type requires a describe",
+          () -> assertEquals("timestamp", ps.getParameterMetaData().getParameterTypeName(1)));
+      ps.setNull(1, Types.DATE);
+      assertRoundtrips(1, "a parameter type change should invalidate the cached describe result",
+          () -> assertEquals("date", ps.getParameterMetaData().getParameterTypeName(1)));
+      ps.clearParameters();
+      assertRoundtrips(0, "the describe result for unset parameter types should still be cached",
+          () -> assertEquals("timestamp", ps.getParameterMetaData().getParameterTypeName(1)));
+      ps.setNull(1, Types.DATE);
+      assertRoundtrips(0, "the describe result for the date parameter should still be cached",
+          () -> assertEquals("date", ps.getParameterMetaData().getParameterTypeName(1)));
+    }
+  }
+
+  @Test
+  void ambiguousTypesAreNotResolvedFromCache() throws SQLException {
+    try (Statement st = con.createStatement()) {
+      st.execute("CREATE OR REPLACE FUNCTION pmd_ambiguous(int4, int4)"
+          + " RETURNS int4 LANGUAGE sql AS 'SELECT $1'");
+      st.execute("CREATE OR REPLACE FUNCTION pmd_ambiguous(text, text)"
+          + " RETURNS text LANGUAGE sql AS 'SELECT $1'");
+    }
+    try (PreparedStatement ps = con.prepareStatement("SELECT pmd_ambiguous(?, ?)")) {
+      ps.setInt(1, 42);
+      assertRoundtrips(1, "the type of the set parameter drives the resolution of the unset one",
+          () -> assertEquals("int4", ps.getParameterMetaData().getParameterTypeName(2)));
+      assertRoundtrips(0, "the describe result for the int variant should be cached",
+          () -> assertEquals("int4", ps.getParameterMetaData().getParameterTypeName(2)));
+
+      ps.clearParameters();
+      ps.setString(1, "42");
+      assertRoundtrips(1, "a different type of the set parameter changes the resolution,"
+          + " so the driver should describe the statement again",
+          () -> assertEquals("text", ps.getParameterMetaData().getParameterTypeName(2)));
+
+      ps.clearParameters();
+      ps.setInt(1, 42);
+      assertRoundtrips(0, "the describe result for the int variant should still be cached",
+          () -> assertEquals("int4", ps.getParameterMetaData().getParameterTypeName(2)));
+
+      // A result described with the first parameter type set says nothing about describing
+      // with it unset, so the driver must ask the server again. The server resolves unknown
+      // arguments with a preference for the string category, hence the text variant
+      ps.clearParameters();
+      assertRoundtrips(1, "unset parameter types should not be resolved from results described"
+          + " with a parameter type set",
+          () -> assertEquals("text", ps.getParameterMetaData().getParameterTypeName(2)));
+    } finally {
+      try (Statement st = con.createStatement()) {
+        st.execute("DROP FUNCTION IF EXISTS pmd_ambiguous(int4, int4)");
+        st.execute("DROP FUNCTION IF EXISTS pmd_ambiguous(text, text)");
+      }
+    }
+  }
+
+  @Test
+  void ambiguityErrorIsNotMaskedByCache() throws SQLException {
+    try (Statement st = con.createStatement()) {
+      st.execute("CREATE OR REPLACE FUNCTION pmd_ambiguous_num(int4, int4)"
+          + " RETURNS int4 LANGUAGE sql AS 'SELECT $1'");
+      st.execute("CREATE OR REPLACE FUNCTION pmd_ambiguous_num(int8, int8)"
+          + " RETURNS int8 LANGUAGE sql AS 'SELECT $1'");
+    }
+    try (PreparedStatement ps = con.prepareStatement("SELECT pmd_ambiguous_num(?, ?)")) {
+      ps.setInt(1, 42);
+      assertRoundtrips(1, "the type of the set parameter drives the resolution of the unset one",
+          () -> assertEquals("int4", ps.getParameterMetaData().getParameterTypeName(2)));
+
+      // With no types set neither variant wins, so the driver must ask the server,
+      // and the cache must not mask the ambiguity error
+      ps.clearParameters();
+      SQLException e = assertThrows(SQLException.class, ps::getParameterMetaData,
+          "with no parameter types set the function call is ambiguous");
+      assertEquals("42725", e.getSQLState(), "expecting ERRCODE_AMBIGUOUS_FUNCTION");
+    } finally {
+      try (Statement st = con.createStatement()) {
+        st.execute("DROP FUNCTION IF EXISTS pmd_ambiguous_num(int4, int4)");
+        st.execute("DROP FUNCTION IF EXISTS pmd_ambiguous_num(int8, int8)");
+      }
+    }
+  }
+
+  @Test
+  void deallocateAllKeepsParameterTypesCorrect() throws SQLException {
+    try (PreparedStatement ps = con.prepareStatement("SELECT ?::int4")) {
+      assertRoundtrips(1, "the first getParameterMetaData() should describe the statement",
+          () -> ps.getParameterMetaData());
+      try (Statement st = con.createStatement()) {
+        st.execute("DEALLOCATE ALL");
+      }
+      // The describe results share the invalidation epoch with the server-side statements, so
+      // DEALLOCATE ALL drops them as well. That costs one extra describe, and the types stay right
+      assertEquals(Types.INTEGER, ps.getParameterMetaData().getParameterType(1));
+    }
+  }
+
+  @Test
+  void describeSurvivesUnnoticedDeallocateAll() throws SQLException {
+    BaseConnection baseConnection = con.unwrap(BaseConnection.class);
+    // Stop the driver from noticing the DEALLOCATE ALL, which is how a server-side statement
+    // disappears when something other than the driver resets the session, a connection pooler
+    // for instance. The driver then still believes its named statement is on the server
+    baseConnection.setFlushCacheOnDeallocate(false);
+    try (PreparedStatement ps = con.prepareStatement("SELECT ?::int4")) {
+      ((PGStatement) ps).setPrepareThreshold(1);
+      ps.setInt(1, 42);
+      // Executing prepares the statement on the server under a name, without describing it
+      ps.executeQuery().close();
+
+      try (Statement st = con.createStatement()) {
+        st.execute("DEALLOCATE ALL");
+      }
+
+      // The describe would target the name the server no longer knows, so the driver has to
+      // re-parse and describe again rather than surface "prepared statement does not exist"
+      assertEquals(Types.INTEGER,
+          assertDoesNotThrow(() -> ps.getParameterMetaData().getParameterType(1),
+              "getParameterMetaData() should not fail once the server-side statement is gone"));
+    } finally {
+      baseConnection.setFlushCacheOnDeallocate(true);
+    }
+  }
+
+  @Test
+  void ddlChangeIsDescribedAgain() throws SQLException {
+    TestUtil.createTempTable(con, "pmd_ddl", "id int4, name varchar(100)");
+    try (PreparedStatement ps =
+        con.prepareStatement("INSERT INTO pmd_ddl(id, name) VALUES (?, ?)")) {
+      assertRoundtrips(1, "the first getParameterMetaData() should describe the statement",
+          () -> assertEquals("int4", ps.getParameterMetaData().getParameterTypeName(1)));
+      assertRoundtrips(0, "the describe result should be cached",
+          () -> assertEquals("int4", ps.getParameterMetaData().getParameterTypeName(1)));
+
+      try (Statement st = con.createStatement()) {
+        st.execute("ALTER TABLE pmd_ddl ALTER COLUMN id TYPE varchar(10)");
+      }
+
+      // A describe stores the resolved types in the parameter list, and the next describe would
+      // then request them explicitly, so ask for the types of unset parameters again
+      ps.clearParameters();
+      // The column now drives a different parameter type. The driver re-prepares statements after
+      // DDL, so the describe results follow the same rule and the caller sees the current type
+      // rather than the one resolved before the ALTER
+      assertRoundtrips(1, "DDL changes how the server resolves the parameter, so the driver"
+          + " should describe the statement again",
+          () -> assertEquals("varchar", ps.getParameterMetaData().getParameterTypeName(1)));
+      assertRoundtrips(0, "the describe result for the altered column should be cached",
+          () -> assertEquals("varchar", ps.getParameterMetaData().getParameterTypeName(1)));
+    }
+  }
+
+  @Test
+  void searchPathChangeIsDescribedAgain() throws SQLException {
+    try (Statement st = con.createStatement()) {
+      // CREATE SCHEMA learnt IF NOT EXISTS in 9.3, so drop leftovers from an interrupted run
+      // instead, which keeps the test runnable against the oldest server we support
+      st.execute("DROP SCHEMA IF EXISTS pmd_sp_int CASCADE");
+      st.execute("DROP SCHEMA IF EXISTS pmd_sp_text CASCADE");
+      st.execute("CREATE SCHEMA pmd_sp_int");
+      st.execute("CREATE SCHEMA pmd_sp_text");
+      st.execute("CREATE OR REPLACE FUNCTION pmd_sp_int.pmd_sp(int4)"
+          + " RETURNS int4 LANGUAGE sql AS 'SELECT $1'");
+      st.execute("CREATE OR REPLACE FUNCTION pmd_sp_text.pmd_sp(text)"
+          + " RETURNS text LANGUAGE sql AS 'SELECT $1'");
+      st.execute("SET search_path TO pmd_sp_int");
+    }
+    try (PreparedStatement ps = con.prepareStatement("SELECT pmd_sp(?)")) {
+      assertRoundtrips(1, "the first getParameterMetaData() should describe the statement",
+          () -> assertEquals("int4", ps.getParameterMetaData().getParameterTypeName(1)));
+      try (Statement st = con.createStatement()) {
+        st.execute("SET search_path TO pmd_sp_text");
+      }
+      // A describe stores the resolved types in the parameter list, and the next describe would
+      // then request them explicitly, so ask for the types of unset parameters again
+      ps.clearParameters();
+      assertRoundtrips(1, "the new search_path resolves pmd_sp to a function with a different"
+          + " parameter type, so the driver should describe the statement again",
+          () -> assertEquals("text", ps.getParameterMetaData().getParameterTypeName(1)));
+      assertRoundtrips(0, "the describe result for the new search_path should be cached",
+          () -> assertEquals("text", ps.getParameterMetaData().getParameterTypeName(1)));
+    } finally {
+      try (Statement st = con.createStatement()) {
+        st.execute("RESET search_path");
+        st.execute("DROP SCHEMA IF EXISTS pmd_sp_int CASCADE");
+        st.execute("DROP SCHEMA IF EXISTS pmd_sp_text CASCADE");
+      }
+    }
+  }
+
+  @Test
+  void setNullBatchDescribesOnce() throws SQLException {
+    TestUtil.createTempTable(con, "pmd_batch", "a int4, b varchar(50)");
+    try (PreparedStatement ps = con.prepareStatement("INSERT INTO pmd_batch(a, b) VALUES (?, ?)")) {
+      assertRoundtrips(1, "querying parameter types for setNull should describe the statement"
+          + " once per batch, not once per row", () -> {
+            for (int i = 0; i < 10; i++) {
+              ParameterMetaData pmd = ps.getParameterMetaData();
+              ps.setNull(1, pmd.getParameterType(1));
+              ps.setNull(2, pmd.getParameterType(2));
+              ps.addBatch();
+            }
+          });
+      ps.executeBatch();
+    }
+  }
+
+  @Test
+  void setNullBatchWithSetParameterDescribesOnce() throws SQLException {
+    TestUtil.createTempTable(con, "pmd_wide",
+        "c1 int4, c2 varchar(50), c3 int8, c4 int2, c5 float4,"
+            + " c6 float8, c7 numeric, c8 date, c9 timestamp, c10 varchar(10)");
+    String sql = "INSERT INTO pmd_wide VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+    try (PreparedStatement ps = con.prepareStatement(sql)) {
+      // The first row describes with the key parameter set and the rest unset. Every following row
+      // asks with the types of the previous setNull calls, which are the ones the server resolved,
+      // so the describe result stays compatible
+      assertRoundtrips(1, "a batch that queries the parameter types of every row should describe"
+          + " the statement once, not once per row", () -> {
+            for (int row = 0; row < 10; row++) {
+              ps.setInt(1, row);
+              ParameterMetaData pmd = ps.getParameterMetaData();
+              for (int column = 2; column <= 10; column++) {
+                ps.setNull(column, pmd.getParameterType(column));
+              }
+              ps.addBatch();
+            }
+          });
+      ps.executeBatch();
+      assertEquals("10", TestUtil.queryForString(con, "SELECT count(*) FROM pmd_wide"),
+          "the batch should insert one row per iteration");
+    }
+  }
+
+  @Test
+  void zeroParameterQueryIsNotDescribed() throws SQLException {
+    try (PreparedStatement ps = con.prepareStatement("SELECT 1")) {
+      assertRoundtrips(0, "a query that binds no parameters leaves the server nothing to resolve,"
+          + " so it should not be described at all",
+          () -> assertEquals(0, ps.getParameterMetaData().getParameterCount()));
+      assertRoundtrips(0, "and it stays that way on a second call",
+          () -> assertEquals(0, ps.getParameterMetaData().getParameterCount()));
+    }
+  }
+
+  @Test
+  void multiStatementQueryUsesCachedDescribe() throws SQLException {
+    // Bounded result types keep the flushIfDeadlockRisk estimation below the forced-Sync
+    // threshold, so every describe of this statement is a single round trip
+    try (PreparedStatement ps = con.prepareStatement("SELECT ?::int4; SELECT ?::int8")) {
+      assertRoundtrips(1, "the first getParameterMetaData() should describe both statements", () -> {
+        ParameterMetaData pmd = ps.getParameterMetaData();
+        assertEquals(2, pmd.getParameterCount());
+        assertEquals(Types.INTEGER, pmd.getParameterType(1));
+        assertEquals(Types.BIGINT, pmd.getParameterType(2));
+      });
+      assertRoundtrips(0, "the second getParameterMetaData() should reuse the cached describe results",
+          () -> assertEquals(Types.INTEGER, ps.getParameterMetaData().getParameterType(1)));
+      ps.setNull(1, Types.BIGINT);
+      assertRoundtrips(1, "a type change in one subquery should describe the whole statement again",
+          () -> assertEquals(Types.BIGINT, ps.getParameterMetaData().getParameterType(1)));
+    }
+  }
+}


### PR DESCRIPTION
## Why

`PgPreparedStatement.getParameterMetaData()` issues a `Describe(statement)` round trip on every call. Frameworks that consult parameter metadata per row (for example, Spring's `setNull` path) pay one network round trip per parameter set, and that dominates batch insert time on high-latency links.

Closes #621. Supersedes #3429.

## What

`SimpleQuery` now caches up to four describe results as pairs of (types sent in `Parse`, types resolved by the server) in most-recently-used order. `getParameterMetaData()` asks the new `QueryExecutor.tryResolveParameterTypes` first and describes only on a cache miss.

A cached result is reused only for a compatible set of parameter types: a set type must equal the resolved type, and an unset type is compatible only when the describe request had it unset as well. The server infers unspecified types from the specified ones (consider overloaded functions), so a type change forces a re-describe, and an ambiguity error is never masked by the cache.

The results live on `SimpleQuery`, so they are shared across `PreparedStatement` instances through the connection query cache and are evicted together with the query. They survive `unprepare()`: they capture how the server resolves types for the SQL text, not the state of a server-side statement.

Each result is stamped with the `deallocateEpoch` it was captured at, and a mismatch is a cache miss. Events after which the server may resolve the types differently discard the cached results: DDL and `SET search_path` both bump that epoch. Reusing the counter is conservative, since it also flushes the results on `DEALLOCATE ALL`, which costs one extra describe. That beats a second invalidation counter that a future epoch bump could forget to update.

The execute path is unchanged, and the describe stays `QUERY_ONESHOT`, so `prepareThreshold` semantics are not affected.

## Note: memory consumption for cached queries with a large number of parameters

The cached results are the memory this change trades for the round trips, and they grow with the parameter count rather than with the length of the SQL text. At 10,000 parameters, each array of type OIDs is 40 KB, so four cached results retain 320 KB per query, on top of the 40 KB `preparedTypes` already held.

That memory was invisible to the `preparedStatementCacheSizeMiB` budget: `CachedQuery.getSize()` estimated an entry from the length of its SQL text alone (`queryLength * 2 + 100`) and never asked the `Query`. The estimate was already off for `preparedTypes` before this change; the describe results would have made it off by roughly 9×.

So `Query` gains `getRetainedSizeExcludingSql()`, which an implementation overrides to report what it retains on top of the text. `CachedQuery` keeps estimating the text from the cache key, so reporting the text there again would count it twice. `SimpleQuery` reports the prepared types plus the cached describe results, `CompositeQuery` sums its subqueries, and the default returns 0, so any other `Query` implementation keeps compiling and behaves as before.

Two points worth a reviewer's attention:

- **The accounting does not drift, even though the estimate is now dynamic.** `LruCache` tracks `currentSize` by hand, but `borrow` removes the entry from the map and subtracts the current estimate, and `put` adds the current estimate back. The size can only change while the query is borrowed, hence out of the map, so the two always agree.
- **A behavior change follows from the honest estimate.** `LruCache.put` refuses to cache an entry larger than half the cache, so a query with enough parameters is now dropped on release instead of cached. With the 5 MiB default the margin is wide (~360 KB at 10,000 parameters), but the byte budget can now actually bite where it silently could not before.

## How to verify

`ParameterMetaDataRoundtripTest` (new) counts describe round trips and covers cache hits, type-change misses, epoch invalidation after DDL and `SET search_path`, and behavior across `unprepare()`. `SimpleQueryRetainedSizeTest` (new) covers the size accounting, including that `CachedQuery.getSize()` grows once a describe result is cached.

```sh
./gradlew :postgresql:test --tests '*ParameterMetaDataRoundtripTest*' --tests '*SimpleQueryRetainedSizeTest*'
```
