### PR TITLE
chore(deps): open Renovate pull requests for com.ongres patch updates only

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -34,6 +34,24 @@
       "groupName": "{{{replace ':.*' '' depName}}}"
     },
     {
+      "description": "The com.ongres SCRAM and stringprep libraries are shaded into the driver, so a minor or major update changes the driver's own code. Keep patch updates in a branch of their own: without separateMinorPatch, Renovate offers only the newest non-major version, and a pending minor update would hide every patch update.",
+      "matchPackageNames": [
+        "com.ongres.**"
+      ],
+      "separateMinorPatch": true
+    },
+    {
+      "description": "A minor or major com.ongres update waits for a pgjdbc minor release. Renovate lists it on the Dependency Dashboard and opens the pull request once its checkbox is ticked.",
+      "matchPackageNames": [
+        "com.ongres.**"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ],
+      "dependencyDashboardApproval": true
+    },
+    {
       "groupName": "checkerframework",
       "matchPackageNames": [
         "org.checkerframework{/,}**"


### PR DESCRIPTION
The com.ongres SCRAM and stringprep libraries are shaded into the driver, so a minor update changes the driver's own code and should not land in a pgjdbc patch release. Renovate still opens such pull requests, for example stringprep 2.2 to 2.4 in #4325.

With this change a minor or major com.ongres update waits on the Dependency Dashboard until a maintainer ticks it, typically before a pgjdbc minor release. Patch updates keep opening pull requests on their own. The rules also set `separateMinorPatch`: without it Renovate puts minor and patch updates in one bucket and offers only the newest version, so a pending minor update would hide every patch update. `enabled: false` for minor updates was rejected for that reason, and because a disabled update never appears on the dashboard.

## Verification

- `renovate-config-validator --strict renovate.json` passes.
- Renovate 44.82.4 with `--platform=github --dry-run=full` against the fork `vlsi/pgjdbc`, using this `renovate.json` with `schedule` removed: the `renovate/com.ongres.scram` branch (scram-client 3.2 to 3.4) gets the result `needs-approval`, logged as `Branch renovate/com.ongres.scram creation is disabled because dependencyDashboardApproval=true`.
- com.ongres has never published a patch release, so the patch path was checked on a scratch repository with `org.roaringbitmap:RoaringBitmap:1.2.0` and the same rules aimed at that package. The current rules produce `renovate/patch-org.roaringbitmap` (1.2.1) and `renovate/org.roaringbitmap` (1.6.23); `enabled: false` without `separateMinorPatch` produces no update for RoaringBitmap at all.

#4325 is not closed by this change; Renovate may close it on the next run, or it can be closed by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
