### PR TITLE
test: stop excluding *Suite* classes from the test run

### DIFF
--- a/build-logic/jvm/src/main/kotlin/build-logic.test-base.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/build-logic.test-base.gradle.kts
@@ -22,7 +22,6 @@ tasks.configureEach<Test> {
     testLogging {
         showStandardStreams = true
     }
-    exclude("**/*Suite*")
     jvmArgs("-Xmx1536m")
     jvmArgs("-Djdk.net.URLClassPath.disableClassPathURLCheck=true")
     if (buildParameters.testJdkVersion >= 21) {

--- a/pgjdbc/build.gradle.kts
+++ b/pgjdbc/build.gradle.kts
@@ -442,7 +442,6 @@ val sourceDistribution = tasks.register<Tar>("sourceDistribution") {
     into("src/test") {
         from("$withoutAnnotations/src/test") {
             exclude("*/org/postgresql/test/osgi/**")
-            exclude("**/*Suite*")
             exclude("*/org/postgresql/test/sspi/*.java")
             exclude("*/org/postgresql/replication/**")
         }

--- a/pgjdbc/src/test/java/org/postgresql/test/socketfactory/SocketFactoryTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/socketfactory/SocketFactoryTest.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Test;
 import java.sql.Connection;
 import java.util.Properties;
 
-class SocketFactoryTestSuite {
+class SocketFactoryTest {
 
   private static final String STRING_ARGUMENT = "name of a socket";
 


### PR DESCRIPTION
## Why

The Gradle test task excluded every class matching `**/*Suite*`, a leftover from the JUnit 4 suite classes. No suites remain, but the mask still matched `SocketFactoryTestSuite`, a plain JUnit 5 test, so CI never ran it. The source distribution dropped the file for the same reason.

## What

Both exclusions are removed: the one in `build-logic.test-base.gradle.kts` that every module's `test` task inherits, and the one in the `sourceDistribution` copy spec. `SocketFactoryTestSuite` is renamed to `SocketFactoryTest`, so the name no longer suggests a suite and Maven Surefire in the source distribution picks it up by its default `*Test` pattern.

## Verification

`./gradlew :postgresql:test --tests 'org.postgresql.test.socketfactory.SocketFactoryTest'` passes against the docker server. The test asserts that the custom factory created exactly one socket; the GSS matrix jobs are the first place it runs with a GSS or SSL fallback that could open a second one, so watch those jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
