### PR TITLE
fix: allow LargeObjectManager operations inside an active XA transaction (#4309)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 Notable changes since version 42.0.0, read the complete [History of Changes](https://jdbc.postgresql.org/documentation/changelog.html).
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
+## [Unreleased]
+
+### Fixed
+* fix: `LargeObjectManager` operations now work inside an active XA transaction. Since 42.7.13 an XA branch keeps the caller's `autoCommit=true`, and the guard rejected large objects as if the connection were idle. It now checks the server transaction state (`getTransactionState()`) instead of `autoCommit`, so a genuine auto-commit connection with no open transaction is still refused [Issue #4309](https://github.com/pgjdbc/pgjdbc/issues/4309) [PR #4310](https://github.com/pgjdbc/pgjdbc/pull/4310)
+
 ## [42.7.13] (2026-07-06)
 
 ### Added

--- a/pgjdbc/src/main/java/org/postgresql/largeobject/LargeObjectManager.java
+++ b/pgjdbc/src/main/java/org/postgresql/largeobject/LargeObjectManager.java
@@ -6,6 +6,7 @@
 package org.postgresql.largeobject;
 
 import org.postgresql.core.BaseConnection;
+import org.postgresql.core.TransactionState;
 import org.postgresql.fastpath.Fastpath;
 import org.postgresql.fastpath.FastpathArg;
 import org.postgresql.util.GT;
@@ -135,6 +136,24 @@ public class LargeObjectManager {
   }
 
   /**
+   * Large objects can only be manipulated inside a transaction, because the lo_* fastpath calls
+   * return handles that are scoped to the surrounding transaction. Normally that transaction is
+   * signalled by {@code autoCommit=false}, but an XA branch keeps {@code autoCommit=true} while a
+   * server-side transaction is open (see
+   * <a href="https://github.com/pgjdbc/pgjdbc/issues/4309">issue #4309</a>). So we refuse only when
+   * we are genuinely in auto-commit mode with no transaction open; when a transaction is already
+   * running we proceed regardless of the JDBC {@code autoCommit} flag.
+   *
+   * @throws SQLException if there is no transaction the large object could take part in
+   */
+  private void requireTransaction() throws SQLException {
+    if (conn.getAutoCommit() && conn.getTransactionState() == TransactionState.IDLE) {
+      throw new PSQLException(GT.tr("Large Objects may not be used in auto-commit mode."),
+          PSQLState.NO_ACTIVE_SQL_TRANSACTION);
+    }
+  }
+
+  /**
    * This opens an existing large object, based on its OID. This method assumes that READ and WRITE
    * access is required (the default).
    *
@@ -240,10 +259,7 @@ public class LargeObjectManager {
    * @throws SQLException on error
    */
   public LargeObject open(long oid, int mode, boolean commitOnClose) throws SQLException {
-    if (conn.getAutoCommit()) {
-      throw new PSQLException(GT.tr("Large Objects may not be used in auto-commit mode."),
-          PSQLState.NO_ACTIVE_SQL_TRANSACTION);
-    }
+    requireTransaction();
     return new LargeObject(fp, oid, mode, conn, commitOnClose);
   }
 
@@ -281,10 +297,7 @@ public class LargeObjectManager {
    * @throws SQLException on error
    */
   public long createLO(int mode) throws SQLException {
-    if (conn.getAutoCommit()) {
-      throw new PSQLException(GT.tr("Large Objects may not be used in auto-commit mode."),
-          PSQLState.NO_ACTIVE_SQL_TRANSACTION);
-    }
+    requireTransaction();
     FastpathArg[] args = new FastpathArg[1];
     args[0] = new FastpathArg(mode);
     return fp.getOID("lo_creat", args);

--- a/pgjdbc/src/test/java/org/postgresql/jdbc/LargeObjectManagerTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/jdbc/LargeObjectManagerTest.java
@@ -6,6 +6,8 @@
 package org.postgresql.jdbc;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
@@ -175,6 +177,32 @@ class LargeObjectManagerTest {
       throw t;
     } finally {
       lom.delete(loId);
+    }
+  }
+
+  /**
+   * A genuine auto-commit connection (autoCommit=true and no open transaction) must still refuse
+   * large object operations: the {@code lo_*} handles would be scoped to a transaction that gets
+   * committed away immediately. This pins the negative side of the {@code requireTransaction()}
+   * guard so a future refactoring cannot silently drop it.
+   *
+   * @see <a href="https://github.com/pgjdbc/pgjdbc/issues/4309">Issue #4309</a>
+   */
+  @Test
+  void refusesInAutoCommitModeWithoutTransaction() throws Exception {
+    try (PgConnection con = (PgConnection) TestUtil.openDB()) {
+      assertTrue(con.getAutoCommit(), "Connection is expected to start in auto-commit mode");
+
+      LargeObjectManager lom = con.getLargeObjectAPI();
+
+      PSQLException createException =
+          assertThrows(PSQLException.class, lom::createLO,
+              "createLO() must be refused in auto-commit mode with no open transaction");
+      assertEquals(PSQLState.NO_ACTIVE_SQL_TRANSACTION.getState(), createException.getSQLState(),
+          "SQLState of the auto-commit refusal");
+
+      assertThrows(PSQLException.class, () -> lom.open(1L, LargeObjectManager.READWRITE),
+          "open() must be refused in auto-commit mode with no open transaction");
     }
   }
 

--- a/pgjdbc/src/test/java/org/postgresql/test/xa/XADataSourceTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/xa/XADataSourceTest.java
@@ -7,6 +7,7 @@ package org.postgresql.test.xa;
 
 import static javax.transaction.xa.XAException.XA_RDONLY;
 import static javax.transaction.xa.XAResource.XA_OK;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -14,8 +15,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+import org.postgresql.PGConnection;
 import org.postgresql.core.BaseConnection;
 import org.postgresql.core.TransactionState;
+import org.postgresql.largeobject.LargeObject;
+import org.postgresql.largeobject.LargeObjectManager;
 import org.postgresql.test.TestUtil;
 import org.postgresql.test.annotations.tags.Xa;
 import org.postgresql.test.jdbc2.optional.BaseDataSourceTest;
@@ -29,6 +33,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -316,6 +321,41 @@ public class XADataSourceTest {
     xaRes.start(xid, XAResource.TMNOFLAGS);
     xaRes.end(xid, XAResource.TMSUCCESS);
     xaRes.rollback(xid);
+  }
+
+  /**
+   * Large object operations must work inside an active XA branch. Before 42.7.13 {@code start()}
+   * forced {@code autoCommit=false} for the duration of the branch and restored it afterwards, so
+   * {@code LargeObjectManager} saw a transaction. Since #4114 {@code start()} no longer changes
+   * {@code autoCommit}, so it stays {@code true} here even though a transaction is open, and the
+   * manager must look at the transaction state rather than {@code autoCommit} alone.
+   *
+   * @see <a href="https://github.com/pgjdbc/pgjdbc/issues/4309">Issue #4309</a>
+   */
+  @Test
+  void largeObjectWithinXaBranch() throws Exception {
+    Xid xid = new CustomXid(7);
+    byte[] payload = "XA large object payload".getBytes(StandardCharsets.UTF_8);
+
+    xaRes.start(xid, XAResource.TMNOFLAGS);
+    try {
+      // Regression precondition (#4309): the XA branch is active, yet autoCommit stays true, so
+      // LargeObjectManager can no longer rely on getAutoCommit() to detect the surrounding transaction.
+      assertTrue(conn.getAutoCommit(), "XA start() must leave autoCommit unchanged");
+
+      LargeObjectManager lom = ((PGConnection) conn).getLargeObjectAPI();
+      long oid = lom.createLO();
+      try (LargeObject lo = lom.open(oid, LargeObjectManager.READWRITE)) {
+        lo.write(payload);
+        lo.seek(0);
+        assertArrayEquals(payload, lo.read(payload.length),
+            "Large object written and read back within the XA branch must round-trip");
+      }
+    } finally {
+      xaRes.end(xid, XAResource.TMSUCCESS);
+      // Roll back so the large object created above never leaks past the test.
+      xaRes.rollback(xid);
+    }
   }
 
   @Test


### PR DESCRIPTION
## Why

Before 42.7.13, XA `start()` set the connection's `autoCommit=false` for the duration of the branch and restored it on end/commit/rollback, so `LargeObjectManager` saw an open transaction and allowed large objects. [PR #4114](https://github.com/pgjdbc/pgjdbc/pull/4114) removed that save/restore, so `start()` no longer touches `autoCommit`; it stays `true` while the branch is open.

`LargeObjectManager.createLO()` / `open()` use `getAutoCommit()` as a proxy for "is there a transaction", so since 42.7.13 they wrongly refuse with "Large Objects may not be used in auto-commit mode" inside an XA branch — a regression from 42.7.12 reported in [#4309](https://github.com/pgjdbc/pgjdbc/issues/4309).

## What

Gate `createLO`/`open` on the server transaction state: refuse only when `autoCommit && TransactionState.IDLE`. A running transaction — an XA branch or a manual `BEGIN` under auto-commit — now permits large objects, while a plain auto-commit connection is still refused.

## How to verify

New tests:
- `XADataSourceTest.largeObjectWithinXaBranch` (`@Xa`) — create/write/read a large object inside an active XA branch. Red before the fix, green after.
- `LargeObjectManagerTest.refusesInAutoCommitModeWithoutTransaction` — pins the negative side so the guard cannot be silently dropped.

```
./gradlew :postgresql:test --tests "org.postgresql.test.xa.XADataSourceTest" \
  --tests "org.postgresql.jdbc.LargeObjectManagerTest"
```

The XA test requires `max_prepared_transactions > 0` and self-skips otherwise.

## Related

A sibling of the same `autoCommit`-as-transaction-signal pattern in `BatchResultHandler` is fixed separately in #4311.