### PR TITLE
docs(core): state the PGStream.skip comments plainly

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/PGStream.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/PGStream.java
@@ -681,14 +681,14 @@ public class PGStream implements Closeable, Flushable {
     while (s < size) {
       long skipped = pgInput.skip(size - s);
       if (skipped == 0) {
-        // A stream is allowed to skip nothing and still have more to give, and a stream that has
-        // ended skips nothing forever, so neither spinning nor failing is right on its own.
-        // Reading blocks for a byte and reports the end as -1
+        // InputStream.skip may return zero and still have data coming, and an ended stream
+        // returns zero from every skip, so zero alone does not distinguish the two cases. A read
+        // does distinguish them: it blocks until a byte arrives, and reports the end as -1.
         if (pgInput.read() == -1) {
           throw new EOFException();
         }
-        // That byte is one of the bytes being discarded, so it counts, and reading it primed the
-        // buffer that the next skip drains
+        // The byte just read is one of the bytes being discarded, so it counts toward the total.
+        // The read also buffered whatever else had arrived, and the next skip drains that buffer.
         skipped = 1;
       }
       s += skipped;

--- a/pgjdbc/src/test/java/org/postgresql/core/PGStreamSkipTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/core/PGStreamSkipTest.java
@@ -31,25 +31,24 @@ import javax.net.SocketFactory;
 /**
  * Fails when {@link PGStream#skip(int)} does not discard exactly the bytes it was asked for.
  *
- * <p>Discarding is where the driver relies on {@link InputStream#skip(long)}, which is allowed to
- * skip nothing and still have more to give. A stream that has ended also skips nothing, and it
- * says so forever. Telling the two apart is the whole job: read the end as the end, and treat a
- * stream that is merely being unhelpful as one that still owes bytes. Getting it wrong either
- * hangs the connection or breaks a usable one, and getting the count wrong leaves the connection
- * off a message boundary, which surfaces later as a protocol error somewhere else.</p>
+ * <p>Discarding goes through {@link InputStream#skip(long)}, which may return zero while more
+ * bytes are still on the way, and a stream that has ended returns zero from every skip. The
+ * driver has to tell the two apart: throw {@link EOFException} once the stream has ended, and
+ * keep discarding while it has not. Treating every zero as the end breaks a usable connection;
+ * treating none of them as the end never finishes. Discarding the wrong number of bytes leaves
+ * the connection off a message boundary, which a later read reports as a protocol error.</p>
  *
- * <p>The streams below stand in for what a {@code socketFactory} may hand the driver, which is
- * where an implementation the driver did not write can reach it.</p>
+ * <p>{@link CountingStream} stands in for what the {@code socketFactory} connection property may
+ * put under the driver: an input stream the driver did not write.</p>
  */
-// A stream that never makes progress used to spin here, so cap the wait: a hang is a failure
-// of the thing under test, and it should read as one rather than stalling the build. The
-// separate thread is what makes that work, since the default mode only checks the clock once
-// the test method returns, which a spinning one never does
+// A skip that never finishes would hang this test, and the separate thread is what turns the
+// hang into a failure: the default mode only checks the clock once the test method returns,
+// which a hung test never does
 @Timeout(value = 30, unit = TimeUnit.SECONDS, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
 class PGStreamSkipTest {
   /**
-   * Payload the stream serves. Every byte differs from its neighbours, so a skip that lands at the
-   * wrong offset is visible in the byte read after it.
+   * Payload the stream serves. Each of the 256 byte values appears once, so the byte read after a
+   * skip identifies the offset the skip landed on.
    */
   private static final byte[] DATA = new byte[256];
 
@@ -60,12 +59,12 @@ class PGStreamSkipTest {
   }
 
   /**
-   * How many bytes a wrapped stream agrees to skip per call.
+   * How many bytes of a requested skip a wrapped stream discards per call.
    */
   enum SkipStyle {
-    /** Skips everything asked of it, the ordinary case. */
+    /** Delegates the skip to the wrapped stream. This is the ordinary case. */
     HONEST,
-    /** Skips nothing, ever, which the contract permits. */
+    /** Skips nothing, ever, which {@link InputStream#skip(long)} permits. */
     REFUSES,
     /** Skips a single byte per call, so progress is real but slow. */
     ONE_AT_A_TIME
@@ -73,10 +72,10 @@ class PGStreamSkipTest {
 
   @Test
   void skipDiscardsExactlyTheRequestedBytes() throws Exception {
-    // The buffer under PGStream is 8192 bytes, so a request below the payload is served from it
-    // once it is primed, and one above it has to reach the wrapped stream
+    // A zero-byte skip never calls down at all, and the buffer under PGStream starts empty, so
+    // every other size here reaches the wrapped stream on the first call
     for (SkipStyle style : SkipStyle.values()) {
-      for (int size : new int[]{0, 1, 100, DATA.length - 1}) {
+      for (int size : new int[]{0, 1, 100, DATA.length - 1, DATA.length}) {
         CountingStream source = new CountingStream(new ByteArrayInputStream(DATA), style);
         try (PGStream stream = openStream(source)) {
           String label = style + " skip=" + size;
@@ -103,8 +102,10 @@ class PGStreamSkipTest {
   }
 
   /**
-   * A stream that refuses to skip must not degrade to one read per byte: the read that breaks the
-   * refusal primes the buffer, and the next skip drains it wholesale.
+   * Fails when a skip over a stream that refuses to skip degrades to one read per byte.
+   *
+   * <p>The read that breaks the refusal fills the buffer, and the next skip drains it in one
+   * call.</p>
    */
   @Test
   void skipDoesNotFallBackToReadingByteByByte() throws Exception {
@@ -118,22 +119,26 @@ class PGStreamSkipTest {
     }
   }
 
+  /**
+   * Opens a {@link PGStream} that reads from {@code source}, with no server behind it. The
+   * {@code 8192} argument sizes the send buffer, not the buffer the driver reads through.
+   */
   private static PGStream openStream(InputStream source) throws IOException {
     return new PGStream(new FixedSocketFactory(source), new HostSpec("localhost", 5432), 0, 8192);
   }
 
   /**
-   * Counts what the driver asked of the stream, and answers skip as the style dictates.
+   * Counts the skip and read calls the driver makes, and skips as {@link SkipStyle} prescribes.
    *
-   * <p>Refuses to play along with a caller that ignores a zero from {@link #skip(long)}: after
-   * {@link #ZERO_SKIP_LIMIT} of them with nothing read in between, it throws instead of letting
-   * the caller spin. That turns the defect this test guards into an immediate failure that names
-   * itself, rather than one the surrounding timeout has to catch.</p>
+   * <p>{@link #skip(long)} throws {@link IllegalStateException} once more than
+   * {@link #ZERO_SKIP_LIMIT} skips in a row have returned zero with nothing read in between. A
+   * caller that ignores a zero skip fails the test there, with a message that states what it
+   * did, rather than spinning until the class timeout ends the test.</p>
    */
   static final class CountingStream extends FilterInputStream {
     /**
-     * Consecutive zero-returning skips that count as a caller making no progress. Reading resets
-     * the count, since that is how a caller reacts to a skip that skipped nothing.
+     * Consecutive zero-returning skips that count as a caller making no progress. A read resets
+     * the count, because a caller that reads after a zero skip has made progress.
      */
     static final int ZERO_SKIP_LIMIT = 10;
 
@@ -190,7 +195,8 @@ class PGStreamSkipTest {
   }
 
   /**
-   * Hands the driver a socket whose input is the given stream, so no server is involved.
+   * Creates sockets that read from the stream given to the constructor, so no server is involved.
+   * Anything the driver writes goes to a buffer nothing reads.
    */
   static final class FixedSocketFactory extends SocketFactory {
     private final InputStream input;


### PR DESCRIPTION
### Why

The comments #4358 added to `PGStream.skip` and `PGStreamSkipTest` explain the zero-skip case as riddles: "a stream that has ended skips nothing forever", "telling the two apart is the whole job", "refuses to play along". #4400 raised the same objection. This rewrite keeps every fact the original stated and adds two facts the old comments left out.

### What

- Each comment names its subject (`InputStream.skip`, the read buffer, `CountingStream`, `EOFException`, `IllegalStateException`) instead of "it", and states the two reasons `skip` can return 0 as two cases.
- `openStream` says that the `8192` it passes is `maxSendBufferSize`, not the buffer `skip` drains. The read buffer is a separate hard-coded 8192 in `changeSocket`, and the old comment two lines above the call invited the reader to conclude the argument sized it.
- The comment in `skipDiscardsExactlyTheRequestedBytes` no longer describes a skip larger than the payload: no size in the loop was, and the buffer is empty when each iteration's first skip is issued, so every non-zero size reaches the wrapped stream on the first call.
- The size loop gains `DATA.length`. The `if (size < DATA.length)` guard on the byte-after-the-skip assertion never fired, since every size was below it; a skip of exactly the payload is the case it exists for.
- `DATA` is described by the property the assertion needs: each of the 256 byte values appears once, so the byte read after a skip identifies the offset.

### Verification

`PGStreamSkipTest` and checkstyle pass; no test method is new. The added `DATA.length` size runs all three skip styles over a skip of exactly the payload, which must finish without `EOFException` and must still ask the wrapped stream to skip. Apart from that one element, every changed line is a comment line.

```bash
./gradlew --quiet :postgresql:checkstyleMain :postgresql:checkstyleTest :postgresql:test --tests org.postgresql.core.PGStreamSkipTest
```

### Scope

#4400 rewrites the same comments in the same two files, so one of the two closes. This branch differs from it on three facts: a wrong count leaves the connection off a message boundary (between messages is the aligned state, not the broken one); `skip` reads a byte after a zero rather than retrying the skip; and `HONEST` delegates to the wrapped stream rather than skipping the full amount, since `ByteArrayInputStream.skip` returns `min(n, remaining)` and `skipReportsAStreamThatEndsEarly` relies on that. No CHANGELOG entry: nothing user-visible changes.
