### PR TITLE
feat: bound FINEST log messages with maxLogMessageLength (alternative to #4332)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 Notable changes since version 42.0.0, read the complete [History of Changes](https://jdbc.postgresql.org/documentation/changelog.html).
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
+## [Unreleased]
+
+### Added
+* feat: add the `maxLogMessageLength` connection property, which caps a single log message at 16384 characters by default and ends a shortened one with `...(truncated)`. A protocol trace logged at `FINEST` copies the query text and every bound value into one message, so a large batch or a large `bytea` could exhaust the heap while the driver built a message nobody reads in full. A bound value that no longer fits is now cut short, and an oversized `bytea` reports its size rather than being spelled out in hex. Set the property to `0` for the previous untruncated traces [Issue #995](https://github.com/pgjdbc/pgjdbc/issues/995)
+* feat: add the `maxLogParameterLength` connection property, which caps a single bound parameter in a `Bind` trace at 2048 characters by default and ends a shortened one with `...`. Without it one long value spends the whole trace on itself and hides every parameter after it, so the log shows the query but not the values it ran on. PostgreSQL bounds its own parameter logging the same way through `log_parameter_max_length`. Set the property to `0` to cap parameters only by `maxLogMessageLength` [Issue #995](https://github.com/pgjdbc/pgjdbc/issues/995)
+
 ## [42.7.13] (2026-07-06)
 
 ### Added

--- a/docs/content/documentation/logging.md
+++ b/docs/content/documentation/logging.md
@@ -24,6 +24,13 @@ to enable logging that it is replaced by the use of `java.util.logging` in curre
 > Please note that while most people asked the use of a Logging Framework for a long time, this support is mainly to
 > debug the driver itself and not for general SQL query debug.
 
+> **NOTE**
+>
+> A `FINEST` message that embeds query text or a data value grows with the data itself, so the driver truncates one
+> longer than the `maxLogMessageLength` connection property allows (16384 characters by default) and ends it with
+> `...(truncated)`. Set the property to `0` to log messages of any length. A single bound parameter is capped
+> separately by `maxLogParameterLength`, so one long value cannot hide the parameters after it.
+
 ## Configuration
 
 The Logging APIs offer both static and dynamic configuration control. Static control enables field service staff to set

--- a/docs/content/documentation/use.md
+++ b/docs/content/documentation/use.md
@@ -216,6 +216,23 @@ This property is no longer used by the driver and will be ignored. All logging c
 * **`loggerFile (`*String*`)`**\
 This property is no longer used by the driver and will be ignored. All logging configuration is handled by java.util.logging.
 
+* **`maxLogMessageLength (`*int*`)`** *Default `16384`*\
+Number of characters a log message that embeds query text or a data value may reach before the driver truncates it.
+The `FINEST` protocol traces copy the query text, every bound parameter value, and the server's error text into one
+message, so a large batch or a large value can exhaust the heap while the driver builds a message nobody reads in full.
+A truncated message ends with `...(truncated)`, a bound value that no longer fits is cut short, and an oversized
+`bytea` reports its size instead of being spelled out in hex. Set to `0`, or to any negative value, to log messages of
+any length.
+  Since: 42.7.14
+
+* **`maxLogParameterLength (`*int*`)`** *Default `2048`*\
+Number of characters a single bound parameter may reach in a `Bind` trace before the driver truncates it. Without the
+cap one long value spends the whole trace on itself and hides every parameter after it, so the log shows the query but
+not the values it ran on. PostgreSQL bounds its own parameter logging the same way through `log_parameter_max_length`.
+A truncated parameter ends with `...`, and `maxLogMessageLength` still bounds the trace as a whole. Set to `0`, or to
+any negative value, to cap parameters only by the message limit.
+  Since: 42.7.14
+
 * **`allowEncodingChanges (`*boolean*`)`** *Default `false`*\
 When using the V3 protocol the driver monitors changes in certain server configuration parameters that should not be touched by end users. 
 The `client_encoding` setting is set by the driver and should not be altered. If the driver detects a change it will abort the connection. 

--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -465,6 +465,34 @@ public enum PGProperty {
       "When connections that are not explicitly closed are garbage collected, log the stacktrace from the opening of the connection to trace the leak source"),
 
   /**
+   * Number of characters a log message that embeds query text or a data value may reach before the
+   * driver truncates it, default is 16384, and any value of {@code 0} or less means no limit.
+   *
+   * <p>Such a message grows with the data the application sends or the server returns, so a large
+   * batch or a large value can exhaust the heap while the driver builds a message nobody reads in
+   * full. A truncated message ends with {@code ...(truncated)}, and a limit narrower than that
+   * marker leaves only as much of the marker as fits.</p>
+   */
+  MAX_LOG_MESSAGE_LENGTH(
+      "maxLogMessageLength",
+      "16384",
+      "Number of characters a log message that embeds query text or a data value may reach before the driver truncates it, 0 means no limit"),
+
+  /**
+   * Number of characters a single bound parameter may reach in a {@code Bind} trace before the
+   * driver truncates it, default is 2048, and any value of {@code 0} or less means no limit.
+   *
+   * <p>The cap keeps one long value from spending the whole trace on itself, so the trace still
+   * shows which values the other parameters carried. PostgreSQL bounds its own parameter logging
+   * the same way through {@code log_parameter_max_length}. A truncated parameter ends with
+   * {@code ...}, and {@link #MAX_LOG_MESSAGE_LENGTH} still bounds the trace as a whole.</p>
+   */
+  MAX_LOG_PARAMETER_LENGTH(
+      "maxLogParameterLength",
+      "2048",
+      "Number of characters a single bound parameter may reach in a Bind trace before the driver truncates it, 0 means no limit"),
+
+  /**
    * Specifies size of buffer during fetching result set. Can be specified as specified size or
    * percent of heap memory.
    */

--- a/pgjdbc/src/main/java/org/postgresql/core/Utils.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/Utils.java
@@ -49,19 +49,23 @@ public class Utils {
     if (sbuf == null) {
       sbuf = new StringBuilder((value.length() + 10) / 10 * 11); // Add 10% for escaping.
     }
-    doAppendEscapedLiteral(sbuf, value, standardConformingStrings);
+    appendEscapedLiteral(sbuf, value, standardConformingStrings);
     return sbuf;
   }
 
   /**
-   * Common part for {@link #escapeLiteral(StringBuilder, String, boolean)}.
+   * Escapes the given literal {@code value} and appends it to {@code sbuf}.
    *
-   * @param sbuf Either StringBuffer or StringBuilder as we do not expect any IOException to be
-   *        thrown
+   * <p>The sink decides how much of the escaped value it keeps, so a sink with a limit can be
+   * handed a value of any size.</p>
+   *
+   * @param sbuf sink to append to; an {@link IOException} it throws is reported as
+   *        {@link PSQLState#UNEXPECTED_ERROR}
    * @param value value to append
    * @param standardConformingStrings if standard conforming strings should be used
+   * @throws SQLException if the string contains a {@code \0} character
    */
-  private static void doAppendEscapedLiteral(Appendable sbuf, String value,
+  public static void appendEscapedLiteral(Appendable sbuf, String value,
       boolean standardConformingStrings) throws SQLException {
     try {
       if (standardConformingStrings) {

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -106,6 +106,7 @@ import org.postgresql.util.PSQLException;
 import org.postgresql.util.PSQLState;
 import org.postgresql.util.PSQLWarning;
 import org.postgresql.util.ServerErrorMessage;
+import org.postgresql.util.internal.BoundedStringBuilder;
 import org.postgresql.util.internal.IntSet;
 import org.postgresql.util.internal.SourceStreamIOException;
 
@@ -233,6 +234,20 @@ public class QueryExecutorImpl extends QueryExecutorBase {
 
   private final AdaptiveFetchCache adaptiveFetchCache;
 
+  /**
+   * Characters a protocol trace message may reach before it is truncated. Query text and bound
+   * values are copied into the message, so the limit is what keeps logging from running the heap
+   * out (issue #995).
+   */
+  private final int maxLogMessageLength;
+
+  /**
+   * Characters a single bound parameter may reach inside a {@code Bind} trace. The cap keeps one
+   * long value from spending the whole message on itself, which would hide every parameter after
+   * it.
+   */
+  private final int maxLogParameterLength;
+
   private boolean inExtendedProtocol;
 
   @SuppressWarnings({"assignment", "argument",
@@ -243,6 +258,8 @@ public class QueryExecutorImpl extends QueryExecutorBase {
 
     long maxResultBuffer = pgStream.getMaxResultBuffer();
     this.adaptiveFetchCache = new AdaptiveFetchCache(maxResultBuffer, info);
+    this.maxLogMessageLength = PGProperty.MAX_LOG_MESSAGE_LENGTH.getInt(info);
+    this.maxLogParameterLength = PGProperty.MAX_LOG_PARAMETER_LENGTH.getInt(info);
 
     this.allowEncodingChanges = PGProperty.ALLOW_ENCODING_CHANGES.getBoolean(info);
     this.cleanupSavePoints = PGProperty.CLEANUP_SAVEPOINTS.getBoolean(info);
@@ -254,6 +271,13 @@ public class QueryExecutorImpl extends QueryExecutorBase {
   @Override
   public ProtocolVersion getProtocolVersion() {
     return protocolVersion;
+  }
+
+  /**
+   * Creates a builder for a protocol trace message, bounded by {@code maxLogMessageLength}.
+   */
+  private BoundedStringBuilder newLogMessage() {
+    return new BoundedStringBuilder(maxLogMessageLength);
   }
 
   /**
@@ -1788,10 +1812,11 @@ public class QueryExecutorImpl extends QueryExecutorBase {
     String nativeSql = query.getNativeSql();
 
     if (LOGGER.isLoggable(Level.FINEST)) {
-      StringBuilder sbuf = new StringBuilder(" FE=> Parse(stmt=" + statementName + ",query=\"");
+      BoundedStringBuilder sbuf = newLogMessage();
+      sbuf.append(" FE=> Parse(stmt=").append(statementName).append(",query=\"");
       sbuf.append(nativeSql);
       sbuf.append("\",oids={");
-      for (int i = 1; i <= params.getParameterCount(); i++) {
+      for (int i = 1; i <= params.getParameterCount() && !sbuf.isFull(); i++) {
         if (i != 1) {
           sbuf.append(",");
         }
@@ -1842,11 +1867,17 @@ public class QueryExecutorImpl extends QueryExecutorBase {
     byte[] encodedPortalName = portal == null ? null : portal.getEncodedPortalName();
 
     if (LOGGER.isLoggable(Level.FINEST)) {
-      StringBuilder sbuf = new StringBuilder(" FE=> Bind(stmt=" + statementName + ",portal=" + portal);
-      for (int i = 1; i <= params.getParameterCount(); i++) {
-        sbuf.append(",$").append(i).append("=<")
-            .append(params.toString(i, getStandardConformingStrings()))
-            .append(">,type=").append(Oid.toString(params.getTypeOID(i)));
+      BoundedStringBuilder sbuf = newLogMessage();
+      sbuf.append(" FE=> Bind(stmt=").append(statementName)
+          .append(",portal=").append(String.valueOf(portal));
+      SqlSerializationContext context =
+          SqlSerializationContext.of(getStandardConformingStrings(), true);
+      for (int i = 1; i <= params.getParameterCount() && !sbuf.isFull(); i++) {
+        sbuf.append(",$").append(i).append("=<");
+        sbuf.beginField(maxLogParameterLength);
+        params.appendTo(sbuf, i, context);
+        sbuf.endField();
+        sbuf.append(">,type=").append(Oid.toString(params.getTypeOID(i)));
       }
       sbuf.append(")");
       LOGGER.log(Level.FINEST, sbuf.toString());
@@ -2261,7 +2292,11 @@ public class QueryExecutorImpl extends QueryExecutorBase {
         params,
         SqlSerializationContext.of(getStandardConformingStrings(), false));
 
-    LOGGER.log(Level.FINEST, " FE=> SimpleQuery(query=\"{0}\")", nativeSql);
+    if (LOGGER.isLoggable(Level.FINEST)) {
+      BoundedStringBuilder sbuf = newLogMessage();
+      sbuf.append(" FE=> SimpleQuery(query=\"").append(nativeSql).append("\")");
+      LOGGER.log(Level.FINEST, sbuf.toString());
+    }
     Encoding encoding = pgStream.getEncoding();
 
     byte[] encoded = encoding.encode(nativeSql);
@@ -2970,7 +3005,12 @@ public class QueryExecutorImpl extends QueryExecutorBase {
     addNotification(new Notification(msg, pid, param));
 
     if (LOGGER.isLoggable(Level.FINEST)) {
-      LOGGER.log(Level.FINEST, " <=BE AsyncNotify({0},{1},{2})", new Object[]{pid, msg, param});
+      // The payload is whatever the notifying session passed to NOTIFY, so this message grows with
+      // application data the same way the outgoing traces do.
+      BoundedStringBuilder sbuf = newLogMessage();
+      sbuf.append(" <=BE AsyncNotify(").append(pid).append(",").append(msg).append(",")
+          .append(param).append(")");
+      LOGGER.log(Level.FINEST, sbuf.toString());
     }
   }
 
@@ -2987,7 +3027,13 @@ public class QueryExecutorImpl extends QueryExecutorBase {
     ServerErrorMessage errorMsg = new ServerErrorMessage(totalMessage);
 
     if (LOGGER.isLoggable(Level.FINEST)) {
-      LOGGER.log(Level.FINEST, " <=BE ErrorMessage({0})", errorMsg.toString());
+      // The server echoes the failing statement back in the error, so this message grows with the
+      // statement just as the outgoing traces do. What the limit bounds here is the record the
+      // handler receives: ServerErrorMessage renders one more copy of text the driver already
+      // holds, since receiveErrorString read the whole message off the wire before this point.
+      BoundedStringBuilder sbuf = newLogMessage();
+      sbuf.append(" <=BE ErrorMessage(").append(errorMsg.toString()).append(")");
+      LOGGER.log(Level.FINEST, sbuf.toString());
     }
 
     PSQLException error = new PSQLException(errorMsg, this.logServerErrorDetail);
@@ -3006,7 +3052,11 @@ public class QueryExecutorImpl extends QueryExecutorBase {
     ServerErrorMessage warnMsg = new ServerErrorMessage(pgStream.receiveString(nlen - 4));
 
     if (LOGGER.isLoggable(Level.FINEST)) {
-      LOGGER.log(Level.FINEST, " <=BE NoticeResponse({0})", warnMsg.toString());
+      // A RAISE NOTICE carries whatever text the server was asked to emit, so this message grows
+      // with that text the same way the error one does.
+      BoundedStringBuilder sbuf = newLogMessage();
+      sbuf.append(" <=BE NoticeResponse(").append(warnMsg.toString()).append(")");
+      LOGGER.log(Level.FINEST, sbuf.toString());
     }
 
     return new PSQLWarning(warnMsg);
@@ -3147,7 +3197,11 @@ public class QueryExecutorImpl extends QueryExecutorBase {
     final String value = pgStream.receiveCanonicalStringIfPresent();
 
     if (LOGGER.isLoggable(Level.FINEST)) {
-      LOGGER.log(Level.FINEST, " <=BE ParameterStatus({0} = {1})", new Object[]{name, value});
+      // PostgreSQL 18 reports search_path through GUC_REPORT, and the server caps neither the
+      // number of schemas an application may set nor the value it echoes back.
+      BoundedStringBuilder sbuf = newLogMessage();
+      sbuf.append(" <=BE ParameterStatus(").append(name).append(" = ").append(value).append(")");
+      LOGGER.log(Level.FINEST, sbuf.toString());
     }
 
     // if the name is empty, there is nothing to do

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/SimpleParameterList.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/SimpleParameterList.java
@@ -20,6 +20,7 @@ import org.postgresql.util.PGbytea;
 import org.postgresql.util.PSQLException;
 import org.postgresql.util.PSQLState;
 import org.postgresql.util.StreamWrapper;
+import org.postgresql.util.internal.BoundedStringBuilder;
 
 import org.checkerframework.checker.index.qual.NonNegative;
 import org.checkerframework.checker.index.qual.Positive;
@@ -44,6 +45,18 @@ class SimpleParameterList implements V3ParameterList {
 
   private static final byte TEXT = 0;
   private static final byte BINARY = 4;
+
+  /**
+   * Characters a hex-encoded {@code bytea} literal spends on decoration, that is {@code '\x} in
+   * front of the hex digits and {@code '::bytea} after them.
+   */
+  private static final int HEX_LITERAL_OVERHEAD = "'\\x".length() + "'::bytea".length();
+
+  /**
+   * Characters a {@code bytea} literal spends on decoration when the value already carries the
+   * hex-format prefix itself.
+   */
+  private static final int STRING_LITERAL_OVERHEAD = "'".length() + "'::bytea".length();
 
   SimpleParameterList(int paramCount, @Nullable TypeTransferModeRegistry transferModeRegistry) {
     this.paramValues = new Object[paramCount];
@@ -210,11 +223,17 @@ class SimpleParameterList implements V3ParameterList {
    * {}
    * </pre>
    **/
-  private static String quoteAndCast(String text, @Nullable String type, boolean standardConformingStrings) {
-    StringBuilder sb = new StringBuilder((text.length() + 10) / 10 * 11); // Add 10% for escaping.
+  private static void quoteAndCast(BoundedStringBuilder sb, String text, @Nullable String type,
+      boolean standardConformingStrings) {
     sb.append("('");
+    sb.ensureRoomFor((text.length() + 10) / 10 * 11); // Add 10% for escaping.
+    // Escaping at most doubles the input, so feeding the sink no more characters than it accepts
+    // keeps the intermediate string within twice the sink's budget.
+    int remaining = sb.remaining();
     try {
-      Utils.escapeLiteral(sb, text, standardConformingStrings);
+      Utils.appendEscapedLiteral(sb,
+          text.length() > remaining ? text.substring(0, remaining) : text,
+          standardConformingStrings);
     } catch (SQLException e) {
       // This should only happen if we have an embedded null
       // and there's not much we can do if we do hit one.
@@ -230,7 +249,75 @@ class SimpleParameterList implements V3ParameterList {
       sb.append(type);
     }
     sb.append(")");
-    return sb.toString();
+  }
+
+  /**
+   * Appends {@code value} as a {@code bytea} literal, or as its size when the literal does not fit
+   * into {@code sb}.
+   */
+  private static void appendByteaLiteral(BoundedStringBuilder sb, Object value,
+      SqlSerializationContext context) throws IOException {
+    if (appendSizeIfTooLong(sb, value, context)) {
+      return;
+    }
+    sb.append(PGbytea.toPGLiteral(value, context));
+  }
+
+  /**
+   * Reports the size of {@code value} in place of its {@code bytea} literal when the literal would
+   * not fit into {@code sb}, and returns whether it did so.
+   *
+   * <p>{@link PGbytea} builds the whole literal before any of it can reach {@code sb}, and two hex
+   * digits per byte make that literal outgrow the value itself, which is the
+   * {@code OutOfMemoryError} issue #995 reports. Measuring first keeps that intermediate within the
+   * budget. A hex prefix of a large value tells the reader nothing, and a literal cut in half would
+   * look like a complete one, so the size is what an oversized value contributes.</p>
+   */
+  private static boolean appendSizeIfTooLong(BoundedStringBuilder sb, Object value,
+      SqlSerializationContext context) {
+    if (sb.isUnbounded()) {
+      return false;
+    }
+    int remaining = sb.remaining();
+    if (value instanceof String) {
+      // A hex-format string is quoted as it stands, so the literal is as long as the string.
+      int length = ((String) value).length();
+      if ((long) length + STRING_LITERAL_OVERHEAD <= remaining) {
+        return false;
+      }
+      sb.append("<").append(length).append(" hex characters>");
+      return true;
+    }
+    int byteCount = renderedByteCount(value, context);
+    if (byteCount < 0 || 2L * byteCount + HEX_LITERAL_OVERHEAD <= remaining) {
+      return false;
+    }
+    sb.append("<").append(byteCount).append(" bytes>");
+    return true;
+  }
+
+  /**
+   * Returns the number of bytes {@link PGbytea#toPGLiteral(Object, SqlSerializationContext)}
+   * spells out for {@code value}, or {@code -1} when the literal stays short whatever the value
+   * holds.
+   */
+  private static int renderedByteCount(Object value, SqlSerializationContext context) {
+    if (value instanceof byte[]) {
+      return ((byte[]) value).length;
+    }
+    if (value instanceof StreamWrapper) {
+      StreamWrapper wrapper = (StreamWrapper) value;
+      if (wrapper.getBytes() == null && context.getIdempotent()) {
+        // An unread stream is rendered as "?" so that rendering does not consume it.
+        return -1;
+      }
+      return wrapper.getLength();
+    }
+    if (value instanceof ByteStreamWriter) {
+      return ((ByteStreamWriter) value).getLength();
+    }
+    // PGbytea rejects every other type, and the rejection message is short.
+    return -1;
   }
 
   private static <E extends Throwable> RuntimeException sneakyThrow(Throwable e) throws E {
@@ -244,12 +331,30 @@ class SimpleParameterList implements V3ParameterList {
 
   @Override
   public String toString(@Positive int index, SqlSerializationContext context) {
+    BoundedStringBuilder sb = new BoundedStringBuilder(BoundedStringBuilder.UNLIMITED);
+    appendTo(sb, index, context);
+    return sb.toString();
+  }
+
+  /**
+   * Appends the SQL literal for a parameter, keeping the output within the space {@code sb} has
+   * left.
+   *
+   * <p>A value that no longer fits is rendered as a prefix of its literal or as its size, so a
+   * bounded builder collects a parameter dump rather than SQL a server would accept. An unbounded
+   * builder receives the literal {@link #toString(int, SqlSerializationContext)} returns.</p>
+   *
+   * @param index 1-based parameter index
+   */
+  void appendTo(BoundedStringBuilder sb, @Positive int index, SqlSerializationContext context) {
     --index;
     Object paramValue = paramValues[index];
     if (paramValue == null) {
-      return "?";
+      sb.append("?");
+      return;
     } else if (paramValue == NULL_OBJECT) {
-      return "(NULL)";
+      sb.append("(NULL)");
+      return;
     }
     String textValue;
     String type;
@@ -258,13 +363,15 @@ class SimpleParameterList implements V3ParameterList {
         // A bytea value supplied as text in the escape format. Quote and cast it
         // like any other literal: quoteAndCast escapes quotes and backslashes per
         // standard_conforming_strings, which keeps the literal valid and safe from
-        // SQL injection. Hex-format strings (\x...) and byte[] values fall through
-        // to PGbytea.toPGLiteral below.
-        return quoteAndCast((String) paramValue, "bytea",
+        // SQL injection. Hex-format strings (\x...) and byte[] values are rendered
+        // by appendByteaLiteral instead.
+        quoteAndCast(sb, (String) paramValue, "bytea",
             context.getStandardConformingStrings());
+        return;
       }
       try {
-        return PGbytea.toPGLiteral(paramValue, context);
+        appendByteaLiteral(sb, paramValue, context);
+        return;
       } catch (Throwable e) {
         Throwable cause = e;
         if (!(cause instanceof IOException)) {
@@ -303,7 +410,8 @@ class SimpleParameterList implements V3ParameterList {
         case Oid.FLOAT4:
           float f = ByteConverter.float4((byte[]) paramValue, 0);
           if (Float.isNaN(f)) {
-            return "('NaN'::real)";
+            sb.append("('NaN'::real)");
+            return;
           }
           textValue = Float.toString(f);
           type = "real";
@@ -312,7 +420,8 @@ class SimpleParameterList implements V3ParameterList {
         case Oid.FLOAT8:
           double d = ByteConverter.float8((byte[]) paramValue, 0);
           if (Double.isNaN(d)) {
-            return "('NaN'::double precision)";
+            sb.append("('NaN'::double precision)");
+            return;
           }
           textValue = Double.toString(d);
           type = "double precision";
@@ -322,7 +431,8 @@ class SimpleParameterList implements V3ParameterList {
           Number n = ByteConverter.numeric((byte[]) paramValue);
           if (n instanceof Double) {
             assert ((Double) n).isNaN();
-            return "('NaN'::numeric)";
+            sb.append("('NaN'::numeric)");
+            return;
           }
           textValue = n.toString();
           type = "numeric";
@@ -349,7 +459,8 @@ class SimpleParameterList implements V3ParameterList {
           break;
 
         default:
-          return "?";
+          sb.append("?");
+          return;
       }
     } else {
       textValue = paramValue.toString();
@@ -406,7 +517,7 @@ class SimpleParameterList implements V3ParameterList {
           type = null;
       }
     }
-    return quoteAndCast(textValue, type, context.getStandardConformingStrings());
+    quoteAndCast(sb, textValue, type, context.getStandardConformingStrings());
   }
 
   @Override

--- a/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
+++ b/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
@@ -475,6 +475,38 @@ public abstract class BaseDataSource implements CommonDataSource, Referenceable 
   }
 
   /**
+   * @return maximum number of characters in a log message, 0 means no limit
+   * @see PGProperty#MAX_LOG_MESSAGE_LENGTH
+   */
+  public int getMaxLogMessageLength() {
+    return PGProperty.MAX_LOG_MESSAGE_LENGTH.getIntNoCheck(properties);
+  }
+
+  /**
+   * @param nchars maximum number of characters in a log message, 0 means no limit
+   * @see PGProperty#MAX_LOG_MESSAGE_LENGTH
+   */
+  public void setMaxLogMessageLength(int nchars) {
+    PGProperty.MAX_LOG_MESSAGE_LENGTH.set(properties, nchars);
+  }
+
+  /**
+   * @return maximum number of characters in a logged bind parameter, 0 means no limit
+   * @see PGProperty#MAX_LOG_PARAMETER_LENGTH
+   */
+  public int getMaxLogParameterLength() {
+    return PGProperty.MAX_LOG_PARAMETER_LENGTH.getIntNoCheck(properties);
+  }
+
+  /**
+   * @param nchars maximum number of characters in a logged bind parameter, 0 means no limit
+   * @see PGProperty#MAX_LOG_PARAMETER_LENGTH
+   */
+  public void setMaxLogParameterLength(int nchars) {
+    PGProperty.MAX_LOG_PARAMETER_LENGTH.set(properties, nchars);
+  }
+
+  /**
    * @param count prepare threshold
    * @see PGProperty#PREPARE_THRESHOLD
    */

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
@@ -53,6 +53,7 @@ import org.postgresql.util.PGmoney;
 import org.postgresql.util.PGobject;
 import org.postgresql.util.PSQLException;
 import org.postgresql.util.PSQLState;
+import org.postgresql.util.internal.BoundedStringBuilder;
 import org.postgresql.xml.DefaultPGXmlFactoryFactory;
 import org.postgresql.xml.LegacyInsecurePGXmlFactoryFactory;
 import org.postgresql.xml.PGXmlFactoryFactory;
@@ -232,6 +233,12 @@ public class PgConnection implements BaseConnection {
   private final @Nullable String xmlFactoryFactoryClass;
   private @Nullable PGXmlFactoryFactory xmlFactoryFactory;
   private final ClassLoaderStrategy classLoaderStrategy;
+  /**
+   * Characters a single log message may reach before it is truncated. Column values reach the
+   * {@code FINEST} log unabridged otherwise, so the limit is what keeps logging from running the
+   * heap out (issue #995).
+   */
+  private final int maxLogMessageLength;
   private final LazyCleaner.Cleanable<IOException> cleanable;
   /* this is actually the database we are connected to */
   private @Nullable String catalog;
@@ -290,6 +297,8 @@ public class PgConnection implements BaseConnection {
     if (prepareThreshold == -1) {
       setForceBinary(true);
     }
+
+    this.maxLogMessageLength = PGProperty.MAX_LOG_MESSAGE_LENGTH.getInt(info);
 
     // Now make the initial connection and set up local state
     this.queryExecutor = ConnectionFactory.openConnection(hostSpecs, info);
@@ -778,7 +787,10 @@ public class PgConnection implements BaseConnection {
     PGobject obj = null;
 
     if (LOGGER.isLoggable(Level.FINEST)) {
-      LOGGER.log(Level.FINEST, "Constructing object from type={0} value=<{1}>", new Object[]{type, value});
+      BoundedStringBuilder message = new BoundedStringBuilder(maxLogMessageLength);
+      message.append("Constructing object from type=").append(type)
+          .append(" value=<").append(value).append(">");
+      LOGGER.log(Level.FINEST, message.toString());
     }
 
     try {

--- a/pgjdbc/src/main/java/org/postgresql/util/internal/BoundedStringBuilder.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/internal/BoundedStringBuilder.java
@@ -1,0 +1,265 @@
+/*
+ * Copyright (c) 2026, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.util.internal;
+
+import org.checkerframework.checker.index.qual.NonNegative;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * Collects characters up to a fixed limit and discards everything past it.
+ *
+ * <p>A protocol trace embeds query text and parameter values, so a message built with a plain
+ * {@link StringBuilder} grows with the data the application sends, and logging becomes a source of
+ * {@code OutOfMemoryError} (issue #995). This class bounds that cost: the buffer never holds more
+ * than the limit given to the constructor, and {@link #toString()} ends a message that lost
+ * characters with a marker.</p>
+ *
+ * <p>Discarding is silent, so a producer that appends without checking anything still stays within
+ * the limit. A producer that can skip work cheaply should ask {@link #remaining()} or
+ * {@link #isFull()} first: appending a discarded 200 MB value costs no memory, but it still costs
+ * the time to walk the value.</p>
+ *
+ * <p>What the builder keeps is always a prefix of what it was offered, because the room never
+ * grows while a budget is in force: neither the message room nor an open field's room recovers
+ * once a character has been dropped, so nothing appended later can overtake it. Closing a field
+ * does restore the message room, which is what lets the next field render at all.</p>
+ *
+ * <p>Instances are not thread-safe.</p>
+ */
+public final class BoundedStringBuilder implements Appendable {
+  /**
+   * Limit that lets the builder grow as far as the heap allows.
+   */
+  public static final int UNLIMITED = 0;
+
+  /**
+   * Marks a message that lost characters. {@link #toString()} keeps the result within the limit by
+   * dropping as many trailing characters as the marker takes, and by shortening the marker itself
+   * when the limit is narrower than it is.
+   */
+  private static final String TRUNCATION_MARKER = "...(truncated)";
+
+  /**
+   * Marks a field that lost characters. A field is cut in the middle of a message, so it needs a
+   * marker of its own rather than the one {@link #toString()} puts at the end.
+   */
+  private static final String FIELD_TRUNCATION_MARKER = "...";
+
+  /**
+   * Characters in the widest decimal representation of an {@code int}, which is
+   * {@code -2147483648}.
+   */
+  private static final int MAX_INT_LENGTH = 11;
+
+  /**
+   * Value of {@link #fieldEnd} while no field is open.
+   */
+  private static final int NO_FIELD = -1;
+
+  private final StringBuilder buf = new StringBuilder();
+  private final int limit;
+  private boolean truncated;
+  private int fieldEnd = NO_FIELD;
+  private boolean fieldTruncated;
+  private int removed;
+
+  /**
+   * Creates a builder that keeps at most {@code limit} characters.
+   *
+   * @param limit number of characters to keep; {@link #UNLIMITED} and any negative value mean no
+   *     limit
+   */
+  public BoundedStringBuilder(int limit) {
+    this.limit = limit;
+  }
+
+  /**
+   * Returns true when nothing bounds the builder right now, so a producer may hand it a value of
+   * any size.
+   *
+   * <p>An open field bounds the builder even when the limit does not, which is why a producer that
+   * decides whether to render a value has to ask this rather than whether a limit was configured.
+   * </p>
+   */
+  public boolean isUnbounded() {
+    return remaining() == Integer.MAX_VALUE;
+  }
+
+  /**
+   * Returns true when no limit was configured, which says nothing about an open field.
+   */
+  private boolean isUnlimited() {
+    return limit <= UNLIMITED;
+  }
+
+  /**
+   * Returns the number of characters the builder still accepts, which is the smaller of what the
+   * limit and the open field allow, or {@link Integer#MAX_VALUE} when neither bounds it.
+   */
+  public @NonNegative int remaining() {
+    int room = isUnlimited() ? Integer.MAX_VALUE : Math.max(0, limit - used());
+    if (fieldEnd == NO_FIELD) {
+      return room;
+    }
+    return Math.min(room, Math.max(0, fieldEnd - used()));
+  }
+
+  /**
+   * Returns the characters the builder has spent, which is what it holds plus what
+   * {@link #dropSplitSurrogate()} took back out of it.
+   *
+   * <p>Counting a removed character as spent is what keeps a budget from re-opening behind a
+   * character it already dropped: the freed slot would otherwise let the next append overtake the
+   * dropped one, and the kept text would no longer be a prefix of the text that was offered.</p>
+   */
+  private int used() {
+    return buf.length() + removed;
+  }
+
+  /**
+   * Returns true when further appends are discarded.
+   */
+  public boolean isFull() {
+    return remaining() == 0;
+  }
+
+  /**
+   * Returns true when the message lost characters. A field cut short by {@link #beginField} does
+   * not count, because it carries its own marker.
+   */
+  public boolean isTruncated() {
+    return truncated;
+  }
+
+  /**
+   * Caps the next {@code chars} characters so that one long field cannot spend the whole message
+   * on itself, and returns this builder.
+   *
+   * <p>The field runs until {@link #endField()}, which marks it when it lost characters. Fields do
+   * not nest: opening one closes the budget of any field still open. A {@code chars} of zero or
+   * less opens no field at all, which is how the caller turns the cap off.</p>
+   */
+  public BoundedStringBuilder beginField(int chars) {
+    endField();
+    fieldEnd = chars <= 0 ? NO_FIELD : (int) Math.min(Integer.MAX_VALUE, (long) used() + chars);
+    return this;
+  }
+
+  /**
+   * Ends the field {@link #beginField} opened, appending {@value #FIELD_TRUNCATION_MARKER} when the
+   * field lost characters, and returns this builder.
+   */
+  public BoundedStringBuilder endField() {
+    fieldEnd = NO_FIELD;
+    if (fieldTruncated) {
+      fieldTruncated = false;
+      append(FIELD_TRUNCATION_MARKER);
+    }
+    return this;
+  }
+
+  /**
+   * Records that characters were dropped, against the field when the field is what ran out and
+   * against the message otherwise.
+   */
+  private void recordDrop() {
+    if (isUnlimited() || used() < limit) {
+      fieldTruncated = true;
+    } else {
+      truncated = true;
+    }
+  }
+
+  /**
+   * Removes a trailing high surrogate, which is unpaired whenever it is the last character in the
+   * buffer, because a pair reaches the buffer in order.
+   */
+  private void dropSplitSurrogate() {
+    int last = buf.length() - 1;
+    if (last >= 0 && Character.isHighSurrogate(buf.charAt(last))) {
+      buf.setLength(last);
+      removed++;
+    }
+  }
+
+  @Override
+  public BoundedStringBuilder append(char c) {
+    if (remaining() > 0) {
+      buf.append(c);
+    } else {
+      recordDrop();
+      dropSplitSurrogate();
+    }
+    return this;
+  }
+
+  @Override
+  public BoundedStringBuilder append(@Nullable CharSequence csq) {
+    CharSequence value = csq == null ? "null" : csq;
+    return append(value, 0, value.length());
+  }
+
+  @Override
+  public BoundedStringBuilder append(@Nullable CharSequence csq, int start, int end) {
+    CharSequence value = csq == null ? "null" : csq;
+    int accepted = Math.min(end - start, remaining());
+    buf.append(value, start, start + accepted);
+    if (accepted < end - start) {
+      recordDrop();
+      dropSplitSurrogate();
+    }
+    return this;
+  }
+
+  /**
+   * Grows the buffer so that {@code chars} more characters fit without another copy, or so that the
+   * rest of the limit does when {@code chars} exceeds it.
+   *
+   * <p>A producer that appends character by character, as escaping a literal does, otherwise makes
+   * the buffer double its way to the final size. A hint that is negative or that overflowed is
+   * ignored.</p>
+   */
+  public BoundedStringBuilder ensureRoomFor(int chars) {
+    buf.ensureCapacity(buf.length() + Math.min(chars, remaining()));
+    return this;
+  }
+
+  /**
+   * Appends the decimal representation of {@code value}.
+   */
+  public BoundedStringBuilder append(int value) {
+    if (remaining() >= MAX_INT_LENGTH) {
+      buf.append(value);
+      return this;
+    }
+    return append(Integer.toString(value));
+  }
+
+  /**
+   * Returns the collected characters, ending with a truncation marker when characters were
+   * discarded.
+   */
+  @Override
+  public String toString() {
+    if (!truncated) {
+      return buf.toString();
+    }
+    // A truncated builder is a bounded one, so the limit is the budget the marker has to fit in.
+    if (limit <= TRUNCATION_MARKER.length()) {
+      return TRUNCATION_MARKER.substring(0, limit);
+    }
+    int keep = Math.min(buf.length(), limit - TRUNCATION_MARKER.length());
+    if (keep > 0 && Character.isHighSurrogate(buf.charAt(keep - 1))) {
+      // Cutting a surrogate pair in half would leave text that is not valid UTF-16, and a handler
+      // that encodes the message would turn the lone surrogate into a replacement character.
+      keep--;
+    }
+    StringBuilder result = new StringBuilder(keep + TRUNCATION_MARKER.length());
+    result.append(buf, 0, keep);
+    result.append(TRUNCATION_MARKER);
+    return result.toString();
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/core/v3/SimpleParameterListTruncationTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/core/v3/SimpleParameterListTruncationTest.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright (c) 2026, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.core.v3;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.postgresql.core.Oid;
+import org.postgresql.util.ByteStreamWriter;
+import org.postgresql.util.internal.BoundedStringBuilder;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.sql.SQLException;
+
+/**
+ * Fails when a bound parameter renders into more characters than the sink accepts.
+ *
+ * <p>{@link SimpleParameterList#appendTo} feeds the protocol trace, so a parameter has to respect
+ * the budget of the sink it writes to whatever the application bound: a value that outgrows the
+ * budget is cut short or replaced by its size, and no intermediate string of the value's own size
+ * is built along the way. An unbounded sink keeps the literal
+ * {@link SimpleParameterList#toString(int, SqlSerializationContext)} returns, because
+ * {@code PreparedStatement.toString()} and simple query mode read it as SQL.</p>
+ */
+class SimpleParameterListTruncationTest {
+  private static final SqlSerializationContext CONTEXT = SqlSerializationContext.of(true, true);
+
+  private static final int LIMIT = 100;
+
+  private static final String FIELD_MARKER = "...";
+
+  /**
+   * U+1F600, which UTF-16 stores as a surrogate pair.
+   */
+  private static final String EMOJI = new String(Character.toChars(0x1F600));
+
+  private static final TypeTransferModeRegistry TEXT_ONLY = new TypeTransferModeRegistry() {
+    @Override
+    public boolean useBinaryForSend(int oid) {
+      return false;
+    }
+
+    @Override
+    public boolean useBinaryForReceive(int oid) {
+      return false;
+    }
+  };
+
+  @Test
+  void smallValueIsRenderedInFull() throws SQLException {
+    SimpleParameterList params = new SimpleParameterList(1, TEXT_ONLY);
+    params.setStringParameter(1, "it's fine", Oid.VARCHAR);
+
+    assertEquals("('it''s fine')", render(params, LIMIT));
+  }
+
+  @Test
+  void longTextKeepsItsPrefix() throws SQLException {
+    SimpleParameterList params = new SimpleParameterList(1, TEXT_ONLY);
+    params.setStringParameter(1, repeat('a', 1_000_000), Oid.VARCHAR);
+
+    BoundedStringBuilder sb = new BoundedStringBuilder(LIMIT);
+    params.appendTo(sb, 1, CONTEXT);
+
+    assertTrue(sb.isTruncated(), "isTruncated");
+    String rendered = sb.toString();
+    assertEquals(LIMIT, rendered.length(), "rendered length");
+    assertTrue(rendered.startsWith("('aaa"), () -> "rendered value should start with the "
+        + "parameter's own text: " + rendered);
+  }
+
+  @Test
+  void longByteaIsRenderedAsItsSize() throws SQLException {
+    SimpleParameterList params = new SimpleParameterList(1, TEXT_ONLY);
+    params.setBytea(1, new byte[1_000_000], 0, 1_000_000);
+
+    assertEquals("<1000000 bytes>", render(params, LIMIT));
+  }
+
+  @Test
+  void longHexStringIsRenderedAsItsLength() throws SQLException {
+    SimpleParameterList params = new SimpleParameterList(1, TEXT_ONLY);
+    params.setStringParameter(1, "\\x" + repeat('a', 1_000_000), Oid.BYTEA);
+
+    assertEquals("<1000002 hex characters>", render(params, LIMIT));
+  }
+
+  @Test
+  void byteaThatFitsIsRenderedAsALiteral() throws SQLException {
+    SimpleParameterList params = new SimpleParameterList(1, TEXT_ONLY);
+    params.setBytea(1, new byte[]{0x1a, 0x2b}, 0, 2);
+
+    assertEquals("'\\x1a2b'::bytea", render(params, LIMIT));
+  }
+
+  @Test
+  void aFieldBudgetBoundsAByteaWithNoMessageLimit() throws SQLException {
+    SimpleParameterList params = new SimpleParameterList(1, TEXT_ONLY);
+    params.setBytea(1, new byte[1_000_000], 0, 1_000_000);
+
+    // What decides whether the literal may be built is the room the sink has left, not whether a
+    // message limit was configured: an open field bounds an otherwise unlimited builder.
+    BoundedStringBuilder sb = new BoundedStringBuilder(BoundedStringBuilder.UNLIMITED);
+    sb.beginField(LIMIT);
+    params.appendTo(sb, 1, CONTEXT);
+    sb.endField();
+
+    assertEquals("<1000000 bytes>", sb.toString());
+  }
+
+  @Test
+  void aCutFieldIsAlwaysAPrefixOfTheWholeLiteral() throws SQLException {
+    SimpleParameterList params = new SimpleParameterList(1, TEXT_ONLY);
+    params.setStringParameter(1, repeat(EMOJI, 8), Oid.VARCHAR);
+    String whole = params.toString(1, CONTEXT);
+
+    // Every budget across the pairs, so no single one can sit where an artifact happens to hide.
+    for (int budget = 1; budget <= 12; budget++) {
+      BoundedStringBuilder sb = new BoundedStringBuilder(BoundedStringBuilder.UNLIMITED);
+      sb.beginField(budget);
+      params.appendTo(sb, 1, CONTEXT);
+      sb.endField();
+
+      String rendered = sb.toString();
+      int cut = budget;
+      assertTrue(rendered.endsWith(FIELD_MARKER),
+          () -> "a budget of " + cut + " cannot hold the literal, so it must be marked: " + rendered);
+      String kept = rendered.substring(0, rendered.length() - FIELD_MARKER.length());
+      assertTrue(whole.startsWith(kept),
+          () -> "a budget of " + cut + " kept <" + kept + ">, which is not a prefix of <" + whole + ">");
+      assertNoLoneSurrogate(kept);
+    }
+  }
+
+  @Test
+  void unboundedSinkRendersTheWholeLiteral() throws SQLException {
+    SimpleParameterList params = new SimpleParameterList(1, TEXT_ONLY);
+    params.setBytea(1, new byte[100], 0, 100);
+
+    BoundedStringBuilder sb = new BoundedStringBuilder(BoundedStringBuilder.UNLIMITED);
+    params.appendTo(sb, 1, CONTEXT);
+
+    assertFalse(sb.isTruncated(), "isTruncated");
+    assertEquals(params.toString(1, CONTEXT), sb.toString());
+    assertEquals(2 * 100 + "'\\x".length() + "'::bytea".length(), sb.toString().length(),
+        "a bytea literal spells out two hex digits per byte");
+  }
+
+  @Test
+  void unreadStreamIsNotConsumed() throws SQLException {
+    SimpleParameterList params = new SimpleParameterList(1, TEXT_ONLY);
+    byte[] data = new byte[1_000_000];
+    params.setBytea(1, new ByteArrayInputStream(data), data.length);
+
+    // An idempotent rendering leaves the stream for the send path, so the size never reaches the
+    // trace, whatever the sink's budget is.
+    assertEquals("?", render(params, LIMIT));
+    assertEquals("?", render(params, BoundedStringBuilder.UNLIMITED));
+  }
+
+  @Test
+  void longWriterIsRenderedAsItsSize() throws SQLException {
+    SimpleParameterList params = new SimpleParameterList(1, TEXT_ONLY);
+    params.setBytea(1, new FailingWriter(1_000_000));
+
+    assertEquals("<1000000 bytes>", render(params, LIMIT),
+        "an oversized writer must not be invoked");
+  }
+
+  @Test
+  void nullAndUnsetParametersAreUnaffected() throws SQLException {
+    SimpleParameterList params = new SimpleParameterList(2, TEXT_ONLY);
+    params.setNull(1, Oid.VARCHAR);
+
+    assertEquals("(NULL)", render(params, LIMIT));
+    assertEquals("?", renderIndex(params, 2, LIMIT));
+  }
+
+  private static String render(SimpleParameterList params, int limit) {
+    return renderIndex(params, 1, limit);
+  }
+
+  private static String renderIndex(SimpleParameterList params, int index, int limit) {
+    BoundedStringBuilder sb = new BoundedStringBuilder(limit);
+    params.appendTo(sb, index, CONTEXT);
+    return sb.toString();
+  }
+
+  /**
+   * Fails when {@code value} is not well-formed UTF-16. An unpaired surrogate does not survive a
+   * round trip through UTF-8, which is what a log handler that encodes the message would do to it.
+   */
+  private static void assertNoLoneSurrogate(String value) {
+    assertEquals(value, new String(value.getBytes(StandardCharsets.UTF_8), StandardCharsets.UTF_8),
+        "value is not well-formed UTF-16");
+  }
+
+  private static String repeat(String value, int count) {
+    StringBuilder sb = new StringBuilder(value.length() * count);
+    for (int i = 0; i < count; i++) {
+      sb.append(value);
+    }
+    return sb.toString();
+  }
+
+  private static String repeat(char c, int count) {
+    byte[] bytes = new byte[count];
+    java.util.Arrays.fill(bytes, (byte) c);
+    return new String(bytes, StandardCharsets.US_ASCII);
+  }
+
+  /**
+   * Reports a length without being able to produce the bytes, which is how a caller-supplied writer
+   * that is too large to render must be treated.
+   */
+  private static final class FailingWriter implements ByteStreamWriter {
+    private final int length;
+
+    private FailingWriter(int length) {
+      this.length = length;
+    }
+
+    @Override
+    public int getLength() {
+      return length;
+    }
+
+    @Override
+    public void writeTo(ByteStreamTarget target) throws IOException {
+      OutputStream unused = target.getOutputStream();
+      throw new IOException("the writer must not be invoked for a trace message");
+    }
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/MaxLogMessageLengthTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/MaxLogMessageLengthTest.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright (c) 2026, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.test.jdbc2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.postgresql.PGProperty;
+import org.postgresql.jdbc.PreferQueryMode;
+import org.postgresql.test.TestUtil;
+import org.postgresql.util.TestLogHandler;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Properties;
+import java.util.logging.Formatter;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+import java.util.logging.SimpleFormatter;
+import java.util.regex.Pattern;
+
+/**
+ * Fails when a protocol trace outgrows {@code maxLogMessageLength}.
+ *
+ * <p>A trace logged at {@code FINEST} copies the query text and every bound value into one message,
+ * so a large statement used to exhaust the heap through logging alone (issue #995). Every message
+ * the driver builds must stay within the configured number of characters, and a message that lost
+ * characters must say so. Setting the property to {@code 0} must restore the untruncated
+ * traces.</p>
+ *
+ * <p>The handler is attached to the driver's shared logger, so every connection in the JVM feeds it.
+ * The class runs isolated to keep a concurrent test's traces, which carry the default limit, out of
+ * the assertions.</p>
+ */
+@Isolated
+class MaxLogMessageLengthTest {
+  private static final Pattern PROTOCOL_TRACE = Pattern.compile("^ FE=> ");
+
+  private static final Pattern SIMPLE_QUERY_TRACE = Pattern.compile("^ FE=> SimpleQuery");
+
+  private static final Pattern BIND_TRACE = Pattern.compile("^ FE=> Bind");
+
+  private static final Pattern SERVER_TRACE = Pattern.compile("^ <=BE (Error|Notice)");
+
+  private static final String TRUNCATION_MARKER = "...(truncated)";
+
+  private static final int LIMIT = 512;
+
+  /**
+   * Long enough that a trace carrying it in full is unmistakably over the limit.
+   */
+  private static final String LONG_VALUE = repeat('v', 100_000);
+
+  /**
+   * Resolves a record the way a handler does. A record logged with parameters carries the format
+   * string in {@code getMessage()}, so measuring that would miss text the handler goes on to
+   * substitute.
+   */
+  private static final Formatter FORMATTER = new SimpleFormatter();
+
+  private TestLogHandler log;
+  private Logger driverLogger;
+  private Level driverLogLevel;
+
+  @BeforeEach
+  void setUp() {
+    log = new TestLogHandler();
+    driverLogger = Logger.getLogger("org.postgresql");
+    driverLogger.addHandler(log);
+    driverLogLevel = driverLogger.getLevel();
+    driverLogger.setLevel(Level.ALL);
+  }
+
+  @AfterEach
+  void tearDown() {
+    driverLogger.removeHandler(log);
+    driverLogger.setLevel(driverLogLevel);
+    log = null;
+  }
+
+  @Test
+  void tracesStayWithinTheLimit() throws SQLException {
+    runQueries(LIMIT, PreferQueryMode.EXTENDED);
+
+    List<LogRecord> traces = log.getRecordsMatching(PROTOCOL_TRACE);
+    assertFalse(traces.isEmpty(), "the driver logged no protocol trace at FINEST");
+    for (LogRecord trace : traces) {
+      String message = FORMATTER.formatMessage(trace);
+      assertTrue(message.length() <= LIMIT,
+          () -> "trace of " + message.length() + " characters exceeds the " + LIMIT
+              + " character limit: " + abbreviate(message));
+    }
+    assertTrue(endsWithMarker(traces),
+        "a trace carrying a " + LONG_VALUE.length() + " character value must report that it was "
+            + "truncated");
+  }
+
+  @Test
+  void simpleQueryTracesStayWithinTheLimit() throws SQLException {
+    // Simple query mode inlines the bound values into the statement text, so the trace grows
+    // through a different path than Bind does.
+    runQueries(LIMIT, PreferQueryMode.SIMPLE);
+
+    List<LogRecord> traces = log.getRecordsMatching(SIMPLE_QUERY_TRACE);
+    assertFalse(traces.isEmpty(), "the driver logged no simple query trace at FINEST");
+    for (LogRecord trace : traces) {
+      String message = FORMATTER.formatMessage(trace);
+      assertTrue(message.length() <= LIMIT,
+          () -> "trace of " + message.length() + " characters exceeds the " + LIMIT
+              + " character limit: " + abbreviate(message));
+    }
+    assertTrue(endsWithMarker(traces),
+        "a trace carrying a " + LONG_VALUE.length() + " character value must report that it was "
+            + "truncated");
+  }
+
+  @Test
+  void aLongParameterDoesNotHideTheOnesAfterIt() throws SQLException {
+    // The message budget alone would be spent on $1, so $2 and $3 would never be reached.
+    Properties props = new Properties();
+    PGProperty.MAX_LOG_MESSAGE_LENGTH.set(props, LIMIT);
+    PGProperty.MAX_LOG_PARAMETER_LENGTH.set(props, 64);
+    runQueries(props);
+
+    List<LogRecord> binds = log.getRecordsMatching(BIND_TRACE);
+    assertTrue(binds.stream().anyMatch(r -> FORMATTER.formatMessage(r).contains("$3=<('42'::int4)>")),
+        () -> "the trace should still reach the last parameter: " + binds);
+  }
+
+  @Test
+  void serverTextStaysWithinTheLimit() throws SQLException {
+    // The server sends back whatever text it was asked to raise, so a receive-side trace grows the
+    // same way an outgoing one does.
+    Properties props = new Properties();
+    PGProperty.MAX_LOG_MESSAGE_LENGTH.set(props, LIMIT);
+    try (Connection con = TestUtil.openDB(props)) {
+      raise(con, "NOTICE");
+      assertThrows(SQLException.class, () -> raise(con, "EXCEPTION"),
+          "RAISE EXCEPTION should reach the caller as a SQLException");
+    }
+
+    List<LogRecord> traces = log.getRecordsMatching(SERVER_TRACE);
+    assertEquals(2, traces.size(), () -> "expected one notice and one error trace, got " + traces);
+    for (LogRecord trace : traces) {
+      String message = FORMATTER.formatMessage(trace);
+      assertTrue(message.length() <= LIMIT,
+          () -> "trace of " + message.length() + " characters exceeds the " + LIMIT
+              + " character limit: " + abbreviate(message));
+    }
+  }
+
+  @Test
+  void zeroLimitRestoresUntruncatedTraces() throws SQLException {
+    runQueries(0, PreferQueryMode.EXTENDED);
+
+    List<LogRecord> traces = log.getRecordsMatching(PROTOCOL_TRACE);
+    assertFalse(endsWithMarker(traces), "no trace should be truncated when the limit is 0");
+    assertTrue(traces.stream().anyMatch(r -> FORMATTER.formatMessage(r).length() > LONG_VALUE.length()),
+        "a trace should carry the bound value in full");
+  }
+
+  private static void runQueries(int maxLogMessageLength, PreferQueryMode queryMode)
+      throws SQLException {
+    Properties props = new Properties();
+    PGProperty.MAX_LOG_MESSAGE_LENGTH.set(props, maxLogMessageLength);
+    PGProperty.MAX_LOG_PARAMETER_LENGTH.set(props, 0);
+    PGProperty.PREFER_QUERY_MODE.set(props, queryMode.value());
+    runQueries(props);
+  }
+
+  private static void runQueries(Properties props) throws SQLException {
+    try (Connection con = TestUtil.openDB(props)) {
+      try (PreparedStatement ps = con.prepareStatement("select ?::text, ?::bytea, ?::int4")) {
+        ps.setString(1, LONG_VALUE);
+        ps.setBytes(2, new byte[100_000]);
+        ps.setInt(3, 42);
+        try (ResultSet rs = ps.executeQuery()) {
+          assertTrue(rs.next(), "select should return a row");
+        }
+      }
+      // A simple query carries the values inside the statement text rather than as binds.
+      try (PreparedStatement ps = con.prepareStatement("select '" + LONG_VALUE + "'::text")) {
+        try (ResultSet rs = ps.executeQuery()) {
+          assertTrue(rs.next(), "select should return a row");
+        }
+      }
+    }
+  }
+
+  private static void raise(Connection con, String level) throws SQLException {
+    try (Statement st = con.createStatement()) {
+      st.execute("do $$ begin raise " + level + " '%', repeat('x', 100000); end $$");
+    }
+  }
+
+  private static boolean endsWithMarker(List<LogRecord> traces) {
+    return traces.stream().anyMatch(r -> FORMATTER.formatMessage(r).endsWith(TRUNCATION_MARKER));
+  }
+
+  private static String abbreviate(String message) {
+    return message.length() <= 200 ? message : message.substring(0, 200) + "...";
+  }
+
+  private static String repeat(char c, int count) {
+    char[] chars = new char[count];
+    Arrays.fill(chars, c);
+    return new String(chars);
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/util/internal/BoundedStringBuilderTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/util/internal/BoundedStringBuilderTest.java
@@ -1,0 +1,326 @@
+/*
+ * Copyright (c) 2026, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.util.internal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Fails when {@link BoundedStringBuilder} keeps more characters than its limit allows.
+ *
+ * <p>The driver builds protocol traces out of query text and bound values, so the limit is what
+ * stops a large statement from exhausting the heap through logging. A builder must never hold more
+ * than the limit, and it must tell the reader that characters went missing.</p>
+ */
+class BoundedStringBuilderTest {
+  private static final String MARKER = "...(truncated)";
+
+  private static final String FIELD_MARKER = "...";
+
+  /**
+   * U+1F600, which UTF-16 stores as a surrogate pair, so a cut between its two characters leaves
+   * text that is not valid UTF-16.
+   */
+  private static final String EMOJI = new String(Character.toChars(0x1F600));
+
+  @Test
+  void unlimitedKeepsEverything() {
+    BoundedStringBuilder sb = new BoundedStringBuilder(BoundedStringBuilder.UNLIMITED);
+    sb.append("abc").append('d').append(42);
+    assertTrue(sb.isUnbounded(), "isUnbounded");
+    assertFalse(sb.isFull(), "isFull");
+    assertFalse(sb.isTruncated(), "isTruncated");
+    assertEquals("abcd42", sb.toString());
+  }
+
+  @Test
+  void negativeLimitMeansUnlimited() {
+    BoundedStringBuilder sb = new BoundedStringBuilder(-7);
+    sb.append("abc");
+    assertTrue(sb.isUnbounded(), "isUnbounded");
+    assertEquals("abc", sb.toString());
+  }
+
+  @Test
+  void fittingValueIsKeptVerbatim() {
+    BoundedStringBuilder sb = new BoundedStringBuilder(64);
+    sb.append("select 1");
+    assertFalse(sb.isTruncated(), "isTruncated");
+    assertEquals("select 1", sb.toString());
+    assertEquals(64 - "select 1".length(), sb.remaining(), "remaining");
+  }
+
+  @Test
+  void charSequenceIsCutAtTheLimit() {
+    BoundedStringBuilder sb = new BoundedStringBuilder(30);
+    sb.append(repeat('x', 1000));
+    assertTrue(sb.isTruncated(), "isTruncated");
+    assertTrue(sb.isFull(), "isFull");
+    assertEquals(0, sb.remaining(), "remaining");
+    String result = sb.toString();
+    assertEquals(30, result.length(), "result length");
+    assertTrue(result.endsWith(MARKER), () -> "result should end with the marker: " + result);
+    assertEquals(repeat('x', 30 - MARKER.length()) + MARKER, result);
+  }
+
+  @Test
+  void appendsAfterTheLimitAreDropped() {
+    BoundedStringBuilder sb = new BoundedStringBuilder(20);
+    sb.append(repeat('x', 20));
+    assertFalse(sb.isTruncated(), "an exactly fitting value is not a truncated one");
+    sb.append('y');
+    sb.append("z");
+    sb.append(7);
+    assertTrue(sb.isTruncated(), "isTruncated");
+    assertEquals(repeat('x', 20 - MARKER.length()) + MARKER, sb.toString());
+  }
+
+  @Test
+  void aLimitNarrowerThanTheMarkerCutsTheMarker() {
+    BoundedStringBuilder narrower = new BoundedStringBuilder(3);
+    narrower.append("abcdef");
+    assertEquals("...", narrower.toString(), "the marker is cut to the limit, not kept whole");
+
+    BoundedStringBuilder exact = new BoundedStringBuilder(MARKER.length());
+    exact.append(repeat('a', MARKER.length() + 1));
+    assertEquals(MARKER, exact.toString());
+
+    BoundedStringBuilder wider = new BoundedStringBuilder(MARKER.length() + 1);
+    wider.append(repeat('a', MARKER.length() + 2));
+    assertEquals("a" + MARKER, wider.toString());
+  }
+
+  @Test
+  void aSurrogatePairIsNotCutInHalf() {
+    // The cut lands 6 characters in, which is the high surrogate of the first pair.
+    BoundedStringBuilder sb = new BoundedStringBuilder(MARKER.length() + 6);
+    sb.append(repeat('a', 5) + repeat(EMOJI, 8));
+
+    String result = sb.toString();
+    assertEquals(repeat('a', 5) + MARKER, result, "the split high surrogate is dropped");
+    assertNoLoneSurrogate(result);
+  }
+
+  @Test
+  void aCutBetweenPairsKeepsEveryCharacter() {
+    // The same value one character further along puts the cut between two pairs.
+    BoundedStringBuilder sb = new BoundedStringBuilder(MARKER.length() + 6);
+    sb.append(repeat('a', 6) + repeat(EMOJI, 8));
+
+    assertEquals(repeat('a', 6) + MARKER, sb.toString(), "nothing is dropped when the cut is clean");
+  }
+
+  @Test
+  void aFieldIsCutAtItsOwnBudget() {
+    BoundedStringBuilder sb = new BoundedStringBuilder(BoundedStringBuilder.UNLIMITED);
+    sb.append("$1=");
+    sb.beginField(5).append(repeat('a', 100)).endField();
+    sb.append(",$2=").append("42");
+
+    assertEquals("$1=aaaaa...,$2=42", sb.toString());
+    assertFalse(sb.isTruncated(), "a cut field does not make the message a truncated one");
+  }
+
+  @Test
+  void aFieldThatFitsIsNotMarked() {
+    BoundedStringBuilder sb = new BoundedStringBuilder(BoundedStringBuilder.UNLIMITED);
+    sb.beginField(5).append("abcde").endField();
+
+    assertEquals("abcde", sb.toString(), "a field filled exactly to its budget lost nothing");
+  }
+
+  @Test
+  void theLimitStillWinsInsideAField() {
+    BoundedStringBuilder sb = new BoundedStringBuilder(20);
+    sb.beginField(1000).append(repeat('a', 100)).endField();
+
+    assertTrue(sb.isTruncated(), "the message ran out, not the field");
+    assertEquals(repeat('a', 20 - MARKER.length()) + MARKER, sb.toString());
+  }
+
+  @Test
+  void anOpenFieldMakesTheBuilderBounded() {
+    BoundedStringBuilder sb = new BoundedStringBuilder(BoundedStringBuilder.UNLIMITED);
+    assertTrue(sb.isUnbounded(), "no limit and no field");
+
+    sb.beginField(5);
+    assertFalse(sb.isUnbounded(), "a field bounds the builder even without a limit");
+
+    sb.endField();
+    assertTrue(sb.isUnbounded(), "the field is closed again");
+  }
+
+  @Test
+  void reopeningAFieldClosesThePreviousOne() {
+    BoundedStringBuilder sb = new BoundedStringBuilder(BoundedStringBuilder.UNLIMITED);
+    sb.append("$1=");
+    sb.beginField(3).append("aaaaaaaa");
+    sb.beginField(100).append("bb");
+    sb.endField();
+
+    assertEquals("$1=aaa...bb", sb.toString(),
+        "the abandoned field keeps its own marker instead of lending it to the next one");
+  }
+
+  @Test
+  void aFieldCutDoesNotSplitASurrogatePair() {
+    BoundedStringBuilder sb = new BoundedStringBuilder(BoundedStringBuilder.UNLIMITED);
+    sb.append("$1=");
+    // The budget ends between the two characters of the first pair.
+    sb.beginField(3).append("ab" + repeat(EMOJI, 4)).endField();
+    sb.append(",$2=42");
+
+    String result = sb.toString();
+    assertEquals("$1=ab...,$2=42", result, "the split high surrogate is dropped");
+    assertNoLoneSurrogate(result);
+  }
+
+  @Test
+  void aDroppedCharacterKeepsTheSinkClosed() {
+    BoundedStringBuilder sb = new BoundedStringBuilder(BoundedStringBuilder.UNLIMITED);
+    // The budget ends inside the pair, so the high surrogate leaves the buffer again. The slot it
+    // frees must not let the next append overtake the character that was dropped.
+    sb.beginField(5).append("abcd" + EMOJI).append("ZZZZ").endField();
+
+    assertEquals("abcd...", sb.toString());
+  }
+
+  @Test
+  void roomNeverGrowsWhileAFieldIsOpen() {
+    int splits = 0;
+    for (int limit : new int[]{BoundedStringBuilder.UNLIMITED, 20, 40, 80}) {
+      // A contiguous range, so some budget has to end between the two characters of a pair.
+      for (int budget = 1; budget <= 8; budget++) {
+        BoundedStringBuilder sb = new BoundedStringBuilder(limit);
+        sb.beginField(budget);
+        int previous = sb.remaining();
+        for (String piece : new String[]{"a", EMOJI, "bb", EMOJI, "ccc"}) {
+          sb.append(piece);
+          int now = sb.remaining();
+          int seen = previous;
+          int cut = budget;
+          assertTrue(now <= seen,
+              () -> "room grew from " + seen + " to " + now + " at limit " + limit
+                  + " and budget " + cut);
+          previous = now;
+        }
+        sb.endField();
+        if (limit == BoundedStringBuilder.UNLIMITED && keptLength(sb) < budget) {
+          // The field kept fewer characters than it was allowed, which only happens when a split
+          // surrogate left the buffer again.
+          splits++;
+        }
+      }
+    }
+    assertTrue(splits > 0, "no budget landed inside a surrogate pair, so nothing was removed");
+  }
+
+  @Test
+  void messageRoomNeverGrowsAcrossFields() {
+    BoundedStringBuilder sb = new BoundedStringBuilder(200);
+    int previous = sb.remaining();
+    for (int i = 1; i <= 10; i++) {
+      sb.append(",$").append(i).append("=<");
+      // A budget that ends inside the pair, so every field leaves a character behind.
+      sb.beginField(2).append("a" + EMOJI + EMOJI).endField();
+      sb.append(">");
+
+      int now = sb.remaining();
+      int seen = previous;
+      assertTrue(now <= seen, () -> "message room grew from " + seen + " to " + now);
+      previous = now;
+    }
+    assertTrue(sb.toString().contains("=<a...>"), () -> "expected every field to be cut just after "
+        + "its first character: " + sb);
+    // Nine parameters spell ",$i=<a...>" and the tenth ",$10=<a...>", which is 101 characters, and
+    // each of the ten cuts charges the surrogate it removed, so 111 of the 200 are spent.
+    assertEquals(200 - 111, sb.remaining(), "room left after ten cut fields");
+  }
+
+  @Test
+  void aZeroBudgetOpensNoField() {
+    BoundedStringBuilder sb = new BoundedStringBuilder(BoundedStringBuilder.UNLIMITED);
+    sb.beginField(0).append(repeat('a', 100)).endField();
+
+    assertEquals(repeat('a', 100), sb.toString());
+  }
+
+  @Test
+  void ensureRoomForDoesNotChangeWhatIsKept() {
+    BoundedStringBuilder bounded = new BoundedStringBuilder(20);
+    bounded.ensureRoomFor(1_000_000);
+    bounded.append(repeat('x', 100));
+    assertEquals(repeat('x', 20 - MARKER.length()) + MARKER, bounded.toString());
+
+    BoundedStringBuilder unlimited = new BoundedStringBuilder(BoundedStringBuilder.UNLIMITED);
+    unlimited.ensureRoomFor(-1);
+    unlimited.append("abc");
+    assertEquals("abc", unlimited.toString(), "a hint that overflowed is ignored");
+  }
+
+  @Test
+  void intIsCutAtTheLimit() {
+    BoundedStringBuilder fits = new BoundedStringBuilder(20);
+    fits.append(1234567);
+    assertFalse(fits.isTruncated(), "isTruncated");
+    assertEquals("1234567", fits.toString());
+
+    BoundedStringBuilder overflows = new BoundedStringBuilder(20);
+    overflows.append(repeat('x', 15)).append(1234567);
+    assertTrue(overflows.isTruncated(), "isTruncated");
+    assertEquals(repeat('x', 20 - MARKER.length()) + MARKER, overflows.toString());
+  }
+
+  @Test
+  void nullCharSequenceIsSpelledOut() {
+    BoundedStringBuilder sb = new BoundedStringBuilder(64);
+    sb.append((CharSequence) null);
+    assertEquals("null", sb.toString());
+  }
+
+  @Test
+  void toStringDoesNotConsumeTheBuilder() {
+    BoundedStringBuilder sb = new BoundedStringBuilder(20);
+    sb.append(repeat('x', 100));
+    assertEquals(sb.toString(), sb.toString(), "toString is repeatable");
+  }
+
+  /**
+   * Fails when {@code value} is not well-formed UTF-16. An unpaired surrogate does not survive a
+   * round trip through UTF-8, which is what a log handler that encodes the message would do to it.
+   */
+  private static void assertNoLoneSurrogate(String value) {
+    assertEquals(value, new String(value.getBytes(StandardCharsets.UTF_8), StandardCharsets.UTF_8),
+        "value is not well-formed UTF-16");
+  }
+
+  private static int keptLength(BoundedStringBuilder sb) {
+    String rendered = sb.toString();
+    return rendered.endsWith(FIELD_MARKER)
+        ? rendered.length() - FIELD_MARKER.length() : rendered.length();
+  }
+
+  private static String repeat(char c, int count) {
+    StringBuilder sb = new StringBuilder(count);
+    for (int i = 0; i < count; i++) {
+      sb.append(c);
+    }
+    return sb.toString();
+  }
+
+  private static String repeat(String value, int count) {
+    StringBuilder sb = new StringBuilder(value.length() * count);
+    for (int i = 0; i < count; i++) {
+      sb.append(value);
+    }
+    return sb.toString();
+  }
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

**This is an alternative to [#4332](https://github.com/pgjdbc/pgjdbc/pull/4332), not a replacement for it.** @sankalpsthakur got there first and their PR carries a review from @davecramer. Both fix [#995](https://github.com/pgjdbc/pgjdbc/issues/995) and both add a `maxLogMessageLength` property with the same default and the same `...(truncated)` marker; they differ in where the bound is enforced. Take whichever you prefer and close the other — I have no stake in which.

### Why

A `FINEST` protocol trace concatenates the query text and every bound value into one message. A `bytea` doubles on the way in, because each byte becomes two hex digits, so the 200 MB parameter reported in [#946](https://github.com/pgjdbc/pgjdbc/pull/946) became a 400 MB string and logging itself ran the heap out. Nobody reads a 400 MB log line.

### What

Two connection properties:

* **`maxLogMessageLength`** — characters a log message that embeds query text or a data value may reach. Default `16384`, `0` for no limit.
* **`maxLogParameterLength`** — characters a single bound parameter may reach inside a `Bind` trace. Default `2048`, `0` for no limit. Without it one long value spends the whole trace on itself and hides every parameter after it, so the log shows the query but not the values it ran on. PostgreSQL bounds its own parameter logging the same way through `log_parameter_max_length`.

`org.postgresql.util.internal.BoundedStringBuilder` is an `Appendable` with a hard limit that discards the overflow. The point of that shape: **a producer cannot make it grow by forgetting to check**, so safety does not rest on a size estimate being correct. What it keeps is always a prefix of what it was offered, and the room never grows while a budget is in force.

`SimpleParameterList.toString(int, SqlSerializationContext)` became a thin wrapper over a new append-based `appendTo`, so there is one rendering implementation rather than two. On the logging path this also removes the intermediate `String` that used to be built per parameter, which makes the traced path cheaper than it was before the fix.

What a truncated value looks like:

* text keeps a readable prefix, which is what you want for JSON or XML;
* `bytea` reports `<1000000 bytes>`, because a hex prefix tells the reader nothing and a literal cut in half would look like a complete one;
* a cut parameter ends with `...`, the message ends with `...(truncated)`, and the whole message stays within the limit, marker included.

Bounded sites, outgoing and incoming: `Parse`, `Bind`, `SimpleQuery`, `ErrorMessage`, `NoticeResponse`, `AsyncNotify`, `ParameterStatus`, and the type-conversion trace in `PgConnection.getObject`. `CommandStatus` is left alone: a command tag carries no application text and measured 33 characters over a 50000-row `CREATE TABLE AS`.

An unbounded builder renders exactly what `toString` rendered before, so `PreparedStatement.toString()` and simple query mode are unchanged, with a test pinning it.

`Utils.doAppendEscapedLiteral` became the public `Utils.appendEscapedLiteral(Appendable, String, boolean)` so escaping can write straight into a sink.

### How to verify

```
./gradlew :postgresql:test \
  --tests 'org.postgresql.util.internal.BoundedStringBuilderTest' \
  --tests 'org.postgresql.core.v3.SimpleParameterListTruncationTest' \
  --tests 'org.postgresql.test.jdbc2.MaxLogMessageLengthTest'
```

`MaxLogMessageLengthTest` is the end-to-end one: it attaches a log handler, runs statements in extended and in simple query mode, raises a 100000-character `NOTICE` and `EXCEPTION`, and asserts that every record honours the limit and that `maxLogMessageLength=0` restores the untruncated traces. Length is measured through `Formatter.formatMessage`, because a record logged with parameters carries only the format string in `getMessage()`.

The full `:postgresql:test` run, `checkstyleMain`, `checkstyleTest`, `autostyleCheck` and `-PenableCheckerframework` are green.

### Changes to Existing Features:

* [x] Does this break existing behaviour? If so please explain.
  * A `FINEST` message longer than 16384 characters is now truncated, and a bound parameter longer than 2048 characters is cut short. Set either property to `0` for the previous behaviour. Nothing outside logging changes.
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### AI/LLM disclosure

* Written with Claude Code. I reviewed the whole change and ran the tests reported above.
* It went through five rounds of adversarial cross-review by two independent reviewers before submission. That found, among other things, that an intermediate version re-armed the very `OutOfMemoryError` this fixes (154 MB of heap to produce 2051 characters) when the message limit was disabled but the parameter limit was not, and that a regression test I had written passed against its own reverted fix because it measured the format string rather than the formatted record. Both are fixed and pinned.
