### PR TITLE
docs: name Conventional Commits in AGENTS.md and CONTRIBUTING.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,3 +40,10 @@ Use the word the code uses. Wrap user-facing exception text in `GT.tr`, which al
 English is the source. `./gradlew :postgresql:generateGettextSources` updates the files under `translation/`
 from it. Refreshing the translations is a separate i18n change, so do not run the task for a change that only
 adds or reworks an English message. Never edit `messages_*.java` by hand.
+
+## Commit messages
+
+Write all commit messages in Conventional Commits format: `type(scope): summary`, where the scope is optional and the
+summary is imperative and lower case. The types in use are `feat`, `fix`, `docs`, `test`, `refactor`, `perf`, `style`,
+`chore`, `ci`, and `build`. A scope names the component the change touches, as in
+`fix(core): make PGStream.skip finish when stream skip returns 0`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -419,50 +419,34 @@ has to reverse engineer the intention behind that code.
 
 ## <a name="commit"></a> Git Commit Guidelines
 
-We have very precise rules over how our git commit messages can be formatted.  This leads to **more
-readable messages** that are easy to follow when looking through the **project history**.  But also,
-we use the git commit messages to **generate the change log**.
+Write commit messages in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. This keeps the
+history readable and lets the release notes be generated from it.
 
-### Commit Message Format
-Each commit message consists of a **header**, a **body** and a **footer**.  The header has a special
-format that includes a **type**, and a **subject**:
+```text
+<type>(<optional scope>): <summary>
 
-```
-<type>: <subject>
-<BLANK LINE>
-<body>
-<BLANK LINE>
-<footer>
+<optional body>
+
+<optional footer>
 ```
 
-Any line of the commit message cannot be longer 100 characters! This allows the message to be easier
-to read on github as well as in various git tools.
+A scope names the component the change touches, as in `fix(core): make PGStream.skip finish when stream skip returns 0`.
 
-### Type
-Must be one of the following:
+The types in use are:
 
-* **feat**: A new feature
-* **fix**: A bug fix
-* **docs**: Documentation only changes
-* **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing
-  semi-colons, etc)
-* **refactor**: A code change that neither fixes a bug or adds a feature
-* **perf**: A code change that improves performance
-* **test**: Adding missing tests
-* **chore**: Changes to the build process or auxiliary tools and libraries such as documentation
-  generation
+* **feat**: a new feature
+* **fix**: a bug fix
+* **docs**: documentation only, including Javadoc and the website
+* **test**: adding or reworking tests
+* **refactor**: a code change that neither fixes a bug nor adds a feature
+* **perf**: a code change that improves performance
+* **style**: a change that does not affect the meaning of the code, such as white space or formatting
+* **build**: the Gradle build and the packaging
+* **ci**: the GitHub Actions workflows and the rest of the continuous integration setup
+* **chore**: anything else that leaves the driver unchanged, such as a dependency update
 
-### Subject
-The subject contains succinct description of the change:
+The summary is imperative and present tense: "change", not "changed" or "changes". It starts in lower case and ends
+without a period.
 
-* use the imperative, present tense: "change" not "changed" nor "changes"
-* don't capitalize first letter
-* no dot (.) at the end
-
-### Body
-Just as in the **subject**, use the imperative, present tense: "change" not "changed" nor "changes"
-The body should include the motivation for the change and contrast this with previous behavior.
-
-### Footer
-The footer should contain any information about **Breaking Changes** and is also the place to
-reference GitHub issues that this commit **Closes**.
+The body gives the motivation for the change and contrasts it with the previous behavior. The footer carries
+`BREAKING CHANGE:` and the issues the commit closes.


### PR DESCRIPTION
## Why

AGENTS.md covers how an agent words comments, error messages, and pull request descriptions, and says nothing about commit messages. The rules live in CONTRIBUTING.md under "Git Commit Guidelines", which an agent reaches only after going looking, so the format ends up guessed from whatever the last few subjects happen to look like.

That section has also drifted from the history it describes. It gives the header as `<type>: <subject>` with no scope, while `fix(core):` and `chore(deps):` are everywhere; it lists eight types and has neither `ci` nor `build`, both in regular use; and its 100-character line limit is enforced by nothing, so 23 of the last 700 subjects exceed it.

## What

AGENTS.md gets a "Commit messages" section: the format, the shape of a subject, and the ten types the history uses. It neither links the specification nor explains a type, because an agent knows both already.

CONTRIBUTING.md names Conventional Commits and links the specification instead of restating a convention of its own. The scope, `ci`, and `build` join the type list, and the 100-character rule goes. Every type keeps its one-line description: the reader here is a first-time contributor, and the choice between `refactor`, `style`, and `chore` is what they cannot infer.

## Scope

Documentation only.

The types are the ones with real use in the history: `chore` (251 of the last 700 subjects), `fix` (222), `test` (52), `ci` (21), `docs` (15), `feat` (14), `refactor` (10), `build` (10), `style` (7), and `perf` (4). Legacy spellings such as `doc` and `packaging` are left out rather than blessed.
