### PR TITLE
fixed microseceond time correction when using OffsetTime

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/TimestampUtils.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/TimestampUtils.java
@@ -1114,7 +1114,7 @@ public class TimestampUtils {
       if (nanosExceed499(nano)) {
         // Technically speaking this is not a proper rounding, however
         // it relies on the fact that appendTime just truncates 000..999 nanosecond part
-        offsetTime = offsetTime.plus(ONE_MICROSECOND);
+        localTime = localTime.plus(ONE_MICROSECOND);
       }
       appendTime(sbuf, localTime);
       appendTimeZone(sbuf, offsetTime.getOffset());


### PR DESCRIPTION
Fixes #4303

The microsecond for rounding an OffsetTime from nano to micro is currently added to the offsetTime, but the time is printed into the statement by using the localTime variable that has been converted before this microsecond modification. So the last three digets of the nano seconds are cut off not rounded as in all the other conversions.
