### PR TITLE
fix: cap FINEST Bind/Parse log message length to avoid OOM

### DIFF
--- a/docs/content/documentation/logging.md
+++ b/docs/content/documentation/logging.md
@@ -24,6 +24,13 @@ to enable logging that it is replaced by the use of `java.util.logging` in curre
 > Please note that while most people asked the use of a Logging Framework for a long time, this support is mainly to
 > debug the driver itself and not for general SQL query debug.
 
+> **NOTE**
+>
+> FINEST protocol dumps (especially `FE=> Bind(...)` with many or large parameters) are capped by the
+> `maxLogMessageLength` connection property (default `16384` characters). Set it to `0` for unlimited
+> messages. See the `maxLogMessageLength` property in the connection parameters documentation for details.
+
+
 ## Configuration
 
 The Logging APIs offer both static and dynamic configuration control. Static control enables field service staff to set

--- a/docs/content/documentation/use.md
+++ b/docs/content/documentation/use.md
@@ -522,6 +522,12 @@ Whether to include server error details in exceptions and log messages (for exam
 Setting to `false` will only include minimal, not sensitive messages.
 By default, this is set to `true`, server error details are propagated. This may include sensitive details such as query parameters.
 
+* **`maxLogMessageLength (`*int*`)`** *Default `16384`*\
+Maximum length in characters of a single driver log message. Caps FINEST protocol dumps such as Bind
+parameter lists so that very large or numerous bind values cannot exhaust memory while logging.
+Set to `0` to disable the limit (legacy unbounded behaviour). Messages that exceed the limit are
+truncated and end with `...(truncated)`.
+
 * **`quoteReturningIdentifiers (`*boolean*`)`** *Default `true`*\
 Quote returning columns. There are some ORM's that quote everything, including returning columns
 If we quote them, then we end up sending ""colname"" to the backend instead of "colname" which will not be found.

--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -465,6 +465,17 @@ public enum PGProperty {
       "When connections that are not explicitly closed are garbage collected, log the stacktrace from the opening of the connection to trace the leak source"),
 
   /**
+   * Maximum length of a single driver log message (characters). Used to cap FINEST protocol dumps
+   * such as Bind parameter lists so that very large or numerous bind values cannot trigger an
+   * {@link OutOfMemoryError} while logging. A value of {@code 0} disables the limit.
+   * Default is {@code 16384}.
+   */
+  MAX_LOG_MESSAGE_LENGTH(
+      "maxLogMessageLength",
+      "16384",
+      "Maximum length of a single driver log message in characters. Caps FINEST Bind/Parse dumps. 0 means unlimited."),
+
+  /**
    * Specifies size of buffer during fetching result set. Can be specified as specified size or
    * percent of heap memory.
    */

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/BindLog.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/BindLog.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.core.v3;
+
+import org.postgresql.core.Oid;
+import org.postgresql.util.LogMessageUtils;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * Formats FINEST {@code FE=> Bind(...)} log lines with a hard length cap so large or numerous
+ * bind parameters cannot OOM the process while logging.
+ *
+ * @see org.postgresql.PGProperty#MAX_LOG_MESSAGE_LENGTH
+ */
+final class BindLog {
+
+  private BindLog() {
+  }
+
+  /**
+   * Builds a Bind dump string.
+   *
+   * @param statementName prepared statement name (may be {@code null} for unnamed)
+   * @param portal destination portal (may be {@code null})
+   * @param params bind parameters
+   * @param standardConformingStrings whether to use standard_conforming_strings when rendering
+   * @param maxLogMessageLength max characters; {@code <= 0} means unlimited (legacy behaviour)
+   * @return log line, never longer than {@code maxLogMessageLength} when that limit is positive
+   */
+  static String format(@Nullable String statementName, @Nullable Portal portal,
+      SimpleParameterList params, boolean standardConformingStrings, int maxLogMessageLength) {
+    // Prefer a modest initial capacity; growth is bounded by the cap when set.
+    int initial = maxLogMessageLength > 0 ? Math.min(256, maxLogMessageLength) : 256;
+    StringBuilder sbuf = new StringBuilder(initial);
+    sbuf.append(" FE=> Bind(stmt=").append(statementName).append(",portal=").append(portal);
+
+    final boolean unlimited = maxLogMessageLength <= 0;
+    for (int i = 1; i <= params.getParameterCount(); i++) {
+      if (!unlimited && sbuf.length() >= maxLogMessageLength) {
+        break;
+      }
+
+      sbuf.append(",$").append(i).append("=<");
+
+      if (!unlimited) {
+        int remaining = maxLogMessageLength - sbuf.length();
+        if (remaining <= 0) {
+          break;
+        }
+        // Avoid materializing huge values just for logging. estimateLogSize is a lower bound for
+        // rendered size (bytea hex expands ~2x; text quoting adds a little).
+        int estimated = params.estimateLogSize(i);
+        if (estimated > remaining) {
+          String placeholder = "...(" + estimated + " bytes)";
+          LogMessageUtils.appendBounded(sbuf, placeholder, maxLogMessageLength);
+          sbuf.append(">,type=").append(Oid.toString(params.getTypeOID(i)));
+          continue;
+        }
+        String value = params.toString(i, standardConformingStrings);
+        LogMessageUtils.appendBounded(sbuf, value, maxLogMessageLength);
+      } else {
+        sbuf.append(params.toString(i, standardConformingStrings));
+      }
+      sbuf.append(">,type=").append(Oid.toString(params.getTypeOID(i)));
+    }
+
+    if (unlimited || sbuf.length() < maxLogMessageLength) {
+      sbuf.append(')');
+    }
+    return LogMessageUtils.truncate(sbuf, maxLogMessageLength);
+  }
+}

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/BindLog.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/BindLog.java
@@ -44,18 +44,29 @@ final class BindLog {
         break;
       }
 
-      sbuf.append(",$").append(i).append("=<");
+      // Build the parameter prefix first so we can decide whether it fits before appending.
+      // Appending ",$i=<" and then breaking leaves a dangling fragment on the truncated line.
+      String prefix = ",$" + i + "=<";
+      if (!unlimited) {
+        int remainingForPrefix = maxLogMessageLength - sbuf.length();
+        if (remainingForPrefix <= prefix.length()) {
+          break;
+        }
+      }
+      sbuf.append(prefix);
 
       if (!unlimited) {
         int remaining = maxLogMessageLength - sbuf.length();
-        if (remaining <= 0) {
-          break;
-        }
-        // Avoid materializing huge values just for logging. estimateLogSize is a lower bound for
-        // rendered size (bytea hex expands ~2x; text quoting adds a little).
+        // Avoid materializing huge values just for logging.
+        // estimateLogSize is a lower-bound for known types (bytea hex expands ~2x; text quoting
+        // adds a little). A negative estimate means an unrecognized value type — do not call
+        // toString (which can fully materialize e.g. a large custom object) and use a placeholder
+        // instead. The final truncate() still guarantees the returned line never exceeds the cap.
         int estimated = params.estimateLogSize(i);
-        if (estimated > remaining) {
-          String placeholder = "...(" + estimated + " bytes)";
+        if (estimated < 0 || estimated > remaining) {
+          String placeholder = estimated < 0
+              ? "...(unestimated)"
+              : "...(~" + estimated + " chars)";
           LogMessageUtils.appendBounded(sbuf, placeholder, maxLogMessageLength);
           sbuf.append(">,type=").append(Oid.toString(params.getTypeOID(i)));
           continue;

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -102,6 +102,7 @@ import org.postgresql.jdbc.ResourceLock;
 import org.postgresql.jdbc.TimestampUtils;
 import org.postgresql.util.ByteStreamWriter;
 import org.postgresql.util.GT;
+import org.postgresql.util.LogMessageUtils;
 import org.postgresql.util.PSQLException;
 import org.postgresql.util.PSQLState;
 import org.postgresql.util.PSQLWarning;
@@ -246,6 +247,7 @@ public class QueryExecutorImpl extends QueryExecutorBase {
 
     this.allowEncodingChanges = PGProperty.ALLOW_ENCODING_CHANGES.getBoolean(info);
     this.cleanupSavePoints = PGProperty.CLEANUP_SAVEPOINTS.getBoolean(info);
+    this.maxLogMessageLength = Math.max(0, PGProperty.MAX_LOG_MESSAGE_LENGTH.getInt(info));
     // assignment, argument
     this.replicationProtocol = new V3ReplicationProtocol(this, pgStream);
     readStartupMessages();
@@ -1789,16 +1791,19 @@ public class QueryExecutorImpl extends QueryExecutorBase {
 
     if (LOGGER.isLoggable(Level.FINEST)) {
       StringBuilder sbuf = new StringBuilder(" FE=> Parse(stmt=" + statementName + ",query=\"");
-      sbuf.append(nativeSql);
+      LogMessageUtils.appendBounded(sbuf, nativeSql, maxLogMessageLength);
       sbuf.append("\",oids={");
       for (int i = 1; i <= params.getParameterCount(); i++) {
+        if (maxLogMessageLength > 0 && sbuf.length() >= maxLogMessageLength) {
+          break;
+        }
         if (i != 1) {
           sbuf.append(",");
         }
         sbuf.append(params.getTypeOID(i));
       }
       sbuf.append("})");
-      LOGGER.log(Level.FINEST, sbuf.toString());
+      LOGGER.log(Level.FINEST, LogMessageUtils.truncate(sbuf, maxLogMessageLength));
     }
 
     //
@@ -1842,14 +1847,8 @@ public class QueryExecutorImpl extends QueryExecutorBase {
     byte[] encodedPortalName = portal == null ? null : portal.getEncodedPortalName();
 
     if (LOGGER.isLoggable(Level.FINEST)) {
-      StringBuilder sbuf = new StringBuilder(" FE=> Bind(stmt=" + statementName + ",portal=" + portal);
-      for (int i = 1; i <= params.getParameterCount(); i++) {
-        sbuf.append(",$").append(i).append("=<")
-            .append(params.toString(i, getStandardConformingStrings()))
-            .append(">,type=").append(Oid.toString(params.getTypeOID(i)));
-      }
-      sbuf.append(")");
-      LOGGER.log(Level.FINEST, sbuf.toString());
+      LOGGER.log(Level.FINEST, BindLog.format(statementName, portal, params,
+          getStandardConformingStrings(), maxLogMessageLength));
     }
 
     // Total size = 4 (size field) + N + 1 (destination portal)
@@ -3353,6 +3352,8 @@ public class QueryExecutorImpl extends QueryExecutorBase {
   private long nextUniqueID = 1;
   private final boolean allowEncodingChanges;
   private final boolean cleanupSavePoints;
+  /** Cap for FINEST protocol dump log lines; {@code 0} means unlimited. */
+  private final int maxLogMessageLength;
 
   /**
    * The estimated server response size since we last consumed the input stream from the server, in

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/SimpleParameterList.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/SimpleParameterList.java
@@ -496,14 +496,26 @@ class SimpleParameterList implements V3ParameterList {
   }
 
   /**
-   * Cheap size estimate for logging only. Avoids encoding the value.
+   * Cheap size estimate for logging only. Avoids encoding or fully rendering the value.
    *
-   * @return estimated character/byte size, or {@code -1} when unknown / null
+   * <p>Recognized value types ({@code byte[]}, {@code String}, {@link StreamWrapper},
+   * {@link ByteStreamWriter}) return a non-negative lower bound on rendered log size. Unset and
+   * SQL-null parameters return the length of their fixed log forms ({@code "?"} /
+   * {@code "(NULL)"}). Any other value type returns {@code -1} (unknown size) so callers can avoid
+   * unbounded {@code toString} materialization.</p>
+   *
+   * @return non-negative estimated size in characters (or raw bytes for binary payloads — a lower
+   *         bound on rendered length), or {@code -1} when the size is unknown
    */
   int estimateLogSize(@Positive int index) {
     Object value = paramValues[index - 1];
-    if (value == null || value == NULL_OBJECT) {
-      return -1;
+    if (value == null) {
+      // Unset parameter renders as "?" in toString.
+      return 1;
+    }
+    if (value == NULL_OBJECT) {
+      // SQL null renders as "(NULL)".
+      return 6;
     }
     if (value instanceof byte[]) {
       return ((byte[]) value).length;
@@ -517,6 +529,7 @@ class SimpleParameterList implements V3ParameterList {
     if (value instanceof ByteStreamWriter) {
       return ((ByteStreamWriter) value).getLength();
     }
+    // Unrecognized type: callers must not assume the value is small enough to render.
     return -1;
   }
 

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/SimpleParameterList.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/SimpleParameterList.java
@@ -495,6 +495,31 @@ class SimpleParameterList implements V3ParameterList {
     return (byte) (flags[index] & INOUT);
   }
 
+  /**
+   * Cheap size estimate for logging only. Avoids encoding the value.
+   *
+   * @return estimated character/byte size, or {@code -1} when unknown / null
+   */
+  int estimateLogSize(@Positive int index) {
+    Object value = paramValues[index - 1];
+    if (value == null || value == NULL_OBJECT) {
+      return -1;
+    }
+    if (value instanceof byte[]) {
+      return ((byte[]) value).length;
+    }
+    if (value instanceof String) {
+      return ((String) value).length();
+    }
+    if (value instanceof StreamWrapper) {
+      return ((StreamWrapper) value).getLength();
+    }
+    if (value instanceof ByteStreamWriter) {
+      return ((ByteStreamWriter) value).getLength();
+    }
+    return -1;
+  }
+
   int getV3Length(@Positive int index) {
     --index;
 

--- a/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
+++ b/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
@@ -1850,6 +1850,23 @@ public abstract class BaseDataSource implements CommonDataSource, Referenceable 
     PGProperty.FLUSH_CACHE_ON_DDL.set(properties, flushCacheOnDdl);
   }
 
+  /**
+   * @return maximum length of a single driver log message in characters
+   * @see PGProperty#MAX_LOG_MESSAGE_LENGTH
+   */
+  public int getMaxLogMessageLength() {
+    return PGProperty.MAX_LOG_MESSAGE_LENGTH.getIntNoCheck(properties);
+  }
+
+  /**
+   * @param maxLogMessageLength maximum length of a single driver log message in characters;
+   *     {@code 0} means unlimited
+   * @see PGProperty#MAX_LOG_MESSAGE_LENGTH
+   */
+  public void setMaxLogMessageLength(int maxLogMessageLength) {
+    PGProperty.MAX_LOG_MESSAGE_LENGTH.set(properties, maxLogMessageLength);
+  }
+
   public @Nullable String getMaxResultBuffer() {
     return PGProperty.MAX_RESULT_BUFFER.getOrDefault(properties);
   }

--- a/pgjdbc/src/main/java/org/postgresql/util/LogMessageUtils.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/LogMessageUtils.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2026, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.util;
+
+/**
+ * Helpers for keeping driver log output bounded.
+ *
+ * <p>FINEST protocol dumps (especially Bind with many or large parameters) can allocate enormous
+ * strings and cause {@link OutOfMemoryError}. These utilities cap message length while preserving a
+ * readable prefix of the original content.</p>
+ *
+ * @see org.postgresql.PGProperty#MAX_LOG_MESSAGE_LENGTH
+ */
+public final class LogMessageUtils {
+
+  /** Suffix appended when a log message is truncated. */
+  public static final String TRUNCATION_SUFFIX = "...(truncated)";
+
+  private LogMessageUtils() {
+  }
+
+  /**
+   * Truncates {@code message} so that its length is at most {@code maxLength} characters.
+   *
+   * <p>If {@code maxLength} is {@code 0} or negative, the message is returned unchanged
+   * (unlimited). When truncation is required, the result ends with
+   * {@link #TRUNCATION_SUFFIX} (or a prefix of it when {@code maxLength} is smaller than the
+   * suffix).</p>
+   *
+   * @param message message to possibly truncate; must not be {@code null}
+   * @param maxLength maximum length in characters; {@code <= 0} means unlimited
+   * @return the original message, or a truncated copy of length {@code maxLength}
+   */
+  public static String truncate(CharSequence message, int maxLength) {
+    if (message == null) {
+      throw new IllegalArgumentException("message must not be null");
+    }
+    if (maxLength <= 0 || message.length() <= maxLength) {
+      return message.toString();
+    }
+    if (maxLength <= TRUNCATION_SUFFIX.length()) {
+      return TRUNCATION_SUFFIX.substring(0, maxLength);
+    }
+    StringBuilder sb = new StringBuilder(maxLength);
+    sb.append(message, 0, maxLength - TRUNCATION_SUFFIX.length());
+    sb.append(TRUNCATION_SUFFIX);
+    return sb.toString();
+  }
+
+  /**
+   * Appends as much of {@code value} as fits into {@code sb} without exceeding {@code maxLength}
+   * total length of {@code sb}. When the value does not fit fully, appends a truncated form ending
+   * with {@link #TRUNCATION_SUFFIX} (budget permitting).
+   *
+   * <p>If {@code maxLength} is {@code <= 0}, the full value is appended (unlimited).</p>
+   *
+   * @param sb destination buffer
+   * @param value text to append
+   * @param maxLength overall cap for {@code sb}; {@code <= 0} means unlimited
+   * @return {@code true} if the full value was appended, {@code false} if truncated or skipped
+   */
+  public static boolean appendBounded(StringBuilder sb, CharSequence value, int maxLength) {
+    if (maxLength <= 0) {
+      sb.append(value);
+      return true;
+    }
+    int remaining = maxLength - sb.length();
+    if (remaining <= 0) {
+      return false;
+    }
+    if (value.length() <= remaining) {
+      sb.append(value);
+      return true;
+    }
+    if (remaining <= TRUNCATION_SUFFIX.length()) {
+      sb.append(TRUNCATION_SUFFIX, 0, remaining);
+      return false;
+    }
+    sb.append(value, 0, remaining - TRUNCATION_SUFFIX.length());
+    sb.append(TRUNCATION_SUFFIX);
+    return false;
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/core/v3/BindLogTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/core/v3/BindLogTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2026, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.core.v3;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.postgresql.core.Oid;
+import org.postgresql.util.LogMessageUtils;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.sql.SQLException;
+
+/**
+ * Unit tests for capped Bind FINEST dump formatting ({@link BindLog}).
+ */
+class BindLogTest {
+  private TypeTransferModeRegistry transferModeRegistry;
+
+  @BeforeEach
+  void setUp() {
+    transferModeRegistry = new TypeTransferModeRegistry() {
+      @Override
+      public boolean useBinaryForSend(int oid) {
+        return false;
+      }
+
+      @Override
+      public boolean useBinaryForReceive(int oid) {
+        return false;
+      }
+    };
+  }
+
+  @Test
+  void smallBindIsNotTruncated() throws SQLException {
+    SimpleParameterList params = new SimpleParameterList(2, transferModeRegistry);
+    params.setIntParameter(1, 1);
+    params.setIntParameter(2, 2);
+
+    String log = BindLog.format("S_1", null, params, true, 16_384);
+    assertTrue(log.startsWith(" FE=> Bind(stmt=S_1,portal=null"));
+    assertTrue(log.contains("$1=<"));
+    assertTrue(log.contains("$2=<"));
+    assertTrue(log.endsWith(")"));
+    assertFalse(log.contains(LogMessageUtils.TRUNCATION_SUFFIX));
+  }
+
+  @Test
+  void manyBindsAreCapped() throws SQLException {
+    final int count = 500;
+    SimpleParameterList params = new SimpleParameterList(count, transferModeRegistry);
+    String filler = repeat('x', 80);
+    for (int i = 1; i <= count; i++) {
+      // Long-ish values so the uncapped message would be well over the limit.
+      params.setStringParameter(i, "value-" + i + "-" + filler, Oid.VARCHAR);
+    }
+
+    final int maxLen = 512;
+    String log = BindLog.format("S_many", null, params, true, maxLen);
+
+    assertEquals(maxLen, log.length(), "capped log must be exactly max length");
+    assertTrue(log.startsWith(" FE=> Bind(stmt=S_many"));
+    assertTrue(log.endsWith(LogMessageUtils.TRUNCATION_SUFFIX)
+            || log.contains(LogMessageUtils.TRUNCATION_SUFFIX),
+        "capped log should indicate truncation");
+    // Must not have expanded every parameter into the log.
+    assertFalse(log.contains("$500="), "late parameters should be omitted when cap is reached");
+  }
+
+  @Test
+  void hugeSingleValueIsNotMaterializedPastBudget() throws SQLException {
+    SimpleParameterList params = new SimpleParameterList(1, transferModeRegistry);
+    // Large string; if fully rendered into the log without a size check this would be huge.
+    String huge = repeat('H', 200_000);
+    params.setStringParameter(1, huge, Oid.VARCHAR);
+
+    final int maxLen = 256;
+    String log = BindLog.format(null, null, params, true, maxLen);
+
+    assertTrue(log.length() <= maxLen, "log length " + log.length() + " exceeds cap " + maxLen);
+    assertFalse(log.contains(huge), "full parameter value must not appear in the capped log");
+    assertTrue(log.contains("bytes"), "huge value should be replaced by a size placeholder: " + log);
+  }
+
+  private static String repeat(char c, int count) {
+    char[] chars = new char[count];
+    java.util.Arrays.fill(chars, c);
+    return new String(chars);
+  }
+
+  @Test
+  void unlimitedKeepsFullDump() throws SQLException {
+    SimpleParameterList params = new SimpleParameterList(3, transferModeRegistry);
+    params.setIntParameter(1, 10);
+    params.setIntParameter(2, 20);
+    params.setIntParameter(3, 30);
+
+    String log = BindLog.format("S_full", null, params, true, 0);
+    assertTrue(log.contains("$1=<"));
+    assertTrue(log.contains("$2=<"));
+    assertTrue(log.contains("$3=<"));
+    assertTrue(log.endsWith(")"));
+    assertFalse(log.contains(LogMessageUtils.TRUNCATION_SUFFIX));
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/core/v3/BindLogTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/core/v3/BindLogTest.java
@@ -15,6 +15,7 @@ import org.postgresql.util.LogMessageUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Field;
 import java.sql.SQLException;
 
 /**
@@ -65,11 +66,14 @@ class BindLogTest {
     final int maxLen = 512;
     String log = BindLog.format("S_many", null, params, true, maxLen);
 
-    assertEquals(maxLen, log.length(), "capped log must be exactly max length");
+    assertTrue(log.length() <= maxLen, "capped log must not exceed max length: " + log.length());
     assertTrue(log.startsWith(" FE=> Bind(stmt=S_many"));
-    assertTrue(log.endsWith(LogMessageUtils.TRUNCATION_SUFFIX)
-            || log.contains(LogMessageUtils.TRUNCATION_SUFFIX),
-        "capped log should indicate truncation");
+    // Cap may stop cleanly between parameters (no suffix) or mid-value (truncation suffix /
+    // partial suffix). Either way late parameters must be omitted and the line stays bounded.
+    assertTrue(log.contains(LogMessageUtils.TRUNCATION_SUFFIX)
+            || log.contains("...")
+            || log.length() < maxLen,
+        "capped log should indicate truncation or stop before the cap; got: " + log);
     // Must not have expanded every parameter into the log.
     assertFalse(log.contains("$500="), "late parameters should be omitted when cap is reached");
   }
@@ -86,7 +90,64 @@ class BindLogTest {
 
     assertTrue(log.length() <= maxLen, "log length " + log.length() + " exceeds cap " + maxLen);
     assertFalse(log.contains(huge), "full parameter value must not appear in the capped log");
-    assertTrue(log.contains("bytes"), "huge value should be replaced by a size placeholder: " + log);
+    // Placeholder uses a character-count estimate (not raw bytes).
+    assertTrue(log.contains("chars"), "huge value should be replaced by a size placeholder: " + log);
+    assertTrue(log.contains("~200000"), "placeholder should report the estimated size: " + log);
+  }
+
+  @Test
+  void unknownValueTypeIsNotFullyMaterialized() throws Exception {
+    SimpleParameterList params = new SimpleParameterList(1, transferModeRegistry);
+    // Inject a value type estimateLogSize does not recognize. Production bind paths only store
+    // String/byte[]/StreamWrapper/ByteStreamWriter/null, but the formatter must still avoid
+    // calling toString on unbounded unknown objects when a length cap is set.
+    final String huge = repeat('U', 500_000);
+    Object unknown = new Object() {
+      @Override
+      public String toString() {
+        return huge;
+      }
+    };
+    Field paramValues = SimpleParameterList.class.getDeclaredField("paramValues");
+    paramValues.setAccessible(true);
+    Object[] values = (Object[]) paramValues.get(params);
+    values[0] = unknown;
+
+    final int maxLen = 256;
+    String log = BindLog.format(null, null, params, true, maxLen);
+
+    assertTrue(log.length() <= maxLen, "log length " + log.length() + " exceeds cap " + maxLen);
+    assertFalse(log.contains(huge), "unknown-type toString must not be fully rendered into the log");
+    assertTrue(log.contains("unestimated"), "unknown size should use an unestimated placeholder: " + log);
+  }
+
+  @Test
+  void nullParameterStillRenders() throws SQLException {
+    SimpleParameterList params = new SimpleParameterList(1, transferModeRegistry);
+    params.setNull(1, Oid.VARCHAR);
+
+    String log = BindLog.format("S_null", null, params, true, 16_384);
+    assertTrue(log.contains("$1=<(NULL)>"), "SQL null should still render: " + log);
+    assertFalse(log.contains("unestimated"), "null is sized, not unknown");
+  }
+
+  @Test
+  void budgetExhaustionDoesNotLeaveDanglingParameterPrefix() throws SQLException {
+    // Fill most of the budget with one parameter, leave room only for a partial next prefix.
+    SimpleParameterList params = new SimpleParameterList(3, transferModeRegistry);
+    params.setStringParameter(1, repeat('a', 40), Oid.VARCHAR);
+    params.setStringParameter(2, "bb", Oid.VARCHAR);
+    params.setStringParameter(3, "cc", Oid.VARCHAR);
+
+    // Cap so that after $1 (and maybe part of the trailer) there is not enough room for ",$2=<".
+    final int maxLen = 80;
+    String log = BindLog.format("S_dangle", null, params, true, maxLen);
+
+    assertTrue(log.length() <= maxLen, "log length " + log.length() + " exceeds " + maxLen);
+    // Must not leave a half-written parameter start such as ",$2=<" or ",$2=<...(truncated)".
+    assertFalse(log.endsWith("=<")
+            || log.endsWith("=<" + LogMessageUtils.TRUNCATION_SUFFIX),
+        "truncated line must not leave a dangling ,$i=< prefix: " + log);
   }
 
   private static String repeat(char c, int count) {

--- a/pgjdbc/src/test/java/org/postgresql/util/LogMessageUtilsTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/util/LogMessageUtilsTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class LogMessageUtilsTest {
+
+  @Test
+  void truncateDoesNotChangeShortMessages() {
+    assertEquals("hello", LogMessageUtils.truncate("hello", 100));
+    assertEquals("hello", LogMessageUtils.truncate("hello", 5));
+  }
+
+  @Test
+  void truncateUnlimitedWhenMaxNonPositive() {
+    String huge = repeat('x', 100_000);
+    assertEquals(huge, LogMessageUtils.truncate(huge, 0));
+    assertEquals(huge, LogMessageUtils.truncate(huge, -1));
+  }
+
+  @Test
+  void truncateAppendsSuffix() {
+    String input = "abcdefghijklmnopqrstuvwxyz";
+    String truncated = LogMessageUtils.truncate(input, 20);
+    assertEquals(20, truncated.length());
+    assertTrue(truncated.endsWith(LogMessageUtils.TRUNCATION_SUFFIX));
+    assertTrue(truncated.startsWith("abcdef"));
+  }
+
+  @Test
+  void truncateVerySmallMaxLength() {
+    assertEquals(".", LogMessageUtils.truncate("abcdefgh", 1));
+    assertEquals("...", LogMessageUtils.truncate("abcdefgh", 3));
+    String longInput = "abcdefghijklmnopqrstuvwxyz0123456789";
+    assertEquals(LogMessageUtils.TRUNCATION_SUFFIX,
+        LogMessageUtils.truncate(longInput, LogMessageUtils.TRUNCATION_SUFFIX.length()));
+  }
+
+  @Test
+  void truncateRejectsNull() {
+    assertThrows(IllegalArgumentException.class, () -> LogMessageUtils.truncate(null, 10));
+  }
+
+  @Test
+  void appendBoundedFitsFully() {
+    StringBuilder sb = new StringBuilder("pre:");
+    assertTrue(LogMessageUtils.appendBounded(sb, "value", 100));
+    assertEquals("pre:value", sb.toString());
+  }
+
+  @Test
+  void appendBoundedTruncates() {
+    StringBuilder sb = new StringBuilder("pre:");
+    assertFalse(LogMessageUtils.appendBounded(sb, "abcdefghijklmnopqrstuvwxyz", 20));
+    assertEquals(20, sb.length());
+    assertTrue(sb.toString().endsWith(LogMessageUtils.TRUNCATION_SUFFIX));
+    assertTrue(sb.toString().startsWith("pre:"));
+  }
+
+  @Test
+  void appendBoundedUnlimited() {
+    StringBuilder sb = new StringBuilder();
+    String value = repeat('x', 50_000);
+    assertTrue(LogMessageUtils.appendBounded(sb, value, 0));
+    assertEquals(value, sb.toString());
+  }
+
+  private static String repeat(char c, int count) {
+    char[] chars = new char[count];
+    java.util.Arrays.fill(chars, c);
+    return new String(chars);
+  }
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes to Existing Features:

* [x] Does this break existing behaviour? If so please explain.
  * Behaviour change only when FINEST protocol dumps would exceed **16384** characters (new default). Truncated messages end with `...(truncated)`. Set `maxLogMessageLength=0` for the previous unlimited dumps.
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

## Summary

Fixes #995; FINEST Bind dumps with many/large parameters could allocate unbounded strings and OOM while logging.

### Changes
- New connection property **`maxLogMessageLength`** (default `16384`, `0` = unlimited)
- Cap `FE=> Bind(...)` dumps via `BindLog` (stop appending params once the budget is exhausted; skip materializing individual values larger than the remaining budget)
- Cap `FE=> Parse(...)` query text dumps similarly
- DataSource getter/setter + docs

### Tests
```
./gradlew :postgresql:test \
  --tests 'org.postgresql.util.LogMessageUtilsTest' \
  --tests 'org.postgresql.core.v3.BindLogTest' \
  --tests 'org.postgresql.test.jdbc2.PGPropertyTest'
```
Also ran `:postgresql:checkstyleMain` / `checkstyleTest`.

### AI/LLM disclosure

- AI coding tools (including Grok and/or Codex agent-assisted editing) were used to help draft or modify code and this PR description.
