### PR TITLE
doc: add java-nullability-use, pgjdbc-teskit-use skills

### DIFF
--- a/.agents/skills/java-nullability-use/SKILL.md
+++ b/.agents/skills/java-nullability-use/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: java-nullability-use
+description: How to write Java code in pgjdbc that satisfies the Checker Framework null-safety verifier. Apply when adding or editing fields, parameters, return types, or generic type arguments in main Java sources.
+---
+
+# Null safety in pgjdbc
+
+Main Java sources (`**/src/main/java`) are verified by the Checker
+Framework's nullness checker, run under `-PenableCheckerframework`.
+Test sources are not verified.
+
+## Defaults
+
+Parameters, return values, and fields default to `@NonNull` — do not
+annotate them as such. Annotate only the type uses where `null` is a
+legal value:
+
+```java
+void f(@Nullable Foo x)                 // parameter
+@Nullable Foo find(int id)              // return type
+private @Nullable Foo cached;           // field
+Map<String, @Nullable Foo> byName;      // generic type argument
+```
+
+Local variables don't need annotations — the checker infers them from
+the assignment.
+
+Type variables are the exception to "don't write `@NonNull`". A bare
+`<T>` gets an implicit `@Nullable Object` bound, so `T` may stand for a
+nullable type. Spell the bound out when the code needs non-null
+elements:
+
+```java
+interface ArrayDecoder<A extends @NonNull Object> { ... }
+```
+
+Annotations come from `org.checkerframework.checker.nullness.qual`. Do
+**not** use `javax.annotation.Nullable` or
+`org.jetbrains.annotations.Nullable` — the verifier ignores them and
+the type use stays implicitly non-null, defeating the point.
+
+## Null in, null out
+
+`@PolyNull` ties several type uses in one signature together: at each
+call site they are either all `@Nullable` or all `@NonNull`, decided
+from the arguments. Reach for it when a method returns null exactly
+when its input was null — the alternatives are two overloads, or a
+`@Nullable` return that forces every caller to cast.
+
+```java
+public @PolyNull Timestamp toTimestamp(@Nullable Calendar cal,
+    @PolyNull String s) throws SQLException
+```
+
+A caller passing a non-null `s` gets a non-null `Timestamp` with no
+`castNonNull`. `cal` is annotated separately, so it stays nullable
+either way.
+
+## Method-by-method analysis
+
+The checker verifies each method in isolation. A `@Nullable` field is
+"could be null" on every method entry, regardless of any earlier check
+in another method. Three options when that bites:
+
+- `@MonotonicNonNull` on a field that starts null and is assigned once
+  (lazy init, init-after-construct). Reads after the assignment don't
+  need a cast.
+- `@RequiresNonNull("field")` on a method whose caller is responsible
+  for null-checking the field. The contract is enforced at every call
+  site, so the body can read the field directly.
+- `org.postgresql.util.internal.Nullness.castNonNull(value)` — or the
+  two-arg overload with a message — when neither annotation fits and
+  you genuinely know the value is non-null at that point. Prefer the
+  message overload when the rationale is non-obvious; the message
+  surfaces in the runtime error if you're wrong.
+
+If you find yourself reaching for `castNonNull` more than once on the
+same field in the same method, hoist it to a local variable and read
+the local instead.
+
+## Array types
+
+The annotation binds to the type component immediately to its right
+(JLS §9.7.4). Position changes meaning:
+
+```java
+String[] x;                       // array: non-null, elements: non-null
+String @Nullable [] x;            // array: nullable,  elements: non-null
+@Nullable String[] x;             // array: non-null,  elements: nullable
+@Nullable String @Nullable [] x;  // both nullable
+```
+
+Multi-dim arrays follow the same rule for each `[]`.
+
+## Overriding annotated JDK entries
+
+The checker ships an annotated JDK with occasional wrong entries.
+Override them with stub files under `config/checkerframework/`. The
+extension must be `.astub` — any other extension is silently ignored.

--- a/.agents/skills/pgjdbc-testkit-use/SKILL.md
+++ b/.agents/skills/pgjdbc-testkit-use/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: pgjdbc-testkit-use
+description: How to use pgjdbc's `TestUtil` and `BaseTest4` helpers when writing JUnit 5 tests that open connections or create PostgreSQL schema. Apply when adding or editing tests under `pgjdbc/src/test/`.
+---
+
+# Using the pgjdbc test kit
+
+Tests run against a live PostgreSQL server provided by the test
+harness. The helpers in `org.postgresql.test.TestUtil` and the
+`BaseTest4` lifecycle base class encode several conventions the suite
+relies on. Apply them whenever a test opens a connection or touches
+schema.
+
+When the test extends `BaseTest4`, override `setUp()` / `tearDown()`
+**without** adding a second `@BeforeEach`/`@AfterEach` annotation —
+`BaseTest4` already wires the JUnit hooks (annotating again breaks
+JUnit 5's override semantics).
+
+## Always go through TestUtil for schema
+
+Naked `CREATE TABLE foo(...)` leaks objects when a previous run died
+between create and drop. Every TestUtil creator drops first; every
+TestUtil dropper is `IF EXISTS … CASCADE` aware:
+
+- Creators: `createTable`, `createTempTable`, `createUnloggedTable`,
+  `createView`, `createMaterializedView`, `createSchema`,
+  `createEnumType`, `createCompositeType`, `createDomain`.
+- Droppers: `dropTable`, `dropView`, `dropMaterializedView`,
+  `dropSchema`, `dropType`, `dropDomain`, `dropSequence`,
+  `dropFunction(name, argTypes)`, `dropReplicationSlot`.
+
+`dropObject` issues `DROP … IF EXISTS … CASCADE` in autocommit and
+plain `DROP … CASCADE` inside a transaction (because `IF EXISTS`
+would swallow an error that should abort the tx). Pick the matching
+`dropXxx()` per created object — do not hand-roll `DROP TABLE …`.
+
+There is no `createFunction` helper. Create functions with
+`TestUtil.execute(con, "CREATE OR REPLACE FUNCTION …")` and drop them
+with `TestUtil.dropFunction(con, name, "<arg types>")`. The argument
+string must match the signature, since PostgreSQL keys functions by
+`(name, argtypes)`.
+
+## Connections
+
+- `TestUtil.openDB()` / `TestUtil.openDB(props)` — the standard test
+  connection. Properties layer on top of system properties and
+  `build.properties`; do not reconstruct the JDBC URL by hand.
+- `TestUtil.openPrivilegedDB()` — connection as the privileged role,
+  required for tests that load C functions, create extensions, or
+  terminate backends.
+- `TestUtil.closeDB(conn)` — null-safe close. Use in `@AfterEach` /
+  `@AfterAll` / `finally` so a partial setup still tears down.
+
+## Version gating
+
+Skip — don't branch — when a feature requires a newer server:
+
+- `TestUtil.assumeHaveMinimumServerVersion(ServerVersion.v15)` —
+  static, opens its own privileged connection. Use from `@BeforeAll`.
+- `BaseTest4.assumeMinimumServerVersion(ServerVersion.v15)` — uses
+  the already-open `con` field. Use from `setUp()` or test methods.
+
+`if (haveMinimumServerVersion(...))` silently passes the test on
+older servers and hides regressions; `assumeTrue` records a skip
+instead.

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# AGENTS.md
+
+After modifying Java code, before reporting the change as done (handing control back to the user), run `./gradlew --quiet classes style` and fix any reported issues.
+
+If the change touched nullability annotations (`@Nullable`, `@MonotonicNonNull`, `@RequiresNonNull`, `Nullness.castNonNull`, generic null-arg parameters, etc.),
+add `-PenableCheckerframework` to verify null-safety. The Checker pass adds ~2 min to the build, so don't enable it for changes that don't affect nullability.
+
+## Build
+
+The build is Gradle, driven through `./gradlew`. The driver sources live in `pgjdbc/`, but that subproject is named `:postgresql`, after the published Maven artifact. Address it by that name when compiling or testing the driver:
+
+    ./gradlew --quiet :postgresql:compileJava
+
+Every other subproject (`testkit`, `benchmarks`, `pgjdbc-osgi-test`, ...) is named after its directory.
+
+Java source level is 1.8.
+
+When editing Java code under `**/src/main/java/`, apply the `java-nullability-use` skill.
+
+## Tests
+
+When writing or editing a pgjdbc test that opens a connection or creates PostgreSQL schema (tables, types, functions, views), apply the `pgjdbc-testkit-use` skill.
+
+Integration tests require a running PostgreSQL instance. Start one with: `docker/postgres-server/docker-compose.yml`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
Let's document custom conventions: Java code targets 1.8, Java code requires nullability annotations, and TestUtil/BaseTest4 are needed for most of the tests.

I do not intend duplicating https://github.com/pgjdbc/pgjdbc/pull/4335 (I would rather keep only those changes here that are not listed in 4335). I have been using the skills for a long time along with https://github.com/Netcracker/qubership-ai-packages/tree/main/agent-packages/english-uk-developer-style.

I've the following relevant entries in my `~/.claude/CLAUDE.md` (that is global, I'm not sure it is worth duplicating those for every project):

```
* always pass `--quiet` when agent calls gradle to reduce output.
* When preparing text for GitHub (PR or issue description, comment, discussion), don't hard-wrap — keep each paragraph and list item on one line; GitHub re-flows it.
```