### PR TITLE
test(jdbc): cover each search_path case of the isUpdateable() key lookup

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
@@ -2492,6 +2492,9 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
   /*
   This is for internal use only to see if a resultset is updateable.
   Unique keys can also be used so we add them to the query.
+  A null or empty schema matches only the table that the unqualified table name resolves to through
+  search_path, as pg_table_is_visible() decides. A null schema in getPrimaryKeys() matches every
+  schema instead.
    */
   protected ResultSet getPrimaryUniqueKeys(@Nullable String catalog, @Nullable String schema, String table)
       throws SQLException {
@@ -2536,12 +2539,6 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
       sql.append(" AND n.nspname = ?");
       args.add(schema);
     } else {
-      // The table name carries no schema qualifier, so it resolves through the session's
-      // search_path. pg_table_is_visible() applies the same visibility rules the server uses,
-      // so only the relation the query actually references is matched. Without it, identically
-      // named tables in other schemas are matched too, which can mis-classify a result set as
-      // updatable when those tables share a constraint name but differ in their key columns.
-      // pg_table_is_visible() has existed since PostgreSQL 7.3.
       sql.append(" AND pg_catalog.pg_table_is_visible(ct.oid)");
     }
 

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/UpdateableResultTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/UpdateableResultTest.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
@@ -1041,55 +1042,126 @@ public class UpdateableResultTest extends BaseTest4 {
     }
   }
 
+  /**
+   * Both tables have a primary key index named {@code same_name_pkey}, over {@code id} in
+   * {@code upd_schema_a} and over {@code (id, other)} in {@code upd_schema_b}. The driver used to
+   * merge the two into one key of three columns, and the result set was rejected as not updatable.
+   *
+   * <p>{@code upd_schema_empty} heads {@code search_path}, so {@code same_name} resolves through a
+   * later entry and {@code current_schema()} returns a schema with no such table. The test
+   * therefore also fails for a key lookup restricted to {@code current_schema()}, the approach of
+   * PR #3400.</p>
+   */
   @Test
-  public void testUpdateableWithSameTableNameInMultipleSchemas() throws SQLException {
-    // Two schemas hold a table with the same name and the same auto-generated primary key
-    // index name (same_name_pkey), but a different set of key columns. An unqualified query
-    // must be classified using only the table visible through search_path, not the union of
-    // both schemas' key columns. Before the fix the union made upd_schema_a's single-column
-    // key look incomplete, so the result set was wrongly rejected as not updatable.
-    //
-    // search_path puts an empty schema first, so the table resolves through a later entry
-    // (upd_schema_a). This also rules out the rejected #3400 approach of defaulting the
-    // schema to current_schema(): current_schema() is the empty schema, which holds no
-    // same_name table, so that approach would still reject the result set.
-    TestUtil.execute(con, "DROP SCHEMA IF EXISTS upd_schema_empty CASCADE");
-    TestUtil.execute(con, "DROP SCHEMA IF EXISTS upd_schema_a CASCADE");
-    TestUtil.execute(con, "DROP SCHEMA IF EXISTS upd_schema_b CASCADE");
-    TestUtil.execute(con, "CREATE SCHEMA upd_schema_empty");
-    TestUtil.execute(con, "CREATE SCHEMA upd_schema_a");
-    TestUtil.execute(con, "CREATE SCHEMA upd_schema_b");
-    String savedSearchPath;
-    try (Statement show = con.createStatement();
-         ResultSet rs = show.executeQuery("SHOW search_path")) {
-      assertTrue(rs.next());
-      String sp = rs.getString(1);
-      savedSearchPath = sp != null ? sp : "\"$user\", public";
-    }
+  public void testUpdateableWhenSameNamedTableInOtherSchemaSharesKeyName() throws SQLException {
+    recreateSchemas("upd_schema_empty", "upd_schema_a", "upd_schema_b");
     try {
       TestUtil.execute(con, "CREATE TABLE upd_schema_a.same_name (id int PRIMARY KEY, val text)");
       TestUtil.execute(con,
           "CREATE TABLE upd_schema_b.same_name (id int, other int, val text, PRIMARY KEY (id, other))");
       TestUtil.execute(con, "INSERT INTO upd_schema_a.same_name (id, val) VALUES (1, 'a')");
-
       TestUtil.execute(con, "SET search_path TO upd_schema_empty, upd_schema_a, upd_schema_b");
+
       try (Statement st = con.createStatement(ResultSet.TYPE_SCROLL_INSENSITIVE,
-          ResultSet.CONCUR_UPDATABLE)) {
-        try (ResultSet rs = st.executeQuery("SELECT id, val FROM same_name")) {
-          assertTrue(rs.next());
+          ResultSet.CONCUR_UPDATABLE);
+           ResultSet rs = st.executeQuery("SELECT id, val FROM same_name")) {
+        assertTrue(rs.next());
+        rs.updateString("val", "updated");
+        rs.updateRow();
+      }
+
+      assertEquals("updated",
+          TestUtil.queryForString(con, "SELECT val FROM upd_schema_a.same_name WHERE id = 1"),
+          "val of upd_schema_a.same_name after updateRow()");
+    } finally {
+      TestUtil.execute(con, "RESET search_path");
+      dropSchemas("upd_schema_empty", "upd_schema_a", "upd_schema_b");
+    }
+  }
+
+  /**
+   * The visible {@code same_name} has no key, and a table of the same name further down
+   * {@code search_path} has a primary key over {@code id}. The driver used to take that key for the
+   * visible table's, and {@code updateRow()} then updated both rows whose {@code id} is 1.
+   */
+  @Test
+  public void testNotUpdateableWhenOnlySameNamedTableInOtherSchemaHasKey() throws SQLException {
+    recreateSchemas("upd_schema_a", "upd_schema_b");
+    try {
+      TestUtil.execute(con, "CREATE TABLE upd_schema_a.same_name (id int, val text)");
+      TestUtil.execute(con, "CREATE TABLE upd_schema_b.same_name (id int PRIMARY KEY, val text)");
+      TestUtil.execute(con,
+          "INSERT INTO upd_schema_a.same_name (id, val) VALUES (1, 'first'), (1, 'second')");
+      TestUtil.execute(con, "SET search_path TO upd_schema_a, upd_schema_b");
+
+      try (Statement st = con.createStatement(ResultSet.TYPE_SCROLL_INSENSITIVE,
+          ResultSet.CONCUR_UPDATABLE);
+           ResultSet rs = st.executeQuery("SELECT id, val FROM same_name ORDER BY val")) {
+        assertTrue(rs.next());
+        SQLException ex = assertThrows(SQLException.class, () -> {
           rs.updateString("val", "updated");
           rs.updateRow();
-        }
-        try (ResultSet rs = st.executeQuery("SELECT val FROM same_name WHERE id = 1")) {
-          assertTrue(rs.next());
-          assertEquals("updated", rs.getString("val"));
-        }
+        });
+        assertEquals(
+            GT.tr("No eligible primary or unique key found for table {0}.", "same_name"),
+            ex.getMessage());
       }
+
+      assertEquals("first,second",
+          TestUtil.queryForString(con,
+              "SELECT string_agg(val, ',' ORDER BY val) FROM upd_schema_a.same_name"),
+          "vals of upd_schema_a.same_name after the rejected update");
     } finally {
-      TestUtil.execute(con, "SET search_path TO " + savedSearchPath);
-      TestUtil.execute(con, "DROP SCHEMA IF EXISTS upd_schema_empty CASCADE");
-      TestUtil.execute(con, "DROP SCHEMA IF EXISTS upd_schema_a CASCADE");
-      TestUtil.execute(con, "DROP SCHEMA IF EXISTS upd_schema_b CASCADE");
+      TestUtil.execute(con, "RESET search_path");
+      dropSchemas("upd_schema_a", "upd_schema_b");
+    }
+  }
+
+  /**
+   * A schema-qualified name selects its table by the schema, not by {@code search_path}, so a table
+   * that {@code search_path} does not make visible stays updatable through its own key.
+   *
+   * <p>The visible {@code same_name} has the wider key, over {@code (id, other)}, and the query
+   * does not select {@code other}. The test therefore fails both when the lookup also requires
+   * visibility and when it matches the table name in every schema.</p>
+   */
+  @Test
+  public void testUpdateableWhenQualifiedTableIsNotVisible() throws SQLException {
+    recreateSchemas("upd_schema_a", "upd_schema_b");
+    try {
+      TestUtil.execute(con,
+          "CREATE TABLE upd_schema_a.same_name (id int, other int, val text, PRIMARY KEY (id, other))");
+      TestUtil.execute(con, "CREATE TABLE upd_schema_b.same_name (id int PRIMARY KEY, val text)");
+      TestUtil.execute(con, "INSERT INTO upd_schema_b.same_name (id, val) VALUES (1, 'b')");
+      TestUtil.execute(con, "SET search_path TO upd_schema_a, upd_schema_b");
+
+      try (Statement st = con.createStatement(ResultSet.TYPE_SCROLL_INSENSITIVE,
+          ResultSet.CONCUR_UPDATABLE);
+           ResultSet rs = st.executeQuery("SELECT id, val FROM upd_schema_b.same_name")) {
+        assertTrue(rs.next());
+        rs.updateString("val", "updated");
+        rs.updateRow();
+      }
+
+      assertEquals("updated",
+          TestUtil.queryForString(con, "SELECT val FROM upd_schema_b.same_name WHERE id = 1"),
+          "val of upd_schema_b.same_name after updateRow()");
+    } finally {
+      TestUtil.execute(con, "RESET search_path");
+      dropSchemas("upd_schema_a", "upd_schema_b");
+    }
+  }
+
+  private void recreateSchemas(String... schemas) throws SQLException {
+    dropSchemas(schemas);
+    for (String schema : schemas) {
+      TestUtil.execute(con, "CREATE SCHEMA " + schema);
+    }
+  }
+
+  private void dropSchemas(String... schemas) throws SQLException {
+    for (String schema : schemas) {
+      TestUtil.execute(con, "DROP SCHEMA IF EXISTS " + schema + " CASCADE");
     }
   }
 }


### PR DESCRIPTION
### Why

#4214 restricted the key lookup behind `PgResultSet.isUpdateable()` to the table an unqualified name resolves to through `search_path`. Its test covers one symptom only: a result set wrongly rejected with `No eligible primary or unique key found for table same_name.` when a same-named table in another schema has a key index of the same name over other columns.

The same fix also closed a worse case that no test guards. When the visible table has no key and a shadowed same-named table has one, the driver used to take the shadowed table's key, and `updateRow()` then updated every row of the visible table whose `id` matched, with no error. Nothing tests the schema-qualified branch (`n.nspname = ?`) either: the suite stays green both when `pg_table_is_visible()` is applied to qualified lookups too, which makes `SELECT ... FROM other_schema.t` non-updatable for a shadowed table, and when the schema filter is dropped.

### What

- A new test for the keyless visible table: the update is rejected, and both rows stay unchanged.
- A new control test for a schema-qualified query over a table that `search_path` does not make visible: it stays updatable through its own key. The visible same-named table has the wider key, so matching the name in every schema also makes the query non-updatable.
- The existing test is renamed to `testUpdateableWhenSameNamedTableInOtherSchemaSharesKeyName` and restores `search_path` with `RESET` instead of re-applying a saved `SHOW` value.
- The rule that a null or empty schema matches only the visible table moves from an inline comment in the `else` branch into the `getPrimaryUniqueKeys()` comment. The inline comment's other sentences are dropped: one described the #4214 symptom as a result set wrongly accepted, and one recorded that `pg_table_is_visible()` exists since PostgreSQL 7.3, which the #4214 commit message already says. No production code changes.

### How to verify

```bash
./gradlew :postgresql:test --tests 'org.postgresql.test.jdbc2.UpdateableResultTest'
```

With the `pg_table_is_visible()` line removed, the keyless-table test fails with `Expected java.sql.SQLException to be thrown, but nothing was thrown.`, and without the `assertThrows` its read-back shows `expected: <first,second> but was: <updated,updated>`. With the visibility filter added to the qualified branch, or with its schema filter removed, the control test fails with `No eligible primary or unique key found for table upd_schema_b.same_name.`

### Scope

Test and comment only, so no changelog entry. The 42.7.13 entry for #4214 mentions only the rejected result set, not the rows updated in the wrong table. It is a released entry, so this PR leaves it as it is.

PS. I found this when reviewing https://github.com/pgjdbc/pgjdbc/pull/923

🤖 Generated with [Claude Code](https://claude.com/claude-code)
