### PR TITLE
fix: map hstore columns to Map when hstore is not in the search_path

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
@@ -201,6 +201,14 @@ public class PgResultSet implements ResultSet, PGRefCursorResultSet {
     return getURL(findColumn(columnName));
   }
 
+  // Matched on oid, not name: getPGType(int) returns "public"."hstore" when the type is off the
+  // search_path. The lookup is cached, so this is not a catalog query per value.
+  @Pure
+  private boolean isHStore(Field field) throws SQLException {
+    int hstoreOid = connection.getTypeInfo().getPGType("hstore");
+    return hstoreOid != Oid.UNSPECIFIED && field.getOID() == hstoreOid;
+  }
+
   @RequiresNonNull({"thisRow"})
   protected @Nullable Object internalGetObject(@Positive int columnIndex, Field field) throws SQLException {
     castNonNull(thisRow, "thisRow");
@@ -305,7 +313,7 @@ public class PgResultSet implements ResultSet, PGRefCursorResultSet {
           ((PgResultSet) rs).closeRefCursor();
           return rs;
         }
-        if ("hstore".equals(type)) {
+        if (isHStore(field)) {
           if (isBinary(columnIndex)) {
             return HStoreConverter.fromBytes(castNonNull(thisRow.get(columnIndex - 1)),
                 connection.getEncoding());
@@ -2449,7 +2457,7 @@ public class PgResultSet implements ResultSet, PGRefCursorResultSet {
         }
         return obj.toString();
       }
-      if ("hstore".equals(getPGType(columnIndex))) {
+      if (isHStore(field)) {
         return HStoreConverter.toString((Map<?, ?>) obj);
       }
       return trimString(columnIndex, obj.toString());

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
@@ -766,6 +766,11 @@ public class TypeInfoCache implements TypeInfo {
         return result;
       }
 
+      // pgNameToJavaClass is keyed by unqualified names, so match hstore on oid instead
+      if (oid == getPGType("hstore")) {
+        return Map.class.getName();
+      }
+
       if (getSQLType(pgTypeName) == Types.ARRAY) {
         result = "java.sql.Array";
         pgNameToJavaClass.put(pgTypeName, result);

--- a/pgjdbc/src/test/java/org/postgresql/test/extensions/HStoreSearchPathTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/extensions/HStoreSearchPathTest.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright (c) 2026, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.test.extensions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import org.postgresql.PGProperty;
+import org.postgresql.core.BaseConnection;
+import org.postgresql.core.Oid;
+import org.postgresql.core.ServerVersion;
+import org.postgresql.jdbc.PreferQueryMode;
+import org.postgresql.test.TestUtil;
+import org.postgresql.test.jdbc2.BaseTest4;
+import org.postgresql.util.internal.Nullness;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * Tests that {@code hstore} values map to {@link Map} when the type is off the connection's
+ * {@code search_path}.
+ *
+ * <p>An extension can be installed only once per database, so these tests move the
+ * {@code search_path} instead of the extension. Reads use a connection that has never sent an
+ * hstore parameter, because that would cache the unqualified name and hide the bug.</p>
+ */
+@ParameterizedClass
+@MethodSource("data")
+public class HStoreSearchPathTest extends BaseTest4 {
+
+  private static final String TEST_SCHEMA = "hstore_search_path";
+  private static final String TEST_TABLE = TEST_SCHEMA + ".hstore_tbl";
+
+  /** Resolved before the connection is opened, because binary transfer needs the oid up front. */
+  private static int hstoreOid = Oid.UNSPECIFIED;
+  private static @Nullable String hstoreSchema;
+  private static boolean bootstrapped;
+
+  public HStoreSearchPathTest(BinaryMode binaryMode) {
+    setBinaryMode(binaryMode);
+  }
+
+  public static Iterable<Object[]> data() {
+    return Arrays.asList(
+        new Object[]{BinaryMode.REGULAR},
+        new Object[]{BinaryMode.FORCE});
+  }
+
+  @Override
+  protected void updateProperties(Properties props) {
+    super.updateProperties(props);
+    // Keep the hstore type off the search_path, and put the test table on it
+    PGProperty.OPTIONS.set(props, "-c search_path=" + TEST_SCHEMA);
+    if (binaryMode == BinaryMode.FORCE && hstoreOid != Oid.UNSPECIFIED) {
+      // forceBinary() enables binary transfer for bool only, so hstore must be added explicitly,
+      // its oid not being static
+      PGProperty.BINARY_TRANSFER_ENABLE.set(props, Oid.BOOL + "," + hstoreOid);
+    }
+  }
+
+  @Override
+  public void setUp() throws Exception {
+    bootstrap();
+    assumeTrue(hstoreOid != Oid.UNSPECIFIED, "server has installed hstore");
+    super.setUp();
+    assumeFalse(preferQueryMode == PreferQueryMode.SIMPLE,
+        "hstore is not supported in simple protocol only mode");
+    assumeMinimumServerVersion("hstore requires PostgreSQL 8.3+", ServerVersion.v8_3);
+
+    Connection con = Nullness.castNonNull(this.con);
+    try (Statement stmt = con.createStatement()) {
+      stmt.execute("DELETE FROM " + TEST_TABLE);
+    }
+  }
+
+  /** Runs on the default search_path, where hstore is still reachable unqualified. */
+  private static void bootstrap() throws SQLException {
+    if (bootstrapped) {
+      return;
+    }
+    bootstrapped = true;
+    try (Connection con = TestUtil.openDB()) {
+      try (Statement stmt = con.createStatement();
+           ResultSet rs = stmt.executeQuery(
+               "SELECT t.oid, n.nspname FROM pg_catalog.pg_type t"
+                   + " JOIN pg_catalog.pg_namespace n ON t.typnamespace = n.oid"
+                   + " WHERE t.typname = 'hstore'")) {
+        if (rs.next()) {
+          hstoreOid = (int) rs.getLong(1);
+          hstoreSchema = rs.getString(2);
+        }
+      }
+      if (hstoreOid == Oid.UNSPECIFIED) {
+        return;
+      }
+      TestUtil.createSchema(con, TEST_SCHEMA);
+      TestUtil.createTable(con, TEST_TABLE,
+          "id int, val \"" + Nullness.castNonNull(hstoreSchema) + "\".\"hstore\"");
+    }
+  }
+
+  private Connection openTestConnection() throws SQLException {
+    Properties props = new Properties();
+    updateProperties(props);
+    return TestUtil.openDB(props);
+  }
+
+  /**
+   * Uses a separate connection: binding an hstore parameter caches the unqualified name, which
+   * would mask what the read assertions check.
+   */
+  private void insert(int id, Map<String, String> value) throws SQLException {
+    try (Connection writer = openTestConnection();
+         PreparedStatement pstmt =
+             writer.prepareStatement("INSERT INTO " + TEST_TABLE + " (id, val) VALUES (?, ?)")) {
+      pstmt.setInt(1, id);
+      pstmt.setObject(2, value);
+      pstmt.executeUpdate();
+    }
+  }
+
+  private ResultSet select(int id) throws SQLException {
+    Connection con = Nullness.castNonNull(this.con);
+    // Guard against passing for the wrong reason: hstore must not be reachable unqualified here
+    assertNotEquals("hstore", ((BaseConnection) con).getTypeInfo().getPGType(hstoreOid),
+        "hstore should be reported schema-qualified when its schema is off the search_path");
+    PreparedStatement pstmt =
+        con.prepareStatement("SELECT val FROM " + TEST_TABLE + " WHERE id = ?");
+    pstmt.setInt(1, id);
+    ResultSet rs = pstmt.executeQuery();
+    assertTrue(rs.next(), "the inserted row should be readable back");
+    return rs;
+  }
+
+  @Test
+  public void testGetObjectPopulated() throws SQLException {
+    Map<String, String> value = new LinkedHashMap<>();
+    value.put("a", "1");
+    value.put("b", "2");
+    insert(1, value);
+
+    try (ResultSet rs = select(1)) {
+      assertEquals(new HashMap<>(value), rs.getObject(1));
+    }
+  }
+
+  @Test
+  public void testGetObjectEmpty() throws SQLException {
+    insert(2, Collections.<String, String>emptyMap());
+
+    try (ResultSet rs = select(2)) {
+      assertEquals(Collections.<String, String>emptyMap(), rs.getObject(1));
+    }
+  }
+
+  @Test
+  public void testGetStringPopulated() throws SQLException {
+    insert(3, Collections.singletonMap("a", "1"));
+
+    try (ResultSet rs = select(3)) {
+      assertEquals("\"a\"=>\"1\"", rs.getString(1));
+    }
+  }
+
+  @Test
+  public void testGetStringEmpty() throws SQLException {
+    insert(4, Collections.<String, String>emptyMap());
+
+    try (ResultSet rs = select(4)) {
+      assertEquals("", rs.getString(1));
+    }
+  }
+
+  /** getColumnClassName() reads the same name-keyed table, so it returned java.lang.String. */
+  @Test
+  public void testGetColumnClassName() throws SQLException {
+    insert(7, Collections.singletonMap("a", "1"));
+
+    try (ResultSet rs = select(7)) {
+      assertEquals(Map.class.getName(), rs.getMetaData().getColumnClassName(1));
+    }
+  }
+
+  /**
+   * {@code currentSchema} and {@link Connection#setSchema(String)} issue
+   * {@code SET SESSION search_path TO '<schema>'}, which replaces the path set on the role or
+   * database. That is how hstore in {@code public} usually ends up off the path.
+   */
+  @Test
+  public void testGetObjectWithCurrentSchemaProperty() throws SQLException {
+    insert(6, Collections.singletonMap("a", "1"));
+
+    Properties props = new Properties();
+    if (binaryMode == BinaryMode.FORCE) {
+      forceBinary(props);
+      PGProperty.BINARY_TRANSFER_ENABLE.set(props, Oid.BOOL + "," + hstoreOid);
+    }
+    PGProperty.CURRENT_SCHEMA.set(props, TEST_SCHEMA);
+
+    try (Connection reader = TestUtil.openDB(props);
+         PreparedStatement pstmt =
+             reader.prepareStatement("SELECT val FROM " + TEST_TABLE + " WHERE id = 6");
+         ResultSet rs = pstmt.executeQuery()) {
+      assertTrue(rs.next(), "the inserted row should be readable back");
+      assertEquals(Collections.singletonMap("a", "1"), rs.getObject(1));
+    }
+  }
+
+  /** Writes already worked off the path; check the fix keeps them working. */
+  @Test
+  public void testWriteWorksOffSearchPath() throws SQLException {
+    insert(5, Collections.singletonMap("a", "1"));
+
+    Connection con = Nullness.castNonNull(this.con);
+    try (PreparedStatement pstmt =
+             con.prepareStatement("SELECT val::text FROM " + TEST_TABLE + " WHERE id = 5");
+         ResultSet rs = pstmt.executeQuery()) {
+      assertTrue(rs.next(), "the inserted row should be readable back");
+      assertEquals("\"a\"=>\"1\"", rs.getString(1));
+    }
+  }
+}


### PR DESCRIPTION
Closes #4312.

`PgResultSet.internalGetObject()` and `getString()` decided a column was `hstore` by comparing `TypeInfoCache.getPGType(int oid)` against the literal `"hstore"`. That method returns a schema-qualified name such as `"public"."hstore"` whenever the type's namespace is not in `current_schemas(true)`, so the comparison fails, `internalGetObject()` returns `null`, and `getObject()` falls through to the generic `PGobject` branch. `TypeInfoCache.getJavaClass()` looks the Java class up in the same name-keyed table, so `ResultSetMetaData.getColumnClassName()` reported `java.lang.String` for a column `getObject()` returns a `Map` for.

Writes were unaffected, because `PgPreparedStatement.setMap()` resolves the OID through `TypeInfoCache.getPGType(String)`, whose query puts the search_path only in `ORDER BY` and never in `WHERE`, so it finds the extension wherever it was installed.

### Approach

Detection is now a comparison of the field OID against the OID that `getPGType(String)` resolves — the same call the write path makes — so the two paths agree by construction and a value that can be sent as `hstore` can be read back as one.

- **No public API change.** `getPGType(String)` is already on `TypeInfo`; nothing was added to the interface.
- **One extra round-trip per connection.** In `internalGetObject()` the hstore lookup is additive, so the first read of any `OTHER`-typed value pays it even when hstore is not installed. Cached (including `UNSPECIFIED`) from then on.
- `isHStore()` is annotated `@Pure`, matching the neighbouring `getPGType(int)`. Without it the Checker Framework drops the `thisRow` non-null refinement across the call.
- The `getJavaClass()` change is placed after the existing name lookup, so ordinary types do no extra work.

### Known limitations

Detection now runs through `getPGType(String)`, which negatively caches `"hstore" → UNSPECIFIED`. This sequence therefore reads hstore as `PGobject`/`String`:

1. hstore not installed; read a json column, caching `"hstore" → UNSPECIFIED`
2. `CREATE EXTENSION hstore` on the same connection
3. read an hstore column — cache hit on `UNSPECIFIED`, detection returns false

The pre-fix read path went through `getPGType(int)`, keyed by the new OID with no such entry, so it would have worked here. `setMap()` already has the identical staleness on the write path, so reads and writes are consistent now, but this is a behaviour change rather than a pure fix.

### Why this is easy to hit

The narrowed search_path usually is not deliberate. The `currentSchema` property and `Connection.setSchema()` both emit `SET SESSION search_path TO '<schema>'`, which replaces the path configured via `ALTER ROLE`/`ALTER DATABASE` instead of adding to it. A deployment with hstore in `public` and `currentSchema=app` therefore has `search_path = app` on every connection while `SHOW search_path` in psql still shows `app, public`.

### Tests

`HStoreSearchPathTest` is a separate first commit so it can be reviewed, or disputed, independently of the fix. It moves the search_path away from the schema holding hstore rather than moving the extension, since an extension can only be installed once per database, and it reads on a connection that has never bound an hstore parameter — resolving the OID for a parameter caches the unqualified name against that OID and masks the problem otherwise.

7 tests × {REGULAR, FORCE} binary transfer: populated and empty maps via `getObject()`, both via `getString()`, `getColumnClassName()`, the `currentSchema` property, and one pinning down that the write path still works off the search_path.

10 of the 14 fail on master. The 4 that pass there are the text-mode `getString()` cases, which return the raw string without reaching the broken branch, and the write-path test.

### Verification

- `./gradlew :postgresql:test --tests "org.postgresql.test.extensions.*"` — 14/14 pass, and the pre-existing `HStoreTest` is unaffected.
- `./gradlew :postgresql:styleCheck -PenableErrorprone -PenableCheckerframework` — clean.
- Wider run over `jdbc2.ResultSet*` and `jdbc4.*` — no regressions.

Tested against PostgreSQL 17 with OpenJDK 21. I have not run the older server versions in the CI matrix; the `assumeMinimumServerVersion(v8_3)` guard in the test is inherited from the existing `HStoreTest`.

### Relationship to #3062

#3062 reworks `TypeInfoCache` and includes hstore handling, and would presumably subsume this. This is offered as a small targeted fix that could ship in a patch release in the meantime, not as a competing design. Happy to align it with #3062 if you would rather.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

#3062 is the only open PR touching hstore; see the note above.

### Changes to Existing Features:

* [x] Does this break existing behaviour? If so please explain.

No. It only affects connections where the comparison already failed, which is exactly the broken case. `getObject()` returns a `Map` where it previously returned a `PGobject`, and `getColumnClassName()` returns `java.util.Map` where it previously returned `java.lang.String` — both matching what the driver already does when hstore is on the search_path, and what it documents unconditionally (#67). Connections with hstore on the search_path are unaffected, as is the write path. No public API was added or changed.

One visible consequence worth flagging: resolving the OID through `getPGType(String)` caches the unqualified name against that OID, so after reading an hstore column `ResultSetMetaData.getColumnTypeName()` reports `hstore` rather than `"public"."hstore"` for an off-path type. `setMap()` has always had this same side effect on the write path, so it is not new behaviour, but it does run counter to the direction #3062 takes for `getColumnTypeName()`.

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

See **Verification** above.

There is no test suite to register the new class in: the only `*Suite*` class in the repo is `SocketFactoryTestSuite`, the existing `HStoreTest` is not in a suite either, and the build excludes `**/*Suite*`.
