### PR TITLE
test: add socketTimeout, loginTimeout, and connectTimeout matrix axes

### DIFF
--- a/.github/workflows/matrix.mjs
+++ b/.github/workflows/matrix.mjs
@@ -249,6 +249,38 @@ matrix.addAxis({
   ]
 });
 
+// Setting socketTimeout is the recommended production configuration, so test both branches.
+matrix.addAxis({
+  name: 'socket_timeout',
+  title: x => x == '' ? '' : 'socketTimeout ' + x,
+  values: [
+    '',
+    '60'
+  ]
+});
+
+// A non-zero loginTimeout hands the whole connect to an executor thread, so it is a different
+// code path rather than a different number.
+matrix.addAxis({
+  name: 'login_timeout',
+  title: x => x == '' ? '' : 'loginTimeout ' + x,
+  values: [
+    '',
+    '13'
+  ]
+});
+
+// connectTimeout defaults to 10, so this shortens the budget the negotiation retries and the
+// SSL handshake share, rather than switching it on. Keep it below loginTimeout.
+matrix.addAxis({
+  name: 'connect_timeout',
+  title: x => x == '' ? '' : 'connectTimeout ' + x,
+  values: [
+    '',
+    '7'
+  ]
+});
+
 // Occasionally constrain the JVM to a single CPU via -XX:ActiveProcessorCount=1. This shrinks
 // JVM-internal pools (ForkJoinPool common pool, GC threads, etc.) and has caught regressions
 // where bursty work cannot keep up with producers — e.g. LazyCleaner backed by FJP, see
@@ -280,7 +312,8 @@ matrix.setNamePattern([
     'java_version', 'java_distribution', 'pg_version', 'query_mode', 'scram', 'ssl', 'hash', 'os',
     'server_tz', 'tz', 'locale',
     'gss', 'replication', 'slow_tests',
-    'adaptive_fetch', 'rewrite_batch_inserts', 'query_timeout',
+    'adaptive_fetch', 'rewrite_batch_inserts', 'query_timeout', 'socket_timeout',
+    'login_timeout', 'connect_timeout',
     'autosave', 'cleanupSavepoints', 'cpu_count', 'assertions'
 ]);
 
@@ -494,6 +527,15 @@ include.forEach(v => {
   }
   if (v.query_timeout) {
       testJvmArgs.push(`-DqueryTimeout=${v.query_timeout}`);
+  }
+  if (v.socket_timeout) {
+      testJvmArgs.push(`-DsocketTimeout=${v.socket_timeout}`);
+  }
+  if (v.login_timeout) {
+      testJvmArgs.push(`-DloginTimeout=${v.login_timeout}`);
+  }
+  if (v.connect_timeout) {
+      testJvmArgs.push(`-DconnectTimeout=${v.connect_timeout}`);
   }
   if (v.autosave !== 'never') {
       testJvmArgs.push(`-Dautosave=${v.autosave}`);


### PR DESCRIPTION
## Why

Three connection timeouts default to a value that keeps CI on a single branch of the driver code:

- `socketTimeout` defaults to `0`, so nothing in CI arms or disarms the read timeout, and the `SocketTimeoutException` handling behind it never runs. Setting it is the recommended production configuration, so the untested branch is the one most users are on.
- `loginTimeout` defaults to `0`, so `Driver.connect` always calls `makeConnection` inline. A non-zero value hands the whole connect to `ConnectTask` on an executor thread and turns on the abandon/cleanup logic — a different code path, not a different number.
- `connectTimeout` already defaults to `10`, so this one does not switch anything on. A shorter budget still exercises the deadline arithmetic in `remainingConnectTimeout()` across the SSL/GSS negotiation retries, and the handshake `soTimeout` in `MakeSSL`.

## What

Three unweighted axes in `.github/workflows/matrix.mjs`, each contributing `-D<property>=<value>` to `testExtraJvmArgs`:

| Axis | Values |
| --- | --- |
| `socket_timeout` | `''`, `60` |
| `login_timeout` | `''`, `13` |
| `connect_timeout` | `''`, `7` |

`TestUtil.mergeDefaultProperties` puts system properties in the `defaults` chain of every test connection, so each one reaches the driver as a connection property.

Notes on the values:

- `7 < 13` keeps the connect deadline tighter than the login one, so a genuinely stuck connect fails with a connect-level error instead of being masked by `loginTimeout`.
- `60` is far above what any healthy test query needs on localhost, so a job that trips it points at a hang rather than at a slow runner.
- `connectTimeout=0` would be the one genuinely distinct branch, but it is a poor fit for CI: a stuck connect would hang the job until the runner limit instead of failing fast.

## How to verify

```
cd .github/workflows && npm ci && RNG_SEED=s3 node matrix.mjs
```

Rows carry the values in the job name (`..., socketTimeout 60, loginTimeout 13, connectTimeout 7, ...`) and in `testExtraJvmArgs`. Over 30 runs of 6 jobs (180 rows), each non-default value landed in roughly half: `socketTimeout=60` in 89, `loginTimeout=13` in 85, `connectTimeout=7` in 86.

Tests that already cover these properties set them explicitly and are unaffected, since explicit props win over the system-property defaults: `ConnectTimeoutTest`, `LoginTimeoutTest`, `ConnectExecutorTest`, `LoginTimeoutInterruptTest`. `ConnectTimeoutTest` additionally goes through `DriverManager.getConnection` with its own `Properties`, which system properties never reach.

Whether the suite stays green under the non-default values is the open question this change is meant to answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)