### PR TITLE
ci: restrict standard_conforming_strings=no to PostgreSQL 18 and older

### DIFF
--- a/.github/workflows/matrix.mjs
+++ b/.github/workflows/matrix.mjs
@@ -313,7 +313,8 @@ matrix.addAxis({
 });
 
 function lessThan(minVersion) {
-    return value => Number(value) < Number(minVersion);
+    // HEAD is the development branch, so it is newer than every numbered major.
+    return value => value === 'HEAD' ? false : Number(value) < Number(minVersion);
 }
 
 matrix.setNamePattern([
@@ -347,6 +348,10 @@ matrix.exclude({os: {value: ['windows-latest', 'macos-latest']}, pg_version: les
 matrix.imply({pg_version: 'HEAD'}, {os: {value: 'ubuntu-latest'}});
 // cleanupSavepoints is not relevant when autosave=never
 matrix.imply({autosave: {value: 'never'}}, {cleanupSavepoints: {value: 'false'}});
+// PostgreSQL 19 accepts standard_conforming_strings=on only, and rejects off with
+// "non-standard string literals are not supported".
+// See https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=4576208
+matrix.imply({standard_conforming_strings: {value: 'no'}}, {pg_version: lessThan('19')});
 
 // Collect coverage from a single job that turns on every feature that moves coverage (ssl,
 // scram, xa, replication, the latest stable server, one query mode). The other flags add at


### PR DESCRIPTION
## Why

The `standard_conforming_strings` axis in `.github/workflows/matrix.mjs` is free to pair with any `pg_version`, so a generated job can run PG HEAD against a server started with `-c standard_conforming_strings=off`. PostgreSQL 19 accepts `standard_conforming_strings=on` only, and rejects `off` with `non-standard string literals are not supported`, so that job fails.

The rejection arrived with [PostgreSQL commit 4576208](https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=4576208), "Force standard_conforming_strings to always be ON." (2026-01-21). The GUC stays, now with a check hook that raises `ERRCODE_FEATURE_NOT_SUPPORTED` for `off`.

## What

`standard_conforming_strings=no` now implies `pg_version` below 19, so the axis only reaches 9.1 through 18. When PG 19 ships and `MAX_PG` reaches it, the numeric comparison covers the released server too.

`lessThan()` already left `HEAD` out, through `Number('HEAD')` being `NaN`. It now returns `false` for `HEAD` explicitly, so a reader does not have to work that out from the coercion. Every other `lessThan()` call keeps its result.

## Verification

`node matrix.mjs` over 40 runs at `MATRIX_JOBS=25`, 1000 rows in total:

- no row pairs `PG HEAD` with `standard_conforming_strings=no`;
- `standard_conforming_strings=no` still appears on every major from 9.1 to 18;
- HEAD rows are still generated, one per run, from the `require` entry, all on `ubuntu-latest`;
- no `windows-latest` or `macos-latest` row below PG 14, which is the other `lessThan()` rule the explicit `HEAD` branch could have changed.

## Scope

CI matrix only, so no changelog entry. The client side of the same server change is already handled: `PreparedStatementTest.testSingleQuotes` carries `@EnabledForServerVersionRange(lt = "19")` from https://github.com/pgjdbc/pgjdbc/pull/3934.
