### PR TITLE
docs: describe protocolVersion values 3.0 and 3.2

### DIFF
--- a/docs/content/documentation/use.md
+++ b/docs/content/documentation/use.md
@@ -207,8 +207,9 @@ If provided will be used by ConsoleCallbackHandler
 * **`sslResponseTimeout (`*Integer*`)`** *Default `5000`*\
 Time in milliseconds to wait for a response after requesting an SSL encrypted connection from the server. If this is greater than the current connectTimeout then connectTimeout will be used.
 
-* **`protocolVersion (`*int*`)`** *Default `null`*\
-The driver supports the V3 frontend/backend protocols. The V3 protocol was introduced in 7.4 and the driver will by default try to connect using the V3 protocol.
+* **`protocolVersion (`*String*`)`** *Default `3`*\
+Protocol version the driver requests when it connects. `3` and `3.0` request version 3.0. `3.2` requests version 3.2, which PostgreSQL 18 introduced and which differs from 3.0 only in a longer query cancellation key. PostgreSQL 11 through 17 negotiate the connection down to 3.0, and so do 9.3 through 10 from minor releases 9.3.21, 9.4.16, 9.5.11, 9.6.7, and 10.2. With an older server, or through a connection pooler that does not implement protocol negotiation, the connection fails. Any other value fails the connection with `A connection could not be made using the requested protocol {0}.`
+  Since: 42.7.6 for `3.0` and `3.2`
 
 * **`loggerLevel (`*String*`)`**\
 This property is no longer used by the driver and will be ignored. All logging configuration is handled by java.util.logging.

--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -573,15 +573,16 @@ public enum PGProperty {
       "Statement prepare threshold. A value of {@code -1} stands for forceBinary"),
 
   /**
-   * Force use of a particular protocol version when connecting, if set, disables protocol version
-   * fallback.
+   * Protocol version the driver requests when it connects: {@code 3} or {@code 3.0} for version
+   * 3.0, {@code 3.2} for version 3.2. A server that implements protocol negotiation but not 3.2
+   * continues the connection with 3.0.
    */
   PROTOCOL_VERSION(
       "protocolVersion",
       "3",
-      "Force use of a particular protocol version when connecting, currently only version 3 is supported.",
+      "Protocol version the driver requests when it connects: 3 or 3.0 for version 3.0, 3.2 for version 3.2. A server that implements protocol negotiation but not 3.2 continues with 3.0.",
       false,
-      new String[]{"3"}),
+      new String[]{"3", "3.0", "3.2"}),
 
   /**
    * Parameter for {@link java.sql.Statement#getQueryTimeout()}. A value of {@code 0} means no timeout.

--- a/pgjdbc/src/main/java/org/postgresql/core/ConnectionFactory.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/ConnectionFactory.java
@@ -28,17 +28,16 @@ public abstract class ConnectionFactory {
   /**
    * Establishes and initializes a new connection.
    *
-   * <p>If the "protocolVersion" property is specified, only that protocol version is tried. Otherwise,
-   * all protocols are tried in order, falling back to older protocols as necessary.</p>
-   *
-   * <p>Currently, protocol versions 3 (7.4+) is supported.</p>
+   * <p>Accepts the {@link PGProperty#PROTOCOL_VERSION} values {@code 3}, {@code 3.0}, and
+   * {@code 3.2}; that property says which protocol version each one requests.</p>
    *
    * @param hostSpecs at least one host and port to connect to; multiple elements for round-robin
    *        failover
    * @param info extra properties controlling the connection; notably, "password" if present
    *        supplies the password to authenticate with.
    * @return the new, initialized, connection
-   * @throws SQLException if the connection could not be established.
+   * @throws SQLException if the connection could not be established, or if
+   *         {@link PGProperty#PROTOCOL_VERSION} holds any other value.
    */
   public static QueryExecutor openConnection(HostSpec[] hostSpecs,
       Properties info) throws SQLException {
@@ -62,17 +61,16 @@ public abstract class ConnectionFactory {
   }
 
   /**
-   * Implementation of {@link #openConnection} for a particular protocol version. Implemented by
-   * subclasses of {@link ConnectionFactory}.
+   * Implementation of {@link #openConnection}, called once its protocol version check passes.
+   * Implemented by subclasses of {@link ConnectionFactory}.
    *
    * @param hostSpecs at least one host and port to connect to; multiple elements for round-robin
    *        failover
    * @param info extra properties controlling the connection; notably, "password" if present
    *        supplies the password to authenticate with.
-   * @return the new, initialized, connection, or <code>null</code> if this protocol version is not
-   *         supported by the server.
-   * @throws SQLException if the connection could not be established for a reason other than
-   *         protocol version incompatibility.
+   * @return the new, initialized, connection, or <code>null</code>, which makes
+   *         {@link #openConnection} throw
+   * @throws SQLException if the connection could not be established
    */
   public abstract QueryExecutor openConnectionImpl(HostSpec[] hostSpecs, Properties info) throws SQLException;
 


### PR DESCRIPTION
## Why

Since 42.7.6 (#3592) the driver accepts `protocolVersion` values `3`, `3.0`, and `3.2`, and `3.2` requests protocol 3.2 from PostgreSQL 18. The documentation still described the pre-3.2 property: the [connection property page](https://jdbc.postgresql.org/documentation/use/) listed it as an `int` with a `null` default that only supports V3, and the `DriverPropertyInfo` description said "currently only version 3 is supported" with `3` as the only choice. A reader had no way to find out how to request 3.2. #1128, which proposed removing the entry as obsolete, is closed for this reason.

## What

- `docs/content/documentation/use.md`: the entry now gives the type (`String`) and default (`3`), what each value requests, what a server without 3.2 support does, and the error any other value produces: `A connection could not be made using the requested protocol {0}.` A server that implements protocol negotiation continues with 3.0: PostgreSQL 11 through 17, and 9.3 through 10 from minor releases 9.3.21, 9.4.16, 9.5.11, 9.6.7, and 10.2. An older server, or a pooler without negotiation, fails the connection.
- `PGProperty.PROTOCOL_VERSION`: new description, and `choices` is now `{"3", "3.0", "3.2"}`, so tools that render `DriverPropertyInfo` offer 3.2 as an option. This is the only change a program can observe.
- `ConnectionFactory`: the Javadoc on `openConnection` and `openConnectionImpl` described a fallback across protocol versions the driver no longer performs. It now states which values `openConnection` accepts and what a `null` from `openConnectionImpl` means.

## Verification

I ran the shadow jar built from this branch against PostgreSQL 17.11 and 18.6:

| `protocolVersion` | PostgreSQL 17 | PostgreSQL 18 |
| --- | --- | --- |
| unset, `3`, `3.0` | 3.0 | 3.0 |
| `3.2` | 3.0 | 3.2 |
| `3.1`, `2`, empty | 08001 | 08001 |

`PGPropertyTest` passes with the new choices. No new tests: the connect path for 3.2 is covered by `StatementTest.closeInProgressStatementProtocol32`.

## Scope

This change documents the current behavior and does not fix the two `protocolVersion` defects in #4422: an empty value fails the connection, and `BaseDataSource.getProtocolVersion()` throws `NumberFormatException` for `3.2`. Both need a maintainer decision first.

No changelog entry: the 42.7.6 entry for #3592 already announces 3.2, and this change only corrects the documentation of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
