### PR TITLE
fix: do not secure batch progress inside an XA transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 Notable changes since version 42.0.0, read the complete [History of Changes](https://jdbc.postgresql.org/documentation/changelog.html).
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
+## [Unreleased]
+
+### Fixed
+* fix: batch update counts are no longer secured as committed inside an XA transaction. `BatchResultHandler` treated per-statement progress as durable whenever `autoCommit=true`, but an XA branch keeps `autoCommit=true` while the transaction is open, so a batch that flushed mid-way and then failed could report rolled-back statements as succeeded. Progress is now secured only when no server transaction is open [Issue #4309](https://github.com/pgjdbc/pgjdbc/issues/4309) [PR #4311](https://github.com/pgjdbc/pgjdbc/pull/4311)
+
 ## [42.7.13] (2026-07-06)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 * fix: `LargeObjectManager` operations now work inside an active XA transaction. Since 42.7.13 an XA branch keeps the caller's `autoCommit=true`, and the guard rejected large objects as if the connection were idle. It now checks the server transaction state (`getTransactionState()`) instead of `autoCommit`, so a genuine auto-commit connection with no open transaction is still refused [Issue #4309](https://github.com/pgjdbc/pgjdbc/issues/4309) [PR #4310](https://github.com/pgjdbc/pgjdbc/pull/4310)
+* fix: batch update counts are no longer secured as committed inside an XA transaction. `BatchResultHandler` treated per-statement progress as durable whenever `autoCommit=true`, but an XA branch keeps `autoCommit=true` while the transaction is open, so a batch that flushed mid-way and then failed could report rolled-back statements as succeeded. Progress is now secured only when no server transaction is open [Issue #4309](https://github.com/pgjdbc/pgjdbc/issues/4309) [PR #4311](https://github.com/pgjdbc/pgjdbc/pull/4311)
 
 ## [42.7.13] (2026-07-06)
 

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/BatchResultHandler.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/BatchResultHandler.java
@@ -7,11 +7,13 @@ package org.postgresql.jdbc;
 
 import static org.postgresql.util.internal.Nullness.castNonNull;
 
+import org.postgresql.core.BaseConnection;
 import org.postgresql.core.Field;
 import org.postgresql.core.ParameterList;
 import org.postgresql.core.Query;
 import org.postgresql.core.ResultCursor;
 import org.postgresql.core.ResultHandlerBase;
+import org.postgresql.core.TransactionState;
 import org.postgresql.core.Tuple;
 import org.postgresql.core.v3.BatchedQuery;
 import org.postgresql.util.GT;
@@ -88,7 +90,7 @@ public class BatchResultHandler extends ResultHandlerBase {
       resultIndex--;
       // If exception thrown, no need to collect generated keys
       // Note: some generated keys might be secured in generatedKeys
-      if (updateCount > 0 && (getException() == null || isAutoCommit())) {
+      if (updateCount > 0 && (getException() == null || isProgressDurable())) {
         List<List<Tuple>> allGeneratedRows = castNonNull(this.allGeneratedRows, "allGeneratedRows");
         allGeneratedRows.add(latestGeneratedRows);
         if (generatedKeys == null) {
@@ -108,20 +110,33 @@ public class BatchResultHandler extends ResultHandlerBase {
     longUpdateCounts[resultIndex++] = updateCount;
   }
 
-  private boolean isAutoCommit() {
+  /**
+   * Batch progress may be secured — recorded as committed so that a later error reports the earlier
+   * rows as succeeded rather than {@code EXECUTE_FAILED} — only when each statement commits on its
+   * own, that is, the connection is in auto-commit mode with no open transaction. An XA branch keeps
+   * {@code autoCommit=true} while a server-side transaction is open (see
+   * <a href="https://github.com/pgjdbc/pgjdbc/issues/4309">issue #4309</a>), so the flag alone would
+   * secure rows that the transaction manager can still roll back. Requiring
+   * {@link TransactionState#IDLE} also covers a manual {@code BEGIN} issued under auto-commit.
+   *
+   * @return true when progress made so far is durable and can be secured
+   */
+  private boolean isProgressDurable() {
     try {
-      return pgStatement.getConnection().getAutoCommit();
+      BaseConnection connection = pgStatement.getPGConnection();
+      return connection.getAutoCommit()
+          && connection.getTransactionState() == TransactionState.IDLE;
     } catch (SQLException e) {
       // getAutoCommit() throws when the connection is already closed (for instance, the server
-      // terminated the connection in the middle of a batch). There is nothing to commit in that
-      // case, so treat the connection as not auto-committing rather than failing with an assertion.
+      // terminated the connection in the middle of a batch). There is nothing to secure in that
+      // case, so treat progress as not durable rather than failing with an assertion.
       return false;
     }
   }
 
   @Override
   public void secureProgress() {
-    if (isAutoCommit()) {
+    if (isProgressDurable()) {
       committedRows = resultIndex;
       updateGeneratedKeys();
     }
@@ -178,7 +193,7 @@ public class BatchResultHandler extends ResultHandlerBase {
     updateGeneratedKeys();
     SQLException batchException = getException();
     if (batchException != null) {
-      if (isAutoCommit()) {
+      if (isProgressDurable()) {
         // Re-create batch exception since rows after exception might indeed succeed.
         BatchUpdateException newException;
         newException = new BatchUpdateException(

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/BatchResultHandler.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/BatchResultHandler.java
@@ -7,11 +7,13 @@ package org.postgresql.jdbc;
 
 import static org.postgresql.util.internal.Nullness.castNonNull;
 
+import org.postgresql.core.BaseConnection;
 import org.postgresql.core.Field;
 import org.postgresql.core.ParameterList;
 import org.postgresql.core.Query;
 import org.postgresql.core.ResultCursor;
 import org.postgresql.core.ResultHandlerBase;
+import org.postgresql.core.TransactionState;
 import org.postgresql.core.Tuple;
 import org.postgresql.core.v3.BatchedQuery;
 import org.postgresql.util.GT;
@@ -88,7 +90,7 @@ public class BatchResultHandler extends ResultHandlerBase {
       resultIndex--;
       // If exception thrown, no need to collect generated keys
       // Note: some generated keys might be secured in generatedKeys
-      if (updateCount > 0 && (getException() == null || isAutoCommit())) {
+      if (updateCount > 0 && (getException() == null || isProgressDurable())) {
         List<List<Tuple>> allGeneratedRows = castNonNull(this.allGeneratedRows, "allGeneratedRows");
         allGeneratedRows.add(latestGeneratedRows);
         if (generatedKeys == null) {
@@ -108,20 +110,34 @@ public class BatchResultHandler extends ResultHandlerBase {
     longUpdateCounts[resultIndex++] = updateCount;
   }
 
-  private boolean isAutoCommit() {
+  /**
+   * Returns whether progress made so far can be secured, that is, recorded as committed so a later
+   * error reports the earlier rows as succeeded rather than {@code EXECUTE_FAILED}.
+   *
+   * <p>Progress is durable only when each statement commits on its own. An XA branch keeps
+   * {@code autoCommit=true} while a server-side transaction is open (see
+   * <a href="https://github.com/pgjdbc/pgjdbc/issues/4309">issue #4309</a>), so the flag alone would
+   * secure rows that the transaction manager can still roll back. Requiring
+   * {@link TransactionState#IDLE} also covers a manual {@code BEGIN} issued under auto-commit.</p>
+   *
+   * @return true when the connection is in auto-commit mode with no transaction open
+   */
+  private boolean isProgressDurable() {
     try {
-      return pgStatement.getConnection().getAutoCommit();
+      BaseConnection connection = pgStatement.getPGConnection();
+      return connection.getAutoCommit()
+          && connection.getTransactionState() == TransactionState.IDLE;
     } catch (SQLException e) {
       // getAutoCommit() throws when the connection is already closed (for instance, the server
-      // terminated the connection in the middle of a batch). There is nothing to commit in that
-      // case, so treat the connection as not auto-committing rather than failing with an assertion.
+      // terminated the connection in the middle of a batch). There is nothing to secure in that
+      // case, so treat progress as not durable rather than failing with an assertion.
       return false;
     }
   }
 
   @Override
   public void secureProgress() {
-    if (isAutoCommit()) {
+    if (isProgressDurable()) {
       committedRows = resultIndex;
       updateGeneratedKeys();
     }
@@ -178,7 +194,7 @@ public class BatchResultHandler extends ResultHandlerBase {
     updateGeneratedKeys();
     SQLException batchException = getException();
     if (batchException != null) {
-      if (isAutoCommit()) {
+      if (isProgressDurable()) {
         // Re-create batch exception since rows after exception might indeed succeed.
         BatchUpdateException newException;
         newException = new BatchUpdateException(

--- a/pgjdbc/src/test/java/org/postgresql/test/xa/XADataSourceTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/xa/XADataSourceTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.sql.BatchUpdateException;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -316,6 +317,51 @@ public class XADataSourceTest {
     xaRes.start(xid, XAResource.TMNOFLAGS);
     xaRes.end(xid, XAResource.TMSUCCESS);
     xaRes.rollback(xid);
+  }
+
+  /**
+   * A failing batch inside an XA branch must not report any statement as committed. The driver
+   * forces a mid-batch {@code Sync} once its estimated receive buffer (64 KB) fills, and that is the
+   * only path that reaches {@code BatchResultHandler.secureProgress()} while an XA branch is active.
+   * Because the branch keeps {@code autoCommit=true}, the handler used to treat the flushed rows as
+   * committed and leak their update counts as {@code 1} instead of {@code EXECUTE_FAILED}. Nothing is
+   * durable until the transaction manager commits, so every entry must be {@code EXECUTE_FAILED}.
+   *
+   * <p>Each unprepared statement is estimated at 250 bytes, so a few hundred statements guarantee at
+   * least one forced Sync before the failing entry.</p>
+   *
+   * @see <a href="https://github.com/pgjdbc/pgjdbc/issues/4309">Issue #4309</a>
+   */
+  @Test
+  void batchProgressNotSecuredWithinXaBranch() throws Exception {
+    int rows = 400;
+
+    Xid xid = new CustomXid(8);
+    xaRes.start(xid, XAResource.TMNOFLAGS);
+    try {
+      assertTrue(conn.getAutoCommit(), "XA start() must leave autoCommit unchanged");
+
+      Statement stmt = conn.createStatement();
+      for (int i = 1; i <= rows; i++) {
+        stmt.addBatch("INSERT INTO testxa2 VALUES (" + i + ")");
+      }
+      // A duplicate primary key fails after the forced Sync has already flushed earlier rows.
+      stmt.addBatch("INSERT INTO testxa2 VALUES (1)");
+
+      try {
+        stmt.executeBatch();
+        fail("Batch with a duplicate primary key must fail");
+      } catch (BatchUpdateException e) {
+        for (int count : e.getUpdateCounts()) {
+          assertEquals(Statement.EXECUTE_FAILED, count,
+              "No batch entry may be reported as committed inside an XA branch");
+        }
+      }
+      stmt.close();
+    } finally {
+      xaRes.end(xid, XAResource.TMFAIL);
+      xaRes.rollback(xid);
+    }
   }
 
   @Test

--- a/pgjdbc/src/test/java/org/postgresql/test/xa/XADataSourceTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/xa/XADataSourceTest.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
+import java.sql.BatchUpdateException;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -354,6 +355,52 @@ public class XADataSourceTest {
     } finally {
       xaRes.end(xid, XAResource.TMSUCCESS);
       // Roll back so the large object created above never leaks past the test.
+      xaRes.rollback(xid);
+    }
+  }
+
+  /**
+   * Fails when the driver reports a statement of a failing batch as committed inside an XA branch.
+   *
+   * <p>The driver forces a mid-batch {@code Sync} once its estimated receive buffer (64 KB) fills,
+   * and that is the only path that reaches {@code BatchResultHandler.secureProgress()} while an XA
+   * branch is active. The branch keeps {@code autoCommit=true}, so a handler that trusts that flag
+   * alone secures the flushed rows and reports their update counts as {@code 1}. Nothing is durable
+   * until the transaction manager commits, so every entry must be {@code EXECUTE_FAILED}.</p>
+   *
+   * <p>Each unprepared statement is estimated at 250 bytes, so a few hundred statements guarantee at
+   * least one forced Sync before the failing entry.</p>
+   *
+   * @see <a href="https://github.com/pgjdbc/pgjdbc/issues/4309">Issue #4309</a>
+   */
+  @Test
+  void batchProgressNotSecuredWithinXaBranch() throws Exception {
+    int rows = 400;
+
+    Xid xid = new CustomXid(8);
+    xaRes.start(xid, XAResource.TMNOFLAGS);
+    try {
+      assertTrue(conn.getAutoCommit(), "XA start() must leave autoCommit unchanged");
+
+      Statement stmt = conn.createStatement();
+      for (int i = 1; i <= rows; i++) {
+        stmt.addBatch("INSERT INTO testxa2 VALUES (" + i + ")");
+      }
+      // A duplicate primary key fails after the forced Sync has already flushed earlier rows.
+      stmt.addBatch("INSERT INTO testxa2 VALUES (1)");
+
+      try {
+        stmt.executeBatch();
+        fail("Batch with a duplicate primary key must fail");
+      } catch (BatchUpdateException e) {
+        for (int count : e.getUpdateCounts()) {
+          assertEquals(Statement.EXECUTE_FAILED, count,
+              "No batch entry may be reported as committed inside an XA branch");
+        }
+      }
+      stmt.close();
+    } finally {
+      xaRes.end(xid, XAResource.TMFAIL);
       xaRes.rollback(xid);
     }
   }


### PR DESCRIPTION
## Why

Since 42.7.13 ([PR #4114](https://github.com/pgjdbc/pgjdbc/pull/4114)) `PGXAConnection` keeps the caller's JDBC `autoCommit` flag invariant across `XAResource` calls, so an XA branch is active while `Connection.getAutoCommit()` still returns `true`. `BatchResultHandler` used `getAutoCommit()` to decide whether per-statement batch progress is durable. Under an XA branch that check is `true` while the transaction is still open, so a batch that forced a mid-batch flush and then failed could report statements the transaction manager later rolls back as succeeded, and could collect generated keys for rows that never committed.

This is the same `autoCommit`-as-transaction-signal pattern behind [#4309](https://github.com/pgjdbc/pgjdbc/issues/4309) (the `LargeObjectManager` regression, fixed in #4310). This path is independent and does not close that issue.

## What

The three call sites that shared the `getAutoCommit()` check now go through one `isProgressDurable()` helper that also requires `TransactionState.IDLE`. Progress is secured only when each statement commits on its own, which excludes an XA branch and a manual `BEGIN` under auto-commit. This also removes the reliance on the transaction-state guard that only one of the two `secureProgress()` call sites had.

## How to verify

New `@Xa` regression test `XADataSourceTest.batchProgressNotSecuredWithinXaBranch`: a large batch forces a mid-batch `Sync` (the only path that reaches `secureProgress()` under XA), then a duplicate key fails; it asserts every entry is `EXECUTE_FAILED` rather than a leaked committed count. The `Sync` trigger is the driver's 64 KB receive-buffer *estimate*, so it is deterministic, not OS-buffer dependent. Red before the fix (`expected <-3> but was <1>`), green after.

```
./gradlew :postgresql:test --tests "org.postgresql.test.xa.XADataSourceTest" \
  --tests "org.postgresql.test.jdbc2.BatchExecuteTest" \
  --tests "org.postgresql.test.jdbc2.BatchFailureTest"
```

The XA test requires `max_prepared_transactions > 0` and self-skips otherwise.