### PR TITLE
docs: add AGENTS.md with acceptable words

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,42 @@
+# AGENTS.md
+
+## Word choice in comments, documentation, and names
+
+Use the right-hand column below in Javadoc, inline comments, error and log messages, `CHANGELOG.md`, `docs/`,
+commit messages, and pull request descriptions.
+
+| Instead of | Write | Note |
+| --- | --- | --- |
+| captured | recorded | Keep `capture` where something really is captured: traffic off a socket, a stack trace at the point of failure. |
+| ceiling, cap | limit | As noun and as verb: limit a length, do not cap it. |
+| desync, desynced | out of sync | |
+| end-of-stream, end of the stream, EOF, end of file; the stream ends, has ended, is exhausted | end of stream | The state an `InputStream` reports by returning -1. |
+| envelope | message | Name the part: the message, its header, or its body. |
+| hard cap, soft cap | say what the limit does | Not `hard limit` or `soft limit` either. |
+| legal | valid | |
+| self-inclusive | say what the field counts | |
+| upper bound on X | largest X | Keep `upper bound` where a lower bound is also in play, or the sentence is about a range. |
+
+The list binds identifiers as well as prose: rename `fieldCap` to `fieldLimit` along with the comment beside it, and
+`rejectsAFieldCountBeyondTheEnvelope` to `rejectsAFieldCountBeyondTheMessage`. This covers names you introduce and
+names in code you are already changing. Do not open a renaming pass over untouched code.
+
+Do not describe code with words borrowed from building or construction. Say the plain thing: critical, not
+load-bearing; the key part, not the cornerstone; a check, not a guardrail. The terms the field already uses literally,
+build, architecture, and framework, are fine; this is about the decorative ones.
+
+These stay as they are:
+
+- Names an outside standard fixes, whether Java, an RFC, or PostgreSQL itself: the SQL function `ceiling()`,
+  `IllegalArgumentException`, frontend/backend protocol message and field names, GUC and connection-property names.
+- Published API, where a name is a compatibility promise. Rename only through deprecation.
+- Text the driver reproduces verbatim: quotations, log lines, wire data.
+
+## Error messages
+
+Use the word the code uses. Wrap user-facing exception text in `GT.tr`, which always formats the string with
+`java.text.MessageFormat`, so double every single quote: `GT.tr("Can''t connect to {0}", host)`.
+
+English is the source. `./gradlew :postgresql:generateGettextSources` updates the files under `translation/`
+from it. Refreshing the translations is a separate i18n change, so do not run the task for a change that only
+adds or reworks an English message. Never edit `messages_*.java` by hand.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## Why

The driver spells one idea several ways, and the reader pays for it. `reWriteBatchedInsertsSize` has a single maximum and master gives it three names: `PgPreparedStatement` calls it a *ceiling* in the comments that compute it, `PGProperty` calls it a *cap* in the javadoc, and the property description a user reads says `capped at 32768 rows`. The message a user is actually handed for a maximum says neither: `Result set exceeded maxResultBuffer limit. Received:  {0}; Current limit: {1}`. So a reader who starts from that message and greps for `limit` lands on code that calls the same thing a cap, or a ceiling, and has to read all three before believing they are one idea.

Settling this per pull request is what happened on #4016, where @davecramer rewrote the hardening comments and we argued the same words twice. A file that states the choice once is cheaper, and it hands an AI agent working in this repository the same list a human reviewer would apply.

## What

`AGENTS.md` fixes one word per idea:

| Instead of | Write | Note |
| --- | --- | --- |
| ceiling, cap | limit | As noun and as verb. |
| envelope | message | Name the part: the message, its header, or its body. |
| desync, desynced | out of sync | |
| headroom | room | |
| legal | valid | |
| captured | recorded | Keep `capture` where something really is captured. |
| self-inclusive | say what the field counts | |
| hard cap, soft cap | say what the limit does | Not `hard limit` or `soft limit` either. |
| Upper bound on X | Largest X | Keep `upper bound` where a lower bound is also in play. |

**The list binds identifiers as well as prose.** A comment that says `limit` beside a parameter named `fieldCap` has moved the word rather than fixed it, and the next sentence that has to name the parameter brings the old word straight back. So the rename goes with the comment. This covers names you introduce and names in code you are already changing, and it is explicitly not a reason to open a renaming pass over untouched code.

Three things stay as they are: names an outside standard fixes, whether Java, an RFC, or PostgreSQL itself (the SQL function `ceiling()` in `EscapedFunctions`, `IllegalArgumentException`, the frontend/backend protocol message and field names, GUC and connection-property names); published API, where a name is a compatibility promise; and text the driver reproduces verbatim. That last one covers strings like the one `StatementTest` expects, `canceling statement due to user request`, spelled the server's way.

Error messages are in scope, and they are the case where it matters most. English is the source language for those strings and `translation/messages_*.po` follows it.

`CLAUDE.md` is a single line, `@AGENTS.md`, so Claude Code reads the same file rather than a second copy that drifts.

**The file carries the instruction and the exceptions to it, and nothing else.** An agent reads all of it on every task, so a sentence that argues for a choice instead of saying what to write costs context on every run. The argument is in this description and in the commit message, which is why the file is 32 lines and this page is longer than it.

## How to verify

Nothing to build: two Markdown files, no code. The `ceiling` / `cap` / `limit` split behind the Why section is at `PgPreparedStatement.java:1820-1824`, `PGProperty.java:687-695`, and `PGStream.java:845` on master.

The file was cut hard to keep the agent's context cheap, so I audited the short version against the long one entry by entry rather than trusting the trim. That found three rules that had gone missing rather than been shortened, all now restored: the RFC half of "Java, an RFC, or PostgreSQL", which no surviving example could stand in for; `hard limit` and `soft limit`, which the table banned only in their `cap` spelling; and "log lines", which I had narrowed to "server messages" while compressing.

Read `AGENTS.md` and disagree with the entries you want to keep; that is the point of the pull request.

## Scope

- The table is my reading of your patches on #4016, not an agreed list. If a word belongs on it that I missed, or one here should not be, say so and I will change it.
- No renaming pass in this pull request. `reWriteBatchedInsertsSize` keeps its `ceiling` and `cap` until something else touches those lines; the rule is for new text and for code already being changed.
- The `pgjdbc.skills` branch also creates an `AGENTS.md`, with build and test instructions. Both create the file from nothing, so whichever lands second needs its section appended rather than merged. The two do not overlap in content.
- No `CHANGELOG.md` entry: this is contributor and agent instructions, nothing a driver user observes.
