### PR TITLE
docs: drop Java 6 and 7 from the JavaVersion Javadoc

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/JavaVersion.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/JavaVersion.java
@@ -6,27 +6,26 @@
 package org.postgresql.core;
 
 public enum JavaVersion {
-  // Note: order is important,
+  // Constants follow release order: TimestampUtils compares versions with compareTo
   v1_8,
   other;
 
   private static final JavaVersion RUNTIME_VERSION = from(System.getProperty("java.version"));
 
   /**
-   * Returns enum value that represents current runtime. For instance, when using -jre7.jar via Java
-   * 8, this would return v18
-   *
-   * @return enum value that represents current runtime.
+   * Returns the enum value for the JVM the driver runs on, which can be newer than the version the
+   * driver was compiled for.
    */
   public static JavaVersion getRuntimeVersion() {
     return RUNTIME_VERSION;
   }
 
   /**
-   * Java version string like in {@code "java.version"} property.
+   * Maps a Java version string to the enum value it belongs to.
    *
-   * @param version string like 1.6, 1.7, etc
-   * @return JavaVersion enum
+   * @param version value of the {@code "java.version"} system property, such as {@code 1.8.0_452}
+   *     or {@code 17.0.9}
+   * @return {@link #v1_8} for a Java 8 version string, {@link #other} for every other value
    */
   public static JavaVersion from(String version) {
     if (version.startsWith("1.8")) {


### PR DESCRIPTION
The Javadoc of `JavaVersion.from` gave `1.6` and `1.7` as example inputs, and `getRuntimeVersion` described `-jre7.jar` returning `v18`. pgjdbc targets Java 8, the jre6 and jre7 projects were removed in #1848, and the enum has no `v18` constant. I promised this cleanup in the [review of #1999](https://github.com/pgjdbc/pgjdbc/pull/1999#issuecomment-5647627849).

The examples now use `1.8.0_452` and `17.0.9`, the `@return` of `from` states which strings map to `v1_8` and which to `other`, and the note above the constants says why their order matters (`TimestampUtils` checks `compareTo(JavaVersion.v1_8) <= 0`). The `@return` tag on `getRuntimeVersion` repeated its summary and is gone; Javadoc runs with `-Xdoclint:all,-missing`, so no tag is required.

The diff changes comments only. `./gradlew :postgresql:checkstyleMain :postgresql:autostyleJavaCheck :postgresql:javadoc` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
