### PR TITLE
Fix: #4328 Release the COPY on a genuine connection failure and not on SocketTimeoutException

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -1362,7 +1362,8 @@ public class QueryExecutorImpl extends QueryExecutorBase {
       } catch (IOException ioe) {
         // Release the lock if still held after a connection failure,
         // otherwise future operations will hang indefinitely in waitOnLock()
-        if (hasLock(op)) {
+        // except for SocketTimeoutException
+        if (!(ioe instanceof SocketTimeoutException) && hasLock(op)) {
           unlock(op);
         }
         throw new PSQLException(GT.tr("Database connection failed when reading from copy"),


### PR DESCRIPTION
COPY on a genuine connection failure

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

# Logical replication breaks on idle slot since 42.7.11: "Tried to write to an inactive copy operation"

## Summary

Since **42.7.11**, a logical replication consumer that uses the blocking
`PGReplicationStream.read()` API fails as soon as the slot is idle for one
status-interval, with:

```
org.postgresql.util.PSQLException: Tried to write to an inactive copy operation
```

The same code works correctly on **42.7.8 and earlier**. The regression is
**still present in 42.7.13**.

The root cause is a change in `QueryExecutorImpl.readFromCopy(...)` /
`writeToCopy(...)` that now calls `unlock(op)` inside the `IOException` catch
block. During logical replication the driver deliberately uses a socket read
timeout (`SocketTimeoutException`, an `IOException`) as its normal wake-up
mechanism to send periodic standby status updates. That routine timeout now
**deactivates the COPY**, and the very next status update fails.

## Environment

| | |
|---|---|
| pgjdbc version | **42.7.11** (also reproduced on 42.7.13; last working: 42.7.8) |
| JDK | 21 (also seen on 17) |
| PostgreSQL server | 14+ with `wal_level = logical` |
| Output plugin | `wal2json` (plugin-agnostic — same issue applies to any logical plugin) |
| OS | macOS / Linux |

## Steps to reproduce

1. Create a logical replication slot:
   ```sql
   SELECT pg_create_logical_replication_slot('test_slot', 'wal2json');
   ```

2. Consume it with the blocking replication API, configuring a finite socket
   read timeout (either a connection `socketTimeout`, or simply a
   `withStatusInterval`, which the driver folds into the socket timeout — see
   note below):

   ```java
   Properties props = new Properties();
   PGProperty.USER.set(props, USER);
   PGProperty.PASSWORD.set(props, PASSWORD);
   PGProperty.ASSUME_MIN_SERVER_VERSION.set(props, "9.4");
   PGProperty.REPLICATION.set(props, "database");
   PGProperty.PREFER_QUERY_MODE.set(props, "simple");
   // Reproduces with or without this; it just shortens the socket timeout:
   PGProperty.SOCKET_TIMEOUT.set(props, 30);

   Connection conn = DriverManager.getConnection(url, props);
   PGConnection repl = conn.unwrap(PGConnection.class);

   PGReplicationStream stream = repl.getReplicationAPI()
           .replicationStream()
           .logical()
           .withSlotName("test_slot")
           .withStatusInterval(3000, TimeUnit.MILLISECONDS)
           .start();

   while (true) {
       ByteBuffer msg = stream.read();          // blocking
       // ... process msg ...
       LogSequenceNumber lsn = stream.getLastReceiveLSN();
       stream.setFlushedLSN(lsn);
       stream.setAppliedLSN(lsn);
   }
   ```

3. Leave the slot **idle** (no changes on the source) for longer than the
   effective socket timeout (here 3 s).

**Result:** `read()` throws `PSQLException: Tried to write to an inactive copy
operation` on the first idle period. On 42.7.8 the reader stays connected
indefinitely across idle periods.

## Stack trace

```
org.postgresql.util.PSQLException: Tried to write to an inactive copy operation
    at org.postgresql.core.v3.QueryExecutorImpl.writeToCopy(QueryExecutorImpl.java:1244)
    at org.postgresql.core.v3.CopyDualImpl.writeToCopy(CopyDualImpl.java:23)
    at org.postgresql.core.v3.replication.V3PGReplicationStream.updateStatusInternal(V3PGReplicationStream.java:199)
    at org.postgresql.core.v3.replication.V3PGReplicationStream.timeUpdateStatus(V3PGReplicationStream.java:191)
    at org.postgresql.core.v3.replication.V3PGReplicationStream.readInternal(V3PGReplicationStream.java:133)
    at org.postgresql.core.v3.replication.V3PGReplicationStream.read(V3PGReplicationStream.java:78)
    at <application>.processRecords(...)
```

## Root cause

The failure is a sequence of interactions between the replication read loop and
a change to the COPY error handling:

1. `V3ReplicationProtocol.configureSocketTimeout(...)` sets the socket
   `SO_TIMEOUT` for the blocking read to
   `min(connectionSocketTimeout, statusInterval)` (or `statusInterval` when no
   connection `socketTimeout` is set). This is by design: the blocking read must
   wake up periodically to send standby status updates.

2. When the slot is idle, that blocking read times out and raises a
   `java.net.SocketTimeoutException` (a subclass of `IOException`).

3. **The regression:** in 42.7.11, `QueryExecutorImpl.readFromCopy(...)` and
   `writeToCopy(...)` were changed so their `IOException` catch blocks now call
   `unlock(op)` before wrapping/rethrowing:

   ```java
   } catch (IOException ioe) {
       if (hasLock(op)) {
           unlock(op);            // <-- NEW in 42.7.11; not present in 42.7.8
       }
       throw new PSQLException(GT.tr("Database connection failed when reading from copy"),
               PSQLState.CONNECTION_FAILURE, ioe);
   }
   ```

   This deactivates the COPY on **every** socket read timeout — including the
   expected, benign replication idle timeout.

4. `V3PGReplicationStream.receiveNextData(...)` treats a `PSQLException` whose
   cause is a `SocketTimeoutException` as normal ("no data yet") and returns
   `null` — correct and unchanged behavior:

   ```java
   } catch (PSQLException e) {
       if (e.getCause() instanceof SocketTimeoutException) {
           return null;
       }
       throw e;
   }
   ```

5. Back in `readInternal(...)`, before the `null` check, the code sends the
   periodic status update: `isTimeUpdate()` → `timeUpdateStatus()` →
   `updateStatusInternal()` → `writeToCopy(op, ...)`.

6. `writeToCopy` calls `hasLock(op)`, which is now `false` (unlocked in step 3),
   and throws **`Tried to write to an inactive copy operation`**.

In 42.7.8 step 3 did not unlock the COPY, so the idle timeout left the stream
active and the status update in step 5 succeeded — the reader survived idle
periods indefinitely.

## Expected behavior

A socket read timeout during logical replication is a normal idle signal, not a
connection failure. It must **not** deactivate the COPY. `read()` should return
after sending the periodic status update and continue streaming, as it did in
42.7.8.

## Suggested fix

In `QueryExecutorImpl.readFromCopy(...)` and `writeToCopy(...)`, do not
`unlock(op)` when the `IOException` is a `SocketTimeoutException` (a read
timeout is recoverable and expected for a replication COPY); only release the
COPY on a genuine connection failure. For example:

```java
} catch (IOException ioe) {
    if (!(ioe instanceof SocketTimeoutException) && hasLock(op)) {
        unlock(op);
    }
    throw new PSQLException(GT.tr("Database connection failed when reading from copy"),
            PSQLState.CONNECTION_FAILURE, ioe);
}
```

(Alternatively, `receiveNextData` / `readInternal` could re-validate the COPY
state after a `SocketTimeoutException` before attempting the status update, but
not unlocking on a benign timeout is the smaller, more correct change.)

